### PR TITLE
GitHub: App token minter — foundation for native GitHub integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+### Added
+- **GitHub App token minter (foundation for native GitHub).** New zero-dependency connector
+  ([`src/connectors/github.ts`](src/connectors/github.ts)) that signs a short-lived App JWT (RS256, via
+  `node:crypto`) and exchanges it for a **1 h installation access token** — the single credential that
+  will drive both the shell (`GH_TOKEN` for `gh`/`git`) and a governed GitHub MCP connector, so a user
+  connects GitHub once in the browser instead of pasting a static PAT. Includes `appJwt`,
+  `listInstallations`, `mintInstallationToken` (optional repo/permission narrowing for least-privilege)
+  and an in-memory `InstallationTokenCache` (reuse until ~5 min before expiry). Not wired into launch
+  yet — see [`docs/github-integration-plan.md`](docs/github-integration-plan.md) for the phased plan
+  (mint-at-launch injection + Settings → Integrations install flow land next).
+
 ## [0.13.0] — 2026-07-06
 
 ### Added

--- a/docs/github-integration-plan.md
+++ b/docs/github-integration-plan.md
@@ -1,0 +1,69 @@
+# Native GitHub integration — plan
+
+**Goal:** a first-party GitHub integration in **Settings → Integrations** (like Slack/Discord) so a
+user connects GitHub once, in the browser, and every agent can act on the org's repos — via **both**
+the shell (`gh`/`git`) and **governed API tools** — without anyone pasting a static PAT.
+
+## Why not a Slack/Discord-style socket
+
+Slack/Discord native = an **outbound WebSocket ingress** (Socket Mode / Gateway): no public URL,
+receive @mentions, run-as the sender. GitHub has **no socket equivalent** — its ingress is webhooks (a
+public URL), already covered by the Composio/`/hooks` lane. So the Slack template is the wrong shape.
+The right shape for GitHub is an **egress credential**: the agent *acts on* GitHub. The "native,
+auth-via-web" version of that is a **GitHub App** whose install flow lives in the console and which
+**mints short-lived tokens** injected at launch.
+
+## The credential: a GitHub App (installation token)
+
+The owner registers **one** GitHub App (per tenant/org) and installs it on the repos it may touch.
+Agent OS holds the App id + RSA private key (vault) + the installation id. At each session launch we:
+
+1. Sign a short-lived **App JWT** (RS256, ≤10 min, `iss = appId`).
+2. Exchange it for a **1 h installation access token** — org-scoped, with the App's fine-grained
+   per-repo permissions.
+
+Nothing long-lived is handed to the agent; the token expires hourly and is minted on demand (cached
+in-memory until ~5 min before expiry). An installation token is simultaneously:
+
+- a valid **`GH_TOKEN`** for `gh` and `git` (the shell path — builds on the per-agent shell-secrets
+  work, `injectShellSecrets`), and
+- a valid **bearer** for GitHub's hosted MCP (`https://api.githubcopilot.com/mcp/`) or a local GitHub
+  MCP server (the governed API-tools path — a per-session connector with the token as an
+  `Authorization: Bearer` header, resolved like any `secret:` ref).
+
+One credential drives both halves.
+
+## Identity
+
+- **v1 — company identity.** The App (bot, `agent-os[bot]`) acts on repos; PRs authored by the bot.
+  Simplest, org-scoped, matches company-scope agents.
+- **Phase 2 — per-member.** `github` is **already** a provider in `member_identities`, so a member can
+  link their GitHub account; a user-to-server OAuth "Connect GitHub" gives a user token and the run-as
+  path authors PRs as the actual human — a one-for-one mirror of Slack's run-as.
+
+## Phases (each its own PR)
+
+1. **Core minter** (`src/connectors/github.ts`) — `appJwt`, `mintInstallationToken`,
+   `listInstallations`, `appMetadata`, plus an in-memory token cache. Pure/offline-testable (generate a
+   keypair, sign, verify). *No UI, no wiring — foundational.*  ← **this PR**
+2. **Launch wiring** (`terminal.ts`) — when GitHub is configured, mint at launch, set `env.GH_TOKEN`
+   (via the shell-secrets plane) and add the GitHub MCP connector to the session `.mcp.json`. Audited
+   `github.token.minted` / `github.token.failed`. A per-agent opt-out/opt-in flag on the manifest.
+3. **Settings → Integrations UI + install flow** — a GitHub card (App id + private key + client
+   id/secret), an **Install on GitHub** button → the App install/callback route
+   (`GET /api/github/installed`) that records the installation id, and a "connected as …" status.
+
+## Settings keys (Settings store / vault)
+
+- `github_app_id`, `github_client_id` — settings.
+- `github_private_key`, `github_client_secret`, `github_webhook_secret` — vault (encrypted).
+- `github_installation_id` — settings (recorded from the install callback, or picked from
+  `listInstallations`).
+
+## Governance
+
+- Shell `GH_TOKEN` is gated coarsely by the PreToolUse Bash gate-hook (as today for any command).
+- The GitHub **MCP connector** routes each API action (open PR, comment) through the connector/gateway
+  path — per-operation policy + audit, the well-governed lane.
+- Token mint is audited; the App's fine-grained permissions are the real blast-radius control (grant
+  only the repos + scopes the fleet needs).

