### PR TITLE
Runtime: per-agent/workspace permission mode knob, default auto (v0.19.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.22.0] — 2026-07-07
+
+### Added
+- **Per-agent / workspace permission mode is a knob again — default `auto`.** `RuntimeTuning` gains a
+  `permissionMode` field (`auto`/`plan`/`acceptEdits`/`manual`/`dontAsk`/`bypassPermissions`, the exact
+  set the CLI accepts), settable per-agent (agent.json) with a workspace fallback (Settings → Runtime
+  defaults) and exposed in the console's runtime-tuning fields. `claude-launch.sh` maps it to
+  `--permission-mode` on the **interactive lane only** — the headless/automation lane keeps
+  `--dangerously-skip-permissions` untouched. It does **not** weaken governance or enable the OS
+  sandbox (a separate, still-off switch): for `Bash`/`Edit`/`Write`/`mcp__*` the PreToolUse gate hook
+  still returns an authoritative decision that bypasses Claude's own permission engine, so the mode
+  only governs the *fallback* for tools the hook leaves alone (Read/WebFetch/…). `auto` lets Claude's
+  classifier auto-approve the safe ones instead of hanging an idle tmux pane on a native prompt no one
+  answers. Unset resolves to `auto` at every level (including resumes of pre-knob sessions).
+
 ## [0.21.0] — 2026-07-07
 
 ### Added
@@ -67,7 +82,6 @@ new version heading in the same commit.
   saved as you type and **restored after an accidental refresh**, then cleared on a successful spawn
   (falling back to the agent's starter prompt when there's no draft). The agent **editor** deep-links
   too (`#/agent/<id>`), fixing a blank page on refresh ([`web/src/App.tsx`](web/src/App.tsx)).
-
 ## [0.18.1] — 2026-07-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,8 @@ Key modules:
   **runtime tuning** (`resolveRuntimeTuning` in `src/types.ts`: agent manifest → workspace default → CLI
   default) and exports `CLAUDE_MODEL`/`CLAUDE_EFFORT`/`CLAUDE_PERMISSION_MODE`, which `claude-launch.sh`
   maps onto `--model`/`--effort`/`--permission-mode` (model+effort both lanes; permission-mode interactive
-  only — headless keeps `--dangerously-skip-permissions`). It also resolves the agent's opt-in
+  only — headless keeps `--dangerously-skip-permissions`; unset → `auto`, which only tunes the fallback for
+  tools the gate hook doesn't govern, never the gate itself). It also resolves the agent's opt-in
   **`shellSecrets`** (manifest list of vault keys, e.g. `["GH_TOKEN"]`) via `injectShellSecrets` and
   exports each as a shell env var — the ONLY path a vault secret reaches the interactive shell (so a
   plain CLI like `gh` authenticates); connectors still get theirs via the MCP bag. Agent-scoped

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1517,7 +1517,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!ag?.dir) return sendJson(res, 404, { error: 'agent not found or has no folder' });
     if (ag.runtime !== 'claude-code') return sendJson(res, 400, { error: 'runtime tuning applies to claude-code agents only' });
     if (method === 'GET') {
-      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, category: ag.category, icon: ag.icon });
+      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, category: ag.category, icon: ag.icon });
     }
     const b = await readBody(req);
     const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
@@ -1531,12 +1531,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
     const icon = 'icon' in b ? sanitizeIcon(b.icon) : ag.icon;
     const description = 'description' in b ? String(b.description ?? '').trim() : ag.description;
