### PR TITLE
Secrets: per-agent shell secrets — vault creds in the agent terminal (v0.12.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-07-06
+
+### Added
+- **Per-agent shell secrets — vault credentials that reach the agent's terminal.** An agent manifest
+  can now carry an opt-in `shellSecrets: ["GH_TOKEN"]` list ([`src/types.ts`](src/types.ts)). At launch,
+  each named key is resolved from the encrypted vault — principal = the agent, widening to the
+  tenant-wide `*` default — and exported as a shell env var into that agent's claude-code session
+  ([`TerminalManager.injectShellSecrets`](src/terminal.ts)), so a plain CLI like `gh` (via `GH_TOKEN`)
+  authenticates without baking the credential into the server process env. Each resolution is audited
+  (`shell.secret.injected` / `shell.secret.unresolved`); a missing value leaves the var **unset** (not
+  blanked) so the tool sees "no token" cleanly. This is the **only** path a vault secret reaches the
+  interactive shell — connectors still get theirs via the MCP bag — so exposure stays explicit and
+  opt-in per agent. Store the value in **Settings → Secrets** (set its principal to the agent id for a
+  per-agent token, or leave tenant-wide) and list the key in the agent's config editor
+  (**Runtime tuning → Shell secrets**). Settable via `POST /api/agents`, the agent config PUT, and the
+  agent-facing `agent_create` / `agent_update` tools.
+
 ## [0.11.0] — 2026-07-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,11 @@ Key modules:
   **runtime tuning** (`resolveRuntimeTuning` in `src/types.ts`: agent manifest → workspace default → CLI
   default) and exports `CLAUDE_MODEL`/`CLAUDE_EFFORT`/`CLAUDE_PERMISSION_MODE`, which `claude-launch.sh`
   maps onto `--model`/`--effort`/`--permission-mode` (model+effort both lanes; permission-mode interactive
-  only — headless keeps `--dangerously-skip-permissions`).
+  only — headless keeps `--dangerously-skip-permissions`). It also resolves the agent's opt-in
+  **`shellSecrets`** (manifest list of vault keys, e.g. `["GH_TOKEN"]`) via `injectShellSecrets` and
+  exports each as a shell env var — the ONLY path a vault secret reaches the interactive shell (so a
+  plain CLI like `gh` authenticates); connectors still get theirs via the MCP bag. Agent-scoped
+  principal (widening to `*`), audited `shell.secret.injected`/`unresolved`, opt-in per agent.
 - `src/governance/` — `policy.ts` (JSON rule engine), `approvals.ts`, `audit.ts`, `team.ts`,
   `settings.ts` (Company context **+ workspace runtime defaults**: the fleet-wide model/effort/permission
   fallback, `runtimeDefaults`/`setRuntimeDefaults`), `skills.ts` (global `.claude/skills` library,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUse
 import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument } from './governance/policy';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
-import { AgentManifest, ApprovalRequest, EmbeddingsConfig, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, TaskStatus } from './types';
+import { AgentManifest, ApprovalRequest, EmbeddingsConfig, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
 
 /** Settings → Memory view: stored backend config with secrets redacted to `…Set` booleans. */
 interface EmbeddingsView { provider: 'openai' | 'ollama'; url: string; model: string; dimensions?: number; apiKeySet: boolean }
@@ -773,12 +773,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const examplePrompts = sanitizeExamplePrompts(b.examplePrompts);
     const category = sanitizeCategory(b.category);
     const icon = sanitizeIcon(b.icon);
+    const shellSecrets = sanitizeShellSecrets(b.shellSecrets);
     const manifest: AgentManifest = {
       id, version: '1.0.0', description,
       ...(category ? { category } : {}),
       principal: `svc-${id}`, policyContext: 'default@v1', runtime: 'claude-code',
       ...tuning,
       ...(examplePrompts ? { examplePrompts } : {}),
+      ...(shellSecrets ? { shellSecrets } : {}),
       ...(icon ? { icon } : {}),
       budget: { usdCap: 2.0, tokenCap: 400000, wallClockMs: 1800000 },
     };
@@ -810,7 +812,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
     const icon = 'icon' in b ? sanitizeIcon(b.icon) : ag.icon;
     const examplePrompts = 'examplePrompts' in b ? sanitizeExamplePrompts(b.examplePrompts) : ag.examplePrompts;
-    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, category, icon, examplePrompts };
+    const shellSecrets = 'shellSecrets' in b ? sanitizeShellSecrets(b.shellSecrets) : ag.shellSecrets;
+    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, category, icon, examplePrompts, shellSecrets };
     const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     if ('claudeMd' in b) fs.writeFileSync(path.join(ag.dir, 'CLAUDE.md'), String(b.claudeMd ?? ''));
