### PR TITLE
Sessions: per-session status line — governance + live metrics in the claude TUI (v0.14.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ new version heading in the same commit.
 ## [Unreleased]
 
 ### Added
+- **Session status line (info bar in every governed claude TUI).** Each interactive agent session now
+  renders a persistent bottom bar via Claude Code's native `statusLine` — a zero-dependency Node
+  renderer ([`terminal/statusline.js`](terminal/statusline.js)) wired in by `claude-launch.sh`. It
+  blends Claude's live session JSON (model·effort, a context-window usage bar, session cost, diff
+  churn) with the two signals only Agent OS knows: **which human identity the run acts as** and **how
+  many approvals it's blocked on** (`⏸ N waiting`), pulled from a new session-secret-gated loopback
+  route [`GET /api/agent/status`](src/server.ts) (pending approvals for the run + run-as name). Polled
+  on a 5 s refresh so the "waiting" indicator stays live while a gate is suspended; the governance
+  fetch is best-effort with a tight timeout, so an old/slow server just drops to the local metrics.
+  Inspired by [ccstatusline](https://github.com/sirmalloc/ccstatusline), built on the same underlying
+  Claude Code mechanism rather than vendoring the tool.
 - **GitHub App token minter (foundation for native GitHub).** New zero-dependency connector
   ([`src/connectors/github.ts`](src/connectors/github.ts)) that signs a short-lived App JWT (RS256, via
   `node:crypto`) and exchanges it for a **1 h installation access token** — the single credential that

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -316,6 +316,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     }));
     return sendJson(res, 200, { members });
   }
+  // Status line (the `statusline.js` bar in a governed claude TUI): live governance for THIS run —
+  // how many approvals it's blocked on and which human identity it acts as. Session-secret gated like
+  // the other agent loopback routes; read-only. Kept cheap: it's polled on the TUI refreshInterval.
+  if (method === 'GET' && p === '/api/agent/status') {
+    const session = url.searchParams.get('session') || '';
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const pending = os.approvals.pending(os.tenant).filter((a) => a.runId === session).length;
+    const runAsId = tm.sessionRunAs(session);
+    const runAs = runAsId ? os.team.getMember(runAsId)?.name ?? null : null;
+    return sendJson(res, 200, { agent, pending, runAs });
+  }
   if (method === 'GET' && p === '/api/agent/policy') {
     const session = url.searchParams.get('session') || '';
     const agent = tm.sessionAgent(session);

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -42,6 +42,8 @@ cd "$AGENT_DIR" 2>/dev/null || { red "agent folder not found: $AGENT_DIR"; exec 
 # are pure dry-runs; all go through the loopback API, which derives identity from the session row).
 # The Notification hook lives beside the gate hook; derive its path so it's correct on every machine.
 NOTIFY_HOOK="$(dirname "$HOOK")/notify-hook.sh"
+# The Agent OS status line renderer (native claude statusLine) lives beside the hooks too.
+STATUSLINE="$(dirname "$HOOK")/statusline.js"
 # NO OS-level Bash sandbox. Governance is the gate hook (PreToolUse), which is now the SOLE
 # authority: it emits an authoritative `permissionDecision` per Bash/connector call, so we don't
 # also wrap the shell in Seatbelt/bubblewrap. The old sandbox was never a real boundary anyway —
@@ -86,7 +88,8 @@ cat > .claude/aos-settings.json <<JSON
     "Notification": [
       { "hooks": [ { "type": "command", "command": "bash '$NOTIFY_HOOK'" } ] }
     ]
-  }
+  },
+  "statusLine": { "type": "command", "command": "node '$STATUSLINE'", "padding": 1, "refreshInterval": 5 }
 }
 JSON
 

