### PR TITLE
Memory: backend-switch migrate-or-clear (v0.24.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.24.0] — 2026-07-07
+
+### Added
+- **Backend-switch migrate-or-clear** (Settings → Memory). Switching to an external memory backend
+  (automem/libsql) leaves the pre-switch memories in the local ledger but not in the new store — the
+  Memory-hub counts then overstate what agents can actually recall. Settings → Memory now detects this
+  **drift** (local rows vs. active backend count) and shows a banner with two actions: **Migrate** —
+  replay the local ledger into the new store (preserving author/scope/tags/type/importance/metadata),
+  with an opt-in *"durable only — skip raw episodes"* filter, then drop the migrated-out originals; and
+  **Clear** — empty the local ledger to match a fresh start. Migrate is idempotent (no-ops when already
+  consistent, so it can't duplicate) and gated (a partial migration deletes nothing). New endpoints
+  `POST /api/settings/memory/migrate` + `/clear`, a `count()` probe on the memory providers, and
+  `memory.migrated`/`memory.cleared` audit events. See `docs/memory-backend-migration-plan.md`.
+
 ## [0.23.0] — 2026-07-07
 
 ### Changed

--- a/docs/memory-backend-migration-plan.md
+++ b/docs/memory-backend-migration-plan.md
@@ -1,0 +1,125 @@
+# Memory backend switch — migrate-or-clear
+
+**Status:** Phase 1 shipped. Hardening for the backend-swap flow that shipped in v0.21.0
+([`memory-model.md`](./memory-model.md) → "Backends that self-consolidate"). Turns a manual, scripted
+cleanup into a first-class Settings action. Phase 1 = the drift banner + migrate/clear endpoints (below);
+Phase 2 (at-switch interstitial, batched progress) remains open.
+
+## The problem (observed live)
+
+Switching a tenant's memory backend (Settings → Memory) is a config flip — but **the old store's
+contents don't come along.** When instapods moved SQLite → automem:
+
+- automem started **empty** (0 memories).
+- the local `memories` table still held the **51 pre-switch rows**.
+- Result: the Memory hub **counts read the local table** (`GET /api/memory/overview`) and showed 51,
+  while **recall reads the backend** (`os.memory.recall` → automem) and returned nothing. Stats said 51,
+  the browse was empty, and agents silently lost recall of everything they'd learned.
+
+We reconciled it by hand — a script that migrated the 27 durable memories into automem (skipping 22 raw
+episodes + 2 stale stat-snapshots) then deleted the 51 orphans. That judgement + plumbing should be a
+button, not a one-off.
+
+## The key insight — the local table is the universal migration source
+
+After v0.21.0, the local `memories` table is *always* a complete local copy of what this OS has stored:
+it **is** the store for SQLite, and it's a **mirror** of every write for external backends
+(`MirroredMemoryProvider`, `src/memory/mirror.ts`). So migration never needs to *read* the old backend —
+it replays the **local table** into the new backend's provider. That's exactly what the manual script
+did, and it makes every transition uniform:
+
+| Transition | Local table before | What's needed |
+|---|---|---|
+| SQLite → external | full (canonical) | **migrate** rows into the empty external store, or **clear** |
+| external A → external B | full (mirror of A) | **migrate** the mirror into B, or **clear** |
+| external → SQLite | full (mirror of ext) | **nothing** — the mirror already *is* the SQLite store; data's already local |
+
+So the awkward direction is "into a fresh store" (the first two); the reverse just works because the
+mirror kept a local copy all along.
+
+## The feature — drift detection + reconcile
+
+Rather than bolt the choice only onto the Save button, detect the mismatch and offer to fix it — which
+covers both "just switched" and "switched a while ago, never reconciled" (our exact situation).
+
+**Drift banner (Settings → Memory).** Compare the local table count (`memories WHERE tenant=?`) against
+the active backend's count (`health().detail` / a `count()` probe). When they diverge:
+
+> ⚠ **N memories are in this workspace's local ledger but not in the active `<backend>` store.** Agents
+> recall from `<backend>`, so they can't see them. **[Migrate to `<backend>`]  [Clear local ledger]  [Dismiss]**
+
+**At switch time.** When `PUT /api/settings/memory` changes the backend and the local table is non-empty,
+the console interstitial offers the same three choices before/after applying:
+- **Migrate** — copy the local memories into the new store (with an optional filter, below).
+- **Start fresh (clear)** — drop the local ledger so counts match the empty new store.
+- **Just switch (leave)** — today's behavior; orphans remain (counts overstate what's recallable).
+
+## Migration mechanics
+
+A new owner/admin endpoint **`POST /api/settings/memory/migrate`** that replicates the verified manual
+flow, server-side (so it can preserve everything the HTTP `POST /api/memory` hack couldn't — `metadata`,
+exact author, scope):
+
+1. **Snapshot** the pre-existing local row ids for the tenant (the "orphans").
+2. **Replay** each selected row through the *current* provider — `os.memory.store({tenant, agentId,
+   content, tags, type, importance, metadata, scope})`. Post-switch that's the new backend + mirror, so
+   each row lands in the new store **and** re-mirrors locally under a fresh id (author/scope/tags/
+   importance/metadata preserved).
+3. **Verify** the new store's count rose by the migrated total.
+4. **Delete the snapshotted orphan ids** from the local table (a direct delete — the mirror's own
+   `delete` won't touch them, since the backend never had them). Gated: **only delete if every row
+   migrated** (a partial migration leaves everything intact for retry).
+5. **Audit** `memory.migrated { from, to, migrated, skipped }`.
+
+**Optional quality filter** (the "good ones only" we applied). Default: migrate everything. A checkbox
+**"Durable only — skip raw session episodes"** drops `tag:episode` rows (the auto-recaps that consolidation
+distills and that rebuild anyway). This is where 22 of our 24 drops came from; the other 2 were transient
+`dreamer` stat-snapshots — leave those to the user's discretion rather than hard-coding a denylist.
+
+**Bounded + resumable.** Batch the replay (e.g. 50/req) with a progress count for large stores; the
+orphan-delete is one transaction with `busy_timeout` (safe alongside live sessions — validated during the
+manual run with 3 sessions active).
+
+## Clear mechanics
+
+**`POST /api/settings/memory/clear`** (owner/admin) — delete the tenant's local `memories` rows, so the
+ledger matches the (empty or external-only) active store. Audited `memory.cleared { count }`. Note in the
+UI that this also resets what Dreaming/consolidation can reflect on (a genuine fresh start), and that it's
+irreversible.
+
+## Surfaces to build
+
+- **Server** (`src/server.ts`): `POST /api/settings/memory/migrate` (opts: `skipEpisodes?`, `batch?`),
+  `POST /api/settings/memory/clear`; extend `GET /api/settings/memory` to return `{ localCount,
+  backendCount, drift }` for the banner. Reuses `os.memory.store` + a direct orphan-delete.
+- **Backend count probe:** most providers expose a count (`automem` health `memory_count`; sqlite = the
+  table). Add a tiny `count?(tenant)` to `MemoryProvider` (optional; falls back to health-parse).
+- **Web** (`web/src/App.tsx` `MemorySettings`): the drift banner + the at-switch interstitial (Migrate /
+  Clear / Leave), the "durable only" checkbox, a progress/result toast, and a confirm on Clear.
+- **Docs:** fold into `memory-model.md` (replace the manual "no data migrates — starts empty" caveat with
+  "migrate or clear on switch"); `CHANGELOG`.
+
+## Edge cases / limits (document these)
+
+- **Only OS-written memories are captured.** The local mirror holds what *this* OS stored; a shared
+  external store written by other clients (automem is designed to be shared) won't be in the ledger, so
+  migrate can't push what it never saw. Fine for our single-writer use; note it.
+- **`sharedWrites: curated`.** Migrating `scope:tenant` rows must honor (or explicitly bypass, as an
+  owner action) the shared-write policy so the 11 shared don't get downgraded to private.
+- **Idempotency.** Re-running migrate would double-write; guard by only migrating rows whose ids are in
+  the pre-switch snapshot (not the freshly-mirrored ones), exactly as the gated delete assumes.
+- **Reverse (external → SQLite).** Offer "keep (already local)" rather than a pointless self-migrate.
+
+## Phasing
+
+- **Phase 1:** the two endpoints + the drift banner with **Migrate (all) / Clear**. Solves the observed
+  problem for any tenant, retroactively.
+- **Phase 2:** the at-switch interstitial + the "durable only" filter + batched progress for large stores.
+
+## Decisions to confirm
+
+1. **Default migrate scope** — all rows (faithful) vs "durable only" default-on (skips episodes). Recommend
+   **migrate all by default, filter opt-in** — least surprising; the user saw us choose to skip episodes,
+   but that's a judgement they should opt into.
+2. **Auto-offer vs manual** — pop the interstitial automatically on every backend change, or only surface
+   the passive drift banner. Recommend **both** (interstitial at switch, banner as the safety net).

--- a/docs/memory-model.md
+++ b/docs/memory-model.md
@@ -93,7 +93,9 @@ it doesn't replace the loop that *steers the fleet*.
 > stats read the built-in SQLite `memories` table directly. So an external backend (automem/libsql) is
 > wrapped in a **mirror** that copies every write into that local table — recall goes to the upgraded
 > store, but the self-learning loop and counts keep working unchanged. Switching a tenant is a config
-> flip; no data migrates (the external store starts empty).
+> flip; the external store starts empty, so **Settings → Memory** shows a drift banner offering to
+> **migrate** the local ledger into the new store or **clear** it — see
+> [`memory-backend-migration-plan.md`](./memory-backend-migration-plan.md).
 
 ## What you actually operate
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.23.0",
+      "version": "0.24.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.23.0",
+  "version": "0.24.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/automem-provider.ts
+++ b/src/memory/automem-provider.ts
@@ -179,6 +179,16 @@ export class AutomemMemoryProvider implements MemoryProvider {
     };
   }
 
