### PR TITLE
Memory: backend-switch reconcile phase 2 — at-switch prompt + batched migrate (v0.25.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.25.0] — 2026-07-07
+
+### Added
+- **Backend-switch reconcile — Phase 2: at-switch prompt + batched migration.** Changing the memory
+  backend (Settings → Memory) now pops an **interstitial** the moment you save, when the switch leaves
+  local memories the new store lacks — Migrate / Start fresh / Later — instead of relying only on the
+  passive drift banner. And migration is now **batched**: `POST /api/settings/memory/migrate` moves one
+  batch per call over a fixed `before` horizon (rows created *strictly before* the run; the mirror's
+  re-inserts land after it and are never re-picked, even on a same-millisecond store), returning
+  `{ migrated, skipped, remaining, done }`; the console loops it with a live *"N moved, M left"* count so
+  a large ledger never blocks a single request, and a failed batch is safely resumable (rows stay put).
+  The idempotency guard (no-op when already consistent) and the "durable only — skip episodes" filter
+  carry over. See `docs/memory-backend-migration-plan.md`.
+
 ## [0.24.0] — 2026-07-07
 
 ### Added

--- a/docs/memory-backend-migration-plan.md
+++ b/docs/memory-backend-migration-plan.md
@@ -1,9 +1,11 @@
 # Memory backend switch — migrate-or-clear
 
-**Status:** Phase 1 shipped. Hardening for the backend-swap flow that shipped in v0.21.0
-([`memory-model.md`](./memory-model.md) → "Backends that self-consolidate"). Turns a manual, scripted
-cleanup into a first-class Settings action. Phase 1 = the drift banner + migrate/clear endpoints (below);
-Phase 2 (at-switch interstitial, batched progress) remains open.
+**Status:** Phase 1 (v0.24.0) + Phase 2 (v0.25.0) shipped. Hardening for the backend-swap flow that
+shipped in v0.21.0 ([`memory-model.md`](./memory-model.md) → "Backends that self-consolidate"). Turns a
+manual, scripted cleanup into a first-class Settings action: Phase 1 = the drift banner + migrate/clear
+endpoints; Phase 2 = the **at-switch interstitial** (a reconcile prompt the moment you change backend)
++ **batched migration** (the endpoint moves a batch per call over a fixed `before` horizon; the client
+loops with a live progress count, so a large ledger never blocks one request).
 
 ## The problem (observed live)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.24.0",
+      "version": "0.25.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.24.0",
+  "version": "0.25.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1729,21 +1729,32 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     }
     const b = await readBody(req);
     const skipEpisodes = b.skipEpisodes === true;
