### PR TITLE
Team: prefetch-safe magic-link invites + per-person agent assignment (v0.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.28.0] — 2026-07-07
+
+### Fixed
+- **Magic-link invites no longer die with "invalid or expired" before the invitee clicks.** `GET
+  /accept` was a one-time token *consumer*, so any link preview / unfurl / mail-security scanner
+  (Slack, WhatsApp, Outlook Safe-Links, Gmail's proxy, corporate gateways) that fetched the URL burned
+  the token first — the human then landed on "invalid or expired". `/accept` is now a two-step landing:
+  the **GET only peeks** and renders a "Continue" confirm page (no side effect), and the token is
+  consumed only by the **POST** the button fires — which bots don't do. One-time, single-use semantics
+  are preserved; the interstitial is self-contained and theme-aware so it works before the session
+  exists. (`TeamStore.peekToken`, `acceptLandingHtml`.)
+
+### Changed
+- **Team page redesign + per-person agent assignment for any member.** Agent access previously showed
+  individual chips only for plain `member`-role people, so a team of all-admins saw no way to scope
+  agents — "can't assign individually". The redesigned **Agent access** section now lists every member
+  per agent: owners/admins render as static *full-access* pills (they run everything by role), plain
+  members are individually toggleable, and an **All members** toggle opens an agent to everyone. Each
+  agent shows a one-line "who can run this" summary. The page also gains a roles legend and tidied
+  member cards.
+
 ### Added
 - **`scripts/wt.sh` — the git-worktree workflow for this shared checkout** (dev tooling; no runtime
   change). Multiple Claude sessions edit this one checkout concurrently and clobber each other; the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.27.1",
+      "version": "0.28.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -176,6 +176,20 @@ export class TeamStore {
   }
 
   // ── login / sessions ─────────────────────────────────────────────────────────
