### PR TITLE
Agents: on-demand rescan of the agents folder

### DIFF
--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -182,6 +182,42 @@ export class AgentOS {
   deregisterAgent(id: string): boolean {
     return this.agents.delete(id);
   }
+  /**
+   * Re-scan the agent folders on disk and sync the live registry — the on-demand counterpart of
+   * the boot scan, for agents dropped into `<home>/agents/` outside the console (git pull, scp,
+   * an agent writing a sibling) while the server runs. Disk is the source of truth: new folders
+   * register, changed manifests re-register, and disk-loaded agents whose folder vanished
+   * deregister. Programmatic registrations (no `dir` — demo/tests) are left alone. Removal here
+   * is registry-only — assignments and memories are kept so a folder restored later (git revert)
+   * comes back intact; full cleanup stays with the delete route.
+   */
+  rescanAgents(): AgentRescanResult {
+    const added: string[] = [], updated: string[] = [], removed: string[] = [];
+    const errors: { folder: string; error: string }[] = [];
+    if (!this.paths) return { added, updated, removed, errors };
+    // Same precedence as boot: bundled examples first, then the user's agents (user wins by id).
+    const onDisk = new Map<string, AgentManifest>();
+    for (const dir of [this.paths.bundledAgents, this.paths.userAgents]) {
+      for (const found of scanAgentDir(dir)) {
+        if (found.manifest) onDisk.set(found.manifest.id, found.manifest);
+        else errors.push({ folder: found.folder, error: found.error! });
+      }
+    }
+    for (const [id, manifest] of onDisk) {
+      const current = this.agents.get(id);
+      if (!current) added.push(id);
+      else if (JSON.stringify(current) !== JSON.stringify(manifest)) updated.push(id);
+      else continue;
+      this.agents.set(id, manifest);
+    }
+    for (const [id, current] of this.agents) {
+      if (current.dir && !onDisk.has(id)) {
+        this.agents.delete(id);
+        removed.push(id);
+      }
+    }
+    return { added, updated, removed, errors };
+  }
   registerMockBehavior(agentId: string, behavior: MockBehavior): this {
     this.mock.register(agentId, behavior);
     return this;
@@ -260,15 +296,48 @@ export function loadAgentOS(
 
 /** Register every `<dir>/<id>/agent.json` found, tagging each manifest with its absolute folder. */
 function loadAgentsFrom(os: AgentOS, dir: string): void {
-  if (!fs.existsSync(dir)) return;
+  for (const found of scanAgentDir(dir)) {
+    if (found.manifest) os.registerAgent(found.manifest);
+    else console.error(`[agents] skipping ${found.folder}: ${found.error}`);
+  }
+}
+
+/** What one rescan changed in the live registry (ids), plus folders whose manifest didn't parse. */
+export interface AgentRescanResult {
+  added: string[];
+  updated: string[];
+  removed: string[];
+  errors: { folder: string; error: string }[];
+}
+
+/** One agent folder found on disk: its manifest (tagged with the folder), or why it didn't load. */
+interface ScannedAgent {
+  folder: string;
+  manifest?: AgentManifest;
+  error?: string;
+}
+
+/**
+ * Scan `<dir>/<id>/agent.json` folders. A malformed or id-less manifest is reported, not thrown —
+ * one broken folder must never take down boot or a rescan alongside healthy agents.
+ */
+function scanAgentDir(dir: string): ScannedAgent[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: ScannedAgent[] = [];
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
     const folder = path.join(dir, entry.name);
     const manifestPath = path.join(folder, 'agent.json');
     if (!fs.existsSync(manifestPath)) continue;
-    const manifest = readJson<AgentManifest>(manifestPath);
-    os.registerAgent({ ...manifest, dir: folder });
+    try {
+      const manifest = readJson<AgentManifest>(manifestPath);
+      if (!manifest || typeof manifest.id !== 'string' || !manifest.id) throw new Error('manifest has no "id"');
+      out.push({ folder, manifest: { ...manifest, dir: folder } });
+    } catch (e) {
+      out.push({ folder, error: e instanceof Error ? e.message : String(e) });
+    }
   }
+  return out;
 }
 
 function readJson<T>(p: string): T {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1327,6 +1327,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, id });
   }
 
