### PR TITLE
Dev: git-worktree workflow for the shared checkout (scripts/wt.sh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+### Added
+- **`scripts/wt.sh` — the git-worktree workflow for this shared checkout** (dev tooling; no runtime
+  change). Multiple Claude sessions edit this one checkout concurrently and clobber each other; the
+  helper keeps the primary checkout clean on `main` and moves all development into per-session
+  worktrees under `~/aos-wt/<name>` (`new`/`list`/`sync`/`integrate`/`done`). Finished branches are
+  batch-merged in a fresh `batch/<ts>` worktree and shipped as **one consolidated PR**. Documented in
+  CLAUDE.md → "Multi-session development (git worktrees)".
+
 ## [0.27.1] — 2026-07-07
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,6 +309,29 @@ in `src/types.ts` and `TeamStore.canRun()`.
   repeat `Host`/`X-Forwarded-*` explicitly — otherwise the app sees `Host: 127.0.0.1:3010` and mints
   wrong invite/webhook links. There's a comment in the config; keep it.
 
+## Multi-session development (git worktrees)
+
+Several Claude sessions (and the fleet) edit this ONE checkout **concurrently** — two sessions writing
+the same files, or one running `git switch` under another, silently clobber each other (on 2026-07-07 a
+commit landed on the wrong branch this way). So the **primary checkout `/Users/vmini/Projects/agent-os`
+is kept on `main`, clean, and never edited directly** — it exists only to sync with origin, integrate
+finished work, and run the live service. **All development happens in per-session worktrees.**
+
+`scripts/wt.sh` wraps the loop (worktrees live under `~/aos-wt/<name>`; override with `AOS_WT_HOME`):
+- `scripts/wt.sh new <name>` — create `~/aos-wt/<name>` on `feat/<name>` off `origin/main`, with the
+  primary checkout's `node_modules` symlinked in so typecheck/build run without an install. Develop and
+  commit **there**, never in the primary checkout.
+- `scripts/wt.sh list` · `scripts/wt.sh sync` (ff-pull `main` in the primary) · `scripts/wt.sh done <name>`
+  (remove the worktree + delete `feat/<name>`).
+- `scripts/wt.sh integrate <name…>` — spin up a fresh `batch/<ts>` worktree off `origin/main` and merge
+  the named feature branches into it. Then, **merge locally, push once**: bump the version + CHANGELOG
+  a single time for the whole batch, `npm run build && (cd web && npm run build) && npm run test:governance`,
+  push the batch branch, and open **one consolidated PR** (`gh … --repo vikasprogrammer/agent-os`,
+  `gh pr merge --squash`). Never `switch`/branch the primary checkout to integrate.
+
+"Make it live" still runs from the primary checkout after `wt.sh sync` (build + `launchctl kickstart` —
+see Versioning / the macOS section).
+
 ## Versioning
 
 Root `package.json` `version` is the single source of truth (`src/version.ts` reads it once at

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# wt.sh — the git-worktree workflow for this SHARED agent-os checkout.
+#
+# Several Claude sessions (and the fleet) edit this one checkout concurrently. Two sessions writing the
+# same files — or one running `git switch` under another — silently clobber each other. So the PRIMARY
+# checkout (the one on `main`) is kept clean and on `main`, used only to run the live service and to
+# integrate finished work; ALL development happens in per-session worktrees under ~/aos-wt/<name>.
+# See CLAUDE.md → "Multi-session development (git worktrees)".
+#
+# Usage:
+#   scripts/wt.sh new <name>          # ~/aos-wt/<name> on feat/<name> off origin/main (+node_modules)
+#   scripts/wt.sh list                # show all worktrees
+#   scripts/wt.sh sync                # ff-pull main in the primary checkout
+#   scripts/wt.sh integrate <name..>  # fresh batch/<ts> worktree off origin/main, merge feat/<name..>
+#   scripts/wt.sh done <name>         # remove the worktree and delete feat/<name>
+#
+# Portable to macOS bash 3.2 + BSD userland (the deploy box is Linux, dev is a Mac).
+set -eu
+
+WT_HOME="${AOS_WT_HOME:-$HOME/aos-wt}"
+
+die() { printf '\033[31m%s\033[0m\n' "$*" >&2; exit 1; }
+say() { printf '\033[36m%s\033[0m\n' "$*"; }
+
+# The primary worktree is always the first entry `git worktree list` prints (the non-linked checkout).
+# Resolving it lets every subcommand run from ANY worktree and still drive the right checkout.
+PRIMARY="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+[ -n "$PRIMARY" ] || die "not inside an agent-os git checkout"
+
+# Symlink the primary checkout's node_modules into a worktree so typecheck/build run with no install.
+link_modules() {
+  wt="$1"
+  [ -d "$PRIMARY/node_modules" ] && [ ! -e "$wt/node_modules" ] && ln -s "$PRIMARY/node_modules" "$wt/node_modules" || true
+  [ -d "$PRIMARY/web/node_modules" ] && [ ! -e "$wt/web/node_modules" ] && ln -s "$PRIMARY/web/node_modules" "$wt/web/node_modules" || true
+}
+
+cmd="${1:-}"; shift 2>/dev/null || true
+case "$cmd" in
+  new)
+    name="${1:-}"; [ -n "$name" ] || die "usage: wt.sh new <name>"
+    dir="$WT_HOME/$name"; branch="feat/$name"
+    [ -e "$dir" ] && die "worktree dir already exists: $dir"
+    git -C "$PRIMARY" fetch origin --quiet
+    mkdir -p "$WT_HOME"
+    git -C "$PRIMARY" worktree add "$dir" -b "$branch" origin/main
+    link_modules "$dir"
+    say "ready: $dir  (branch $branch off origin/main)"
+    echo "  cd \"$dir\"   # develop + commit; then: scripts/wt.sh integrate $name"
+    ;;
+  list)
+    git -C "$PRIMARY" worktree list
+    ;;
+  sync)
+    git -C "$PRIMARY" switch main
+    git -C "$PRIMARY" fetch origin --quiet
+    git -C "$PRIMARY" merge --ff-only origin/main
+    say "primary synced to origin/main: $(git -C "$PRIMARY" rev-parse --short main)"
+    ;;
+  integrate)
+    [ "$#" -ge 1 ] || die "usage: wt.sh integrate <name> [<name>...]"
+    git -C "$PRIMARY" fetch origin --quiet
+    stamp="$(date +%Y%m%d-%H%M)"
+    branch="batch/$stamp"; dir="$WT_HOME/_batch-$stamp"
+    git -C "$PRIMARY" worktree add "$dir" -b "$branch" origin/main
+    link_modules "$dir"
+    for name in "$@"; do
+      say "merging feat/$name into $branch …"
+      git -C "$dir" merge --no-ff "feat/$name" -m "Merge feat/$name into $branch"
+    done
+    say "batch worktree ready: $dir  (branch $branch ← $*)"
+    echo "  cd \"$dir\", then: bump version + CHANGELOG once for the batch, and"
+    echo "    npm run build && (cd web && npm run build) && npm run test:governance"
+    echo "    git push -u origin $branch"
+    echo "    gh pr create --repo vikasprogrammer/agent-os --base main --head $branch ... && gh pr merge --squash"
+    ;;
+  done)
+    name="${1:-}"; [ -n "$name" ] || die "usage: wt.sh done <name>"
+    dir="$WT_HOME/$name"
+    rm -f "$dir/node_modules" "$dir/web/node_modules" 2>/dev/null || true
+    git -C "$PRIMARY" worktree remove --force "$dir"
+    git -C "$PRIMARY" branch -D "feat/$name" 2>/dev/null || true
+    git -C "$PRIMARY" worktree prune
+    say "removed worktree $dir and branch feat/$name"
+    ;;
+  *)
+    die "usage: wt.sh {new|list|sync|integrate|done} ..."
+    ;;
+esac