--- a/terminal/statusline.js
+++ b/terminal/statusline.js
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Agent OS status line — the persistent info bar at the bottom of a governed claude TUI.
+//
+// Claude Code invokes this on every event (and on the refreshInterval below) with the live session
+// JSON on stdin (model, context window, cost, diff — see code.claude.com/docs/en/statusline). We
+// blend those native metrics with the two things ONLY Agent OS knows: how many approvals this run
+// has waiting in the inbox, and which human identity it's running as. The governance bit comes from
+// a single tight-timeout loopback GET to /api/agent/status (session-secret gated, same lane as the
+// gate hook); if the server is old or slow the fetch fails silent and we still render the local part.
+//
+// Zero deps, Node built-ins only (matches the repo's stance). Wired in by claude-launch.sh, which
+// writes `statusLine.command = node <this>` into the per-session .claude/aos-settings.json.
+
+const C = {
+  reset: '\x1b[0m', dim: '\x1b[2m', bold: '\x1b[1m',
+  cyan: '\x1b[36m', green: '\x1b[32m', yellow: '\x1b[33m', red: '\x1b[31m', gray: '\x1b[90m',
+};
+const sep = `${C.gray} · ${C.reset}`;
+
+function readStdin() {
+  return new Promise((resolve) => {
+    let buf = '';
+    if (process.stdin.isTTY) return resolve({});
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (c) => (buf += c));
+    process.stdin.on('end', () => {
+      try { resolve(JSON.parse(buf || '{}')); } catch { resolve({}); }
+    });
+    // Never hang the TUI: if stdin never closes, bail with what we have.
+    setTimeout(() => resolve((() => { try { return JSON.parse(buf || '{}'); } catch { return {}; } })()), 400);
+  });
+}
+
+// Live governance for THIS run: pending approvals + run-as. Best-effort, fails to nulls.
+async function governance() {
+  const base = process.env.AOS_URL, session = process.env.SESSION, secret = process.env.AOS_SECRET;
+  if (!base || !session || !secret) return {};
+  try {
+    const r = await fetch(`${base}/api/agent/status?session=${encodeURIComponent(session)}`, {
+      headers: { 'x-aos-secret': secret, 'x-aos-tenant': process.env.AOS_TENANT || '' },
+      signal: AbortSignal.timeout(700),
+    });
+    if (!r.ok) return {};
+    return await r.json();
+  } catch { return {}; }
+}
+
+function contextBar(cw) {
+  const pct = cw && cw.used_percentage != null ? Math.round(cw.used_percentage) : null;
+  if (pct == null) return `${C.gray}context —${C.reset}`;
+  const width = 10, filled = Math.max(0, Math.min(width, Math.round((pct * width) / 100)));
+  const color = pct >= 80 ? C.red : pct >= 50 ? C.yellow : C.green;
+  const bar = '▓'.repeat(filled) + '░'.repeat(width - filled);
+  return `${color}${bar}${C.reset} ${color}${pct}%${C.reset}`;
+}
+
+(async () => {
+  const [d, g] = await Promise.all([readStdin(), governance()]);
+
+  const parts = [];
+
+  // Agent + short AOS session id (maps the TUI to the console row) + run-as identity.
+  const agent = process.env.AGENT || (d.agent && d.agent.name) || 'agent';
+  const sid = process.env.SESSION ? String(process.env.SESSION).slice(-4) : '';
+  let head = `${C.cyan}${C.bold}◆ ${agent}${C.reset}`;
+  if (sid) head += ` ${C.gray}#${sid}${C.reset}`;
+  parts.push(head);
+  if (g.runAs) parts.push(`${C.dim}as ${g.runAs}${C.reset}`);
+
+  // Model · effort (JSON first, env fallback for either).
+  const model = (d.model && d.model.display_name) || process.env.CLAUDE_MODEL;
+  const effort = (d.effort && d.effort.level) || process.env.CLAUDE_EFFORT;
+  if (model) parts.push(`${C.dim}${model}${effort ? `·${effort}` : ''}${C.reset}`);
+
+  // Context window bar.
+  parts.push(contextBar(d.context_window));
+
+  // Cost (skip when free/zero).
+  const cost = d.cost && typeof d.cost.total_cost_usd === 'number' ? d.cost.total_cost_usd : 0;
+  if (cost > 0) parts.push(`${C.dim}$${cost < 1 ? cost.toFixed(3) : cost.toFixed(2)}${C.reset}`);
+
+  // Diff churn this session.
+  const add = (d.cost && d.cost.total_lines_added) || 0;
+  const del = (d.cost && d.cost.total_lines_removed) || 0;
+  if (add || del) parts.push(`${C.green}+${add}${C.reset}${C.gray}/${C.reset}${C.red}-${del}${C.reset}`);
+
+  // The Agent-OS-distinctive signal: approvals this run is blocked on, right in the bar.
+  if (g.pending > 0) parts.push(`${C.yellow}${C.bold}⏸ ${g.pending} waiting${C.reset}`);
+
+  process.stdout.write(parts.join(sep));
+})();


### PR DESCRIPTION
## What

Every interactive agent session now renders a persistent **info bar** at the bottom of its governed `claude` TUI, using Claude Code's **native `statusLine`** mechanism (the same one [ccstatusline](https://github.com/sirmalloc/ccstatusline) is built on — we build on the mechanism rather than vendoring the heavy interactive tool).

```
◆ pod-troubleshooter #a3f1 · as Vikas · Opus·high · ▓▓▓░░░░░░░ 28% · $0.04 · +156/-23 · ⏸ 1 waiting
```

It blends Claude's live session JSON with the two signals **only Agent OS knows**:
- **native metrics** — model·effort, a color-graded context-window usage bar, session cost, diff churn (`+adds/-dels`)
- **run-as identity** — which human the session acts as
- **pending approvals** — `⏸ N waiting`, so an operator watching the terminal sees at a glance that the run is blocked on the inbox

## How

- **`terminal/statusline.js`** — zero-dependency Node renderer. Reads Claude's stdin JSON + session env, does one tight-timeout (700 ms) loopback GET for governance, fails silent to the local metrics if the server is old/slow. Renders on Claude's events + a 5 s `refreshInterval` so the "waiting" indicator stays live while a gate is suspended.
- **`GET /api/agent/status`** — new session-secret-gated loopback route (same lane as `/api/agent/directory`, before the member-auth gate) returning `{ agent, pending, runAs }` for the run. Reuses `os.approvals.pending()` + `tm.sessionRunAs()`.
- **`terminal/claude-launch.sh`** — injects `statusLine` into the per-session `.claude/aos-settings.json` (interactive lane; inert in headless `-p`, which has no TUI).

## Validation

- `npm run build` clean.
- Route placement confirmed via isolated ephemeral server: unknown session → **404** (route present, before the auth gate), not 401.
- `statusline.js` rendered against sample JSON incl. edge cases (null context early in session, zero cost, env-only model fallback) — degrades cleanly.
- Generated `aos-settings.json` validated as well-formed JSON with the new key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)