### PR TITLE
Sessions: surface resumable flag — completes the console Resume affordance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.3.0] — 2026-07-04
+
 ### Added
-- This changelog.
+- This changelog (#11).
+- **Resumable sessions surfaced to the console**: session rows now carry `resumable`
+  (a persisted `session-<id>.env` exists, i.e. an interactive claude-code session the
+  ttyd attach wrapper can resurrect via `claude --resume`). Completes the loop for the
+  already-shipped console Resume button, which never appeared because the server didn't
+  send the flag. Headless automation runs correctly report `resumable: false`.
 
 ## [0.2.0] — 2026-07-04
 
@@ -38,6 +45,7 @@ memory plane (recall/remember/revise/forget + consolidation), knowledge base, ta
 queue, skills library, secrets vault, artifacts gallery; self-learning ("Dreaming") with
 the consolidation gardener; kill switch; governance-conformance CI (44 checks).
 
-[Unreleased]: https://github.com/vikasprogrammer/agent-os/compare/e5b2b81...HEAD
+[Unreleased]: https://github.com/vikasprogrammer/agent-os/compare/main...HEAD
+[0.3.0]: https://github.com/vikasprogrammer/agent-os/pull/12
 [0.2.0]: https://github.com/vikasprogrammer/agent-os/pull/10
 [0.1.0]: https://github.com/vikasprogrammer/agent-os/commits/895bf26

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -88,6 +88,14 @@ export interface Session {
    * (launcher backend, or the tmux poll failed): consumers then fall back to `status`.
    */
   alive?: boolean;
+  /**
+   * Whether this session can be resurrected in place via `claude --resume` when its terminal is
+   * re-opened (the ttyd attach wrapper sources its persisted `session-<id>.env`). True only for
+   * interactive claude-code sessions — headless automation runs write no env file, so they're never
+   * resumable. Independent of `status`: a running session is also "resumable", but the console only
+   * offers a Resume affordance once it's no longer live.
+   */
+  resumable?: boolean;
   /** Raw provenance: member id, or `automation:<id>` when a trigger spawned it. */
   spawnedBy?: string;
   /** Human-readable provenance for the console (member name/email, or the automation's name). */
@@ -274,11 +282,33 @@ export class TerminalManager {
       }
     }
     const visible = viewer ? rows.filter((r) => this.canViewRow(r.spawned_by, r.run_as, viewer)) : rows;
+    const resumable = this.resumableIds();
     return visible.map((r) => ({
       ...toSession(r),
       alive: alive ? alive.has(r.tmux) : undefined,
+      resumable: resumable.has(r.id),
       spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as),
     }));
+  }
+
+  /**
+   * Session ids that have a persisted launch env (`session-<id>.env`) — i.e. an interactive session
+   * the ttyd attach wrapper can resurrect via `claude --resume` (see `writeEnvFile`/`terminal/attach.sh`).
+   * Headless runs write no env file, so they're absent (and correctly report `resumable:false`). One
+   * readdir serves the whole list; no data home (demo/tests) → nothing resumable.
+   */
+  private resumableIds(): Set<string> {
+    const ids = new Set<string>();
+    if (!this.os.paths) return ids;
+    try {
+      for (const f of fs.readdirSync(this.os.paths.connectors)) {
+        const m = /^session-(.+)\.env$/.exec(f);
+        if (m) ids.add(m[1]);
+      }
+    } catch {
+      /* connectors dir may not exist yet — nothing resumable */
+    }
+    return ids;
   }
 
   /**


### PR DESCRIPTION
The console already ships `canResume()` and Resume buttons keyed on `Session.resumable`, but the server never sent the flag, so the affordance could never appear. This is the missing server half.

## What changed

- `TerminalManager.listSessions()` now sets `resumable` per row: true when the session's persisted launch env (`connectors/session-<id>.env`, written by `writeEnvFile` for interactive claude-code sessions) still exists — exactly the precondition for `terminal/attach.sh` to resurrect it via `claude --resume`. Headless automation runs write no env file and correctly report `false`. One `readdir` serves the whole list.
- Version bump **0.3.0**; Unreleased changelog entries folded into the new heading per the CLAUDE.md convention.

## Validation

- `npm run build`, `npm run test:governance` (44/44) pass.
- In-process e2e against an isolated `AGENT_OS_HOME`: two stopped session rows, one with a planted `session-<id>.env` → `resumable: true`, one without → `resumable: false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X9j1R2k1zz9MD35zxLynGP