### PR TITLE
Agents: per-agent icons — library picker + custom SVG upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ new version heading in the same commit.
   new material. The Memory hub drops from three tabs to **two** (Memories · Self-learning) under a slim
   stats strip; the "Lever N" and "Dreaming vs Consolidation" jargon is retired from the product surface.
 
+## [0.7.0] — 2026-07-05
+
+### Added
+- **Agent icons.** Every agent can now carry a visual icon — pick one from a curated built-in library
+  (a lucide subset spanning engineering / comms / ops / finance roles) or **upload a custom SVG**. The
+  icon shows everywhere an agent is listed (the spawn picker + its trigger, the assignments page, and
+  the task/schedule pickers), with a Bot glyph as the default fallback. It's a single cosmetic `icon`
+  field on the manifest (`AgentManifest.icon`) — a library id like `"Bot"` or raw `<svg>` markup —
+  persisted in `agent.json` and edited from both the New-agent and per-agent settings forms. Uploaded
+  SVGs are sanitised server-side (`sanitizeIcon`/`sanitizeSvgIcon`: strips scripts, `on*` handlers,
+  `javascript:` links and `<foreignObject>`, 20 KB cap) and rendered via an `<img>` data-URI so any
+  residual markup can't execute.
+
 ## [0.6.0] — 2026-07-05
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUse
 import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument } from './governance/policy';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
-import { AgentManifest, ApprovalRequest, EmbeddingsConfig, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeRuntimeTuning, TaskStatus } from './types';
+import { AgentManifest, ApprovalRequest, EmbeddingsConfig, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, TaskStatus } from './types';
 
 /** Settings → Memory view: stored backend config with secrets redacted to `…Set` booleans. */
 interface EmbeddingsView { provider: 'openai' | 'ollama'; url: string; model: string; dimensions?: number; apiKeySet: boolean }
@@ -47,7 +47,7 @@ const WEB_DIST = path.resolve(__dirname, '../web/dist');
 /** Agents available for terminal sessions = whatever manifests this instance loaded.
  *  `deletable` = lives under the data home (user-created), so it can be removed; the bundled
  *  examples that ship with the software are read-only. */
-function terminalAgents(os: AgentOS): { id: string; description: string; category?: string; runtime: string; deletable: boolean; model?: string; effort?: string; examplePrompts?: string[] }[] {
+function terminalAgents(os: AgentOS): { id: string; description: string; category?: string; runtime: string; deletable: boolean; model?: string; effort?: string; examplePrompts?: string[]; icon?: string }[] {
   const userRoot = os.paths ? path.resolve(os.paths.userAgents) + path.sep : null;
   return [...os.agents.values()].map((a) => ({
     id: a.id,
@@ -61,6 +61,8 @@ function terminalAgents(os: AgentOS): { id: string; description: string; categor
     effort: a.effort,
     // Suggested first tasks for the spawn card (clickable chips that prefill the box).
     examplePrompts: a.examplePrompts,
+    // Cosmetic per-agent icon: a library id (lucide name) or raw custom SVG markup.
+    icon: a.icon,
   }));
 }
 
@@ -1323,6 +1325,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
 
     const examplePrompts = sanitizeExamplePrompts(b.examplePrompts);
     const category = sanitizeCategory(b.category);
+    const icon = sanitizeIcon(b.icon);
     const manifest: AgentManifest = {
       id,
       version: '1.0.0',
@@ -1333,6 +1336,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       runtime: 'claude-code',
       ...tuning,
       ...(examplePrompts ? { examplePrompts } : {}),
+      ...(icon ? { icon } : {}),
       budget: { usdCap: 2.0, tokenCap: 400000, wallClockMs: 1800000 },
     };
     fs.mkdirSync(folder, { recursive: true });
@@ -1415,23 +1419,24 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!ag?.dir) return sendJson(res, 404, { error: 'agent not found or has no folder' });
     if (ag.runtime !== 'claude-code') return sendJson(res, 400, { error: 'runtime tuning applies to claude-code agents only' });
     if (method === 'GET') {
-      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, examplePrompts: ag.examplePrompts, category: ag.category });
+      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, examplePrompts: ag.examplePrompts, category: ag.category, icon: ag.icon });
     }
     const b = await readBody(req);
     const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
     if (tErr) return sendJson(res, 400, { error: tErr });
     // Replace the tuning fields wholesale (sanitize already dropped empties to undefined → those
