### PR TITLE
ci: scope triggers to main pushes + all PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ name: CI
 # live gate must satisfy. The runner needs dist/, so we build first.
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:


### PR DESCRIPTION
Tightens the CI triggers: `on: push` now filters to `branches: [main]`, and `pull_request` (unfiltered) covers all PRs.

Result: branch work is validated via its PR rather than on every intermediate push, and merges to `main` still run. No change to the job itself (typecheck → build → governance conformance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)