### PR TITLE
Agents: agent discovery + delegation wiring (v0.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.29.0] — 2026-07-07
+
+### Added
+- **Agent discovery + delegation wiring — the fleet can hand work to the right peer instead of guessing.**
+  A new `list_agents` MCP tool (backed by `GET /api/agent/roster`) returns the other claude-code agents
+  in the workspace (id, description, category) so an agent can pick the right specialist to delegate to;
+  every session's company context now injects a **"Your fleet — who you can delegate to"** roster with
+  the `task_create({ assignee: "agent:<id>", autoDispatch: true })` hand-off pattern; and `task_create`
+  now **rejects an `agent:<id>` assignee that doesn't exist** (returning the valid roster) instead of
+  silently filing an inert task that never dispatches. Motivated by a 36-run primitive-use eval where
+  agents, told to hand work off, filed unassigned tasks (5/6) or shelled out to the filesystem to
+  discover peers; with this change delegation goes from 1/6 to 6/6 agents producing a dispatchable
+  hand-off, with no regression on the other primitives.
+
 ## [0.28.0] — 2026-07-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.28.0",
+      "version": "0.29.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.28.0",
+  "version": "0.29.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -347,6 +347,16 @@ const TOOLS = [
     },
   },
   {
+    name: 'list_agents',
+    description:
+      'List the OTHER agents in this workspace you can hand work to — the fleet roster. Returns each ' +
+      "agent's id, what it does, and its category, so you can pick the RIGHT specialist and delegate to " +
+      'it with task_create({ assignee: "agent:<id>", autoDispatch: true }). Use this before delegating ' +
+      'instead of guessing an id — a task assigned to a non-existent agent never runs. Read-only.',
+    annotations: { readOnlyHint: true },
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+  },
+  {
     name: 'check_inbox',
     description:
       'Read your own inbox feed for this session WITHOUT blocking — answers the operator gave to questions ' +
@@ -1033,6 +1043,20 @@ async function policyCheck(args: Record<string, unknown>): Promise<string> {
   return `NEEDS APPROVAL — "${capability}" would pause for ${d.level ?? 'human'} approval${why}.`;
 }
 
+async function listAgents(): Promise<string> {
+  const u = new URL(AOS_URL + '/api/agent/roster');
+  u.searchParams.set('session', SESSION);
+  const res = await fetch(u, { headers: H() });
+  const data = (await res.json()) as { agents?: Array<{ id: string; description: string; category?: string }>; error?: string };
+  if (data.error) return `Could not list agents: ${data.error}`;
+  const agents = data.agents ?? [];
+  if (!agents.length) return 'No other agents are available to delegate to.';
+  return (
+    'Fleet roster — delegate with task_create({ assignee: "agent:<id>", autoDispatch: true }):\n' +
+    agents.map((a) => `- agent:${a.id}${a.category ? ` (${a.category})` : ''} — ${a.description}`).join('\n')
+  );
+}
+
 async function directoryLookup(args: Record<string, unknown>): Promise<string> {
   const u = new URL(AOS_URL + '/api/agent/directory');
   u.searchParams.set('session', SESSION);
@@ -1099,6 +1123,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'list_capabilities' ? await listCapabilities()
         : name === 'policy_check' ? await policyCheck(args)
         : name === 'directory_lookup' ? await directoryLookup(args)
+        : name === 'list_agents' ? await listAgents()
         : name === 'check_inbox' ? await checkInbox(args)
         : name === 'artifacts_list' ? await artifactsList(args)
         : name === 'schedule' ? await schedule(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -337,6 +337,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     }));
     return sendJson(res, 200, { members });
   }
+  // Fleet roster — the OTHER agents this session can hand work to (the agent-discovery primitive backing
+  // `list_agents`). Session-secret gated like the other agent loopback routes; read-only. Excludes the
+  // caller and non-claude-code (mock) agents, so an agent only sees peers it can actually delegate to.
+  if (method === 'GET' && p === '/api/agent/roster') {
+    const session = url.searchParams.get('session') || '';
+    const self = tm.sessionAgent(session);
+    if (!self) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const agents = [...os.agents.values()]
+      .filter((a) => a.runtime === 'claude-code' && a.id !== self)
+      .map((a) => ({ id: a.id, description: a.description, category: a.category }));
+    return sendJson(res, 200, { agents });
+  }
   // Status line (the `statusline.js` bar in a governed claude TUI): live governance for THIS run —
   // how many approvals it's blocked on and which human identity it acts as. Session-secret gated like
   // the other agent loopback routes; read-only. Kept cheap: it's polled on the TUI refreshInterval.
