### PR TITLE
governance: fail-closed gate + never tier + Settings → Governance caps

### DIFF
--- a/config/policy/default.policy.json
+++ b/config/policy/default.policy.json
@@ -1,9 +1,13 @@
 {
   "id": "default@v1",
-  "description": "What your agents may do on their own vs. what needs a human. Allow = runs immediately; Ask = pauses for an admin/owner to approve; Block = never. These cover what real agents actually do (shell + tools); add Advanced rules for finer control.",
+  "description": "What your agents may do on their own vs. what needs a human. Allow = runs immediately; Ask = pauses for an admin/owner to approve; Never = refused outright, regardless of who approves (irreversible actions). The Never rules read the caps in Settings → Governance ($moneyCapUsd / $bulkDeleteCount).",
   "defaultRisk": "yellow",
   "approvalRouting": { "yellow": "head", "red": "owner" },
   "rules": [
+    { "match": { "capability": "*", "when": { "arg": "destructive", "op": "eq", "value": true } }, "risk": "deny" },
+    { "match": { "capability": "*", "when": { "arg": "amountUsd", "op": "gt", "value": "$moneyCapUsd" } }, "risk": "deny" },
+    { "match": { "capability": "*", "when": { "arg": "deleteCount", "op": "gt", "value": "$bulkDeleteCount" } }, "risk": "deny" },
+
     { "match": { "capability": "shell.exec", "when": { "arg": "risky", "op": "eq", "value": true } }, "risk": "red" },
     { "match": { "capability": "shell.exec" }, "risk": "green" },
 

--- a/docs/governance-model.md
+++ b/docs/governance-model.md
@@ -1,0 +1,281 @@
+# Agent OS — The Governance & Policy Model
+
+This is the design north star for the trust layer: *what the governance layer is meant to be*, stated
+as principles, with each current gap mapped to the principle it violates. It sits above the
+implementation — `src/gateway/gateway.ts`, `src/governance/policy.ts`, `src/governance/approvals.ts`,
+and the real enforcement path `terminal/gate-hook.sh` — and exists so that feature work has something
+to check itself against. When you change the trust layer, change it *toward* these principles, and
+update this doc if a principle itself moves.
+
+The one invariant restated: **every side effect an agent has on the world passes through a single
+mediated gateway.** Everything below is what that gateway must actually do to be worth having.
+
+---
+
+## The core reframing
+
+Most of the layer's current problems are one problem wearing different masks: **the decision collapses
+four separate questions into a single heuristic.** Today the brain is effectively `classify(action)` —
+a capability string mapped to a risk colour by a substring match. Pull the questions apart and the
+right architecture falls out of them.
+
+A governance decision is a function of **four inputs**, not one:
+
+```
+decide( action, actor, context, target ) → allow | approve(level) | deny
+```
+
+- **Action** — the capability *and its real arguments*: the SQL inside `db_query`, the dollar amount,
+  the payload — not just a tool name.
+- **Actor** — who set this in motion: a human with a role (and whether that role can already approve),
+  or an autonomous trigger (cron / Slack / webhook).
+- **Context** — attended vs unattended, budget remaining, rate, environment posture, time.
+- **Target** — *what* it touches: prod vs staging, the blast radius of the specific resource.
+
+Nearly every policy you will ever want to write is a sentence over those four nouns — *"a member's
+unattended agent may not run a destructive verb against prod."* You cannot express that today because
+three of the four nouns never reach the decision (`classify(attempt, _ctx)` discards the context
+entirely). Wiring the missing nouns in is the central piece of work; the principles below are what that
+buys you.
+
+---
+
+## Principle 1 — The master axis is reversibility, not "risk"
+
+Green / yellow / red asks "how scared am I," which nobody can calibrate consistently. Replace it with
+the axis that actually determines the correct control: **can this be undone?**
+
+| Reversibility | Examples | Control |
+|---|---|---|
+| **Reversible** | reads, drafts, staging writes | allow, just record it |
+| **Recoverable** | spends money, mutates prod but restorable from backup | approve (human in the loop) |
+| **Irreversible** | drop database, delete account, unclawbackable spend | **deny / out-of-band** — never a one-click inbox card |
+
+This single reframing makes the two recurring questions consistent:
+
+- *"Should the owner approve their own agent's action?"* — fine for the **recoverable** tier (it's just
+  a confirmation you can grant yourself); forbidden for the **irreversible** tier (a second pair of
+  eyes is the whole point, and you can't undo it).
+- *"What if an agent mistakenly deletes prod?"* — that lands in the **irreversible** tier, which is
+  `deny`, not `approve`. Recovery is a deliberate out-of-band human action, never an inbox click made
+  by a tired operator.
+
+You don't need a courage rating. You need to know whether you can take it back.
+
+---
+
+## Principle 2 — Defense in depth: policy is one layer, never the only one
+
+An agent should be able to perform action *X* **only if all of these hold**:
+
+1. it *holds a credential* that can do *X* — **identity / least privilege**
+2. policy *permits* *X* in this context — **the rule engine**
+3. a human *approved*, if *X* requires it — **approvals**
+4. *X* is *recoverable* if 1–3 all failed — **backups / soft-delete / dry-run-first**
+
+Each layer assumes the others may fail. The strongest guarantee that "an agent never deletes prod" is
+not a clever rule — it is that **the agent never holds a prod-destructive credential**, with policy as
+the backstop and recoverability as the floor. Today only layer 2 exists in practice, and (see
+Principle 4) it fails open — so the entire guarantee rests on one shell `case` statement. That is the
+structural weakness, not any individual missing rule.
+
+---
+
+## Principle 3 — Split the classifier from the policy
+
+Policy-as-data (the JSON ruleset) is the right call: it keeps `src/core` and the kernel generic and
+open-sourceable, and lets an owner edit rules live. Keep it. But *"what is this action, really?"* —
+parsing destructive SQL out of `db_query`, telling prod from staging, computing reversibility and
+amount — **cannot** live in declarative JSON, and must not live in a bash heuristic. So two components
+with a clean seam between them:
+
+- **Enricher** — deterministic, server-side, unit-testable code that turns a raw tool call into
+  *facts*: `{ verb: "delete", target: "prod-db", reversible: false, amountUsd: 0, … }`. This is where
+  case-insensitivity, SQL/argument inspection, and environment resolution live.
+- **Policy** — the declarative ruleset, mapping `facts + actor + context → decision`.
+
+The bash hook's job then shrinks to **dumb, fail-closed transport**: ship the raw call to the server,
+obey the verdict. All the brittleness collapses into one tested function instead of being smeared
+across substring matches in a shell script.
+
+---
+
+## Principle 4 — One chokepoint, and it fails closed — or the layer is theatre
+
+The value proposition is "every side effect passes through one mediated boundary." That is only true
+when:
+
+- **There is exactly one decision brain.** Today there are two — the clean `gateway.ts` (used by the
+  mock/demo path) and the real `gate-hook.sh` (used by live claude-code agents) — and they do not share
+  a classifier. Two brains means two policies means the guarantee is fiction for whichever path is
+  weaker. Unify them onto one decision function.
+- **Every path fails closed.** A governance layer with a single fail-open branch provides *zero*
+  guarantee, because any accident or adversary simply steers toward that branch. The hook's current
+  `*) exit 0 ;;  # fail-open` fallback — which also triggers during the documented stale-server restart
+  window when the gate route 404s→401 — must become deny-on-error and deny-on-unknown. Pair it with a
+  "gate unreachable → blocked, retrying" UX so a flaky network degrades safely instead of silently
+  opening.
+
+Auditability is the other half of trustworthiness: every decision must emit a record of
+`(facts, rule matched, decision, actor)` so the gateway is provable after the fact, not just hopeful in
+the moment. Audit-at-every-step already exists in `gateway.ts`; the hook path must reach the same bar.
+
+---
+
+## Principle 5 — Humans handle exceptions, not operations
+
+The layer's job is to let the routine flow and route only the genuinely exceptional to a person. If a
+human is asked to approve everything, they approve nothing — **alarm fatigue is itself a security
+failure**, which is why self-approval spam is a real problem and not merely an annoyance. The tuning
+target:
+
+> **Deny the catastrophic. Allow the routine. Ask a human only on genuine ambiguity.**
+
+Two consequences:
+
+- **Context-aware routing.** When the actor is a human who *already* holds approval authority for the
+  required level and the run is attended, a recoverable action is theirs to take without a self-
+  addressed approval card — but this shortcut is **fenced out of the irreversible tier** (Principle 1).
+  The `spawned_by` initiator signal already exists on every session; the decision just has to read it.
+- **Learn what's routine.** What counts as "ambiguous" should shrink over time as the system observes
+  outcomes. The Dreaming engine (`src/edge/dreaming.ts`) is the natural home for that feedback loop —
+  proposing (human-applied) policy refinements rather than silently widening what agents may do.
+
+And keep the layer **legible to the agent**: `policy_check` / dry-run (already in `memory-mcp.ts`) lets
+an agent ask "can I?" before it acts, so the gate is a planning aid, not a surprise — which cuts the
+blocked-then-retry waste that itself pushes agents toward edge cases.
+
+---
+
+## Where we are vs. the north star
+
+The hard parts already exist: a single conceptual gateway, policy-as-data with a live console editor,
+audit-at-every-step, idempotency, and an initiator signal (`term_sessions.spawned_by`). The gaps are
+all *"a principle not yet wired,"* not *"a layer that needs inventing":*
+
+| Gap (today) | Principle violated | Direction |
+|---|---|---|
+| `classify(attempt, _ctx)` ignores context | Core reframing | thread actor / context / target into the decision |
+| No `deny` tier in `default.policy.json` — worst case is `approve(owner)` | P1 reversibility | add an irreversible tier that denies regardless of approver |
+| Owner is asked to approve their own attended agent | P1 + P5 | context-aware auto-approve for the recoverable tier, fenced from irreversible |
+| Classification by tool *name* — `db_query` / `execute_php` args unseen | P3 classifier split | server-side, argument-aware enricher |
+| Case-sensitive substring matching in the hook (`*DROP*` misses `drop`) | P3 + P4 | move classification off the shell, make it deterministic + tested |
+| Two decision paths (`gateway.ts` vs `gate-hook.sh`) | P4 one chokepoint | one shared decision function |
+| `*) exit 0` fail-open fallback | P4 fail-closed | deny on error and on unknown |
+| Agents hold the same creds regardless of environment | P2 defense in depth | least privilege / environment-scoped identity |
+
+None of this is a rewrite. It is threading inputs we already collect into a decision we already make,
+then refusing to fail open.
+
+---
+
+## The v1 policy framework (decided)
+
+The model above is the *why*; this is the *what we are building*, with the open choices now locked.
+
+**One function, three outcomes, on the reversibility axis:**
+
+```
+decide(action, actor, context, target) → allow | ask(level) | never
+```
+
+- **allow** — reversible (reads, drafts, staging writes). Runs; just audited.
+- **ask(level)** — recoverable (spends money, mutates prod but restorable). Pauses for a human.
+- **never** — irreversible. Refused, full stop.
+
+**Two invariants:**
+1. **`never` always wins** over any `allow`/`ask` (Cedar's forbid-overrides). Structural — no rule,
+   role, or approver overrides it.
+2. **`ask` auto-satisfies only when** the actor is a *human who can approve that level* **and** the run
+   is *attended*. Never applies to the `never` tier.
+
+**Locked decisions (2026-06-29):**
+
+| Choice | Decision |
+|---|---|
+| Self-approval | **Auto-approve attended** — owner *or* admin driving an attached session clears their own `ask`-tier actions (audited as auto-approved by them). Unattended/automation runs always pause for a human. |
+| Gate failure mode | **Fail-closed** — gate unreachable/error/unknown ⇒ block + retry; never run ungoverned. Replaces the `*) exit 0` fallback. |
+| Scope | **One global ruleset** for v1, reshaped to this model. Per-agent / per-environment overlays are a later additive layer. |
+| `never` tier | Prod DB destruction · bulk content/site deletion · destructive infra/shell · large/irreversible money. |
+
+**Starter `never`-tier rules** (exact patterns/thresholds to be confirmed; enricher inspects arguments
+incl. SQL inside `db_query`/`execute_php`, case-insensitive):
+
+```jsonc
+{ "when": { "verb": "db.destroy",   "target.env": "prod" }, "then": "never" },  // DROP/TRUNCATE DATABASE|TABLE, schema delete
+{ "when": { "verb": "site.delete" },                        "then": "never" },  // delete a WP/InstaWP site
+{ "when": { "verb": "content.delete", "count": { "gt": 25 } }, "then": "never" }, // mass content/user delete
+{ "when": { "verb": "fs.destroy" },                         "then": "never" },  // rm -rf data paths, mkfs, dd
+{ "when": { "verb": "infra.destroy" },                      "then": "never" },  // terraform destroy, kubectl delete, force-push main
+{ "when": { "verb": "secret.delete", "target.env": "prod" }, "then": "never" },
+{ "when": { "verb": "payment", "amountUsd": { "gt": 500 } }, "then": "never" }  // above the cap; at/below → ask(owner)
+```
+
+Everything not matched by a `never` or `ask` rule falls through to `allow` for reversible verbs and
+`ask(head)` for anything the enricher can't prove safe (a safe default that won't flood the inbox once
+the common reversible verbs are explicitly `allow`ed).
+
+---
+
+## Prior art & alignment
+
+This model was checked against the public agent-governance landscape (Microsoft's Agent Governance
+Toolkit; the `awesome-ai-governance` index — Cedar, OPA, the OWASP/NIST/CSA standards, the MCP-gateway
+projects). The short version: **the model holds**, the convergence is strong enough to be reassuring,
+and the external work supplies a few concrete, low-dependency upgrades rather than any rethink.
+
+### Convergence (we are not alone, and not wrong)
+
+Microsoft's **Agent Governance Toolkit (AGT)** independently arrived at the same architecture — to the
+point of shipping a subpackage literally named **"Agent OS"** ("kernel-level governance with
+POSIX-inspired primitives"), with an `Agent → Policy → Identity → Audit` pipeline that is our 7-step
+gateway minus budget/idempotency. Its thesis — make violations *"structurally impossible rather than
+relying on probabilistic prompt-level safety"* — restates our one invariant. AWS's **Cedar** evaluates
+authorization over **Principal · Action · Resource · Context**, which is exactly our
+`f(action, actor, context, target)` (the four-input reframing above), with the same default-deny and a
+`forbid`-always-wins rule that *is* our irreversible tier. We re-derived these independently; that they
+match is evidence the shape is right.
+
+### Mapping to the OWASP Agentic threat taxonomy
+
+The OWASP Agentic Security Initiative's threat list names several risks this model already targets —
+useful both as a checklist and as external vocabulary when explaining the layer:
+
+| OWASP agentic threat | Addressed by |
+|---|---|
+| **Overwhelming Human-in-the-Loop** (approval fatigue) | Principle 5 — deny the catastrophic, allow the routine, ask only on ambiguity |
+| **Tool Misuse** | Principle 3 — argument-aware enricher (sees the SQL inside `db_query`, not just the name) |
+| **Privilege Compromise** | Principle 2 — least privilege / environment-scoped identity |
+| **Repudiation & Untraceability** | Principle 4 — fail-closed + tamper-evident audit |
+| **Identity Spoofing** | the *actor* input — initiator resolved from `term_sessions.spawned_by` |
+
+That approval fatigue is a *named threat in the standard* is the external validation of why "the owner
+approving their own agent" is a real problem and not a nicety.
+
+### Borrowed primitives (low-dependency, on the roadmap)
+
+Four things worth taking from the landscape, none of which compromise the zero-dependency, generic core:
+
+1. **A shared conformance suite.** AGT defines its policy by a golden table of `(call → expected
+   decision)` tested across implementations. We adopt the *idea*: one fixture both enforcement paths
+   (`gateway.ts` and the `gate-hook.sh` server endpoint) must satisfy — the structural fix for the
+   "two brains" gap (P4), and cheap in our in-process Node test style.
+2. **Hash-chained audit.** Signed Decision Receipts (IETF) / Merkle audit logs / Ed25519 receipts all
+   point the same way. We can get tamper-evidence with *zero deps* — each audit event carries the hash
+   of the previous one (`crypto`), so the JSONL system-of-record becomes append-only-provable (P4 / the
+   Repudiation threat).
+3. **Kill switch + denylist.** AGT's runtime has a global stop-all and a hard command denylist. The
+   denylist *is* the irreversible tier (P1); the kill switch is an operational control we lack.
+4. **`require_approval` as a first-class action + richer conditions.** AGT's YAML treats approval as a
+   policy outcome with expressive conditions (`action.type in ['drop','delete','truncate']`). Our JSON
+   `when` (single arg, one comparison) should grow toward this. Note Cedar *cannot* express an approval
+   workflow (it is pure allow/deny), so the human-in-the-loop tier stays ours regardless of engine.
+
+### Deliberately out of scope (for now)
+
+SPIFFE/DIDs, TEE / confidential compute (cMCP, OPAQUE), on-chain trust scoring, and RL-with-violation
+training are real but overkill for a single-box Tailscale deployment. Revisit only if Agent OS goes
+multi-org or into a regulated setting. We also keep the JSON policy engine as the zero-dep default
+rather than taking Cedar/OPA as a hard dependency — Cedar may later be offered as a *pluggable* advanced
+engine (same pattern as the swappable memory backends), but the generic core must run with no external
+policy runtime.

--- a/src/governance/policy.ts
+++ b/src/governance/policy.ts
@@ -63,9 +63,33 @@ function globToRegExp(glob: string): RegExp {
   return new RegExp(`^${escaped}$`);
 }
 
-function evalWhen(when: NonNullable<PolicyRule['match']['when']>, args: Record<string, unknown>): boolean {
+/**
+ * A `when.value` of the form `"$name"` is a reference to a named governance threshold (e.g.
+ * `"$moneyCapUsd"`), resolved live from the engine's thresholds provider at classify time. This keeps
+ * the numeric caps editable in Settings → Governance without rewriting policy rules. The kernel always
+ * wires a provider backed by defaults (500 / 25), so a reference normally resolves; an UNwired engine
+ * (e.g. an isolated test) yields `undefined`, in which case the rule simply does not match and the
+ * attempt flows on through the remaining rules (mutations still hit their risky→approval rule). We
+ * deliberately don't treat "unknown cap" as match-and-deny, since the same `$ref` mechanism may feed
+ * non-deny rules; the cap is guaranteed present in the real system.
+ */
+function resolveValue(value: number | string | boolean, thresholds: Record<string, number>): number | string | boolean | undefined {
+  if (typeof value === 'string' && value.startsWith('$')) {
+    const resolved = thresholds[value.slice(1)];
+    return typeof resolved === 'number' && Number.isFinite(resolved) ? resolved : undefined;
+  }
+  return value;
+}
+
+function evalWhen(
+  when: NonNullable<PolicyRule['match']['when']>,
+  args: Record<string, unknown>,
+  thresholds: Record<string, number>,
+): boolean {
   const actual = args[when.arg];
-  const { op, value } = when;
+  const { op } = when;
+  const value = resolveValue(when.value, thresholds);
+  if (value === undefined) return false; // unresolved threshold ref → fail closed (no match)
   if (op === 'eq') return actual === value;
   if (op === 'ne') return actual !== value;
   const a = Number(actual);
@@ -79,8 +103,16 @@ function evalWhen(when: NonNullable<PolicyRule['match']['when']>, args: Record<s
 
 export class JsonPolicyEngine implements PolicyEngine {
   private doc: PolicyDocument;
+  /** Live provider for named numeric thresholds (`$moneyCapUsd`, …). Wired by the kernel after the
+   *  AgentOS (and thus its settings store) exists; until then rules referencing thresholds fail closed. */
+  private thresholdsProvider: () => Record<string, number> = () => ({});
   constructor(doc: PolicyDocument) {
     this.doc = doc;
+  }
+
+  /** Inject the threshold resolver (e.g. `() => os.settings.governanceThresholds()`). */
+  setThresholds(fn: () => Record<string, number>): void {
+    this.thresholdsProvider = fn;
   }
 
   /** Ruleset id — read live so a hot reload is reflected everywhere `os.policy.id` is used. */
@@ -100,9 +132,10 @@ export class JsonPolicyEngine implements PolicyEngine {
   }
 
   classify(attempt: ActionAttempt, _ctx: RunContext): Decision {
+    const thresholds = this.thresholdsProvider();
     const rule = this.doc.rules.find((r) => {
       if (!globToRegExp(r.match.capability).test(attempt.capabilityId)) return false;
-      if (r.match.when && !evalWhen(r.match.when, attempt.args)) return false;
+      if (r.match.when && !evalWhen(r.match.when, attempt.args, thresholds)) return false;
       return true;
     });
     const risk = rule?.risk ?? this.doc.defaultRisk;

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -17,6 +17,7 @@ const COMPOSIO_KEY = 'composio_api_key';
 const COMPOSIO_WEBHOOK_KEY = 'composio_webhook_secret';
 const SLACK_APP_TOKEN_KEY = 'slack_app_token'; // xapp-… (Socket Mode, connections:write)
 const SLACK_BOT_TOKEN_KEY = 'slack_bot_token'; // xoxb-… (chat.postMessage, users.info)
+const DISCORD_BOT_TOKEN_KEY = 'discord_bot_token'; // Bot … (Gateway connect + post messages)
 const MEMORY_KEY = 'memory_config'; // the live memory backend (JSON MemoryConfig; overrides the file default)
 const RUNTIME_DEFAULTS_KEY = 'runtime_defaults'; // workspace-wide model/effort/permission fallback (JSON RuntimeTuning)
 const DREAMING_KEY = 'dreaming_every_hours'; // self-learning cadence in hours; 0/unset = off
@@ -24,6 +25,18 @@ const DREAMING_STATE_KEY = 'dreaming_state'; // compounding self-learning state 
 const LEARNED_GUIDANCE_KEY = 'learned_guidance'; // distilled imperatives injected into every agent's prompt
 const LEARNED_APPLY_KEY = 'learned_guidance_apply'; // 'off' to stop injecting (default on once guidance exists)
 const RECOMMENDATIONS_KEY = 'learned_recommendations'; // { open: Recommendation[], dismissed: string[] }
+const GOVERNANCE_KEY = 'governance_thresholds'; // numeric caps the never-tier policy rules read (JSON GovernanceThresholds)
+
+/** Numeric governance caps the policy's never-tier rules reference by name (e.g. `$moneyCapUsd`).
+ *  Live-editable in Settings → Governance; resolved at classify time by the policy engine. */
+export interface GovernanceThresholds {
+  /** A single payment/refund at or below this (USD) may be approved; above it is refused outright. */
+  moneyCapUsd: number;
+  /** A delete of at most this many items may be approved; above it is refused outright. */
+  bulkDeleteCount: number;
+}
+
+export const DEFAULT_GOVERNANCE_THRESHOLDS: GovernanceThresholds = { moneyCapUsd: 500, bulkDeleteCount: 25 };
 
 export interface CompanySettings {
   /** The company-wide markdown context. Empty string when unset. */
@@ -126,6 +139,28 @@ export class SettingsStore {
   }
   setSlackBotToken(token: string, by?: string): void {
     this.set(SLACK_BOT_TOKEN_KEY, token.trim(), by);
+  }
+
+  // ── native Discord (Gateway) ───────────────────────────────────────────────────
+  // One company Discord bot, configured once here, shared across the whole workspace. The single bot
+  // token both opens the outbound Gateway WebSocket (no public URL needed) and posts replies. Unlike
+  // Slack there is no separate app-level token — Discord uses one bot token for both.
+
+  /** Bot token (`Bot …`) for the Gateway + posting messages, or '' when unset. */
+  discordBotToken(): string {
+    return this.getRow(DISCORD_BOT_TOKEN_KEY)?.value?.trim() ?? '';
+  }
+  /** The bot token present — the minimum to open a Gateway connection and reply. */
+  discordConfigured(): boolean {
+    return !!this.discordBotToken();
+  }
+  /** Whether the Discord token is set + who last touched it (never returns the token itself). */
+  discordMeta(): { botToken: boolean; updatedAt?: number; updatedBy?: string } {
+    const bot = this.getRow(DISCORD_BOT_TOKEN_KEY);
+    return { botToken: !!bot?.value, updatedAt: bot?.updated_at ?? undefined, updatedBy: bot?.updated_by ?? undefined };
+  }
+  setDiscordBotToken(token: string, by?: string): void {
+    this.set(DISCORD_BOT_TOKEN_KEY, token.trim(), by);
   }
 
   // ── memory backend ───────────────────────────────────────────────────────────────
@@ -241,5 +276,45 @@ export class SettingsStore {
   }
   setRecommendations(value: { open: Recommendation[]; dismissed: string[] }, by?: string): void {
     this.set(RECOMMENDATIONS_KEY, JSON.stringify(value), by);
+  }
+
+  // ── governance thresholds ────────────────────────────────────────────────────────
+  // Numeric caps the never-tier policy rules reference by name ($moneyCapUsd / $bulkDeleteCount).
+  // Kept here (not hard-coded in the policy JSON) so an owner can retune the caps live without
+  // editing rules; the policy engine resolves them at classify time. Unset → DEFAULT_*.
+
+  /** The live governance caps, merged over the defaults so a partial save can't drop a field. */
+  governanceThresholds(): GovernanceThresholds {
+    const raw = this.getRow(GOVERNANCE_KEY)?.value;
+    if (!raw) return { ...DEFAULT_GOVERNANCE_THRESHOLDS };
+    try {
+      const v = JSON.parse(raw) as Partial<GovernanceThresholds>;
+      return {
+        moneyCapUsd: Number.isFinite(v.moneyCapUsd) ? Number(v.moneyCapUsd) : DEFAULT_GOVERNANCE_THRESHOLDS.moneyCapUsd,
+        bulkDeleteCount: Number.isFinite(v.bulkDeleteCount) ? Number(v.bulkDeleteCount) : DEFAULT_GOVERNANCE_THRESHOLDS.bulkDeleteCount,
+      };
+    } catch {
+      return { ...DEFAULT_GOVERNANCE_THRESHOLDS };
+    }
+  }
+
+  governanceMeta(): { updatedAt?: number; updatedBy?: string } {
+    const row = this.getRow(GOVERNANCE_KEY);
+    return { updatedAt: row?.updated_at, updatedBy: row?.updated_by ?? undefined };
+  }
+
+  /** Persist new caps (clamped to non-negative integers) and return the resolved set. */
+  setGovernanceThresholds(t: Partial<GovernanceThresholds>, by?: string): GovernanceThresholds {
+    const cur = this.governanceThresholds();
+    const clamp = (n: unknown, fallback: number) => {
+      const v = Number(n);
+      return Number.isFinite(v) && v >= 0 ? Math.floor(v) : fallback;
+    };
+    const next: GovernanceThresholds = {
+      moneyCapUsd: clamp(t.moneyCapUsd, cur.moneyCapUsd),
+      bulkDeleteCount: clamp(t.bulkDeleteCount, cur.bulkDeleteCount),
+    };
+    this.set(GOVERNANCE_KEY, JSON.stringify(next), by);
+    return next;
   }
 }

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -44,6 +44,8 @@ import { Paths, resolvePaths } from './home';
 
 export interface AgentOSOptions {
   tenant: string;
+  /** Optional human label for the tenant (e.g. "Instapods"); defaults to `tenant`. Display only. */
+  tenantName?: string;
   policy: PolicyEngine;
   /** Durable audit dir; pass null to keep audit in-memory only (tests/demo). */
   auditDir?: string | null;
@@ -55,6 +57,8 @@ export interface AgentOSOptions {
 
 export class AgentOS {
   readonly tenant: string;
+  /** Human-facing tenant label (branding); falls back to the tenant id. */
+  readonly tenantName: string;
   readonly registry = new CapabilityRegistry();
   readonly memoryAudit = new InMemoryAuditSink();
   readonly audit: AuditSink;
@@ -94,6 +98,7 @@ export class AgentOS {
 
   constructor(opts: AgentOSOptions) {
     this.tenant = opts.tenant;
+    this.tenantName = opts.tenantName || opts.tenant;
     this.policy = opts.policy;
     this.paths = opts.paths;
     // The per-workspace DB backs everything user-facing. No paths (tests/demo) → ephemeral in-memory.
@@ -207,19 +212,25 @@ export interface RootConfig {
 export function loadAgentOS(
   configPath = 'config/agent-os.config.json',
   baseDir = process.cwd(),
-  overrides?: { tenant?: string; paths?: Paths },
+  overrides?: { tenant?: string; tenantName?: string; paths?: Paths },
 ): AgentOS {
   const cfg = readJson<RootConfig>(path.resolve(baseDir, configPath));
   const paths = overrides?.paths ?? resolvePaths(baseDir, cfg);
   const policyDoc = readJson<PolicyDocument>(paths.policyFile);
 
+  const policyEngine = new JsonPolicyEngine(policyDoc);
   const os = new AgentOS({
     tenant: overrides?.tenant ?? cfg.tenant,
-    policy: new JsonPolicyEngine(policyDoc),
+    tenantName: overrides?.tenantName ?? process.env.AGENT_OS_TENANT_NAME,
+    policy: policyEngine,
     auditDir: paths.audit,
     paths,
     memory: cfg.memory,
   });
+
+  // The never-tier rules reference governance caps by name ($moneyCapUsd / $bulkDeleteCount); resolve
+  // them live from the settings store (editable in Settings → Governance) now that `os` exists.
+  policyEngine.setThresholds(() => os.settings.governanceThresholds() as unknown as Record<string, number>);
 
   // A backend saved from Settings → Memory (DB) overrides the file default and survives restarts.
   // Build it synchronously here (no health check) so boot never blocks on a network call; a broken

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,11 +15,12 @@ import { evaluate } from './observability/evaluation';
 import { TerminalManager } from './terminal';
 import { Automation, Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
+import { DiscordSocket } from './edge/discord-socket';
 import { DreamingEngine } from './edge/dreaming';
 import { CATALOG, redact } from './connectors/connectors';
 import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUserId, initiateConnection, verifyComposioWebhook, parseComposioEvent } from './connectors/composio';
 import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument } from './governance/policy';
-import { AgentManifest, ApprovalRequest, EmbeddingsConfig, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeExamplePrompts, sanitizeRuntimeTuning } from './types';
+import { AgentManifest, ApprovalRequest, EmbeddingsConfig, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeExamplePrompts, sanitizeRuntimeTuning } from './types';
 
 /** Settings → Memory view: stored backend config with secrets redacted to `…Set` booleans. */
 interface EmbeddingsView { provider: 'openai' | 'ollama'; url: string; model: string; dimensions?: number; apiKeySet: boolean }
@@ -84,7 +85,7 @@ export function createHttpServer(registry: TenantRegistry): http.Server {
     }
     const rt = resolveRuntime(registry, req);
     if (!rt) return sendJson(res, 404, { error: 'no such workspace' });
-    handle(rt.os, rt.tm, rt.autos, req, res, rt.ttydPort, rt.slack).catch((err) =>
+    handle(rt.os, rt.tm, rt.autos, req, res, rt.ttydPort, rt.slack, rt.discord).catch((err) =>
       sendJson(res, 500, { error: err instanceof Error ? err.message : String(err) }),
     );
   });
@@ -188,7 +189,7 @@ export function startServer(port = Number(process.env.PORT) || 3010): http.Serve
   return server;
 }
 
-async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req: http.IncomingMessage, res: http.ServerResponse, ttydPort?: number, slack?: SlackSocket): Promise<void> {
+async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req: http.IncomingMessage, res: http.ServerResponse, ttydPort?: number, slack?: SlackSocket, discord?: DiscordSocket): Promise<void> {
   const url = new URL(req.url || '/', 'http://localhost');
   const p = url.pathname;
   const method = req.method || 'GET';
@@ -203,7 +204,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const idx = path.join(WEB_DIST, 'index.html');
     return sendFile(res, fs.existsSync(idx) ? idx : CONSOLE_HTML, 'text/html; charset=utf-8');
   }
-  if (method === 'GET' && p === '/health') return sendJson(res, 200, { ok: true, tenant: os.tenant });
+  if (method === 'GET' && p === '/health') return sendJson(res, 200, { ok: true, tenant: os.tenant, name: os.tenantName });
   // static assets from the built React app (web/dist)
   if (method === 'GET' && (p.startsWith('/assets/') || /\.(js|css|svg|png|ico|woff2?|json|map)$/.test(p))) {
     const file = path.join(WEB_DIST, p.replace(/^\/+/, ''));
@@ -286,6 +287,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
 
   // Policy preview: the agent asks what it's allowed to do BEFORE attempting it. Pure dry-run of the
   // same classify() the gate uses — no approval card, no audit, no side effect.
+  // Directory lookup (the `directory_lookup` OS tool): a session resolves teammates by name/email →
+  // member + their external accounts (slack/discord/github/email), so an agent knows who to reach on
+  // which channel. Session-secret gated like the other agent loopback routes; read-only.
+  if (method === 'GET' && p === '/api/agent/directory') {
+    const session = url.searchParams.get('session') || '';
+    if (!tm.sessionAgent(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const q = url.searchParams.get('q') || '';
+    const members = os.team.searchMembers(q, Number(url.searchParams.get('limit')) || 10).map((m) => ({
+      id: m.id,
+      name: m.name,
+      email: m.email,
+      role: m.role,
+      identities: os.team.externalIdsFor(m.id).map((i) => ({ provider: i.provider, externalId: i.externalId })),
+    }));
+    return sendJson(res, 200, { members });
+  }
   if (method === 'GET' && p === '/api/agent/policy') {
     const session = url.searchParams.get('session') || '';
     const agent = tm.sessionAgent(session);
@@ -407,6 +425,17 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const out = await slack.reply(session, String(b.text || ''));
     return sendJson(res, out.ok ? 200 : 400, out.ok ? { ok: true } : { ok: false, error: out.error });
   }
+  // native Discord egress: the analogue of slack/reply. Channel/message come from the server-side
+  // binding (discord_threads) — the agent only sends text.
+  if (method === 'POST' && p === '/api/agent/discord/reply') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    if (!discord) return sendJson(res, 503, { error: 'discord not available' });
+    const out = await discord.reply(session, String(b.text || ''));
+    return sendJson(res, out.ok ? 200 : 400, out.ok ? { ok: true } : { ok: false, error: out.error });
+  }
   // launcher signal that the claude process exited (→ completion fallback + mark idle).
   if (method === 'POST' && p === '/api/ended') {
     const b = await readBody(req);
@@ -477,6 +506,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const agents = terminalAgents(os).filter((a) => os.team.canRun(me, a.id));
     return sendJson(res, 200, {
       tenant: os.tenant,
+      tenantName: os.tenantName,
       policy: os.policy.id,
       home: os.paths?.home,
       me,
@@ -508,6 +538,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       me,
       members: os.team.listMembers(),
       assignments: os.team.listAssignments(),
+      identities: os.team.identitiesByMember(), // member id → external accounts (chat run-as join keys)
       agents: terminalAgents(os), // ALL agents, so owner/admin can assign access
     });
   }
@@ -539,6 +570,36 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const issued = os.team.issueLoginLink(target.email)!;
     return sendJson(res, 200, { link: linkFor(req, issued.token) });
   }
+  // Identity map: link/unlink the external accounts a member is known by (Slack/Discord/email/github),
+  // the join key chat triggers use for run-as. Owner/admin only. The id segment excludes the literal
+  // "identities"-suffixed paths from the single-segment member routes below.
+  const teamIdentSet = p.match(/^\/api\/team\/([\w-]+)\/identities$/);
+  if (method === 'POST' && teamIdentSet) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req);
+    const provider = String(b.provider || '') as IdentityProvider;
+    if (!IDENTITY_PROVIDERS.includes(provider)) return sendJson(res, 400, { error: 'unknown provider' });
+    const externalId = String(b.externalId || '').trim();
+    if (!os.team.getMember(teamIdentSet[1])) return sendJson(res, 404, { error: 'not found' });
+    // Empty externalId clears the handle (the UI sends '' on blur of an emptied field).
+    if (!externalId) {
+      os.team.clearIdentity(teamIdentSet[1], provider);
+    } else {
+      const out = os.team.setIdentity(teamIdentSet[1], provider, externalId, me.email);
+      if (!out) return sendJson(res, 400, { error: 'could not link identity' });
+    }
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'identity.linked', data: { member: teamIdentSet[1], provider, set: !!externalId } });
+    return sendJson(res, 200, { ok: true, identities: os.team.externalIdsFor(teamIdentSet[1]) });
+  }
+  const teamIdentDel = p.match(/^\/api\/team\/([\w-]+)\/identities\/([\w-]+)$/);
+  if (method === 'DELETE' && teamIdentDel) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const provider = teamIdentDel[2] as IdentityProvider;
+    if (!IDENTITY_PROVIDERS.includes(provider)) return sendJson(res, 400, { error: 'unknown provider' });
+    os.team.clearIdentity(teamIdentDel[1], provider);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'identity.unlinked', data: { member: teamIdentDel[1], provider } });
+    return sendJson(res, 200, { ok: true, identities: os.team.externalIdsFor(teamIdentDel[1]) });
+  }
   const teamMember = p.match(/^\/api\/team\/([\w-]+)$/);
   if (method === 'DELETE' && teamMember) {
     if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
@@ -568,7 +629,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const b = await readBody(req);
     try {
-      const type = b.type === 'webhook' ? 'webhook' : b.type === 'composio' ? 'composio' : b.type === 'slack' ? 'slack' : 'cron';
+      const type = b.type === 'webhook' ? 'webhook' : b.type === 'composio' ? 'composio' : b.type === 'slack' ? 'slack' : b.type === 'discord' ? 'discord' : 'cron';
       const created = autos.add({
         agentId: String(b.agentId || ''),
         name: String(b.name || ''),
@@ -967,6 +1028,22 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, ...saved });
   }
 
+  // ── governance thresholds (the numeric caps the never-tier policy rules read) ──
+  if (method === 'GET' && p === '/api/settings/governance') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { ...os.settings.governanceThresholds(), ...os.settings.governanceMeta() });
+  }
+  if (method === 'PUT' && p === '/api/settings/governance') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req);
+    const saved = os.settings.setGovernanceThresholds(
+      { moneyCapUsd: Number(b.moneyCapUsd), bulkDeleteCount: Number(b.bulkDeleteCount) },
+      me.email,
+    );
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.governance.updated', data: { ...saved } });
+    return sendJson(res, 200, { ok: true, ...saved });
+  }
+
   // ── company settings (workspace-wide context injected into every claude-code agent) ──
   if (method === 'GET' && p === '/api/settings') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
@@ -1004,12 +1081,28 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       }
     }
     if (slackTouched && slack) void slack.restart();
-    return sendJson(res, 200, { ok: true, removedSlackAutomations, ...integrationsView(os) });
+    // Discord bot token: the analogue of the Slack tokens — changing it re-dials (or tears down) the
+    // Gateway connection, and clearing it orphans discord automations the same way.
+    const discordTouched = typeof b.discordBotToken === 'string';
+    if (typeof b.discordBotToken === 'string') os.settings.setDiscordBotToken(b.discordBotToken, me.email);
+    let removedDiscordAutomations = 0;
+    if (discordTouched && !os.settings.discordConfigured()) {
+      for (const a of autos.list()) {
+        if (a.type === 'discord' && autos.remove(a.id)) removedDiscordAutomations++;
+      }
+    }
+    if (discordTouched && discord) void discord.restart();
+    return sendJson(res, 200, { ok: true, removedSlackAutomations, removedDiscordAutomations, ...integrationsView(os) });
   }
   // Live Slack Socket-Mode connection status (owner/admin) — for the Integrations panel.
   if (method === 'GET' && p === '/api/settings/slack/status') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     return sendJson(res, 200, slack ? slack.status() : { configured: os.settings.slackConfigured(), connected: false, botUserId: '' });