+  /** Whole-instance memory count from /health (exact per-tenant on a dedicated instance). */
+  async count(): Promise<number | null> {
+    try {
+      const res = (await this.req('GET', '/health')) as { memory_count?: number };
+      return typeof res.memory_count === 'number' ? res.memory_count : null;
+    } catch {
+      return null;
+    }
+  }
+
   async health(): Promise<{ ok: boolean; backend: string; detail?: string }> {
     try {
       const res = (await this.req('GET', '/health')) as { status?: string; memory_count?: number };

--- a/src/memory/mirror.ts
+++ b/src/memory/mirror.ts
@@ -61,6 +61,11 @@ export class MirroredMemoryProvider implements MemoryProvider {
     return this.backend.health();
   }
 
+  /** Report the EXTERNAL backend's count (what the drift banner compares the local mirror against). */
+  count(tenant: string): Promise<number | null> {
+    return this.backend.count ? this.backend.count(tenant) : Promise.resolve(null);
+  }
+
   async maintain(opts: MemoryMaintenance): Promise<MemoryMaintenanceResult> {
     // The backend self-maintains (automem) or prunes its own store (libsql); either way, keep the
     // local mirror bounded with the same policy so it doesn't grow forever behind an external store.

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -96,6 +96,11 @@ export class SqliteMemoryProvider implements MemoryProvider {
     this.db.prepare('DELETE FROM memories WHERE tenant = ? AND id = ?').run(tenant, id);
   }
 
+  /** How many memories this tenant has in the table (for the backend-switch drift banner). */
+  async count(tenant: string): Promise<number> {
+    return Number(this.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ?').get<{ n: number }>(tenant)?.n ?? 0);
+  }
+
   async recall(q: RecallQuery): Promise<MemoryRecord[]> {
     const limit = Math.max(1, Math.min(q.limit ?? 8, 100));
     // Over-fetch so an optional tag filter (applied in JS) still returns up to `limit`.

--- a/src/server.ts
+++ b/src/server.ts
@@ -1671,7 +1671,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   // ── memory backend (sqlite / libsql / automem) — owner/admin, applied live without a restart ──
   if (method === 'GET' && p === '/api/settings/memory') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    return sendJson(res, 200, { ...memoryView(os), health: await os.memory.health() });
+    // Drift: local `memories` rows the ACTIVE backend doesn't have (only meaningful for an external
+    // backend — for sqlite the local table IS the store). Drives the migrate-or-clear banner.
+    const localCount = Number(os.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ?').get<{ n: number }>(os.tenant)?.n ?? 0);
+    const external = (os.settings.memoryConfig()?.backend ?? 'sqlite') !== 'sqlite';
+    const backendCount = external && os.memory.count ? await os.memory.count(os.tenant) : null;
+    const drift = external && backendCount != null && localCount > backendCount ? localCount - backendCount : 0;
+    return sendJson(res, 200, { ...memoryView(os), health: await os.memory.health(), localCount, backendCount, drift });
   }
   // Probe a (local) Ollama for the embeddings UI: is it reachable, which models are pulled, and —
   // if unreachable — is the binary at least installed (so we can say "not running" vs "not installed").
@@ -1712,6 +1718,67 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     } catch (e) {
       return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
     }
+  }
+  // ── backend-switch reconcile: migrate the local `memories` ledger into the active external store, or
+  //    clear it, so the Memory-hub counts stop overstating what agents can actually recall (see
+  //    docs/memory-backend-migration-plan.md). Owner/admin. ──
+  if (method === 'POST' && p === '/api/settings/memory/migrate') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if ((os.settings.memoryConfig()?.backend ?? 'sqlite') === 'sqlite') {
+      return sendJson(res, 400, { error: 'migration applies only when an external backend is active (sqlite IS the local table)' });
+    }
+    const b = await readBody(req);
+    const skipEpisodes = b.skipEpisodes === true;
+    const rows = os.db
+      .prepare('SELECT id, agent_id, content, tags, type, importance, metadata, scope FROM memories WHERE tenant = ?')
+      .all<{ id: string; agent_id: string; content: string; tags: string | null; type: string | null; importance: number | null; metadata: string | null; scope: string }>(os.tenant);
+    // Idempotency guard: migrate replays the local ledger into the backend on the assumption those rows
+    // are ORPHANS (not yet in the store). If the store already holds them (no drift), replaying would
+    // duplicate — so no-op. Canonical case (fresh switch) has an empty store, so this passes through.
+    const backendCount = os.memory.count ? await os.memory.count(os.tenant) : null;
+    if (backendCount != null && backendCount >= rows.length) {
+      return sendJson(res, 200, { ok: true, migrated: 0, skipped: 0, deleted: 0, note: 'already consistent — nothing to migrate' });
+    }
+    const snapshotIds = rows.map((r) => r.id); // the pre-existing rows to remove after a clean migration
+    const keep = skipEpisodes ? rows.filter((r) => !(r.tags ?? '').includes('"episode"')) : rows;
+    let migrated = 0;
+    const errors: string[] = [];
+    for (const r of keep) {
+      try {
+        await os.memory.store({
+          tenant: os.tenant, agentId: r.agent_id, content: r.content,
+          tags: parseTags(r.tags), type: (r.type as MemoryType) ?? undefined,
+          importance: r.importance ?? undefined,
+          metadata: r.metadata ? safeJson(r.metadata) : undefined,
+          scope: r.scope === 'tenant' ? 'tenant' : 'agent',
+        });
+        migrated++;
+      } catch (e) {
+        errors.push(`${r.agent_id}: ${e instanceof Error ? e.message : String(e)}`);
+      }
+    }
+    // Gated: only drop the old rows if EVERY kept row landed — a partial migration leaves all intact.
+    if (migrated !== keep.length) {
+      return sendJson(res, 500, { error: `migrated ${migrated}/${keep.length}; nothing deleted`, migrated, skipped: rows.length - keep.length, errors: errors.slice(0, 5) });
+    }
+    const del = os.db.prepare('DELETE FROM memories WHERE tenant = ? AND id = ?');
+    os.db.exec('BEGIN');
+    try {
+      for (const id of snapshotIds) del.run(os.tenant, id);
+      os.db.exec('COMMIT');
+    } catch (e) {
+      os.db.exec('ROLLBACK');
+      return sendJson(res, 500, { error: `migrated ${migrated} but cleanup failed: ${e instanceof Error ? e.message : String(e)}`, migrated });
+    }
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'memory.migrated', data: { backend: os.settings.memoryConfig()?.backend, migrated, skipped: rows.length - keep.length, deleted: snapshotIds.length } });
+    return sendJson(res, 200, { ok: true, migrated, skipped: rows.length - keep.length, deleted: snapshotIds.length });
+  }
+  if (method === 'POST' && p === '/api/settings/memory/clear') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const cleared = Number(os.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ?').get<{ n: number }>(os.tenant)?.n ?? 0);
+    os.db.prepare('DELETE FROM memories WHERE tenant = ?').run(os.tenant);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'memory.cleared', data: { count: cleared } });
+    return sendJson(res, 200, { ok: true, cleared });
   }
 
   // ── skills (the global Claude Code Skills library, materialised into claude-code agents) ──
