### PR TITLE
Sessions: status line shows current folder + weekly usage limit (v0.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ new version heading in the same commit.
 ## [Unreleased]
 
 ### Added
+- **GitHub App token minter (foundation for native GitHub).** New zero-dependency connector
+  ([`src/connectors/github.ts`](src/connectors/github.ts)) that signs a short-lived App JWT (RS256, via
+  `node:crypto`) and exchanges it for a **1 h installation access token** — the single credential that
+  will drive both the shell (`GH_TOKEN` for `gh`/`git`) and a governed GitHub MCP connector, so a user
+  connects GitHub once in the browser instead of pasting a static PAT. Includes `appJwt`,
+  `listInstallations`, `mintInstallationToken` (optional repo/permission narrowing for least-privilege)
+  and an in-memory `InstallationTokenCache` (reuse until ~5 min before expiry). Not wired into launch
+  yet — see [`docs/github-integration-plan.md`](docs/github-integration-plan.md) for the phased plan
+  (mint-at-launch injection + Settings → Integrations install flow land next).
+
+## [0.15.0] — 2026-07-06
+
+### Added
+- **Status line: current folder + weekly usage limit.** The session bar
+  ([`terminal/statusline.js`](terminal/statusline.js)) gains two segments: the current working
+  **folder** (compacted — `~` for `$HOME`, collapsed to the last two path segments when deep) and the
+  **weekly usage limit** (`wk 41%`, color-graded green→yellow→red) from Claude's `rate_limits.seven_day`.
+  Both skip silently when absent — the folder when there's no cwd, the weekly meter for non-Pro/Max
+  accounts or before the first API response of a session.
+
+## [0.14.0] — 2026-07-06
+
+### Added
 - **Session status line (info bar in every governed claude TUI).** Each interactive agent session now
   renders a persistent bottom bar via Claude Code's native `statusLine` — a zero-dependency Node
   renderer ([`terminal/statusline.js`](terminal/statusline.js)) wired in by `claude-launch.sh`. It
@@ -20,15 +43,6 @@ new version heading in the same commit.
   fetch is best-effort with a tight timeout, so an old/slow server just drops to the local metrics.
   Inspired by [ccstatusline](https://github.com/sirmalloc/ccstatusline), built on the same underlying
   Claude Code mechanism rather than vendoring the tool.
-- **GitHub App token minter (foundation for native GitHub).** New zero-dependency connector
-  ([`src/connectors/github.ts`](src/connectors/github.ts)) that signs a short-lived App JWT (RS256, via
-  `node:crypto`) and exchanges it for a **1 h installation access token** — the single credential that
-  will drive both the shell (`GH_TOKEN` for `gh`/`git`) and a governed GitHub MCP connector, so a user
-  connects GitHub once in the browser instead of pasting a static PAT. Includes `appJwt`,
-  `listInstallations`, `mintInstallationToken` (optional repo/permission narrowing for least-privilege)
-  and an in-memory `InstallationTokenCache` (reuse until ~5 min before expiry). Not wired into launch
-  yet — see [`docs/github-integration-plan.md`](docs/github-integration-plan.md) for the phased plan
-  (mint-at-launch injection + Settings → Integrations install flow land next).
 
 ## [0.13.0] — 2026-07-06
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/terminal/statusline.js
+++ b/terminal/statusline.js
@@ -45,13 +45,26 @@ async function governance() {
   } catch { return {}; }
 }
 
+// Green under half, yellow past half, red near the ceiling — shared by context + usage meters.
+const pctColor = (pct) => (pct >= 80 ? C.red : pct >= 50 ? C.yellow : C.green);
+
 function contextBar(cw) {
   const pct = cw && cw.used_percentage != null ? Math.round(cw.used_percentage) : null;
   if (pct == null) return `${C.gray}context —${C.reset}`;
   const width = 10, filled = Math.max(0, Math.min(width, Math.round((pct * width) / 100)));
-  const color = pct >= 80 ? C.red : pct >= 50 ? C.yellow : C.green;
+  const color = pctColor(pct);
   const bar = '▓'.repeat(filled) + '░'.repeat(width - filled);
   return `${color}${bar}${C.reset} ${color}${pct}%${C.reset}`;
+}
+
+// Compact working dir: ~ for $HOME, and collapse to the last two segments when deep.
+function folderLabel(cwd) {
+  if (!cwd) return null;
+  const home = process.env.HOME || '';
+  let p = home && cwd.startsWith(home) ? '~' + cwd.slice(home.length) : cwd;
+  const segs = p.split('/').filter(Boolean);
+  if (segs.length > 2) p = (p.startsWith('~') ? '~/…/' : '…/') + segs.slice(-2).join('/');
+  return p;
 }
 
 (async () => {
@@ -67,6 +80,10 @@ function contextBar(cw) {
   parts.push(head);
   if (g.runAs) parts.push(`${C.dim}as ${g.runAs}${C.reset}`);
 
+  // Current working folder (compact).
+  const folder = folderLabel((d.workspace && d.workspace.current_dir) || d.cwd);
+  if (folder) parts.push(`${C.cyan}${folder}${C.reset}`);
+
   // Model · effort (JSON first, env fallback for either).
   const model = (d.model && d.model.display_name) || process.env.CLAUDE_MODEL;
   const effort = (d.effort && d.effort.level) || process.env.CLAUDE_EFFORT;
@@ -74,6 +91,13 @@ function contextBar(cw) {
 
   // Context window bar.
   parts.push(contextBar(d.context_window));
+
+  // Weekly usage limit (Pro/Max only, present after the first API response — else skip silently).
+  const wk = d.rate_limits && d.rate_limits.seven_day && d.rate_limits.seven_day.used_percentage;
+  if (typeof wk === 'number') {
+    const p = Math.round(wk);
+    parts.push(`${C.gray}wk ${C.reset}${pctColor(p)}${p}%${C.reset}`);
+  }
 
   // Cost (skip when free/zero).
   const cost = d.cost && typeof d.cost.total_cost_usd === 'number' ? d.cost.total_cost_usd : 0;


### PR DESCRIPTION
## What

Adds the two segments you asked for to the session status bar:

```
◆ pod-troubleshooter #a3f1 · as Vikas · ~/…/agents/pod-troubleshooter · Opus·high · ▓▓▓░░░░░░░ 28% · wk 41% · $0.04 · +156/-23
```

- **Current folder** — from `workspace.current_dir`/`cwd`, compacted: `~` for `$HOME`, collapsed to the last two path segments when deep, so it stays short as the agent `cd`s around.
- **Weekly usage limit** — `wk N%` from Claude's `rate_limits.seven_day.used_percentage`, color-graded green→yellow→red (shares the context-bar thresholds).

Both **skip silently** when the data isn't there: the folder when there's no cwd, the weekly meter for non-Pro/Max accounts or before the session's first API response (per the statusLine schema).

## Validation

- `npm run build` clean.
- Rendered against sample JSON: deep path → `~/…/agents/pod-troubleshooter`; shallow `/srv/app` shown whole; weekly 41% green / 88% red; and the non-subscriber case where both segments correctly disappear.

Also tidies CHANGELOG: the v0.14.0 status-line entry moves out of **Unreleased** into its own version heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)