-    // become "inherit"). Starter prompts + category are only touched when the body carries the field
-    // (a tuning-only save from the runtime card leaves them as-is). Preserve everything else.
+    // become "inherit"). Starter prompts + category + icon are only touched when the body carries the
+    // field (a tuning-only save from the runtime card leaves them as-is). Preserve everything else.
     const prompts = 'examplePrompts' in b ? sanitizeExamplePrompts(b.examplePrompts) : ag.examplePrompts;
     const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
+    const icon = 'icon' in b ? sanitizeIcon(b.icon) : ag.icon;
     const description = 'description' in b ? String(b.description ?? '').trim() : ag.description;
-    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, category };
+    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, category, icon };
     const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     os.registerAgent(next);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, category } });
-    return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, category });
+    return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, category, icon });
   }
 
   // ── workspace runtime defaults (the fleet-wide model/effort/permission fallback) — owner/admin only ──

--- a/src/types.ts
+++ b/src/types.ts
@@ -648,6 +648,10 @@ export interface AgentManifest extends RuntimeTuning {
   /** Suggested first tasks shown on the agent's spawn card (clickable chips that prefill the box).
    *  Per-agent so each agent advertises how it wants to be invoked, instead of a generic default. */
   examplePrompts?: string[];
+  /** The agent's visual icon. Either a built-in library id (a lucide icon name like `"Bot"`) or a raw
+   *  custom `<svg>…</svg>` markup string the user uploaded. Undefined → the console falls back to a
+   *  default glyph. Purely cosmetic. Rendered in an `<img>` so inline SVG can't execute scripts. */
+  icon?: string;
   /** Absolute folder the manifest was loaded from — the cwd a claude-code session opens in. Set at load. */
   dir?: string;
 }
