### PR TITLE
Agents: agent-author — a default System agent that builds other agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.11.0] — 2026-07-06
+
+### Added
+- **The agent-author — a default *System* agent that builds other agents.** Agent OS now ships a
+  meta-agent ([`src/edge/agent-author.ts`](src/edge/agent-author.ts)) provisioned into every data home
+  under the **System** category (like the consolidator): it interviews you about a role, drafts a
+  manifest + CLAUDE.md, and **creates the agent for real** via two new agent-facing MCP tools —
+  `agent_create` and `agent_update` (`memory-mcp.ts`). These are session-secret-gated loopback routes
+  (`POST /api/agents/create|update`) sitting before the member gate, following the same **auto-apply +
+  audited** posture as `kb_write` / `task_create` (`agent.created` / `agent.config.updated`,
+  `principal: agent:<id>`). A new agent is live in the console immediately — no restart. Creating a
+  *definition* escalates nothing: the new agent still passes every effect through the gate, and only a
+  human can run or assign it. `agent_update` edits only user-home agents (bundled examples stay
+  read-only). Docs: [`docs/agent-mcp-tools.md`](docs/agent-mcp-tools.md) (now 27 always-on + 2
+  conditional tools).
+
 ## [0.10.0] — 2026-07-06
 
 ### Changed

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -34,10 +34,12 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `task_get` | `GET /api/tasks/get` | `TaskStore.withEvents` | R | task + full activity timeline |
 | `task_claim` | `POST /api/tasks/claim` | `TaskStore.claim` | W | atomic take (→ doing); loses if already claimed |
 | `task_update` | `POST /api/tasks/update` | `TaskStore.update` | W | status/note/reassign; closes a dispatched loop |