+  }
+  // Live Discord Gateway connection status (owner/admin) — for the Integrations panel.
+  if (method === 'GET' && p === '/api/settings/discord/status') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, discord ? discord.status() : { configured: os.settings.discordConfigured(), connected: false, botUserId: '' });
   }
 
   // ── memory backend (sqlite / libsql / automem) — owner/admin, applied live without a restart ──
@@ -1232,6 +1325,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         connected: slack ? slack.status().connected : false,
         botUserId: slack ? slack.status().botUserId : '',
       },
+      discord: {
+        configured: os.settings.discordConfigured(),
+        connected: discord ? discord.status().connected : false,
+        botUserId: discord ? discord.status().botUserId : '',
+      },
       custom: os.connectors
         .list()
         .filter((c) => c.scope === 'org')
@@ -1344,12 +1442,40 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     }
     if (method === 'PATCH') {
       const b = await readBody(req);
+      // Share/un-share a personal connector with the team (owner or admin, enforced by canManage above).
+      if (typeof b.shared === 'boolean') {
+        const c = os.connectors.get(id);
+        if (c && c.scope !== 'personal') return sendJson(res, 400, { error: 'only personal connectors can be shared' });
+        const updated = os.connectors.setShared(id, b.shared);
+        if (updated) os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'connector.shared', data: { connector: id, shared: b.shared } });
+        return sendJson(res, updated ? 200 : 404, updated ? redact(updated) : { error: 'not found' });
+      }
       const updated = os.connectors.setEnabled(id, !!b.enabled);
       return sendJson(res, updated ? 200 : 404, updated ? redact(updated) : { error: 'not found' });
     }
   }
 
   // ── approvals (shared with the console) ──────────────────────────────────────