@@ -688,6 +692,38 @@ export function sanitizeCategory(input: unknown): string | undefined {
   if (typeof input !== 'string') return undefined;
   const out = input.trim().replace(/\s+/g, ' ').slice(0, 40);
   return out || undefined;
+}
+
+/** Normalize an agent icon (from an API body or config file). Two accepted forms:
+ *   - a built-in library id — a bare lucide icon name (`Bot`, `Wrench`); kept as-is if it's a plain
+ *     identifier (the console maps it to a component, falling back to a default if unknown).
+ *   - raw custom SVG markup — sanitised defensively below and capped in size.
+ *  Anything else → undefined (the manifest carries no `icon` key → default glyph). */
+export function sanitizeIcon(input: unknown): string | undefined {
+  if (typeof input !== 'string') return undefined;
+  const raw = input.trim();
+  if (!raw) return undefined;
+  if (/^<svg[\s>]/i.test(raw)) return sanitizeSvgIcon(raw);
+  // A built-in library id: PascalCase-ish lucide name. Reject anything with markup/odd chars.
+  return /^[A-Za-z][A-Za-z0-9]{0,39}$/.test(raw) ? raw : undefined;
+}
+
+/** Defensively clean an uploaded inline SVG so it's safe to persist and embed. The console renders it
+ *  via an `<img src="data:image/svg+xml,…">`, which already prevents script execution, but we strip
+ *  active content here too (defence in depth) and cap the size so a manifest can't be bloated. Returns
+ *  undefined if the result no longer looks like a lone `<svg>…</svg>` element. */
+export function sanitizeSvgIcon(input: string): string | undefined {
+  if (input.length > 20000) return undefined; // ~20 KB — plenty for an icon, guards manifest bloat
+  let s = input
+    .replace(/<\?xml[\s\S]*?\?>/gi, '')                       // XML prolog
+    .replace(/<!DOCTYPE[\s\S]*?>/gi, '')                      // doctype
+    .replace(/<!--[\s\S]*?-->/g, '')                          // comments
+    .replace(/<script[\s\S]*?<\/script\s*>/gi, '')            // scripts
+    .replace(/<foreignObject[\s\S]*?<\/foreignObject\s*>/gi, '') // arbitrary HTML embed
+    .replace(/\son\w+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)/gi, '') // on* event handlers
+    .replace(/\s(?:xlink:href|href)\s*=\s*("\s*javascript:[^"]*"|'\s*javascript:[^']*')/gi, '') // js: links
+    .trim();
+  return /^<svg[\s\S]*<\/svg\s*>$/i.test(s) ? s : undefined;
 }
 
 /** Resolve the effective tuning for a launch: each field is the agent's own value, else the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent } from 'react'
 import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw } from 'lucide-react'
+import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -75,6 +76,82 @@ function RuntimeBadge({ runtime }: { runtime: AgentInfo['runtime'] }) {
     <Badge variant={claude ? 'default' : 'secondary'} className="px-1.5 py-0 text-[10px] font-normal">
       {claude ? 'claude' : 'mock'}
     </Badge>
+  )
+}
+
+/** The curated built-in icon library — a lucide subset picked for agent roles. The key is stored in
+ *  the manifest's `icon` field verbatim; the value is the component. Unknown/absent keys fall back to
+ *  the default glyph (Bot) in AgentIcon, so the list can grow without breaking old manifests. */
+const AGENT_ICONS: Record<string, LucideIcon> = {
+  Bot, Sparkles, Wand2, Brain, Rocket, Zap, Boxes, Package,
+  Code2, Bug, Terminal, GitBranch, Server, Database, Cloud, Cog, Wrench,
+  Shield, Search, Compass, Globe, Activity, LineChart, BarChart3,
+  MessageSquare, Mail, Megaphone, Send, Headphones, Users, Bell,
+  FileText, ScrollText, BookText, BookOpen, PenTool, Feather, ListChecks, Calendar,
+  DollarSign, ShoppingCart, Building2, Flag, Star, Heart, Palette, Camera, Music,
+}
+const ICON_NAMES = Object.keys(AGENT_ICONS)
+const isCustomSvg = (v?: string) => !!v && /^\s*<svg[\s>]/i.test(v)
+
+/** Renders an agent's icon: a custom uploaded SVG (via an `<img>` data-URI, so any embedded script is
+ *  inert), a built-in library glyph, or — when unset/unknown — the default Bot. */
+function AgentIcon({ icon, className }: { icon?: string; className?: string }) {
+  if (isCustomSvg(icon)) {
+    return <img src={'data:image/svg+xml,' + encodeURIComponent(icon!)} alt="" aria-hidden className={className} />
+  }
+  const Cmp = (icon && AGENT_ICONS[icon]) || Bot
+  return <Cmp className={className} />
+}
+
+const MAX_SVG_BYTES = 20000 // mirrors the server-side cap in sanitizeSvgIcon
+
+/** Icon chooser used by the create + edit forms: a preview, an SVG upload button, and the library
+ *  grid. `value` is a library name or raw SVG; `onChange(undefined)` clears back to the default. */
+function IconPicker({ value, onChange }: { value?: string; onChange: (v: string | undefined) => void }) {
+  const fileRef = useRef<HTMLInputElement>(null)
+  const [err, setErr] = useState('')
+  const custom = isCustomSvg(value)
+
+  const onFile = async (f: File) => {
+    setErr('')
+    if (f.size > MAX_SVG_BYTES) return setErr(`SVG too large (max ${Math.round(MAX_SVG_BYTES / 1000)} KB)`)
+    const text = await f.text()
+    if (!/^\s*<svg[\s>]/i.test(text)) return setErr('not an SVG file')
+    onChange(text)
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md border bg-muted/40">
+          <AgentIcon icon={value} className="h-5 w-5 text-foreground" />
+        </div>
+        <span className="text-[11px] text-muted-foreground">{custom ? 'Custom SVG' : (value || 'Default')}</span>
+        <div className="ml-auto flex items-center gap-1">
+          <input ref={fileRef} type="file" accept=".svg,image/svg+xml" hidden onChange={(e) => { const f = e.target.files?.[0]; if (f) onFile(f); e.target.value = '' }} />
+          <Button type="button" size="sm" variant="outline" className="gap-1" onClick={() => fileRef.current?.click()}><Upload className="h-3.5 w-3.5" /> Upload SVG</Button>
+          {value && <Button type="button" size="sm" variant="ghost" onClick={() => { setErr(''); onChange(undefined) }}>Clear</Button>}
+        </div>
+      </div>
+      {err && <p className="text-[11px] text-destructive">{err}</p>}
+      <div className="grid grid-cols-12 gap-1">
+        {ICON_NAMES.map((name) => {
+          const Cmp = AGENT_ICONS[name]
+          const active = value === name
+          return (
+            <button
+              key={name}
+              type="button"
+              title={name}
+              onClick={() => onChange(name)}
+              className={'flex h-8 w-full items-center justify-center rounded-md border ' + (active ? 'border-primary bg-primary/10 text-primary' : 'border-transparent text-muted-foreground hover:bg-muted hover:text-foreground')}
+            >
+              <Cmp className="h-4 w-4" />
+            </button>
+          )
+        })}
+      </div>
+    </div>
   )
 }
 