-    const rows = os.db
-      .prepare('SELECT id, agent_id, content, tags, type, importance, metadata, scope FROM memories WHERE tenant = ?')
-      .all<{ id: string; agent_id: string; content: string; tags: string | null; type: string | null; importance: number | null; metadata: string | null; scope: string }>(os.tenant);
-    // Idempotency guard: migrate replays the local ledger into the backend on the assumption those rows
-    // are ORPHANS (not yet in the store). If the store already holds them (no drift), replaying would
-    // duplicate — so no-op. Canonical case (fresh switch) has an empty store, so this passes through.
-    const backendCount = os.memory.count ? await os.memory.count(os.tenant) : null;
-    if (backendCount != null && backendCount >= rows.length) {
-      return sendJson(res, 200, { ok: true, migrated: 0, skipped: 0, deleted: 0, note: 'already consistent — nothing to migrate' });
+    const limit = Math.max(1, Math.min(Number(b.limit) || 50, 500)); // rows migrated per batch (progress-friendly)
+    const localTotal = () => Number(os.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ?').get<{ n: number }>(os.tenant)?.n ?? 0);
+    const remainingBefore = (t: number) => Number(os.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ? AND created_at < ?').get<{ n: number }>(os.tenant, t)?.n ?? 0);
+    // `before` fixes the migration horizon: rows STRICTLY before it are the ORPHANS to move; rows the
+    // mirror writes DURING migration (created_at >= `before`, since the backend stamps Date.now() ≥ our
+    // capture) are excluded — so a batch never re-migrates what an earlier batch just mirrored, even if a
+    // store lands in the same millisecond. The client passes the server-assigned `before` back each batch.
+    let before = Number(b.before) || 0;
+    if (!before) {
+      // First batch — idempotency guard: if the backend already holds everything (no drift), no-op so a
+      // stray click can't duplicate. Otherwise fix the horizon at now. (Fresh switch → empty store → passes.)
+      const backendCount = os.memory.count ? await os.memory.count(os.tenant) : null;
+      if (backendCount != null && backendCount >= localTotal()) {
+        return sendJson(res, 200, { ok: true, done: true, migrated: 0, skipped: 0, remaining: 0, note: 'already consistent — nothing to migrate' });
+      }
+      before = Date.now();
     }
-    const snapshotIds = rows.map((r) => r.id); // the pre-existing rows to remove after a clean migration
-    const keep = skipEpisodes ? rows.filter((r) => !(r.tags ?? '').includes('"episode"')) : rows;
-    let migrated = 0;
-    const errors: string[] = [];
-    for (const r of keep) {
+    // One batch of the oldest remaining orphans. We delete each as we go (migrated → re-mirrored under a
+    // new id with created_at > before; skipped episode → simply dropped), so it won't resurface next batch.
+    const rows = os.db
+      .prepare('SELECT id, agent_id, content, tags, type, importance, metadata, scope FROM memories WHERE tenant = ? AND created_at < ? ORDER BY created_at, id LIMIT ?')
+      .all<{ id: string; agent_id: string; content: string; tags: string | null; type: string | null; importance: number | null; metadata: string | null; scope: string }>(os.tenant, before, limit);
+    const del = os.db.prepare('DELETE FROM memories WHERE tenant = ? AND id = ?');
+    let migrated = 0, skipped = 0;
+    for (const r of rows) {
+      if (skipEpisodes && (r.tags ?? '').includes('"episode"')) { del.run(os.tenant, r.id); skipped++; continue; }
       try {
         await os.memory.store({
           tenant: os.tenant, agentId: r.agent_id, content: r.content,
@@ -1752,26 +1763,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
           metadata: r.metadata ? safeJson(r.metadata) : undefined,
           scope: r.scope === 'tenant' ? 'tenant' : 'agent',
         });
-        migrated++;
       } catch (e) {
-        errors.push(`${r.agent_id}: ${e instanceof Error ? e.message : String(e)}`);
+        // Stop cleanly: this orphan stays put (not deleted). The client retries with the SAME `before` to resume.
+        return sendJson(res, 500, { error: `store failed after ${migrated} migrated: ${e instanceof Error ? e.message : String(e)}`, before, migrated, skipped, remaining: remainingBefore(before) });
       }
+      del.run(os.tenant, r.id); migrated++;
     }
-    // Gated: only drop the old rows if EVERY kept row landed — a partial migration leaves all intact.
-    if (migrated !== keep.length) {
-      return sendJson(res, 500, { error: `migrated ${migrated}/${keep.length}; nothing deleted`, migrated, skipped: rows.length - keep.length, errors: errors.slice(0, 5) });
-    }
-    const del = os.db.prepare('DELETE FROM memories WHERE tenant = ? AND id = ?');
-    os.db.exec('BEGIN');
-    try {
-      for (const id of snapshotIds) del.run(os.tenant, id);
-      os.db.exec('COMMIT');
-    } catch (e) {
-      os.db.exec('ROLLBACK');
-      return sendJson(res, 500, { error: `migrated ${migrated} but cleanup failed: ${e instanceof Error ? e.message : String(e)}`, migrated });
-    }
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'memory.migrated', data: { backend: os.settings.memoryConfig()?.backend, migrated, skipped: rows.length - keep.length, deleted: snapshotIds.length } });
-    return sendJson(res, 200, { ok: true, migrated, skipped: rows.length - keep.length, deleted: snapshotIds.length });
+    const remaining = remainingBefore(before);
+    const done = remaining === 0;
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'memory.migrated', data: { backend: os.settings.memoryConfig()?.backend, migrated, skipped, remaining, done } });
+    return sendJson(res, 200, { ok: true, done, before, migrated, skipped, remaining });
   }
   if (method === 'POST' && p === '/api/settings/memory/clear') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4994,13 +4994,24 @@ function MemorySettings({ me }: { me: Member }) {
   const [reconBusy, setReconBusy] = useState(false)
   const [reconSkipEp, setReconSkipEp] = useState(false) // migrate all by default; opt in to skipping raw episodes
   const [reconMsg, setReconMsg] = useState('')
+  const [reconcileOpen, setReconcileOpen] = useState(false) // the at-switch interstitial
   const refreshView = () => api.memorySettings().then((v) => { if (!v.error) apply(v) }).catch(() => {})
+  // Batched migrate: loop the endpoint (each call moves ≤ a batch) passing back the server's `before`
+  // horizon until it reports `done`, showing progress. Safe to resume — a failed batch leaves rows put.
   const doMigrate = async () => {
-    setReconBusy(true); setReconMsg('')
-    const r = await api.migrateMemory(reconSkipEp)
+    setReconBusy(true); setReconMsg('Migrating…')
+    let before: number | undefined
+    let migrated = 0, skipped = 0
+    for (let guard = 0; guard < 10000; guard++) {
+      const r = await api.migrateMemory({ skipEpisodes: reconSkipEp, before })
+      if (r.error) { setReconBusy(false); return setReconMsg('⚠ ' + r.error) }
+      migrated += r.migrated ?? 0; skipped += r.skipped ?? 0; before = r.before
+      if (r.done) break
+      setReconMsg(`Migrating… ${migrated} moved${skipped ? ` / ${skipped} skipped` : ''}, ${r.remaining ?? 0} left`)
+    }
     setReconBusy(false)
-    if (r.error) return setReconMsg('⚠ ' + r.error)
-    setReconMsg(`Migrated ${r.migrated ?? 0}${r.skipped ? `, skipped ${r.skipped} episode(s)` : ''}; removed ${r.deleted ?? 0} local rows.`)
+    setReconMsg(`Migrated ${migrated}${skipped ? `, skipped ${skipped} episode(s)` : ''}; local ledger reconciled.`)
+    setReconcileOpen(false)
     refreshView()
   }
   const doClear = async () => {
@@ -5010,6 +5021,7 @@ function MemorySettings({ me }: { me: Member }) {
     setReconBusy(false)
     if (r.error) return setReconMsg('⚠ ' + r.error)
     setReconMsg(`Cleared ${r.cleared ?? 0} local rows.`)
+    setReconcileOpen(false)
     refreshView()
   }
 
@@ -5049,6 +5061,7 @@ function MemorySettings({ me }: { me: Member }) {
     setTestResult(r.health ?? null)
   }
   const save = async () => {
+    const prevBackend = view?.backend
     setBusy(true); setHint(''); setTestResult(null)
     const r = await api.saveMemorySettings(body())
     setBusy(false)
@@ -5056,6 +5069,8 @@ function MemorySettings({ me }: { me: Member }) {
     setApiKey(''); setToken(''); setAuthToken('')
     apply(r)
     setHint('saved — applied live'); setTimeout(() => setHint(''), 1800)
+    // At-switch interstitial: a backend CHANGE that left local rows the new store lacks → prompt to reconcile.
+    if (r.backend !== prevBackend && (r.drift ?? 0) > 0) { setReconSkipEp(false); setReconMsg(''); setReconcileOpen(true) }
   }
 
   if (!isAdmin) return <div className="text-sm text-muted-foreground">Owner or admin access required.</div>
@@ -5116,6 +5131,22 @@ function MemorySettings({ me }: { me: Member }) {
 
   return (
     <div className="max-w-3xl space-y-4">
+      {/* At-switch interstitial: pops right after a backend change that left local rows behind. */}
+      {reconcileOpen && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => !reconBusy && setReconcileOpen(false)}>
+          <div className="w-full max-w-lg space-y-3 rounded-lg border bg-background p-4 shadow-lg" onClick={(e) => e.stopPropagation()}>
+            <div className="text-sm font-medium">Switched to {view?.backend} — reconcile the {view?.localCount ?? 0} existing {(view?.localCount ?? 0) === 1 ? 'memory' : 'memories'}?</div>
+            <p className="text-xs text-muted-foreground">Agents now recall from {view?.backend}, which has {view?.backendCount ?? 0}. Your {view?.drift ?? 0} local {(view?.drift ?? 0) === 1 ? 'memory' : 'memories'} aren't in it yet. <strong>Migrate</strong> copies them into {view?.backend}; <strong>Start fresh</strong> clears the local ledger; <strong>Later</strong> leaves them (the drift banner stays until you reconcile).</p>
+            <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground"><input type="checkbox" checked={reconSkipEp} onChange={(e) => setReconSkipEp(e.target.checked)} />durable only — skip raw session episodes</label>
+            <div className="flex flex-wrap items-center gap-2">
+              <Button size="sm" onClick={doMigrate} disabled={reconBusy}><Upload className="mr-1 h-3.5 w-3.5" />Migrate to {view?.backend}</Button>
+              <Button size="sm" variant="outline" onClick={doClear} disabled={reconBusy}><Trash2 className="mr-1 h-3.5 w-3.5" />Start fresh</Button>
+              <Button size="sm" variant="ghost" onClick={() => setReconcileOpen(false)} disabled={reconBusy}>Later</Button>
+              {reconMsg && <span className="font-mono text-[11px] text-muted-foreground">{reconMsg}</span>}
+            </div>
+          </div>
+        </div>
+      )}
       <div className="flex items-start justify-between gap-3">
         <p className="text-sm text-muted-foreground">
           The <strong>persistent memory</strong> every agent recalls across sessions. Changing the backend applies

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -658,7 +658,8 @@ export const api = {
   testMemorySettings: (body: MemorySettingsReq) => call<{ ok: boolean; health?: MemoryHealth; error?: string }>('POST', '/api/settings/memory/test', body),
   ollamaStatus: (url: string) => call<OllamaStatus>('GET', '/api/settings/memory/ollama?url=' + encodeURIComponent(url)),
   maintainMemory: () => call<{ ok: boolean; pruned?: number; merged?: number; error?: string }>('POST', '/api/settings/memory/maintain'),
-  migrateMemory: (skipEpisodes: boolean) => call<{ ok: boolean; migrated?: number; skipped?: number; deleted?: number; error?: string }>('POST', '/api/settings/memory/migrate', { skipEpisodes }),
+  // Batched: call with { skipEpisodes } first, then loop passing back the server-assigned `before` until `done`.
+  migrateMemory: (opts: { skipEpisodes: boolean; before?: number; limit?: number }) => call<{ ok: boolean; done?: boolean; before?: number; migrated?: number; skipped?: number; remaining?: number; note?: string; error?: string }>('POST', '/api/settings/memory/migrate', opts),
   clearMemoryLedger: () => call<{ ok: boolean; cleared?: number; error?: string }>('POST', '/api/settings/memory/clear'),
 
   kb: (q = '', section = '') => call<{ pages: KbPage[]; sections: string[]; enabled: boolean }>('GET', `/api/kb?q=${encodeURIComponent(q)}&section=${encodeURIComponent(section)}`),


### PR DESCRIPTION
Phase 2 of [`docs/memory-backend-migration-plan.md`](docs/memory-backend-migration-plan.md), on top of the Phase-1 drift banner (#42).

## What's here
- **At-switch interstitial.** Saving a backend *change* that leaves local memories the new store lacks now pops a **Migrate / Start fresh / Later** dialog right away — a can't-miss prompt at the moment of switching, rather than only the passive drift banner as the safety net.
- **Batched migration.** `POST /api/settings/memory/migrate` now moves **one batch per call** over a fixed `before` horizon and returns `{ migrated, skipped, remaining, done }`. The console **loops** it, showing a live *"N moved, M left"* count, so a large ledger never blocks a single request. A failed batch is **resumable** (rows stay put; retry with the same horizon continues). The `before` horizon is **strict** (`created_at < before`): orphans are always older, and the mirror's re-inserted rows (stamped `Date.now() >= before`) are never re-picked — even if a store lands in the same millisecond. Idempotency guard (no-op when consistent → can't duplicate) and the "durable only — skip episodes" filter carry over.

## Testing
- `tsc --noEmit` + `vite build` clean (in-worktree against latest `main`).
- **11-check algorithm test** against the *real* `MirroredMemoryProvider` + an in-memory DB: batched migrate-all converges in the expected number of calls with **no duplication** (backend ends at exactly N), skip-episodes drops the episodes and migrates the rest, and the guard no-ops when the backend is already consistent. (Caught a real same-millisecond re-pick edge, fixed by the strict `<` horizon.)

Phase-1 already verified live on instapods; this extends that path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)