+  // ── audit viewer (owner/admin): the queryable SQLite mirror of the JSONL system-of-record ──
+  if (method === 'GET' && p === '/api/audit') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const session = url.searchParams.get('session') || '';
+    const type = url.searchParams.get('type') || '';
+    const principal = url.searchParams.get('principal') || '';
+    const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit')) || 200, 1000));
+    const where = ['tenant = ?'];
+    const params: unknown[] = [os.tenant];
+    if (session) { where.push('run_id = ?'); params.push(session); }
+    if (type) { where.push('type LIKE ?'); params.push(type.replace(/[%_]/g, (c) => '\\' + c) + '%'); }
+    if (principal) { where.push('principal = ?'); params.push(principal); }
+    const rows = os.db
+      .prepare(`SELECT id, ts, run_id, type, principal, data FROM audit_events WHERE ${where.join(' AND ')} ORDER BY ts DESC, id DESC LIMIT ?`)
+      .all<{ id: number; ts: number; run_id: string; type: string; principal: string | null; data: string }>(...params, limit);
+    const events = rows.map((r) => ({ id: r.id, ts: r.ts, runId: r.run_id, type: r.type, principal: r.principal ?? undefined, data: safeJson(r.data) }));
+    // Distinct types (capped) for the filter dropdown.
+    const types = os.db.prepare('SELECT DISTINCT type FROM audit_events WHERE tenant = ? ORDER BY type LIMIT 200').all<{ type: string }>(os.tenant).map((t) => t.type);
+    return sendJson(res, 200, { events, types });
+  }
   if (method === 'GET' && p === '/api/approvals') return sendJson(res, 200, os.approvals.pending(os.tenant).filter((a) => tm.canViewSession(a.runId, me)).map(approvalView));
   const apMatch = p.match(/^\/api\/approvals\/([\w-]+)$/);
   if (method === 'POST' && apMatch) {
@@ -1378,6 +1504,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
 
 function runView(r: Run) {
   return { id: r.id, agent: r.agent.id, status: r.status, outcome: r.outcome, cost: r.cost, createdAt: r.createdAt };
+}
+
+/** Parse a stored JSON column, degrading to a `{ raw }` wrapper rather than throwing on bad data. */
+function safeJson(s: string): Record<string, unknown> {
+  try { const v = JSON.parse(s); return v && typeof v === 'object' ? v : { value: v }; } catch { return { raw: s }; }
 }
 function approvalView(a: ApprovalRequest) {
   return { id: a.id, runId: a.runId, level: a.level, capability: a.attempt.capabilityId, args: a.attempt.args, reason: a.reason };
@@ -1506,15 +1637,18 @@ function integrationsView(os: AgentOS): {
   composio: { set: boolean; hint: string };
   webhook: { set: boolean };
   slack: { appToken: boolean; botToken: boolean; configured: boolean };
+  discord: { botToken: boolean; configured: boolean };
   updatedAt?: number;
   updatedBy?: string;
 } {
   const meta = os.settings.composioMeta();
   const slack = os.settings.slackMeta();
+  const discord = os.settings.discordMeta();
   return {
     composio: { set: meta.set, hint: redactSecret(os.settings.composioApiKey()) },
     webhook: { set: os.settings.composioWebhookSet() },
     slack: { appToken: slack.appToken, botToken: slack.botToken, configured: os.settings.slackConfigured() },
+    discord: { botToken: discord.botToken, configured: os.settings.discordConfigured() },
     updatedAt: meta.updatedAt,
     updatedBy: meta.updatedBy,
   };

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -21,13 +21,24 @@ case "$TOOL" in
   mcp__agentos__*) exit 0 ;;
 esac
 
-# Classify the attempt into an Agent OS capability + a riskiness flag the policy routes on.
+# Classify the attempt into an Agent OS capability + two flags the policy routes on:
+#   risky       → mutation that needs human approval (yellow/red)
+#   destructive → IRREVERSIBLE op that the never-tier denies outright (drop db, delete site, rm -rf…)
+# Matching is case-INSENSITIVE (SQL/flags are written in any case): `drop database` must catch `DROP`.
+# NOTE: we only see the Bash command string and the MCP tool NAME here — not MCP call arguments, so
+# destructive SQL passed *inside* a tool like db_query/execute_php is not yet caught. That argument-aware
+# classification is the server-side enricher (governance PR #2); this hook is the first, name/command cut.
 RISKY=false
+DESTRUCTIVE=false
+shopt -s nocasematch 2>/dev/null || true
 case "$TOOL" in
   Bash)
     CAP="shell.exec"
-    case " $CMD " in
-      *stripe*|*refund*|*" rm "*|*deploy*|*prod*|*DROP*|*DELETE*|*kubectl*|*systemctl*|*shutdown*) RISKY=true ;;
+    case "$CMD" in
+      *"drop database"*|*"drop table"*|*"drop schema"*|*truncate*|*"rm -rf"*|*"rm -fr"*|*"rm -r "*|*mkfs*|*"dd if="*|*"dd of="*|*"terraform destroy"*|*"kubectl delete"*|*"git push --force"*|*"git push -f"*) DESTRUCTIVE=true ;;
+    esac
+    case "$CMD" in
+      *stripe*|*refund*|*" rm "*|*deploy*|*prod*|*drop*|*delete*|*kubectl*|*systemctl*|*shutdown*) RISKY=true ;;
     esac
     ;;
   mcp__*)