@@ -1403,6 +1406,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const examplePrompts = sanitizeExamplePrompts(b.examplePrompts);
     const category = sanitizeCategory(b.category);
     const icon = sanitizeIcon(b.icon);
+    const shellSecrets = sanitizeShellSecrets(b.shellSecrets);
     const manifest: AgentManifest = {
       id,
       version: '1.0.0',
@@ -1413,6 +1417,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       runtime: 'claude-code',
       ...tuning,
       ...(examplePrompts ? { examplePrompts } : {}),
+      ...(shellSecrets ? { shellSecrets } : {}),
       ...(icon ? { icon } : {}),
       budget: { usdCap: 2.0, tokenCap: 400000, wallClockMs: 1800000 },
     };
@@ -1496,24 +1501,26 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!ag?.dir) return sendJson(res, 404, { error: 'agent not found or has no folder' });
     if (ag.runtime !== 'claude-code') return sendJson(res, 400, { error: 'runtime tuning applies to claude-code agents only' });
     if (method === 'GET') {
-      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, examplePrompts: ag.examplePrompts, category: ag.category, icon: ag.icon });
+      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, category: ag.category, icon: ag.icon });
     }
     const b = await readBody(req);
     const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
     if (tErr) return sendJson(res, 400, { error: tErr });
     // Replace the tuning fields wholesale (sanitize already dropped empties to undefined → those
-    // become "inherit"). Starter prompts + category + icon are only touched when the body carries the
-    // field (a tuning-only save from the runtime card leaves them as-is). Preserve everything else.
+    // become "inherit"). Starter prompts + shell secrets + category + icon are only touched when the
+    // body carries the field (a tuning-only save from the runtime card leaves them as-is). Preserve
+    // everything else.
     const prompts = 'examplePrompts' in b ? sanitizeExamplePrompts(b.examplePrompts) : ag.examplePrompts;
+    const shellSecrets = 'shellSecrets' in b ? sanitizeShellSecrets(b.shellSecrets) : ag.shellSecrets;
     const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
     const icon = 'icon' in b ? sanitizeIcon(b.icon) : ag.icon;
     const description = 'description' in b ? String(b.description ?? '').trim() : ag.description;