+| `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
+| `agent_update` | `POST /api/agents/update` | `AgentOS.registerAgent` | W | rewrites manifest (+CLAUDE.md); user-home agents only; audited `agent.config.updated` |
 | `slack_reply` | `POST /api/agent/slack/reply` | SlackSocket | W | only when `SLACK_REPLY=1` (chat-triggered) |
 | `discord_reply` | `POST /api/agent/discord/reply` | DiscordSocket | W | only when `DISCORD_REPLY=1` (chat-triggered) |
 
-25 always-on tools + 2 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+27 always-on tools + 2 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 
@@ -52,6 +54,18 @@ run-as identity, just later. So it takes **no fresh approval** — but it's boun
 scheduler `tick()` fires it once when due, then disables it. Recurring (cron) schedules remain
 human-only. A future tightening could classify `schedule` through Policy for workspaces that want
 sign-off on deferred runs.
+
+### `agent_create` / `agent_update` — governance model
+
+These are the **agent-author's** build tools (the default *System* agent provisioned by
+`src/edge/agent-author.ts`), though — like the Tasks tools — they're the general **delegation surface**
+available to any agent. Creating an agent **definition escalates nothing**: the new agent still passes
+every side effect through the gate, and only a **human** can run or assign it (spawn is role-gated). So
+they follow the same **auto-apply + audited** posture as `kb_write` / `task_create` — no approval card —
+emitting `agent.created` / `agent.config.updated` with `principal: agent:<id>`. Guards: strict id
+validation + collision check on create; `agent_update` only touches agents that live under the data home
+(the read-only bundled examples can't be edited) and rewrites only the fields the caller supplied. A
+future tightening could classify agent creation through Policy for workspaces that want sign-off.
 
 ## Remaining gaps (not yet exposed)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/agent-author.ts
+++ b/src/edge/agent-author.ts
@@ -1,0 +1,106 @@
+/**
+ * The **agent-author** — a default *System* agent that builds other agents.
+ *
+ * Agent OS ships one meta-agent whose job is to create and refine the rest of the fleet: it interviews
+ * you about the role you need, drafts a manifest + a good CLAUDE.md, and then materialises the agent for
+ * real via its own `agent_create` / `agent_update` tools (loopback → `/api/agents/create|update`, the
+ * same session-secret-gated, auto-apply + audited path every other agent-facing tool uses). So a new
+ * agent is live in the console immediately — no restart, no hand-editing JSON.
+ *
+ * Like the consolidator (src/edge/consolidation.ts) it is *code-provisioned*: `ensureAgentAuthor` writes
+ * an isolated folder (`<home>/agents/agent-author/{agent.json,CLAUDE.md}`) into the data home on boot,
+ * idempotently, so every workspace has it under the **System** category without shipping a config/agents
+ * folder. User edits to either file are preserved (only written when absent); delete it and boot
+ * restores it.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AgentOS } from '../kernel';
+import type { AgentManifest } from '../types';
+
+export const AGENT_AUTHOR_ID = 'agent-author';
+
+const MANIFEST: AgentManifest = {
+  id: AGENT_AUTHOR_ID,
+  version: '1.0.0',
+  description: 'Builds and refines other agents — interview a role, draft its prompt, and create it live.',
+  category: 'System',
+  principal: 'svc-agent-author',
+  policyContext: 'default@v1',
+  runtime: 'claude-code',
+  model: 'claude-opus-4-8',
+  icon: 'Wand2',
+  examplePrompts: [
+    'Create a support agent that triages inbound bug reports',
+    'I need an agent that writes weekly SEO reports — help me build it',
+    'Review the engineer agent and tighten its instructions',
+  ],
+  budget: { usdCap: 2, tokenCap: 400_000, wallClockMs: 1_800_000 },
+};
+
+const CLAUDE_MD = `# Agent author
+
+You are Agent OS's **agent author** — the System agent that builds and refines the rest of the fleet.
+A person comes to you with a job they want done by an agent; you turn that into a real, governed agent
+in this workspace. You don't do the downstream work yourself — you create the *agent that will*.
+
+## What an agent is here
+An agent is a folder under the data home — \`<home>/agents/<id>/\` — with two files:
+- **agent.json** — the manifest (id, description, category, runtime, model/effort, icon, starter prompts).
+- **CLAUDE.md** — the agent's system prompt: who it is, how it works, its boundaries.
+Every side effect it later has on the world still passes through the OS gate (policy → approval →
+budget → audit), so you never have to build safety into the prompt — you build *competence* into it.
+
+## Your tools
+- **agent_create** — create a brand-new agent and register it live (no restart). You supply \`id\`,
+  \`description\`, \`claudeMd\`, and optionally \`category\`, \`model\`, \`effort\`, \`examplePrompts\`, \`icon\`.
+- **agent_update** — edit an existing agent: pass \`id\` plus only the fields you want to change
+  (\`claudeMd\`, \`description\`, \`category\`, \`model\`, \`effort\`, \`examplePrompts\`, \`icon\`).
+- Plus the usual OS tools — \`recall\`/\`remember\` to reuse what you've learned about good agent design,
+  \`kb_search\`/\`kb_read\` for house conventions, \`report\` to close out.
+
+## Method
+1. **Interview first.** Before creating anything, get clear on: the agent's single job, its typical
+   inputs, what "done" looks like, who it acts for, and any tools/connectors it leans on. Ask 2–4 sharp
+   questions if the request is thin — don't invent a mandate.
+2. **Propose, then build.** Sketch the id, category, and a short description back to the person, and the
+   shape of the CLAUDE.md, before calling \`agent_create\`. If they're clearly ready, just build it and
+   show what you made.
+3. **Write a CLAUDE.md that's specific.** Good agent prompts: state the role in one line; give a crisp
+   *method* (numbered steps for the common case); name the tools it should reach for; set explicit
+   boundaries ("you do X, you never Y"); and tell it how to finish (e.g. \`report\` / reply in the
+   channel). Concrete beats generic. Match the tone of the existing fleet.
+4. **Pick sensible metadata:**
+   - **id** — lowercase letters, digits, hyphens (2–40 chars, starts with a letter), e.g. \`seo-writer\`.
+   - **category** — one of the house buckets: Support, Engineering, Marketing, Sales, Research, Ops
+     (reserve **System** for OS-internal agents like you). It's just a grouping label in the console.
+   - **model/effort** — omit to inherit the workspace defaults unless the role clearly needs a specific
+     tier. Effort is one of: low, medium, high, xhigh, max.
+   - **icon** — a lucide name from the library (e.g. Bot, Wrench, Code2, Bug, MessageSquare, Megaphone,
+     LineChart, FileText, Shield, Headphones, ShoppingCart). Omit for the default.
+   - **examplePrompts** — 2–3 clickable starter tasks that show how to invoke it.
+5. **Confirm it's live.** After \`agent_create\`, tell the person the agent now appears in the console
+   (grouped under its category) and how to run or assign it. If they want tweaks, use \`agent_update\`.
+6. **Finish with \`report\`** — a one-line summary of the agent you created or changed.
+
+## Boundaries
+- You create and refine *agent definitions*. You don't run the agents, assign them to people, or grant
+  access — a human does that from the console (running an agent is role-gated).
+- Reuse over duplication: if an existing agent nearly fits, prefer \`agent_update\` to refine it over
+  spawning a near-twin. \`recall\` and check before you build.
+- Keep new agents single-purpose. If a request spans two clearly different jobs, propose two agents.`;
+
+/** Provision the agent-author into the data home on boot (isolated folder + manifest + CLAUDE.md), then
+ *  register it live so it resolves to a real claude-code runtime. Idempotent: skips when already
+ *  registered with a folder, and never overwrites a manifest/CLAUDE.md a user has edited. No-op in the
+ *  in-memory demo/test build (no data home). */
+export function ensureAgentAuthor(os: AgentOS): void {
+  if (!os.paths) return; // demo/tests run in-memory with no agents home to write into
+  if (os.agents.get(AGENT_AUTHOR_ID)?.dir) return;
+  const dir = path.join(os.paths.userAgents, AGENT_AUTHOR_ID);
+  fs.mkdirSync(dir, { recursive: true });
+  const manifestPath = path.join(dir, 'agent.json');
+  if (!fs.existsSync(manifestPath)) fs.writeFileSync(manifestPath, JSON.stringify(MANIFEST, null, 2) + '\n');
+  if (!fs.existsSync(path.join(dir, 'CLAUDE.md'))) fs.writeFileSync(path.join(dir, 'CLAUDE.md'), CLAUDE_MD);
+  os.registerAgent({ ...MANIFEST, dir });
+}

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -38,6 +38,7 @@ import { InMemoryIdempotencyStore } from './gateway/idempotency';
 import { JsonPolicyEngine, PolicyDocument } from './governance/policy';
 import { EnvSecretsVault, SqliteSecretsVault } from './edge/secrets';
 import { resolveMasterKey } from './edge/secret-crypto';