@@ -36,6 +47,10 @@ case "$TOOL" in
     # rest (get/list/search/read/…) are reads → auto-allow. Composio names tools like SLACK_SEND_MESSAGE.
     CAP="connector.call"
     UPPER=$(printf '%s' "$TOOL" | tr '[:lower:]' '[:upper:]')
+    # Irreversible by name: deleting a whole site or dropping a database → never tier.
+    case "$UPPER" in
+      *DELETE_SITE*|*DROP_DATABASE*|*DROP_TABLE*|*DROP_SCHEMA*) DESTRUCTIVE=true ;;
+    esac
     case "$UPPER" in
       *CREATE*|*SEND*|*UPDATE*|*DELETE*|*REMOVE*|*WRITE*|*POST*|*PUT*|*PATCH*|*MERGE*|*PUBLISH*|*UPLOAD*|*DEPLOY*|*PAY*|*REFUND*|*ARCHIVE*|*INVITE*|*EXECUTE*) RISKY=true ;;
     esac
@@ -48,22 +63,30 @@ case "$TOOL" in
     ;;
   *) exit 0 ;;  # any other built-in tool (Read/Glob/Grep/…) isn't a world side effect → allow
 esac
+shopt -u nocasematch 2>/dev/null || true
 
-resp=$(curl -s -X POST "$AOS_URL/api/gate" -H 'content-type: application/json' -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" \
-  -d "$(node -e 'const[s,a,cap,t,c,r]=process.argv.slice(1);console.log(JSON.stringify({sessionId:s,agent:a,capability:cap,args:{tool:t,command:c,risky:r==="true"},reasoning:"claude PreToolUse: "+t+(c?" "+c:"")}))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$CMD" "$RISKY")")
-gid=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.gateId||"")})')
-dec=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.decision||"")})')
+payload=$(node -e 'const[s,a,cap,t,c,r,d]=process.argv.slice(1);console.log(JSON.stringify({sessionId:s,agent:a,capability:cap,args:{tool:t,command:c,risky:r==="true",destructive:d==="true"},reasoning:"claude PreToolUse: "+t+(c?" "+c:"")}))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$CMD" "$RISKY" "$DESTRUCTIVE")
 
-case "$dec" in
-  allow) exit 0 ;;
-  deny)  echo "Agent OS policy: denied." >&2; exit 2 ;;
-  pending)
-    echo "Agent OS: this action needs approval — see the inbox. Waiting…" >&2
-    while :; do
-      sleep 1
-      st=$(curl -s "$AOS_URL/api/gate/$gid" -H "x-aos-tenant: ${AOS_TENANT:-}" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.status||"")})')
-      [ "$st" = "allow" ] && exit 0
-      [ "$st" = "deny" ]  && { echo "Agent OS: rejected by human." >&2; exit 2; }
-    done ;;
-  *) exit 0 ;;  # fail-open in demo; flip to exit 2 to fail-closed
-esac
+# FAIL-CLOSED classify. Retry the gate until it returns a usable decision; a transient failure (server
+# restart, network blip, the documented stale-server 401/404 window) must NEVER fall through to "allow".
+# The agent simply waits here, ungoverned action impossible, until the gate answers.
+while :; do
+  resp=$(curl -s --max-time 10 -X POST "$AOS_URL/api/gate" -H 'content-type: application/json' -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" -d "$payload")
+  dec=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.decision||"")})')
+  gid=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.gateId||"")})')
+  case "$dec" in
+    allow) exit 0 ;;
+    deny)  echo "Agent OS policy: denied — this action is blocked (irreversible or not permitted)." >&2; exit 2 ;;
+    pending) break ;;
+    *) echo "Agent OS: gate unreachable — blocking this action until it responds…" >&2; sleep 2 ;;
+  esac
+done
+
+echo "Agent OS: this action needs approval — see the inbox. Waiting…" >&2
+while :; do
+  sleep 1
+  st=$(curl -s --max-time 10 "$AOS_URL/api/gate/$gid" -H "x-aos-tenant: ${AOS_TENANT:-}" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.status||"")})')
+  [ "$st" = "allow" ] && exit 0
+  [ "$st" = "deny" ]  && { echo "Agent OS: rejected by human." >&2; exit 2; }
+  # any other status (pending / empty / gate momentarily unreachable) → keep waiting, never proceed
+done

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ReactNode } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, BookText, History as HistoryIcon } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, BookText, History as HistoryIcon, ScrollText } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button } from '@/components/ui/button'
@@ -10,9 +10,9 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog'
-import { api, EFFORTS, PERMISSION_MODES, type StateResp, type AgentInfo, type Session, type Msg, type ConnectorsResp, type CatalogEntry, type AddConnectorReq, type Connector, type ConnectorScope, type Member, type Role, type TeamResp, type Automation, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type RiskClass, type PolicyOp, type DirListing, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type IntegrationsResp, type SlackStatus, type ConnectionsResp, type IntegrationsOverview, type Effort, type PermissionMode, type RuntimeTuning } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type StateResp, type AgentInfo, type Session, type Msg, type ConnectorsResp, type CatalogEntry, type AddConnectorReq, type Connector, type ConnectorScope, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type RiskClass, type PolicyOp, type DirListing, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type ConnectionsResp, type IntegrationsOverview, type Effort, type PermissionMode, type RuntimeTuning } from '@/lib/api'
 
-type Route = 'inbox' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'memory' | 'kb' | 'skills' | 'files' | 'artifacts' | 'settings' | 'agent'
+type Route = 'inbox' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'memory' | 'kb' | 'skills' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent'
 type Selected = { tmux: string; title: string } | null
 
 /** Mirror of the server rule: owner approves anything, admin approves head-level only. */
