### PR TITLE
Version system: package.json as source of truth, surfaced at /health, console, CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -295,6 +295,15 @@ in `src/types.ts` and `TeamStore.canRun()`.
   repeat `Host`/`X-Forwarded-*` explicitly — otherwise the app sees `Host: 127.0.0.1:3010` and mints
   wrong invite/webhook links. There's a comment in the config; keep it.
 
+## Versioning
+
+Root `package.json` `version` is the single source of truth (`src/version.ts` reads it once at
+boot). It surfaces at `GET /health`, `GET /api/state`, the console sidebar (next to the tenant
+name), and `agent-os version`. Pre-beta convention: bump the **minor** for each feature merge and
+the **patch** for fixes, in the same PR (`npm version <x.y.z> --no-git-tag-version` — never let npm
+tag; tags come later with releases). The sidebar version therefore tells you exactly which build a
+long-running server is holding in memory — the first thing to check when a change "isn't taking".
+
 ## Gotchas
 
 - `node:sqlite` emits an `ExperimentalWarning` on first use; `src/cli.ts` filters just that one line.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,6 +16,7 @@ import { loadAgentOS, readRootConfig } from './kernel';
 import { controlHome, resolveTenantPaths } from './home';
 import { TenantStore } from './state/control';
 import { Role } from './types';
+import { VERSION } from './version';
 
 // `node:sqlite` is stable enough to depend on but still emits an ExperimentalWarning on first
 // use. Swallow just that one line so the console output stays clean; surface every other warning.
@@ -60,6 +61,11 @@ async function main(): Promise<void> {
       startLauncherDaemon(rest);
       break;
     }
+    case 'version':
+    case '--version':
+    case '-v':
+      console.log(VERSION);
+      break;
     case 'help':
     case '--help':
     case '-h':
@@ -199,6 +205,7 @@ function usage(): void {
   tenant <sub>          multi-tenant admin: list | create <slug> --owner <email> | remove <slug>
   demo                  run the scripted governance demo in the terminal
   launcher [--socket=…] run the privileged per-member session launcher (root; Phase A)
+  version               print the software version (from package.json)
   help                  show this help
 
   PORT env var also sets the serve port; TTYD_PORT defaults to PORT+1.

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,6 +9,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import { AgentOS, loadAgentOS } from './kernel';
+import { VERSION } from './version';
 import { TenantRegistry, TenantRuntime } from './tenant-registry';
 import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
@@ -212,7 +213,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const idx = path.join(WEB_DIST, 'index.html');
     return sendFile(res, fs.existsSync(idx) ? idx : CONSOLE_HTML, 'text/html; charset=utf-8');
   }
-  if (method === 'GET' && p === '/health') return sendJson(res, 200, { ok: true, tenant: os.tenant, name: os.tenantName });
+  if (method === 'GET' && p === '/health') return sendJson(res, 200, { ok: true, tenant: os.tenant, name: os.tenantName, version: VERSION });
   // static assets from the built React app (web/dist)
   if (method === 'GET' && (p.startsWith('/assets/') || /\.(js|css|svg|png|ico|woff2?|json|map)$/.test(p))) {
     const file = path.join(WEB_DIST, p.replace(/^\/+/, ''));
@@ -755,6 +756,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, {
       tenant: os.tenant,
       tenantName: os.tenantName,
+      version: VERSION,
       policy: os.policy.id,
       home: os.paths?.home,
       me,

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,0 +1,17 @@
+/**
+ * The software version — single source of truth is the root package.json, read once at module
+ * load so `/health`, `/api/state`, the console sidebar and `agent-os version` all report the
+ * same build. Resolved relative to the compiled file (dist/version.js → ../package.json), with
+ * a fallback so a packaging oddity can never take down boot.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+export const VERSION: string = (() => {
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')) as { version?: string };
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+})();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -291,7 +291,7 @@ function Console({ me }: { me: Member }) {
           <div className="mb-4 flex items-start justify-between">
             <div className="min-w-0">
               <div className="flex items-center gap-2 text-[15px] font-semibold">⚙️ Agent OS</div>
-              {state && <div className="mt-0.5 truncate text-[11px] text-muted-foreground" title="tenant">{state.tenantName || state.tenant}</div>}
+              {state && <div className="mt-0.5 truncate text-[11px] text-muted-foreground" title={`tenant${state.version ? ` · Agent OS v${state.version}` : ''}`}>{state.tenantName || state.tenant}{state.version ? ` · v${state.version}` : ''}</div>}
             </div>
             <Button size="icon" variant="ghost" className="-mr-1 h-7 w-7 shrink-0 text-muted-foreground" title="collapse sidebar" onClick={() => setSidebarCollapsed(true)}>
               <PanelLeftClose className="h-4 w-4" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -46,6 +46,8 @@ export interface StateResp {
   tenant: string
   /** Human label for the tenant (branding); falls back to the tenant id server-side. */
   tenantName?: string
+  /** Software version (package.json), shown in the sidebar so a browser and the box can be compared. */
+  version?: string
   policy: string
   home?: string
   me: Member


### PR DESCRIPTION
Adds a lightweight version system, per the pre-beta convention now documented in CLAUDE.md.

## What changed

- **`src/version.ts`** — reads the root `package.json` version once at boot (fallback `0.0.0`, never throws).
- **Surfaced at**: `GET /health` (public), `GET /api/state`, the console sidebar (`<tenant> · v0.2.0`), and a new `agent-os version` CLI command.
- **Bump to 0.2.0** (agents rescan + versioning).
- **Convention** (CLAUDE.md → Versioning): minor per feature merge, patch per fix, bumped in the same PR with `npm version <x.y.z> --no-git-tag-version`. The sidebar version doubles as a stale-server detector — it shows exactly which build the long-running process holds in memory.

## Validation

`npm run build`, `npm run test:governance` (44/44), `cd web && npm run build`, and `node dist/cli.js version` → `0.2.0` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9j1R2k1zz9MD35zxLynGP