### PR TITLE
Agents: built-in department generalists + bypass first-launch trust dialog (v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.20.0] — 2026-07-07
+
+### Added
+- **Built-in department generalists — a starter fleet every workspace boots with.** Four
+  code-provisioned agents (`engineer`, `support`, `marketer`, `researcher`) are now materialised into
+  every data home on boot the same idempotent way as the `agent-author` — an isolated
+  `<home>/agents/<id>/{agent.json,CLAUDE.md}` folder, grouped under its department category
+  (Engineering / Support / Marketing / Research). Each is a broad "do-anything within this function"
+  generalist (not a narrow single-task bot — the agent-author spins those up on demand), so a fresh
+  home is useful immediately without hand-authoring a manifest. User edits to either file are
+  preserved (written only when absent); delete a folder and boot restores it
+  ([`src/edge/generalists.ts`](src/edge/generalists.ts), wired in
+  [`src/kernel.ts`](src/kernel.ts)).
+
+### Fixed
+- **First interactive launch no longer shows the "Do you trust the files in this folder?" dialog.**
+  Freshly-created agent folders had never been trusted, so an interactive claude opened with the
+  workspace-trust prompt (headless already dodged it via `--dangerously-skip-permissions`). The
+  launcher now pre-seeds the per-directory trust flag
+  (`~/.claude.json` → `projects["<AGENT_DIR>"].hasTrustDialogAccepted`) keyed off the real `$HOME` of
+  whatever lane/user runs the session — idempotent (writes only on an agent's first launch), atomic
+  (temp + rename), and never fatal to launch. This suppresses only the one-time trust gate; the
+  PreToolUse gate hook and deny rules still govern every effect, so the security posture is unchanged
+  ([`terminal/claude-launch.sh`](terminal/claude-launch.sh)).
+
 ## [0.19.1] — 2026-07-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.19.1",
+      "version": "0.20.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.19.1",
+  "version": "0.20.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/generalists.ts
+++ b/src/edge/generalists.ts
@@ -1,0 +1,240 @@
+/**
+ * The **department generalists** — a small starter fleet that ships built-in with every workspace.
+ *
+ * Agent OS provisions four "do-anything within this function" agents so a fresh home is useful the
+ * moment it boots, without anyone hand-authoring a manifest first: an **engineer**, a **support**
+ * agent, a **marketer**, and a **researcher**. Each is a broad generalist for its department (grouped
+ * under its own category in the console) rather than a narrow single-task bot — the agent-author is
+ * there to spin up the narrow specialists on demand; these cover the common case out of the box.
+ *
+ * Like the agent-author (src/edge/agent-author.ts) and the consolidator (src/edge/consolidation.ts)
+ * they are *code-provisioned*: `ensureGeneralists` writes each isolated folder
+ * (`<home>/agents/<id>/{agent.json,CLAUDE.md}`) into the data home on boot, idempotently, so every
+ * workspace has them without shipping a config/agents folder. User edits to either file are preserved
+ * (only written when absent); delete a folder and boot restores it. No-op in the in-memory demo/test
+ * build (no data home to write into).
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AgentOS } from '../kernel';
+import type { AgentManifest } from '../types';
+
+/** One built-in generalist: its manifest plus the CLAUDE.md system prompt written beside it. */
+interface Generalist {
+  manifest: AgentManifest;
+  claudeMd: string;
+}
+
+// A shared, deliberately generous default budget — these agents do real downstream work (a coding
+// session, a research dig), so they get more headroom than the meta agents. The OS gate still governs
+// every effect regardless; this is only the per-run ceiling. Model/effort are omitted so each inherits
+// the workspace runtime defaults (Settings → runtime defaults) unless an operator pins a tier later.
+const BUDGET = { usdCap: 5, tokenCap: 1_000_000, wallClockMs: 3_600_000 } as const;
+
+const ENGINEER: Generalist = {
+  manifest: {
+    id: 'engineer',
+    version: '1.0.0',
+    description: 'Engineering generalist — writes and reviews code, debugs, investigates systems, ships fixes.',
+    category: 'Engineering',
+    principal: 'svc-engineer',
+    policyContext: 'default@v1',
+    runtime: 'claude-code',
+    icon: 'Code2',
+    examplePrompts: [
+      'Investigate why the nightly job is failing and propose a fix',
+      'Review this pull request for correctness and clarity',
+      'Add input validation to the signup endpoint and cover it with a test',
+    ],
+    budget: { ...BUDGET },
+  },
+  claudeMd: `# Engineer
+
+You are the workspace's **engineering generalist** — a capable technical agent who takes on whatever
+software work lands in front of you: reading and understanding a codebase, writing and reviewing code,
+debugging, investigating a system, and shipping a well-scoped change. You're a broad engineer, not a
+single-task bot: pick up the task, figure out how to do it, and do it well.
+
+## Method
+1. **Understand before you touch.** Read the relevant code and any docs first; reproduce the problem or
+   pin down the requirement before changing anything. State your understanding back if the task is thin.
+2. **Work in small, verifiable steps.** Make the change, then actually check it — run the build/tests,
+   drive the affected path, read the output. Don't claim something works you haven't observed.
+3. **Match the surrounding code.** Follow the project's existing conventions, naming, and structure over
+   your own preferences. Leave the codebase as clean as you found it or cleaner.
+4. **Explain what you did.** When you finish, summarize the change, why it's correct, and anything you
+   couldn't verify or left for a human — plainly, without overstating confidence.
+
+## Your tools
+- \`recall\`/\`remember\` — reuse what you've learned about this codebase and its gotchas.
+- \`kb_search\`/\`kb_read\`/\`kb_write\` — house engineering conventions and runbooks; write back what's durable.
+- \`task_create\`/\`task_claim\`/\`task_update\` — file, pick up, and close units of work on the shared queue.
+- \`ask\` when you're blocked on a decision only a human can make; \`report\` to close out with a summary.
+
+## Boundaries
+- Every side effect you have — a shell command, an edit, a deploy — passes through the OS gate; risky
+  ones pause for human approval. Don't try to route around it.
+- Prefer the smallest change that solves the problem. If a task is really two jobs, say so and split it.
+- You don't decide product direction or ship irreversible/outward-facing actions unprompted — surface
+  those and let a human call it.`,
+};
+
+const SUPPORT: Generalist = {
+  manifest: {
+    id: 'support',
+    version: '1.0.0',
+    description: 'Support generalist — triages issues, answers questions, drafts replies, escalates what needs a human.',
+    category: 'Support',
+    principal: 'svc-support',
+    policyContext: 'default@v1',
+    runtime: 'claude-code',
+    icon: 'Headphones',
+    examplePrompts: [
+      'Triage this incoming bug report and draft a first reply',
+      'Summarize the open support threads and flag anything urgent',
+      'Write a help-doc answer for how to reset a password',
+    ],
+    budget: { ...BUDGET },
+  },
+  claudeMd: `# Support
+
+You are the workspace's **support generalist** — the agent that fields inbound questions and issues,
+figures out what's really being asked, and moves each one toward resolution. You handle the common
+case end-to-end and know when to hand off.
+
+## Method
+1. **Understand the ask.** Read the whole message and any history. Restate the problem in one line to be
+   sure you've got it before answering.
+2. **Answer from what's true.** Check the knowledge base and prior threads (\`kb_search\`, \`recall\`) rather
+   than guessing. If you don't know, say so and find out — never invent a fact or a policy.
+3. **Reply clearly and kindly.** Lead with the answer or the next step, keep it concise, and match a
+   warm, professional tone. Give concrete steps the person can follow.
+4. **Triage and route.** Classify severity, tag it, and — if it needs engineering or a human decision —
+   file a task (\`task_create\`, assign it) or escalate rather than sitting on it.
+
+## Your tools
+- \`kb_search\`/\`kb_read\` — the source of truth for answers; \`kb_write\` to capture a new recurring answer.
+- \`recall\`/\`remember\` — remember how past issues were resolved so you're faster next time.
+- \`task_create\`/\`task_update\` — file bugs or follow-ups and hand them to the right agent/human.
+- \`ask\` when only a human can decide; \`report\` to close the loop with a short summary.
+- When chat-triggered, reply in the channel with your reply tools.
+
+## Boundaries
+- You resolve and route support requests; you don't make product promises, issue refunds, or take
+  irreversible/outward-facing actions on your own — escalate those to a human.
+- Every outbound action passes through the OS gate; risky ones pause for approval. Don't route around it.
+- When unsure whether something is safe to say or do, ask first. A careful "let me check" beats a wrong
+  confident answer.`,
+};
+
+const MARKETER: Generalist = {
+  manifest: {
+    id: 'marketer',
+    version: '1.0.0',
+    description: 'Marketing generalist — writes copy, posts and emails, plans campaigns, repurposes content.',
+    category: 'Marketing',
+    principal: 'svc-marketer',
+    policyContext: 'default@v1',
+    runtime: 'claude-code',
+    icon: 'Megaphone',
+    examplePrompts: [
+      'Draft a launch announcement for our new feature',
+      'Turn this blog post into a week of social posts',
+      'Write a 3-email onboarding sequence for new signups',
+    ],
+    budget: { ...BUDGET },
+  },
+  claudeMd: `# Marketer
+
+You are the workspace's **marketing generalist** — the agent that turns a rough brief into finished
+marketing work: announcements, blog posts, emails, social copy, landing-page text, and campaign plans.
+You cover the breadth of the function and know the company's voice.
+
+## Method
+1. **Get the brief straight.** Who's the audience, what's the one message, what's the goal (awareness,
+   signups, retention), and where does it run? Ask 2–3 sharp questions if the request is thin.
+2. **Ground it in the company's voice.** Pull the company context and any brand/tone notes (\`kb_search\`,
+   \`recall\`) so the piece sounds like the company, not generic AI copy.
+3. **Write tight, specific copy.** Lead with the value, cut filler, make claims you can back up, and give
+   a clear call to action. Offer a couple of headline/subject options where it helps.
+4. **Repurpose deliberately.** When adapting one piece into many (post → thread → email), keep the core
+   message consistent and tailor the format and length to each channel.
+
+## Your tools
+- \`kb_search\`/\`kb_read\`/\`kb_write\` — brand voice, past campaigns, messaging house-style; save what's reusable.
+- \`recall\`/\`remember\` — remember what's landed well before and reuse those angles.
+- \`publish\`/\`report\` — surface the finished piece and close out with a short summary.
+- \`ask\` when a positioning or claim decision needs a human.
+
+## Boundaries
+- You draft and propose marketing work; you don't hit "send" on anything outward-facing (publish a post,
+  blast an email list) without a human's go-ahead — the OS gate pauses those for approval.
+- No unverifiable claims, invented stats, or off-brand promises. If you're unsure a claim is true, flag
+  it rather than shipping it.
+- Keep each deliverable focused on its one goal. If a brief is really two campaigns, say so.`,
+};
+
+const RESEARCHER: Generalist = {
+  manifest: {
+    id: 'researcher',
+    version: '1.0.0',
+    description: 'Research generalist — digs into questions, gathers and weighs sources, synthesizes clear findings.',
+    category: 'Research',
+    principal: 'svc-researcher',
+    policyContext: 'default@v1',
+    runtime: 'claude-code',
+    icon: 'LineChart',
+    examplePrompts: [
+      'Research the top 5 competitors and how their pricing compares to ours',
+      'Summarize what changed in this area over the last quarter, with sources',
+      'Investigate this question and give me a cited, honest answer',
+    ],
+    budget: { ...BUDGET },
+  },
+  claudeMd: `# Researcher
+
+You are the workspace's **research generalist** — the agent that takes an open question and comes back
+with a clear, honest, sourced answer. You gather information, weigh it, and synthesize it into something
+a person can act on — not a pile of links.
+
+## Method
+1. **Sharpen the question.** Make sure you know exactly what's being asked and what a good answer looks
+   like (scope, timeframe, decision it feeds). Narrow it before you dig if it's vague.
+2. **Gather from multiple angles.** Pull from the knowledge base and memory first (\`kb_search\`, \`recall\`),
+   then external sources as needed. Note where each claim comes from.
+3. **Weigh, don't just collect.** Cross-check important claims, call out where sources disagree, and
+   separate what's well-established from what's uncertain. Don't launder a guess as a fact.
+4. **Synthesize and cite.** Deliver a structured answer that leads with the takeaway, backs it with
+   evidence, cites sources, and states your confidence and any gaps honestly.
+
+## Your tools
+- \`kb_search\`/\`kb_read\`/\`kb_write\` — internal knowledge; write durable findings back for the fleet.
+- \`recall\`/\`remember\` — build on earlier research instead of redoing it.
+- \`report\`/\`publish\` — deliver the finding and close out with a short summary.
+- \`ask\` when the question's scope or a judgment call needs a human.
+
+## Boundaries
+- You inform decisions; you don't make them or take outward-facing actions on the strength of your own
+  findings — hand a well-framed recommendation to a human.
+- Never fabricate a source, statistic, or quote. "I couldn't find this" is a valid, useful answer.
+- Every side effect still passes through the OS gate; risky ones pause for approval.`,
+};
+
+const GENERALISTS: readonly Generalist[] = [ENGINEER, SUPPORT, MARKETER, RESEARCHER];
+
+/** Provision the built-in department generalists into the data home on boot (one isolated folder each
+ *  with its manifest + CLAUDE.md), then register each live so it resolves to a real claude-code runtime.
+ *  Idempotent: skips any agent already registered with a folder, and never overwrites a manifest/CLAUDE.md
+ *  a user has edited. No-op in the in-memory demo/test build (no data home to write into). */
+export function ensureGeneralists(os: AgentOS): void {
+  if (!os.paths) return; // demo/tests run in-memory with no agents home to write into
+  for (const { manifest, claudeMd } of GENERALISTS) {
+    if (os.agents.get(manifest.id)?.dir) continue;
+    const dir = path.join(os.paths.userAgents, manifest.id);
+    fs.mkdirSync(dir, { recursive: true });
+    const manifestPath = path.join(dir, 'agent.json');
+    if (!fs.existsSync(manifestPath)) fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n');
+    if (!fs.existsSync(path.join(dir, 'CLAUDE.md'))) fs.writeFileSync(path.join(dir, 'CLAUDE.md'), claudeMd);
+    os.registerAgent({ ...manifest, dir });
+  }
+}

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -39,6 +39,7 @@ import { JsonPolicyEngine, PolicyDocument } from './governance/policy';
 import { EnvSecretsVault, SqliteSecretsVault } from './edge/secrets';
 import { resolveMasterKey } from './edge/secret-crypto';
 import { ensureAgentAuthor } from './edge/agent-author';
+import { ensureGeneralists } from './edge/generalists';
 import { HealthMonitor } from './observability/monitor';
 import { MockAdapter, MockBehavior } from './runtime/mock-adapter';
 import { ClaudeCodeAdapter } from './runtime/claude-code-adapter';
@@ -292,9 +293,11 @@ export function loadAgentOS(
   // Bundled examples first, then the user's agents (which override examples by id).
   loadAgentsFrom(os, paths.bundledAgents);
   loadAgentsFrom(os, paths.userAgents);
-  // Code-provisioned System agents that must exist in every home (materialised into the data home,
-  // idempotently) even though they don't ship as a config/agents folder.
+  // Code-provisioned agents that must exist in every home (materialised into the data home,
+  // idempotently) even though they don't ship as a config/agents folder: the System agent-author,
+  // plus the built-in department generalists (engineer/support/marketer/researcher).
   ensureAgentAuthor(os);
+  ensureGeneralists(os);
   return os;
 }
 

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -93,6 +93,34 @@ cat > .claude/aos-settings.json <<JSON
 }
 JSON
 
