### PR TITLE
Sessions: task/chat-triggered runs show in their owner's sidebar (v0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.16.1] — 2026-07-07
+
+### Fixed
+- **Task/chat-triggered sessions now show in their owner's sidebar.** The left "my sessions" switcher
+  keyed only off `spawnedBy === me.id`, so a session an auto-dispatched **Task** (or a chat message)
+  spawned — whose provenance is `task:<id>`/`automation:<id>` but which *runs as* the owning member —
+  was hidden from that member's sidebar even though they own it. The session DTO now carries **`runAs`**
+  ([`src/terminal.ts`](src/terminal.ts), [`web/src/lib/api.ts`](web/src/lib/api.ts)) and the sidebar
+  includes sessions where `spawnedBy === me.id` **or** `runAs === me.id`
+  ([`web/src/App.tsx`](web/src/App.tsx)) — matching the run-as visibility rule the inbox already used.
+
 ## [0.16.0] — 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.16.0",
+      "version": "0.16.1",
       "license": "MIT",
       "dependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -109,10 +109,14 @@ export interface Session {
    * offers a Resume affordance once it's no longer live.
    */
   resumable?: boolean;
-  /** Raw provenance: member id, or `automation:<id>` when a trigger spawned it. */
+  /** Raw provenance: member id, or `automation:<id>`/`task:<id>`/`chat:<name>` when a trigger spawned it. */
   spawnedBy?: string;
   /** Human-readable provenance for the console (member name/email, or the automation's name). */
   spawnedByLabel?: string;
+  /** The member id this session ACTS AS (run_as) — distinct from `spawnedBy` provenance. A task- or
+   *  chat-triggered run is spawned by `task:`/`automation:` but runs as (and is owned by) a member,
+   *  so the console keys "my sessions" off this too. */
+  runAs?: string;
   createdAt: number;
 }
 
@@ -1419,7 +1423,7 @@ function titleFromSummary(summary: string): string {
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, createdAt: r.created_at };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, createdAt: r.created_at };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -480,10 +480,12 @@ function Console({ me }: { me: Member }) {
   // Sessions where Claude is blocked waiting on the human — drives the per-session bell everywhere.
   const waiting = new Set(messages.filter((m) => m.type === 'notification' && m.status === 'open').map((m) => m.sessionId))
   const runningSessions = sessions.filter(isLive).length
-  // The sidebar is a switcher over the sessions *I* started (spawnedBy is the member id),
-  // running first, then newest first.
+  // The sidebar is a switcher over the sessions *I'm accountable for* — ones I started directly
+  // (spawnedBy is my member id) OR ones a trigger spawned that run AS me (runAs): a Task I own that
+  // auto-dispatched, a chat message I sent. Those have a `task:`/`automation:` provenance, so keying
+  // only off spawnedBy hid them from their owner's sidebar. Running first, then newest first.
   const mySessions = sessions
-    .filter((s) => s.spawnedBy === me.id)
+    .filter((s) => s.spawnedBy === me.id || s.runAs === me.id)
     .sort((a, b) => {
       const rank = (s: Session) => (isLive(s) ? 0 : 1) // live first; all terminal (dead) states tie
       return rank(a) - rank(b) || b.createdAt - a.createdAt

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -111,6 +111,9 @@ export interface Session {
   resumable?: boolean
   spawnedBy?: string
   spawnedByLabel?: string
+  /** The member id this session runs AS (run_as). A task/chat-triggered run is spawnedBy `task:`/
+   *  `automation:` but runs as a member — the sidebar keys "my sessions" off this too. */
+  runAs?: string
   createdAt: number
 }
 export interface AuditEvent {


### PR DESCRIPTION
## Problem

A session spawned by an auto-dispatched **Task** (e.g. `1603ccea`) has provenance `task:<id>` but *runs as* — and is owned by — a member. The left-sidebar "my sessions" switcher filtered on `spawnedBy === me.id` only, so those runs were hidden from the very member accountable for them, even though the inbox and session-list already showed them (via the `run_as` visibility rule).

## Fix

- Expose **`runAs`** on the session DTO (`src/terminal.ts` `Session` + `toSession`, `web/src/lib/api.ts`).
- Sidebar filter now includes sessions where `spawnedBy === me.id` **or** `runAs === me.id` (`web/src/App.tsx`) — mirroring `canViewRow`.

## Test

- `npm run typecheck` — clean.
- `cd web && npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)