### PR TITLE
governance: argument-aware enricher + context auto-approve + conformance suite (PR #2 & #3)

### DIFF
--- a/docs/governance-model.md
+++ b/docs/governance-model.md
@@ -150,22 +150,27 @@ blocked-then-retry waste that itself pushes agents toward edge cases.
 ## Where we are vs. the north star
 
 The hard parts already exist: a single conceptual gateway, policy-as-data with a live console editor,
-audit-at-every-step, idempotency, and an initiator signal (`term_sessions.spawned_by`). The gaps are
-all *"a principle not yet wired,"* not *"a layer that needs inventing":*
+audit-at-every-step, idempotency, and an initiator signal (`term_sessions.spawned_by`). Most gaps were
+*"a principle not yet wired,"* not *"a layer that needs inventing"* — and three PRs have now wired them:
 
-| Gap (today) | Principle violated | Direction |
+| Gap | Principle | Status |
 |---|---|---|
-| `classify(attempt, _ctx)` ignores context | Core reframing | thread actor / context / target into the decision |
-| No `deny` tier in `default.policy.json` — worst case is `approve(owner)` | P1 reversibility | add an irreversible tier that denies regardless of approver |
-| Owner is asked to approve their own attended agent | P1 + P5 | context-aware auto-approve for the recoverable tier, fenced from irreversible |
-| Classification by tool *name* — `db_query` / `execute_php` args unseen | P3 classifier split | server-side, argument-aware enricher |
-| Case-sensitive substring matching in the hook (`*DROP*` misses `drop`) | P3 + P4 | move classification off the shell, make it deterministic + tested |
-| Two decision paths (`gateway.ts` vs `gate-hook.sh`) | P4 one chokepoint | one shared decision function |
-| `*) exit 0` fail-open fallback | P4 fail-closed | deny on error and on unknown |
-| Agents hold the same creds regardless of environment | P2 defense in depth | least privilege / environment-scoped identity |
+| `classify` ignored context | Core reframing | ✅ the decision *pipeline* now uses all four inputs — `enrichArgs` derives action/target facts, `attendedApprover` adds actor/context; `classify` itself stays a pure facts→risk function |
+| No `deny` tier — worst case was `approve(owner)` | P1 reversibility | ✅ PR #1 — never-tier deny rules in `default.policy.json`, refused regardless of approver |
+| Owner asked to approve their own attended agent | P1 + P5 | ✅ PR #3 — `autoClearsApproval` clears the `ask` tier for an attended owner/admin, fenced out of the never tier |
+| Classification by tool *name* — `db_query`/`execute_php` args unseen | P3 classifier split | ✅ PR #2 — `src/governance/enricher.ts` inspects arguments (the SQL inside the call, the amount, the count) |
+| Case-sensitive substring matching in the shell | P3 + P4 | ✅ PR #2 — classification moved off bash into the deterministic, case-insensitive enricher |
+| Two decision paths (`gateway.ts` vs `gate-hook.sh`) | P4 one chokepoint | 🟡 the live gate-hook path is now one brain (`enrich → classify → context`, pinned by the conformance suite); the mock `gateway.ts` demo path still classifies without the enricher — fold it in next |
+| `*) exit 0` fail-open fallback | P4 fail-closed | ✅ PR #1 — retries until the gate answers; never falls through to allow |
+| Agents hold the same creds regardless of environment | P2 defense in depth | ⬜ open — least privilege / environment-scoped identity (future) |
 
-None of this is a rewrite. It is threading inputs we already collect into a decision we already make,
-then refusing to fail open.
+The brain is now testable and pinned: **`test/governance/conformance.json`** is a golden table of
+`(call → decision)` and `(approval context → auto-clear?)` cases; `node scripts/governance-conformance.cjs`
+(`npm run test:governance`) drives the exact functions the live gate uses and fails CI on any drift.
+Add a case there before changing the enricher or the default policy.
+
+What remains is genuinely additive: route `gateway.ts` through the enricher too (one brain everywhere),
+environment-scoped least privilege (P2), hash-chained audit, and the kill switch — none a rewrite.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "start": "node dist/cli.js serve",
     "demo": "node dist/cli.js demo",
     "dev": "ts-node src/cli.ts serve",
-    "demo:dev": "ts-node src/demo.ts"
+    "demo:dev": "ts-node src/demo.ts",
+    "test:governance": "node scripts/governance-conformance.cjs"
   },
   "keywords": [
     "agents",

--- a/scripts/governance-conformance.cjs
+++ b/scripts/governance-conformance.cjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+/**
+ * Governance conformance runner — the golden test that pins what the gate decides.
+ *
+ * It drives the SAME brain `tm.gate` uses: `enrichArgs()` → `JsonPolicyEngine.classify()` for the
+ * decision tier, and `autoClearsApproval()` for the attended-approver shortcut. If this passes, the
+ * live gate behaves as the fixture says; when you change the enricher or the default policy, update
+ * test/governance/conformance.json in the same commit. No test runner needed — `node` + dist.
+ *
+ *   npm run build && node scripts/governance-conformance.cjs
+ *
+ * Exits 0 when every case matches, 1 otherwise (CI-friendly).
+ */
+const path = require('path');
+const fs = require('fs');
+
+const ROOT = path.resolve(__dirname, '..');
+const { enrichArgs, autoClearsApproval } = require(path.join(ROOT, 'dist/governance/enricher'));
+const { JsonPolicyEngine } = require(path.join(ROOT, 'dist/governance/policy'));
+
+const fixture = JSON.parse(fs.readFileSync(path.join(ROOT, 'test/governance/conformance.json'), 'utf8'));
+const policyDoc = JSON.parse(fs.readFileSync(path.join(ROOT, 'config/policy/default.policy.json'), 'utf8'));
+
+/** Map a Decision to the fixture's compact expectation string. */
+function tag(decision) {
+  if (decision.effect === 'allow') return 'allow';
+  if (decision.effect === 'deny') return 'never';
+  return `ask:${decision.level}`;
+}
+
+const ctx = { run: { id: 'r', tenant: 't', principal: 'a' } };
+let pass = 0;
+const failures = [];
+
+for (const c of fixture.decisions) {
+  const engine = new JsonPolicyEngine(policyDoc);
+  const thresholds = c.thresholds || fixture.thresholdsDefault;
+  engine.setThresholds(() => thresholds);
+  const args = enrichArgs(c.capability, c.args);
+  const got = tag(engine.classify({ capabilityId: c.capability, args, reasoning: '' }, ctx));
+  if (got === c.expect) pass++;
+  else failures.push(`decision  ✗ ${c.name}\n            expected ${c.expect}, got ${got}  (facts: destructive=${args.destructive} risky=${args.risky} amountUsd=${args.amountUsd} deleteCount=${args.deleteCount})`);
+}
+
+for (const c of fixture.context) {
+  const got = autoClearsApproval(c.level, c.ctx);
+  if (got === c.expectAutoClear) pass++;
+  else failures.push(`context   ✗ ${c.name}\n            expected autoClear=${c.expectAutoClear}, got ${got}`);
+}
+
+const total = fixture.decisions.length + fixture.context.length;
+if (failures.length) {
+  console.error(`\nGOVERNANCE CONFORMANCE: ${pass}/${total} passed, ${failures.length} FAILED\n`);
+  for (const f of failures) console.error('  ' + f);
+  console.error('');
+  process.exit(1);
+}
+console.log(`GOVERNANCE CONFORMANCE: ${pass}/${total} passed ✓`);

--- a/src/governance/enricher.ts
+++ b/src/governance/enricher.ts
@@ -1,0 +1,125 @@
+/**
+ * The ENRICHER — turns a raw tool call into the *facts* the policy rules read.
+ *
+ * Governance principle 3 (docs/governance-model.md): split the classifier from the policy. Policy is
+ * declarative data ("amountUsd > $cap → never"); deciding *what an action really is* — parsing
+ * destructive SQL, telling a bulk delete from a single one, finding the dollar amount — is code, and
+ * it must be case-insensitive and look INSIDE arguments. That code lives here, server-side and
+ * unit-tested (scripts/governance-conformance.cjs), NOT smeared across the bash gate-hook.
+ *
+ * The gate-hook is now dumb transport: it sends `{ tool, input }` (the raw Claude tool name + full
+ * tool_input) and `enrichArgs` computes the booleans/numbers the JSON ruleset matches on:
+ *   - destructive  → irreversible op (the never tier denies it): drop/truncate db, DELETE without
+ *                    WHERE, rm -rf, mkfs, dd, terraform destroy, kubectl delete, force-push; and by
+ *                    name a connector delete_site / drop_*.
+ *   - risky        → a mutation that needs approval (create/send/update/delete/pay/… verbs, or a
+ *                    shell command touching stripe/deploy/prod/…).
+ *   - amountUsd    → a USD figure pulled from the call (for the money cap).
+ *   - deleteCount  → how many items a delete affects (for the bulk-delete cap).
+ *
+ * Detection is deliberately CONSERVATIVE on the numeric facts: we'd rather miss a fact (and fall back
+ * to the risky→approval path) than fabricate one and deny legitimate work. Caller-supplied facts win
+ * if already truthy, so a structured caller (a test, the policy_check tool) can assert them directly.
+ *
+ * Known limit (documented): we still can't see what we're not given. If a tool hides destructive
+ * intent behind opaque/encoded arguments, only the executing layer truly knows — defense in depth
+ * (least privilege, recoverability) remains the backstop, not this one function.
+ */
+import { ApprovalLevel, Role, canApprove } from '../types';
+
+const DESTRUCTIVE: RegExp[] = [
+  /\bdrop\s+(database|table|schema)\b/i,
+  /\btruncate\b/i,
+  /\bdelete\s+from\b(?![\s\S]*\bwhere\b)/i, // DELETE FROM ... with no WHERE → whole-table wipe
+  /\brm\s+-[a-z]*r[a-z]*f|\brm\s+-[a-z]*f[a-z]*r|\brm\s+-r\b/i, // rm -rf / -fr / -r
+  /\bmkfs\b/i,
+  /\bdd\s+(if|of)=/i,
+  /\bterraform\s+destroy\b/i,
+  /\bkubectl\s+delete\b/i,
+  /\bgit\s+push\s+(--force|-f)\b/i,
+];
+const DESTRUCTIVE_TOOL = /delete_site|drop_database|drop_table|drop_schema/i;
+const MUTATION_TOOL = /create|send|update|delete|remove|write|post|put|patch|merge|publish|upload|deploy|pay|refund|archive|invite|execute/i;
+const RISKY_SHELL = /\b(stripe|refund|deploy|prod|drop|delete|kubectl|systemctl|shutdown)\b/i;
+const AMOUNT_KEY = /amount.*usd|usd.*amount|amountusd|amount_usd/i;
+const PAYMENT_TOOL = /refund|payment|charge|payout|\bpay\b/i;
+const PAYMENT_AMOUNT_KEY = /^(amount|total|amount_cents|amountcents)$/i;
+const DELETE_VERB = /delete|remove|purge|destroy|truncate|drop/i;
+
+const num = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
+
+/** Flatten a tool_input one level (plus array element scalars) into a text blob + the raw entries. */
+function scan(input: unknown): { text: string; entries: [string, unknown][] } {
+  if (!input || typeof input !== 'object') return { text: typeof input === 'string' ? input : '', entries: [] };
+  const entries = Object.entries(input as Record<string, unknown>);
+  const parts: string[] = [];
+  for (const [, v] of entries) {
+    if (typeof v === 'string') parts.push(v);
+    else if (Array.isArray(v)) parts.push(v.filter((x) => typeof x === 'string').join(' '));
+    else if (v != null && typeof v !== 'object') parts.push(String(v));
+  }
+  return { text: parts.join(' \n '), entries };
+}
+
+/**
+ * Compute governance facts and return a NEW args object (original + facts). Pure; no I/O.
+ * `args` is what the gate received: `{ tool?, input?, command?, ...callerFacts }`.
+ */
+export function enrichArgs(capability: string, args: Record<string, unknown>): Record<string, unknown> {
+  const tool = typeof args.tool === 'string' ? args.tool : '';
+  const input = (args.input && typeof args.input === 'object' ? args.input : args) as Record<string, unknown>;
+  // Text to pattern-match: an explicit shell command (Bash) and/or the connector input's string values.
+  const command = typeof args.command === 'string' ? args.command : typeof input.command === 'string' ? input.command : '';
+  const { text: inputText, entries } = scan(input);
+  const haystack = `${command}\n${inputText}`;
+
+  let destructive = args.destructive === true;
+  if (!destructive) {
+    destructive = DESTRUCTIVE.some((re) => re.test(haystack)) || (!!tool && DESTRUCTIVE_TOOL.test(tool));
+  }
+
+  let risky = args.risky === true || destructive;
+  if (!risky) {
+    if (capability === 'shell.exec') risky = RISKY_SHELL.test(haystack);
+    else if (capability.startsWith('connector')) risky = !!tool && MUTATION_TOOL.test(tool);
+  }
+
+  // amountUsd: explicit fact → a *_usd key → for a payment tool, a bare amount/total (treated as USD).
+  let amountUsd = num(args.amountUsd);
+  if (amountUsd === undefined) {
+    for (const [k, v] of entries) {
+      if (AMOUNT_KEY.test(k) && num(v) !== undefined) { amountUsd = num(v); break; }
+    }
+  }
+  if (amountUsd === undefined && tool && PAYMENT_TOOL.test(tool)) {
+    for (const [k, v] of entries) {
+      if (PAYMENT_AMOUNT_KEY.test(k) && num(v) !== undefined) { amountUsd = num(v); break; }
+    }
+  }
+
+  // deleteCount: explicit fact → for a delete-ish call, the longest array's length (e.g. ids: [...]),
+  // else a numeric count/limit field.
+  let deleteCount = num(args.deleteCount);
+  if (deleteCount === undefined && (destructive || (!!tool && DELETE_VERB.test(tool)))) {
+    let maxArr = -1;
+    for (const [, v] of entries) if (Array.isArray(v)) maxArr = Math.max(maxArr, v.length);
+    if (maxArr >= 0) deleteCount = maxArr;
+    else for (const [k, v] of entries) if (/^(count|limit)$/i.test(k) && num(v) !== undefined) { deleteCount = num(v); break; }
+  }
+
+  const facts: Record<string, unknown> = { ...args, destructive, risky };
+  if (amountUsd !== undefined) facts.amountUsd = amountUsd;
+  if (deleteCount !== undefined) facts.deleteCount = deleteCount;
+  return facts;
+}
+
+/**
+ * The CONTEXT rule for the `ask` tier (governance principle 5). An approval auto-clears — flows without
+ * a self-addressed inbox card — only when the run is ATTENDED (a human started it, not an automation)
+ * AND that human already holds approval authority for this level. Never applies to the `never` tier
+ * (deny is decided before approval) — so this can't auto-clear an irreversible action.
+ */
+export function autoClearsApproval(level: ApprovalLevel, ctx: { initiatorRole?: Role | null; attended: boolean }): boolean {
+  if (!ctx.attended || !ctx.initiatorRole) return false;
+  return canApprove(ctx.initiatorRole, level);
+}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -13,7 +13,8 @@ import * as path from 'path';
 import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
-import { ActionAttempt, AuditEvent, Decision, Member, RunContext, resolveRuntimeTuning } from './types';
+import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, Role, RunContext, resolveRuntimeTuning } from './types';
+import { enrichArgs, autoClearsApproval } from './governance/enricher';
 import { LauncherClient } from './edge/launcher';
 import { LauncherSessionBackend, LocalSessionBackend, SessionBackend, SpawnErrorSink } from './edge/session-backend';
 
