### PR TITLE
Docs: move instapods data home outside the repo checkout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,8 +34,10 @@ running such a script, or you will pollute live data.
   restart: `curl -XPOST localhost:3010/api/<route> -d '{"session":"nope"}'` should give **404**
   (route present), not 401. (Prod Linux: `sudo systemctl restart agent-os`. **This Mac Mini** — the
   `instapods` tenant runs under launchd as `com.agentos.instapods` (`~/Library/LaunchAgents/com.agentos.instapods.plist`,
-  KeepAlive, `./data` on :3010, fronted by `tailscale serve` http→3010): rebuild + bounce with
-  `npm run build && launchctl kickstart -k gui/$(id -u)/com.agentos.instapods`; logs at `data/server.log`;
+  KeepAlive, home `~/agent-os-data/instapods` (kept OUTSIDE the repo checkout so a spawned agent's
+  parent-dir CLAUDE.md walk can't pick up this repo's own CLAUDE.md; new tenants go alongside as
+  `~/agent-os-data/<slug>`), on :3010, fronted by `tailscale serve` http→3010): rebuild + bounce with
+  `npm run build && launchctl kickstart -k gui/$(id -u)/com.agentos.instapods`; logs at `~/agent-os-data/instapods/server.log`;
   load/unload with `launchctl load -w|unload <plist>`.)
 - **Agent-facing MCP tools (`src/memory/memory-mcp.ts` — `recall`/`remember`/`revise`/`forget`, the
   `kb_*` tools, `ask`/`check_inbox`/`report`/`update`/`publish`/`artifacts_list`, `schedule`/`unschedule`,


### PR DESCRIPTION
## Why

A spawned claude-code agent runs with cwd `<home>/agents/<name>`. With the data home at `./data` **inside** the repo checkout, Claude Code's normal upward `CLAUDE.md` discovery walked:

```
data/agents/<name> → data/agents → data → <repo root, has CLAUDE.md> → …
```

so the repo's own developer-facing `CLAUDE.md` (build/deploy/architecture notes) leaked into **every** governed agent as project memory.

## Change

- Relocated the live `instapods` home to `~/agent-os-data/instapods` (outside the checkout) — an ops move already applied on the Mac Mini (plist arg + log paths repointed, dir moved intact with DB/`secret.key`/`control`/`tenants`). New tenants go alongside as `~/agent-os-data/<slug>`.
- This commit updates the `CLAUDE.md` launchd runbook + log-path references to match.

Verified: from an agent's new cwd, the only `CLAUDE.md` on the parent walk is the intended per-agent one; the repo `CLAUDE.md` is no longer reachable. Server healthy on :3010 from the new home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)