### PR TITLE
Add CHANGELOG.md, wire into the versioning convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+All notable changes to Agent OS are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow semver
+(pre-beta: minor per feature merge, patch per fix — see CLAUDE.md → Versioning).
+Every PR that bumps `package.json` moves its entries from **Unreleased** into a
+new version heading in the same commit.
+
+## [Unreleased]
+
+### Added
+- This changelog.
+
+## [0.2.0] — 2026-07-04
+
+### Added
+- **Agents rescan** (#9): `POST /api/agents/rescan` + a console button syncs the live
+  registry with the agents folder on disk — agents dropped in via git pull/scp/another
+  agent register without a server restart. Removal is registry-only (assignments and
+  memories are kept in case the folder returns); audited as `agents.rescanned`.
+- **Version system** (#10): root `package.json` is the single source of truth
+  (`src/version.ts`), surfaced at `GET /health`, `GET /api/state`, the console sidebar,
+  and `agent-os version`. The sidebar version doubles as a stale-server detector.
+
+### Changed
+- A malformed `agent.json` no longer aborts boot — the folder is skipped with a logged
+  error and every healthy agent still loads (#9).
+
+## [0.1.0] — 2026-07-03
+
+The pre-versioning baseline (2026-06-11 → 2026-07-03, PRs #1–#8): the governed gateway
+(policy / approvals / budget / identity / idempotency / audit) with fail-closed never-tier
+and gateway enricher; tmux-backed claude-code sessions behind the PreToolUse gate hook;
+the web console + JSON API + browser terminal; team/roles/magic-link login with the
+identity map; multi-tenant registry + process-per-tenant deploys; automations (cron /
+webhook / Composio / native Slack + Discord sockets) with the `/agent` chat router; the
+memory plane (recall/remember/revise/forget + consolidation), knowledge base, tasks
+queue, skills library, secrets vault, artifacts gallery; self-learning ("Dreaming") with
+the consolidation gardener; kill switch; governance-conformance CI (44 checks).
+
+[Unreleased]: https://github.com/vikasprogrammer/agent-os/compare/e5b2b81...HEAD
+[0.2.0]: https://github.com/vikasprogrammer/agent-os/pull/10
+[0.1.0]: https://github.com/vikasprogrammer/agent-os/commits/895bf26

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -301,8 +301,11 @@ Root `package.json` `version` is the single source of truth (`src/version.ts` re
 boot). It surfaces at `GET /health`, `GET /api/state`, the console sidebar (next to the tenant
 name), and `agent-os version`. Pre-beta convention: bump the **minor** for each feature merge and
 the **patch** for fixes, in the same PR (`npm version <x.y.z> --no-git-tag-version` — never let npm
-tag; tags come later with releases). The sidebar version therefore tells you exactly which build a
-long-running server is holding in memory — the first thing to check when a change "isn't taking".
+tag; tags come later with releases). Every feature/fix PR adds a line under **Unreleased** in
+`CHANGELOG.md` (Keep-a-Changelog style), and the PR that bumps the version moves those entries into
+a new version heading in the same commit. The sidebar version therefore tells you exactly which
+build a long-running server is holding in memory — the first thing to check when a change "isn't
+taking".
 
 ## Gotchas
 


### PR DESCRIPTION
Adds `CHANGELOG.md` in [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format, aligned with the semver convention from #10:

- **Unreleased** section collects entries as feature/fix PRs land; the PR that bumps `package.json` moves them into a new version heading in the same commit (now documented in CLAUDE.md → Versioning).
- Backfilled: **0.2.0** (agents rescan #9, version system #10) and the **0.1.0** pre-versioning baseline summarizing PRs #1–#8.

Docs-only — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9j1R2k1zz9MD35zxLynGP