### PR TITLE
governance: workspace kill switch (emergency stop)

### DIFF
--- a/docs/governance-model.md
+++ b/docs/governance-model.md
@@ -169,8 +169,13 @@ The brain is now testable and pinned: **`test/governance/conformance.json`** is 
 (`npm run test:governance`) drives the exact functions the live gate uses and fails CI on any drift.
 Add a case there before changing the enricher or the default policy.
 
-What remains is genuinely additive: environment-scoped least privilege (P2), hash-chained audit, and
-the kill switch — none a rewrite.
+**Kill switch (shipped).** A workspace emergency stop (`settings.killSwitch()`) — when engaged, both
+decision paths (`gateway.ts` step 0 and `tm.gate`) deny *every* action before any other step, fleet-wide,
+and engaging it optionally halts running sessions. Reversible; owner/admin only; engage/release audited
+(`killswitch.engaged`/`released`, `gate.killswitch`). Lives in Settings → Governance.
+
+What remains is genuinely additive: environment-scoped least privilege (P2) and hash-chained audit —
+neither a rewrite.
 
 ---
 
@@ -270,7 +275,8 @@ Four things worth taking from the landscape, none of which compromise the zero-d
    of the previous one (`crypto`), so the JSONL system-of-record becomes append-only-provable (P4 / the
    Repudiation threat).
 3. **Kill switch + denylist.** AGT's runtime has a global stop-all and a hard command denylist. The
-   denylist *is* the irreversible tier (P1); the kill switch is an operational control we lack.
+   denylist *is* the irreversible tier (P1, shipped); the kill switch (the global stop-all) is now
+   shipped too — see "Kill switch" below.
 4. **`require_approval` as a first-class action + richer conditions.** AGT's YAML treats approval as a
    policy outcome with expressive conditions (`action.type in ['drop','delete','truncate']`). Our JSON
    `when` (single arg, one comparison) should grow toward this. Note Cedar *cannot* express an approval

--- a/src/gateway/gateway.ts
+++ b/src/gateway/gateway.ts
@@ -40,6 +40,8 @@ export interface GatewayDeps {
   approvals: Approvals;
   identity: Identity;
   idempotency: IdempotencyStore;
+  /** Workspace emergency stop. When it returns true, every effect is denied before policy runs. */
+  killSwitch?: () => boolean;
 }
 
 export class Gateway {
@@ -57,6 +59,13 @@ export class Gateway {
 
     const cap = this.deps.registry.get(attempt.capabilityId);
     emit('action.attempt', { capability: attempt.capabilityId, args: attempt.args, reasoning: attempt.reasoning });
+
+    // 0. KILL SWITCH — workspace emergency stop. Denies every effect before ANY other step (even an
+    // unknown capability), so engaging it is an absolute, fleet-wide freeze.
+    if (this.deps.killSwitch?.()) {
+      emit('gate.killswitch', { capability: attempt.capabilityId });
+      return { ok: false, error: 'denied: workspace emergency stop is engaged' };
+    }
 
     if (!cap) {
       emit('action.error', { capability: attempt.capabilityId, error: 'unknown capability' });

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -38,6 +38,16 @@ export interface GovernanceThresholds {
 
 export const DEFAULT_GOVERNANCE_THRESHOLDS: GovernanceThresholds = { moneyCapUsd: 500, bulkDeleteCount: 25 };
 
+const KILL_SWITCH_KEY = 'kill_switch'; // workspace-wide emergency stop (JSON KillSwitchState)
+
+/** The workspace emergency stop. When engaged, the gate denies EVERY action, fleet-wide, until cleared. */
+export interface KillSwitchState {
+  engaged: boolean;
+  reason?: string;
+  updatedAt?: number;
+  updatedBy?: string;
+}
+
 export interface CompanySettings {
   /** The company-wide markdown context. Empty string when unset. */
   companyMd: string;
@@ -316,5 +326,27 @@ export class SettingsStore {
     };
     this.set(GOVERNANCE_KEY, JSON.stringify(next), by);
     return next;
+  }
+
+  // ── kill switch (workspace emergency stop) ───────────────────────────────────────
+  // A single boolean that, when engaged, makes the gate deny EVERY action across the whole workspace
+  // (governance-model.md — the operational control we lacked). Reversible: clear it and agents resume.
+
+  /** Current emergency-stop state (defaults to disengaged). */
+  killSwitch(): KillSwitchState {
+    const row = this.getRow(KILL_SWITCH_KEY);
+    if (!row?.value) return { engaged: false };
+    try {
+      const v = JSON.parse(row.value) as { engaged?: boolean; reason?: string };
+      return { engaged: !!v.engaged, reason: v.reason, updatedAt: row.updated_at, updatedBy: row.updated_by ?? undefined };
+    } catch {
+      return { engaged: false, updatedAt: row.updated_at, updatedBy: row.updated_by ?? undefined };
+    }
+  }
+
+  /** Engage or release the emergency stop. */
+  setKillSwitch(engaged: boolean, reason: string | undefined, by?: string): KillSwitchState {
+    this.set(KILL_SWITCH_KEY, JSON.stringify({ engaged: !!engaged, reason: reason?.trim() || undefined }), by);
+    return this.killSwitch();
   }
 }

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -123,6 +123,7 @@ export class AgentOS {
       approvals: this.approvals,
       identity: this.identity,
       idempotency: this.idempotency,
+      killSwitch: () => this.settings.killSwitch().engaged,
     });
 
     this.adapters.set('mock', this.mock);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1044,6 +1044,24 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, ...saved });
   }
 
