### PR TITLE
Build: regenerate stale package-lock.json to match package.json (v0.18.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.18.1] — 2026-07-07
+
+### Fixed
+- **Stale `package-lock.json` no longer dirties every box's working tree.** The committed lockfile
+  still pinned `@libsql/client` (the opt-in native-vectors memory provider) at its root `dependencies`,
+  even though `package.json` had dropped it to make it opt-in. Any box running `npm install` reconciled
+  the lock down to match `package.json`, leaving the tree dirty and **blocking the self-update's
+  fast-forward pull**. Regenerated the lockfile so it matches `package.json` — installs are now a no-op
+  against a clean tree.
+
 ## [0.18.0] — 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "agent-os",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
-      "dependencies": {
-        "@libsql/client": "^0.14.0"
-      },
       "bin": {
         "agent-os": "bin/agent-os"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
## Why

The committed `package-lock.json` still pinned `@libsql/client` (`^0.14.0`) at its root `dependencies`, even though `package.json` had dropped it long ago to make the native-vectors memory provider **opt-in** (per CLAUDE.md).

Because the lock and `package.json` disagreed, **any box that runs `npm install` reconciles the lock down to match `package.json`** — deleting those 3 lines and leaving the working tree dirty. A dirty tree blocks the self-update's fast-forward `git pull`, which is exactly what stranded the jump-server at v0.11.0 (6 commits behind) with a lone `M package-lock.json`.

## Fix

Regenerated the lockfile so its root `dependencies` matches `package.json` (`{}`). `npm install` is now a no-op against a clean tree, so no box gets a spurious dirty lockfile again.

## Test

- `npm install` locally → clean tree (was: 3-line deletion)
- Root `dependencies` in lock now `{}`, consistent with `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)