### PR TITLE
Automations: cron schedule presets + fix Select label display (v0.30.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.30.0] — 2026-07-07
+
+### Added
+- **Cron automations now offer schedule presets — no cron expression required.** The New-automation
+  **Schedule** field is a dropdown of common cadences (every 15/30 min, hourly, every 6h, daily at
+  midnight/9 AM, weekdays at 9 AM, Mondays, first of the month), with a **Custom cron expression…**
+  option that reveals the raw 5-field input for advanced schedules. The backend is unchanged — each
+  preset just sets the same cron string, still validated by `parseCron()`.
+
+### Fixed
+- **Dropdowns now show the selected option's label, not its raw value.** Base UI's `Select.Value`
+  renders the underlying value unless the root is given an `items` (value → label) map, so any select
+  whose value differed from its label (Trigger showed `cron` instead of *Schedule (cron)*; Priority,
+  Assignee, Run-mode, and the Audit type filter likewise) displayed the wrong text in the collapsed
+  trigger. Added `items` maps across the affected selects in the console.
+
 ## [0.29.2] — 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.29.2",
+      "version": "0.30.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.29.2",
+  "version": "0.30.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2579,6 +2579,8 @@ const TASK_COLUMNS: { status: TaskStatus; label: string }[] = [
   { status: 'done', label: 'Done' },
 ]
 const PRIORITY_LABEL = ['Urgent', 'High', 'Normal', 'Low']
