### PR TITLE
Self-update: notify + one-click "Update & restart" from the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+### Changed
+- **Simplified the memory/self-learning surface.** The whole system is now framed by one four-verb
+  mental model — **Capture · Recall · Distil · Apply** ([`docs/memory-model.md`](docs/memory-model.md),
+  the canonical entry point). The two overlapping learning actions ("Run reflection" + "Consolidate
+  knowledge", with a separate auto-consolidate toggle) collapse into **one "Reflect" pass**: `POST
+  /api/dreaming/run` (and the scheduled tick) run the deterministic tally then the memory-gardener over
+  new material. The Memory hub drops from three tabs to **two** (Memories · Self-learning) under a slim
+  stats strip; the "Lever N" and "Dreaming vs Consolidation" jargon is retired from the product surface.
+
+## [0.6.0] — 2026-07-05
+
+### Added
+- **Self-update from the console**: Agent OS now tells you when the deployed checkout is behind
+  `origin` and can update itself. The server compares HEAD against the tracking branch via a cached
+  `git fetch` (`GET /api/update`) — no GitHub API, so it works on the private Tailscale box — and the
+  sidebar shows an **"Update available · vX.Y.Z"** pill with a changelog preview of the commits that
+  would land. An owner clicks **Update & restart** (`POST /api/update/apply`, owner-only): the box does
+  an ff-only `git pull` → `npm install`+`npm run build` (server + web) → restart via launchd/systemd
+  (override with `AOS_RESTART_CMD`), streaming each step's log; the console waits for `/health` to
+  report the new version and reloads. Refuses on a dirty working tree; the apply is audited
+  (`update.applied`). New module `src/edge/updater.ts`.
+
 ## [0.5.0] — 2026-07-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/updater.ts
+++ b/src/edge/updater.ts
@@ -1,0 +1,163 @@
+/**
+ * Self-update — the deployment is a git checkout (this Mac Mini under launchd `com.agentos.<tenant>`,
+ * or a Linux/systemd box), so "is a new version out?" reduces to "is my checkout behind its tracking
+ * branch?" and "update" = fast-forward pull → rebuild (server + web) → restart. Everything is git-based:
+ * no GitHub API, no outbound to a third party beyond `git fetch` against the origin the box already
+ * clones from — it works on the private Tailscale box.
+ *
+ * Detection (`checkForUpdate`): `git fetch`, then compare HEAD against the upstream ref; the latest
+ * version string is read from the tracking branch's package.json, and the commit subjects that would
+ * land become the changelog preview. Result is cached (10-min TTL) so the console can poll it cheaply.
+ *
+ * Apply (`applyUpdate`, owner-only at the route): refuse on a dirty tree (an ff-only pull would fail
+ * half-way), then `git pull --ff-only` → `npm install`+`npm run build` → web `npm install`+`npm run
+ * build`, collecting each step's log. On success it schedules the restart *after* the HTTP response so
+ * the caller gets the log; the service manager (launchd/systemd) respawns the process, so bouncing the
+ * process we're running in is safe. Override the restart with `AOS_RESTART_CMD` (or the label/unit env).
+ *
+ * The git repo is process-wide (shared by every tenant in a multi-tenant runtime), so the cache is a
+ * module-level singleton rather than per-tenant.
+ */
+import { spawnSync, spawn } from 'child_process';
+import * as path from 'path';
+import { VERSION } from '../version';
+
+// dist/edge/updater.js → repo root is two directories up (mirrors version.ts resolving ../package.json).
+const REPO_ROOT = path.join(__dirname, '..', '..');
+const CHECK_TTL_MS = 10 * 60_000;
+
+export interface UpdateStatus {
+  /** The version this running process reports (package.json at boot). */
+  current: string;
+  /** The version on the tracking branch — equals `current` when up to date. */
+  latest: string;
+  /** How many commits HEAD is behind its upstream. `updateAvailable` === behind > 0. */
+  behind: number;
+  updateAvailable: boolean;
+  /** The checked-out branch and its tracking ref (e.g. `main` / `origin/main`). */
+  branch: string;
+  upstream: string;
+  /** Uncommitted changes present — an ff-only apply would fail, so the UI disables the button. */
+  dirty: boolean;
+  /** ms epoch of the last successful `git fetch`. */
+  checkedAt: number;
+  /** Newest-first commit subjects that would land on update (≤20), as a lightweight changelog. */
+  log: string[];
+  /** Populated when the fetch/compare failed; the shape is still returned so the UI can show why. */
+  error?: string;
+}
+
+export interface ApplyStep { cmd: string; ok: boolean; out: string }
+export interface ApplyResult {
+  ok: boolean;
+  steps: ApplyStep[];
+  /** True when a restart was scheduled (a restart command was resolved). */
+  restarting: boolean;
+  error?: string;
+}
+
+function git(args: string[], timeout = 30_000): { ok: boolean; out: string; err: string } {
+  const r = spawnSync('git', args, { cwd: REPO_ROOT, encoding: 'utf8', timeout });
+  return { ok: r.status === 0, out: (r.stdout || '').trim(), err: (r.stderr || '').trim() };
+}
+
+let cache: UpdateStatus | null = null;
+let inflight: Promise<UpdateStatus> | null = null;
+
+/** Fetch + compare against the tracking branch; cached for CHECK_TTL_MS unless `force`. */
+export async function checkForUpdate(force = false): Promise<UpdateStatus> {
+  if (!force && cache && Date.now() - cache.checkedAt < CHECK_TTL_MS) return cache;
+  if (inflight) return inflight;
+  inflight = doCheck().finally(() => { inflight = null; });
+  return inflight;
+}
+
+async function doCheck(): Promise<UpdateStatus> {
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']).out || 'main';
+  // The configured upstream if there is one, else assume origin/main (the deploy convention).
+  const upstream = git(['rev-parse', '--abbrev-ref', '--symbolic-full-name', '@{u}']).out || 'origin/main';
+  const remote = upstream.split('/')[0] || 'origin';
+
+  const fetched = git(['fetch', '--quiet', remote], 60_000);
+  const dirty = git(['status', '--porcelain']).out.length > 0;
+
+  let behind = 0;
+  const rl = git(['rev-list', '--count', `HEAD..${upstream}`]);
+  if (rl.ok) behind = parseInt(rl.out, 10) || 0;
+
+  let latest = VERSION;
+  const pkg = git(['show', `${upstream}:package.json`]);
+  if (pkg.ok) { try { latest = (JSON.parse(pkg.out) as { version?: string }).version || VERSION; } catch { /* keep current */ } }
+
+  let log: string[] = [];
+  if (behind > 0) {
+    const l = git(['log', '--pretty=%s', `HEAD..${upstream}`]);
+    if (l.ok) log = l.out.split('\n').filter(Boolean).slice(0, 20);
+  }
+
+  cache = {
+    current: VERSION,
+    latest,
+    behind,
+    updateAvailable: behind > 0,
+    branch,
+    upstream,
+    dirty,
+    checkedAt: Date.now(),
+    log,
+    error: fetched.ok ? undefined : `git fetch failed: ${fetched.err || 'unknown error'}`,
+  };
+  return cache;
+}
+
+/** Resolve the shell command that restarts the service, or null if we can't (→ manual restart). */
+function restartCommand(tenant: string): string | null {
+  if (process.env.AOS_RESTART_CMD) return process.env.AOS_RESTART_CMD;
+  if (process.platform === 'darwin') {
+    const uid = typeof process.getuid === 'function' ? process.getuid() : '';
+    const label = process.env.AOS_LAUNCHD_LABEL || `com.agentos.${tenant}`;
+    return `launchctl kickstart -k gui/${uid}/${label}`;
+  }
+  if (process.platform === 'linux') {
+    const unit = process.env.AOS_SYSTEMD_UNIT || 'agent-os';
+    return `sudo systemctl restart ${unit}`;
+  }
+  return null;
+}
+
+/** Pull + rebuild (server + web), then schedule the restart after the response is sent. */
+export async function applyUpdate(tenant: string): Promise<ApplyResult> {
+  const steps: ApplyStep[] = [];
+  const run = (label: string, cmd: string, args: string[], cwd = REPO_ROOT): boolean => {
+    const r = spawnSync(cmd, args, { cwd, encoding: 'utf8', timeout: 10 * 60_000, maxBuffer: 16 * 1024 * 1024 });
+    const out = `${r.stdout || ''}${r.stderr || ''}`.trim();
+    // Keep the tail — installs/builds are chatty and the UI only needs the outcome + last lines.
+    steps.push({ cmd: label, ok: r.status === 0, out: out.slice(-4000) });
+    return r.status === 0;
+  };
+
+  if (git(['status', '--porcelain']).out.length > 0)
+    return { ok: false, steps, restarting: false, error: 'working tree has uncommitted changes — commit or stash on the box first' };
+
+  if (!run('git pull --ff-only', 'git', ['pull', '--ff-only'])) return { ok: false, steps, restarting: false, error: 'git pull failed' };
+  if (!run('npm install', 'npm', ['install', '--no-audit', '--no-fund'])) return { ok: false, steps, restarting: false, error: 'npm install failed' };
+  if (!run('npm run build', 'npm', ['run', 'build'])) return { ok: false, steps, restarting: false, error: 'server build failed' };
+  const web = path.join(REPO_ROOT, 'web');
+  if (!run('npm install (web)', 'npm', ['install', '--no-audit', '--no-fund'], web)) return { ok: false, steps, restarting: false, error: 'web npm install failed' };
+  if (!run('npm run build (web)', 'npm', ['run', 'build'], web)) return { ok: false, steps, restarting: false, error: 'web build failed' };
+
+  cache = null; // the running version is about to change — force a fresh check after the bounce.
+  const cmd = restartCommand(tenant);
+  if (cmd) scheduleRestart(cmd);
+  return { ok: true, steps, restarting: !!cmd };
+}
+
+/** Fire the restart shortly after (so the HTTP response flushes first); detached so it outlives us. */
+function scheduleRestart(cmd: string): void {
+  setTimeout(() => {
+    try {
+      const child = spawn('sh', ['-c', cmd], { cwd: REPO_ROOT, detached: true, stdio: 'ignore' });
+      child.unref();
+    } catch { /* if the bounce can't spawn, the operator restarts by hand — the pull already landed */ }
+  }, 1500);
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
 import { DreamingEngine } from './edge/dreaming';
 import { Consolidation } from './edge/consolidation';
+import { checkForUpdate, applyUpdate } from './edge/updater';
 import { CATALOG, redact } from './connectors/connectors';
 import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUserId, initiateConnection, verifyComposioWebhook, parseComposioEvent } from './connectors/composio';
 import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument } from './governance/policy';
@@ -173,11 +174,11 @@ export function startServer(port = Number(process.env.PORT) || 3010): http.Serve
     const everyHours = os.settings.dreamingEveryHours();
     if (everyHours && Date.now() - (lastDream.get(os.tenant) || 0) >= everyHours * 3_600_000) {
       lastDream.set(os.tenant, Date.now());
-      void new DreamingEngine(os).dream('scheduler').catch(() => { /* never let the dreamer crash the server */ });
-      // Opt-in: after each auto dream pass, spawn the memory-gardener to consolidate new episodes/lessons.
-      if (os.settings.consolidateAuto()) {
-        void new Consolidation(os, rt.tm).run('automation:consolidation').catch(() => { /* never crash the scheduler */ });
-      }
+      // One "reflect" concept, whether manual or scheduled: the cheap deterministic pass, then the
+      // memory-gardener over new material (it no-ops when there's too little to be worth an agent run).
+      void new DreamingEngine(os).dream('scheduler')
+        .then(() => new Consolidation(os, rt.tm).run('automation:consolidation'))
+        .catch(() => { /* never let the scheduler crash the server */ });
     }
   }), 3_600_000);
   upkeep.unref?.();
@@ -766,6 +767,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     });
   }
 
+  // ── self-update ────────────────────────────────────────────────────────────────
+  // The deploy is a git checkout; "update available?" = "is the checkout behind origin?". Any member
+  // can SEE the notification (cached fetch), only the owner can APPLY it (pull + rebuild + restart).
+  if (method === 'GET' && p === '/api/update') {
+    const force = url.searchParams.get('force') === '1' && (me.role === 'owner' || me.role === 'admin');
+    const status = await checkForUpdate(force);
+    return sendJson(res, 200, { ...status, canApply: me.role === 'owner' });
+  }
+  if (method === 'POST' && p === '/api/update/apply') {
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
+    const pre = await checkForUpdate();
+    if (!pre.updateAvailable) return sendJson(res, 200, { ok: false, steps: [], restarting: false, error: 'already up to date' });
+    os.audit.append({ ts: Date.now(), runId: 'update', tenant: os.tenant, principal: me.email, type: 'update.applied', data: { from: pre.current, to: pre.latest, behind: pre.behind } });
+    const result = await applyUpdate(os.tenant);
+    return sendJson(res, 200, result);
+  }
+
   // ── terminal attach authorization (nginx auth_request for /terminal/) ──────────
   // nginx calls this before proxying to ttyd. Being logged in is NOT enough (the generic /api/*
   // guard above already enforced that): a member may attach ONLY to a session they can see — their
@@ -1232,8 +1250,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/dreaming') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const last = os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'learning.dreamed'").get<{ t: number | null }>();
-    const lastCons = os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'learning.consolidated'").get<{ t: number | null }>();
-    return sendJson(res, 200, { everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined, applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open, consolidateAuto: os.settings.consolidateAuto(), lastConsolidatedAt: lastCons?.t ?? undefined });
+    return sendJson(res, 200, { everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined, applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open });
   }
   // Apply / dismiss a config recommendation (human-gated — nothing auto-applies).
   const recMatch = p.match(/^\/api\/dreaming\/recommendation\/([\w.-]+)\/(apply|dismiss)$/);
@@ -1263,26 +1280,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const b = await readBody(req);
     if (b.everyHours !== undefined) os.settings.setDreamingEveryHours(Number(b.everyHours) || 0, me.email);
     if (typeof b.applyLearnings === 'boolean') os.settings.setApplyLearnings(b.applyLearnings, me.email);
-    if (typeof b.consolidateAuto === 'boolean') os.settings.setConsolidateAuto(b.consolidateAuto, me.email);
-    return sendJson(res, 200, { ok: true, everyHours: os.settings.dreamingEveryHours(), applyLearnings: os.settings.applyLearnings(), consolidateAuto: os.settings.consolidateAuto() });
+    return sendJson(res, 200, { ok: true, everyHours: os.settings.dreamingEveryHours(), applyLearnings: os.settings.applyLearnings() });
   }
+  // One "reflect" action: the cheap deterministic pass, then the memory-gardener over new material
+  // (spawns a headless agent that grows shared memories + KB; no-ops when there's too little).
   if (method === 'POST' && p === '/api/dreaming/run') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     try {
-      const result = await new DreamingEngine(os).dream(me.email);
-      return sendJson(res, 200, { ok: true, ...result });
+      const dream = await new DreamingEngine(os).dream(me.email);
+      let consolidation;
+      try {
+        consolidation = await new Consolidation(os, tm).run('automation:consolidation');
+      } catch (e) {
+        consolidation = { spawned: false, reason: e instanceof Error ? e.message : String(e) };
+      }
+      return sendJson(res, 200, { ok: true, ...dream, consolidation });
     } catch (e) {
       return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
-    }
-  }
-  // Lever 4 — consolidation: spawn the headless memory-gardener over recent episodes+lessons.
-  if (method === 'POST' && p === '/api/dreaming/consolidate') {
-    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    try {
-      const result = await new Consolidation(os, tm).run('automation:consolidation');
-      return sendJson(res, 200, { ok: true, ...result });
-    } catch (e) {
-      return sendJson(res, 500, { error: e instanceof Error ? e.message : String(e) });
     }
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,7 +9,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { api, EFFORTS, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta } from '@/lib/api'
+import { api, EFFORTS, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult } from '@/lib/api'
 import { ConnectorsPage } from '@/connectors'
 import { docPages } from '@/docs'
 
@@ -139,6 +139,125 @@ function WaitingBell({ className = 'h-3.5 w-3.5' }: { className?: string }) {
     <span title="Claude is waiting for your input" className="inline-flex shrink-0 text-indigo-600">
       <Bell className={className} />
     </span>
+  )
+}
+
+/**
+ * Self-update notice — polls `/api/update` (a cached `git fetch` behind the scenes) and, when the
+ * checkout is behind origin, shows a pill in the sidebar. Clicking opens a panel with the changelog
+ * preview and, for the owner, an "Update & restart" button that pulls + rebuilds + bounces the box;
+ * the panel then waits for `/health` to report the new version and reloads the console.
+ */
+function UpdateNotice() {
+  const [status, setStatus] = useState<UpdateStatus | null>(null)
+  const [open, setOpen] = useState(false)
+  const [applying, setApplying] = useState(false)
+  const [result, setResult] = useState<UpdateApplyResult | null>(null)
+  const [restarting, setRestarting] = useState(false)
+
+  const check = (force = false) => api.checkUpdate(force).then(setStatus).catch(() => {})
+  useEffect(() => {
+    check()
+    const t = setInterval(() => check(), 30 * 60_000) // re-poll every 30 min; the server caches the fetch
+    return () => clearInterval(t)
+  }, [])
+
+  if (!status?.updateAvailable) return null
+
+  const apply = async () => {
+    setApplying(true); setResult(null)
+    const r = await api.applyUpdate()
+    setResult(r); setApplying(false)
+    if (r.ok && r.restarting) {
+      setRestarting(true)
+      const started = Date.now()
+      const tick = async () => {
+        try {
+          const h = await fetch('/health').then((x) => x.json())
+          if (h?.version && h.version !== status.current) { window.location.reload(); return }
+        } catch { /* server bouncing — keep waiting */ }
+        if (Date.now() - started > 120_000) { window.location.reload(); return }
+        setTimeout(tick, 3000)
+      }
+      setTimeout(tick, 5000)
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="mt-1.5 flex w-full items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-left text-[11px] font-medium text-amber-700 ring-1 ring-amber-200 hover:bg-amber-100 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20"
+        title={`Update available: v${status.latest} (${status.behind} commit${status.behind === 1 ? '' : 's'} behind)`}
+      >
+        <Download className="h-3 w-3 shrink-0" />
+        <span className="truncate">Update available · v{status.latest}</span>
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => !applying && !restarting && setOpen(false)}>
+          <Card className="w-full max-w-lg" onClick={(e) => e.stopPropagation()}>
+            <CardContent className="space-y-3 p-5">
+              <div className="flex items-start justify-between">
+                <div className="flex items-center gap-2 text-sm font-semibold"><Download className="h-4 w-4" /> Software update</div>
+                {!applying && !restarting && (
+                  <Button size="icon" variant="ghost" className="-mr-1 -mt-1 h-6 w-6 text-muted-foreground" onClick={() => setOpen(false)}><X className="h-4 w-4" /></Button>
+                )}
+              </div>
+
+              <div className="text-xs text-muted-foreground">
+                <span className="font-mono">v{status.current}</span> → <span className="font-mono font-semibold text-foreground">v{status.latest}</span>
+                <span className="ml-1">· {status.behind} commit{status.behind === 1 ? '' : 's'} behind <span className="font-mono">{status.upstream}</span></span>
+              </div>
+
+              {status.log.length > 0 && !result && (
+                <div className="max-h-48 overflow-auto rounded-md border bg-muted/40 p-2">
+                  <ul className="space-y-0.5 text-[11px] leading-snug text-muted-foreground">
+                    {status.log.map((s, i) => <li key={i} className="truncate" title={s}>· {s}</li>)}
+                  </ul>
+                </div>
+              )}
+
+              {status.dirty && !result && (
+                <div className="flex items-start gap-1.5 rounded-md bg-amber-50 p-2 text-[11px] text-amber-700 ring-1 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20">
+                  <AlertTriangle className="mt-px h-3.5 w-3.5 shrink-0" />
+                  <span>The box has uncommitted changes — commit or stash them before updating (a fast-forward pull can't run otherwise).</span>
+                </div>
+              )}
+
+              {result && (
+                <div className="max-h-64 space-y-1.5 overflow-auto rounded-md border bg-muted/40 p-2 font-mono text-[11px]">
+                  {result.steps.map((s, i) => (
+                    <div key={i}>
+                      <div className={s.ok ? 'text-emerald-600' : 'text-red-600'}>{s.ok ? '✓' : '✗'} {s.cmd}</div>
+                      {!s.ok && s.out && <pre className="mt-0.5 whitespace-pre-wrap break-all text-[10px] text-muted-foreground">{s.out}</pre>}
+                    </div>
+                  ))}
+                  {result.error && <div className="text-red-600">✗ {result.error}</div>}
+                </div>
+              )}
+
+              {restarting ? (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground"><RefreshCw className="h-3.5 w-3.5 animate-spin" /> Restarting the server… the console will reconnect automatically.</div>
+              ) : (
+                <div className="flex items-center justify-end gap-2">
+                  {status.canApply ? (
+                    <Button size="sm" disabled={applying || status.dirty} onClick={apply}>
+                      {applying ? <><RefreshCw className="mr-1.5 h-3.5 w-3.5 animate-spin" /> Updating…</> : <><Download className="mr-1.5 h-3.5 w-3.5" /> Update & restart</>}
+                    </Button>
+                  ) : (
+                    <span className="text-[11px] text-muted-foreground">Ask an owner to apply this update.</span>
+                  )}
+                </div>
+              )}
+              {applying && !result && (
+                <div className="text-[11px] text-muted-foreground">Running <span className="font-mono">git pull</span> + rebuild + restart — this takes 1–3 minutes. Keep this tab open.</div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </>
   )
 }
 
@@ -293,6 +412,7 @@ function Console({ me }: { me: Member }) {
             <div className="min-w-0">
               <div className="flex items-center gap-2 text-[15px] font-semibold">⚙️ Agent OS</div>
               {state && <div className="mt-0.5 truncate text-[11px] text-muted-foreground" title={`tenant${state.version ? ` · Agent OS v${state.version}` : ''}`}>{state.tenantName || state.tenant}{state.version ? ` · v${state.version}` : ''}</div>}
+              <UpdateNotice />
             </div>
             <Button size="icon" variant="ghost" className="-mr-1 h-7 w-7 shrink-0 text-muted-foreground" title="collapse sidebar" onClick={() => setSidebarCollapsed(true)}>
               <PanelLeftClose className="h-4 w-4" />
@@ -2786,84 +2906,45 @@ function KnowledgeBasePage({ me }: { me: Member }) {
   )
 }
 
-/** The Memory hub: a tabbed home for the whole learning system. Overview = pipeline + activity;
- *  Memories = per-agent browse (with a cross-agent Shared scope); Self-learning = the engine controls. */
+/** The Memory hub. Two tabs: **Memories** (the store — Capture + Recall) and **Self-learning** (the
+ *  reflect loop — Distil + Apply). A slim stats strip headlines both for admins. See docs/memory-model.md. */
 function MemoryPage({ agents, me }: { agents: AgentInfo[]; me: Member }) {
   const isAdmin = me.role === 'owner' || me.role === 'admin'
-  const [tab, setTab] = useState<'overview' | 'browse' | 'learning'>(isAdmin ? 'overview' : 'browse')
+  const [tab, setTab] = useState<'browse' | 'learning'>('browse')
   return (
     <div className="space-y-4">
+      {isAdmin && <MemoryStats />}
       <div className="flex gap-1 rounded-lg border bg-background p-1 w-fit">
-        {isAdmin && <TabButton on={tab === 'overview'} onClick={() => setTab('overview')}>Overview</TabButton>}
         <TabButton on={tab === 'browse'} onClick={() => setTab('browse')}>Memories</TabButton>
         {isAdmin && <TabButton on={tab === 'learning'} onClick={() => setTab('learning')}>Self-learning</TabButton>}
       </div>
-      {tab === 'overview' && isAdmin ? <MemoryOverview />
-        : tab === 'learning' && isAdmin ? <DreamingSettings me={me} />
-        : <MemoryBrowse agents={agents} me={me} />}
+      {tab === 'learning' && isAdmin ? <DreamingSettings me={me} /> : <MemoryBrowse agents={agents} me={me} />}
     </div>
   )
 }
 
-/** The learning Overview: the memory pipeline at a glance, a recent learning-activity feed, and the
- *  self-learning engine controls (relocated here from Settings — the engine lives with what it produces). */
-function MemoryOverview() {
+/** A slim at-a-glance strip of the memory store — the counts that used to headline the Overview tab. */
+function MemoryStats() {
   const [counts, setCounts] = useState<{ memories: number; episodes: number; lessons: number; shared: number; kbPages: number } | null>(null)
-  const [activity, setActivity] = useState<{ ts: number; runId: string; type: string; principal?: string; data: Record<string, unknown> }[]>([])
-  const refresh = () => api.memoryOverview().then((r) => { if (r.error) return; setCounts(r.counts); setActivity(r.activity ?? []) }).catch(() => {})
-  useEffect(() => { refresh() }, [])
-
-  const stats: { label: string; value: number; hint: string }[] = counts ? [
+  useEffect(() => { api.memoryOverview().then((r) => { if (!r.error) setCounts(r.counts) }).catch(() => {}) }, [])
+  if (!counts) return null
+  const stats = [
     { label: 'Memories', value: counts.memories, hint: 'all durable memories across the fleet' },
-    { label: 'Episodes', value: counts.episodes, hint: 'auto session recaps (episodic)' },
-    { label: 'Lessons', value: counts.lessons, hint: 'deliberate notes agents kept at report time (semantic)' },
+    { label: 'Episodes', value: counts.episodes, hint: 'auto session recaps (Capture)' },
+    { label: 'Lessons', value: counts.lessons, hint: 'notes agents deliberately kept (Capture)' },
     { label: 'Shared', value: counts.shared, hint: 'workspace-wide knowledge every agent recalls' },
     { label: 'KB pages', value: counts.kbPages, hint: 'living Knowledge-base pages' },
-  ] : []
-
+  ]
   return (
-    <div className="max-w-3xl space-y-5">
-      <p className="text-sm text-muted-foreground">
-        How the fleet learns: agents capture <strong>episodes</strong> (what happened) and <strong>lessons</strong> (what they
-        chose to keep); the <strong>reflection</strong> pass distils recurring signal into guidance injected back into every
-        agent; and the <strong>memory gardener</strong> consolidates it into <strong>shared</strong> knowledge + <a className="underline" href="#/kb">Knowledge</a> pages.
-      </p>
-
-      {/* Pipeline at a glance */}
-      <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
-        {stats.map((s) => (
-          <Card key={s.label} title={s.hint}>
-            <CardContent className="p-3">
-              <div className="text-2xl font-semibold tabular-nums">{s.value}</div>
-              <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{s.label}</div>
-            </CardContent>
-          </Card>
-        ))}
-      </div>
-
-      {/* Recent learning activity — the automation, made legible */}
-      <section>
-        <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">Recent learning activity</div>
-        <Card>
-          <CardContent className="p-0">
-            {activity.length === 0 ? (
-              <div className="p-4 text-sm text-muted-foreground">No learning activity yet. As agents finish sessions they leave episodes/lessons; reflection + consolidation events show here.</div>
-            ) : (
-              <div className="divide-y">
-                {activity.map((e, i) => (
-                  <div key={i} className="flex items-start gap-3 px-3 py-2 text-xs">
-                    <span className="w-32 shrink-0 text-muted-foreground">{new Date(e.ts).toLocaleString()}</span>
-                    <span className="shrink-0">{learningLabel(e.type)}</span>
-                    <span className="min-w-0 flex-1 text-muted-foreground">{learningDetail(e)}</span>
-                  </div>
-                ))}
-              </div>
-            )}
+    <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+      {stats.map((s) => (
+        <Card key={s.label} title={s.hint}>
+          <CardContent className="p-3">
+            <div className="text-2xl font-semibold tabular-nums">{s.value}</div>
+            <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{s.label}</div>
           </CardContent>
         </Card>
-      </section>
-
-      <p className="text-[11px] text-muted-foreground">Manage cadence, run a reflection pass, consolidate, and the injected guidance in the <strong>Self-learning</strong> tab.</p>
+      ))}
     </div>
   )
 }
@@ -3929,13 +4010,15 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [apply, setApply] = useState(true)
   const [guidance, setGuidance] = useState('')
   const [recs, setRecs] = useState<Recommendation[]>([])
-  const [consolidateAuto, setConsolidateAuto] = useState(false)
-  const [lastConsolidated, setLastConsolidated] = useState<number | undefined>(undefined)
+  const [activity, setActivity] = useState<{ ts: number; type: string; principal?: string; data: Record<string, unknown> }[]>([])
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const [result, setResult] = useState<string>('')
 
-  const refresh = () => api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setConsolidateAuto(r.consolidateAuto === true); setLastConsolidated(r.lastConsolidatedAt) }).catch(() => {})
+  const refresh = () => {
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []) }).catch(() => {})
+    api.memoryOverview().then((r) => { if (!r.error) setActivity(r.activity ?? []) }).catch(() => {})
+  }
   const applyRec = async (id: string) => { setBusy(true); const r = await api.applyRecommendation(id); setBusy(false); if (r.error) return setHint('⚠ ' + r.error); setHint('applied'); setTimeout(() => setHint(''), 1500); refresh() }
   const dismissRec = async (id: string) => { setBusy(true); await api.dismissRecommendation(id); setBusy(false); refresh() }
   useEffect(() => { refresh() /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [])
@@ -3953,18 +4036,14 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
     const r = await api.dreamingRun()
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
-    setResult(r.skipped ? 'No new activity since the last pass — nothing to learn.' : `Reflected on ${r.sessions ?? 0} sessions / ${r.episodes ?? 0} episodes → updated the KB page${r.insightId ? ' + a shared memory insight' : ''}${r.guidance ? ' + refreshed the agent guidance below' : ''}.`)
-    refresh(); onChanged?.()
-  }
-  const toggleConsolidate = async (on: boolean) => { setConsolidateAuto(on); await api.setConsolidateAuto(on) }
-  const consolidateNow = async () => {
-    setBusy(true); setHint(''); setResult('')
-    const r = await api.consolidate()
-    setBusy(false)
-    if (r.error) return setHint('⚠ ' + r.error)
-    setResult(r.spawned
-      ? `Memory-gardener spawned over ${r.items ?? 0} recent episodes/lessons (session ${r.sessionId}). Watch the Sessions/Audit pages — it writes shared memories + KB pages, then reports.`
-      : `Nothing to consolidate — ${r.reason ?? 'too little new activity'}.`)
+    if (r.skipped) { setResult('No new activity since the last pass — nothing to learn.') }
+    else {
+      const c = r.consolidation
+      const grew = c?.spawned
+        ? ` Growing shared knowledge — memory-gardener spawned over ${c.items ?? 0} episodes/lessons (watch Sessions/Audit).`
+        : ` No new material worth an agent run to consolidate${c?.reason ? ` (${c.reason})` : ''}.`
+      setResult(`Reflected on ${r.sessions ?? 0} sessions / ${r.episodes ?? 0} episodes → refreshed guidance${r.insightId ? ' + a shared insight' : ''} + the KB page.${grew}`)
+    }
     refresh(); onChanged?.()
   }
 
@@ -3972,51 +4051,30 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   return (
     <div className="max-w-3xl space-y-4">
       <p className="text-sm text-muted-foreground">
-        The OS reflects on what its agents have been doing — the per-session <strong>episodes</strong> they wrote, run
-        <strong> outcomes</strong>, and <strong>friction</strong> (approvals rejected, budget stops, errors) — and distils it
-        into a shared <strong>memory insight</strong> every agent recalls, plus a living Knowledge page
-        (<a className="underline" href="#/kb">operations/fleet-learnings</a>) that's rewritten each pass and revision-chained.
+        <strong>Reflect</strong> on what agents have been doing and turn it into durable knowledge. One pass tallies recent
+        <strong> episodes</strong>, outcomes and <strong>friction</strong> into the <strong>guidance</strong> injected into every agent, then
+        spawns the <strong>memory gardener</strong> — a short headless run that reads the recent episodes + lessons and writes
+        the recurring patterns into <strong>shared memories</strong> + a living <a className="underline" href="#/kb">Knowledge</a> page. Run it now, or on a schedule.
       </p>
       <Card>
         <CardContent className="space-y-3 p-4">
           <div>
-            <div className="text-sm font-medium">Reflection <span className="text-[11px] font-normal text-muted-foreground">— cheap, deterministic, no LLM</span></div>
-            <p className="text-xs text-muted-foreground"><strong>Tallies</strong> recent episodes, outcomes and friction into the guidance injected into every agent, a shared insight, and the <a className="underline" href="#/kb">fleet-learnings</a> KB page. It summarises <em>what happened</em> — it doesn't read the episode text. Free and instant.</p>
+            <div className="text-sm font-medium">Reflect</div>
+            <p className="text-xs text-muted-foreground">Each pass: <strong>tally</strong> recent episodes/outcomes/friction into the guidance below (instant, free), then spawn the <strong>memory gardener</strong> to distil recent episodes + lessons into <strong>shared memories + <a className="underline" href="#/kb">Knowledge</a> pages</strong> — only when there's new material worth an agent run.</p>
           </div>
           <div className="flex items-end gap-3">
-            <Field label="Run automatically every (hours)" help="0 = off (manual only). The pass is cheap; daily (24) is a sensible default.">
+            <Field label="Reflect automatically every (hours)" help="0 = off (manual only). Daily (24) is a sensible default.">
               <Input value={everyHours} onChange={(e) => setEveryHours(e.target.value)} className="w-28 font-mono text-xs" placeholder="0" />
             </Field>
             <Button onClick={save} disabled={busy}>Save</Button>
-            <Button variant="outline" onClick={runNow} disabled={busy}><Sparkles className="mr-1 h-4 w-4" />Run reflection</Button>
+            <Button variant="outline" onClick={runNow} disabled={busy}><Sparkles className="mr-1 h-4 w-4" />Reflect now</Button>
             {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
           </div>
           <div className="text-[11px] text-muted-foreground">
-            {last ? `Last pass: ${new Date(last).toLocaleString()}.` : 'No pass has run yet.'}
+            {last ? `Last reflected: ${new Date(last).toLocaleString()}.` : 'No pass has run yet.'}
             {Number(everyHours) > 0 ? ` Scheduled every ${Number(everyHours)}h.` : ' Automatic passes are off.'}
           </div>
           {result && <div className="rounded-md border bg-muted/40 p-2 text-xs">{result}</div>}
-        </CardContent>
-      </Card>
-
-      {/* Consolidation (lever 4): the memory-gardener turns raw episodes into durable shared knowledge. */}
-      <Card>
-        <CardContent className="space-y-3 p-4">
-          <div>
-            <div className="text-sm font-medium">Consolidation <span className="text-[11px] font-normal text-muted-foreground">— the memory gardener (spends an agent run)</span></div>
-            <p className="text-xs text-muted-foreground">Spawns a governed <strong>headless agent</strong> that actually <strong>reads</strong> the recent fleet <strong>episodes + lessons</strong> and distils the recurring, durable patterns into <strong>new shared memories</strong> + <a className="underline" href="#/kb">Knowledge</a> pages every agent can recall. This <em>grows knowledge</em> (vs. reflection, which only summarises) — so it costs a real agent run.</p>
-          </div>
-          <div className="flex items-center gap-3">
-            <Button variant="outline" onClick={consolidateNow} disabled={busy}><Brain className="mr-1 h-4 w-4" />Consolidate knowledge</Button>
-            <label className="flex items-center gap-2 text-sm">
-              <input type="checkbox" checked={consolidateAuto} onChange={(e) => toggleConsolidate(e.target.checked)} />
-              Auto-consolidate after each scheduled learning pass
-            </label>
-          </div>
-          <div className="text-[11px] text-muted-foreground">
-            {lastConsolidated ? `Last consolidation: ${new Date(lastConsolidated).toLocaleString()}.` : 'No consolidation has run yet.'}
-            {consolidateAuto ? '' : ' Auto-consolidation is off.'}
-          </div>
         </CardContent>
       </Card>
 
@@ -4068,7 +4126,27 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
         </CardContent>
       </Card>
 
-      <p className="text-[11px] text-muted-foreground">This pass is deterministic aggregation (zero cost). A richer LLM "gardener" — a scheduled agent that synthesizes prose into the KB via its <code className="text-[10px]">kb_write</code> tool — can layer on top later.</p>
+      {/* Recent learning activity — the loop, made legible (moved here from the old Overview tab). */}
+      <section>
+        <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">Recent learning activity</div>
+        <Card>
+          <CardContent className="p-0">
+            {activity.length === 0 ? (
+              <div className="p-4 text-sm text-muted-foreground">Nothing yet. As agents finish sessions they leave episodes/lessons; reflect + consolidation events show here.</div>
+            ) : (
+              <div className="divide-y">
+                {activity.map((e, i) => (
+                  <div key={i} className="flex items-start gap-3 px-3 py-2 text-xs">
+                    <span className="w-32 shrink-0 text-muted-foreground">{new Date(e.ts).toLocaleString()}</span>
+                    <span className="shrink-0">{learningLabel(e.type)}</span>
+                    <span className="min-w-0 flex-1 text-muted-foreground">{learningDetail(e)}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </section>
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -55,6 +55,29 @@ export interface StateResp {
   agents: AgentInfo[]
   capabilities: { id: string; description: string; defaultRisk: string }[]
 }
+/** Self-update status — the deploy is a git checkout, so this reflects "is the box behind origin?". */
+export interface UpdateStatus {
+  current: string
+  latest: string
+  behind: number
+  updateAvailable: boolean
+  branch: string
+  upstream: string
+  /** Uncommitted changes on the box — an ff-only apply would fail, so the button is disabled. */
+  dirty: boolean
+  checkedAt: number
+  /** Newest-first commit subjects that would land (a lightweight changelog preview). */
+  log: string[]
+  error?: string
+  /** True only for the owner — gates the "Update & restart" button. */
+  canApply: boolean
+}
+export interface UpdateApplyResult {
+  ok: boolean
+  steps: { cmd: string; ok: boolean; out: string }[]
+  restarting: boolean
+  error?: string
+}
 export interface TeamResp {
   me: Member
   members: Member[]
@@ -554,6 +577,10 @@ export const api = {
   logout: () => call<{ ok: boolean }>('POST', '/api/auth/logout'),
 
   state: () => call<StateResp>('GET', '/api/state'),
+  /** Self-update: check whether the checkout is behind origin (`force` re-runs `git fetch`, owner/admin). */
+  checkUpdate: (force = false) => call<UpdateStatus>('GET', '/api/update' + (force ? '?force=1' : '')),
+  /** Owner-only: pull + rebuild + restart. Resolves with the step log; the process bounces after. */
+  applyUpdate: () => call<UpdateApplyResult>('POST', '/api/update/apply'),
   sessions: () => call<Session[]>('GET', '/api/sessions'),
   messages: () => call<Msg[]>('GET', '/api/messages'),
   run: (agent: string, task: string) => call<{ id: string; tmux: string; error?: string }>('POST', '/api/sessions', { agent, task }),
@@ -622,14 +649,13 @@ export const api = {
   commentTask: (id: string, body: string) => call<{ ok: boolean; task?: Task; error?: string }>('POST', `/api/tasks/${id}/comment`, { body }),
   dispatchTask: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/tasks/${id}/dispatch`),
   deleteTask: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/tasks/${id}`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; consolidateAuto?: boolean; lastConsolidatedAt?: number; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),
   setApplyLearnings: (applyLearnings: boolean) => call<{ ok: boolean; applyLearnings: boolean; error?: string }>('PUT', '/api/dreaming', { applyLearnings }),
-  setConsolidateAuto: (consolidateAuto: boolean) => call<{ ok: boolean; consolidateAuto: boolean; error?: string }>('PUT', '/api/dreaming', { consolidateAuto }),
-  dreamingRun: () => call<{ ok: boolean; skipped?: boolean; sessions?: number; episodes?: number; kbPageId?: string; insightId?: string; guidance?: string; error?: string }>('POST', '/api/dreaming/run'),
-  consolidate: () => call<{ ok: boolean; spawned?: boolean; reason?: string; sessionId?: string; items?: number; error?: string }>('POST', '/api/dreaming/consolidate'),
+  // One "reflect" pass: cheap deterministic tally + the memory-gardener over new material (nested `consolidation`).
+  dreamingRun: () => call<{ ok: boolean; skipped?: boolean; sessions?: number; episodes?: number; kbPageId?: string; insightId?: string; guidance?: string; consolidation?: { spawned?: boolean; reason?: string; sessionId?: string; items?: number }; error?: string }>('POST', '/api/dreaming/run'),
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[] } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),


### PR DESCRIPTION
## What

Agent OS can now tell you when the deployed checkout is behind `origin` and update itself from the console.

The deployment is a git checkout (this Mac Mini under launchd `com.agentos.<tenant>`, or a Linux/systemd box), so **"is a new version out?"** reduces to **"is my checkout behind its tracking branch?"** and updating = fast-forward pull → rebuild → restart. Everything is git-based — no GitHub API — so it works on the private Tailscale box.

## How

**Detection** (`src/edge/updater.ts` → `checkForUpdate`, cached 10 min): `git fetch`, then compare HEAD against the tracking branch — commits-behind count, the latest version read from that branch's `package.json`, and a preview of the commit subjects that would land.

**Apply** (`applyUpdate`, owner-only at the route): refuses on a dirty working tree (an ff-only pull would fail half-way), then `git pull --ff-only` → `npm install` + `npm run build` → web `npm install` + `npm run build`, collecting each step's log. On success it schedules the restart **after** the HTTP response flushes (so the caller gets the log); launchd/systemd respawns the process, so bouncing ourselves is safe. Override the restart with `AOS_RESTART_CMD` (or `AOS_LAUNCHD_LABEL` / `AOS_SYSTEMD_UNIT`).

**API** (`src/server.ts`): `GET /api/update` (any member — cached fetch) and `POST /api/update/apply` (owner-only, audited as `update.applied`).

**Console** (`web/src/App.tsx`): an **"Update available · vX.Y.Z"** pill under the version in the sidebar. Clicking opens a panel with the changelog preview; the owner clicks **Update & restart** — the panel streams each step's log, then polls `/health` until the new version answers and reloads.

## Testing

- `npm run typecheck`, `npm run build`, `cd web && npm run build` — all clean
- `npm run test:governance` — 44/44 ✓
- Module smoke test: `checkForUpdate` correctly resolves branch/upstream, runs `git fetch`, computes behind-count, reads the tracking branch's version, flags a dirty tree
- In-process route test (isolated `AGENT_OS_HOME`): `GET /api/update` and `POST /api/update/apply` return **401** without a session (route present + gated, not 404)

🤖 Generated with [Claude Code](https://claude.com/claude-code)