--- a/src/connectors/github.ts
+++ b/src/connectors/github.ts
@@ -1,0 +1,166 @@
+/**
+ * Native GitHub — a thin, zero-dependency client for the slice of GitHub's App API the OS needs to
+ * mint short-lived **installation access tokens** for agents. One company GitHub App, registered once
+ * (Settings → Integrations) and installed on the org's repos, is the single credential source for both
+ * consumption paths:
+ *   - the shell (`gh` / `git`) — the minted token is exported as `GH_TOKEN` at launch, and
+ *   - governed API tools — the same token is a valid bearer for a GitHub MCP connector.
+ *
+ * Why an App (not a static PAT): the installation token is org-scoped, carries only the App's
+ * fine-grained per-repo permissions, and **expires hourly** — minted on demand, so nothing long-lived
+ * is ever handed to an agent. The App's private key never leaves the server (vault), and the JWT we
+ * sign to obtain a token lives ≤10 min.
+ *
+ * All calls use the global `fetch` (Node 22+) and `node:crypto` for the RS256 signature — no runtime
+ * dependency, matching the Slack/Composio connectors' stance. Every call returns `{ error }` rather
+ * than throwing, so a flaky network or bad credential degrades gracefully at the call site.
+ */
+import { createSign } from 'crypto';
+
+const GH_API = 'https://api.github.com';
+const UA = 'agent-os';
+/** Standard headers for the REST v3 JSON API (minus auth, which each call adds). */
+const BASE_HEADERS = { accept: 'application/vnd.github+json', 'x-github-api-version': '2022-11-28', 'user-agent': UA };
+
+function b64url(input: Buffer | string): string {
+  return Buffer.from(input).toString('base64url');
+}
+
+/**
+ * Sign a GitHub **App JWT** (RS256) — the credential used to call the App-level endpoints (list
+ * installations, mint an installation token). `iss` is the App id; the token is short-lived (GitHub
+ * rejects an `exp` more than 10 min out). We back-date `iat` 30 s to tolerate clock skew between us
+ * and GitHub. `privateKeyPem` is the App's RSA private key (PKCS#1 or PKCS#8 PEM).
+ *
+ * Pure + synchronous — the launch path and the offline test both call it directly. `nowMs` is
+ * injectable so the test can assert exact claims without wall-clock flake.
+ */
+export function appJwt(appId: string | number, privateKeyPem: string, nowMs: number = Date.now()): string {
+  const iat = Math.floor(nowMs / 1000) - 30; // clock-skew cushion
+  const exp = iat + 9 * 60; // 9 min — comfortably inside GitHub's 10-min ceiling
+  const header = b64url(JSON.stringify({ alg: 'RS256', typ: 'JWT' }));
+  const payload = b64url(JSON.stringify({ iat, exp, iss: String(appId) }));
+  const signingInput = `${header}.${payload}`;
+  const signature = createSign('RSA-SHA256').update(signingInput).sign(privateKeyPem);
+  return `${signingInput}.${b64url(signature)}`;
+}
+
+/** A GitHub App installation — one org/user the App is installed on. `account` is the org/user login. */
+export interface GithubInstallation {
+  id: number;
+  account: string;
+  /** The repository selection the installer granted: `all` or `selected`. */
+  repositorySelection?: string;
+}
+
+/**
+ * List the App's installations (`GET /app/installations`) — for the settings UI to confirm/pick which
+ * installation to mint tokens against, and to validate the App id + private key are correct (a bad key
+ * → 401 here). Returns `{ error }` on any non-2xx or network failure.
+ */
+export async function listInstallations(
+  appId: string | number,
+  privateKeyPem: string,
+): Promise<{ installations: GithubInstallation[] } | { error: string }> {
+  let jwt: string;
+  try {
+    jwt = appJwt(appId, privateKeyPem);
+  } catch (e) {
+    return { error: `could not sign App JWT (check the private key): ${e instanceof Error ? e.message : e}` };
+  }
+  try {
+    const res = await fetch(`${GH_API}/app/installations`, { headers: { ...BASE_HEADERS, authorization: `Bearer ${jwt}` } });
+    if (!res.ok) return { error: `GET /app/installations → ${res.status} ${await res.text().catch(() => '')}`.trim() };
+    const arr = (await res.json().catch(() => [])) as any[];
+    const installations = (Array.isArray(arr) ? arr : []).map((i) => ({
+      id: Number(i?.id),
+      account: String(i?.account?.login ?? i?.account?.slug ?? '?'),
+      repositorySelection: i?.repository_selection ? String(i.repository_selection) : undefined,
+    }));
+    return { installations };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'GET /app/installations failed' };
+  }
+}
+
+/** A freshly minted installation token: the bearer + when it expires (epoch ms) for cache eviction. */
+export interface InstallationToken {
+  token: string;
+  expiresAt: number;
+}
+
+/**
+ * Mint a 1 h **installation access token**
+ * (`POST /app/installations/:id/access_tokens`) — the credential handed to the agent (as `GH_TOKEN`
+ * and/or an MCP bearer). Optionally narrow it to specific `repositories` / `permissions` (a subset of
+ * what the installation granted) for least-privilege; omitted → the installation's full grant.
+ * Returns `{ error }` on any failure (the caller then leaves `GH_TOKEN` unset rather than acting on a
+ * bad credential).
+ */
+export async function mintInstallationToken(
+  appId: string | number,
+  privateKeyPem: string,
+  installationId: string | number,
+  opts: { repositories?: string[]; permissions?: Record<string, string> } = {},
+): Promise<InstallationToken | { error: string }> {
+  let jwt: string;
+  try {
+    jwt = appJwt(appId, privateKeyPem);
+  } catch (e) {
+    return { error: `could not sign App JWT (check the private key): ${e instanceof Error ? e.message : e}` };
+  }
+  const body: Record<string, unknown> = {};
+  if (opts.repositories?.length) body.repositories = opts.repositories;
+  if (opts.permissions && Object.keys(opts.permissions).length) body.permissions = opts.permissions;
+  try {
+    const res = await fetch(`${GH_API}/app/installations/${installationId}/access_tokens`, {
+      method: 'POST',
+      headers: { ...BASE_HEADERS, authorization: `Bearer ${jwt}`, 'content-type': 'application/json' },
+      body: Object.keys(body).length ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) return { error: `POST access_tokens → ${res.status} ${await res.text().catch(() => '')}`.trim() };
+    const j = (await res.json().catch(() => ({}))) as any;
+    if (typeof j?.token !== 'string') return { error: 'access_tokens response had no token' };
+    const expiresAt = j?.expires_at ? Date.parse(j.expires_at) : Date.now() + 55 * 60_000;
+    return { token: j.token, expiresAt };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'POST access_tokens failed' };
+  }
+}
+
+/**
+ * A tiny in-memory installation-token cache: mint once, reuse until ~5 min before expiry, so a burst
+ * of session launches doesn't hammer the mint endpoint (nor exhaust GitHub's rate limit). Keyed by
+ * installation id + the repo/permission narrowing, since those change the token's scope. Process-local
+ * by design — tokens are short-lived and must not outlive a restart.
+ */
+export class InstallationTokenCache {
+  private readonly cache = new Map<string, InstallationToken>();
+  /** Evict this many ms before the real expiry so a token handed out now is still valid for a while. */
+  private readonly skewMs = 5 * 60_000;
+
+  constructor(
+    private readonly appId: string | number,
+    private readonly privateKeyPem: string,
+  ) {}
+
+  /** Return a live token for `installationId` (minting/refreshing as needed), or `{ error }`. */
+  async get(
+    installationId: string | number,
+    opts: { repositories?: string[]; permissions?: Record<string, string> } = {},
+    nowMs: number = Date.now(),
+  ): Promise<InstallationToken | { error: string }> {
+    const key = `${installationId}|${(opts.repositories ?? []).join(',')}|${JSON.stringify(opts.permissions ?? {})}`;
+    const hit = this.cache.get(key);
+    if (hit && hit.expiresAt - this.skewMs > nowMs) return hit;
+    const minted = await mintInstallationToken(this.appId, this.privateKeyPem, installationId, opts);
+    if ('error' in minted) return minted;
+    this.cache.set(key, minted);
+    return minted;
+  }
+
+  /** Drop all cached tokens — call when the App credentials change. */
+  clear(): void {
+    this.cache.clear();
+  }
+}