+// Base UI's Select.Value shows the raw value unless the root gets an items map (value → label).
+const PRIORITY_ITEMS: Record<string, string> = Object.fromEntries(PRIORITY_LABEL.map((l, i) => [String(i), l]))
 const priorityTone = (p: number) => ['text-red-600', 'text-amber-600', 'text-muted-foreground', 'text-muted-foreground/70'][p] ?? 'text-muted-foreground'
 
 function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; onOpen: (tmux: string, title: string) => void }) {
@@ -2654,7 +2656,7 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
             <Field label="Details"><Textarea value={body} onChange={(e) => setBody(e.target.value)} rows={3} placeholder="Context, acceptance criteria — enough for whoever works it." /></Field>
             <div className="grid grid-cols-3 gap-3">
               <Field label="Assign to">
-                <Select value={assignee || 'none'} onValueChange={(v) => setAssignee(!v || v === 'none' ? '' : v)}>
+                <Select items={[{ value: 'none', label: 'Unassigned' }, ...chatAgents.map((a) => ({ value: `agent:${a.id}`, label: `agent · ${a.id}` }))]} value={assignee || 'none'} onValueChange={(v) => setAssignee(!v || v === 'none' ? '' : v)}>
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="none">Unassigned</SelectItem>
@@ -2663,7 +2665,7 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
                 </Select>
               </Field>
               <Field label="Priority">
-                <Select value={String(priority)} onValueChange={(v) => v && setPriority(Number(v))}>
+                <Select items={PRIORITY_ITEMS} value={String(priority)} onValueChange={(v) => v && setPriority(Number(v))}>
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>{PRIORITY_LABEL.map((l, i) => <SelectItem key={i} value={String(i)}>{l}</SelectItem>)}</SelectContent>
                 </Select>
@@ -2677,7 +2679,7 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
             </div>
             {assignee.startsWith('agent:') && (
               <Field label="Run mode">
-                <Select value={mode} onValueChange={(v) => v && setMode(v as 'headless' | 'interactive')}>
+                <Select items={{ headless: 'Headless — works to completion, then exits', interactive: 'Interactive — attachable TUI you can watch/drive' }} value={mode} onValueChange={(v) => v && setMode(v as 'headless' | 'interactive')}>
                   <SelectTrigger className="w-56"><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="headless">Headless — works to completion, then exits</SelectItem>
@@ -2745,14 +2747,14 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
                   </Select>
                 </Field>
                 <Field label="Priority">
-                  <Select value={String(detail.task.priority)} onValueChange={(v) => v && patch(detail.task.id, { priority: Number(v) })}>
+                  <Select items={PRIORITY_ITEMS} value={String(detail.task.priority)} onValueChange={(v) => v && patch(detail.task.id, { priority: Number(v) })}>
                     <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
                     <SelectContent>{PRIORITY_LABEL.map((l, i) => <SelectItem key={i} value={String(i)}>{l}</SelectItem>)}</SelectContent>
                   </Select>
                 </Field>
               </div>
               <Field label="Assignee">
-                <Select value={detail.task.assignee || 'none'} onValueChange={(v) => patch(detail.task.id, { assignee: !v || v === 'none' ? null : v })}>
+                <Select items={[{ value: 'none', label: 'Unassigned' }, ...chatAgents.map((a) => ({ value: `agent:${a.id}`, label: `agent · ${a.id}` })), ...(detail.task.assignee && !detail.task.assignee.startsWith('agent:') ? [{ value: detail.task.assignee, label: detail.task.assignee }] : [])]} value={detail.task.assignee || 'none'} onValueChange={(v) => patch(detail.task.id, { assignee: !v || v === 'none' ? null : v })}>
                   <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="none">Unassigned</SelectItem>
@@ -2763,7 +2765,7 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
               </Field>
               {(detail.task.assignee || '').startsWith('agent:') && (
                 <Field label="Run mode">
-                  <Select value={detail.task.mode} onValueChange={(v) => v && patch(detail.task.id, { mode: v as 'headless' | 'interactive' })}>
+                  <Select items={{ headless: 'Headless — runs to completion, then exits', interactive: 'Interactive — attachable TUI you drive' }} value={detail.task.mode} onValueChange={(v) => v && patch(detail.task.id, { mode: v as 'headless' | 'interactive' })}>
                     <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="headless">Headless — runs to completion, then exits</SelectItem>
@@ -2991,7 +2993,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
                   </Select>
                 </Field>
                 <Field label="Run mode" help={mode === 'headless' ? 'Headless: runs to completion and exits — unattended-correct.' : 'Interactive: attachable TUI that stays open until you close it.'}>
-                  <Select value={mode} onValueChange={(v) => v && setMode(v as 'interactive' | 'headless')}>
+                  <Select items={{ headless: 'Headless (recommended)', interactive: 'Interactive' }} value={mode} onValueChange={(v) => v && setMode(v as 'interactive' | 'headless')}>
                     <SelectTrigger><SelectValue /></SelectTrigger>
                     <SelectContent>
                       <SelectItem value="headless">Headless (recommended)</SelectItem>
@@ -4539,7 +4541,7 @@ function AuditPage() {
       </p>
       <div className="flex flex-wrap items-end gap-2">
         <Field label="Type">
-          <Select value={type || '__all'} onValueChange={(v) => { const t = !v || v === '__all' ? '' : v; setType(t); load({ type: t }) }}>
+          <Select items={[{ value: '__all', label: 'All types' }, ...types.map((t) => ({ value: t, label: t }))]} value={type || '__all'} onValueChange={(v) => { const t = !v || v === '__all' ? '' : v; setType(t); load({ type: t }) }}>
             <SelectTrigger className="h-8 w-56"><SelectValue /></SelectTrigger>
             <SelectContent>
               <SelectItem value="__all">All types</SelectItem>


### PR DESCRIPTION
## What

**Cron presets.** The New-automation **Schedule** field is now a dropdown of common cadences instead of a bare cron text box:

- Every 15 / 30 minutes
- Every hour · Every 6 hours
- Every day at midnight · at 9:00 AM
- Weekdays at 9:00 AM · Every Monday at 9:00 AM · First of the month at 9:00 AM
- **Custom cron expression…** — reveals the original monospace 5-field input for advanced schedules

Frontend-only: each preset just sets the same `schedule` string the form already submitted; the backend `parseCron()` still validates on create/update. Default (`*/30 * * * *`) unchanged.

**Select label fix.** While adding the preset dropdown, the automation **Trigger** select surfaced a latent bug — Base UI's `Select.Value` renders the raw *value*, not the chosen option's label, unless the root is given an `items` (value → label) map. So the collapsed trigger showed `cron` while the open list showed *Schedule (cron)*.

Swept every `Select` in `web/src/App.tsx` and added `items` maps to the ones where value ≠ label:
- automation **Trigger** and new **Schedule** presets
- Create-task & task-detail **Priority**, **Assignee**, **Run mode**
- New-automation **Run mode**
- Audit **Type** filter

Left as-is where value already equals the shown text (roles, task status, automation-card mode) and the agent pickers (collapsed already shows the correct agent id; `items` would pull the icon/badge into the trigger and change layout).

## Test
- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 44/44 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)