@@ -201,9 +201,7 @@ function Console({ me }: { me: Member }) {
           <nav className="space-y-1">
             <NavItem icon={<InboxIcon className="h-4 w-4" />} label="Inbox" active={route === 'inbox'} badge={pendingApprovals || undefined} onClick={() => nav('inbox')} />
             <NavItem icon={<Bot className="h-4 w-4" />} label="Agents" active={route === 'agents' || route === 'agent'} onClick={() => nav('agents')} />
-            <NavItem icon={<TerminalSquare className="h-4 w-4" />} label="Sessions" active={route === 'sessions'} badge={runningSessions || undefined} onClick={() => nav('sessions')} />
             <NavItem icon={<Package className="h-4 w-4" />} label="Artifacts" active={route === 'artifacts'} onClick={() => nav('artifacts')} />
-            <NavItem icon={<BookText className="h-4 w-4" />} label="Knowledge" active={route === 'kb'} onClick={() => nav('kb')} />
           </nav>
         </div>
 
@@ -211,7 +209,16 @@ function Console({ me }: { me: Member }) {
         <div className="min-h-0 flex-1 overflow-y-auto px-4">
           <div className="mb-2 flex items-center justify-between">
             <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Sessions</span>
-            <Button size="icon" variant="ghost" className="h-5 w-5 text-emerald-600" onClick={() => nav('agents')} title="spawn an agent"><Plus className="h-3.5 w-3.5" /></Button>
+            <div className="flex items-center gap-1">
+              <button
+                onClick={() => { setSelected(null); nav('sessions') }}
+                className={`flex items-center gap-1 text-[11px] uppercase tracking-wider hover:text-foreground ${route === 'sessions' ? 'text-primary' : 'text-muted-foreground'}`}
+                title="all sessions"
+              >
+                All{runningSessions ? <span className="rounded-full bg-emerald-500/15 px-1 text-[10px] font-medium text-emerald-600">{runningSessions}</span> : null}
+              </button>
+              <Button size="icon" variant="ghost" className="h-5 w-5 text-emerald-600" onClick={() => nav('agents')} title="spawn an agent"><Plus className="h-3.5 w-3.5" /></Button>
+            </div>
           </div>
           {mySessions.length === 0 && (
             <div className="text-xs text-muted-foreground">
@@ -251,6 +258,7 @@ function Console({ me }: { me: Member }) {
           {manageOpen && (
             <nav className="mb-1 space-y-1">
               <NavItem icon={<Zap className="h-4 w-4" />} label="Automations" active={route === 'automations'} onClick={() => nav('automations')} />
+              <NavItem icon={<BookText className="h-4 w-4" />} label="Knowledge" active={route === 'kb'} onClick={() => nav('kb')} />
               <NavItem icon={<Brain className="h-4 w-4" />} label="Memory" active={route === 'memory'} onClick={() => nav('memory')} />
               {(me.role === 'owner' || me.role === 'admin') && (
                 <NavItem icon={<Sparkles className="h-4 w-4" />} label="Skills" active={route === 'skills'} onClick={() => nav('skills')} />
@@ -259,6 +267,9 @@ function Console({ me }: { me: Member }) {
               <NavItem icon={<Users className="h-4 w-4" />} label="Team" active={route === 'team'} onClick={() => nav('team')} />
               {(me.role === 'owner' || me.role === 'admin') && (
                 <NavItem icon={<FolderTree className="h-4 w-4" />} label="Files" active={route === 'files'} onClick={() => nav('files')} />
+              )}
+              {(me.role === 'owner' || me.role === 'admin') && (
+                <NavItem icon={<ScrollText className="h-4 w-4" />} label="Audit" active={route === 'audit'} onClick={() => nav('audit')} />
               )}
               {(me.role === 'owner' || me.role === 'admin') && (
                 <NavItem icon={<Building2 className="h-4 w-4" />} label="Settings" active={route === 'settings'} onClick={() => nav('settings')} />
@@ -288,11 +299,11 @@ function Console({ me }: { me: Member }) {
       <main className="flex flex-1 flex-col overflow-hidden">
         <div className="flex items-center justify-between border-b px-6 py-4">
           <h1 className="text-lg font-semibold">
-            {route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connectors' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Artifacts' : route === 'settings' ? 'Company settings' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
+            {route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connectors' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Artifacts' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
           </h1>
           {state && (
             <span className="text-xs text-muted-foreground">
-              tenant={state.tenant} · policy={state.policy}
+              tenant={state.tenantName || state.tenant} · policy={state.policy}
               {state.home ? ' · home=' + state.home : ''}
             </span>
           )}
@@ -311,6 +322,7 @@ function Console({ me }: { me: Member }) {
           {route === 'skills' && <SkillsPage />}
           {route === 'files' && <FilesPage />}
           {route === 'artifacts' && <ArtifactsPage me={me} initialId={artifactFocus} />}
+          {route === 'audit' && <AuditPage />}
           {route === 'settings' && <SettingsPage me={me} />}
           {route === 'agent' && editAgent && <AgentPage agentId={editAgent} agents={state?.agents ?? []} />}
         </div>
@@ -333,8 +345,10 @@ function NavItem({ icon, label, active, badge, onClick }: { icon: ReactNode; lab
 }
 
 // ── Agents ─────────────────────────────────────────────────────────────────────
-/** The agent catalog: one card per agent — give it a task and Run to spawn a session,
- *  or (owner/admin) edit its CLAUDE.md. This is where spawning lives now. */
+/** Spawning, ChatGPT-style: one big centered composer. Pick an agent from the dropdown,
+ *  type a task, hit Run to spawn a live session. Owner/admin can tune the selected agent's
+ *  Settings (CLAUDE.md + runtime), delete it, or create a new one — all the catalog actions,
+ *  just scoped to the chosen agent instead of a grid of cards. */
 function AgentsPage({
   me, agents, run, onEdit, onNew, onDelete,
 }: {
@@ -346,107 +360,112 @@ function AgentsPage({
   onDelete: (id: string) => void
 }) {
   const canEdit = me.role === 'owner' || me.role === 'admin'
-  return (
-    <div className="space-y-3">
-      <div className="flex items-start justify-between gap-3">
-        <p className="max-w-3xl text-sm text-muted-foreground">
-          Your agents. Give one a task and hit Run to spawn a session — it opens in a live terminal and every
-          effect it has still passes the gate. Owners and admins can edit an agent's{' '}
-          <span className="font-mono text-xs">CLAUDE.md</span> (its system prompt).
-        </p>
-        {canEdit && (
-          <Button size="sm" className="shrink-0 gap-1" onClick={onNew}>
-            <Plus className="h-4 w-4" /> New agent
-          </Button>
-        )}
-      </div>
-      {agents.length === 0 ? (
-        <div className="text-sm text-muted-foreground">
-          {canEdit ? 'No agents yet — create one to get started.' : 'No agents assigned to you.'}
-        </div>
-      ) : (
-        <div className="grid gap-3 lg:grid-cols-2">
-          {agents.map((a) => (
-            <AgentCard key={a.id} agent={a} canEdit={canEdit} run={run} onEdit={onEdit} onDelete={onDelete} />
-          ))}
-        </div>
-      )}
-    </div>
-  )
-}
-
-function AgentCard({
-  agent, canEdit, run, onEdit, onDelete,
-}: {
-  agent: AgentInfo
-  canEdit: boolean
-  run: (agentId: string, task: string) => Promise<string | null>
-  onEdit: (id: string) => void
-  onDelete: (id: string) => void
-}) {
-  const [task, setTask] = useState(exampleTask(agent))
+  const [agentId, setAgentId] = useState('')
+  const [task, setTask] = useState('')
   const [hint, setHint] = useState('')
   const [busy, setBusy] = useState(false)
+
+  // Keep the selection valid as the agent list loads/changes; default to the first agent.
+  useEffect(() => {
+    if (agents.length === 0) { if (agentId) setAgentId(''); return }
+    if (!agents.some((a) => a.id === agentId)) setAgentId(agents[0].id)
+  }, [agents, agentId])
+
+  const agent = agents.find((a) => a.id === agentId)
+  // Switching agents prefills its first starter prompt and clears any stale hint.
+  useEffect(() => { setTask(exampleTask(agent)); setHint('') }, [agentId]) // eslint-disable-line react-hooks/exhaustive-deps
+
   const spawn = async () => {
+    if (!agent || !task.trim()) return
     setBusy(true); setHint('spawning…')
     const err = await run(agent.id, task)
     setBusy(false)
     setHint(err ? '⚠ ' + err : '')
   }
+
+  if (agents.length === 0) {
+    return (
+      <div className="flex min-h-full flex-col items-center justify-center gap-3 text-center">
+        <p className="text-sm text-muted-foreground">{canEdit ? 'No agents yet — create one to get started.' : 'No agents assigned to you.'}</p>
+        {canEdit && <Button size="sm" className="gap-1" onClick={onNew}><Plus className="h-4 w-4" /> New agent</Button>}
+      </div>
+    )
+  }
+
   return (
-    <Card>
-      <CardContent className="flex h-full flex-col gap-2 p-4">
-        <div className="flex items-start justify-between gap-2">
-          <div className="min-w-0">
-            <div className="flex items-center gap-1.5 text-sm font-medium">
-              {agent.id}
-              <RuntimeBadge runtime={agent.runtime} />
+    <div className="flex min-h-full flex-col items-center justify-center">
+      <div className="w-full max-w-2xl space-y-5">
+        <h1 className="text-center text-xl font-semibold tracking-tight">What should an agent do?</h1>
+
+        <Card className="shadow-sm">
+          <CardContent className="flex flex-col gap-3 p-4">
+            {/* agent picker + per-agent actions */}
+            <div className="flex items-center gap-2">
+              <Select value={agentId} onValueChange={(v) => v && setAgentId(v)}>
+                <SelectTrigger className="h-9 min-w-0 flex-1"><SelectValue /></SelectTrigger>
+                <SelectContent>
+                  {agents.map((a) => (
+                    <SelectItem key={a.id} value={a.id}>
+                      <span className="flex items-center gap-1.5">{a.id}<RuntimeBadge runtime={a.runtime} /></span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {canEdit && agent?.runtime === 'claude-code' && (
+                <Button size="icon" variant="ghost" className="h-9 w-9 shrink-0 text-muted-foreground" onClick={() => onEdit(agent.id)} title="agent settings — runtime tuning, starter prompts, CLAUDE.md">
+                  <SlidersHorizontal className="h-4 w-4" />
+                </Button>
+              )}
+              {canEdit && agent?.deletable && (
+                <Button size="icon" variant="ghost" className="h-9 w-9 shrink-0 text-destructive" onClick={() => onDelete(agent.id)} title="delete agent (removes its folder)">
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              )}
+              {canEdit && (
+                <Button size="icon" variant="ghost" className="h-9 w-9 shrink-0 text-muted-foreground" onClick={onNew} title="new agent">
+                  <Plus className="h-4 w-4" />
+                </Button>
+              )}
             </div>
-            {agent.description && <div className="mt-0.5 text-xs text-muted-foreground">{agent.description}</div>}
-          </div>
-          <div className="flex shrink-0 items-center gap-1">
-            {canEdit && agent.runtime === 'claude-code' && (
-              <Button size="sm" variant="ghost" className="h-7 gap-1 px-2 text-xs text-muted-foreground" onClick={() => onEdit(agent.id)} title="edit CLAUDE.md">
-                <FileText className="h-3.5 w-3.5" /> CLAUDE.md
-              </Button>
+
+            {agent?.description && <p className="text-xs text-muted-foreground">{agent.description}</p>}
+
+            {agent?.examplePrompts && agent.examplePrompts.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {agent.examplePrompts.map((p, i) => (
+                  <button
+                    key={i}
+                    type="button"
+                    onClick={() => setTask(p)}
+                    title={p}
+                    className="max-w-full truncate rounded-full border bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
             )}
-            {canEdit && agent.deletable && (
-              <Button size="icon" variant="ghost" className="h-7 w-7 text-destructive" onClick={() => onDelete(agent.id)} title="delete agent (removes its folder)">
-                <Trash2 className="h-3.5 w-3.5" />
+
+            <Textarea
+              value={task}
+              onChange={(e) => setTask(e.target.value)}
+              onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') spawn() }}
+              className="min-h-[140px] text-sm"
+              placeholder="Describe the task…  (⌘/Ctrl+Enter to Run)"
+            />
+
+            <div className="flex items-center gap-3">
+              <Button onClick={spawn} disabled={busy || !task.trim()}>
+                <Play className="mr-1 h-4 w-4" /> Run
               </Button>
-            )}
-          </div>
-        </div>
-        {agent.examplePrompts && agent.examplePrompts.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {agent.examplePrompts.map((p, i) => (
-              <button
-                key={i}
-                type="button"
-                onClick={() => setTask(p)}
-                title={p}
-                className="max-w-full truncate rounded-full border bg-muted/50 px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground"
-              >
-                {p}
-              </button>
-            ))}
-          </div>
-        )}
-        <Textarea
-          value={task}
-          onChange={(e) => setTask(e.target.value)}
-          onKeyDown={(e) => { if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') spawn() }}
-          className="min-h-[60px] text-sm"
-          placeholder="Describe the task…"
-        />
-        <div className="mt-auto flex items-center gap-3">
-          <Button size="sm" onClick={spawn} disabled={busy || !task.trim()}>
-            <Play className="mr-1 h-4 w-4" /> Run
-          </Button>
-          {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
-        </div>
-      </CardContent>
-    </Card>
+              {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
+            </div>
+          </CardContent>
+        </Card>
+
+        <p className="text-center text-xs text-muted-foreground">Run spawns a live session — every effect still passes the gate.</p>
+      </div>
+    </div>
   )
 }
 
@@ -893,7 +912,10 @@ function MessageCard({ m, me, onOpen, onOpenArtifact, unread }: { m: Msg; me: Me
 const TYPE_ICON: Record<string, string> = { slack: '💬', github: '🐙', gdrive: '📁', gmail: '✉️', composio: '🧩', custom: '🔌', 'custom-remote': '🌐' }
 
 /** One connector row — reused across the Company / My / team-members sections. */
-function ConnectorCard({ c, busy, onToggle, onRemove }: { c: Connector; busy: string; onToggle: (id: string, enabled: boolean) => void; onRemove: (id: string) => void }) {
+function ConnectorCard({ c, me, busy, onToggle, onRemove, onShare }: { c: Connector; me?: Member | null; busy: string; onToggle: (id: string, enabled: boolean) => void; onRemove: (id: string) => void; onShare?: (id: string, shared: boolean) => void }) {
+  const isAdmin = me?.role === 'owner' || me?.role === 'admin'
+  // The owner of a personal connector (or an admin) may share it with the whole team.
+  const canShare = c.scope === 'personal' && !!onShare && (isAdmin || c.ownerMemberId === me?.id)
   return (
     <Card>
       <CardContent className="flex items-center justify-between gap-4 p-4">
@@ -904,6 +926,9 @@ function ConnectorCard({ c, busy, onToggle, onRemove }: { c: Connector; busy: st
             <Badge variant={c.enabled ? 'default' : 'secondary'} className="px-1.5 py-0 text-[10px]">
               {c.enabled ? 'enabled' : 'disabled'}
             </Badge>
+            {c.scope === 'personal' && c.shared && (
+              <Badge variant="outline" className="px-1.5 py-0 text-[10px] text-emerald-600" title="Shared with the whole team — runs as you">shared with team</Badge>
+            )}
           </div>
           <div className="mt-0.5 truncate text-xs text-muted-foreground">{c.description}</div>
           <div className="mt-1 truncate font-mono text-[11px] text-muted-foreground">
@@ -913,6 +938,11 @@ function ConnectorCard({ c, busy, onToggle, onRemove }: { c: Connector; busy: st
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
+          {canShare && (
+            <Button size="sm" variant="outline" disabled={busy === c.id} onClick={() => onShare!(c.id, !c.shared)} title={c.shared ? 'Stop sharing with the team' : 'Share with the whole team (agents act as you)'}>
+              {c.shared ? 'Unshare' : 'Share with team'}
+            </Button>
+          )}
           <Button size="sm" variant="outline" disabled={busy === c.id} onClick={() => onToggle(c.id, !c.enabled)}>
             {c.enabled ? 'Disable' : 'Enable'}
           </Button>
@@ -1018,7 +1048,7 @@ function CompanySection({ me, custom, catalog, cardProps, onPickCatalog }: {
   me: Member | null
   custom: Connector[]
   catalog: CatalogEntry[]
-  cardProps: { busy: string; onToggle: (id: string, enabled: boolean) => void; onRemove: (id: string) => void }
+  cardProps: { me: Member | null; busy: string; onToggle: (id: string, enabled: boolean) => void; onRemove: (id: string) => void; onShare: (id: string, shared: boolean) => void }
   onPickCatalog: (t: CatalogEntry) => void
 }) {
   const isAdmin = me?.role === 'owner' || me?.role === 'admin'
@@ -1080,6 +1110,22 @@ function CompanySection({ me, custom, catalog, cardProps, onPickCatalog }: {
           {ov?.slack.connected
             ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px] text-emerald-600">connected{ov.slack.botUserId ? ` · ${ov.slack.botUserId}` : ''}</Badge>
             : ov?.slack.configured
+              ? <Badge variant="outline" className="px-1.5 py-0 text-[10px] text-amber-600">configured · not connected</Badge>
+              : <Badge variant="outline" className="px-1.5 py-0 text-[10px]">not configured</Badge>}
+          {isAdmin
+            ? <a href="#/settings" className="text-[11px] text-muted-foreground underline hover:text-foreground">set up in Settings → Integrations</a>
+            : <span className="text-[11px] text-muted-foreground">managed by an admin</span>}
+        </div>
+      </div>
+
+      {/* Native Discord */}
+      <div>
+        <div className="mb-1.5 text-[11px] uppercase tracking-wider text-muted-foreground">Discord (native)</div>
+        <div className="flex flex-wrap items-center gap-2 text-sm">
+          <span className="font-medium">Discord bot</span>
+          {ov?.discord?.connected
+            ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px] text-emerald-600">connected{ov.discord.botUserId ? ` · ${ov.discord.botUserId}` : ''}</Badge>
+            : ov?.discord?.configured
               ? <Badge variant="outline" className="px-1.5 py-0 text-[10px] text-amber-600">configured · not connected</Badge>
               : <Badge variant="outline" className="px-1.5 py-0 text-[10px]">not configured</Badge>}
           {isAdmin
@@ -1194,12 +1240,18 @@ function ConnectorsPage({ me }: { me: Member | null }) {
     await load()
     setBusy('')
   }
+  const share = async (id: string, shared: boolean) => {
+    setBusy(id)
+    await api.shareConnector(id, shared)
+    await load()
+    setBusy('')
+  }
 
   const conns = data?.connectors ?? []
   // The only connector ROWS are bespoke custom MCP servers (the escape hatch); Composio apps + native
   // Slack are surfaced live inside <CompanySection/> and <MyConnections/>.
   const custom = conns.filter((c) => c.type === 'custom' || c.type === 'custom-remote')
-  const cardProps = { busy, onToggle: toggle, onRemove: remove }
+  const cardProps = { me, busy, onToggle: toggle, onRemove: remove, onShare: share }
 
   return (
     <div className="max-w-4xl space-y-6">
@@ -1814,6 +1866,102 @@ function SlackSetupGuide() {
   )
 }
 
+// Discord's analogue of the Slack setup guide. Discord has no app manifest deep-link, so it's a short
+// portal walkthrough: create the app, enable the MESSAGE CONTENT privileged intent, copy the bot token,
+// and invite the bot with the right scopes. The server then dials out over the Gateway — no public URL.
+const DISCORD_BOT_PERMISSIONS = '274877991936' // View Channels + Send Messages + Read Message History
+function DiscordSetupGuide() {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="rounded-md border">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm font-medium hover:bg-muted/40"
+      >
+        {open ? <ChevronDown className="h-4 w-4 shrink-0" /> : <ChevronRight className="h-4 w-4 shrink-0" />}
+        Setup steps — create the Discord bot (~3 min)
+      </button>
+      {open && (
+        <div className="space-y-3 border-t px-4 py-3 text-xs text-muted-foreground">
+          <ol className="list-decimal space-y-2 pl-4">
+            <li>
+              <strong className="text-foreground">Create the application.</strong> Open the
+              <a href="https://discord.com/developers/applications" target="_blank" rel="noreferrer" className="mx-1 font-medium text-foreground underline">Discord Developer Portal</a>
+              → <strong>New Application</strong> → name it "Agent OS".
+            </li>
+            <li><strong>Bot</strong> tab → <strong>Reset Token</strong> → copy it into <strong>Bot token</strong> below.</li>
+            <li>
+              On the same <strong>Bot</strong> tab, under <strong>Privileged Gateway Intents</strong>, turn ON
+              <strong> MESSAGE CONTENT INTENT</strong> (and Server Members if you'll map members later), then save. Without it the
+              bot receives empty message text.
+            </li>
+            <li>
+              <strong>Invite the bot</strong> to your server: OAuth2 → URL Generator → scopes <code className="text-[11px]">bot</code>,
+              permissions <em>View Channels · Send Messages · Read Message History</em> — or use this link template (swap in your
+              application id):
+              <div className="mt-2"><CopyBlock text={`https://discord.com/oauth2/authorize?client_id=<APPLICATION_ID>&scope=bot&permissions=${DISCORD_BOT_PERMISSIONS}`} label="Copy invite URL" /></div>
+            </li>
+            <li><strong>Save</strong> below. The status badge flips to <strong className="text-emerald-600">connected</strong> within a second or two. Then add a <strong>Discord message</strong> automation on the Automations page.</li>
+          </ol>
+          <p className="border-t pt-2">
+            The bot connects over Discord's <strong>Gateway</strong> (an outbound WebSocket) and routes <code className="text-[11px]">mention</code> +
+            <code className="text-[11px]"> direct_message</code> events — no request URL or public endpoint needed; the server dials out to Discord.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+const PROVIDER_META: Record<IdentityProvider, { label: string; placeholder: string }> = {
+  slack: { label: 'Slack user ID', placeholder: 'U0123ABCD' },
+  discord: { label: 'Discord user ID', placeholder: '123456789012345678' },
+  email: { label: 'Alt email', placeholder: 'name@other.com' },
+  github: { label: 'GitHub login', placeholder: 'octocat' },
+}
+
+// Per-member identity map editor: the external account ids (Slack/Discord/email/github) that let a chat
+// trigger run AS this member. One handle per provider; saved on blur (empty clears it).
+function IdentityEditor({ member, identities, onChange }: { member: Member; identities: MemberIdentity[]; onChange: () => void }) {
+  const current = (p: IdentityProvider) => identities.find((i) => i.provider === p)?.externalId ?? ''
+  const [vals, setVals] = useState<Record<string, string>>(() => Object.fromEntries(IDENTITY_PROVIDERS.map((p) => [p, current(p)])))
+  const [busy, setBusy] = useState('')
+  useEffect(() => { setVals(Object.fromEntries(IDENTITY_PROVIDERS.map((p) => [p, current(p)]))) }, [identities]) // eslint-disable-line react-hooks/exhaustive-deps
+  const save = async (p: IdentityProvider) => {
+    const v = (vals[p] ?? '').trim()
+    if (v === current(p)) return // no change → skip the round-trip
+    setBusy(p)
+    await api.setIdentity(member.id, p, v)
+    setBusy('')
+    onChange()
+  }
+  return (
+    <div className="mt-2 rounded-md border bg-muted/30 p-3">
+      <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">Chat identities — run-as for Slack / Discord triggers</div>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {IDENTITY_PROVIDERS.map((p) => (
+          <Field key={p} label={PROVIDER_META[p].label}>
+            <Input
+              value={vals[p] ?? ''}
+              onChange={(e) => setVals((s) => ({ ...s, [p]: e.target.value }))}
+              onBlur={() => save(p)}
+              onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+              placeholder={PROVIDER_META[p].placeholder}
+              className="font-mono text-xs"
+              disabled={busy === p}
+            />
+          </Field>
+        ))}
+      </div>
+      <p className="mt-2 text-[11px] text-muted-foreground">
+        When a Slack/Discord message triggers an automation, the OS runs it <strong>as the member whose handle matches the sender</strong>
+        {' '}— their connectors + inbox. Slack also falls back to matching the sender's profile email.
+      </p>
+    </div>
+  )
+}
+
 function TeamPage({ me }: { me: Member }) {
   const [data, setData] = useState<TeamResp | null>(null)
   const [links, setLinks] = useState<Record<string, string>>({})
@@ -1821,6 +1969,7 @@ function TeamPage({ me }: { me: Member }) {
   const [role, setRole] = useState<Role>('member')
   const [inviteLink, setInviteLink] = useState('')
   const [hint, setHint] = useState('')
+  const [identOpen, setIdentOpen] = useState<Record<string, boolean>>({})
 
   const load = () => api.team().then(setData)
   useEffect(() => { load() }, [])
@@ -1895,6 +2044,9 @@ function TeamPage({ me }: { me: Member }) {
                     </Select>
                   )}
                   {isAdmin && (
+                    <Button size="sm" variant="outline" onClick={() => setIdentOpen((p) => ({ ...p, [m.id]: !p[m.id] }))}>Chat IDs</Button>
+                  )}
+                  {isAdmin && (
                     <Button size="sm" variant="outline" onClick={() => loginLink(m.id)}>Login link</Button>
                   )}
                   {isOwner && m.id !== me.id && (
@@ -1903,6 +2055,11 @@ function TeamPage({ me }: { me: Member }) {
                     </Button>
                   )}
                 </div>
+                {isAdmin && identOpen[m.id] && (
+                  <div className="w-full">
+                    <IdentityEditor member={m} identities={data.identities?.[m.id] ?? []} onChange={load} />
+                  </div>
+                )}
                 {links[m.id] && <div className="w-full"><CopyLink link={links[m.id]} /></div>}
               </CardContent>
             </Card>
@@ -1978,7 +2135,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
   // create form
   const [name, setName] = useState('')
   const [agentId, setAgentId] = useState(agents[0]?.id ?? '')
-  const [type, setType] = useState<'cron' | 'webhook' | 'composio' | 'slack'>('cron')
+  const [type, setType] = useState<'cron' | 'webhook' | 'composio' | 'slack' | 'discord'>('cron')
   const [mode, setMode] = useState<'interactive' | 'headless'>('headless')
   const [schedule, setSchedule] = useState('*/30 * * * *')
   const [filter, setFilter] = useState('')
@@ -1991,7 +2148,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
 
   const create = async () => {
     setHint('')
-    const r = await api.addAutomation({ name, agentId, type, mode, schedule: type === 'cron' ? schedule : undefined, filter: type === 'composio' || type === 'slack' ? filter : undefined, task })
+    const r = await api.addAutomation({ name, agentId, type, mode, schedule: type === 'cron' ? schedule : undefined, filter: type === 'composio' || type === 'slack' || type === 'discord' ? filter : undefined, task })
     if (r.error) return setHint('⚠ ' + r.error)
     setName(''); setTask('')
     load()
@@ -2014,8 +2171,8 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
     <div className="max-w-4xl space-y-6">
       <p className="text-sm text-muted-foreground">
         Automations run agents without you: on a <strong>cron schedule</strong>, when an external service hits a
-        <strong> webhook</strong>, on a <strong>Composio event</strong>, or on a <strong>Slack message</strong> (the
-        company Slack app @-mentioned or DMed → run an agent, as the member who sent it). Each firing spawns a normal
+        <strong> webhook</strong>, on a <strong>Composio event</strong>, or on a <strong>Slack</strong> / <strong>Discord
+        message</strong> (the company bot @-mentioned or DMed → run an agent, as the member who sent it). Each firing spawns a normal
         session — its task lands in the Inbox and any risky action still waits for approval.
       </p>
 
@@ -2037,7 +2194,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
                   <div className="mt-0.5 text-xs text-muted-foreground">
                     {a.agentId}
                     {a.type === 'cron' && <span className="ml-2 font-mono">{a.schedule}</span>}
-                    {(a.type === 'composio' || a.type === 'slack') && <span className="ml-2 font-mono">{a.filter || 'any event'}</span>}
+                    {(a.type === 'composio' || a.type === 'slack' || a.type === 'discord') && <span className="ml-2 font-mono">{a.filter || 'any event'}</span>}
                     {a.lastFiredAt ? <span className="ml-2">last fired {new Date(a.lastFiredAt).toLocaleString()}</span> : <span className="ml-2">never fired</span>}
                   </div>
                   {a.type === 'cron' && a.mode === 'interactive' && (
@@ -2095,12 +2252,13 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
                   </Select>
                 </Field>
                 <Field label="Trigger">
-                  <Select value={type} onValueChange={(v) => v && setType(v as 'cron' | 'webhook' | 'composio' | 'slack')}>
+                  <Select value={type} onValueChange={(v) => v && setType(v as 'cron' | 'webhook' | 'composio' | 'slack' | 'discord')}>
                     <SelectTrigger><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="cron">Schedule (cron)</SelectItem>
                       <SelectItem value="webhook">Webhook</SelectItem>
                       <SelectItem value="slack">Slack message (native)</SelectItem>
+                      <SelectItem value="discord">Discord message (native)</SelectItem>
                       <SelectItem value="composio">Composio event</SelectItem>
                     </SelectContent>
                   </Select>
@@ -2125,6 +2283,10 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
                 ) : type === 'slack' ? (
                   <Field label="Trigger filter" help="Scope to an event type (app_mention / message) or a channel id (e.g. C0123…). Blank = any Slack message the app receives. Needs Slack tokens in Settings → Integrations.">
                     <Input value={filter} onChange={(e) => setFilter(e.target.value)} className="font-mono" placeholder="app_mention  ·  or a channel id  (blank = any)" />
+                  </Field>
+                ) : type === 'discord' ? (
+                  <Field label="Trigger filter" help="Scope to an event type (mention / direct_message) or a channel id. Blank = any Discord message the bot receives. Needs a bot token in Settings → Integrations.">
+                    <Input value={filter} onChange={(e) => setFilter(e.target.value)} className="font-mono" placeholder="mention  ·  or a channel id  (blank = any)" />
                   </Field>
                 ) : (
                   <Field label="Trigger filter" help="Composio trigger slug to match — e.g. SLACK_DIRECT_MESSAGE_RECEIVED. Blank = any Composio event. Needs a webhook secret in Settings → Integrations.">
@@ -2990,8 +3152,68 @@ function DreamingSettings({ me }: { me: Member }) {
   )
 }
 
+function AuditPage() {
+  const [events, setEvents] = useState<AuditEvent[]>([])
+  const [types, setTypes] = useState<string[]>([])
+  const [type, setType] = useState('')
+  const [session, setSession] = useState('')
+  const [principal, setPrincipal] = useState('')
+  const [loading, setLoading] = useState(false)
+  const load = (over: { type?: string } = {}) => {
+    setLoading(true)
+    api.audit({ type: over.type ?? type, session: session.trim(), principal: principal.trim(), limit: 300 })
+      .then((r) => { if (!r.error) { setEvents(r.events ?? []); if (r.types?.length) setTypes(r.types) } })
+      .finally(() => setLoading(false))
+  }
+  useEffect(() => { load() }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return (
+    <div className="max-w-5xl space-y-4">
+      <p className="text-sm text-muted-foreground">
+        The append-only <strong>audit trail</strong> — every gateway/gate decision, approval, and console mutation.
+        The per-run JSONL is the durable system of record; this is its queryable mirror (owner/admin only).
+      </p>
+      <div className="flex flex-wrap items-end gap-2">
+        <Field label="Type">
+          <Select value={type || '__all'} onValueChange={(v) => { const t = !v || v === '__all' ? '' : v; setType(t); load({ type: t }) }}>
+            <SelectTrigger className="h-8 w-56"><SelectValue /></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__all">All types</SelectItem>
+              {types.map((t) => <SelectItem key={t} value={t}>{t}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        </Field>
+        <Field label="Session"><Input value={session} onChange={(e) => setSession(e.target.value)} placeholder="session id" className="h-8 w-36 font-mono text-xs" /></Field>
+        <Field label="Principal"><Input value={principal} onChange={(e) => setPrincipal(e.target.value)} placeholder="email / agent / system" className="h-8 w-48 font-mono text-xs" /></Field>
+        <Button size="sm" variant="outline" onClick={() => load()} disabled={loading}>{loading ? 'Loading…' : 'Apply'}</Button>
+      </div>
+
+      <Card>
+        <CardContent className="p-0">
+          {events.length === 0 ? (
+            <div className="p-6 text-sm text-muted-foreground">{loading ? 'Loading…' : 'No matching audit events.'}</div>
+          ) : (
+            <div className="divide-y">
+              {events.map((e) => (
+                <div key={e.id} className="flex items-start gap-3 px-3 py-2 text-xs">
+                  <span className="w-36 shrink-0 text-muted-foreground">{new Date(e.ts).toLocaleString()}</span>
+                  <Badge variant="outline" className="shrink-0 px-1.5 py-0 font-mono text-[10px]">{e.type}</Badge>
+                  <span className="w-40 shrink-0 truncate font-mono text-[11px] text-muted-foreground" title={e.principal}>{e.principal || '—'}</span>
+                  <span className="w-20 shrink-0 truncate font-mono text-[11px] text-muted-foreground" title={e.runId}>{e.runId === '-' ? '' : e.runId}</span>
+                  <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-muted-foreground" title={JSON.stringify(e.data)}>{JSON.stringify(e.data)}</span>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+      <p className="text-[11px] text-muted-foreground">Showing up to 300 most-recent events{events.length ? ` · ${events.length} shown` : ''}.</p>
+    </div>
+  )
+}
+
 function SettingsPage({ me }: { me: Member }) {
-  const [tab, setTab] = useState<'company' | 'runtime' | 'integrations' | 'memory' | 'dreaming' | 'policy'>('company')
+  const [tab, setTab] = useState<'company' | 'runtime' | 'integrations' | 'memory' | 'dreaming' | 'policy' | 'governance'>('company')
   if (me.role !== 'owner' && me.role !== 'admin') return <div className="text-sm text-muted-foreground">Owner or admin access required.</div>
   return (
     <div className="max-w-3xl space-y-4">
@@ -3001,6 +3223,7 @@ function SettingsPage({ me }: { me: Member }) {
         <TabButton on={tab === 'integrations'} onClick={() => setTab('integrations')}>Integrations</TabButton>
         <TabButton on={tab === 'memory'} onClick={() => setTab('memory')}>Memory</TabButton>
         <TabButton on={tab === 'dreaming'} onClick={() => setTab('dreaming')}>Self-learning</TabButton>
+        <TabButton on={tab === 'governance'} onClick={() => setTab('governance')}>Governance</TabButton>
         <TabButton on={tab === 'policy'} onClick={() => setTab('policy')}>Policy</TabButton>
       </div>
       {tab === 'company' ? <CompanySettings me={me} />
@@ -3008,8 +3231,67 @@ function SettingsPage({ me }: { me: Member }) {
         : tab === 'integrations' ? <IntegrationsSettings me={me} />
         : tab === 'memory' ? <MemorySettings me={me} />
         : tab === 'dreaming' ? <DreamingSettings me={me} />
+        : tab === 'governance' ? <GovernanceSettings me={me} />
         : <PolicyEditor me={me} />}
     </div>
+  )
+}
+
+/** Settings → Governance — the numeric caps the policy's "never" tier enforces. A single payment at or
+ *  below the money cap, or a delete of at most the bulk count, can still be approved; anything above is
+ *  refused outright (no approver can override). Editing these retunes the deny rules live — no restart. */
+function GovernanceSettings({ me }: { me: Member }) {
+  const [t, setT] = useState<{ moneyCapUsd: number; bulkDeleteCount: number }>({ moneyCapUsd: 500, bulkDeleteCount: 25 })
+  const [saved, setSaved] = useState(t)
+  const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
+  const [busy, setBusy] = useState(false)
+  const [hint, setHint] = useState('')
+  const canEdit = me.role === 'owner' || me.role === 'admin'
+
+  useEffect(() => {
+    api.governance().then((r) => {
+      if (r.error) return
+      const v = { moneyCapUsd: r.moneyCapUsd, bulkDeleteCount: r.bulkDeleteCount }
+      setT(v); setSaved(v); setMeta({ updatedAt: r.updatedAt, updatedBy: r.updatedBy })
+    }).catch(() => {})
+  }, [])
+
+  const dirty = JSON.stringify(t) !== JSON.stringify(saved)
+  const save = async () => {
+    setBusy(true); setHint('')
+    const r = await api.saveGovernance(t)
+    setBusy(false)
+    if (r.error) return setHint('⚠ ' + r.error)
+    const v = { moneyCapUsd: r.moneyCapUsd, bulkDeleteCount: r.bulkDeleteCount }
+    setT(v); setSaved(v); setHint('saved — applies to the policy immediately'); setTimeout(() => setHint(''), 3000)
+  }
+
+  return (
+    <Card>
+      <CardContent className="space-y-4 p-4">
+        <p className="text-sm text-muted-foreground">
+          The caps the policy's <strong>never</strong> tier enforces. At or below the limit an action can still be{' '}
+          <em>approved</em> by a human; <strong>above</strong> it the action is <strong>refused outright</strong> — no approver,
+          attended or not, can override. These feed the deny rules as <span className="font-mono text-xs">$moneyCapUsd</span> /{' '}
+          <span className="font-mono text-xs">$bulkDeleteCount</span> and apply live.
+        </p>
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="Money cap (USD)" help="A single payment/refund above this is never allowed.">
+            <Input type="number" min={0} value={t.moneyCapUsd}
+              onChange={(e) => setT({ ...t, moneyCapUsd: Number(e.target.value) })} disabled={!canEdit} />
+          </Field>
+          <Field label="Bulk-delete cap (items)" help="A delete of more than this many items is never allowed.">
+            <Input type="number" min={0} value={t.bulkDeleteCount}
+              onChange={(e) => setT({ ...t, bulkDeleteCount: Number(e.target.value) })} disabled={!canEdit} />
+          </Field>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button onClick={save} disabled={!canEdit || busy || !dirty}>{dirty ? 'Save caps' : 'Saved'}</Button>
+          {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
+          {!hint && meta.updatedBy && <span className="text-[11px] text-muted-foreground">last set by {meta.updatedBy}</span>}
+        </div>
+      </CardContent>
+    </Card>
   )
 }
 
@@ -3399,23 +3681,31 @@ function IntegrationsSettings({ me }: { me: Member }) {
   const [webhook, setWebhook] = useState<{ set: boolean }>({ set: false })
   const [slack, setSlack] = useState<IntegrationsResp['slack']>({ appToken: false, botToken: false, configured: false })
   const [slackState, setSlackState] = useState<SlackStatus | null>(null)
+  const [discord, setDiscord] = useState<IntegrationsResp['discord']>({ botToken: false, configured: false })
+  const [discordState, setDiscordState] = useState<DiscordStatus | null>(null)
   const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
   const [key, setKey] = useState('')
   const [wh, setWh] = useState('')
   const [appTok, setAppTok] = useState('')
   const [botTok, setBotTok] = useState('')
+  const [discordTok, setDiscordTok] = useState('')
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
 
   // Defensive defaults so an older backend (one that predates a field) never white-screens the page.
   const SLACK_DEFAULT = { appToken: false, botToken: false, configured: false }
+  const DISCORD_DEFAULT = { botToken: false, configured: false }
   const apply = (r: IntegrationsResp) => {
     if (r.composio) setComposio(r.composio)
     if (r.webhook) setWebhook(r.webhook)
     setSlack(r.slack ?? SLACK_DEFAULT)
+    setDiscord(r.discord ?? DISCORD_DEFAULT)
     setMeta({ updatedAt: r.updatedAt, updatedBy: r.updatedBy })
   }
-  const loadStatus = () => api.slackStatus().then((s) => { if (s && !s.error) setSlackState(s) }).catch(() => {})
+  const loadStatus = () => {
+    api.slackStatus().then((s) => { if (s && !s.error) setSlackState(s) }).catch(() => {})
+    api.discordStatus().then((s) => { if (s && !s.error) setDiscordState(s) }).catch(() => {})
+  }
   useEffect(() => {
     api.integrations().then((r) => {
       if (r.error) return setHint('⚠ ' + r.error)
@@ -3424,16 +3714,16 @@ function IntegrationsSettings({ me }: { me: Member }) {
     loadStatus()
   }, [])
 
-  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string }, label: string) => {
+  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string }, label: string) => {
     setBusy(true); setHint('')
     const r = await api.saveIntegrations(body)
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
-    setKey(''); setWh(''); setAppTok(''); setBotTok('')
+    setKey(''); setWh(''); setAppTok(''); setBotTok(''); setDiscordTok('')
     apply(r)
     setHint(label); setTimeout(() => setHint(''), 1500)
-    // The Socket-Mode connection re-dials on the server when tokens change — poll the new state.
-    if (body.slackAppToken !== undefined || body.slackBotToken !== undefined) setTimeout(loadStatus, 1200)
+    // The Socket-Mode / Gateway connection re-dials on the server when tokens change — poll the new state.
+    if (body.slackAppToken !== undefined || body.slackBotToken !== undefined || body.discordBotToken !== undefined) setTimeout(loadStatus, 1200)
   }
 
   if (!isAdmin) return <div className="text-sm text-muted-foreground">Owner or admin access required.</div>
@@ -3540,6 +3830,47 @@ function IntegrationsSettings({ me }: { me: Member }) {
             >Save</Button>
             {(slack.appToken || slack.botToken) && (
               <Button variant="ghost" onClick={() => save({ slackAppToken: '', slackBotToken: '' }, 'removed')} disabled={busy}>Remove</Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-medium">
+              Discord (native, Gateway)
+              {discordState && (discordState.connected
+                ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px] text-emerald-600">connected{discordState.botUserId ? ` · ${discordState.botUserId}` : ''}</Badge>
+                : discord.configured
+                  ? <Badge variant="outline" className="px-1.5 py-0 text-[10px] text-amber-600">configured · not connected</Badge>
+                  : <Badge variant="outline" className="px-1.5 py-0 text-[10px]">not configured</Badge>)}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              One company Discord bot, configured once and shared across the workspace — no public URL needed (the server
+              dials out to Discord over the Gateway). When the bot is @-mentioned or DMed, matching <strong>Discord</strong>
+              automations run. <span className="text-foreground">Note:</span> Discord can't expose a user's email, so triggered
+              runs currently act as the <strong>company identity</strong> (per-member run-as lands with the identity map).
+            </p>
+            {discordState?.lastError && <p className="mt-1 font-mono text-[11px] text-destructive">last error: {discordState.lastError}</p>}
+          </div>
+          <DiscordSetupGuide />
+          <Field label="Bot token" help="Discord Developer Portal → your app → Bot → Reset/Copy Token. Enable the MESSAGE CONTENT privileged intent on the same page.">
+            <Input
+              type="password"
+              value={discordTok}
+              onChange={(e) => setDiscordTok(e.target.value)}
+              placeholder={discord.botToken ? '•••• (saved) — type a new token to replace' : 'bot token (MTI…/…)'}
+              className="font-mono text-xs"
+            />
+          </Field>
+          <div className="flex items-center gap-3">
+            <Button
+              onClick={() => save({ discordBotToken: discordTok.trim() }, 'saved')}
+              disabled={busy || !discordTok.trim()}
+            >Save</Button>
+            {discord.botToken && (
+              <Button variant="ghost" onClick={() => save({ discordBotToken: '' }, 'removed')} disabled={busy}>Remove</Button>
             )}
           </div>
         </CardContent>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,6 +7,15 @@ export interface Member {
   status: 'invited' | 'active'
   createdAt: number
 }
+export type IdentityProvider = 'slack' | 'discord' | 'email' | 'github'
+export const IDENTITY_PROVIDERS: IdentityProvider[] = ['slack', 'discord', 'email', 'github']
+export interface MemberIdentity {
+  memberId: string
+  provider: IdentityProvider
+  externalId: string
+  createdAt: number
+  createdBy?: string
+}
 export interface AgentAccess {
   allowedRoles: Role[]
   allowedMembers: string[]
@@ -37,6 +46,8 @@ export interface AgentInfo {
 }
 export interface StateResp {
   tenant: string
+  /** Human label for the tenant (branding); falls back to the tenant id server-side. */
+  tenantName?: string
   policy: string
   home?: string
   me: Member
@@ -48,6 +59,8 @@ export interface TeamResp {
   me: Member
   members: Member[]
   assignments: Record<string, AgentAccess>
+  /** member id → their linked external accounts (Slack/Discord/email/github), for chat run-as. */
+  identities: Record<string, MemberIdentity[]>
   agents: AgentInfo[]
 }
 export interface Session {
@@ -60,6 +73,19 @@ export interface Session {
   spawnedBy?: string
   spawnedByLabel?: string
   createdAt: number
+}
+export interface AuditEvent {
+  id: number
+  ts: number
+  runId: string
+  type: string
+  principal?: string
+  data: Record<string, unknown>
+}
+export interface AuditResp {
+  events: AuditEvent[]
+  types: string[]
+  error?: string
 }
 export interface Artifact {
   id: string
@@ -140,7 +166,7 @@ export interface Automation {
   id: string
   agentId: string
   name: string
-  type: 'cron' | 'webhook' | 'composio' | 'slack'
+  type: 'cron' | 'webhook' | 'composio' | 'slack' | 'discord'
   mode: ExecMode
   schedule?: string
   /** composio: trigger slug. slack: event type (app_mention/message) or channel id. '' = any. */
@@ -156,7 +182,7 @@ export interface Automation {
 export interface AddAutomationReq {
   agentId: string
   name: string
-  type: 'cron' | 'webhook' | 'composio' | 'slack'
+  type: 'cron' | 'webhook' | 'composio' | 'slack' | 'discord'
   mode: ExecMode
   schedule?: string
   filter?: string
@@ -178,6 +204,8 @@ export interface Connector {
   enabled: boolean
   scope: ConnectorScope
   ownerMemberId?: string
+  /** personal-only: shared with the whole team (injected into everyone's sessions, as the owner). */
+  shared: boolean
   createdAt: number
   envKeys: string[]
   headerKeys: string[]
@@ -313,6 +341,12 @@ export interface CompanySettings {
   error?: string
 }
 
+/** Numeric governance caps the never-tier policy rules read ($moneyCapUsd / $bulkDeleteCount). */
+export interface GovernanceThresholds {
+  moneyCapUsd: number
+  bulkDeleteCount: number
+}
+
 export interface IntegrationsResp {
   /** Never the raw key — only whether it's set and a masked hint (••••last4). */
   composio: { set: boolean; hint: string }
@@ -320,6 +354,8 @@ export interface IntegrationsResp {
   webhook: { set: boolean }
   /** Native Slack (Socket Mode) — which tokens are set; never the tokens. */
   slack: { appToken: boolean; botToken: boolean; configured: boolean }
+  /** Native Discord (Gateway) — whether the bot token is set; never the token. */
+  discord: { botToken: boolean; configured: boolean }
   updatedAt?: number
   updatedBy?: string
   error?: string
@@ -332,6 +368,9 @@ export interface SlackStatus {
   lastError?: string
   error?: string
 }
+
+/** Live Discord Gateway status — same shape as SlackStatus. */
+export type DiscordStatus = SlackStatus
 
 export interface ComposioConnection {
   id: string
@@ -353,6 +392,7 @@ export interface ConnectionsResp {
 export interface IntegrationsOverview {
   composio: { keySet: boolean; entity: string; apps: { id: string; toolkit: string; status: string }[] }
   slack: { configured: boolean; connected: boolean; botUserId: string }
+  discord: { configured: boolean; connected: boolean; botUserId: string }
   custom: { label: string; type: string; enabled: boolean }[]
   error?: string
 }
@@ -429,11 +469,21 @@ export const api = {
   dismissMessage: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/dismiss`),
 
   team: () => call<TeamResp>('GET', '/api/team'),
+  audit: (f: { session?: string; type?: string; principal?: string; limit?: number } = {}) => {
+    const q = new URLSearchParams()
+    if (f.session) q.set('session', f.session)
+    if (f.type) q.set('type', f.type)
+    if (f.principal) q.set('principal', f.principal)
+    if (f.limit) q.set('limit', String(f.limit))
+    return call<AuditResp>('GET', '/api/audit' + (q.toString() ? `?${q}` : ''))
+  },
   invite: (email: string, role: Role) => call<{ member: Member; link: string; error?: string }>('POST', '/api/team/invite', { email, role }),
   setRole: (id: string, role: Role) => call<Member | { error: string }>('POST', `/api/team/${id}/role`, { role }),
   removeMember: (id: string) => call<{ ok: boolean; reason?: string }>('DELETE', '/api/team/' + id),
   loginLink: (id: string) => call<{ link: string; error?: string }>('POST', `/api/team/${id}/login-link`),
   setAssignment: (agentId: string, access: AgentAccess) => call<{ ok: boolean; assignment: AgentAccess }>('PUT', '/api/team/assignments/' + agentId, access),
+  setIdentity: (id: string, provider: IdentityProvider, externalId: string) => call<{ ok: boolean; identities: MemberIdentity[]; error?: string }>('POST', `/api/team/${id}/identities`, { provider, externalId }),
+  clearIdentity: (id: string, provider: IdentityProvider) => call<{ ok: boolean; identities: MemberIdentity[]; error?: string }>('DELETE', `/api/team/${id}/identities/${provider}`),
 
   automations: () => call<{ automations: Automation[] }>('GET', '/api/automations'),
   addAutomation: (a: AddAutomationReq) => call<Automation & { error?: string }>('POST', '/api/automations', a),
@@ -478,6 +528,9 @@ export const api = {
   runtimeDefaults: () => call<RuntimeTuning & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/runtime-defaults'),
   saveRuntimeDefaults: (tuning: RuntimeTuning) => call<{ ok: boolean; error?: string } & RuntimeTuning>('PUT', '/api/settings/runtime-defaults', tuning),
 
+  governance: () => call<GovernanceThresholds & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/governance'),
+  saveGovernance: (t: GovernanceThresholds) => call<{ ok: boolean; error?: string } & GovernanceThresholds>('PUT', '/api/settings/governance', t),
+
   settings: () => call<CompanySettings>('GET', '/api/settings'),
   saveCompany: (companyMd: string) => call<CompanySettings & { ok: boolean; error?: string }>('PUT', '/api/settings/company', { companyMd }),
   connections: () => call<ConnectionsResp>('GET', '/api/connections'),
@@ -488,8 +541,9 @@ export const api = {
   disconnectApp: (body: { id: string; scope: 'company' | 'personal' }) =>
     call<{ ok?: boolean; error?: string }>('POST', '/api/connections/disconnect', body),
   integrations: () => call<IntegrationsResp>('GET', '/api/settings/integrations'),
-  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
+  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
   slackStatus: () => call<SlackStatus>('GET', '/api/settings/slack/status'),
+  discordStatus: () => call<DiscordStatus>('GET', '/api/settings/discord/status'),
 
   skills: () => call<SkillsResp>('GET', '/api/skills'),
   skill: (name: string) => call<SkillDetail & { error?: string }>('GET', '/api/skills/' + encodeURIComponent(name)),
@@ -517,4 +571,5 @@ export const api = {
   addConnector: (c: AddConnectorReq) => call<Connector | { error: string }>('POST', '/api/connectors', c),
   deleteConnector: (id: string) => call<{ ok: boolean }>('DELETE', '/api/connectors/' + id),
   toggleConnector: (id: string, enabled: boolean) => call<Connector>('PATCH', '/api/connectors/' + id, { enabled }),
+  shareConnector: (id: string, shared: boolean) => call<Connector>('PATCH', '/api/connectors/' + id, { shared }),
 }


### PR DESCRIPTION
PR #1 of the governance-model.md plan. Closes the fail-open hole and adds a hard **never** (deny) tier for irreversible actions — refused regardless of who approves.

## What changed
- **`gate-hook.sh` — fail-closed.** The `*) exit 0` fail-open fallback is gone; classify now **retries until the gate answers**, so a server restart / the documented stale-server 401-404 window / a network blip blocks the action instead of running it ungoverned. Destructive detection is now **case-insensitive** (`drop database`, not just `DROP`) and sends a `destructive` flag for `drop/truncate database|table|schema`, `rm -rf/-fr`, `mkfs`, `dd if=/of=`, `terraform destroy`, `kubectl delete`, `git push --force/-f`, and MCP `*DELETE_SITE*`/`*DROP_*`.
- **`default.policy.json` — never tier.** New `deny` rules evaluated first (deny wins): `destructive==true`; `amountUsd > $moneyCapUsd`; `deleteCount > $bulkDeleteCount`.
- **`policy.ts`** resolves `$`-prefixed threshold refs live from a provider at classify time (`JsonPolicyEngine.setThresholds()`).
- **`settings.ts`** — `governanceThresholds()` (defaults `moneyCapUsd: 500`, `bulkDeleteCount: 25`), `setGovernanceThresholds()` with clamping + partial-save preservation.
- **`kernel.ts`** wires the engine's threshold provider to `os.settings` post-construction.
- **`server.ts`** — `GET/PUT /api/settings/governance` (owner/admin, audited).
- **web** — Settings → Governance tab for the two caps.
- **`docs/governance-model.md`** — the design north star this PR implements.

## Verification
Policy decision matrix (12 cases), live cap retune on the same engine instance (raising the cap flips a \$600 payment deny→allow with no restart), partial-save/garbage-clamp, `npm run typecheck`, `npm run demo`, `cd web && npm run build`, `bash -n` on the hook.

## Scope
Classification still sees the Bash command + MCP tool **name**, not MCP call **arguments** — so destructive SQL passed *inside* `db_query`/`execute_php` is not yet caught. That argument-aware enricher is PR #2.

> Note: this commit also carries some pre-existing working-tree edits in `server.ts` / `web/src/App.tsx` / `web/src/lib/api.ts` that predated the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)