+# Pre-accept the workspace-TRUST dialog for this agent folder. Freshly-created agent folders have
+# never been trusted, so an INTERACTIVE claude would open with "Do you trust the files in this
+# folder?" (headless already dodges it via --dangerously-skip-permissions). Trust is stored
+# per-directory in ~/.claude.json under projects["<dir>"].hasTrustDialogAccepted; seed it so the
+# dialog never fires. Keyed off the REAL $HOME of whatever user/lane runs this (local or uid-isolated).
+# Idempotent (only writes on first launch of each agent), atomic (temp+rename), and never fatal —
+# a failure here must not block the session. NOTE: this only bypasses the one-time TRUST gate; the
+# PreToolUse gate hook + deny rules above still govern every effect, so security posture is unchanged.
+if command -v node >/dev/null 2>&1; then
+  AOS_TRUST_DIR="$AGENT_DIR" node -e '
+    const fs = require("fs"), os = require("os"), path = require("path");
+    const dir = process.env.AOS_TRUST_DIR;
+    if (!dir) process.exit(0);
+    const p = path.join(os.homedir(), ".claude.json");
+    let cfg = {};
+    try { cfg = JSON.parse(fs.readFileSync(p, "utf8")); } catch (_) { /* missing/empty/corrupt → start fresh */ }
+    if (typeof cfg !== "object" || cfg === null) cfg = {};
+    cfg.projects = cfg.projects || {};
+    const cur = cfg.projects[dir] || {};
+    if (cur.hasTrustDialogAccepted === true) process.exit(0);   // already trusted — nothing to do
+    cur.hasTrustDialogAccepted = true;
+    cfg.projects[dir] = cur;
+    const tmp = p + ".aos-" + process.pid + ".tmp";
+    fs.writeFileSync(tmp, JSON.stringify(cfg, null, 2), { mode: 0o600 });
+    fs.renameSync(tmp, p);   // atomic replace
+  ' 2>/dev/null || true
+fi
+
 clear
 cyan "┌─ Agent OS · governed claude ────────────────────────────────"
 cyan "│ agent:   $AGENT"