+  /**
+   * Look up a magic-link token WITHOUT consuming it — the read the interstitial
+   * landing page uses to show "sign in as <email>". Returns null if the token is
+   * unknown, already consumed, or expired. Kept side-effect-free so a link
+   * preview / scanner's GET can never burn a one-time token (only the POST does).
+   */
+  peekToken(tok: string): { email: string; role: Role } | null {
+    if (!tok) return null;
+    const inv = this.db
+      .prepare('SELECT email, role FROM invites WHERE token = ? AND accepted_at IS NULL AND expires_at > ?')
+      .get<{ email: string; role: Role }>(tok, Date.now());
+    return inv ? { email: inv.email, role: inv.role } : null;
+  }
+
   /** Consume a magic-link token: activate the member and mint a session. Null if invalid/expired. */
   acceptToken(tok: string): { member: Member; sid: string } | null {
     const now = Date.now();

--- a/src/server.ts
+++ b/src/server.ts
@@ -238,7 +238,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/favicon.ico') return end(res, 204);
 
   // ── auth: magic-link landing + session introspection (the only PUBLIC /api routes) ──────────
+  // Magic links use a two-step landing so a link preview / scanner / mail-gateway that GETs the
+  // URL can't burn the one-time token before the human clicks. GET only PEEKS (renders a confirm
+  // page); the token is consumed only by the POST the "Continue" button fires — which bots don't do.
   if (method === 'GET' && p === '/accept') {
+    const token = url.searchParams.get('token') || '';
+    const peek = os.team.peekToken(token);
+    if (!peek) return redirect(res, '/?login=invalid');
+    return sendHtml(res, 200, acceptLandingHtml(peek.email, token));
+  }
+  if (method === 'POST' && p === '/accept') {
     const accepted = os.team.acceptToken(url.searchParams.get('token') || '');
     if (!accepted) return redirect(res, '/?login=invalid');
     res.writeHead(302, { location: '/', 'set-cookie': sessionCookie(accepted.sid) });
@@ -2662,6 +2671,62 @@ function linkFor(req: http.IncomingMessage, token: string): string {
 function redirect(res: http.ServerResponse, location: string): void {
   res.writeHead(302, { location });
   res.end();
+}
+function sendHtml(res: http.ServerResponse, status: number, html: string): void {
+  res.writeHead(status, { 'content-type': 'text/html; charset=utf-8' });
+  res.end(html);
+}
+function escapeHtml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
+}
+/**
+ * The interstitial shown by GET /accept. A plain confirm page — no auto-submit — so a link
+ * preview / mail-scanner that renders it never consumes the token; only the "Continue" POST does.
+ * Self-contained (no app bundle) and theme-aware so it works before the SPA/session exists.
+ */
+function acceptLandingHtml(email: string, token: string): string {
+  const safeEmail = escapeHtml(email);
+  const action = `/accept?token=${encodeURIComponent(token)}`;
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex">
+<title>Sign in — Agent OS</title>
+<style>
+  :root { color-scheme: light dark; }
+  * { box-sizing: border-box; }
+  body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 24px;
+    font: 15px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: #f6f7f9; color: #0b0d12; }
+  .card { width: 100%; max-width: 380px; background: #fff; border: 1px solid #e6e8ec; border-radius: 14px;
+    padding: 28px; box-shadow: 0 1px 3px rgba(0,0,0,.06), 0 8px 24px rgba(0,0,0,.05); text-align: center; }
+  .logo { width: 40px; height: 40px; margin: 0 auto 16px; border-radius: 10px; display: grid; place-items: center;
+    background: #0b0d12; color: #fff; font-weight: 700; font-size: 18px; }
+  h1 { font-size: 17px; margin: 0 0 6px; }
+  p { margin: 0 0 20px; color: #5b6470; font-size: 14px; }
+  .email { color: #0b0d12; font-weight: 600; }
+  button { width: 100%; padding: 11px 16px; border: 0; border-radius: 9px; background: #0b0d12; color: #fff;
+    font-size: 15px; font-weight: 600; cursor: pointer; }
+  button:hover { background: #23262e; }
+  .foot { margin: 16px 0 0; font-size: 12px; color: #8a94a3; }
+  @media (prefers-color-scheme: dark) {
+    body { background: #0b0d12; color: #f3f5f8; }
+    .card { background: #14171d; border-color: #262b33; box-shadow: none; }
+    .logo { background: #f3f5f8; color: #0b0d12; }
+    .email { color: #f3f5f8; }
+    p { color: #9aa4b2; }
+    button { background: #f3f5f8; color: #0b0d12; }
+    button:hover { background: #dfe3e9; }
+  }
+</style></head>
+<body><div class="card">
+  <div class="logo">A</div>
+  <h1>Sign in to Agent OS</h1>
+  <p>You're accepting an invitation as <span class="email">${safeEmail}</span>.</p>
+  <form method="POST" action="${action}">
+    <button type="submit">Continue</button>
+  </form>
+  <p class="foot">If this wasn't you, you can safely close this page.</p>
+</div></body></html>`;
 }
 
 // ── file-browser containment ───────────────────────────────────────────────────

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2406,24 +2406,46 @@ function TeamPage({ me }: { me: Member }) {
 
   if (!data) return <div className="text-sm text-muted-foreground">Loading…</div>
   const plainMembers = data.members.filter((m) => m.role === 'member')
+  const fullAccessCount = data.members.filter((m) => m.role !== 'member').length
+
+  // A one-line, human summary of who can run an agent, given its access row.
+  const accessSummary = (agentId: string): string => {
+    const acc = access(agentId)
+    const parts: string[] = []
+    if (fullAccessCount > 0) parts.push(`${fullAccessCount} owner/admin`)
+    if (acc.allowedRoles.includes('member')) parts.push('all members')
+    else if (acc.allowedMembers.length) parts.push(`${acc.allowedMembers.length} member${acc.allowedMembers.length > 1 ? 's' : ''}`)
+    return parts.length ? `Runnable by ${parts.join(' · ')}` : 'Only owners & admins can run this'
+  }
 
   return (
-    <div className="max-w-4xl space-y-6">
-      <p className="text-sm text-muted-foreground">
-        Members sign in with a one-time magic link. <strong>Owners</strong> run everything and approve
-        red (owner) requests; <strong>admins</strong> approve yellow (admin) requests and manage the team;
-        <strong> members</strong> can only run the agents they're assigned and never approve.
-      </p>
+    <div className="max-w-4xl space-y-8">
+      {/* Roles legend */}
+      <div className="grid gap-2 sm:grid-cols-3">
+        {[
+          { role: 'owner' as Role, blurb: 'Runs everything, approves red requests, manages the team.' },
+          { role: 'admin' as Role, blurb: 'Runs every agent, approves yellow requests, manages the team.' },
+          { role: 'member' as Role, blurb: 'Runs only assigned agents. Never approves.' },
+        ].map((r) => (
+          <div key={r.role} className="rounded-lg border bg-muted/30 p-3">
+            <RoleBadge role={r.role} />
+            <p className="mt-1.5 text-xs leading-snug text-muted-foreground">{r.blurb}</p>
+          </div>
+        ))}
+      </div>
 
       {/* Members */}
       <section>
-        <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">Members</div>
+        <div className="mb-2 flex items-baseline justify-between">
+          <div className="text-[11px] uppercase tracking-wider text-muted-foreground">Members</div>
+          <div className="text-[11px] text-muted-foreground">{data.members.length} total</div>
+        </div>
         <div className="space-y-2">
           {data.members.map((m) => (
             <Card key={m.id}>
               <CardContent className="flex flex-wrap items-center justify-between gap-3 p-3">
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-muted text-xs font-medium uppercase">{m.name.slice(0, 1)}</span>
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-muted text-xs font-semibold uppercase text-foreground/70">{m.name.slice(0, 1)}</span>
                   <div className="min-w-0">
                     <div className="flex items-center gap-1.5 text-sm font-medium">
                       <span className="truncate">{m.name}</span>
@@ -2493,7 +2515,7 @@ function TeamPage({ me }: { me: Member }) {
               {hint && <div className="font-mono text-xs text-destructive">{hint}</div>}
               {inviteLink && (
                 <div>
-                  <div className="mb-1 text-[11px] text-muted-foreground">Send this one-time link to the invitee:</div>
+                  <div className="mb-1 text-[11px] text-muted-foreground">Send this one-time link to the invitee — they confirm on a landing page, so link previews won't consume it:</div>
                   <CopyLink link={inviteLink} />
                 </div>
               )}
@@ -2506,18 +2528,38 @@ function TeamPage({ me }: { me: Member }) {
       {isAdmin && (
         <section>
           <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">Agent access</div>
-          <p className="mb-2 text-xs text-muted-foreground">Owners and admins can run every agent. Grant <strong>members</strong> access below — by role (all members) or individually.</p>
+          <p className="mb-3 text-xs text-muted-foreground">
+            Owners &amp; admins can run every agent. Grant <strong>members</strong> access per agent — toggle
+            <span className="mx-1 rounded bg-muted px-1 py-0.5 font-medium text-foreground">All members</span>
+            to open it to everyone, or pick people individually.
+          </p>
+          {data.agents.length === 0 && <div className="text-xs text-muted-foreground">No agents yet.</div>}
           <div className="space-y-2">
             {data.agents.map((a) => {
               const acc = access(a.id)
+              const allMembers = acc.allowedRoles.includes('member')
               return (
                 <Card key={a.id}>
-                  <CardContent className="flex flex-wrap items-center gap-2 p-3">
-                    <span className="mr-1 flex items-center gap-1.5 text-sm font-medium"><AgentIcon icon={a.icon} className="h-4 w-4 shrink-0 text-muted-foreground" />{a.id}<RuntimeBadge runtime={a.runtime} /></span>
-                    <Chip on={acc.allowedRoles.includes('member')} onClick={() => toggleRole(a.id, 'member')}>all members</Chip>
-                    {plainMembers.map((m) => (
-                      <Chip key={m.id} on={acc.allowedMembers.includes(m.id)} onClick={() => toggleMember(a.id, m.id)}>{m.name}</Chip>
-                    ))}
+                  <CardContent className="space-y-2.5 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <span className="flex items-center gap-1.5 text-sm font-medium"><AgentIcon icon={a.icon} className="h-4 w-4 shrink-0 text-muted-foreground" />{a.id}<RuntimeBadge runtime={a.runtime} /></span>
+                      <span className="text-[11px] text-muted-foreground">{accessSummary(a.id)}</span>
+                    </div>
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      <Chip on={allMembers} onClick={() => toggleRole(a.id, 'member')}>All members</Chip>
+                      <span className="mx-0.5 h-4 w-px bg-border" />
+                      {/* Owners/admins always have access — shown as static, non-toggle pills. */}
+                      {data.members.filter((m) => m.role !== 'member').map((m) => (
+                        <span key={m.id} title={`${m.role}s run every agent`} className="inline-flex items-center gap-1 rounded-full border border-dashed border-muted-foreground/30 px-2.5 py-0.5 text-xs text-muted-foreground">
+                          <Check className="h-3 w-3" />{m.name}
+                        </span>
+                      ))}
+                      {/* Plain members — individually assignable (or covered by "All members"). */}
+                      {plainMembers.map((m) => (
+                        <Chip key={m.id} on={allMembers || acc.allowedMembers.includes(m.id)} onClick={() => toggleMember(a.id, m.id)}>{m.name}</Chip>
+                      ))}
+                      {plainMembers.length === 0 && <span className="text-[11px] text-muted-foreground">No members to assign yet — invite one above.</span>}
+                    </div>
                   </CardContent>
                 </Card>
               )


### PR DESCRIPTION
## Why

Two user-reported breakages on the deployed instawp tenant:

1. **Invites fail with "invalid or expired"** for whoever gets invited.
2. **Can't assign agents to team members individually**, and the Team page needs a UI/UX pass.

## 1. Invites — root cause + fix

`GET /accept?token=…` was a **one-time token consumer**. Reproduced on the live jump-server: hitting the URL twice → 1st GET redirects & marks the invite accepted, 2nd GET → `/?login=invalid`. So any **link preview / unfurl / mail-security scanner** (Slack, WhatsApp, Outlook Safe-Links, Gmail's image proxy, corporate gateways) that fetches the pasted URL **burns the token before the human clicks** — hence the intermittent "expired". (The server-side accept path itself was fine; the flaw was consuming state on a bare GET.)

**Fix:** `/accept` is now a two-step landing.
- **`GET /accept`** → `peekToken` (side-effect-free) → renders a self-contained, theme-aware "Continue" confirm page.
- **`POST /accept`** (the button) → `acceptToken` consumes the token, mints the session.

Bots GET but don't POST, so previews can't burn the link; true one-time single-use semantics are preserved. Verified end-to-end against an isolated runtime:

```
GET #1 (prefetch):  200 landing, NOT consumed
GET #2:             200 landing, still valid
POST #1 (human):    302 → / + session cookie
POST #2 (reuse):    302 → /?login=invalid
```

## 2. Team page redesign + per-person assignment

Agent-access chips rendered only for `member`-role people (`plainMembers`), so a team of all-admins saw **no individual assignment at all**. Redesigned **Agent access**: every member is listed per agent — owners/admins as static *full-access* pills (they run everything by role), plain members individually toggleable, plus an **All members** toggle and a one-line "who can run this" summary. Also adds a roles legend and tidies the member cards.

## Test plan
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → 44/44 ✓
- Drove the real `/accept` flow (GET peeks, POST consumes) against an isolated `TenantRegistry` — all four cases as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)