+import { ensureAgentAuthor } from './edge/agent-author';
 import { HealthMonitor } from './observability/monitor';
 import { MockAdapter, MockBehavior } from './runtime/mock-adapter';
 import { ClaudeCodeAdapter } from './runtime/claude-code-adapter';
@@ -291,6 +292,9 @@ export function loadAgentOS(
   // Bundled examples first, then the user's agents (which override examples by id).
   loadAgentsFrom(os, paths.bundledAgents);
   loadAgentsFrom(os, paths.userAgents);
+  // Code-provisioned System agents that must exist in every home (materialised into the data home,
+  // idempotently) even though they don't ship as a config/agents folder.
+  ensureAgentAuthor(os);
   return os;
 }
 

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -494,6 +494,53 @@ const TOOLS = [
       required: ['id'],
     },
   },
+  // ── Agents: author new agents (the agent-author's build tools) ──
+  {
+    name: 'agent_create',
+    description:
+      'Create a brand-new agent in this workspace and register it live (no restart) — the way to turn a ' +
+      'role into a real, governed teammate. You supply its id, description, and CLAUDE.md (its system ' +
+      'prompt), plus optional category/model/effort/icon/example prompts. The new agent appears in the ' +
+      'console under its category and can then be run or assigned by a human. Use this when someone asks ' +
+      'you to build or spin up an agent for a job.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string', description: 'Lowercase letters, digits and hyphens (2–40 chars, starts with a letter), e.g. "seo-writer".' },
+        description: { type: 'string', description: 'One-line summary of what the agent does.' },
+        claudeMd: { type: 'string', description: "The agent's system prompt (CLAUDE.md): role, method, tools it uses, boundaries, how it finishes." },
+        category: { type: 'string', description: 'Grouping label for the console, e.g. Support / Engineering / Marketing / Sales / Research / Ops. Omit → Uncategorized.' },
+        model: { type: 'string', description: 'Model alias/id override, e.g. "claude-opus-4-8". Omit → inherit the workspace default.' },
+        effort: { type: 'string', enum: ['low', 'medium', 'high', 'xhigh', 'max'], description: 'Reasoning effort override. Omit → inherit the workspace default.' },
+        examplePrompts: { type: 'array', items: { type: 'string' }, description: '2–3 clickable starter tasks shown on the agent\'s spawn card.' },
+        icon: { type: 'string', description: 'A lucide icon name from the built-in library (e.g. "Bot", "Wrench", "Megaphone"). Omit → default glyph.' },
+      },
+      required: ['id', 'description', 'claudeMd'],
+    },
+  },
+  {
+    name: 'agent_update',
+    description:
+      'Refine an existing agent: pass its id plus only the fields you want to change (its CLAUDE.md, ' +
+      'description, category, model, effort, example prompts, or icon). Re-registers it live so the next ' +
+      'session uses the new values. Prefer this over creating a near-duplicate when an agent nearly fits.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string', description: 'The id of the agent to edit.' },
+        description: { type: 'string', description: 'New one-line description.' },
+        claudeMd: { type: 'string', description: "Replacement CLAUDE.md (the agent's system prompt)." },
+        category: { type: 'string', description: 'New grouping label (empty string clears it → Uncategorized).' },
+        model: { type: 'string', description: 'Model override (empty string clears → inherit the workspace default).' },
+        effort: { type: 'string', enum: ['low', 'medium', 'high', 'xhigh', 'max'], description: 'Reasoning-effort override.' },
+        examplePrompts: { type: 'array', items: { type: 'string' }, description: 'Replacement starter prompts.' },
+        icon: { type: 'string', description: 'New lucide icon name (or raw <svg>).' },
+      },
+      required: ['id'],
+    },
+  },
 ];
 
 function send(msg: JsonRpc): void {
@@ -837,6 +884,50 @@ async function taskCreate(args: Record<string, unknown>): Promise<string> {
   return `Filed task ${d.id}: "${title}"${who}. Track it with task_get "${d.id}".`;
 }
 
+// ── Agents: author new agents ─────────────────────────────────────────────────
+async function agentCreate(args: Record<string, unknown>): Promise<string> {
+  const id = String(args.id ?? '').trim().toLowerCase();
+  const description = String(args.description ?? '').trim();
+  const claudeMd = String(args.claudeMd ?? '');
+  if (!id) return 'A new agent needs an id (lowercase letters, digits and hyphens).';
+  if (!description) return 'A new agent needs a one-line description.';
+  if (!claudeMd.trim()) return "A new agent needs a CLAUDE.md (its system prompt).";
+  const res = await fetch(AOS_URL + '/api/agents/create', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({
+      session: SESSION, id, description, claudeMd,
+      category: args.category !== undefined ? String(args.category) : undefined,
+      model: args.model !== undefined ? String(args.model) : undefined,
+      effort: args.effort !== undefined ? String(args.effort) : undefined,
+      examplePrompts: Array.isArray(args.examplePrompts) ? args.examplePrompts.map(String) : undefined,
+      icon: args.icon !== undefined ? String(args.icon) : undefined,
+    }),
+  });
+  const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
+  if (!d.ok) return `Could not create the agent: ${d.error ?? 'unknown error'}`;
+  return `Created agent "${d.id}". It's live in the console now (grouped under ${args.category ? String(args.category) : 'Uncategorized'}); a human can run or assign it. Use agent_update "${d.id}" to refine it.`;
+}
+
+async function agentUpdate(args: Record<string, unknown>): Promise<string> {
+  const id = String(args.id ?? '').trim().toLowerCase();
+  if (!id) return 'Which agent? (id is required).';
+  // Only forward fields the caller actually supplied, so an unset field is left untouched server-side.
+  const body: Record<string, unknown> = { session: SESSION, id };
+  for (const k of ['description', 'claudeMd', 'category', 'model', 'effort', 'icon'] as const) {
+    if (args[k] !== undefined) body[k] = String(args[k]);
+  }
+  if (Array.isArray(args.examplePrompts)) body.examplePrompts = args.examplePrompts.map(String);
+  const res = await fetch(AOS_URL + '/api/agents/update', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify(body),
+  });
+  const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
+  if (!d.ok) return `Could not update the agent: ${d.error ?? 'unknown error'}`;
+  return `Updated agent "${id}". The next session it runs will use the new configuration.`;
+}
+
 async function taskList(args: Record<string, unknown>): Promise<string> {
   const u = new URL(AOS_URL + '/api/tasks/list');
   u.searchParams.set('session', SESSION);
@@ -1017,6 +1108,8 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'task_get' ? await taskGet(args)
         : name === 'task_claim' ? await taskClaim(args)
         : name === 'task_update' ? await taskUpdate(args)
+        : name === 'agent_create' ? await agentCreate(args)
+        : name === 'agent_update' ? await agentUpdate(args)
         : `unknown tool: ${name}`;
       send({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text }] } });
     } catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -748,6 +748,77 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, task });
   }
 
