### PR TITLE
Agents: fleet-coordination operating notes + read-only viewer in Settings → System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.12.0] — 2026-07-06
+## [0.13.0] — 2026-07-06
+
+### Added
+- **Agent operating notes: fleet-coordination section + a read-only viewer in Settings → System.** The
+  OS-owned orientation appended to every claude-code agent's system prompt
+  ([`AGENT_OS_OPERATING_NOTES`](src/terminal.ts)) gains a **"You are one agent in a fleet"** section, so
+  agents stop treating the shared planes as isolated tools and understand how to coordinate: **Tasks**
+  (`task_*`) as the shared work queue + hand-off path (delegate specialist work by assigning a task),
+  the **Knowledge Base** (`kb_*`) as the fleet's shared living wiki, **shared memory**
+  (`remember` with `shared: true`) for fleet-wide facts, and `directory_lookup` for reaching teammates.
+  The notes were previously invisible — hardcoded in source, in no UI. They're now surfaced **read-only**
+  in **Settings → System** (the constant is exported, rides the existing `/api/state` payload, and
+  renders in a read-only textarea beside Company context) so operators can see exactly what the whole
+  fleet is told about running inside Agent OS. Company context stays the tenant-editable half; these
+  notes stay OS-owned.
 
 ### Added
 - **Per-agent shell secrets — vault credentials that reach the agent's terminal.** An agent manifest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -13,7 +13,7 @@ import { VERSION } from './version';
 import { TenantRegistry, TenantRuntime } from './tenant-registry';
 import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
-import { TerminalManager } from './terminal';
+import { TerminalManager, AGENT_OS_OPERATING_NOTES } from './terminal';
 import { Automation, Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
@@ -840,6 +840,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       terminalAgents: agents.map((a) => a.id), // back-compat: existing UI lists ids
       agents, // richer: { id, description, runtime }
       capabilities: os.registry.list().map((c) => ({ id: c.id, description: c.description, defaultRisk: c.defaultRisk })),
+      // OS-owned orientation appended to every claude-code agent's system prompt (after Company
+      // context). Surfaced read-only in Settings → System so operators can see what the fleet is told.
+      operatingNotes: AGENT_OS_OPERATING_NOTES,
     });
   }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -25,7 +25,7 @@ import { LauncherSessionBackend, LocalSessionBackend, SessionBackend, SpawnError
 // the agent's orientation: it is otherwise a stock `claude` dropped into a folder, blind to the OS it
 // runs inside. Keep it tight — it costs tokens on every session. Describe the environment and how to
 // operate well in it; don't restate what the MCP tool descriptions already say.
-const AGENT_OS_OPERATING_NOTES = `# You are running inside Agent OS
+export const AGENT_OS_OPERATING_NOTES = `# You are running inside Agent OS
 
 You are an autonomous agent operating inside **Agent OS**, a governed runtime. You are not a chat
 assistant in a sandbox — your actions can touch real systems (shells, connected apps, money), and the
@@ -60,6 +60,19 @@ Your terminal output may not be read. The operator lives in the Inbox:
   \`lessons\` — it's saved to your memory as a note to your future self.
 - \`publish\` real deliverables (a document, PDF, image, chart) to the Artifacts gallery — not scratch
   files.
+
+## You are one agent in a fleet — don't work alone
+Other agents run in this workspace and you share state with them. You are a node, not a silo:
+- **Tasks** (\`task_*\`) are the shared work queue and the hand-off path. If work belongs to a specialist
+  agent or is too big for this run, \`task_create\` and assign it — an agent-assigned task spawns that
+  agent as a governed run under the same accountable human. Prefer delegating specialised work over
+  doing it poorly yourself; \`task_list\` / \`task_claim\` to pull shared work.
+- **Knowledge Base** (\`kb_*\`) is the fleet's shared, living wiki. \`kb_search\` before assuming a fact
+  isn't already written down; \`kb_write\` durable facts, runbooks, and conventions that help *other*
+  agents and humans. (Memory is for facts only *you* reuse; the KB is for the whole fleet.)
+- **Shared memory**: \`remember\` with \`shared: true\` publishes a fact fleet-wide instead of only to
+  your own recall — use it for things the whole team should know.
+- **The team**: \`directory_lookup\` finds who's on the team and how to reach them (Slack/Discord/email).
 
 ## Environment notes
 - Links aren't clickable in this terminal: always print any URL the user must open or copy

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4363,6 +4363,23 @@ function SystemSettings({ state, me }: { state: StateResp | null; me: Member }) 
           </dl>
         </CardContent>
       </Card>
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <div>
+            <p className="text-sm font-medium">Agent operating notes</p>
+            <p className="text-sm text-muted-foreground">
+              OS-owned orientation appended to <strong>every claude-code agent's</strong> system prompt,
+              after your Company context. This is what the fleet is told about running inside Agent OS —
+              it's built into the platform and read-only here.
+            </p>
+          </div>
+          <Textarea
+            value={state.operatingNotes ?? ''}
+            readOnly
+            className="min-h-[320px] font-mono text-xs leading-relaxed"
+          />
+        </CardContent>
+      </Card>
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -56,6 +56,8 @@ export interface StateResp {
   terminalAgents: string[]
   agents: AgentInfo[]
   capabilities: { id: string; description: string; defaultRisk: string }[]
+  /** OS-owned operating notes appended to every claude-code agent's system prompt. Read-only. */
+  operatingNotes?: string
 }
 /** Self-update status — the deploy is a git checkout, so this reflects "is the box behind origin?". */
 export interface UpdateStatus {


### PR DESCRIPTION
## What & why

The OS-owned orientation appended to every claude-code agent's system prompt (`AGENT_OS_OPERATING_NOTES`) was **invisible** — hardcoded in `src/terminal.ts`, surfaced in no UI — and it told agents about *themselves* (governance, memory, inbox) but not the **fleet** they're part of. So agents treated the shared planes (tasks, KB, shared memory) as isolated tools rather than a coordination model.

## Changes

- **Fleet-coordination section** added to the notes — "You are one agent in a fleet": Tasks (`task_*`) as the shared work queue + hand-off path, the Knowledge Base (`kb_*`) as the shared living wiki, shared memory (`remember` with `shared: true`) for fleet-wide facts, and `directory_lookup` for reaching teammates.
- **Read-only viewer in Settings → System** — the constant is now exported, rides the existing `/api/state` payload, and renders in a read-only textarea beside Company context. Operators can finally see exactly what the whole fleet is told. Company context stays tenant-editable; these notes stay OS-owned.
- Bump `0.12.0 → 0.13.0`, CHANGELOG updated.

## Verification

`npm run typecheck`, `npm run build`, and `cd web && npm run build` all clean. `operatingNotes` confirmed present in the compiled `/api/state` payload; fleet text confirmed in the compiled notes constant. Deployed live to the instapods tenant (`/health` → `0.13.0`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gi4VvZ9agC9kWoL13tXMp