### PR TITLE
governance: route gateway.ts through the enricher (one brain everywhere)

### DIFF
--- a/docs/governance-model.md
+++ b/docs/governance-model.md
@@ -160,7 +160,7 @@ audit-at-every-step, idempotency, and an initiator signal (`term_sessions.spawne
 | Owner asked to approve their own attended agent | P1 + P5 | ✅ PR #3 — `autoClearsApproval` clears the `ask` tier for an attended owner/admin, fenced out of the never tier |
 | Classification by tool *name* — `db_query`/`execute_php` args unseen | P3 classifier split | ✅ PR #2 — `src/governance/enricher.ts` inspects arguments (the SQL inside the call, the amount, the count) |
 | Case-sensitive substring matching in the shell | P3 + P4 | ✅ PR #2 — classification moved off bash into the deterministic, case-insensitive enricher |
-| Two decision paths (`gateway.ts` vs `gate-hook.sh`) | P4 one chokepoint | 🟡 the live gate-hook path is now one brain (`enrich → classify → context`, pinned by the conformance suite); the mock `gateway.ts` demo path still classifies without the enricher — fold it in next |
+| Two decision paths (`gateway.ts` vs `gate-hook.sh`) | P4 one chokepoint | ✅ both paths now classify over `enrichArgs` — one brain everywhere, pinned by the conformance suite. (The gateway enriches for the decision only; execution/idempotency/audit keep the original args.) |
 | `*) exit 0` fail-open fallback | P4 fail-closed | ✅ PR #1 — retries until the gate answers; never falls through to allow |
 | Agents hold the same creds regardless of environment | P2 defense in depth | ⬜ open — least privilege / environment-scoped identity (future) |
 
@@ -169,8 +169,8 @@ The brain is now testable and pinned: **`test/governance/conformance.json`** is 
 (`npm run test:governance`) drives the exact functions the live gate uses and fails CI on any drift.
 Add a case there before changing the enricher or the default policy.
 
-What remains is genuinely additive: route `gateway.ts` through the enricher too (one brain everywhere),
-environment-scoped least privilege (P2), hash-chained audit, and the kill switch — none a rewrite.
+What remains is genuinely additive: environment-scoped least privilege (P2), hash-chained audit, and
+the kill switch — none a rewrite.
 
 ---
 

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -31,6 +31,7 @@ import {
 } from '../types';
 import { CapabilityRegistry } from '../capabilities/registry';
 import { stableHash } from './idempotency';
+import { enrichArgs } from '../governance/enricher';
 
 export interface GatewayDeps {
   registry: CapabilityRegistry;
@@ -62,8 +63,10 @@ export class Gateway {
       return { ok: false, error: `unknown capability: ${attempt.capabilityId}` };
     }
 
-    // 1. POLICY
-    const decision = this.deps.policy.classify(attempt, ctx);
+    // 1. POLICY — classify over ENRICHED facts (destructive/risky/amountUsd/deleteCount), the same
+    // classifier the live gate-hook path uses, so there is one decision brain everywhere. Enrichment
+    // feeds the decision only; execution, idempotency and audit below use the original attempt.args.
+    const decision = this.deps.policy.classify({ ...attempt, args: enrichArgs(attempt.capabilityId, attempt.args) }, ctx);
     emit('policy.decision', { capability: cap.id, decision, policy: this.deps.policy.id });
     if (decision.effect === 'deny') {
       return { ok: false, error: `denied by policy: ${decision.reason}` };


### PR DESCRIPTION
Closes the last "two brains" gap (P4 in `docs/governance-model.md`). The mock/demo `gateway.ts` path now classifies over `enrichArgs()` — the same brain the live gate-hook path uses.

- Enrichment feeds the **decision only**; execution, idempotency and audit keep the original `attempt.args`.
- **Behavior-preserving** for the demo (stripe.refund 49→yellow / 5000→red, prod.*→deny, echo→allow — all unchanged), since the demo policy matches on capability + explicit args. The effect: the never-tier facts (`destructive`/`amountUsd`/`deleteCount`) now apply on this path too if the active policy uses them.
- Conformance 28/28; docs status table row updated 🟡 → ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)