+  // ── Agents (agent loopback) ──────────────────────────────────────────────────
+  // The agent-author (and any agent, as the delegation surface) creates/refines agents AS ITSELF. Like
+  // the tasks/kb tools this is auto-apply + audited (creating a definition escalates nothing — every
+  // effect the new agent later has still passes the gate, and only a human can run/assign it). Mirrors
+  // the member-facing POST /api/agents + /:id/config routes below, minus the admin gate.
+  if (method === 'POST' && p === '/api/agents/create') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    if (!os.paths) return sendJson(res, 200, { ok: false, error: 'creating agents requires a data home' });
+    const id = String(b.id || '').trim().toLowerCase();
+    const description = String(b.description || '').trim();
+    const claudeMd = String(b.claudeMd ?? '');
+    const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
+    if (tErr) return sendJson(res, 200, { ok: false, error: tErr });
+    if (!/^[a-z][a-z0-9-]{1,39}$/.test(id)) return sendJson(res, 200, { ok: false, error: 'id must be lowercase letters, digits and hyphens (2–40 chars, starting with a letter)' });
+    if (os.agents.get(id)) return sendJson(res, 200, { ok: false, error: `an agent named "${id}" already exists` });
+    if (!claudeMd.trim()) return sendJson(res, 200, { ok: false, error: 'a CLAUDE.md is required' });
+    const folder = path.join(os.paths.userAgents, id);
+    if (fs.existsSync(folder)) return sendJson(res, 200, { ok: false, error: `folder "${id}" already exists in the agents home` });
+    const examplePrompts = sanitizeExamplePrompts(b.examplePrompts);
+    const category = sanitizeCategory(b.category);
+    const icon = sanitizeIcon(b.icon);
+    const manifest: AgentManifest = {
+      id, version: '1.0.0', description,
+      ...(category ? { category } : {}),
+      principal: `svc-${id}`, policyContext: 'default@v1', runtime: 'claude-code',
+      ...tuning,
+      ...(examplePrompts ? { examplePrompts } : {}),
+      ...(icon ? { icon } : {}),
+      budget: { usdCap: 2.0, tokenCap: 400000, wallClockMs: 1800000 },
+    };
+    fs.mkdirSync(folder, { recursive: true });
+    fs.writeFileSync(path.join(folder, 'agent.json'), JSON.stringify(manifest, null, 2) + '\n');
+    fs.writeFileSync(path.join(folder, 'CLAUDE.md'), claudeMd);
+    os.registerAgent({ ...manifest, dir: folder });
+    os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: 'agent.created', data: { agent: id, runtime: 'claude-code', dir: folder, by: `agent:${agent}` } });
+    return sendJson(res, 200, { ok: true, id });
+  }
+  if (method === 'POST' && p === '/api/agents/update') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    if (!os.paths) return sendJson(res, 200, { ok: false, error: 'editing agents requires a data home' });
+    const id = String(b.id || '').trim().toLowerCase();
+    const ag = os.agents.get(id);
+    if (!ag?.dir) return sendJson(res, 200, { ok: false, error: `unknown agent "${id}"` });
+    if (ag.runtime !== 'claude-code') return sendJson(res, 200, { ok: false, error: 'only claude-code agents can be edited' });
+    // Only agents that live under the data home are editable (the read-only bundled examples are not).
+    const userRoot = path.resolve(os.paths.userAgents) + path.sep;
+    if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return sendJson(res, 200, { ok: false, error: 'built-in agents cannot be edited' });
+    const { tuning, error: tErr } = sanitizeRuntimeTuning({ model: 'model' in b ? b.model : ag.model, effort: 'effort' in b ? b.effort : ag.effort });
+    if (tErr) return sendJson(res, 200, { ok: false, error: tErr });
+    // Only fields present in the body are changed; everything else is preserved.
+    const description = 'description' in b ? String(b.description ?? '').trim() : ag.description;
+    const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
+    const icon = 'icon' in b ? sanitizeIcon(b.icon) : ag.icon;
+    const examplePrompts = 'examplePrompts' in b ? sanitizeExamplePrompts(b.examplePrompts) : ag.examplePrompts;
+    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, category, icon, examplePrompts };
+    const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
+    fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
+    if ('claudeMd' in b) fs.writeFileSync(path.join(ag.dir, 'CLAUDE.md'), String(b.claudeMd ?? ''));
+    os.registerAgent(next);
+    os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: 'agent.config.updated', data: { agent: id, model: tuning.model, effort: tuning.effort, category, claudeMd: 'claudeMd' in b, by: `agent:${agent}` } });
+    return sendJson(res, 200, { ok: true, id });
+  }
+
   // Every other /api/* route requires a logged-in member.
   const member = memberFor(os, req);
   if (p.startsWith('/api/') && !member) return sendJson(res, 401, { error: 'not authenticated' });