### PR DESCRIPTION
## What

**Phase 1** of native GitHub (see [`docs/github-integration-plan.md`](docs/github-integration-plan.md)): a zero-dependency connector that mints short-lived **GitHub App installation tokens**. This is the single credential source that later phases inject into the shell (`GH_TOKEN` for `gh`/`git`) and feed to a governed GitHub MCP connector — so a user connects GitHub **once in the browser** instead of pasting a static PAT.

## Why an App, not a PAT
An installation token is org-scoped, carries only the App's fine-grained per-repo permissions, and **expires hourly** — minted on demand, so nothing long-lived reaches an agent. The private key never leaves the server; the signing JWT lives ≤10 min.

## This PR (foundation only — no launch wiring)
`src/connectors/github.ts`:
- `appJwt(appId, privateKeyPem, nowMs?)` — RS256 App JWT via `node:crypto` (30 s skew back-date, 9 min exp).
- `listInstallations()` — for the settings UI to confirm/pick the install + validate the key.
- `mintInstallationToken()` — the 1 h token, with optional `repositories`/`permissions` narrowing for least-privilege.
- `InstallationTokenCache` — reuse until ~5 min before expiry; process-local (tokens must not outlive a restart).

Every call returns `{ error }` rather than throwing, matching the Slack/Composio connectors.

## Not in this PR (next phases)
- **Phase 2** — mint at launch → inject `GH_TOKEN` (via the shell-secrets plane) + add the GitHub MCP connector to the session `.mcp.json`.
- **Phase 3** — Settings → Integrations GitHub card + install callback.

## Verification
- `npm run build` clean.
- Offline test with a **real** generated RSA keypair: 12 checks pass — JWT segments/claims exact, **signature verifies against the public key**, **tampered payload fails**, cache expiry-skew boundary correct, and `get()` returns `{error}` (not a throw) with no network. (No live GitHub App needed to prove the crypto.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)