### PR TITLE
docs: record procedural skills (Lever 6) as a planned roadmap item

### DIFF
--- a/docs/PILLARS.md
+++ b/docs/PILLARS.md
@@ -387,6 +387,14 @@ mock-runtime agents don't receive skills (they're scripted); supporting-file edi
 the console (edit SKILL.md text; richer assets via Files). A future step mirrors agent↔member
 assignment: a `skill_grants` table for per-agent scoping.
 
+**Planned — procedural skills (Lever 6 of the learning loop).** Skills are authored/installed today;
+nothing turns the fleet's own repeated successes into skills. The plan closes the episodic→**procedural**
+gap (the layer Hermes Agent leads with): a governed producer (any agent post-task, and the consolidation
+gardener across the batch) proposes a `SKILL.md` from a recurring, reusable procedure, staged as a draft
+**not** materialised to agents until a human reviews and publishes it — reusing the skills store + the
+Dreaming recommendations' approval pattern. Spec: [`procedural-skills-plan.md`](./procedural-skills-plan.md).
+This is the natural extension of Pillar 10 (Distil now emits facts → memories/KB; Lever 6 adds procedures → skills).
+
 ## 13. Tools / Apps — ⬜ Not started
 
 **The idea.** Tools *built by agents* (or users) for specific/general use — the

--- a/docs/v1-mvp-scope.md
+++ b/docs/v1-mvp-scope.md
@@ -42,7 +42,7 @@ self-learning, multi-tenancy, and native Slack via Socket Mode. Graded against t
 | **Discord** ingress + egress | Secrets vault (connector creds stay plaintext in DB — documented debt) |
 | **Act-as-member** email — agent acts under the individual's accounts (UC5) | Foreign CLIs (Codex/Gemini runtimes) |
 | Cron + webhook automations — ✅ shipped | Email invite delivery, SSO |
-| Audit viewer + chat approval notifications | |
+| Audit viewer + chat approval notifications | **Procedural skills (Lever 6)** — auto-propose a `SKILL.md` from recurring successful procedures, human-gated ([`procedural-skills-plan.md`](./procedural-skills-plan.md)) |
 | **Already shipped here** (was deferred in the frozen plan): Memory layer (9), Knowledge Base (15), Dreaming / self-learning (10), Multi-tenancy | |
 
 ## Channel matrix (v1)


### PR DESCRIPTION
Logs **procedural skills (Lever 6)** as a tracked roadmap item — to build later. No code change.

- **PILLARS.md** (Pillar 12 · Skills): a "Planned — procedural skills" note explaining the episodic→procedural gap (auto-propose a `SKILL.md` from recurring successful procedures, human-gated before it reaches agents), tied to Pillar 10's self-learning loop.
- **v1-mvp-scope.md**: added to the "Out of v1 (deferred)" list.

Both point at the existing spec, [`procedural-skills-plan.md`](docs/procedural-skills-plan.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)