### PR TITLE
In-app Docs: bundled product manual (0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.4.0] — 2026-07-04
+
+### Added
+- **In-app Docs** (#13): a bundled product manual — *What is Agent OS?*, *Getting started*,
+  *Core concepts*, *Working with agents*, *Governance & approvals*, *Memory/Knowledge/Tasks* —
+  at a new **Docs** sidebar route (one click away for every role, outside the Manage group).
+  Ships WITH the software (Markdown bundled via Vite `?raw`, versioned with the code), so it's
+  identical for every tenant — distinct from the per-tenant Knowledge base. Adding a page = drop
+  a `.md` in `web/src/docs` + one entry in its `index.ts`.
+
 ## [0.3.0] — 2026-07-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, Search, BookText, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -11,8 +11,9 @@ import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { api, EFFORTS, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta } from '@/lib/api'
 import { ConnectorsPage } from '@/connectors'
+import { docPages } from '@/docs'
 
-type Route = 'inbox' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'tasks' | 'memory' | 'kb' | 'skills' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent'
+type Route = 'inbox' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'tasks' | 'memory' | 'kb' | 'skills' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent' | 'docs'
 type Selected = { tmux: string; title: string } | null
 
 /** Mirror of the server rule: owner approves anything, admin approves head-level only. */
@@ -109,7 +110,7 @@ function TuningFields({ tuning, onChange, modelPlaceholder = 'inherit', inheritL
 function useHashRoute(): [Route, (r: Route) => void] {
   const parse = (): Route => {
     const h = window.location.hash.replace(/^#\/?/, '')
-    return h === 'sessions' || h === 'agents' || h === 'new-agent' || h === 'connectors' || h === 'team' || h === 'automations' || h === 'tasks' || h === 'memory' || h === 'kb' || h === 'skills' || h === 'files' || h === 'artifacts' || h === 'settings' || h === 'agent' ? h : 'inbox'
+    return h === 'sessions' || h === 'agents' || h === 'new-agent' || h === 'connectors' || h === 'team' || h === 'automations' || h === 'tasks' || h === 'memory' || h === 'kb' || h === 'skills' || h === 'files' || h === 'artifacts' || h === 'settings' || h === 'agent' || h === 'docs' ? h : 'inbox'
   }
   const [route, setRoute] = useState<Route>(parse())
   useEffect(() => {
@@ -379,6 +380,11 @@ function Console({ me }: { me: Member }) {
               )}
             </nav>
           )}
+          {/* Docs sits OUTSIDE the collapsible group: the product manual should stay one click away
+              for members even when Manage is collapsed (or hidden entirely for their role). */}
+          <nav className="mb-1 space-y-1">
+            <NavItem icon={<BookOpen className="h-4 w-4" />} label="Docs" active={route === 'docs'} onClick={() => nav('docs')} />
+          </nav>
 
           <Separator className="my-3" />
           <div className="flex items-center justify-between">
@@ -402,7 +408,7 @@ function Console({ me }: { me: Member }) {
       <main className="flex flex-1 flex-col overflow-hidden">
         <div className="flex items-center justify-between border-b px-6 py-4">
           <h1 className="text-lg font-semibold">
-            {route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connectors' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Artifacts' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
+            {route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connectors' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Artifacts' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'docs' ? 'Docs' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
           </h1>
         </div>
 
@@ -421,6 +427,7 @@ function Console({ me }: { me: Member }) {
           {route === 'files' && <FilesPage />}
           {route === 'artifacts' && <ArtifactsPage me={me} initialId={artifactFocus} />}
           {route === 'audit' && <AuditPage />}
+          {route === 'docs' && <DocsPage />}
           {route === 'settings' && <SettingsPage me={me} state={state} />}
           {route === 'agent' && editAgent && <AgentPage agentId={editAgent} agents={state?.agents ?? []} onSaved={refreshState} />}
         </div>
@@ -2552,6 +2559,32 @@ function KindChip({ on, onClick, children }: { on: boolean; onClick: () => void;
     >
       {children}
     </button>
+  )
+}
+
+/** Product manual bundled into the build (web/src/docs) — read-only, identical for every tenant,
+ *  unlike the KB, which is the tenant's own living wiki. Adding a page = drop a .md in web/src/docs
+ *  and register it in web/src/docs/index.ts. */
+function DocsPage() {
+  const [slug, setSlug] = useState(docPages[0].slug)
+  const sel = docPages.find((p) => p.slug === slug) ?? docPages[0]
+  return (
+    <div className="flex gap-4">
+      <div className="w-64 shrink-0 space-y-3">
+        <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">Manual</div>
+        <div className="space-y-0.5">
+          {docPages.map((p) => (
+            <button key={p.slug} onClick={() => setSlug(p.slug)} className={`block w-full truncate rounded px-2 py-1 text-left text-xs ${sel.slug === p.slug ? 'bg-primary/10 text-foreground' : 'text-muted-foreground hover:bg-muted/50'}`}>{p.title}</button>
+          ))}
+        </div>
+        <div className="text-[11px] leading-relaxed text-muted-foreground">
+          These docs ship with Agent OS. Your company's own pages live in <button className="text-primary underline" onClick={() => { window.location.hash = '/kb' }}>Knowledge</button>.
+        </div>
+      </div>
+      <div className="min-w-0 max-w-3xl flex-1">
+        <Card><CardContent className="p-6 text-sm"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{sel.body}</ReactMarkdown></CardContent></Card>
+      </div>
+    </div>
   )
 }
 

--- a/web/src/docs/core-concepts.md
+++ b/web/src/docs/core-concepts.md
@@ -1,0 +1,46 @@
+# Core concepts
+
+The vocabulary, and — most importantly — how to decide **what should be an agent vs. a skill**.
+
+## Agent — a *who*
+
+An agent is an **identity that accumulates accountability**: its own access, policy envelope, budget cap, memory, and the set of humans allowed to run it. Think of it as a role you could point to when something goes wrong. `coding`, `support`, `consolidator` — each answers *who did this and under what rules*.
+
+## Skill — a *how*
+
+A skill is a **procedure or body of knowledge**: "how to write an SEO brief", "how to add a 1-click app", "how to triage a pod error". Skills are stateless, have no identity, and are **shared by the whole fleet** — every agent gets the skills library at launch. A skill can't be held accountable; it's just know-how.
+
+### The split test
+
+Create a **separate agent** only when at least one of these must differ:
+
+1. **Permission envelope** — different red lines (deploying to prod ≠ drafting a doc).
+2. **Accountability chain** — different humans assigned, different approvers.
+3. **Memory hygiene** — its context would pollute (or be polluted by) another agent's.
+4. **Trigger surface / budget** — its own schedule, SLA, or spend cap.
+
+If none of those differ, it's a **skill** of an existing agent. A good heuristic: *create an agent when a different human would be accountable if it misbehaves; create a skill when it's just another thing the same agent should know how to do.*
+
+## Session — a *run*
+
+One execution of an agent. Sessions separate **provenance** (what started it — you, an automation, a chat message) from **run-as** (whose identity it acts under). A Slack-triggered run is *started by* the automation but *acts as* — and is visible to — the person who sent the message.
+
+## Automation — a *trigger*
+
+A standing rule that starts an agent without a human: a cron schedule, a webhook, a Slack/Discord mention. Automations answer *when does work start*; agents answer *who does it*.
+
+## Task — a *unit of work*
+
+A durable item in the shared queue between "something should happen" and "a session ran". Tasks have a status (`todo → doing → blocked → done`), an assignee (human **or** agent), and an owner. Assigning a task to an agent with auto-dispatch is how agents delegate to each other — support files a task, coding picks it up, and the accountable human carries through the hand-off.
+
+## Artifact — a *deliverable*
+
+A file an agent published: report, PDF, image, doc. Snapshots, kept forever, listed under Artifacts.
+
+## Memory vs. Knowledge
+
+Both persist, but they're different organs — see **Memory, Knowledge & Tasks** for when each applies. Short version: **Memory** is what an *agent* remembers (its own notes); **Knowledge** is what the *company* knows (the shared wiki both humans and agents edit).
+
+## Approval — a *pause*
+
+When policy classifies an action yellow or red, the session freezes mid-step until a human with the right role decides. Approvals are the guardrail working, not the system failing.

--- a/web/src/docs/getting-started.md
+++ b/web/src/docs/getting-started.md
@@ -1,0 +1,35 @@
+# Getting started
+
+You're reading this, so you've already accepted your invite link and you're logged in. Here's the lay of the land.
+
+## Your first five minutes
+
+1. **Open Agents** (left sidebar). These are the agents your team runs. You can run any agent that's been *assigned* to you — if the Run button is missing, ask an admin for access.
+2. **Run one.** Pick an agent, give it a prompt (most have example prompts), and hit Run. A **session** starts — you can watch it work in a live terminal, or close the tab and let it finish on its own.
+3. **Check your Inbox.** This is the home page for a reason. Agents post here when they:
+   - **ask you a question** mid-run (answer inline and they continue),
+   - **need an approval** for a risky action (approve/deny — see *Governance* for who can approve what),
+   - **report** what they did, or **publish an artifact** (a PDF, doc, image…).
+4. **Look at Sessions.** Every run — yours, your teammates', and automation-triggered ones you're allowed to see — with a green dot when it's live. Click to attach to the terminal.
+
+## Talking to agents from Slack or Discord
+
+If your workspace has chat connected, you don't need the console to start work. In a channel the bot is in (or a DM):
+
+```
+@AgentOS /coding the pricing page footer link 404s — fix it
+```
+
+Address any agent by name with a leading `/agent-name`. The bot acks in a thread and the agent replies there when done. The run happens **as you** — your identity, your visibility — if an admin has linked your Slack/Discord handle on the Team page (ask them to add your Chat ID if replies come back as "company").
+
+## Where things live
+
+- **Inbox** — questions, approvals, reports, published artifacts. Start here every morning.
+- **Agents / Sessions** — start work, watch work.
+- **Tasks** — the shared to-do queue. File a task instead of pinging a person; an agent may pick it up.
+- **Artifacts** — every deliverable agents have published, in one place.
+- **Knowledge** — the team wiki agents read *and write*. Correct it when it's wrong; agents will read your correction.
+
+## What you can't do (by design)
+
+Members can't approve risky actions, manage the team, or run unassigned agents. If an agent you started hits a yellow/red action, the right approver gets pinged (console + Slack/Discord DM) — you don't need to chase anyone.

--- a/web/src/docs/governance.md
+++ b/web/src/docs/governance.md
@@ -1,0 +1,46 @@
+# Governance: roles, approvals, budgets, audit
+
+How Agent OS keeps autonomous agents accountable — without a human babysitting every step.
+
+## Roles
+
+| Role | Runs agents | Approves | Manages |
+| --- | --- | --- | --- |
+| **Owner** | any | everything, incl. **red** (owner-level) | team, roles, settings, policy |
+| **Admin** | any | **yellow** (head-level) | team, assignments, connectors, automations |
+| **Member** | only **assigned** agents | nothing | — |
+
+Assignment is the member-facing access control: a member simply cannot start an agent they haven't been given. Role changes and member removal are owner-only.
+
+## The traffic light
+
+Every side effect an agent attempts is classified by policy **before it happens**:
+
+- 🟢 **Green** — allowed, executed, audited. Most reads and low-risk writes.
+- 🟡 **Yellow** — suspended until an **admin or owner** approves. Riskier writes, external sends.
+- 🔴 **Red** — suspended until the **owner** approves. The irreversible stuff: money, deletion, production.
+
+A suspended action *blocks the agent mid-step* — it isn't "flagged and done", it hasn't happened yet. Approvers are notified in the console Inbox and by Slack/Discord DM. Approvals survive restarts: a pending gate stays pending until someone decides.
+
+Policy is a rule engine, not a hardcoded list — what's green vs. red is configuration your owner controls, per capability. Agents can preview it themselves (they have a *policy check* tool), so a well-behaved agent knows in advance which of its plans will need a human.
+
+## Identity: provenance vs. run-as
+
+Every session records two things:
+
+- **Provenance** — what started it (a person, an automation, a chat message).
+- **Run-as** — whose identity it *acts under*, which drives connector access and visibility.
+
+So "the cron started it" and "it acted as Priya" are both true and both recorded. Chat-triggered runs act as the sender via the identity map (Team page → Chat IDs). A hand-off between agents carries the accountable human along — delegation never launders responsibility.
+
+## Budgets
+
+Every agent has caps — dollars, tokens, wall-clock — per run. A runaway agent runs out of budget before it runs out of ideas. Budgets are set per agent by admins.
+
+## Audit
+
+Everything lands in an append-only audit trail: every gated action, decision, approval, notification, spawn. The JSONL file on disk is the durable system of record; the **Audit** page (owner/admin) is a queryable mirror — filter by session, type, or principal. If a question ever starts with "wait, who did—", the answer is in there.
+
+## The emergency brake
+
+Owners can stop any live session immediately, and the whole fleet is subject to the gateway — there is no side-effect path around it. That invariant is the product.

--- a/web/src/docs/index.ts
+++ b/web/src/docs/index.ts
@@ -1,0 +1,20 @@
+// The Docs section ships WITH the software (same for every tenant, versioned with the code) —
+// deliberately not the KB plane, which is the tenant's own living wiki. Markdown is bundled at
+// build time via Vite ?raw imports; adding a page = add the .md file + one entry here.
+import whatIsAgentOs from './what-is-agent-os.md?raw'
+import gettingStarted from './getting-started.md?raw'
+import coreConcepts from './core-concepts.md?raw'
+import workingWithAgents from './working-with-agents.md?raw'
+import governance from './governance.md?raw'
+import sharedPlanes from './shared-planes.md?raw'
+
+export type DocPage = { slug: string; title: string; body: string }
+
+export const docPages: DocPage[] = [
+  { slug: 'what-is-agent-os', title: 'What is Agent OS?', body: whatIsAgentOs },
+  { slug: 'getting-started', title: 'Getting started', body: gettingStarted },
+  { slug: 'core-concepts', title: 'Core concepts', body: coreConcepts },
+  { slug: 'working-with-agents', title: 'Working with agents', body: workingWithAgents },
+  { slug: 'governance', title: 'Governance & approvals', body: governance },
+  { slug: 'shared-planes', title: 'Memory, Knowledge & Tasks', body: sharedPlanes },
+]

--- a/web/src/docs/shared-planes.md
+++ b/web/src/docs/shared-planes.md
@@ -1,0 +1,39 @@
+# Memory, Knowledge & Tasks
+
+Three shared planes persist across sessions. They look similar ("stuff agents remember") but they're different organs — knowing which is which tells you where to look and where to write.
+
+## Memory — what an *agent* remembers
+
+Private-ish, per-agent recall: preferences it learned, outcomes of past runs, things you told it once so you don't have to repeat them. Agents save and retrieve memories themselves; useful ones get reinforced, stale ones fade. Admins can browse and prune each agent's memory on the **Memory** page, and optionally share memories fleet-wide.
+
+**Write here when:** you never do — agents manage their own memory. *Tell the agent* something worth remembering and it will save it.
+
+## Knowledge — what the *company* knows
+
+The shared wiki, co-authored by humans and agents: runbooks, product facts, policies, "how we do X here". Every agent can search and read it, and agents write pages as they learn. Full revision history with one-click revert — so agent edits are safe to allow: nothing is ever lost, and every change says who made it.
+
+**Write here when:** a fact should be true for *everyone* — humans and all agents. If an agent keeps getting something wrong, fixing the Knowledge page it reads is usually the highest-leverage correction you can make.
+
+## Tasks — what the team has *committed to do*
+
+The shared work queue humans and agents drain together. A task is structured: status (`todo → doing → blocked → done`), priority, assignee (human **or** agent), and an owner — the accountable human. The board lives under **Tasks**.
+
+Two things make it more than a to-do list:
+
+- **Claiming is atomic** — two workers can't grab the same task, so a pool of agents can drain a queue safely.
+- **Auto-dispatch** — a task assigned to an agent spawns a governed session when due, and the agent closes its own loop by marking the task done. This is the delegation path: *support doesn't ping coding; support files a task for coding*, and the hand-off is durable, auditable, and carries the accountable human with it.
+
+**Write here when:** something should happen but not necessarily now, or by you. Filing a task beats a chat ping — it can't be lost, and the right agent may do it before a human gets around to it.
+
+## Rule of thumb
+
+| You have… | Put it in |
+| --- | --- |
+| A fact the whole team/fleet should know | **Knowledge** |
+| A preference or context for one agent | Tell that agent (→ its **Memory**) |
+| Work someone (or some agent) should do | **Tasks** |
+| A deliverable an agent produced | It's already in **Artifacts** |
+
+## And these docs?
+
+This Docs section ships with Agent OS itself — it's the manual, same for every workspace, updated with the software. **Knowledge** is what *your company* writes on top of it. If you're documenting how *your* team uses an agent, that belongs in Knowledge, not here.

--- a/web/src/docs/what-is-agent-os.md
+++ b/web/src/docs/what-is-agent-os.md
@@ -1,0 +1,36 @@
+# What is Agent OS?
+
+Agent OS is a **governed operating system for running autonomous AI agents inside a company**. It lets your team hand real work to agents — support triage, marketing, coding, research — without handing them the keys to everything.
+
+The one idea everything else hangs off:
+
+> **Every side effect an agent has on the world passes through a single mediated gateway.**
+
+Before an agent sends an email, pushes code, changes a record, or spends money, that action is:
+
+1. **Classified** by policy — is this green (safe), yellow (needs a lead), or red (needs the owner)?
+2. **Suspended for approval** when a human needs to sign off — the agent literally waits.
+3. **Debited** against the agent's budget — every agent has a spend/token/time cap.
+4. **Attributed** to an identity — every action runs *as someone*, and that someone is accountable.
+5. **Recorded** in an append-only audit trail you can inspect any time.
+
+Remove the gateway and all of that becomes documentation. Keep it, and "an AI did something" is never the end of the story — you can always answer *which agent, acting as whom, approved by whom, at what cost*.
+
+## Why not just give everyone a super-agent?
+
+An unrestricted agent with company-wide access is a great experience for one trusted person and a terrifying one for a team. Agent OS exists to share that experience safely: everyone gets capable agents, and the *guardrails live in the system*, not in each person's judgment.
+
+## What's in the box
+
+| Piece | What it is |
+| --- | --- |
+| **Agents** | Governed identities that do work — each with its own access, budget, and approval chain |
+| **Sessions** | Individual runs of an agent — watch them live in a terminal, or let them run headless |
+| **Inbox** | Where agents ask questions, request approvals, and report results |
+| **Automations** | Triggers (cron, webhooks, Slack, Discord) that start agents without you |
+| **Tasks** | A shared work queue humans and agents drain together |
+| **Knowledge** | A living wiki agents and humans co-author |
+| **Memory** | What each agent remembers across sessions |
+| **Audit** | The tamper-evident record of everything that happened |
+
+Continue with **Getting started** if you're new here, or **Core concepts** for the mental model.

--- a/web/src/docs/working-with-agents.md
+++ b/web/src/docs/working-with-agents.md
@@ -1,0 +1,45 @@
+# Working with agents
+
+The three ways work starts, and what to do while it runs.
+
+## 1. From the console
+
+**Agents → pick one → Run** with a prompt. You get a live terminal you can watch or type into — the agent may ask you things right there. Closing the tab doesn't kill the run; find it again under **Sessions** (green dot = still live) and re-attach any time. Interactive sessions that ended can often be **resumed** in place, picking the conversation back up.
+
+## 2. From chat (Slack / Discord)
+
+Mention the bot and address an agent by name:
+
+```
+@AgentOS /support customer says checkout 500s on the annual plan
+```
+
+- The bot acks in a **thread**; all agent replies land in that thread.
+- The run acts **as you** (via your linked Chat ID on the Team page).
+- No `/agent-name` prefix, or an unknown name? The bot replies with the list of agents you can address.
+
+## 3. From automations and tasks
+
+- **Automations** start agents on a schedule or webhook — no human in the loop at start, but the same guardrails apply during the run.
+- **Tasks** assigned to an agent (with auto-dispatch) spawn a session when the scheduler picks them up. This is also how *agents delegate to each other*: an agent files a task for another agent instead of doing work outside its lane.
+- Agents can also **schedule themselves** ("check this again in 2 hours") — bounded, visible under Automations.
+
+## While it runs
+
+- **Questions** — the agent may pause and ask you something; it lands in your Inbox (and the session terminal). Answer and it continues.
+- **Approvals** — if the agent hits a yellow/red action, the right approver is pinged in the console and by Slack/Discord DM. The session waits; nothing happens until a decision.
+- **Updates / reports** — agents post progress notes and a final report to the Inbox.
+- **Artifacts** — deliverables are published to the Artifacts page, linked from the report.
+
+## Good prompts for agents
+
+Same rules as briefing a new teammate:
+
+- **Give the goal, not the steps.** "Get the refund report to finance by noon" beats a 12-step recipe.
+- **State the constraints.** "Don't email the customer yet", "draft only, I'll review".
+- **Point at context.** Name the customer, ticket, page, or repo — agents can search Knowledge and their memory, but a direct pointer saves a detour.
+- **Say what done looks like.** "Publish a markdown summary as an artifact" gives the run a finish line.
+
+## When something goes wrong
+
+Stop a runaway session from **Sessions** (stop button). Every action it already took is in the **Audit** log — nothing is invisible. If an agent keeps making the same mistake, fix the **Knowledge** page it's reading or tell an admin to adjust its instructions; that's how the fleet learns.

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
## What
A read-only **Docs** section — the product manual — bundled with the software and reachable from a new **Docs** sidebar item (placed outside the collapsible *Manage* group, so it's one click away for every role).

Six pages: *What is Agent OS?*, *Getting started*, *Core concepts*, *Working with agents*, *Governance & approvals*, *Memory / Knowledge / Tasks*.

## How
- Markdown lives in `web/src/docs/*.md`, bundled at build time via Vite `?raw` imports and registered in `web/src/docs/index.ts` (`?raw` module types come from the added `web/src/vite-env.d.ts`).
- `DocsPage` renders with the existing markdown components; new `docs` hash route + title wiring in `App.tsx`.
- **Ships WITH the code** (identical for every tenant, versioned with the build) — deliberately distinct from the per-tenant **Knowledge** base (a living wiki). Adding a page = drop a `.md` + one `index.ts` entry.

## Versioning
Bumps **0.3.0 → 0.4.0** (minor: feature) and moves the entry into the `0.4.0` heading in `CHANGELOG.md`, per CLAUDE.md → Versioning.

## Test
`npm run test:governance` → 44/44 ✓ · `cd web && npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)