+  // ── rescan the agent folders: pick up agents added/edited/removed on disk outside the console
+  //    (git pull, scp, an agent writing a sibling) without a restart — owner/admin only. Removal
+  //    here is registry-only (assignments + memories kept, in case the folder comes back); the
+  //    DELETE route below stays the full-cleanup path.
+  if (method === 'POST' && p === '/api/agents/rescan') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (!os.paths) return sendJson(res, 400, { error: 'rescanning agents requires a data home' });
+    const diff = os.rescanAgents();
+    if (diff.added.length || diff.updated.length || diff.removed.length) {
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agents.rescanned', data: { added: diff.added, updated: diff.updated, removed: diff.removed } });
+    }
+    return sendJson(res, 200, { ok: true, ...diff });
+  }
+
   // ── delete a user-created agent: deregister + remove its folder — owner/admin only ──
   //    Only agents that live UNDER the data home can be deleted; the bundled examples that
   //    ship with the software are read-only (they'd reappear on restart anyway).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, Search, BookText, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, Search, BookText, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -34,6 +34,12 @@ const statusDot = (s: Session): string =>
 /** The status word shown next to the dot. A live pane whose stored status is a terminal state (a
  *  `done` interactive session still running) reads "live" so the label never contradicts a green dot. */
 const statusLabel = (s: Session): string => (isLive(s) && s.status !== 'running' ? 'live' : s.status)
+
+/** A stopped/ended/crashed interactive session that can be resurrected in place: re-opening its
+ *  terminal runs `claude --resume` (via terminal/attach.sh), picking the conversation back up. Shown
+ *  as a Resume affordance. Requires a persisted launch env (`resumable`) and no live pane — a live
+ *  session is just "open", not "resume". */
+const canResume = (s: Session): boolean => Boolean(s.resumable) && !isLive(s)
 
 const ROLE_LABEL: Record<Role, string> = { owner: 'owner', admin: 'admin', member: 'member' }
 
@@ -183,6 +189,19 @@ function Console({ me }: { me: Member }) {
   const openAgent = (id: string) => {
     setEditAgent(id)
     nav('agent')
+  }
+  // Sync the registry with the agents folder on disk — picks up folders added/edited/removed
+  // outside the console (git pull, scp, another agent) without a server restart.
+  const rescanAgents = async () => {
+    const r = await api.rescanAgents()
+    if (r.error) { alert(r.error); return }
+    await refreshState()
+    const parts: string[] = []
+    if (r.added.length) parts.push(`Added: ${r.added.join(', ')}`)
+    if (r.updated.length) parts.push(`Updated: ${r.updated.join(', ')}`)
+    if (r.removed.length) parts.push(`Removed: ${r.removed.join(', ')}`)
+    if (r.errors.length) parts.push(`Skipped (bad agent.json): ${r.errors.map((e) => e.folder).join(', ')}`)
+    alert(parts.length ? parts.join('\n') : 'No changes — the agents folder already matches.')
   }
   const openTerminal = (tmux: string, title: string) => {
     setSelected({ tmux, title })
@@ -388,7 +407,7 @@ function Console({ me }: { me: Member }) {
         </div>
 
         <div className={`min-h-0 flex-1 ${fullBleed ? '' : 'overflow-y-auto p-6'}`}>
-          {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} />}
+          {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onRescan={rescanAgents} />}
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); openAgent(id) }} />}
           {route === 'sessions' && <SessionsPage sessions={sessions} waiting={waiting} selected={selected} onOpen={openTerminal} onSpawn={() => nav('agents')} onClose={() => setSelected(null)} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} />}
