### PR TITLE
Docs: "Import into AOS" page + procedural-skills plan (spec)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+### Added
+- **Docs: "Import into AOS" console page** — a master-prompt guide for bringing an agent over from
+  another system (raw Claude Code project, CrewAI/LangGraph, a folder of prompts) by emitting a
+  file-based bundle that mirrors how AOS stores agents, so the manifest/instructions/skills need no
+  importer. Wired into the Docs section (`web/src/docs`).
+- **Docs: procedural-skills plan (spec)** — `docs/procedural-skills-plan.md`, the Lever 6 proposal for
+  closing the episodic→procedural gap (the fleet writing its own `SKILL.md` from repeated successes).
+
 ## [0.24.0] — 2026-07-07
 
 ### Added

--- a/docs/procedural-skills-plan.md
+++ b/docs/procedural-skills-plan.md
@@ -1,0 +1,144 @@
+# Procedural skills — Lever 6 of the learning loop
+
+**Status:** proposed (spec). Closes the last open gap in the memory chapter: the fleet learns *facts*
+but not yet *procedures*.
+
+## The gap
+
+Levers 1–5 close the **episodic → semantic** loop — episodes, lessons, salience, the consolidation
+gardener, retrieval reinforcement — but every output is a *fact*: a memory or a KB page. The skills
+library (`src/governance/skills.ts`) is the OS's **procedural** store (a reusable multi-step *how-to*,
+materialised into every agent at launch), yet nothing ever *writes* to it from experience. Skills only
+arrive three ways, all external to the fleet's own work: hand-authored in the console, installed from
+the bundled catalog (`config/skills`), or pulled from a GitHub repo / skills.sh (`skill-registry.ts`).
+
+This is precisely the layer Nous Research's **Hermes Agent** leads with — its "procedural memory": when
+the agent solves a hard problem or repeats a workflow, it *writes its own `SKILL.md`* so it never
+re-derives it. We have the store, the materialisation path, the editor, and a governance model they
+don't — we're just missing the pipe from *"the fleet did this successfully, more than once"* to *"here
+is a skill for it."*
+
+**Lever 6 builds that pipe — and keeps it governed:** a proposed skill is a *draft*, never live, until a
+human reviews and publishes it.
+
+## Design principle — compose two patterns we already ship
+
+Nothing here is novel infrastructure; it's the two proven learning-loop patterns pointed at a new output:
+
+1. **Quality synthesis via a governed headless agent** — exactly the consolidation gardener
+   (`src/edge/consolidation.ts`). Real-Claude synthesis over a batch of episodes, reusing all
+   governance/audit, no in-process LLM client. The gardener already reads the recurring signal; we give
+   it a third output channel.
+2. **Human-gated rollout** — exactly the Dreaming *recommendations* flow (`deriveRecommendations` →
+   `settings.recommendations()` → console **Apply / Dismiss**). A generated skill is a *proposal*; a
+   human publishes it (or dismisses it). This preserves the invariant that **nothing changes how the
+   fleet works without a human's ok** — and even after publish, the PreToolUse gate still governs every
+   effect the skill drives (a skill packages *how* an agent works, never *what it may do*).
+
+## Two producers, one review queue
+
+A skill-worthy procedure surfaces in two places; both feed the same gated queue:
+
+- **(a) At the point of experience — any agent, post-task.** A new always-on MCP tool `skill_propose`
+  (sibling of `report` / `remember`), guided by an operating-notes trigger: *"When you complete a
+  reusable, multi-step procedure that a teammate could follow verbatim, propose it as a skill."* This is
+  Lever 1/2's encoding-trigger idea applied to **procedures** — and it mirrors Hermes's "solved a hard
+  problem → writes a skill." Safe fleet-wide because every call lands as a **proposal**, not a live skill.
+- **(b) Across the batch — the gardener.** Extend the consolidator's remit from *"episode → fact
+  (memory/KB)"* to *"distil each episode into the right artifact"*: a durable **fact** → `remember`
+  (shared) / `kb_write` (unchanged), a **repeatable procedure seen ≥ N times** → `skill_propose`. One
+  governed run over the same watermarked batch, same dedup discipline (check existing skills first).
+
+Producer (a) catches the one-off brilliant solution immediately; (b) catches the pattern that only
+emerges across many sessions. Together they match Hermes's "writes after a hard problem" **and** its
+"after enough similar tasks" triggers — with a review gate neither of theirs has.
+
+## Staging model — draft-in-library (recommended)
+
+A proposal must be **reviewable and editable** before it goes live (auto-drafts need a human polish),
+and skills already have a first-class console editor. So stage a proposal as a **real skill folder in the
+library, flagged not-yet-published** — reusing the entire existing read/edit/save/delete surface:
+
+- `SkillsStore.propose(input)` writes `<home>/skills/<name>/SKILL.md` **plus a `.aos-proposed` marker**
+  (sibling to `.aos-managed`) and stamps `x-aos-origin: auto` + source provenance into the frontmatter.
+- `materialize()` **skips any folder carrying `.aos-proposed`** — so a proposed skill is invisible to
+  agents until published. (One-line filter alongside the existing managed/hand-authored logic.)
+- `list()` / `read()` surface `proposed: boolean` so the console can separate them.
+- **Publish** = `SkillsStore.publish(name)` removes the marker → the skill materialises to agents on
+  their next session. **Dismiss** = the existing `remove(name)`.
+
+This beats a settings-blob "recommendation card" (the Dreaming pattern) because a `SKILL.md` is a
+first-class file that wants the real editor, not a one-shot Apply button. *(Alternative if we want the
+proposal to sit next to config recommendations on the Self-learning tab: a `skill_proposals` settings
+blob holding `{name, description, body, source, createdAt}`, Apply = `create()`. Rejected as the default
+— it duplicates the skill editor and can't hold supporting files. Kept as a fallback.)*
+
+To keep staging simple, **auto-generated proposals are a single `SKILL.md`** (no supporting
+scripts/templates) — the store's `installFiles` path stays reserved for the remote installer.
+
+## Governance
+
+- **Proposals never materialise.** The `.aos-proposed` gate is the whole safety story: unreviewed skills
+  can't reach an agent.
+- **Publish is owner/admin.** Skill mutations are already owner/admin in `server.ts`; publish/dismiss
+  join them. Proposing (by an agent) is a session-secret loopback call *before* the member gate, like
+  every other agent tool.
+- **Audit:** `skill.proposed` (principal = the proposing agent + source session), `skill.published` /
+  `skill.proposal.dismissed` (principal = the human). Reuses the audit sink + the Audit page.
+- **Anti-flood:** cap open proposals (e.g. ≤ 25/tenant); dedupe by name; the gardener must `list` existing
+  skills first and prefer *refining* an existing one over a near-duplicate (same discipline its CLAUDE.md
+  already enforces for `recall`/`kb_search`).
+- **Opt-in auto-publish (phase 2, default OFF).** Mirror `consolidate_auto`: a `skills_autopublish`
+  setting that publishes *gardener* proposals without review, for teams that trust the loop. Ships off.
+
+## Surfaces to build
+
+**Store (`src/governance/skills.ts`)**
+- `propose(input): SkillDetail` — create folder + `.aos-proposed` + origin frontmatter.
+- `publish(name): boolean` — delete the marker (idempotent; false if unknown/not-proposed).
+- `proposed` flag on `SkillSummary`/`SkillDetail`; `materialize()` excludes proposed folders.
+- `remove()` already covers dismiss (drops the folder + assignment rows).
+
+**Agent tool (`src/memory/memory-mcp.ts` + `src/server.ts`)**
+- `skill_propose { name, description, body, rationale? }` → loopback `POST /api/skill/propose`
+  (session-secret gated, pre-auth), → `SkillsStore.propose` + `skill.proposed` audit. Always-on tool.
+- Operating notes (`AGENT_OS_OPERATING_NOTES` in `terminal.ts`): add the procedure encoding trigger.
+- **Schema change ⇒ rebuild + relaunch sessions; handler ⇒ rebuild + restart server** (per CLAUDE.md).
+
+**Gardener (`src/edge/consolidation.ts`)**
+- Extend `CLAUDE_MD` method: add "repeatable procedure → `skill_propose` (check existing skills first;
+  refine over duplicate)"; expose `skill_propose` to the consolidator session. No new run — same batch.
+
+**Server routes (`src/server.ts`)**
+- `POST /api/skills/:name/publish` (owner/admin) → `publish` + `skill.published` audit.
+- Dismiss reuses `DELETE /api/skills/:name`. Proposals list via the existing `GET /api/skills` (now
+  carrying `proposed`), or a dedicated `GET /api/skills/proposed`.
+
+**Console (`web/src`)**
+- Skills page: a **"Proposed by self-learning"** section — each card → **Review** (opens the existing
+  editor prefilled, editable) → **Publish** or **Dismiss**; an `auto` badge + source-session link.
+- Self-learning tab: a small **"N skills proposed"** count linking to that section (keeps the learning
+  loop's outputs — guidance, config recs, *and now skills* — visible in one place).
+
+**Docs / release**
+- Fold Lever 6 into `docs/memory-encoding-and-consolidation.md` + this plan; update `docs/PILLARS.md`
+  and the self-learning row; `CHANGELOG.md` under Unreleased; minor version bump on the feature PR.
+
+## Phasing
+
+- **Phase 1 (MVP):** `skill_propose` (fleet + gardener) → draft-in-library staging → Skills-page
+  Review/Publish/Dismiss → audit. Human-gated only. This alone closes the Hermes gap.
+- **Phase 2:** opt-in `skills_autopublish` for gardener proposals; usage-based **retirement** proposals
+  (skills carry an invocation/materialise counter, like memory `recall_count`; the gardener proposes
+  retiring never-used auto-skills — the procedural analogue of Lever 5's prune-the-never-recalled);
+  auto-suggested per-agent scoping (`skill_assignments`) from which agents' episodes produced it.
+
+## Decisions to confirm before building
+
+1. **Who may propose** — whole fleet (any agent post-task, recommended) vs gardener-only. Fleet-wide is
+   safe because of the gate and matches Hermes; gardener-only is narrower/quieter.
+2. **Staging** — draft-in-library via `.aos-proposed` (recommended, reuses the editor) vs a settings-blob
+   card on the Self-learning tab.
+3. **Auto-publish** — gated-only for v1 (recommended) vs ship the opt-in `skills_autopublish` now.
+
+Defaults in this spec: **fleet-wide propose · draft-in-library · gated-only v1.**

--- a/web/src/docs/import-into-aos.md
+++ b/web/src/docs/import-into-aos.md
@@ -1,0 +1,143 @@
+# Import into AOS
+
+Bringing an agent over from another system (a raw Claude Code project, a CrewAI/LangGraph agent, a folder of prompts, a custom harness)? This page gives you a **master prompt** to paste into that agent. It briefs the agent on what Agent OS is and has it emit a **bundle** — a small, standard folder — that drops straight into AOS.
+
+The trick: the bundle mirrors how AOS actually stores things, so the file parts need **no importer at all**.
+
+## How an AOS agent is stored (why the bundle looks the way it does)
+
+| Entity | Where it lives in AOS | Drops in as a file? |
+| --- | --- | --- |
+| **Agent manifest** (`agent.json`) | `data/agents/<id>/agent.json` | ✅ yes |
+| **Instructions** (`CLAUDE.md`) | `data/agents/<id>/CLAUDE.md` | ✅ yes |
+| **Skills** | `data/skills/<name>/SKILL.md` (global, shared by all agents) | ✅ yes |
+| **Memory** | SQLite (`memories` table) | ❌ needs replay/import |
+| **Knowledge** | SQLite + `data/kb/…` | ❌ needs replay/import |
+
+So an agent's *brain* (manifest + instructions + skills) is pure files — copy them in, hit **Rescan** on the Agents page, and the agent exists. Its *memory* isn't files, so the bundle carries it as `memory.jsonl` that gets replayed in (see **Finishing the import** below).
+
+**Never put in a bundle:** secrets/API keys/tokens, absolute filesystem paths, or the auto-generated `.claude/aos-settings.json` and materialized `.claude/skills/` — AOS regenerates those at launch for its own environment.
+
+## The bundle format
+
+```
+<agent-id>/
+├── bundle.json          # metadata: schema version, source system, what's inside
+├── agent.json           # AOS manifest (identity, model, budget)
+├── CLAUDE.md            # the agent's system prompt / operating instructions
+├── memory.jsonl         # one JSON memory per line (durable facts the agent learned)
+├── skills/              # optional — reusable procedures this agent relies on
+│   └── <skill-name>/
+│       ├── SKILL.md
+│       └── references/…
+└── knowledge/           # optional — shared reference docs to seed the KB
+    └── <section>/<slug>.md
+```
+
+## The master prompt
+
+Paste everything between the lines into the agent you're migrating **on its current system**. It will produce the bundle.
+
+~~~text
+You are being migrated into Agent OS (AOS), a governed runtime for autonomous
+agents. Your job right now is to package YOURSELF into an "AOS bundle" — a folder
+another operator will import so that a faithful copy of you runs inside AOS.
+
+────────────────────────────────────────────────────────────────────────
+WHAT AGENT OS IS (context, so you package the right things)
+────────────────────────────────────────────────────────────────────────
+AOS runs agents under guardrails. Every real-world side effect an agent
+attempts (sending mail, pushing code, spending money) passes through one
+mediated gateway that classifies it green/yellow/red and pauses for a human
+when needed. You do NOT need to build any of that — AOS provides it. You only
+need to hand over your identity, instructions, skills, and memory.
+
+The AOS entities you map onto:
+• AGENT   — a WHO: an identity with instructions, a model, and a budget. That's you.
+• SKILL   — a HOW: a reusable procedure/knowledge doc (e.g. "how to file a refund").
+            Stateless, shareable. Anything you "know how to do" that is a
+            self-contained playbook is a skill, not part of your core instructions.
+• MEMORY  — durable facts YOU learned across runs (preferences, outcomes, gotchas).
+            One self-contained fact per entry.
+• KNOWLEDGE — shared reference material a whole team would consult (optional).
+
+────────────────────────────────────────────────────────────────────────
+WHAT TO PRODUCE
+────────────────────────────────────────────────────────────────────────
+Create a folder named after your agent id (lowercase, hyphens, e.g.
+"support-triage") containing these files. Write real files if you can; if you
+cannot write files, print each file's full contents under a clear "=== path ==="
+header so it can be reconstructed.
+
+1) bundle.json
+   {
+     "schema": "aos-bundle/v1",
+     "agentId": "<lowercase-hyphen-id>",
+     "sourceSystem": "<where you run today, e.g. 'Claude Code project'>",
+     "contents": ["agent.json","CLAUDE.md","memory.jsonl","skills","knowledge"]
+   }
+
+2) agent.json  — your AOS manifest. Fill what you can; the operator completes the rest.
+   {
+     "id": "<same lowercase-hyphen id>",
+     "version": "1.0.0",
+     "description": "<one sentence: what you do and when to run you>",
+     "category": "<Support|Engineering|Marketing|Sales|Research|Ops|System>",
+     "runtime": "claude-code",
+     "model": "claude-opus-4-8",
+     "examplePrompts": ["<2-4 prompts that show how you're typically invoked>"]
+   }
+   (Leave out principal/policyContext/budget — AOS assigns safe defaults.)
+
+3) CLAUDE.md  — your operating instructions: role, how you work, hard rules,
+   domain facts, API/endpoint notes, common pitfalls. This is your brain.
+   RULES:
+   • Strip every secret, password, API key, token, and private key. If a
+     credential is needed, write a placeholder like <SET_IN_AOS_CONNECTORS>
+     and note what it's for.
+   • Remove absolute paths tied to your current machine (e.g. /Users/you/…);
+     describe the resource instead.
+   • Pull anything that is a standalone reusable procedure OUT into skills/ (below).
+
+4) memory.jsonl  — one JSON object per line, each a single durable fact you've
+   learned that a fresh copy of you should still know. Format:
+   {"content":"<self-contained fact>","tags":["short","labels"],"importance":0.5,"shared":false}
+   • content: a complete statement understandable with no other context.
+   • importance: 0..1 — ~0.8+ for a key rule/decision, ~0.5 default, ~0.3 minor.
+   • shared: true only if the fact is useful to OTHER agents too (team-wide).
+   • Be selective. 10 sharp facts beat 200 noisy ones. Skip anything transient,
+     secret, or already covered by your CLAUDE.md.
+
+5) skills/<name>/SKILL.md  (optional, repeatable) — each reusable procedure you
+   rely on, as its own folder. SKILL.md starts with a one-line purpose, then the
+   steps. Put long reference material in skills/<name>/references/*.md.
+
+6) knowledge/<section>/<slug>.md  (optional) — shared reference docs (runbooks,
+   product facts) that belong to the whole team, not just you.
+
+────────────────────────────────────────────────────────────────────────
+BEFORE YOU FINISH — self-audit
+────────────────────────────────────────────────────────────────────────
+□ No secrets, keys, tokens, or passwords anywhere in any file.
+□ No machine-specific absolute paths.
+□ agent.json id is lowercase-hyphen and matches the folder + bundle.json.
+□ Every memory line is valid JSON and a self-contained fact.
+□ Reusable playbooks are in skills/, not buried in CLAUDE.md.
+□ You could hand CLAUDE.md to a stranger and they'd know how to be you.
+
+Produce the bundle now.
+~~~
+
+## Finishing the import (operator side)
+
+Once you have the bundle folder:
+
+1. **Agent brain — drop in + rescan (no code):**
+   - Copy `agent.json` and `CLAUDE.md` into `data/agents/<agent-id>/`.
+   - Copy each `skills/<name>/` into the global `data/skills/<name>/`.
+   - On the **Agents** page click **Rescan** (or `POST /api/agents/rescan`). The agent appears.
+   - Open it, set its **budget, model, and assignments**, and review the `CLAUDE.md` for anything that still assumes the old environment. Wire any credentials it needs via **Connectors**, not in the file.
+
+2. **Memory — replay:** memory lives in SQLite, so it isn't a drop-in file. The simplest path with no new code: run the agent once and tell it *"Read the memory.jsonl in your folder and `remember` each line with its tags, importance, and shared flag."* It replays its own memory through the standard tool. (A one-shot bulk importer would make this lossless — see below.)
+
+3. **Knowledge — replay:** same idea — have the agent `kb_write` each `knowledge/<section>/<slug>.md`, or paste them into the **Knowledge** page yourself.

--- a/web/src/docs/index.ts
+++ b/web/src/docs/index.ts
@@ -7,6 +7,7 @@ import coreConcepts from './core-concepts.md?raw'
 import workingWithAgents from './working-with-agents.md?raw'
 import governance from './governance.md?raw'
 import sharedPlanes from './shared-planes.md?raw'
+import importIntoAos from './import-into-aos.md?raw'
 
 export type DocPage = { slug: string; title: string; body: string }
 
@@ -17,4 +18,5 @@ export const docPages: DocPage[] = [
   { slug: 'working-with-agents', title: 'Working with agents', body: workingWithAgents },
   { slug: 'governance', title: 'Governance & approvals', body: governance },
   { slug: 'shared-planes', title: 'Memory, Knowledge & Tasks', body: sharedPlanes },
+  { slug: 'import-into-aos', title: 'Import into AOS', body: importIntoAos },
 ]


### PR DESCRIPTION
## What

Two docs, both **preserved WIP** that was sitting uncommitted in the local checkout and was rescued during a `main`↔`origin/main` reconcile. Rebased cleanly onto current `main` (v0.24.0) and put up for review rather than left floating:

- **`web/src/docs/import-into-aos.md`** (+ `web/src/docs/index.ts` registration) — a user-facing **console Docs page**. A master prompt to paste into an agent living in another system (raw Claude Code project, CrewAI/LangGraph, a folder of prompts, a custom harness) that briefs it on AOS and has it emit a **file-based bundle** mirroring how AOS stores agents — so the manifest/instructions/skills drop in with no importer.
- **`docs/procedural-skills-plan.md`** — an internal **spec/proposal** (Lever 6 of the learning loop): closing the episodic→procedural gap by having the fleet author its own `SKILL.md` from repeated successes. Explicitly `Status: proposed (spec)`.

## Scope

Docs-only — no code or behavior change. Web bundle builds clean (the new page imports via Vite `?raw`). No version bump; a CHANGELOG entry was added under **Unreleased**.

## Note for reviewers

I preserved this content byte-for-byte from the working tree; I did **not** author or finish it. If you're the original author, please confirm both docs are complete before merging (the procedural-skills doc is a proposal by nature).

🤖 Generated with [Claude Code](https://claude.com/claude-code)