### PR TITLE
Agents: default the chooser to list view + dock the gallery composer (v0.27.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.27.1] — 2026-07-07
+
+### Changed
+- **The agent chooser defaults to the list (split) view** instead of the gallery — the compact
+  list-rail + detail layout is the quicker default for picking an agent. The gallery is still one
+  toggle away and the choice persists.
+- **In the gallery view the task composer now docks to the bottom of the viewport** once the cards
+  overflow, so it stays reachable without scrolling past every card. It's clamped to its container, so
+  a short fleet shows the composer right under the cards with no gap.
+
 ## [0.27.0] — 2026-07-07
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.27.0",
+      "version": "0.27.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.27.0",
+  "version": "0.27.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,7 +60,7 @@ const exampleTask = (a?: AgentInfo): string => a?.examplePrompts?.[0] ?? ''
 const LAST_AGENT_KEY = 'aos_last_agent'
 const taskDraftKey = (agentId: string) => `aos_task_draft:${agentId}`
 // Which agent-chooser layout the user prefers: a card gallery ('grid') or a list-rail + detail
-// ('split'). Persisted so it sticks across visits; defaults to the visual grid.
+// ('split'). Persisted so it sticks across visits; defaults to the compact list-rail split view.
 const AGENTS_VIEW_KEY = 'aos_agents_view'
 type AgentsView = 'grid' | 'split'
 
@@ -750,7 +750,7 @@ function AgentsPage({
   const [task, setTask] = useState('')
   const [hint, setHint] = useState('')
   const [busy, setBusy] = useState(false)
-  const [view, setView] = useState<AgentsView>(() => (localStorage.getItem(AGENTS_VIEW_KEY) === 'split' ? 'split' : 'grid'))
+  const [view, setView] = useState<AgentsView>(() => (localStorage.getItem(AGENTS_VIEW_KEY) === 'grid' ? 'grid' : 'split'))
   const setViewPersist = (v: AgentsView) => { setView(v); localStorage.setItem(AGENTS_VIEW_KEY, v) }
   const [query, setQuery] = useState('')
 
@@ -925,7 +925,10 @@ function AgentsPage({
               </div>
             </div>
           ))}
-          <Card className="shadow-sm"><CardContent className="p-4">{composer}</CardContent></Card>
+          {/* Docked composer: sits after the cards, but sticks to the bottom of the scroll viewport
+              once the gallery is tall enough to overflow — so the task box stays reachable without
+              scrolling past every card. Clamped to its container, so short fleets show no gap. */}
+          <Card className="sticky bottom-0 z-10 shadow-lg"><CardContent className="p-4">{composer}</CardContent></Card>
         </div>
       ) : (
         <div className="grid gap-4 md:grid-cols-[minmax(190px,230px)_1fr]">


### PR DESCRIPTION
Follow-ups to the reimagined agent chooser (v0.27.0):

- **Default to the list (split) view** instead of the gallery — quicker for picking an agent. The gallery is one toggle away and the choice still persists.
- **Dock the gallery composer to the bottom.** In gallery view the task composer now `sticky bottom-0` pins to the scroll viewport once the cards overflow, so it's reachable without scrolling past every card. It's clamped to its container, so a short fleet shows the composer right under the cards with no gap.

## Testing
- `cd web && npm run build` ✓
- `npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)