### PR TITLE
Skills: make engineering-discipline opt-in, not always-on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,19 +20,15 @@ new version heading in the same commit.
 ## [0.8.0] — 2026-07-06
 
 ### Added
-- **Default `engineering-discipline` skill, always on across the fleet.** A single, tone-neutral
-  coding-conduct skill — surface assumptions before coding, keep the solution minimal (reuse before
-  you write), make surgical changes, leave a verifiable check, and a "never simplify away" safety floor
-  (validation / error handling / security / a11y / tests / anything asked for). Distilled from the best
-  of the public Karpathy-guidelines and Ponytail skills, with the personas/comment-conventions stripped
-  and a **headless override** added so unattended runs (cron / Slack / Discord / dispatched tasks) make
-  the most reasonable assumption and proceed instead of stalling on a clarifying question. Ships in the
-  bundled catalog (`config/skills/engineering-discipline`) with `default: true` in its frontmatter.
-- **Always-on default skills.** Catalog skills flagged `default: true` now materialise into **every**
-  claude-code agent at launch with no per-tenant install (`SkillsStore.materialize` unions the library
-  with default catalog skills; `CatalogSkill.isDefault` surfaces the flag). A library or hand-authored
-  skill of the same name still shadows the default, and the `.aos-managed` marker keeps re-syncs from
-  clobbering an agent's own copies.
+- **`engineering-discipline` skill in the bundled catalog.** A single, tone-neutral coding-conduct skill
+  — surface assumptions before coding, keep the solution minimal (reuse before you write), make surgical
+  changes, leave a verifiable check, and a "never simplify away" safety floor (validation / error
+  handling / security / a11y / tests / anything asked for). Distilled from the best of the public
+  Karpathy-guidelines and Ponytail skills, with the personas/comment-conventions stripped and a
+  **headless override** added so unattended runs (cron / Slack / Discord / dispatched tasks) make the
+  most reasonable assumption and proceed instead of stalling on a clarifying question. Opt-in per tenant
+  from the Skills catalog (`config/skills/engineering-discipline`); once installed it materialises into
+  every claude-code agent at launch like any other library skill.
 
 ## [0.7.0] — 2026-07-05
 

--- a/config/skills/engineering-discipline/SKILL.md
+++ b/config/skills/engineering-discipline/SKILL.md
@@ -2,7 +2,6 @@
 name: engineering-discipline
 description: Baseline engineering conduct for writing, reviewing, editing, or refactoring code — surface assumptions before coding, keep the solution minimal, make surgical changes, leave a verifiable check, and never simplify away safety. Use on any coding, scripting, or code-review task.
 license: MIT
-default: true
 ---
 
 # Engineering discipline