-    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, category, icon };
+    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, shellSecrets, category, icon };
     const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     os.registerAgent(next);
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, category } });
-    return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, category, icon });
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, category, shellSecrets: shellSecrets ?? [] } });
+    return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, shellSecrets, category, icon });
   }
 
   // ── workspace runtime defaults (the fleet-wide model/effort/permission fallback) — owner/admin only ──

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -572,6 +572,10 @@ export class TerminalManager {
       // can be resumed in-place with `claude --resume <id>` when the user reconnects in the browser.
       env.CLAUDE_SESSION_ID = randomUUID();
 
+      // The agent's opt-in shell secrets (vault keys → shell env vars, e.g. GH_TOKEN for `gh`). Done
+      // here so both isolation lanes and the resurrect env file (writeEnvFile below) carry them.
+      this.injectShellSecrets(env, agent, manifest, id);
+
       if (this.uidIsolation) {
         // Flag on: the launcher writes the files INTO the member's home (member-readable), copies the
         // agent dir to a per-member working copy (AGENT_DIR override), and sets MCP_CONFIG/COMPANY_FILE/
@@ -1257,6 +1261,35 @@ export class TerminalManager {
     }
   }
 
+  /**
+   * Resolve the agent's opt-in `shellSecrets` (vault keys) and export each as a shell env var into
+   * the session — so a plain CLI like `gh` (GH_TOKEN) authenticates without the OS baking the
+   * credential into the server env. Agent-scoped principal (the agent IS the identity for its
+   * tooling), widening to the tenant-wide `*` default inside the vault. Audited per key: `injected`
+   * on success, `unresolved` when the vault has no value (env var left unset rather than blanked, so
+   * `gh` sees "no token" cleanly instead of "set but empty"). This is the ONLY path a vault secret
+   * reaches the interactive shell — connectors get theirs via the MCP bag — so exposure stays
+   * explicit and opt-in per agent (the manifest list).
+   */
+  private injectShellSecrets(
+    env: Record<string, string>,
+    agent: string,
+    manifest: { shellSecrets?: string[] } | undefined,
+    sessionId: string,
+  ): void {
+    const keys = manifest?.shellSecrets;
+    if (!keys?.length) return;
+    for (const key of keys) {
+      const value = this.os.secrets.getSync(this.os.tenant, agent, key);
+      if (value === undefined) {
+        this.audit(sessionId, agent, 'shell.secret.unresolved', { key, principal: agent });
+        continue;
+      }
+      env[key] = value;
+      this.audit(sessionId, agent, 'shell.secret.injected', { key, principal: agent });
+    }
+  }
+
   /** The JSON policy engine ignores ctx; provide a minimal stand-in to satisfy the type. */
   private ctx(sessionId: string, agent: string): RunContext {
     return {
@@ -1280,7 +1313,8 @@ const EPISODE_NOISE = new Set([
   'session.created', 'session.ended', 'session.reported', 'session.resumed', 'session.stopped',
   'session.error', 'session.tuning', 'session.progress', 'session.notified', 'session.attachment',
   'skills.materialized', 'skills.error', 'connector.minted', 'connector.mint.failed',
-  'connector.secret.unresolved', 'gate.attempt', 'gate.killswitch', 'approval.resolved',
+  'connector.secret.unresolved', 'shell.secret.injected', 'shell.secret.unresolved',
+  'gate.attempt', 'gate.killswitch', 'approval.resolved',
   'approval.auto_approved', 'episode.stored', 'episode.error',
 ]);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -648,6 +648,13 @@ export interface AgentManifest extends RuntimeTuning {
   /** Suggested first tasks shown on the agent's spawn card (clickable chips that prefill the box).
    *  Per-agent so each agent advertises how it wants to be invoked, instead of a generic default. */
   examplePrompts?: string[];
+  /** Opt-in list of vault keys to resolve and export as shell env vars into this agent's claude-code
+   *  sessions (e.g. `["GH_TOKEN"]` so the `gh` CLI authenticates). Each string is BOTH the vault key
+   *  and the env var name, so it must be a valid identifier. Resolved at launch with principal = the
+   *  agent (widening to the tenant-wide `*` default), and audited per key. This is the only path a
+   *  vault secret reaches the interactive shell — connectors get theirs via the MCP bag — so it's
+   *  deliberately explicit per agent. Undefined/empty → nothing is exported. */
+  shellSecrets?: string[];
   /** The agent's visual icon. Either a built-in library id (a lucide icon name like `"Bot"`) or a raw
    *  custom `<svg>…</svg>` markup string the user uploaded. Undefined → the console falls back to a
    *  default glyph. Purely cosmetic. Rendered in an `<img>` so inline SVG can't execute scripts. */
@@ -682,6 +689,34 @@ export function sanitizeExamplePrompts(input: unknown): string[] | undefined {
     .map((s) => s.trim().slice(0, 500))
     .filter(Boolean)
     .slice(0, 6);
+  return out.length ? out : undefined;
+}
+
+/** Valid POSIX-ish env var / vault key name: a letter or underscore, then letters/digits/underscores.
+ *  A `shellSecrets` entry is used verbatim as both the vault key and the exported shell variable, so
+ *  it must satisfy this or the shell can't reference it. */
+const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+/** Normalize a `shellSecrets` payload (from an API body or config file): coerce to an array of
+ *  trimmed strings, drop anything that isn't a valid env-var name, dedupe (order-preserving), cap
+ *  each at 64 chars and the list at 32. Returns undefined when the result is empty so the manifest
+ *  carries no `shellSecrets` key at all. */
+export function sanitizeShellSecrets(input: unknown): string[] | undefined {
+  const raw = Array.isArray(input)
+    ? input
+    : typeof input === 'string'
+      ? input.split(/[\s,]+/) // accept a comma/space/newline-separated string from a UI field too
+      : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of raw) {
+    if (typeof x !== 'string') continue;
+    const k = x.trim().slice(0, 64);
+    if (!ENV_NAME.test(k) || seen.has(k)) continue;
+    seen.add(k);
+    out.push(k);
+    if (out.length >= 32) break;
+  }
   return out.length ? out : undefined;
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3438,6 +3438,8 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
   const [savedCategory, setSavedCategory] = useState('')
   const [icon, setIcon] = useState<string | undefined>(undefined)
   const [savedIcon, setSavedIcon] = useState<string | undefined>(undefined)
+  const [secrets, setSecrets] = useState('')
+  const [savedSecrets, setSavedSecrets] = useState('')
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
 
@@ -3448,23 +3450,26 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
       const d = r.description ?? ''
       const p = (r.examplePrompts ?? []).join('\n')
       const c = r.category ?? ''
-      setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon)
+      const s = (r.shellSecrets ?? []).join(' ')
+      setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon); setSecrets(s); setSavedSecrets(s)
     }).catch(() => {})
   }, [agentId])
 