@@ -2274,6 +2341,11 @@ function runView(r: Run) {
 /** Parse a stored JSON column, degrading to a `{ raw }` wrapper rather than throwing on bad data. */
 function safeJson(s: string): Record<string, unknown> {
   try { const v = JSON.parse(s); return v && typeof v === 'object' ? v : { value: v }; } catch { return { raw: s }; }
+}
+/** Parse a stored `tags` JSON column into a string[] (empty on null/garbage). */
+function parseTags(s: string | null): string[] {
+  if (!s) return [];
+  try { const v = JSON.parse(s); return Array.isArray(v) ? v.map(String) : []; } catch { return []; }
 }
 function approvalView(a: ApprovalRequest) {
   return { id: a.id, runId: a.runId, level: a.level, capability: a.attempt.capabilityId, args: a.attempt.args, reason: a.reason };

--- a/src/types.ts
+++ b/src/types.ts
@@ -364,6 +364,12 @@ export interface MemoryProvider {
   forgetAgent?(tenant: string, agentId: string): Promise<number>;
   health(): Promise<{ ok: boolean; backend: string; detail?: string }>;
   /**
+   * Optional: how many memories the backend holds (for the backend-switch **drift banner** — compared
+   * against the local `memories` table). SQLite/libsql count their table for the tenant; automem reports
+   * its whole-instance count (exact for a dedicated per-tenant instance). Returns null if unknown.
+   */
+  count?(tenant: string): Promise<number | null>;
+  /**
    * Optional periodic upkeep: prune stale/never-recalled memories and merge near-duplicates. Returns
    * what it did. Backends that consolidate server-side (automem) may no-op. Safe to call repeatedly.
    */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4990,6 +4990,29 @@ function MemorySettings({ me }: { me: Member }) {
   }
   useEffect(() => { api.memorySettings().then((v) => { if (v.error) return setHint('⚠ ' + v.error); apply(v) }).catch(() => {}) }, [])
 
+  // Backend-switch reconcile: the local ledger has rows the active external store doesn't (see the drift banner).
+  const [reconBusy, setReconBusy] = useState(false)
+  const [reconSkipEp, setReconSkipEp] = useState(false) // migrate all by default; opt in to skipping raw episodes
+  const [reconMsg, setReconMsg] = useState('')
+  const refreshView = () => api.memorySettings().then((v) => { if (!v.error) apply(v) }).catch(() => {})
+  const doMigrate = async () => {
+    setReconBusy(true); setReconMsg('')
+    const r = await api.migrateMemory(reconSkipEp)
+    setReconBusy(false)
+    if (r.error) return setReconMsg('⚠ ' + r.error)
+    setReconMsg(`Migrated ${r.migrated ?? 0}${r.skipped ? `, skipped ${r.skipped} episode(s)` : ''}; removed ${r.deleted ?? 0} local rows.`)
+    refreshView()
+  }
+  const doClear = async () => {
+    if (!confirm('Delete ALL local memory rows for this workspace? This resets the local ledger (and what the reflection loop can look back on). Cannot be undone.')) return
+    setReconBusy(true); setReconMsg('')
+    const r = await api.clearMemoryLedger()
+    setReconBusy(false)
+    if (r.error) return setReconMsg('⚠ ' + r.error)
+    setReconMsg(`Cleared ${r.cleared ?? 0} local rows.`)
+    refreshView()
+  }
+
   // Preset the embedding defaults when toggling provider (the two stacks use different models/dims/ports).
   const pickProvider = (pv: 'openai' | 'ollama') => {
     setProvider(pv)
@@ -5104,6 +5127,26 @@ function MemorySettings({ me }: { me: Member }) {
           </Badge>
         )}
       </div>
+
+      {/* drift banner — local ledger has rows the active external store doesn't (migrate or clear) */}
+      {(view?.drift ?? 0) > 0 && (
+        <div className="space-y-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-3 text-xs">
+          <div className="flex items-start gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <div>
+              <div className="font-medium text-amber-700">{view!.drift} {view!.drift === 1 ? 'memory is' : 'memories are'} in this workspace's local ledger but not in the active {view?.backend} store.</div>
+              <div className="mt-0.5 text-muted-foreground">Agents recall from {view?.backend} ({view?.backendCount ?? 0} there), so they can't see these {view?.localCount ?? 0} local rows. Migrate them into {view?.backend}, or clear the ledger so the count matches what's recallable.</div>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-2 pl-6">
+            <Button size="sm" onClick={doMigrate} disabled={reconBusy}><Upload className="mr-1 h-3.5 w-3.5" />Migrate to {view?.backend}</Button>
+            <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground"><input type="checkbox" checked={reconSkipEp} onChange={(e) => setReconSkipEp(e.target.checked)} />durable only (skip raw episodes)</label>
+            <Button size="sm" variant="outline" onClick={doClear} disabled={reconBusy}><Trash2 className="mr-1 h-3.5 w-3.5" />Clear local ledger</Button>
+            {reconBusy && <span className="text-[11px] text-muted-foreground">working…</span>}
+            {reconMsg && <span className="font-mono text-[11px] text-muted-foreground">{reconMsg}</span>}
+          </div>
+        </div>
+      )}
 
       {/* backend picker */}
       <div className="grid gap-2 sm:grid-cols-3">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -376,6 +376,11 @@ export interface MemorySettings {
   maintenance?: MemoryMaintenance
   sharedWrites?: 'open' | 'curated'
   health?: MemoryHealth
+  /** Rows in the local `memories` ledger vs. the active external store — drives the migrate/clear banner. */
+  localCount?: number
+  backendCount?: number | null
+  /** Local rows the active external backend doesn't have (0 for sqlite). */
+  drift?: number
   updatedAt?: number
   updatedBy?: string
   error?: string
@@ -653,6 +658,8 @@ export const api = {
   testMemorySettings: (body: MemorySettingsReq) => call<{ ok: boolean; health?: MemoryHealth; error?: string }>('POST', '/api/settings/memory/test', body),
   ollamaStatus: (url: string) => call<OllamaStatus>('GET', '/api/settings/memory/ollama?url=' + encodeURIComponent(url)),
   maintainMemory: () => call<{ ok: boolean; pruned?: number; merged?: number; error?: string }>('POST', '/api/settings/memory/maintain'),
+  migrateMemory: (skipEpisodes: boolean) => call<{ ok: boolean; migrated?: number; skipped?: number; deleted?: number; error?: string }>('POST', '/api/settings/memory/migrate', { skipEpisodes }),
+  clearMemoryLedger: () => call<{ ok: boolean; cleared?: number; error?: string }>('POST', '/api/settings/memory/clear'),
 
   kb: (q = '', section = '') => call<{ pages: KbPage[]; sections: string[]; enabled: boolean }>('GET', `/api/kb?q=${encodeURIComponent(q)}&section=${encodeURIComponent(section)}`),
   kbPage: (id: string) => call<{ page?: KbPage; error?: string }>('GET', `/api/kb/page/${id}`),


### PR DESCRIPTION
Phase 1 of [`docs/memory-backend-migration-plan.md`](docs/memory-backend-migration-plan.md). Switching a tenant to an external memory backend (automem/libsql) leaves the pre-switch memories in the local ledger but **not** in the new store, so the Memory-hub counts overstate what agents can actually recall. (We hit exactly this switching instapods to automem and reconciled it by hand — this turns that into a button.)

## What's here
- **Drift banner** (Settings → Memory): detects local `memories` rows the active external backend doesn't have (`localCount` vs a new provider `count()`), and offers **Migrate** / **Clear**.
- **`POST /api/settings/memory/migrate`** — replays the local ledger into the active backend via `os.memory.store` (preserving author / scope / tags / type / importance / **metadata**, re-mirrored locally under fresh ids), then deletes the migrated-out originals. **Idempotent** (no-ops when already consistent → can't duplicate) and **gated** (a partial migration deletes nothing). Opt-in *"durable only — skip raw episodes"*.
- **`POST /api/settings/memory/clear`** — empties the local ledger for a clean fresh start.
- **`count()`** on the providers (sqlite table count / automem health / mirror delegates to the backend); `memory.migrated` + `memory.cleared` audit events.

Only the drift banner is user-facing; SQLite tenants never drift (the table *is* the store), so nothing changes for them.

## Testing
`tsc` + `vite build` clean (verified in-worktree against latest `main`). Live smoke test on instapods: the GET returns `local 27 / backend 27 / drift 0`, and calling migrate on the consistent ledger **no-ops** (`already consistent — nothing to migrate`, automem stays 27 — no duplication). The migrate+gated-delete path itself is the same flow already run by hand to migrate the 27 durable memories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)