-    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, shellSecrets, category, icon };
+    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, category, icon };
     const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     os.registerAgent(next);
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, category, shellSecrets: shellSecrets ?? [] } });
-    return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, examplePrompts: prompts, shellSecrets, category, icon });
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, category, shellSecrets: shellSecrets ?? [] } });
+    return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, category, icon });
   }
 
   // ── workspace runtime defaults (the fleet-wide model/effort/permission fallback) — owner/admin only ──

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -575,16 +575,20 @@ export class TerminalManager {
       if (headless) env.HEADLESS = '1';
       env.AGENT_DIR = manifest.dir;
       env.HOOK = this.hook;
-      // No OS sandbox env: the gate hook (PreToolUse) is the sole authority now (it emits an
-      // authoritative permissionDecision per Bash/connector call), so we no longer wrap the shell in
-      // Seatbelt/bubblewrap. Real OS containment, where wanted, is the Linux uid-isolation path.
-      // Per-agent model / effort, each falling back to the workspace default. The launcher
-      // (claude-launch.sh) turns these into `--model` / `--effort`. Resolved here (not in bash) so the
-      // resume env file captures the exact values a reconnect re-uses.
+      // No OS sandbox env: the gate hook (PreToolUse) is the sole authority for governed side effects
+      // (it emits an authoritative permissionDecision per Bash/write/connector call, which bypasses
+      // Claude's own permission engine), so we don't wrap the shell in Seatbelt/bubblewrap. Real OS
+      // containment, where wanted, is the Linux uid-isolation path.
+      // Per-agent model / effort / permission-mode, each falling back to the workspace default. The
+      // launcher (claude-launch.sh) turns these into `--model` / `--effort` / `--permission-mode`
+      // (permission-mode on the INTERACTIVE lane only — headless keeps --dangerously-skip-permissions;
+      // it only tunes the fallback for tools the gate hook doesn't decide, and defaults to `auto`).
+      // Resolved here (not in bash) so the resume env file captures the exact values a reconnect re-uses.
       const tuning = resolveRuntimeTuning(manifest, this.os.settings.runtimeDefaults());
       if (tuning.model) env.CLAUDE_MODEL = tuning.model;
       if (tuning.effort) env.CLAUDE_EFFORT = tuning.effort;
-      this.audit(id, agent, 'session.tuning', { model: tuning.model, effort: tuning.effort });
+      if (tuning.permissionMode) env.CLAUDE_PERMISSION_MODE = tuning.permissionMode;
+      this.audit(id, agent, 'session.tuning', { model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode });
       // A stable claude session id we choose (vs letting claude mint its own), so a stopped session
       // can be resumed in-place with `claude --resume <id>` when the user reconnects in the browser.
       env.CLAUDE_SESSION_ID = randomUUID();

--- a/src/types.ts
+++ b/src/types.ts
@@ -618,16 +618,29 @@ export interface TaskQuery {
 export type Effort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 export const EFFORTS: readonly Effort[] = ['low', 'medium', 'high', 'xhigh', 'max'];
 
-/** The two knobs that tune a claude-code session — settable per-agent (manifest) with a
- *  workspace-wide fallback (Settings → runtime defaults). An undefined field means "inherit".
- *  Permission posture is deliberately NOT a knob: the gate hook is the single authority (it emits an
- *  authoritative PreToolUse decision per side-effecting tool), so `--permission-mode` is neither set
- *  nor needed — one brain, not a second one layered on top. */
+/** Permission mode for a claude-code session (`claude --permission-mode <mode>`). These are the exact
+ *  choices the CLI accepts. It matters ONLY on the interactive lane, and ONLY for tools the gate hook
+ *  doesn't already decide: for `Bash`/`Edit`/`Write`/`mcp__*` the PreToolUse hook returns an
+ *  authoritative `allow`/`deny`, which bypasses Claude's own permission engine (the classifier never
+ *  runs). So the mode governs the *fallback* for tools the hook leaves alone (Read/Glob/Grep,
+ *  WebFetch, …) — `auto` lets Claude's classifier auto-approve the safe ones instead of blocking on a
+ *  native prompt no one answers in an idle tmux pane. It is NOT the OS sandbox (a separate switch we
+ *  deliberately don't enable) and does NOT weaken the gate hook. */
+export type PermissionMode = 'auto' | 'plan' | 'acceptEdits' | 'manual' | 'dontAsk' | 'bypassPermissions';
+export const PERMISSION_MODES: readonly PermissionMode[] = ['auto', 'plan', 'acceptEdits', 'manual', 'dontAsk', 'bypassPermissions'];
+
+/** The knobs that tune a claude-code session — settable per-agent (manifest) with a workspace-wide
+ *  fallback (Settings → runtime defaults). An undefined field means "inherit". `model`/`effort` apply
+ *  to both lanes; `permissionMode` is interactive-only (the headless lane keeps
+ *  `--dangerously-skip-permissions`) and defaults to `auto` when unset at every level. The gate hook
+ *  remains the sole authority for governed side effects regardless of the mode — see PermissionMode. */
 export interface RuntimeTuning {
   /** Model alias or full id (`claude --model`). Undefined → the CLI's configured default. */
   model?: string;
   /** Reasoning effort (`claude --effort`). Undefined → the CLI default. */
   effort?: Effort;
+  /** Permission mode (`claude --permission-mode`), interactive lane only. Undefined → `auto`. */
+  permissionMode?: PermissionMode;
 }
 
 export interface AgentManifest extends RuntimeTuning {
@@ -675,6 +688,11 @@ export function sanitizeRuntimeTuning(input: Partial<Record<keyof RuntimeTuning,
   if (effort) {
     if (!EFFORTS.includes(effort as Effort)) return { tuning, error: `effort must be one of: ${EFFORTS.join(', ')}` };
     tuning.effort = effort as Effort;
+  }
+  const mode = typeof input.permissionMode === 'string' ? input.permissionMode.trim() : '';
+  if (mode) {
+    if (!PERMISSION_MODES.includes(mode as PermissionMode)) return { tuning, error: `permissionMode must be one of: ${PERMISSION_MODES.join(', ')}` };
+    tuning.permissionMode = mode as PermissionMode;
   }
   return { tuning };
 }
@@ -762,11 +780,14 @@ export function sanitizeSvgIcon(input: string): string | undefined {
 }
 
 /** Resolve the effective tuning for a launch: each field is the agent's own value, else the
- *  workspace default, else undefined (CLI default). Pure — used by the terminal launcher. */
+ *  workspace default, else undefined (CLI default) — except `permissionMode`, whose floor is `auto`
+ *  (the interactive lane always runs with a mode; the built-in default is `auto`, not the CLI's own).
+ *  Pure — used by the terminal launcher. */
 export function resolveRuntimeTuning(agent: RuntimeTuning, defaults: RuntimeTuning): RuntimeTuning {
   return {
     model: agent.model ?? defaults.model,
     effort: agent.effort ?? defaults.effort,
+    permissionMode: agent.permissionMode ?? defaults.permissionMode ?? 'auto',
   };
 }
 

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -176,9 +176,12 @@ notify_resumed() {
 }
 
 # Per-agent runtime tuning, resolved by the server (agent manifest → workspace default) and passed
-# in as env. Model + effort apply to both lanes. An empty var means "inherit" — we add no flag, so
-# the claude CLI's own default stands. There is NO permission-mode flag: the gate hook is the single
-# authority (it emits an authoritative PreToolUse decision), so we don't layer Claude's own on top.
+# in as env. Model + effort apply to both lanes (COMMON_ARGS below). An empty var means "inherit" — we
+# add no flag, so the claude CLI's own default stands. CLAUDE_PERMISSION_MODE is handled separately,
+# AFTER the headless branch exits, so `--permission-mode` lands on the INTERACTIVE lane only. It doesn't
+# weaken governance: the gate hook still emits an authoritative PreToolUse decision for every governed
+# tool (which bypasses Claude's own permission engine); the mode only tunes the fallback for the tools
+# the hook leaves alone (Read/WebFetch/…), and `auto` keeps an idle pane from hanging on a native prompt.
 RUNTIME_ARGS=()
 [ -n "${CLAUDE_MODEL:-}" ]  && RUNTIME_ARGS+=(--model "$CLAUDE_MODEL")
 [ -n "${CLAUDE_EFFORT:-}" ] && RUNTIME_ARGS+=(--effort "$CLAUDE_EFFORT")
@@ -209,6 +212,12 @@ if [ "${HEADLESS:-}" = "1" ]; then
   notify_ended
   exit 0
 fi
+
+# INTERACTIVE lane only (the headless branch above already exited). Add the permission mode here — NOT
+# in COMMON_ARGS — so it never touches the headless `-p --dangerously-skip-permissions` run. Defaults to
+# `auto` if the env is unset (e.g. resuming a session launched before this knob existed).
+COMMON_ARGS+=(--permission-mode "${CLAUDE_PERMISSION_MODE:-auto}")
+dim "permission mode: ${CLAUDE_PERMISSION_MODE:-auto} (gate hook still governs every side effect)"
 
 # Fullscreen rendering for the TUI. Inside tmux, claude's normal renderer degrades — the scrollbar
 # vanishes and the mouse wheel scrolls the input history instead of the conversation. Fullscreen mode

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,7 +10,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectGroup, SelectItem, SelectLabel, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { api, EFFORTS, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult } from '@/lib/api'
 import { ConnectorsPage } from '@/connectors'
 import { docPages } from '@/docs'
 
@@ -161,15 +161,17 @@ function IconPicker({ value, onChange }: { value?: string; onChange: (v: string 
   )
 }
 
-/** The model / effort pair, reused by the create form, the agent editor, and the workspace defaults
- *  panel. Empty model/effort = "inherit" (the placeholder/option says so). These map 1:1 to
- *  `claude --model/--effort`. Permission posture is NOT a knob — the gate hook governs every side
- *  effect authoritatively, so there's no `--permission-mode` to tune. */
-function TuningFields({ tuning, onChange, modelPlaceholder = 'inherit', inheritLabel = 'inherit' }: {
+/** The model / effort / permission-mode trio, reused by the create form, the agent editor, and the
+ *  workspace defaults panel. Empty model/effort = "inherit" (the placeholder/option says so). Model +
+ *  effort map 1:1 to `claude --model/--effort`; permissionMode maps to `--permission-mode` on the
+ *  INTERACTIVE lane only and its blank/floor is `auto` (the gate hook governs every side effect
+ *  regardless of the mode — it only tunes the fallback for tools the hook leaves alone). */
+function TuningFields({ tuning, onChange, modelPlaceholder = 'inherit', inheritLabel = 'inherit', permInheritLabel }: {
   tuning: RuntimeTuning
   onChange: (t: RuntimeTuning) => void
   modelPlaceholder?: string
   inheritLabel?: string
+  permInheritLabel?: string
 }) {
   const selCls = 'h-8 w-full rounded-md border bg-background px-2 text-xs'
   return (
@@ -184,6 +186,14 @@ function TuningFields({ tuning, onChange, modelPlaceholder = 'inherit', inheritL
           <option value="">{inheritLabel}</option>
           {EFFORTS.map((x) => <option key={x} value={x}>{x}</option>)}
         </select>
+      </div>
+      <div className="space-y-1">
+        <label className="text-xs font-medium">Permission mode</label>
+        <select className={selCls} value={tuning.permissionMode ?? ''} onChange={(e) => onChange({ ...tuning, permissionMode: (e.target.value || undefined) as PermissionMode | undefined })}>
+          <option value="">{permInheritLabel ?? inheritLabel}</option>
+          {PERMISSION_MODES.map((x) => <option key={x} value={x}>{x}</option>)}
+        </select>
+        <p className="text-[11px] text-muted-foreground">Interactive only — headless stays fully skipped. The gate hook governs regardless.</p>
       </div>
     </div>
   )
@@ -3500,7 +3510,7 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
   useEffect(() => {
     api.agentConfig(agentId).then((r) => {
       if (r.error) return
-      const t: RuntimeTuning = { model: r.model, effort: r.effort }
+      const t: RuntimeTuning = { model: r.model, effort: r.effort, permissionMode: r.permissionMode }
       const d = r.description ?? ''
       const p = (r.examplePrompts ?? []).join('\n')
       const c = r.category ?? ''
@@ -4820,7 +4830,7 @@ function RuntimeDefaultsSettings({ me }: { me: Member }) {
   useEffect(() => {
     api.runtimeDefaults().then((r) => {
       if (r.error) return
-      const t: RuntimeTuning = { model: r.model, effort: r.effort }
+      const t: RuntimeTuning = { model: r.model, effort: r.effort, permissionMode: r.permissionMode }
       setTuning(t); setSaved(t); setMeta({ updatedAt: r.updatedAt, updatedBy: r.updatedBy })
     }).catch(() => {})
   }, [])
@@ -4844,7 +4854,7 @@ function RuntimeDefaultsSettings({ me }: { me: Member }) {
           a blank field here means each unset agent falls through to the <span className="font-mono text-xs">claude</span> CLI's own default.
           Applies on each agent's next session.
         </p>
-        <TuningFields tuning={tuning} onChange={setTuning} modelPlaceholder="CLI default" inheritLabel="CLI default" />
+        <TuningFields tuning={tuning} onChange={setTuning} modelPlaceholder="CLI default" inheritLabel="CLI default" permInheritLabel="auto (default)" />
         <div className="flex items-center gap-3">
           <Button onClick={save} disabled={!canEdit || busy || !dirty}>{dirty ? 'Save defaults' : 'Saved'}</Button>
           {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -22,10 +22,15 @@ export interface AgentAccess {
 }
 export type Effort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 export const EFFORTS: Effort[] = ['low', 'medium', 'high', 'xhigh', 'max']
-/** Per-agent / workspace runtime tuning for claude-code sessions. Each field optional → inherit. */
+/** `claude --permission-mode` choices. Interactive lane only; the gate hook governs regardless. */
+export type PermissionMode = 'auto' | 'plan' | 'acceptEdits' | 'manual' | 'dontAsk' | 'bypassPermissions'
+export const PERMISSION_MODES: PermissionMode[] = ['auto', 'plan', 'acceptEdits', 'manual', 'dontAsk', 'bypassPermissions']
+/** Per-agent / workspace runtime tuning for claude-code sessions. Each field optional → inherit
+ *  (permissionMode's floor is `auto`). */
 export interface RuntimeTuning {
   model?: string
   effort?: Effort
+  permissionMode?: PermissionMode
 }
 
 export interface AgentInfo {
@@ -163,7 +168,7 @@ export interface Recommendation {
   kind: 'runtime' | 'policy' | 'budget'
   title: string
   rationale: string
-  apply?: { runtimeDefaults?: { model?: string; effort?: string } }
+  apply?: { runtimeDefaults?: { model?: string; effort?: string; permissionMode?: PermissionMode } }
   link?: string
   createdAt: number
 }


### PR DESCRIPTION
## What

Re-adds a **permission-mode knob** for claude-code sessions, defaulting to **`auto`**. `RuntimeTuning` gains a `permissionMode` field (`auto` / `plan` / `acceptEdits` / `manual` / `dontAsk` / `bypassPermissions` — the exact set the v2.1.x CLI accepts), settable per-agent (`agent.json`) with a workspace fallback (Settings → Runtime defaults), and surfaced in the console runtime-tuning fields (create form, agent editor, workspace defaults).

`claude-launch.sh` maps it to `--permission-mode` on the **interactive lane only** — added *after* the headless branch exits, so the headless/automation lane keeps `--dangerously-skip-permissions` completely untouched (deliberate: avoids unforeseen issues on non-interactive runs).

## Why it's safe (sandbox / policy analysis)

Confirmed against the official Claude Code docs:

- **`auto` mode is not the OS sandbox.** They're independent layers; the sandbox (`sandbox.enabled`) stays off. This change does **not** re-introduce the Seatbelt/bubblewrap containment that was deliberately removed.
- **The gate hook stays the sole authority.** For `Bash`/`Edit`/`Write`/`mcp__*` the PreToolUse hook returns an authoritative `allow`/`deny` that bypasses Claude's own permission engine (the classifier never runs for those). PreToolUse hooks fire in *every* mode, and a hook `deny` blocks even in `bypassPermissions`.
- So the mode only governs the **fallback for tools the hook leaves alone** (Read/Glob/Grep, WebFetch, …). `auto` lets Claude's classifier auto-approve the safe ones instead of hanging an idle tmux pane on a native permission prompt no one answers.
- Unset resolves to `auto` at every level (agent → workspace → floor), including resumes of pre-knob sessions.

This re-aligns the code with what `CLAUDE.md` already documented.

## Files
Core: `types.ts` (type + validation + resolution), `terminal.ts` (env export + audit), `server.ts` (config GET/PUT threading), `claude-launch.sh` (interactive-only flag). Console: `App.tsx` + `api.ts` (dropdown in shared `TuningFields`).

## Test
- `npm run typecheck` ✅
- `cd web && npm run build` ✅
- `npm run build` (tsc → dist) ✅
- `npm run test:governance` → **44/44 passed ✓**

🤖 Generated with [Claude Code](https://claude.com/claude-code)