### PR TITLE
Docs: dedicated "Automations" page in the in-console guide (v0.29.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.29.2] — 2026-07-07
+
+### Added
+- **Docs: a dedicated "Automations" page in the in-console Docs section.** The `/#/docs` guide now
+  has a full Automations page (between "Working with agents" and "Governance & approvals") covering the
+  five triggers (cron/webhook/Composio/Slack/Discord), how an automated run stays governed (provenance
+  vs. run-as, approvals still pause it), headless vs. interactive execution + the pile-up guard, the
+  no-automation-needed chat router, agent self-scheduling, and agent→agent delegation via auto-dispatch
+  tasks. Previously Automations only got a one-line mention in Core concepts and Working with agents.
+
 ## [0.29.1] — 2026-07-07
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.29.1",
+      "version": "0.29.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.29.1",
+  "version": "0.29.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/docs/automations.md
+++ b/web/src/docs/automations.md
@@ -1,0 +1,72 @@
+# Automations — starting work without a human
+
+Most runs start because *you* clicked Run or messaged an agent. **Automations** are standing rules
+that start a run when nobody's watching — on a schedule, on an inbound event, or on a chat message —
+while keeping every guardrail the console gives you. Manage them on the **Automations** page.
+
+An **Automation** is the rule; its **trigger** is what makes it fire. Agents answer *who does the
+work*; automations answer *when the work starts*.
+
+## The triggers
+
+| Trigger | Fires when… | Good for |
+|---|---|---|
+| **Schedule (cron)** | a time rolls around | nightly reports, hourly health checks, a Monday digest |
+| **Webhook** | an HTTP call hits its private URL | wiring up an external tool or a "when X happens in our app" hook |
+| **Composio** | a connected third-party app emits an event | reacting to Stripe, GitHub, a form, etc. via Composio |
+| **Slack message** | the bot is @mentioned or DM'd | "hey @AgentOS, /support look at this ticket" |
+| **Discord message** | the bot is @mentioned or DM'd | the same, in a Discord server or DM |
+
+Slack and Discord run over an **outbound** connection, so there's no public URL to expose — set the
+tokens once in **Settings → Integrations**. Webhooks get a secret URL (the key in the link *is* the
+auth); treat it like a password.
+
+## An automated run is still a governed run
+
+Firing an automation spawns a normal **session** — the same gateway, gate hook, approvals, budgets,
+and audit apply. Two identities are tracked:
+
+- **Provenance** — *the automation started this* (so you can trace it back to the rule).
+- **Run-as** — *whose identity it acts under*. A chat trigger runs **as the person who sent the
+  message** (matched via their Chat ID on the Team page); a schedule or webhook with no obvious
+  person runs as the **company** identity.
+
+So an unattended run can still hit a yellow/red action and **pause for approval** — the right person
+is pinged in the console and by Slack/Discord DM, and nothing happens until they decide.
+
+## Headless vs. interactive
+
+- **Headless** (default) — the agent runs to completion and exits, then the session goes idle. Best
+  for scheduled/triggered work you don't intend to watch. Risky actions are **still** gated and still
+  wait for approval; "headless" doesn't mean "ungoverned".
+- **Interactive** — keeps an attachable terminal you can jump into, like a console run.
+
+A **pile-up guard** stops a schedule from re-firing while its previous run is still alive, so a slow
+job never stacks copies of itself.
+
+## You don't need an automation to reach an agent
+
+If a Slack/Discord mention matches **no** automation, the bot still works: address any agent by name
+and it spawns a one-off run as you.
+
+```
+@AgentOS /support customer says checkout 500s on the annual plan
+```
+
+So the whole fleet is reachable out of the box — per-agent automations become optional shortcuts, not
+a requirement. (No name, or one that doesn't exist? The bot replies with the agents you can address.)
+
+## Agents scheduling themselves, and each other
+
+- **Deferred self-runs.** An agent can say "check this again in 2 hours" and schedule a future run of
+  itself. These are bounded (a floor and ceiling on the delay, a cap on how many can be pending) and
+  show up under Automations like any other rule.
+- **Delegation.** An agent hands work to another agent by filing a **Task** assigned to it with
+  auto-dispatch — the scheduler starts that agent when it picks the task up. The accountable human
+  carries through the hand-off. See **Memory, Knowledge & Tasks**.
+
+## Where to look when one fires
+
+Everything an automated run does lands in the same places as a console run: live under **Sessions**,
+progress and reports in your **Inbox**, deliverables under **Artifacts**, and every governed action in
+the **Audit** log. An automation is never a black box.

--- a/web/src/docs/index.ts
+++ b/web/src/docs/index.ts
@@ -5,6 +5,7 @@ import whatIsAgentOs from './what-is-agent-os.md?raw'
 import gettingStarted from './getting-started.md?raw'
 import coreConcepts from './core-concepts.md?raw'
 import workingWithAgents from './working-with-agents.md?raw'
+import automations from './automations.md?raw'
 import governance from './governance.md?raw'
 import sharedPlanes from './shared-planes.md?raw'
 
@@ -15,6 +16,7 @@ export const docPages: DocPage[] = [
   { slug: 'getting-started', title: 'Getting started', body: gettingStarted },
   { slug: 'core-concepts', title: 'Core concepts', body: coreConcepts },
   { slug: 'working-with-agents', title: 'Working with agents', body: workingWithAgents },
+  { slug: 'automations', title: 'Automations', body: automations },
   { slug: 'governance', title: 'Governance & approvals', body: governance },
   { slug: 'shared-planes', title: 'Memory, Knowledge & Tasks', body: sharedPlanes },
 ]


### PR DESCRIPTION
## What

Adds a dedicated **Automations** page to the in-console Docs section (the `/#/docs` route the user pointed at), registered in the nav between **Working with agents** and **Governance & approvals**.

Previously Automations only got a one-line mention in *Core concepts* and *Working with agents*. The new page covers:

- The five triggers — **cron / webhook / Composio / Slack / Discord** — with what each is good for.
- How an automated run stays **governed**: provenance vs. run-as, and that yellow/red actions still pause for approval even with no human at the start.
- **Headless vs. interactive** execution and the tmux **pile-up guard**.
- The **chat router** fallback — the fleet is reachable by name without any automation.
- Agents **scheduling themselves** and **delegating** via auto-dispatch tasks.

Matches the existing docs' concise, conceptual voice; no reference-dump.

## Notes

- Docs-only + one nav registration (`web/src/docs/index.ts`). `web && npm run build` passes.
- Patch version bump 0.29.0 → **0.29.1**, CHANGELOG entry moved under the new heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)