-  const dirty = JSON.stringify(tuning) !== JSON.stringify(saved) || description !== savedDescription || prompts !== savedPrompts || category !== savedCategory || icon !== savedIcon
+  const dirty = JSON.stringify(tuning) !== JSON.stringify(saved) || description !== savedDescription || prompts !== savedPrompts || category !== savedCategory || icon !== savedIcon || secrets !== savedSecrets
   const save = async () => {
     setBusy(true); setHint('')
     const examplePrompts = prompts.split('\n').map((s) => s.trim()).filter(Boolean)
+    const shellSecrets = secrets.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean)
     // Always send `icon` (empty string clears it → server drops the manifest key).
-    const r = await api.saveAgentConfig(agentId, { ...tuning, description: description.trim(), examplePrompts, category: category.trim(), icon: icon ?? '' })
+    const r = await api.saveAgentConfig(agentId, { ...tuning, description: description.trim(), examplePrompts, shellSecrets, category: category.trim(), icon: icon ?? '' })
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
     const t: RuntimeTuning = { model: r.model, effort: r.effort }
     const d = r.description ?? ''
     const p = (r.examplePrompts ?? []).join('\n')
     const c = r.category ?? ''
-    setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon); setHint('saved — applies on the next session'); setTimeout(() => setHint(''), 2500)
+    const s = (r.shellSecrets ?? []).join(' ')
+    setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon); setSecrets(s); setSavedSecrets(s); setHint('saved — applies on the next session'); setTimeout(() => setHint(''), 2500)
     onSaved?.()
   }
 
@@ -3488,6 +3493,11 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
         <div className="space-y-1">
           <label className="text-xs font-medium">Starter prompts</label>
           <Textarea value={prompts} onChange={(e) => setPrompts(e.target.value)} className="min-h-[70px] text-sm" placeholder={'One per line — clickable chips on the spawn card (up to 6).'} />
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium">Shell secrets</label>
+          <Input value={secrets} onChange={(e) => setSecrets(e.target.value)} className="font-mono text-sm" placeholder="e.g. GH_TOKEN  (space/comma separated env-var names)" />
+          <p className="text-[11px] text-muted-foreground">Vault keys exported as env vars into this agent's shell (so CLIs like <span className="font-mono">gh</span> authenticate). Store the value in <span className="font-medium">Settings → Secrets</span> (key = the name here; set its principal to <span className="font-mono">{agentId}</span> for a per-agent value, or leave tenant-wide). Resolved at launch, audited per key.</p>
         </div>
         <div className="flex items-center gap-3">
           <Button size="sm" onClick={save} disabled={busy || !dirty}>{dirty ? 'Save' : 'Saved'}</Button>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -667,13 +667,13 @@ export const api = {
   // One "reflect" pass: cheap deterministic tally + the memory-gardener over new material (nested `consolidation`).
   dreamingRun: () => call<{ ok: boolean; skipped?: boolean; sessions?: number; episodes?: number; kbPageId?: string; insightId?: string; guidance?: string; consolidation?: { spawned?: boolean; reason?: string; sessionId?: string; items?: number }; error?: string }>('POST', '/api/dreaming/run'),
 
-  createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
+  createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),
   rescanAgents: () => call<{ ok: boolean; added: string[]; updated: string[]; removed: string[]; errors: { folder: string; error: string }[]; error?: string }>('POST', '/api/agents/rescan'),
   agentClaude: (id: string) => call<{ agent: string; runtime: string; exists: boolean; content: string; error?: string }>('GET', `/api/agents/${encodeURIComponent(id)}/claude`),
   saveAgentClaude: (id: string, content: string) => call<{ ok: boolean; error?: string }>('PUT', `/api/agents/${encodeURIComponent(id)}/claude`, { content }),