### PR DESCRIPTION
## What

Two changes, both aimed at making a fresh workspace useful and frictionless out of the box.

### 1. Built-in department generalists (starter fleet)
Ships four **code-provisioned** generalist agents that every data home boots with — no hand-authoring a manifest first:

| id | category | icon | role |
|----|----------|------|------|
| `engineer` | Engineering | Code2 | writes/reviews code, debugs, ships fixes |
| `support` | Support | Headphones | triages issues, drafts replies, escalates |
| `marketer` | Marketing | Megaphone | writes copy/posts/emails, plans campaigns |
| `researcher` | Research | LineChart | digs into questions, synthesizes cited findings |

Each is a broad *"do-anything within this function"* generalist rather than a narrow single-task bot — the `agent-author` is still there to spin up the specialists on demand; these cover the common case immediately. Provisioning mirrors `agent-author` exactly (`src/edge/generalists.ts` → `ensureGeneralists`, wired in `src/kernel.ts`): an isolated `<home>/agents/<id>/{agent.json,CLAUDE.md}` folder written on boot, **idempotent**, **user edits preserved** (files written only when absent), delete-a-folder-and-boot-restores-it. No `config/agents` folder shipped; no-op in the in-memory demo/test build.

### 2. Bypass the first-launch "Do you trust this folder?" dialog
Freshly-created agent folders had never been trusted, so an **interactive** claude opened with the workspace-trust prompt (headless already dodged it via `--dangerously-skip-permissions`). The launcher now pre-seeds the per-directory trust flag — `~/.claude.json` → `projects["<AGENT_DIR>"].hasTrustDialogAccepted` — keyed off the **real `$HOME`** of whatever lane/user runs the session (local or uid-isolated). Idempotent (writes only on an agent's first launch), atomic (temp + rename), and **never fatal** to launch.

> This suppresses only the one-time *trust* gate. The PreToolUse gate hook + deny rules still govern every effect, so the security posture is unchanged.

## Testing
- `npm run typecheck` ✅ · `npm run build` ✅
- Loaded `loadAgentOS()` against an isolated scratch home: all four generalists register live with the right category/icon/dir, folders written to disk, and a reload is a clean no-op (idempotent). ✅
- Trust-seed logic exercised in isolation: seeds when `~/.claude.json` is missing, no-ops when already trusted, preserves other projects' entries and top-level keys, `0600` perms. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)