### PR TITLE
Console: show the open session's title in the header (v0.26.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.26.0] — 2026-07-07
+
+### Changed
+- **The open session's title leads the console header.** When you're in a terminal, the page header
+  now shows that session's title (truncated to fit) instead of the generic "Sessions" — so you can tell
+  which run you're looking at at a glance. The redundant "All sessions" back button *inside* the terminal
+  view is removed, since the header already pins one next to the title.
+
 ## [0.25.0] — 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -663,8 +663,8 @@ function Console({ me }: { me: Member }) {
       <main className="flex flex-1 flex-col overflow-hidden">
         <div className="flex items-center justify-between border-b px-6 py-4">
           <div className="flex items-center gap-3">
-            <h1 className="text-lg font-semibold">
-              {route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connectors' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Artifacts' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'docs' ? 'Docs' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
+            <h1 className="max-w-[60vw] truncate text-lg font-semibold">
+              {route === 'sessions' && selected ? selected.title : route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connectors' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Artifacts' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'docs' ? 'Docs' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
             </h1>
             {/* When a terminal is open the page fills with the iframe; this pins a way back to the list next to the title. */}
             {route === 'sessions' && selected && (
@@ -678,7 +678,7 @@ function Console({ me }: { me: Member }) {
         <div className={`min-h-0 flex-1 ${fullBleed ? '' : 'overflow-y-auto p-6'}`}>
           {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onRescan={rescanAgents} />}
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); openAgent(id) }} />}
-          {route === 'sessions' && <SessionsPage sessions={sessions} waiting={waiting} selected={selected} onOpen={openTerminal} onActivity={clearAlerts} onSpawn={() => nav('agents')} onClose={() => nav('sessions')} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} />}
+          {route === 'sessions' && <SessionsPage sessions={sessions} waiting={waiting} selected={selected} onOpen={openTerminal} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} />}
           {route === 'connectors' && <ConnectorsPage me={me} />}
           {route === 'team' && <TeamPage me={me} />}
@@ -1129,7 +1129,7 @@ function ImageDropZone({ session, children, onActivity }: { session?: Session; c
 }
 
 function SessionsPage({
-  sessions, waiting, selected, onOpen, onActivity, onSpawn, onClose, onStop, onDelete, onBulkStop, onBulkDelete,
+  sessions, waiting, selected, onOpen, onActivity, onSpawn, onStop, onDelete, onBulkStop, onBulkDelete,
 }: {
   sessions: Session[]
   waiting: Set<string>
@@ -1137,7 +1137,6 @@ function SessionsPage({
   onOpen: (tmux: string, title: string) => void
   onActivity: (sid: string) => void
   onSpawn: () => void
-  onClose: () => void
   onStop: (id: string) => void
   onDelete: (id: string, tmux: string) => void
   onBulkStop: (ids: string[]) => void
@@ -1228,13 +1227,6 @@ function SessionsPage({
               </>
             )}
           </div>
-          <button
-            className="flex shrink-0 items-center gap-1 rounded bg-neutral-800 px-2 py-1 font-medium text-neutral-200 hover:bg-neutral-700"
-            onClick={onClose}
-            title="exit the terminal and go back to the sessions list"
-          >
-            <ArrowLeft className="h-3.5 w-3.5" /> All sessions
-          </button>
         </div>
         <TerminalFrame key={selected.tmux} session={sessions.find((s) => s.tmux === selected.tmux)} tmux={selected.tmux} onActivity={onActivity} />
       </div>


### PR DESCRIPTION
When a terminal is open, the console page header now shows **that session's title** (truncated to fit the width) instead of the generic "Sessions" — so you can tell which run you're looking at at a glance. The now-redundant **"All sessions"** back button *inside* the terminal view is removed, since the header already pins one next to the title.

Small, self-contained UI change (only `web/src/App.tsx`): the `<h1>` gains `max-w-[60vw] truncate` and a `route === 'sessions' && selected ? selected.title : …` branch, and `SessionsPage` drops its now-unused `onClose` prop + the duplicate button.

Provenance: this was an in-progress working-tree change on the deploy box; picked it up, rebased onto latest `main`, and finished it.

`tsc` + `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)