--- a/src/governance/skills.ts
+++ b/src/governance/skills.ts
@@ -62,12 +62,6 @@ export interface CatalogSkill {
   files: string[];
   /** True when the tenant's library already contains a skill of this name. */
   installed: boolean;
-  /**
-   * `default: true` in the catalog SKILL.md frontmatter — a fleet-wide DEFAULT skill. These
-   * materialise into every agent automatically (no per-tenant install), unless a library or
-   * hand-authored skill of the same name shadows them. See `materialize`.
-   */
-  isDefault: boolean;
 }
 
 export interface CreateSkillInput {
@@ -233,7 +227,7 @@ export class SkillsStore {
    * library skill is synced (back-compat for non-agent callers).
    */
   materialize(claudeDir: string, agent?: string): string[] {
-    if (!this.dir && !this.catalogDir) return [];
+    if (!this.dir) return [];
     const target = path.join(claudeDir, 'skills');
     const managed = new Set<string>(); // names we own in the target right now
     const handAuthored = new Set<string>(); // agent's own — leave alone, they shadow globals
@@ -249,15 +243,9 @@ export class SkillsStore {
     const library = this.list().filter(
       (s) => agent === undefined || s.agents.length === 0 || s.agents.includes(agent),
     );
-    const libNames = new Set(library.map((s) => s.name));
+    const wanted = new Set(library.map((s) => s.name));
 
-    // Fleet-wide DEFAULT catalog skills (`default: true`) materialise into EVERY agent with no
-    // per-tenant install — always on. A library skill of the same name (the tenant installed/edited
-    // its own copy) shadows the default, so we skip those. Hand-authored copies win over both below.
-    const defaults = this.defaultSkillNames().filter((n) => !libNames.has(n));
-    const wanted = new Set<string>([...libNames, ...defaults]);
-
-    // Drop managed skills that have left the library/defaults (or are now shadowed by hand-authored).
+    // Drop managed skills that have left the library (or are now shadowed by a hand-authored one).
     for (const name of managed) {
       if (!wanted.has(name) || handAuthored.has(name)) {
         fs.rmSync(path.join(target, name), { recursive: true, force: true });
@@ -269,11 +257,6 @@ export class SkillsStore {
       if (handAuthored.has(s.name)) continue; // agent's own copy wins
       this.copySkill(s.name, path.join(target, s.name));
       done.push(s.name);
-    }
-    for (const name of defaults) {
-      if (handAuthored.has(name)) continue; // agent's own copy wins
-      this.copyFrom(this.catalogDir!, name, path.join(target, name));
-      done.push(name);
     }
     return done;
   }
@@ -324,19 +307,7 @@ export class SkillsStore {
       .readdirSync(folder, { withFileTypes: true })
       .filter((e) => !(e.isFile() && e.name === 'SKILL.md') && e.name !== MARKER && e.name !== 'node_modules')
       .map((e) => (e.isDirectory() ? e.name + '/' : e.name));
-    return { name, description: fm.description ?? '', bytes: stat.size, files, isDefault: fm.default === 'true' };
-  }
-
-  /** Names of the fleet-wide DEFAULT catalog skills (`default: true`) — always materialised. */
-  private defaultSkillNames(): string[] {
-    if (!this.catalogDir || !fs.existsSync(this.catalogDir)) return [];
-    const out: string[] = [];
-    for (const entry of fs.readdirSync(this.catalogDir, { withFileTypes: true })) {
-      if (!entry.isDirectory() || !validSkillName(entry.name)) continue;
-      const c = this.readCatalog(entry.name);
-      if (c?.isDefault) out.push(entry.name);
-    }
-    return out;
+    return { name, description: fm.description ?? '', bytes: stat.size, files };
   }
 
   // ── per-agent assignment (skill_assignments join table) ──────────────────────
@@ -371,23 +342,6 @@ export class SkillsStore {
     fs.rmSync(dest, { recursive: true, force: true });
     fs.mkdirSync(dest, { recursive: true });
     fs.cpSync(src, dest, { recursive: true });
-    fs.writeFileSync(path.join(dest, MARKER), '');
-  }
-
-  /**
-   * Copy a skill folder from an arbitrary source dir (the bundled catalog) into `dest`, skipping
-   * `node_modules` and any stale marker, then stamp our managed marker. Used for the always-on
-   * DEFAULT catalog skills — the per-agent copy is refreshed from the software on every launch, so a
-   * skill's own first-run step reinstalls deps as needed (as `design-review` already does).
-   */
-  private copyFrom(srcDir: string, name: string, dest: string): void {
-    const src = path.join(srcDir, name);
-    fs.rmSync(dest, { recursive: true, force: true });
-    fs.mkdirSync(dest, { recursive: true });
-    fs.cpSync(src, dest, {
-      recursive: true,
-      filter: (s) => path.basename(s) !== 'node_modules' && path.basename(s) !== MARKER,
-    });
     fs.writeFileSync(path.join(dest, MARKER), '');
   }
 }


### PR DESCRIPTION
## What

Reverses the always-on behavior from #17. An always-on **default** skill that still shows an **Install** button in the Skills catalog is contradictory UX — "default on" and "install me" can't both be true.

So `engineering-discipline` becomes a **normal opt-in bundled catalog skill** (off by default): install it from the catalog when you want it, and once installed it materializes into every agent like any other library skill.

## Changes
- Drops the `default: true` frontmatter flag from `config/skills/engineering-discipline/SKILL.md` (the skill content is otherwise unchanged).
- Removes the now-unused always-on materialization plumbing added in #17 — `CatalogSkill.isDefault`, `defaultSkillNames`, `copyFrom`, and the `materialize` default-union. `src/governance/skills.ts` returns **byte-identical** to pre-#17 main.
- Rewords the 0.8.0 CHANGELOG entry to describe an opt-in catalog skill.

## Verification
- `npm run typecheck` — clean
- `npm run test:governance` — 44/44 ✓
- `git diff 772ae79 -- src/governance/skills.ts` is empty (skills.ts back to pre-feature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)