### PR TITLE
Skills: always-on default engineering-discipline skill for the whole fleet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ new version heading in the same commit.
   new material. The Memory hub drops from three tabs to **two** (Memories · Self-learning) under a slim
   stats strip; the "Lever N" and "Dreaming vs Consolidation" jargon is retired from the product surface.
 
+## [0.8.0] — 2026-07-06
+
+### Added
+- **Default `engineering-discipline` skill, always on across the fleet.** A single, tone-neutral
+  coding-conduct skill — surface assumptions before coding, keep the solution minimal (reuse before
+  you write), make surgical changes, leave a verifiable check, and a "never simplify away" safety floor
+  (validation / error handling / security / a11y / tests / anything asked for). Distilled from the best
+  of the public Karpathy-guidelines and Ponytail skills, with the personas/comment-conventions stripped
+  and a **headless override** added so unattended runs (cron / Slack / Discord / dispatched tasks) make
+  the most reasonable assumption and proceed instead of stalling on a clarifying question. Ships in the
+  bundled catalog (`config/skills/engineering-discipline`) with `default: true` in its frontmatter.
+- **Always-on default skills.** Catalog skills flagged `default: true` now materialise into **every**
+  claude-code agent at launch with no per-tenant install (`SkillsStore.materialize` unions the library
+  with default catalog skills; `CatalogSkill.isDefault` surfaces the flag). A library or hand-authored
+  skill of the same name still shadows the default, and the `.aos-managed` marker keeps re-syncs from
+  clobbering an agent's own copies.
+
 ## [0.7.0] — 2026-07-05
 
 ### Added