-  agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; category?: string; icon?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),
-  saveAgentConfig: (id: string, patch: RuntimeTuning & { description?: string; examplePrompts?: string[]; category?: string; icon?: string }) => call<{ ok: boolean; error?: string; description?: string; examplePrompts?: string[]; category?: string; icon?: string } & RuntimeTuning>('PUT', `/api/agents/${encodeURIComponent(id)}/config`, patch),
+  agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),
+  saveAgentConfig: (id: string, patch: RuntimeTuning & { description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string }) => call<{ ok: boolean; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string } & RuntimeTuning>('PUT', `/api/agents/${encodeURIComponent(id)}/config`, patch),
   runtimeDefaults: () => call<RuntimeTuning & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/runtime-defaults'),
   saveRuntimeDefaults: (tuning: RuntimeTuning) => call<{ ok: boolean; error?: string } & RuntimeTuning>('PUT', '/api/settings/runtime-defaults', tuning),
 


### PR DESCRIPTION
## What

Adds an opt-in **`shellSecrets`** list to the agent manifest so vault credentials can be exported as **shell env vars** into an agent's `claude-code` session. This is what lets a plain CLI like `gh` authenticate (`GH_TOKEN`) with a **per-agent** token — governed and audited — instead of baking one shared credential into the server process env.

### Motivation
`gh` and other CLIs read their credential from the process environment. Today the only way to feed that is the systemd unit env (fleet-wide, one identity for every agent). The vault existed but only fed **MCP connector subprocesses**, never the interactive shell. This closes that gap with an explicit, per-agent opt-in.

## How it works
1. Store the value in **Settings → Secrets** — key = the env var name (e.g. `GH_TOKEN`); set its **principal** to the agent id for a per-agent token, or leave it tenant-wide (`*`).
2. List the key in the agent's **Runtime tuning → Shell secrets** (or `shellSecrets` in `agent.json`).
3. At launch, `TerminalManager.injectShellSecrets` resolves each key (principal = the agent, widening to `*`) and exports it into the session env — both isolation lanes and the resume env file.

- Audited per key: `shell.secret.injected` / `shell.secret.unresolved`.
- A missing value leaves the var **unset** (not blanked) so the tool sees "no token" cleanly rather than "set but empty".
- Only path a vault secret reaches the interactive shell — connectors still use the MCP bag — so exposure is explicit and opt-in per agent.

## Changes
- `src/types.ts` — `shellSecrets?` on `AgentManifest` + `sanitizeShellSecrets()` (valid env-var names, dedupe, caps).
- `src/terminal.ts` — `injectShellSecrets()` at launch + `EPISODE_NOISE` entries.
- `src/server.ts` — wired through `POST /api/agents`, the agent config GET/PUT, and agent-facing `/api/agents/create|update`.
- `web/src/App.tsx` + `lib/api.ts` — Shell secrets field in the Runtime tuning card.
- Docs: CHANGELOG (v0.12.0), CLAUDE.md note.

## Verification
- `npm run typecheck` clean; `cd web && npm run build` clean.
- Isolated test (scratch `AGENT_OS_HOME`) exercising the **real** `injectShellSecrets` against the **real** vault: 10/10 pass — agent-scoped resolve, tenant-wide widening, per-agent override, missing-key-left-unset, no-op when empty, plus `sanitizeShellSecrets` cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)