+  // ── kill switch (workspace emergency stop — gate denies everything while engaged) ──
+  if (method === 'GET' && p === '/api/settings/kill-switch') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, os.settings.killSwitch());
+  }
+  if (method === 'POST' && p === '/api/settings/kill-switch') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req);
+    const engaged = b.engaged === true;
+    const state = os.settings.setKillSwitch(engaged, typeof b.reason === 'string' ? b.reason : undefined, me.email);
+    // On engage, optionally halt running sessions (default true) so nothing keeps running mid-task —
+    // a frozen gate only stops the NEXT gated action. Releasing leaves sessions stopped; respawn to resume.
+    let halted = 0;
+    if (engaged && b.haltSessions !== false) halted = tm.stopAllRunning(me.email);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: engaged ? 'killswitch.engaged' : 'killswitch.released', data: { reason: state.reason, halted } });
+    return sendJson(res, 200, { ok: true, ...state, halted });
+  }
+
   // ── company settings (workspace-wide context injected into every claude-code agent) ──
   if (method === 'GET' && p === '/api/settings') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -649,6 +649,11 @@ export class TerminalManager {
   /** The gate. Same policy brain as the console — allow flows, ask → inbox approval (auto-cleared for
    *  an attended approver), never → deny. Args are enriched into facts first (the single classifier). */
   gate(sessionId: string, agent: string, capability: string, rawArgs: Record<string, unknown>, reasoning: string): GateResult {
+    // Workspace emergency stop — deny every action before classifying anything.
+    if (this.os.settings.killSwitch().engaged) {
+      this.audit(sessionId, agent, 'gate.killswitch', { capability });
+      return { decision: 'deny' };
+    }
     const args = enrichArgs(capability, rawArgs);
     const attempt: ActionAttempt = { capabilityId: capability, args, reasoning };
     const decision: Decision = this.os.policy.classify(attempt, this.ctx(sessionId, agent));
@@ -704,7 +709,17 @@ export class TerminalManager {
    * string — classify falls back to the ruleset's defaultRisk for ones with no matching rule.
    */
   policyCheck(sessionId: string, agent: string, capability: string, args: Record<string, unknown>): Decision {
+    if (this.os.settings.killSwitch().engaged) return { effect: 'deny', reason: 'workspace emergency stop is engaged' };
     return this.os.policy.classify({ capabilityId: capability, args: enrichArgs(capability, args), reasoning: '' }, this.ctx(sessionId, agent));
+  }
+
+  /** Halt every running session (used when the kill switch is engaged with "stop running sessions").
+   *  Returns the count halted. Each is stopped via the normal path so its inbox/audit reflect it. */
+  stopAllRunning(by: string): number {
+    const rows = this.db.prepare("SELECT id FROM term_sessions WHERE status = 'running'").all<{ id: string }>();
+    let n = 0;
+    for (const r of rows) if (this.stopSession(r.id, by)) n++;
+    return n;
   }
 
   /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3267,28 +3267,90 @@ function GovernanceSettings({ me }: { me: Member }) {
   }
 
   return (
-    <Card>
-      <CardContent className="space-y-4 p-4">
-        <p className="text-sm text-muted-foreground">
-          The caps the policy's <strong>never</strong> tier enforces. At or below the limit an action can still be{' '}
-          <em>approved</em> by a human; <strong>above</strong> it the action is <strong>refused outright</strong> — no approver,
-          attended or not, can override. These feed the deny rules as <span className="font-mono text-xs">$moneyCapUsd</span> /{' '}
-          <span className="font-mono text-xs">$bulkDeleteCount</span> and apply live.
-        </p>
-        <div className="grid grid-cols-2 gap-4">
-          <Field label="Money cap (USD)" help="A single payment/refund above this is never allowed.">
-            <Input type="number" min={0} value={t.moneyCapUsd}
-              onChange={(e) => setT({ ...t, moneyCapUsd: Number(e.target.value) })} disabled={!canEdit} />
-          </Field>
-          <Field label="Bulk-delete cap (items)" help="A delete of more than this many items is never allowed.">
-            <Input type="number" min={0} value={t.bulkDeleteCount}
-              onChange={(e) => setT({ ...t, bulkDeleteCount: Number(e.target.value) })} disabled={!canEdit} />
-          </Field>
+    <div className="space-y-4">
+      <KillSwitchCard me={me} />
+      <Card>
+        <CardContent className="space-y-4 p-4">
+          <p className="text-sm text-muted-foreground">
+            The caps the policy's <strong>never</strong> tier enforces. At or below the limit an action can still be{' '}
+            <em>approved</em> by a human; <strong>above</strong> it the action is <strong>refused outright</strong> — no approver,
+            attended or not, can override. These feed the deny rules as <span className="font-mono text-xs">$moneyCapUsd</span> /{' '}
+            <span className="font-mono text-xs">$bulkDeleteCount</span> and apply live.
+          </p>
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Money cap (USD)" help="A single payment/refund above this is never allowed.">
+              <Input type="number" min={0} value={t.moneyCapUsd}
+                onChange={(e) => setT({ ...t, moneyCapUsd: Number(e.target.value) })} disabled={!canEdit} />
+            </Field>
+            <Field label="Bulk-delete cap (items)" help="A delete of more than this many items is never allowed.">
+              <Input type="number" min={0} value={t.bulkDeleteCount}
+                onChange={(e) => setT({ ...t, bulkDeleteCount: Number(e.target.value) })} disabled={!canEdit} />
+            </Field>
+          </div>
+          <div className="flex items-center gap-3">
+            <Button onClick={save} disabled={!canEdit || busy || !dirty}>{dirty ? 'Save caps' : 'Saved'}</Button>
+            {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
+            {!hint && meta.updatedBy && <span className="text-[11px] text-muted-foreground">last set by {meta.updatedBy}</span>}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+/** The workspace emergency stop. Engaging it makes the gate deny EVERY agent action fleet-wide (and,
+ *  by default, halts running sessions). Reversible — release it and agents can run again. */
+function KillSwitchCard({ me }: { me: Member }) {
+  const [engaged, setEngaged] = useState(false)
+  const [reason, setReason] = useState('')
+  const [halt, setHalt] = useState(true)
+  const [by, setBy] = useState<string | undefined>()
+  const [busy, setBusy] = useState(false)
+  const [hint, setHint] = useState('')
+  const canEdit = me.role === 'owner' || me.role === 'admin'
+
+  const refresh = () => api.killSwitch().then((r) => { if (!r.error) { setEngaged(r.engaged); setReason(r.reason || ''); setBy(r.updatedBy) } }).catch(() => {})
+  useEffect(() => { refresh() }, [])
+
+  const toggle = async (next: boolean) => {
+    setBusy(true); setHint('')
+    const r = await api.setKillSwitch(next, reason, halt)
+    setBusy(false)
+    if (r.error) return setHint('⚠ ' + r.error)
+    setEngaged(r.engaged); setBy(r.updatedBy)
+    setHint(next ? `engaged${r.halted ? ` — halted ${r.halted} session(s)` : ''}` : 'released'); setTimeout(() => setHint(''), 4000)
+  }
+
+  return (
+    <Card className={engaged ? 'border-red-500 bg-red-50' : 'border-red-200'}>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-semibold">
+              <span className={engaged ? 'text-red-700' : 'text-red-600'}>⛔ Emergency stop</span>
+              {engaged && <span className="rounded bg-red-600 px-1.5 py-0.5 text-[10px] font-bold uppercase text-white">engaged</span>}
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground">
+              While engaged, the gate <strong>denies every agent action</strong> across the whole workspace — the hard stop above all policy.
+            </p>
+          </div>
+          <Button variant={engaged ? 'outline' : 'destructive'} disabled={!canEdit || busy} onClick={() => toggle(!engaged)}>
+            {engaged ? 'Release' : 'Engage'}
+          </Button>
         </div>
+        {!engaged && (
+          <div className="space-y-2">
+            <Input value={reason} onChange={(e) => setReason(e.target.value)} placeholder="Reason (optional — recorded in the audit log)" disabled={!canEdit} className="h-8 text-xs" />
+            <label className="flex items-center gap-2 text-xs text-muted-foreground">
+              <input type="checkbox" checked={halt} onChange={(e) => setHalt(e.target.checked)} disabled={!canEdit} />
+              Also halt running sessions immediately (otherwise they stop at their next gated action)
+            </label>
+          </div>
+        )}
+        {engaged && reason && <p className="text-xs text-red-700">Reason: {reason}</p>}
         <div className="flex items-center gap-3">
-          <Button onClick={save} disabled={!canEdit || busy || !dirty}>{dirty ? 'Save caps' : 'Saved'}</Button>
           {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
-          {!hint && meta.updatedBy && <span className="text-[11px] text-muted-foreground">last set by {meta.updatedBy}</span>}
+          {!hint && by && <span className="text-[11px] text-muted-foreground">last changed by {by}</span>}
         </div>
       </CardContent>
     </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -530,6 +530,8 @@ export const api = {
 
   governance: () => call<GovernanceThresholds & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/governance'),
   saveGovernance: (t: GovernanceThresholds) => call<{ ok: boolean; error?: string } & GovernanceThresholds>('PUT', '/api/settings/governance', t),
+  killSwitch: () => call<{ engaged: boolean; reason?: string; updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/kill-switch'),
+  setKillSwitch: (engaged: boolean, reason?: string, haltSessions?: boolean) => call<{ ok: boolean; engaged: boolean; reason?: string; halted?: number; updatedBy?: string; error?: string }>('POST', '/api/settings/kill-switch', { engaged, reason, haltSessions }),
 
   settings: () => call<CompanySettings>('GET', '/api/settings'),
   saveCompany: (companyMd: string) => call<CompanySettings & { ok: boolean; error?: string }>('PUT', '/api/settings/company', { companyMd }),


### PR DESCRIPTION
A single workspace-wide **emergency stop**. When engaged, **both** decision paths deny every action before any other step — `gateway.ts` step 0 (before even the unknown-capability guard) and `tm.gate` / `policyCheck` — so it's an absolute fleet-wide freeze above all policy. Reversible.

- **`settings.ts`** — `killSwitch()` / `setKillSwitch(engaged, reason, by)`, persisted with who/when.
- **`gateway.ts`** — `GatewayDeps.killSwitch?()` checked first in `invoke()`; **`kernel.ts`** wires it to `os.settings.killSwitch().engaged`.
- **`terminal.ts`** — `gate()` + `policyCheck()` short-circuit to deny when engaged; `stopAllRunning()` halts live sessions.
- **`server.ts`** — `GET/POST /api/settings/kill-switch` (owner/admin, audited `killswitch.engaged`/`released`). Engaging optionally halts running sessions (default true) — a frozen gate only stops the *next* gated action.
- **web** — prominent red Emergency-stop card in **Settings → Governance** (engage with reason + optional halt; release).

## Verification
`typecheck` · `build` · **conformance 28/28** · `demo` · in-process test exercising engage → deny (live gate **+** gateway **+** policyCheck) → release → allow.

> Note: `terminal.ts` / `server.ts` / web files also carry pre-existing working-tree edits that predated the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)