--- a/config/skills/engineering-discipline/SKILL.md
+++ b/config/skills/engineering-discipline/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: engineering-discipline
+description: Baseline engineering conduct for writing, reviewing, editing, or refactoring code — surface assumptions before coding, keep the solution minimal, make surgical changes, leave a verifiable check, and never simplify away safety. Use on any coding, scripting, or code-review task.
+license: MIT
+default: true
+---
+
+# Engineering discipline
+
+House rules for how this fleet writes and changes code. They target the failure
+modes that hurt output quality regardless of language or stack: silent
+assumptions, over-engineering, drive-by edits, and unverifiable "done". Apply
+them to every coding, scripting, or review task — they describe *how* you build,
+not *what* you're allowed to do (the gateway still governs that).
+
+## 1. Think before coding
+- State the assumptions your solution depends on. If a request has more than one
+  reasonable reading, name them and pick the most likely — don't silently guess.
+- If the ask looks wrong, more complex than needed, or conflicts with the code
+  you can see, say so before building it.
+- **Interactive vs. unattended.** When a human is attached and a genuine fork
+  would change the result, ask. When running **headless/unattended** (cron,
+  Slack/Discord, a dispatched task — you cannot get an answer), do **not** stall:
+  make the most reasonable assumption, state it plainly in your report, and
+  proceed. A blocked question in a headless run is a failed run.
+
+## 2. Simplicity first
+- Write the minimum code that fully solves the problem. Nothing speculative — no
+  features, config, abstractions, or error paths beyond what the task needs.
+- **Reuse before you write.** Prefer an existing helper, the standard library, or
+  a dependency already in the project over new code. The best code is the code you
+  didn't have to write.
+- If you produced 200 lines and 50 would do, rewrite it. Ask: "would a senior
+  engineer call this overcomplicated?" If yes, simplify.
+
+## 3. Surgical changes
+- Touch only what the request requires. Every changed line should trace to the
+  ask. No drive-by refactors, renames, or reformatting of code you're not there
+  to change.
+- Match the surrounding style, naming, and comment density even if you'd do it
+  differently. Clean up only the mess your own change created (orphaned imports,
+  dead branches you introduced).
+- Notice unrelated dead code or a real bug nearby? **Mention it, don't fix it**
+  in the same change.
+
+## 4. Leave it verifiable
+- Turn a vague task into a checkable goal: "add validation" → "inputs X and Y are
+  rejected, and here's the check that proves it."
+- For any non-trivial logic, leave behind the smallest runnable thing that fails
+  if the logic breaks — a test, an assertion, or a command in your report the
+  reviewer can run. Logic without a check is unfinished.
+
+## 5. Never simplify away
+Minimalism has a floor. Do **not** drop, in the name of brevity:
+- input validation at trust boundaries,
+- error handling that prevents data loss or corruption,
+- security and authorization checks,
+- accessibility basics,
+- tests for non-trivial logic,
+- anything the task explicitly asked for.
+A shortcut here is a defect, not a simplification.
+
+## 6. Report concisely
+When you finish, lead with the change, then at most a few short lines: what you
+deliberately skipped and when it should be added, and any assumption you made.
+If your explanation is longer than the change, cut the explanation — a paragraph
+defending a shortcut is complexity smuggled back in as prose.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/skills.ts
+++ b/src/governance/skills.ts
@@ -62,6 +62,12 @@ export interface CatalogSkill {
   files: string[];
   /** True when the tenant's library already contains a skill of this name. */
   installed: boolean;
+  /**
+   * `default: true` in the catalog SKILL.md frontmatter — a fleet-wide DEFAULT skill. These
+   * materialise into every agent automatically (no per-tenant install), unless a library or
+   * hand-authored skill of the same name shadows them. See `materialize`.
+   */
+  isDefault: boolean;
 }
 
 export interface CreateSkillInput {
@@ -227,7 +233,7 @@ export class SkillsStore {
    * library skill is synced (back-compat for non-agent callers).
    */
   materialize(claudeDir: string, agent?: string): string[] {
-    if (!this.dir) return [];
+    if (!this.dir && !this.catalogDir) return [];
     const target = path.join(claudeDir, 'skills');
     const managed = new Set<string>(); // names we own in the target right now
     const handAuthored = new Set<string>(); // agent's own — leave alone, they shadow globals
@@ -243,9 +249,15 @@ export class SkillsStore {
     const library = this.list().filter(
       (s) => agent === undefined || s.agents.length === 0 || s.agents.includes(agent),
     );
-    const wanted = new Set(library.map((s) => s.name));
+    const libNames = new Set(library.map((s) => s.name));
 
-    // Drop managed skills that have left the library (or are now shadowed by a hand-authored one).
+    // Fleet-wide DEFAULT catalog skills (`default: true`) materialise into EVERY agent with no
+    // per-tenant install — always on. A library skill of the same name (the tenant installed/edited
+    // its own copy) shadows the default, so we skip those. Hand-authored copies win over both below.
+    const defaults = this.defaultSkillNames().filter((n) => !libNames.has(n));
+    const wanted = new Set<string>([...libNames, ...defaults]);
+
+    // Drop managed skills that have left the library/defaults (or are now shadowed by hand-authored).
     for (const name of managed) {
       if (!wanted.has(name) || handAuthored.has(name)) {
         fs.rmSync(path.join(target, name), { recursive: true, force: true });
@@ -257,6 +269,11 @@ export class SkillsStore {
       if (handAuthored.has(s.name)) continue; // agent's own copy wins
       this.copySkill(s.name, path.join(target, s.name));
       done.push(s.name);
+    }
+    for (const name of defaults) {
+      if (handAuthored.has(name)) continue; // agent's own copy wins
+      this.copyFrom(this.catalogDir!, name, path.join(target, name));
+      done.push(name);
     }
     return done;
   }
@@ -307,7 +324,19 @@ export class SkillsStore {
       .readdirSync(folder, { withFileTypes: true })
       .filter((e) => !(e.isFile() && e.name === 'SKILL.md') && e.name !== MARKER && e.name !== 'node_modules')
       .map((e) => (e.isDirectory() ? e.name + '/' : e.name));
-    return { name, description: fm.description ?? '', bytes: stat.size, files };
+    return { name, description: fm.description ?? '', bytes: stat.size, files, isDefault: fm.default === 'true' };
+  }
+
+  /** Names of the fleet-wide DEFAULT catalog skills (`default: true`) — always materialised. */
+  private defaultSkillNames(): string[] {
+    if (!this.catalogDir || !fs.existsSync(this.catalogDir)) return [];
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(this.catalogDir, { withFileTypes: true })) {
+      if (!entry.isDirectory() || !validSkillName(entry.name)) continue;
+      const c = this.readCatalog(entry.name);
+      if (c?.isDefault) out.push(entry.name);
+    }
+    return out;
   }
 
   // ── per-agent assignment (skill_assignments join table) ──────────────────────
@@ -342,6 +371,23 @@ export class SkillsStore {
     fs.rmSync(dest, { recursive: true, force: true });
     fs.mkdirSync(dest, { recursive: true });
     fs.cpSync(src, dest, { recursive: true });
+    fs.writeFileSync(path.join(dest, MARKER), '');
+  }
+
+  /**
+   * Copy a skill folder from an arbitrary source dir (the bundled catalog) into `dest`, skipping
+   * `node_modules` and any stale marker, then stamp our managed marker. Used for the always-on
+   * DEFAULT catalog skills — the per-agent copy is refreshed from the software on every launch, so a
+   * skill's own first-run step reinstalls deps as needed (as `design-review` already does).
+   */
+  private copyFrom(srcDir: string, name: string, dest: string): void {
+    const src = path.join(srcDir, name);
+    fs.rmSync(dest, { recursive: true, force: true });
+    fs.mkdirSync(dest, { recursive: true });
+    fs.cpSync(src, dest, {
+      recursive: true,
+      filter: (s) => path.basename(s) !== 'node_modules' && path.basename(s) !== MARKER,
+    });
     fs.writeFileSync(path.join(dest, MARKER), '');
   }
 }


### PR DESCRIPTION
## What

Adds a fleet-wide **default skill** and the plumbing to make it always-on.

**The skill — `engineering-discipline`** (`config/skills/engineering-discipline/SKILL.md`, ~2 KB, tone-neutral):
- **Think before coding** — surface assumptions, name ambiguous readings, push back on wrong asks.
- **Simplicity first** — minimum code, reuse before you write, "could 200 lines be 50?".
- **Surgical changes** — touch only what the ask requires; mention nearby bugs, don't fix them.
- **Leave it verifiable** — turn vague tasks into checkable goals; leave the smallest runnable check.
- **Never simplify away** — a safety floor (validation / error handling / security / a11y / tests / anything asked for).
- **Headless override** — unattended runs (cron / Slack / Discord / dispatched tasks) make the most reasonable assumption and proceed instead of stalling on a clarifying question.

Distilled from the best of the public Karpathy-guidelines and Ponytail skills, with the personas and `// ponytail:` comment conventions stripped. The Caveman terseness skill was evaluated and **not** adopted — it's a cost lever, not a quality lever, and reads jarringly in the Slack/Discord/chat surfaces.

**Always-on materialization** (`src/governance/skills.ts`):
- Catalog skills with `default: true` in their frontmatter now materialize into **every** claude-code agent at launch — no per-tenant install step.
- `SkillsStore.materialize` unions the tenant library with the default catalog skills; `CatalogSkill.isDefault` surfaces the flag to the API/console.
- A library or hand-authored skill of the same name still **shadows** the default, and the `.aos-managed` marker keeps re-syncs from clobbering an agent's own copies.

## Why

The three studied repos are ~70% the same "write less, over-engineer less" advice. Rather than ship overlapping personas, this merges the additive parts into one house skill and adds the one thing they lack for a governed fleet: a headless-safe execution bias. Shipping it as a skill (not a `buildCompanyMd` system-prompt block) keeps it out of non-coding turns (chat/ops) and lets it auto-load by description-match when an agent is actually writing code.

## Verification

- `npm run typecheck` — clean
- `npm run build` — clean
- `npm run test:governance` — 44/44 ✓
- Isolated `SkillsStore` test (scratch home): default skill materializes into a fresh agent with no install; marker stamped; a hand-authored same-named skill is preserved (shadow rule holds, no duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)