@@ -707,12 +720,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     const title = String(b.title || '').trim();
     if (!title) return sendJson(res, 400, { error: 'title is required' });
+    // Resolve the assignee, then validate an `agent:<id>` target actually exists — a task assigned to a
+    // non-existent agent silently never dispatches (it just rots on the board), so reject it up front
+    // with the valid roster instead of accepting an inert hand-off.
+    const assignee = b.assignee === 'me' ? `agent:${agent}` : (typeof b.assignee === 'string' && b.assignee ? b.assignee : undefined);
+    if (assignee && assignee.startsWith('agent:')) {
+      const targetId = assignee.slice('agent:'.length);
+      if (!os.agents.get(targetId)) {
+        const valid = [...os.agents.values()].filter((a) => a.runtime === 'claude-code').map((a) => a.id).join(', ');
+        return sendJson(res, 200, { ok: false, error: `no agent "${targetId}" — assign to one of: ${valid} (call list_agents to see the roster)` });
+      }
+    }
     try {
       // owner defaults to the creating session's run-as member — HUMAN PASSTHROUGH: a task filed by an
       // agent acting as Alice dispatches (later) as Alice too, so accountability ladders to the person.
       const task = os.tasks.create({
         tenant: os.tenant, title, body: b.body !== undefined ? String(b.body) : '',
-        assignee: b.assignee === 'me' ? `agent:${agent}` : (typeof b.assignee === 'string' ? b.assignee : undefined),
+        assignee,
         owner: tm.sessionRunAs(session),
         priority: typeof b.priority === 'number' ? b.priority : undefined,
         labels: Array.isArray(b.labels) ? b.labels.map(String) : undefined,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -570,7 +570,7 @@ export class TerminalManager {
       const env = this.sessionEnv(id, agent, task, secret);
       // Build the per-session connector + company payloads once (Composio is minted here).
       const mcpJson = this.buildMcpConfigJson(id, agent, actingMember, secret, !!slack?.channel, !!discord?.channel);
-      const companyMd = this.buildCompanyMd();
+      const companyMd = this.buildCompanyMd(agent);
       this.materializeSkills(id, agent, manifest.dir);
       if (headless) env.HEADLESS = '1';
       env.AGENT_DIR = manifest.dir;
@@ -705,12 +705,27 @@ export class TerminalManager {
    *  We tack on OS-owned operating notes after the user's content. The terminal here is a browser
    *  xterm (over ttyd) running the TUI on the alternate screen with mouse reporting on, so embedded
    *  terminal hyperlinks (OSC 8) aren't clickable — the agent must surface raw URLs as plain text. */
-  private buildCompanyMd(): string {
+  private buildCompanyMd(selfAgent?: string): string {
     const company = this.os.settings.company().companyMd.trim();
     // Close the self-learning loop: the Dreamer's distilled guidance rides in every agent's prompt, so
     // the fleet's accumulated experience shapes each new session. Toggleable in Settings → Self-learning.
     const learned = this.os.settings.applyLearnings() ? this.os.settings.learnedGuidance().trim() : '';
-    return [company, AGENT_OS_OPERATING_NOTES, learned].filter(Boolean).join('\n\n');
+    // The fleet roster — WHO this agent can delegate to. Injected so "hand off to the right agent" is
+    // answerable straight from the prompt without a discovery round-trip (`list_agents` is the live
+    // equivalent). Excludes self and mock agents, so it only lists peers this agent can actually dispatch.
+    const roster = [...this.os.agents.values()]
+      .filter((a) => a.runtime === 'claude-code' && a.id !== selfAgent)
+      .map((a) => `- \`agent:${a.id}\`${a.category ? ` (${a.category})` : ''} — ${a.description}`)
+      .join('\n');
+    const fleet = roster
+      ? '# Your fleet — who you can delegate to\n\n' +
+        'These are the other agents in this workspace. To hand work to one, `task_create({ title, ' +
+        'assignee: "agent:<id>", autoDispatch: true })` — it spawns that agent as a governed run under ' +
+        'the same accountable human. Assign specialised work to the right agent rather than doing it ' +
+        'poorly yourself or filing an unassigned task (which nobody picks up).\n\n' +
+        roster
+      : '';
+    return [company, AGENT_OS_OPERATING_NOTES, fleet, learned].filter(Boolean).join('\n\n');
   }
 
   /**

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -79,7 +79,7 @@ rm -f .claude/settings.json
 cat > .claude/aos-settings.json <<JSON
 {
   "permissions": {
-    "allow": ["mcp__agentos__recall", "mcp__agentos__remember", "mcp__agentos__kb_search", "mcp__agentos__kb_read", "mcp__agentos__kb_write", "mcp__agentos__ask", "mcp__agentos__report", "mcp__agentos__publish", "mcp__agentos__list_capabilities", "mcp__agentos__policy_check", "mcp__agentos__directory_lookup", "mcp__agentos__task_create", "mcp__agentos__task_list", "mcp__agentos__task_get", "mcp__agentos__task_claim", "mcp__agentos__task_update"]$DENY_LINE
+    "allow": ["mcp__agentos__recall", "mcp__agentos__remember", "mcp__agentos__kb_search", "mcp__agentos__kb_read", "mcp__agentos__kb_write", "mcp__agentos__ask", "mcp__agentos__report", "mcp__agentos__publish", "mcp__agentos__list_capabilities", "mcp__agentos__policy_check", "mcp__agentos__directory_lookup", "mcp__agentos__list_agents", "mcp__agentos__task_create", "mcp__agentos__task_list", "mcp__agentos__task_get", "mcp__agentos__task_claim", "mcp__agentos__task_update"]$DENY_LINE
   },
   "hooks": {
     "PreToolUse": [


### PR DESCRIPTION
## Why

An empirical **36-run primitive-use eval** (6 fleet agents × 6 primitives, isolated scratch tenant, model held constant) found that agents use the *solo* primitives well (memory, KB, context, scheduling all ≈3.0) but **A2A delegation was the systemic floor (1.17/3)**: told to hand work to the right specialist agent,

- **5/6 agents filed inert *unassigned* tasks** → they never auto-dispatch,
- the 1/6 that delegated had to **shell out** (`ls` the agents dir + read peer `CLAUDE.md`) because `directory_lookup` returns humans only,
- there was **no agent-discovery primitive**, and `task_create` silently accepted a `agent:<id>` that doesn't exist (the exact footgun behind the stale `sales-agent`/`marketing-agent` names still in some prompts).

## What

- **`list_agents` MCP tool** + **`GET /api/agent/roster`** — returns the other claude-code agents (id, description, category) so an agent can pick the right specialist.
- **Fleet roster injected into every session's company context** — a "Your fleet — who you can delegate to" block with the `task_create({ assignee: "agent:<id>", autoDispatch: true })` hand-off pattern.
- **`task_create` validates `agent:<id>` assignees** — rejects a non-existent agent with the valid roster instead of filing a task that rots on the board.

## Measured lift (re-ran the full 36-run battery on this branch)

| | before | after |
|---|---|---|
| agents producing a **dispatchable** hand-off | 1/6 (via filesystem hack) | **6/6** |
| inert unassigned tasks | 5/6 | **0/6** |
| delegate score (0–3) | 1.17 | **≈2.8** |

Attribution: the injected roster alone fixed 3/6 (no tool call needed — incl. the 8-line `coding` stub); the other 3 additionally called `list_agents` to verify. **No regression** on the other five primitives (recall/KB/context/schedule/policy all held; a recall wobble was traced to pre-existing FTS query brittleness, not this diff — the memory replays fine via API and a second sample flipped back to pass). 0 errors across 36 runs. **Governance conformance 44/44.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)