### PR DESCRIPTION
## What

Codifies a **git-worktree workflow** so concurrent Claude sessions stop clobbering each other in the shared `/Users/vmini/Projects/agent-os` checkout (a commit landed on the wrong branch on 2026-07-07 when one session ran `git switch` under another).

**Principle:** the primary checkout stays on `main`, clean, and is used only to sync with origin, integrate finished work, and run the live service. **All development happens in per-session worktrees** under `~/aos-wt/<name>` — separate working dirs + indexes = zero file collision, independent HEADs.

## `scripts/wt.sh`
- `new <name>` — `~/aos-wt/<name>` on `feat/<name>` off `origin/main`, with `node_modules` symlinked in for instant typecheck/build.
- `list` · `sync` (ff-pull `main`) · `done <name>` (remove worktree + branch).
- `integrate <name…>` — fresh `batch/<ts>` worktree off `origin/main`, merges the named feature branches, ready for **one consolidated PR** (bump version + CHANGELOG once, build + `test:governance`, push, `gh pr merge --squash`). Merge locally, push once.

Portable to macOS bash 3.2 + BSD userland. Documented in CLAUDE.md → "Multi-session development (git worktrees)".

## Notes
- **No runtime code touched** (`scripts/` isn't compiled or served) → no version bump, matching the docs-only #46 precedent; a note is added under CHANGELOG `Unreleased`.
- This PR was itself produced via the workflow it documents (built in its own worktree).

## Test
- `bash -n scripts/wt.sh` ✓, `wt.sh list` smoke ✓
- `npm run test:governance` → **44/44 ✓**

🤖 Generated with [Claude Code](https://claude.com/claude-code)