@@ -429,7 +448,7 @@ function NavItem({ icon, label, active, badge, onClick }: { icon: ReactNode; lab
  *  Settings (CLAUDE.md + runtime), delete it, or create a new one — all the catalog actions,
  *  just scoped to the chosen agent instead of a grid of cards. */
 function AgentsPage({
-  me, agents, run, onEdit, onNew, onDelete,
+  me, agents, run, onEdit, onNew, onDelete, onRescan,
 }: {
   me: Member
   agents: AgentInfo[]
@@ -437,8 +456,11 @@ function AgentsPage({
   onEdit: (id: string) => void
   onNew: () => void
   onDelete: (id: string) => void
+  onRescan: () => Promise<void>
 }) {
   const canEdit = me.role === 'owner' || me.role === 'admin'
+  const [rescanning, setRescanning] = useState(false)
+  const rescan = async () => { setRescanning(true); try { await onRescan() } finally { setRescanning(false) } }
   const [agentId, setAgentId] = useState('')
   const [task, setTask] = useState('')
   const [hint, setHint] = useState('')
@@ -466,7 +488,14 @@ function AgentsPage({
     return (
       <div className="flex min-h-full flex-col items-center justify-center gap-3 text-center">
         <p className="text-sm text-muted-foreground">{canEdit ? 'No agents yet — create one to get started.' : 'No agents assigned to you.'}</p>
-        {canEdit && <Button size="sm" className="gap-1" onClick={onNew}><Plus className="h-4 w-4" /> New agent</Button>}
+        {canEdit && (
+          <div className="flex items-center gap-2">
+            <Button size="sm" className="gap-1" onClick={onNew}><Plus className="h-4 w-4" /> New agent</Button>
+            <Button size="sm" variant="outline" className="gap-1" onClick={rescan} disabled={rescanning} title="pick up agents added to the agents folder on disk">
+              <RefreshCw className={'h-4 w-4' + (rescanning ? ' animate-spin' : '')} /> Rescan folder
+            </Button>
+          </div>
+        )}
       </div>
     )
   }
@@ -508,6 +537,11 @@ function AgentsPage({
               {canEdit && (
                 <Button size="icon" variant="ghost" className="h-9 w-9 shrink-0 text-muted-foreground" onClick={onNew} title="new agent">
                   <Plus className="h-4 w-4" />
+                </Button>
+              )}
+              {canEdit && (
+                <Button size="icon" variant="ghost" className="h-9 w-9 shrink-0 text-muted-foreground" onClick={rescan} disabled={rescanning} title="rescan the agents folder — pick up agents added on disk without a restart">
+                  <RefreshCw className={'h-4 w-4' + (rescanning ? ' animate-spin' : '')} />
                 </Button>
               )}
             </div>
@@ -799,8 +833,13 @@ function SessionsPage({
                   <span className="max-w-[180px] truncate">{s.title}</span>
                   {waiting.has(s.id) && <WaitingBell className="h-3 w-3" />}
                 </button>
-                {/* per-tab controls — stop (running only) + delete, revealed on hover or when active */}
+                {/* per-tab controls — resume (resumable + not live) / stop (running only) + delete, revealed on hover or when active */}
                 <span className={`flex items-center gap-1 ${selected.tmux === s.tmux ? '' : 'opacity-0 group-hover/tab:opacity-100'}`}>
+                  {canResume(s) && (
+                    <button className="rounded p-0.5 text-emerald-400 hover:bg-neutral-600 hover:text-emerald-300" onClick={() => onOpen(s.tmux, s.agent + ' · ' + s.id)} title="resume — reopen and continue this session (claude --resume)">
+                      <Play className="h-3 w-3" />
+                    </button>
+                  )}
                   {isLive(s) && (
                     <button className="rounded p-0.5 text-amber-400 hover:bg-neutral-600 hover:text-amber-300" onClick={() => onStop(s.id)} title="stop — kill this session's shell">
                       <Square className="h-3 w-3" />
@@ -888,6 +927,11 @@ function SessionsPage({
                 <div className="mt-1"><StartedBy label={s.spawnedByLabel} /></div>
               </button>
               <div className="mt-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                {canResume(s) && (
+                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-emerald-600" onClick={() => onOpen(s.tmux, s.agent + ' · ' + s.id)} title="reopen and continue this session (claude --resume)">
+                    <Play className="h-3 w-3" /> Resume
+                  </Button>
+                )}
                 {isLive(s) && (
                   <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-amber-600" onClick={() => onStop(s.id)} title="kill this session's shell">
                     <X className="h-3 w-3" /> Stop
@@ -921,6 +965,11 @@ function SessionsPage({
                 <span className="w-16 shrink-0 text-xs text-muted-foreground">{statusLabel(s)}</span>
               </button>
               <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+                {canResume(s) && (
+                  <Button size="icon" variant="ghost" className="h-7 w-7 text-emerald-600" onClick={() => onOpen(s.tmux, s.agent + ' · ' + s.id)} title="resume — reopen and continue this session (claude --resume)">
+                    <Play className="h-3.5 w-3.5" />
+                  </Button>
+                )}
                 {isLive(s) && (
                   <Button size="icon" variant="ghost" className="h-7 w-7 text-amber-600" onClick={() => onStop(s.id)} title="stop — kill this session's shell">
                     <Square className="h-3.5 w-3.5" />
@@ -3845,12 +3894,16 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
       </p>
       <Card>
         <CardContent className="space-y-3 p-4">
+          <div>
+            <div className="text-sm font-medium">Reflection <span className="text-[11px] font-normal text-muted-foreground">— cheap, deterministic, no LLM</span></div>
+            <p className="text-xs text-muted-foreground"><strong>Tallies</strong> recent episodes, outcomes and friction into the guidance injected into every agent, a shared insight, and the <a className="underline" href="#/kb">fleet-learnings</a> KB page. It summarises <em>what happened</em> — it doesn't read the episode text. Free and instant.</p>
+          </div>
           <div className="flex items-end gap-3">
             <Field label="Run automatically every (hours)" help="0 = off (manual only). The pass is cheap; daily (24) is a sensible default.">
               <Input value={everyHours} onChange={(e) => setEveryHours(e.target.value)} className="w-28 font-mono text-xs" placeholder="0" />
             </Field>
             <Button onClick={save} disabled={busy}>Save</Button>
-            <Button variant="outline" onClick={runNow} disabled={busy}><Sparkles className="mr-1 h-4 w-4" />Run now</Button>
+            <Button variant="outline" onClick={runNow} disabled={busy}><Sparkles className="mr-1 h-4 w-4" />Run reflection</Button>
             {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
           </div>
           <div className="text-[11px] text-muted-foreground">
@@ -3865,11 +3918,11 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
       <Card>
         <CardContent className="space-y-3 p-4">
           <div>
-            <div className="text-sm font-medium">Consolidate memory <span className="text-[11px] font-normal text-muted-foreground">— the memory gardener</span></div>
-            <p className="text-xs text-muted-foreground">Spawns a governed <strong>headless agent</strong> that reads the recent fleet <strong>episodes + lessons</strong> and distils the recurring, durable patterns into <strong>shared memories</strong> + <a className="underline" href="#/kb">Knowledge</a> pages every agent can recall. Unlike the reflection pass above, this spends a real agent run.</p>
+            <div className="text-sm font-medium">Consolidation <span className="text-[11px] font-normal text-muted-foreground">— the memory gardener (spends an agent run)</span></div>
+            <p className="text-xs text-muted-foreground">Spawns a governed <strong>headless agent</strong> that actually <strong>reads</strong> the recent fleet <strong>episodes + lessons</strong> and distils the recurring, durable patterns into <strong>new shared memories</strong> + <a className="underline" href="#/kb">Knowledge</a> pages every agent can recall. This <em>grows knowledge</em> (vs. reflection, which only summarises) — so it costs a real agent run.</p>
           </div>
           <div className="flex items-center gap-3">
-            <Button variant="outline" onClick={consolidateNow} disabled={busy}><Brain className="mr-1 h-4 w-4" />Consolidate now</Button>
+            <Button variant="outline" onClick={consolidateNow} disabled={busy}><Brain className="mr-1 h-4 w-4" />Consolidate knowledge</Button>
             <label className="flex items-center gap-2 text-sm">
               <input type="checkbox" checked={consolidateAuto} onChange={(e) => toggleConsolidate(e.target.checked)} />
               Auto-consolidate after each scheduled learning pass

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -71,6 +71,9 @@ export interface Session {
   /** True when the tmux pane is alive now, regardless of the stored lifecycle `status` (an interactive
    *  session that reported `done` keeps a live pane). Undefined when the server couldn't poll tmux. */
   alive?: boolean
+  /** True when this session can be resurrected in place via `claude --resume` on re-open (interactive
+   *  session with a persisted launch env). Headless runs are never resumable. */
+  resumable?: boolean
   spawnedBy?: string
   spawnedByLabel?: string
   createdAt: number
@@ -628,6 +631,7 @@ export const api = {
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[] } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),
+  rescanAgents: () => call<{ ok: boolean; added: string[]; updated: string[]; removed: string[]; errors: { folder: string; error: string }[]; error?: string }>('POST', '/api/agents/rescan'),
   agentClaude: (id: string) => call<{ agent: string; runtime: string; exists: boolean; content: string; error?: string }>('GET', `/api/agents/${encodeURIComponent(id)}/claude`),
   saveAgentClaude: (id: string, content: string) => call<{ ok: boolean; error?: string }>('PUT', `/api/agents/${encodeURIComponent(id)}/claude`, { content }),
   agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; category?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),


### PR DESCRIPTION
Agents dropped into `<home>/agents/` outside the console (git pull, scp, another agent writing a sibling) were invisible until a server restart — the boot scan in `loadAgentOS()` was the only time disk was read.

## What changed

- **kernel** — `AgentOS.rescanAgents()`: re-reads the bundled + user agent dirs with boot precedence and diffs against the live registry, returning `{added, updated, removed, errors}`. New folders register, changed manifests re-register, disk-loaded agents whose folder vanished deregister; dir-less programmatic registrations are untouched. Boot and rescan now share one `scanAgentDir()` scanner — a malformed `agent.json` skips that folder with a `console.error` instead of killing boot.
- **server** — `POST /api/agents/rescan` (owner/admin, data home required), audited as `agents.rescanned` when anything changed. Removal is registry-only — assignments and memories are kept in case the folder returns (git revert); full cleanup stays with `DELETE /api/agents/:id`.
- **console** — a rescan button next to the agent picker (and on the empty state) that reports the diff.

## Validation

- `npm run build`, `cd web && npm run build`, `npm run demo` all pass.
- In-process e2e against an isolated `AGENT_OS_HOME`: clean rescan no-ops; dropped folder → added; edited manifest → updated; broken sibling → reported without affecting healthy agents; deleted folder → removed; in-memory-only registration survives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9j1R2k1zz9MD35zxLynGP