@@ -112,6 +113,7 @@ interface SessionRow {
   tmux: string;
   status: 'running' | 'idle';
   spawned_by: string | null;
+  run_as: string | null;
   created_at: number;
 }
 interface MessageRow {
@@ -138,6 +140,17 @@ interface MessageRow {
   question_answered_by: string | null;
   /** The spawning member/automation of this message's session — for per-member inbox scoping. */
   session_spawned_by?: string | null;
+  /** The run-as member of this message's session (P2) — also grants that member inbox visibility. */
+  session_run_as?: string | null;
+}
+
+/** What the approval-notifier sink receives when a risky action lands an approval card. */
+export interface ApprovalNotice {
+  sessionId: string;
+  agent: string;
+  capability: string;
+  level: ApprovalLevel;
+  reason?: string;
 }
 
 export class TerminalManager {
@@ -158,6 +171,10 @@ export class TerminalManager {
   private readonly uidIsolation = process.env.AOS_UID_ISOLATION === '1';
   /** Idle grace before a member's uid/ttyd is reclaimed once they have no running sessions (A5). */
   private readonly idleGraceMs = Number(process.env.AOS_IDLE_GRACE_MS) || 15 * 60_000;
+  /** Optional sink notified when an approval card lands, so an out-of-band channel (Slack/Discord DM)
+   *  can ping the approver. Set by the registry once the chat sockets exist; absent = no notifications. */
+  private approvalNotifier?: (notice: ApprovalNotice) => void;
+  setApprovalNotifier(fn: (notice: ApprovalNotice) => void): void { this.approvalNotifier = fn; }
 
   constructor(
     private readonly os: AgentOS,
@@ -185,10 +202,10 @@ export class TerminalManager {
   reapIdleSpaces(): void {
     const spaces = this.backend.managedSpaces();
     if (!spaces.length) return;
-    const rows = this.db.prepare('SELECT spawned_by, status, created_at FROM term_sessions').all<{ spawned_by: string | null; status: string; created_at: number }>();
+    const rows = this.db.prepare('SELECT spawned_by, run_as, status, created_at FROM term_sessions').all<{ spawned_by: string | null; run_as: string | null; status: string; created_at: number }>();
     const now = Date.now();
     for (const space of spaces) {
-      const inSpace = rows.filter((r) => this.spaceFor(r.spawned_by) === space);
+      const inSpace = rows.filter((r) => this.spaceFor(r.run_as ?? r.spawned_by) === space);
       if (inSpace.some((r) => r.status === 'running')) continue; // still active
       const latest = inSpace.reduce((m, r) => Math.max(m, r.created_at), 0);
       if (latest && now - latest < this.idleGraceMs) continue; // keep warm — recent activity
@@ -218,8 +235,8 @@ export class TerminalManager {
         }
       }
     }
-    const visible = viewer ? rows.filter((r) => this.canViewSpawn(r.spawned_by, viewer)) : rows;
-    return visible.map((r) => ({ ...toSession(r), spawnedByLabel: this.spawnedByLabel(r.spawned_by) }));
+    const visible = viewer ? rows.filter((r) => this.canViewRow(r.spawned_by, r.run_as, viewer)) : rows;
+    return visible.map((r) => ({ ...toSession(r), spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as) }));
   }
 
   /**
@@ -238,10 +255,20 @@ export class TerminalManager {
     return false;
   }
 
-  /** Whether `viewer` may see a specific session (resolves its spawned_by, then applies the rule). */
+  /**
+   * The full visibility rule including run-as (P2): a session is visible to the member it ACTED AS
+   * (`run_as`), on top of the provenance rule (`canViewSpawn`). So a chat-triggered session — whose
+   * `spawned_by` is the automation — still lands in the inbox of the person it ran as.
+   */
+  private canViewRow(spawnedBy: string | null, runAs: string | null, viewer: Member): boolean {
+    if (runAs && runAs === viewer.id) return true;
+    return this.canViewSpawn(spawnedBy, viewer);
+  }
+
+  /** Whether `viewer` may see a specific session (resolves its provenance + run-as, then the rule). */
   canViewSession(sessionId: string, viewer: Member): boolean {
-    const r = this.db.prepare('SELECT spawned_by FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null }>(sessionId);
-    return this.canViewSpawn(r ? r.spawned_by : null, viewer);
+    const r = this.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(sessionId);
+    return this.canViewRow(r ? r.spawned_by : null, r ? r.run_as : null, viewer);
   }
 
   /** Whether `viewer` may act on a pending question (resolves its session, then the inbox rule). */
@@ -256,9 +283,9 @@ export class TerminalManager {
    * `/terminal/<space>/?arg=…` that the app reverse-proxies to that member's port. null if unknown.
    */
   async attachUrl(sessionId: string): Promise<string | null> {
-    const r = this.db.prepare('SELECT tmux, spawned_by FROM term_sessions WHERE id = ?').get<{ tmux: string; spawned_by: string | null }>(sessionId);
+    const r = this.db.prepare('SELECT tmux, spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ tmux: string; spawned_by: string | null; run_as: string | null }>(sessionId);
     if (!r) return null;
-    return this.backend.attachUrl(this.spaceFor(r.spawned_by), r.tmux);
+    return this.backend.attachUrl(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
   }
 
   /**
@@ -272,12 +299,15 @@ export class TerminalManager {
     return this.backend.ttydPortFor(space) ?? null;
   }
 
-  /** Resolve a session's `spawned_by` to a console-friendly label: member name/email, or automation. */
-  private spawnedByLabel(spawnedBy: string | null): string | undefined {
-    if (!spawnedBy) return undefined;
+  /** Resolve a session's provenance (+ run-as) to a console-friendly label: member name/email, or
+   *  automation — and "Automation · X · as Alice" when it ran as a resolved member. */
+  private spawnedByLabel(spawnedBy: string | null, runAs?: string | null): string | undefined {
+    const asMember = runAs ? this.os.team.getMember(runAs) : undefined;
+    const asSuffix = asMember && asMember.id !== spawnedBy ? ` · as ${asMember.name || asMember.email}` : '';
+    if (!spawnedBy) return asMember ? `as ${asMember.name || asMember.email}` : undefined;
     if (spawnedBy.startsWith('automation:')) {
       const auto = this.db.prepare('SELECT name FROM automations WHERE id = ?').get<{ name: string }>(spawnedBy.slice('automation:'.length));
-      return auto ? `Automation · ${auto.name}` : 'Automation';
+      return `${auto ? `Automation · ${auto.name}` : 'Automation'}${asSuffix}`;
     }
     const m = this.os.team.getMember(spawnedBy);
     return m ? m.name || m.email : spawnedBy;
@@ -300,7 +330,7 @@ export class TerminalManager {
       .prepare(
         `SELECT m.*, a.status AS approval_status, a.reason AS approval_reason, a.resolved_by AS approval_resolved_by,
                 q.status AS question_status, q.answer AS question_answer, q.answered_by AS question_answered_by,
-                ts.spawned_by AS session_spawned_by
+                ts.spawned_by AS session_spawned_by, ts.run_as AS session_run_as
          FROM messages m
          LEFT JOIN approvals a ON m.approval_id = a.id
          LEFT JOIN questions q ON m.question_id = q.id
@@ -309,7 +339,7 @@ export class TerminalManager {
          ORDER BY m.created_at DESC`,
       )
       .all<MessageRow>();
-    const visible = viewer ? rows.filter((r) => this.canViewSpawn(r.session_spawned_by ?? null, viewer)) : rows;
+    const visible = viewer ? rows.filter((r) => this.canViewRow(r.session_spawned_by ?? null, r.session_run_as ?? null, viewer)) : rows;
     return visible.map(toMessage);
   }
 
@@ -321,16 +351,16 @@ export class TerminalManager {
   dismissMessage(id: string, viewer: Member): 'ok' | 'not_found' | 'forbidden' | 'pending' {
     const row = this.db
       .prepare(
-        `SELECT m.type, a.status AS approval_status, q.status AS question_status, ts.spawned_by AS session_spawned_by
+        `SELECT m.type, a.status AS approval_status, q.status AS question_status, ts.spawned_by AS session_spawned_by, ts.run_as AS session_run_as
          FROM messages m
          LEFT JOIN approvals a ON m.approval_id = a.id
          LEFT JOIN questions q ON m.question_id = q.id
          LEFT JOIN term_sessions ts ON m.session_id = ts.id
          WHERE m.id = ?`,
       )
-      .get<{ type: FeedMessage['type']; approval_status: string | null; question_status: string | null; session_spawned_by: string | null }>(id);
+      .get<{ type: FeedMessage['type']; approval_status: string | null; question_status: string | null; session_spawned_by: string | null; session_run_as: string | null }>(id);
     if (!row) return 'not_found';
-    if (!this.canViewSpawn(row.session_spawned_by ?? null, viewer)) return 'forbidden';
+    if (!this.canViewRow(row.session_spawned_by ?? null, row.session_run_as ?? null, viewer)) return 'forbidden';
     const stillWaiting =
       (row.type === 'approval' && (row.approval_status ?? 'pending') === 'pending') ||
       (row.type === 'question' && (row.question_status ?? 'pending') === 'pending');
@@ -345,16 +375,24 @@ export class TerminalManager {
    * the automations pile-up guard releases. Interactive (the default, e.g. manual spawns) opens a
    * normal attachable TUI that stays live until closed.
    */
-  createSession(agent: string, title: string, task: string, spawnedBy?: string, headless = false, slack?: { channel: string; threadTs: string }): Session {
+  createSession(agent: string, title: string, task: string, spawnedBy?: string, headless = false, slack?: { channel: string; threadTs: string }, discord?: { channel: string; messageId: string }, runAs?: string): Session {
     const id = randomUUID().slice(0, 8);
     const tmux = `aos-${id}`;
+    // P2 — provenance vs identity:
+    //   `spawnedBy`     = what TRIGGERED this run (an `automation:<id>` or the console member). Stays
+    //                     provenance: drives the inbox source label, the audit principal, isolation
+    //                     fallback, and the automation-creator's visibility.
+    //   `actingMember`  = whose IDENTITY the agent acts under (connectors / Composio / inbox / uid).
+    //                     `runAs` when a trigger resolved a member, else the console member who spawned.
+    // When no runAs is given this collapses to today's behavior (identity = the spawning member).
+    const actingMember = runAs ?? (spawnedBy && !spawnedBy.startsWith('automation:') ? spawnedBy : undefined);
     // Per-session bearer (0d): exported into the session env and required on the loopback agent
     // endpoints, so one session's runtime can't gate/recall/report AS another by forging its id.
     const secret = randomBytes(24).toString('hex');
     const session: Session = { id, agent, title, task, tmux, status: 'running', createdAt: Date.now() };
     this.db
-      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, secret, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
-      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, secret, session.createdAt);
+      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, session.createdAt);
     this.addMessage({ type: 'task', sessionId: id, agent, title: `(New Session) ${agent}`, body: task, status: 'open', source: spawnedBy });
 
     // Native Slack egress: bind this session to the channel/thread it should reply into, so the
@@ -363,12 +401,19 @@ export class TerminalManager {
       this.db.prepare('INSERT OR REPLACE INTO slack_threads (session_id, channel, thread_ts, created_at) VALUES (?, ?, ?, ?)')
         .run(id, slack.channel, slack.threadTs || '', Date.now());
     }
+    // Native Discord egress: the exact analogue — bind the channel + triggering message for discord_reply.
+    if (discord?.channel) {
+      this.db.prepare('INSERT OR REPLACE INTO discord_threads (session_id, channel, message_id, created_at) VALUES (?, ?, ?, ?)')
+        .run(id, discord.channel, discord.messageId || '', Date.now());
+    }
 
     // Pick the runtime from the agent's manifest: claude-code → real claude in its folder;
     // anything else (incl. unknown/demo names) → the scripted mock runner.
     const manifest = this.os.agents.get(agent);
     const runtime = manifest?.runtime ?? 'mock';
-    this.audit(id, agent, 'session.created', { tmux, task, runtime, dir: manifest?.dir, headless });
+    // Audit records BOTH provenance and the run-as principal — when they differ (a trigger acting as
+    // a member), the trail shows what fired it AND whose identity it used.
+    this.audit(id, agent, 'session.created', { tmux, task, runtime, dir: manifest?.dir, headless, spawnedBy: spawnedBy ?? null, runAs: actingMember ?? null });
 
     if (runtime === 'claude-code' && manifest?.dir) {
       // Real claude in the agent's own folder, governed by the gate hook. Memory and connectors
@@ -377,7 +422,7 @@ export class TerminalManager {
       // agent's own decision, guided by its CLAUDE.md and the tools' own descriptions.
       const env = this.sessionEnv(id, agent, task, secret);
       // Build the per-session connector + company payloads once (Composio is minted here).
-      const mcpJson = this.buildMcpConfigJson(id, agent, spawnedBy, secret, !!slack?.channel);
+      const mcpJson = this.buildMcpConfigJson(id, agent, actingMember, secret, !!slack?.channel, !!discord?.channel);
       const companyMd = this.buildCompanyMd();
       this.materializeSkills(id, agent, manifest.dir);
       if (headless) env.HEADLESS = '1';
@@ -399,7 +444,7 @@ export class TerminalManager {
         // Flag on: the launcher writes the files INTO the member's home (member-readable), copies the
         // agent dir to a per-member working copy (AGENT_DIR override), and sets MCP_CONFIG/COMPANY_FILE/
         // LOG_DIR itself — the app dir is unreadable/unwritable by the member uid.
-        this.backend.spawn(this.spaceFor(spawnedBy), { sessionId: id, agent, tmuxName: tmux, env, argv: ['bash', this.launcher], files: { mcp: mcpJson || undefined, company: companyMd || undefined }, agentSrc: manifest.dir });
+        this.backend.spawn(this.spaceFor(actingMember ?? spawnedBy), { sessionId: id, agent, tmuxName: tmux, env, argv: ['bash', this.launcher], files: { mcp: mcpJson || undefined, company: companyMd || undefined }, agentSrc: manifest.dir });
       } else {
         // Flag off: materialise into the app's connectors dir (the session runs as the app uid, so it
         // can read them), set the env, and persist the launch context so the ttyd attach wrapper can
@@ -410,10 +455,10 @@ export class TerminalManager {
         if (companyFile) env.COMPANY_FILE = companyFile;
         if (headless) env.LOG_DIR = this.os.paths?.connectors ?? '/tmp';
         if (!headless) this.writeEnvFile(id, env);
-        this.backend.spawn(this.spaceFor(spawnedBy), { sessionId: id, agent, tmuxName: tmux, env, argv: ['bash', this.launcher] });
+        this.backend.spawn(this.spaceFor(actingMember ?? spawnedBy), { sessionId: id, agent, tmuxName: tmux, env, argv: ['bash', this.launcher] });
       }
     } else {
-      this.backend.spawn(this.spaceFor(spawnedBy), { sessionId: id, agent, tmuxName: tmux, env: this.sessionEnv(id, agent, task, secret), argv: ['bash', this.runner] });
+      this.backend.spawn(this.spaceFor(actingMember ?? spawnedBy), { sessionId: id, agent, tmuxName: tmux, env: this.sessionEnv(id, agent, task, secret), argv: ['bash', this.runner] });
     }
     return session;
   }
@@ -511,11 +556,11 @@ export class TerminalManager {
    * session can read it: the app's connectors dir (local), or the member's home (launcher). The
    * memory server is ALWAYS included and scoped to this session+agent. '' when there's no data home.
    */
-  private buildMcpConfigJson(sessionId: string, agent: string, spawnedBy: string | undefined, secret: string, slackReply = false): string {
+  private buildMcpConfigJson(sessionId: string, agent: string, actingMember: string | undefined, secret: string, slackReply = false, discordReply = false): string {
     if (!this.os.paths) return '';
-    // Resolve the spawning HUMAN, if any: automation/system spawns (`automation:<id>`) have no member,
-    // so they bind to org connectors only — never a person's personal credentials.
-    const memberId = spawnedBy && !spawnedBy.startsWith('automation:') ? spawnedBy : undefined;
+    // `actingMember` is the identity the session runs AS (runAs ?? the spawning member). Undefined for a
+    // pure automation/system spawn → org + shared connectors only, never a person's private credentials.
+    const memberId = actingMember;
     const config = this.os.connectors.mcpConfig(memberId);
 
     // Composio (egress) is driven by the workspace key in Settings → Integrations — NOT by connector
@@ -528,7 +573,7 @@ export class TerminalManager {
       // → apps connected under the shared service entity, usable by every agent. Automation/system spawns
       // get only the company entity (no person's personal credentials).
       const sessions = [{ id: 'composio-company', userId: serviceUserId(this.os.tenant), scope: 'company' }];
-      if (memberId) sessions.unshift({ id: 'composio', userId: this.composioUserId(spawnedBy, agent), scope: 'personal' });
+      if (memberId) sessions.unshift({ id: 'composio', userId: this.composioUserId(memberId, agent), scope: 'personal' });
       for (const s of sessions) {
         const res = mintToolRouterSession(apiKey, s.userId);
         if ('url' in res) {
@@ -545,9 +590,10 @@ export class TerminalManager {
     config.mcpServers.agentos = {
       command: 'node',
       args: [this.memoryMcp],
-      // SLACK_REPLY: '1' makes the agentos server expose the native `slack_reply` tool — only for
-      // Slack-triggered sessions (which have a bound thread), so other agents aren't cluttered by it.
-      env: { AOS_URL: this.baseUrl, AOS_TENANT: this.os.tenant, SESSION: sessionId, AGENT: agent, AOS_SECRET: secret, ...(slackReply ? { SLACK_REPLY: '1' } : {}) },
+      // SLACK_REPLY / DISCORD_REPLY: '1' makes the agentos server expose the native `slack_reply` /
+      // `discord_reply` tool — only for chat-triggered sessions (which have a bound thread/channel),
+      // so other agents aren't cluttered by it.
+      env: { AOS_URL: this.baseUrl, AOS_TENANT: this.os.tenant, SESSION: sessionId, AGENT: agent, AOS_SECRET: secret, ...(slackReply ? { SLACK_REPLY: '1' } : {}), ...(discordReply ? { DISCORD_REPLY: '1' } : {}) },
     };
     return JSON.stringify(config, null, 2);
   }
@@ -557,9 +603,9 @@ export class TerminalManager {
    * sees exactly the apps that member connected on composio.dev. An automation/system spawn has no
    * member, so we fall back to a stable per-agent id (consistent across that agent's runs).
    */
-  private composioUserId(spawnedBy: string | undefined, agent: string): string {
-    if (spawnedBy && !spawnedBy.startsWith('automation:')) {
-      const email = this.os.team.getMember(spawnedBy)?.email;
+  private composioUserId(memberId: string | undefined, agent: string): string {
+    if (memberId) {
+      const email = this.os.team.getMember(memberId)?.email;
       if (email) return email;
     }
     return `agent-os:${this.os.tenant}:${agent}`;
@@ -600,8 +646,10 @@ export class TerminalManager {
     this.addMessage({ type: 'update', sessionId, agent: s.agent, title: `Task Update (${s.agent})`, body, status: 'open' });
   }
 
-  /** The gate. Same policy brain as the console — green allows, risky → inbox approval + block. */
-  gate(sessionId: string, agent: string, capability: string, args: Record<string, unknown>, reasoning: string): GateResult {
+  /** The gate. Same policy brain as the console — allow flows, ask → inbox approval (auto-cleared for
+   *  an attended approver), never → deny. Args are enriched into facts first (the single classifier). */
+  gate(sessionId: string, agent: string, capability: string, rawArgs: Record<string, unknown>, reasoning: string): GateResult {
+    const args = enrichArgs(capability, rawArgs);
     const attempt: ActionAttempt = { capabilityId: capability, args, reasoning };
     const decision: Decision = this.os.policy.classify(attempt, this.ctx(sessionId, agent));
     this.audit(sessionId, agent, 'gate.attempt', { capability, args, reasoning });
@@ -609,6 +657,15 @@ export class TerminalManager {
 
     if (decision.effect === 'allow') return { decision: 'allow' };
     if (decision.effect === 'deny') return { decision: 'deny' };
+
+    // Context-aware `ask` (governance P5): if an attended human who can approve this level started the
+    // run, clear it without a self-addressed card — audited as auto-approved. The never tier (deny)
+    // already returned above, so this can never auto-clear an irreversible action.
+    const approver = this.attendedApprover(sessionId, decision.level);
+    if (approver) {
+      this.audit(sessionId, agent, 'approval.auto_approved', { capability, level: decision.level, by: approver.email, reason: decision.reason });
+      return { decision: 'allow' };
+    }
 
     const { req, decision: settle } = this.os.approvals.request({
       runId: sessionId,
@@ -630,6 +687,8 @@ export class TerminalManager {
       level: decision.level,
     });
     this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability });
+    // Out-of-band ping (Slack/Discord DM to whoever can approve) — best-effort, never blocks the gate.
+    try { this.approvalNotifier?.({ sessionId, agent, capability, level: decision.level, reason: decision.reason }); } catch { /* notifications are advisory */ }
 
     // The message + gate status are derived from the approvals table at read time, so all this
     // waiter has to do is leave an audit trail. (It won't fire across a restart — that's fine.)
@@ -645,7 +704,22 @@ export class TerminalManager {
    * string — classify falls back to the ruleset's defaultRisk for ones with no matching rule.
    */
   policyCheck(sessionId: string, agent: string, capability: string, args: Record<string, unknown>): Decision {
-    return this.os.policy.classify({ capabilityId: capability, args, reasoning: '' }, this.ctx(sessionId, agent));
+    return this.os.policy.classify({ capabilityId: capability, args: enrichArgs(capability, args), reasoning: '' }, this.ctx(sessionId, agent));
+  }
+
+  /**
+   * The attended approver for the `ask` tier, or null. A run is "attended" when a human member (not an
+   * `automation:`) started it; if that member already holds approval authority for `level`, their own
+   * recoverable actions clear without a self-addressed card (governance P5). Automation-fired and
+   * member-can't-approve runs return null → the normal human approval flow.
+   */
+  private attendedApprover(sessionId: string, level: ApprovalLevel): Member | null {
+    const r = this.db.prepare('SELECT spawned_by FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null }>(sessionId);
+    const sb = r?.spawned_by;
+    if (!sb || sb.startsWith('automation:')) return null; // unattended / automation → always ask
+    const m = this.os.team.getMember(sb);
+    const role: Role | undefined = m?.role;
+    return m && autoClearsApproval(level, { initiatorRole: role, attended: true }) ? m : null;
   }
 
   /** Gate status for the PreToolUse hook — derived from the approval's live row. */
@@ -712,7 +786,10 @@ export class TerminalManager {
     if (!agent) return { ok: false, error: 'unknown session' };
     const manifest = this.os.agents.get(agent);
     if (!manifest?.dir) return { ok: false, error: 'agent has no working folder' };
-    const source = this.db.prepare('SELECT spawned_by FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null }>(sessionId)?.spawned_by ?? undefined;
+    // Provenance for the gallery's per-member visibility: the member the session acted as (so they see
+    // their own deliverable), falling back to the trigger provenance for pure automation runs.
+    const srow = this.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(sessionId);
+    const source = srow?.run_as ?? srow?.spawned_by ?? undefined;
     const title = (input.title || '').trim() || path.basename(input.path);
     const r = this.os.artifacts.publish({
       sessionId, agent, source, title, description: input.description,
@@ -799,9 +876,9 @@ export class TerminalManager {
    * Emits a 'completed'/stopped card so the inbox reflects the interruption. No-op on unknown id.
    */
   stopSession(sessionId: string, by: string): boolean {
-    const r = this.db.prepare('SELECT agent, tmux, status, spawned_by FROM term_sessions WHERE id = ?').get<{ agent: string; tmux: string; status: string; spawned_by: string | null }>(sessionId);
+    const r = this.db.prepare('SELECT agent, tmux, status, spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ agent: string; tmux: string; status: string; spawned_by: string | null; run_as: string | null }>(sessionId);
     if (!r) return false;
-    this.backend.kill(this.spaceFor(r.spawned_by), r.tmux);
+    this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
     if (r.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'idle' WHERE id = ?").run(sessionId);
     // Halting kills the tmux shell, so the launcher's /api/ended never fires — capture the episode
     // here instead, BEFORE the 'Stopped' card so it summarises the work done (audit stream) rather
@@ -820,9 +897,9 @@ export class TerminalManager {
    * system-of-record) is preserved — a `session.deleted` event is appended. No-op on unknown id.
    */
   deleteSession(sessionId: string, by: string): boolean {
-    const r = this.db.prepare('SELECT agent, tmux, spawned_by FROM term_sessions WHERE id = ?').get<{ agent: string; tmux: string; spawned_by: string | null }>(sessionId);
+    const r = this.db.prepare('SELECT agent, tmux, spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ agent: string; tmux: string; spawned_by: string | null; run_as: string | null }>(sessionId);
     if (!r) return false;
-    this.backend.kill(this.spaceFor(r.spawned_by), r.tmux);
+    this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
     this.removeSessionFiles(sessionId);
     this.db.prepare('DELETE FROM messages WHERE session_id = ?').run(sessionId);
     this.db.prepare('DELETE FROM questions WHERE run_id = ?').run(sessionId);

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -3,8 +3,8 @@
 #
 # Wire this in a session's settings.json (see terminal/claude-settings.json) so a REAL
 # `claude` agent running in tmux is governed by Agent OS: before every tool call, Claude
-# runs this hook. We classify the call; green → exit 0 (allow); risky → create an inbox
-# approval and BLOCK here until a human decides, then exit 0 (allow) or 2 (deny).
+# runs this hook. The server decides: allow → exit 0; ask → create an inbox approval and
+# BLOCK here until a human decides (then exit 0/2); never → exit 2 (denied outright).
 #
 # Contract: PreToolUse hook reads a JSON event on stdin; exit 0 lets the tool run, exit 2
 # blocks it (reason on stderr is shown to Claude).
@@ -13,7 +13,11 @@
 set -u
 EVENT=$(cat)
 
-read -r TOOL CMD <<<"$(printf '%s' "$EVENT" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const e=JSON.parse(d||"{}");const t=e.tool_name||"";const i=e.tool_input||{};const cmd=(i.command||i.file_path||i.url||"").toString().replace(/\s+/g," ");console.log(t+" "+cmd)})')"
+# This hook is now DUMB TRANSPORT (governance PR #2): it only routes the tool to a capability and ships
+# the FULL tool_input to the server, which enriches it into facts (case-insensitive, argument-aware —
+# it sees the SQL inside db_query/execute_php, the dollar amount, the delete count) and classifies.
+# Tab-separated so the JSON input survives `read` on one line (JSON.stringify escapes tabs/newlines).
+IFS=$'\t' read -r TOOL INPUT <<<"$(printf '%s' "$EVENT" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const e=JSON.parse(d||"{}");process.stdout.write((e.tool_name||"")+"\t"+JSON.stringify(e.tool_input||{}))})')"
 
 # The OS-owned tools (memory recall/remember, ask/report, policy preview) are internal and never
 # touch the outside world, so they bypass the gate entirely.
@@ -21,51 +25,18 @@ case "$TOOL" in
   mcp__agentos__*) exit 0 ;;
 esac
 
-# Classify the attempt into an Agent OS capability + two flags the policy routes on:
-#   risky       → mutation that needs human approval (yellow/red)
-#   destructive → IRREVERSIBLE op that the never-tier denies outright (drop db, delete site, rm -rf…)
-# Matching is case-INSENSITIVE (SQL/flags are written in any case): `drop database` must catch `DROP`.
-# NOTE: we only see the Bash command string and the MCP tool NAME here — not MCP call arguments, so
-# destructive SQL passed *inside* a tool like db_query/execute_php is not yet caught. That argument-aware
-# classification is the server-side enricher (governance PR #2); this hook is the first, name/command cut.
-RISKY=false
-DESTRUCTIVE=false
-shopt -s nocasematch 2>/dev/null || true
+# Route the tool to an Agent OS capability (structural — the only thing the hook still decides). All
+# riskiness/destructiveness classification now happens server-side in the enricher + policy.
 case "$TOOL" in
-  Bash)
-    CAP="shell.exec"
-    case "$CMD" in
-      *"drop database"*|*"drop table"*|*"drop schema"*|*truncate*|*"rm -rf"*|*"rm -fr"*|*"rm -r "*|*mkfs*|*"dd if="*|*"dd of="*|*"terraform destroy"*|*"kubectl delete"*|*"git push --force"*|*"git push -f"*) DESTRUCTIVE=true ;;
-    esac
-    case "$CMD" in
-      *stripe*|*refund*|*" rm "*|*deploy*|*prod*|*drop*|*delete*|*kubectl*|*systemctl*|*shutdown*) RISKY=true ;;
-    esac
-    ;;
-  mcp__*)
-    # A connector tool (Slack / GitHub / Composio / …). We can't see inside the call, so we classify
-    # by the tool NAME: mutation verbs (create/send/update/delete/…) are writes → need approval; the
-    # rest (get/list/search/read/…) are reads → auto-allow. Composio names tools like SLACK_SEND_MESSAGE.
-    CAP="connector.call"
-    UPPER=$(printf '%s' "$TOOL" | tr '[:lower:]' '[:upper:]')
-    # Irreversible by name: deleting a whole site or dropping a database → never tier.
-    case "$UPPER" in
-      *DELETE_SITE*|*DROP_DATABASE*|*DROP_TABLE*|*DROP_SCHEMA*) DESTRUCTIVE=true ;;
-    esac
-    case "$UPPER" in
-      *CREATE*|*SEND*|*UPDATE*|*DELETE*|*REMOVE*|*WRITE*|*POST*|*PUT*|*PATCH*|*MERGE*|*PUBLISH*|*UPLOAD*|*DEPLOY*|*PAY*|*REFUND*|*ARCHIVE*|*INVITE*|*EXECUTE*) RISKY=true ;;
-    esac
-    # Managing/reconnecting a COMPANY-wide connection (the composio-company entity) grants the whole
-    # fleet access to an app — an owner/admin decision. Route it to approval so a non-admin's agent
-    # run can't silently wire or replace company-wide access. (Personal-entity connects stay as-is.)
-    case "$TOOL" in
-      mcp__composio-company__*MANAGE_CONNECTION*|mcp__composio-company__*INITIATE_CONNECTION*) CAP="connector.connect"; RISKY=true ;;
-    esac
-    ;;
+  Bash) CAP="shell.exec" ;;
+  mcp__composio-company__*MANAGE_CONNECTION*|mcp__composio-company__*INITIATE_CONNECTION*)
+    # Managing a COMPANY-wide connection grants the whole fleet access to an app — an owner/admin call.
+    CAP="connector.connect" ;;
+  mcp__*) CAP="connector.call" ;;
   *) exit 0 ;;  # any other built-in tool (Read/Glob/Grep/…) isn't a world side effect → allow
 esac
-shopt -u nocasematch 2>/dev/null || true
 
-payload=$(node -e 'const[s,a,cap,t,c,r,d]=process.argv.slice(1);console.log(JSON.stringify({sessionId:s,agent:a,capability:cap,args:{tool:t,command:c,risky:r==="true",destructive:d==="true"},reasoning:"claude PreToolUse: "+t+(c?" "+c:"")}))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$CMD" "$RISKY" "$DESTRUCTIVE")
+payload=$(node -e 'const[s,a,cap,t,inp]=process.argv.slice(1);let input={};try{input=JSON.parse(inp||"{}")}catch(e){};console.log(JSON.stringify({sessionId:s,agent:a,capability:cap,args:{tool:t,input},reasoning:"claude PreToolUse: "+t}))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$INPUT")
 
 # FAIL-CLOSED classify. Retry the gate until it returns a usable decision; a transient failure (server
 # restart, network blip, the documented stale-server 401/404 window) must NEVER fall through to "allow".

--- a/test/governance/conformance.json
+++ b/test/governance/conformance.json
@@ -1,0 +1,42 @@
+{
+  "_about": "Golden governance fixture: the single source of truth for what the gate decides. `decisions` feed enrichArgs() → JsonPolicyEngine.classify() (the brain tm.gate uses); `context` feed autoClearsApproval(). Run with `node scripts/governance-conformance.cjs` (exits non-zero on any mismatch). Add a case here before changing the enricher or the default policy.",
+  "thresholdsDefault": { "moneyCapUsd": 500, "bulkDeleteCount": 25 },
+
+  "decisions": [
+    { "name": "bash read is allowed", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "ls -la /var/www" } }, "expect": "allow" },
+    { "name": "bash deploy needs owner", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "npm run deploy:prod" } }, "expect": "ask:owner" },
+    { "name": "rm -rf data is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "rm -rf /var/lib/data" } }, "expect": "never" },
+    { "name": "lowercase drop database is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "psql -c \"drop database production\"" } }, "expect": "never" },
+    { "name": "TRUNCATE is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "mysql -e 'TRUNCATE TABLE users'" } }, "expect": "never" },
+    { "name": "delete from with no where is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "psql -c \"delete from sessions\"" } }, "expect": "never" },
+    { "name": "delete from with where is just risky", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "psql -c \"delete from sessions where id=1\"" } }, "expect": "ask:owner" },
+    { "name": "terraform destroy is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "terraform destroy -auto-approve" } }, "expect": "never" },
+    { "name": "force push is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "git push --force origin main" } }, "expect": "never" },
+
+    { "name": "connector read is allowed", "capability": "connector.call", "args": { "tool": "mcp__instawp__list_sites", "input": {} }, "expect": "allow" },
+    { "name": "connector send needs approval", "capability": "connector.call", "args": { "tool": "mcp__slack__SLACK_SEND_MESSAGE", "input": { "text": "hi" } }, "expect": "ask:head" },
+    { "name": "delete_site is never (by name)", "capability": "connector.call", "args": { "tool": "mcp__instawp__delete_site", "input": { "site_id": 5 } }, "expect": "never" },
+    { "name": "db_query DROP TABLE is never (argument-aware — the closed hole)", "capability": "connector.call", "args": { "tool": "mcp__instawp__db_query", "input": { "sql": "DROP TABLE wp_posts" } }, "expect": "never" },
+    { "name": "execute_php with rm -rf is never", "capability": "connector.call", "args": { "tool": "mcp__site__execute_php", "input": { "code": "shell_exec('rm -rf /var/www')" } }, "expect": "never" },
+    { "name": "db_query SELECT is just a read-ish call", "capability": "connector.call", "args": { "tool": "mcp__instawp__db_query", "input": { "sql": "SELECT * FROM wp_posts LIMIT 10" } }, "expect": "allow" },
+
+    { "name": "refund under cap → approval", "capability": "connector.call", "args": { "tool": "mcp__stripe__REFUND_CHARGE", "input": { "amount": 200 } }, "expect": "ask:head" },
+    { "name": "refund over cap → never", "capability": "connector.call", "args": { "tool": "mcp__stripe__REFUND_CHARGE", "input": { "amount": 600 } }, "expect": "never" },
+    { "name": "explicit amount_usd over cap → never", "capability": "connector.call", "args": { "tool": "mcp__billing__charge_customer", "input": { "amount_usd": 1000 } }, "expect": "never" },
+
+    { "name": "bulk delete over cap → never", "capability": "connector.call", "args": { "tool": "mcp__instawp__delete_content", "input": { "ids": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26] } }, "expect": "never" },
+    { "name": "small delete under cap → approval", "capability": "connector.call", "args": { "tool": "mcp__instawp__delete_content", "input": { "ids": [1,2,3] } }, "expect": "ask:head" },
+
+    { "name": "company connection management → owner", "capability": "connector.connect", "args": { "tool": "mcp__composio-company__GMAIL_MANAGE_CONNECTION", "input": {} }, "expect": "ask:owner" }
+  ],
+
+  "context": [
+    { "name": "owner attended clears head", "level": "head", "ctx": { "initiatorRole": "owner", "attended": true }, "expectAutoClear": true },
+    { "name": "admin attended clears head", "level": "head", "ctx": { "initiatorRole": "admin", "attended": true }, "expectAutoClear": true },
+    { "name": "owner attended clears owner", "level": "owner", "ctx": { "initiatorRole": "owner", "attended": true }, "expectAutoClear": true },
+    { "name": "admin attended CANNOT clear owner", "level": "owner", "ctx": { "initiatorRole": "admin", "attended": true }, "expectAutoClear": false },
+    { "name": "member attended cannot clear head", "level": "head", "ctx": { "initiatorRole": "member", "attended": true }, "expectAutoClear": false },
+    { "name": "owner UNattended (automation) cannot clear", "level": "head", "ctx": { "initiatorRole": "owner", "attended": false }, "expectAutoClear": false },
+    { "name": "no initiator role cannot clear", "level": "head", "ctx": { "initiatorRole": null, "attended": true }, "expectAutoClear": false }
+  ]
+}


### PR DESCRIPTION
Builds on the never tier (#1) with the two structural pieces from `docs/governance-model.md`.

## PR #2 — the enricher (P3: split classifier from policy)
- **`src/governance/enricher.ts`** — `enrichArgs()` turns a raw tool call into the facts the policy reads (`destructive` / `risky` / `amountUsd` / `deleteCount`), **case-insensitive** and **argument-aware**. Closes the `db_query`/`execute_php` hole: `DROP TABLE` *inside* a tool call is now seen and denied; also `DELETE` without `WHERE`, `rm -rf`, `terraform destroy`, force-push, etc. Numeric facts are deliberately conservative — a miss falls back to the approval path; it never fabricates a fact and denies legitimate work.
- **`terminal/gate-hook.sh`** — now **dumb transport**: ships `{ tool, input }` (the full `tool_input`) and routes the capability; all riskiness/destructiveness classification moved server-side.
- **`terminal.ts`** — `gate()` / `policyCheck()` enrich args before `classify` (one classifier).

## PR #3 — context-aware `ask` + conformance (P5 + P4)
- **`autoClearsApproval()`** + **`attendedApprover()`** — an `ask`-tier approval auto-clears (no self-addressed card) only when the run is **attended** (a human, not an automation, started it) **and** that human can approve the level. Initiator resolved from `term_sessions.spawned_by` → member role; `gate()` audits `approval.auto_approved`. The never tier is decided before approval, so it can **never** auto-clear.
- **`test/governance/conformance.json`** + **`scripts/governance-conformance.cjs`** (`npm run test:governance`) — a golden `(call → decision)` + `(approval context → auto-clear?)` table driving the exact functions the live gate uses. 28/28. The structural fix for the "two brains" gap — the gate-hook path is now one pinned brain.

## Verification
`npm run typecheck` · `npm run build` · **`npm run test:governance` (28/28)** · `npm run demo` · plus an in-process integration test of `gate()` across owner/admin/member/automation initiators (owner & admin attended auto-clear; member & automation pend; `DROP` and over-cap refund deny **even for the owner**).

## Scope
- The mock `gateway.ts` demo path still classifies without the enricher — folding it in is the remaining "one brain everywhere" step (status table in the doc, marked 🟡).
- `terminal.ts` carries some pre-existing working-tree edits that predated the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)