### PR DESCRIPTION
## What

Adds **agent-author** — a default *System* agent whose job is to build the rest of the fleet. A person describes the job they want done by an agent; agent-author interviews them, drafts a manifest + CLAUDE.md, and **creates the agent for real** so it's live in the console with no restart.

## How

- **Code-provisioned System agent** (`src/edge/agent-author.ts`), materialised into every data home on boot (idempotent; never overwrites user-edited files; delete it and boot restores it) — the same pattern as the consolidator.
- **Two new agent-facing MCP tools** (`src/memory/memory-mcp.ts`):
  - `agent_create` — id + description + CLAUDE.md (+ optional category/model/effort/icon/example prompts) → new agent registered live.
  - `agent_update` — edit an existing agent's fields (only what you pass).
- **Loopback routes** `POST /api/agents/create|update` (`src/server.ts`), session-secret + tenant gated, sitting **before** the member-auth gate — faithful copies of the proven member-facing `/api/agents` + `/:id/config` handlers, minus the admin gate.

## Governance

Creating an agent *definition* escalates nothing: the new agent still passes every side effect through the gate, and only a **human** can run/assign it (spawn is role-gated). So these follow the established **auto-apply + audited** posture (`kb_write` / `task_create`) — no approval card — emitting `agent.created` / `agent.config.updated` with `principal: agent:<id>`. Guards: strict id validation + collision check on create; `agent_update` only touches user-home agents (bundled examples stay read-only).

## Verification

- `npm run build` clean; `npm run test:governance` → 44/44.
- Isolated (scratch `AGENT_OS_HOME`) provisioning test: agent-author registers under **System** (model opus, icon Wand2, files written), and idempotency preserves a user-edited CLAUDE.md across reload.
- Live scratch server: both new routes return **404** for a bogus session (present, before the gate), while an unknown agent route returns **401** (correctly gated) — the CLAUDE.md stale-server check.

Docs: `docs/agent-mcp-tools.md` (now 27 always-on + 2 conditional, plus a governance note). Version 0.10.0 → 0.11.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)