@@ -644,7 +721,7 @@ function AgentsPage({
                       <SelectLabel>{cat}</SelectLabel>
                       {list.map((a) => (
                         <SelectItem key={a.id} value={a.id}>
-                          <span className="flex items-center gap-1.5">{a.id}<RuntimeBadge runtime={a.runtime} /></span>
+                          <span className="flex items-center gap-1.5"><AgentIcon icon={a.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />{a.id}<RuntimeBadge runtime={a.runtime} /></span>
                         </SelectItem>
                       ))}
                     </SelectGroup>
@@ -2241,7 +2318,7 @@ function TeamPage({ me }: { me: Member }) {
               return (
                 <Card key={a.id}>
                   <CardContent className="flex flex-wrap items-center gap-2 p-3">
-                    <span className="mr-1 flex items-center gap-1.5 text-sm font-medium">{a.id}<RuntimeBadge runtime={a.runtime} /></span>
+                    <span className="mr-1 flex items-center gap-1.5 text-sm font-medium"><AgentIcon icon={a.icon} className="h-4 w-4 shrink-0 text-muted-foreground" />{a.id}<RuntimeBadge runtime={a.runtime} /></span>
                     <Chip on={acc.allowedRoles.includes('member')} onClick={() => toggleRole(a.id, 'member')}>all members</Chip>
                     {plainMembers.map((m) => (
                       <Chip key={m.id} on={acc.allowedMembers.includes(m.id)} onClick={() => toggleMember(a.id, m.id)}>{m.name}</Chip>
@@ -2632,7 +2709,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
                     <SelectContent>
                       {agents.map((a) => (
                         <SelectItem key={a.id} value={a.id}>
-                          <span className="flex items-center gap-1.5">{a.id}<RuntimeBadge runtime={a.runtime} /></span>
+                          <span className="flex items-center gap-1.5"><AgentIcon icon={a.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />{a.id}<RuntimeBadge runtime={a.runtime} /></span>
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -3071,7 +3148,7 @@ function MemoryBrowse({ agents, me }: { agents: AgentInfo[]; me: Member }) {
             <SelectContent>
               {agents.map((a) => (
                 <SelectItem key={a.id} value={a.id}>
-                  <span className="flex items-center gap-1.5">{a.id}<RuntimeBadge runtime={a.runtime} /></span>
+                  <span className="flex items-center gap-1.5"><AgentIcon icon={a.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />{a.id}<RuntimeBadge runtime={a.runtime} /></span>
                 </SelectItem>
               ))}
             </SelectContent>
@@ -3261,6 +3338,7 @@ function NewAgentPage({ me, onCreated }: { me: Member; onCreated: (id: string) =
   const [id, setId] = useState('')
   const [description, setDescription] = useState('')
   const [category, setCategory] = useState('')
+  const [icon, setIcon] = useState<string | undefined>(undefined)
   const [tuning, setTuning] = useState<RuntimeTuning>({ model: 'claude-opus-4-8' })
   const [claudeMd, setClaudeMd] = useState(NEW_AGENT_CLAUDE_TEMPLATE)
   const [prompts, setPrompts] = useState('')
@@ -3278,7 +3356,7 @@ function NewAgentPage({ me, onCreated }: { me: Member; onCreated: (id: string) =
   const create = async () => {
     setBusy(true); setHint('')
     const examplePrompts = prompts.split('\n').map((s) => s.trim()).filter(Boolean)
-    const r = await api.createAgent({ id: slug, description: description.trim(), category: category.trim(), claudeMd, examplePrompts, ...tuning })
+    const r = await api.createAgent({ id: slug, description: description.trim(), category: category.trim(), icon, claudeMd, examplePrompts, ...tuning })
     setBusy(false)
     if (!r.ok || r.error) return setHint('⚠ ' + (r.error || 'failed to create agent'))
     onCreated(r.id || slug)
@@ -3311,6 +3389,11 @@ function NewAgentPage({ me, onCreated }: { me: Member; onCreated: (id: string) =
             <label className="text-xs font-medium">Category</label>
             <Input value={category} onChange={(e) => setCategory(e.target.value)} placeholder="e.g. Engineering, Marketing" className="text-sm" />
             <p className="text-[11px] text-muted-foreground">Optional. Groups the agent in the picker. Leave blank for “Uncategorized”.</p>
+          </div>
+          <div className="space-y-1">
+            <label className="text-xs font-medium">Icon</label>
+            <IconPicker value={icon} onChange={setIcon} />
+            <p className="text-[11px] text-muted-foreground">Optional. Pick from the library or upload a custom SVG. Shown next to the agent everywhere it’s listed.</p>
           </div>
           <div className="space-y-1">
             <label className="text-xs font-medium">Starter prompts</label>
@@ -3351,6 +3434,8 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
   const [savedPrompts, setSavedPrompts] = useState('')
   const [category, setCategory] = useState('')
   const [savedCategory, setSavedCategory] = useState('')
+  const [icon, setIcon] = useState<string | undefined>(undefined)
+  const [savedIcon, setSavedIcon] = useState<string | undefined>(undefined)
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
 
@@ -3361,22 +3446,23 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
       const d = r.description ?? ''
       const p = (r.examplePrompts ?? []).join('\n')
       const c = r.category ?? ''
-      setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c)
+      setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon)
     }).catch(() => {})
   }, [agentId])
 
-  const dirty = JSON.stringify(tuning) !== JSON.stringify(saved) || description !== savedDescription || prompts !== savedPrompts || category !== savedCategory
+  const dirty = JSON.stringify(tuning) !== JSON.stringify(saved) || description !== savedDescription || prompts !== savedPrompts || category !== savedCategory || icon !== savedIcon
   const save = async () => {
     setBusy(true); setHint('')
     const examplePrompts = prompts.split('\n').map((s) => s.trim()).filter(Boolean)
-    const r = await api.saveAgentConfig(agentId, { ...tuning, description: description.trim(), examplePrompts, category: category.trim() })
+    // Always send `icon` (empty string clears it → server drops the manifest key).
+    const r = await api.saveAgentConfig(agentId, { ...tuning, description: description.trim(), examplePrompts, category: category.trim(), icon: icon ?? '' })
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
     const t: RuntimeTuning = { model: r.model, effort: r.effort }
     const d = r.description ?? ''
     const p = (r.examplePrompts ?? []).join('\n')
     const c = r.category ?? ''
-    setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setHint('saved — applies on the next session'); setTimeout(() => setHint(''), 2500)
+    setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon); setHint('saved — applies on the next session'); setTimeout(() => setHint(''), 2500)
     onSaved?.()
   }
 
@@ -3392,6 +3478,10 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
         <div className="space-y-1">
           <label className="text-xs font-medium">Category</label>
           <Input value={category} onChange={(e) => setCategory(e.target.value)} className="text-sm" placeholder="e.g. Engineering, Marketing — blank for Uncategorized" />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium">Icon</label>
+          <IconPicker value={icon} onChange={setIcon} />
         </div>
         <div className="space-y-1">
           <label className="text-xs font-medium">Starter prompts</label>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -41,6 +41,8 @@ export interface AgentInfo {
   effort?: Effort
   /** Suggested first tasks shown as clickable chips on the spawn card. */
   examplePrompts?: string[]
+  /** Cosmetic per-agent icon: a built-in library id (a lucide name) or raw custom `<svg>` markup. */
+  icon?: string
 }
 export interface StateResp {
   tenant: string
@@ -657,13 +659,13 @@ export const api = {
   // One "reflect" pass: cheap deterministic tally + the memory-gardener over new material (nested `consolidation`).
   dreamingRun: () => call<{ ok: boolean; skipped?: boolean; sessions?: number; episodes?: number; kbPageId?: string; insightId?: string; guidance?: string; consolidation?: { spawned?: boolean; reason?: string; sessionId?: string; items?: number }; error?: string }>('POST', '/api/dreaming/run'),
 
-  createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[] } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
+  createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),
   rescanAgents: () => call<{ ok: boolean; added: string[]; updated: string[]; removed: string[]; errors: { folder: string; error: string }[]; error?: string }>('POST', '/api/agents/rescan'),
   agentClaude: (id: string) => call<{ agent: string; runtime: string; exists: boolean; content: string; error?: string }>('GET', `/api/agents/${encodeURIComponent(id)}/claude`),
   saveAgentClaude: (id: string, content: string) => call<{ ok: boolean; error?: string }>('PUT', `/api/agents/${encodeURIComponent(id)}/claude`, { content }),
-  agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; category?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),
-  saveAgentConfig: (id: string, patch: RuntimeTuning & { description?: string; examplePrompts?: string[]; category?: string }) => call<{ ok: boolean; error?: string; description?: string; examplePrompts?: string[]; category?: string } & RuntimeTuning>('PUT', `/api/agents/${encodeURIComponent(id)}/config`, patch),
+  agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; category?: string; icon?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),
+  saveAgentConfig: (id: string, patch: RuntimeTuning & { description?: string; examplePrompts?: string[]; category?: string; icon?: string }) => call<{ ok: boolean; error?: string; description?: string; examplePrompts?: string[]; category?: string; icon?: string } & RuntimeTuning>('PUT', `/api/agents/${encodeURIComponent(id)}/config`, patch),
   runtimeDefaults: () => call<RuntimeTuning & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/runtime-defaults'),
   saveRuntimeDefaults: (tuning: RuntimeTuning) => call<{ ok: boolean; error?: string } & RuntimeTuning>('PUT', '/api/settings/runtime-defaults', tuning),
 


### PR DESCRIPTION
## What

Agents can now carry a **visual icon**. Two ways to set one:

- **Built-in library** — a curated lucide subset (~48 glyphs spanning engineering, comms, ops, finance roles), shown as a grid picker.
- **Custom SVG upload** — pick any `.svg`; it's stored inline on the manifest.

The icon renders everywhere an agent is listed: the spawn picker (and its trigger), the assignments page, and the task/schedule pickers. Agents without one fall back to a default **Bot** glyph.

## How

- **Model** — one cosmetic `icon` field on `AgentManifest` (a library id like `"Bot"`, or raw `<svg>` markup). Persisted in `agent.json`, no DB migration. Round-trips through the loader → `terminalAgents` → the console.
- **Create + edit** — accepted by `POST /api/agents` and `PUT /api/agents/:id/config` (the config PUT clears the icon on an empty string). Edited from the New-agent form and the per-agent settings card.
- **Safety** — uploaded SVGs are sanitised server-side (`sanitizeIcon`/`sanitizeSvgIcon`): strips `<script>`, `on*` handlers, `javascript:` links and `<foreignObject>`, with a 20 KB cap. The console additionally renders custom SVG via an `<img>` data-URI, so any residual markup is inert (no script execution).

## Verification

- `npm run typecheck` ✓ · `cd web && npm run build` ✓
- Unit-tested `sanitizeIcon` (library names, bad input, script/handler/js-link/foreignObject stripping, oversize rejection) — all pass.
- Confirmed the `icon` field round-trips through the manifest loader in an isolated scratch home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)