### PR TITLE
Updater: install devDependencies so self-update can build (v0.19.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.19.1] — 2026-07-07
+
+### Fixed
+- **Self-update no longer fails with `sh: tsc: not found` on a production box.** The in-console updater's
+  `npm install` inherited the service environment — and the systemd/launchd units run with
+  `NODE_ENV=production`, which makes npm **omit devDependencies**. Since `typescript` (the `tsc` the build
+  step needs) is a devDependency, the very next `npm run build` had no compiler and the update aborted at
+  "server build failed". Both the server and web installs now pass `--include=dev` so the build always has
+  its toolchain regardless of `NODE_ENV` ([`src/edge/updater.ts`](src/edge/updater.ts)).
+
 ## [0.19.0] — 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/updater.ts
+++ b/src/edge/updater.ts
@@ -140,10 +140,13 @@ export async function applyUpdate(tenant: string): Promise<ApplyResult> {
     return { ok: false, steps, restarting: false, error: 'working tree has uncommitted changes — commit or stash on the box first' };
 
   if (!run('git pull --ff-only', 'git', ['pull', '--ff-only'])) return { ok: false, steps, restarting: false, error: 'git pull failed' };
-  if (!run('npm install', 'npm', ['install', '--no-audit', '--no-fund'])) return { ok: false, steps, restarting: false, error: 'npm install failed' };
+  // --include=dev is mandatory: the build step below needs `tsc` (a devDependency), and the service
+  // this runs under sets NODE_ENV=production, which would otherwise make npm omit devDependencies →
+  // "sh: tsc: not found". Same for the web build (vite/tsc live in web's devDependencies).
+  if (!run('npm install', 'npm', ['install', '--include=dev', '--no-audit', '--no-fund'])) return { ok: false, steps, restarting: false, error: 'npm install failed' };
   if (!run('npm run build', 'npm', ['run', 'build'])) return { ok: false, steps, restarting: false, error: 'server build failed' };
   const web = path.join(REPO_ROOT, 'web');
-  if (!run('npm install (web)', 'npm', ['install', '--no-audit', '--no-fund'], web)) return { ok: false, steps, restarting: false, error: 'web npm install failed' };
+  if (!run('npm install (web)', 'npm', ['install', '--include=dev', '--no-audit', '--no-fund'], web)) return { ok: false, steps, restarting: false, error: 'web npm install failed' };
   if (!run('npm run build (web)', 'npm', ['run', 'build'], web)) return { ok: false, steps, restarting: false, error: 'web build failed' };
 
   cache = null; // the running version is about to change — force a fresh check after the bounce.


### PR DESCRIPTION
## Problem

Self-updating the jump-server (instawp) tenant failed at the build step:

```
✗ npm run build
> tsc
sh: 1: tsc: not found
✗ server build failed
```

## Root cause

The in-console updater runs `npm install` then `npm run build` via `spawnSync`, inheriting the service's environment. The systemd/launchd units run with **`NODE_ENV=production`**, which makes `npm install` **omit devDependencies**. Since `typescript` (which provides `tsc`) is a devDependency, the subsequent `npm run build` has no compiler and the update aborts.

Confirmed on the droplet: `Environment=NODE_ENV=production …` and `node_modules/.bin/tsc` absent after the updater's install.

## Fix

Pass `--include=dev` to both the server and web `npm install` calls in `src/edge/updater.ts`, so the build toolchain (server `typescript`; web `vite`/`tsc`) is always installed regardless of `NODE_ENV`.

## Live box

The instawp + instapods tenants on the droplet were unblocked out-of-band (manual `npm install --include=dev` + build + restart); both are healthy on 0.19.0. This PR prevents recurrence for the next self-update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)