### PR TITLE
Agents: inject the team roster into every session's context (v0.31.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.31.0] — 2026-07-07
+
+### Added
+- **Agents now see the team roster in their prompt — the human counterpart of the fleet roster.** Every
+  session's company context gains a **"Your team — the people in this workspace"** block listing each
+  member's name, role (owner/admin/member → who can approve what), email, and any linked Slack/Discord
+  identities, so an agent can loop in the right person via `ask` without a `directory_lookup` round-trip.
+  Capped at 30 members — past that it stays tool-only (a one-line pointer to `directory_lookup`) so a
+  large org doesn't bloat every prompt. Mirrors the agent-roster injection from v0.29.0.
+
 ## [0.30.0] — 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.30.0",
+      "version": "0.31.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.30.0",
+  "version": "0.31.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -725,7 +725,30 @@ export class TerminalManager {
         'poorly yourself or filing an unassigned task (which nobody picks up).\n\n' +
         roster
       : '';
-    return [company, AGENT_OS_OPERATING_NOTES, fleet, learned].filter(Boolean).join('\n\n');
+    // The team roster — WHO this agent works for and with. Injected so an agent can loop in the right
+    // person (roles set who can approve what) without a `directory_lookup` round-trip. Capped: past a
+    // small team it stays tool-only, so a big org doesn't bloat every prompt.
+    const members = this.os.team.listMembers();
+    const TEAM_CAP = 30;
+    const teamList = members.length && members.length <= TEAM_CAP
+      ? members
+          .map((m) => {
+            const ids = this.os.team.externalIdsFor(m.id).map((i) => `${i.provider}:${i.externalId}`).join(', ');
+            return `- ${m.name} (${m.role}) — ${m.email}${ids ? ` — ${ids}` : ''}`;
+          })
+          .join('\n')
+      : '';
+    const team = teamList
+      ? '# Your team — the people in this workspace\n\n' +
+        'The humans you work for and with. Roles set who can approve what: **owner** approves anything, ' +
+        '**admin** approves most, **member** runs only assigned agents. Use `ask` to get a decision or ' +
+        'sign-off from the right person; `directory_lookup` returns this same list with more on how to ' +
+        'reach each one (Slack/Discord/email).\n\n' +
+        teamList
+      : members.length > TEAM_CAP
+        ? `# Your team\n\n${members.length} people are on the team — use \`directory_lookup\` to find someone by name or email.`
+        : '';
+    return [company, AGENT_OS_OPERATING_NOTES, fleet, team, learned].filter(Boolean).join('\n\n');
   }
 
   /**


### PR DESCRIPTION
## Why

Follow-up to the v0.29.0 **fleet-roster** injection. Agents could already look up humans via the `directory_lookup` tool, but — unlike the agent roster — the *team* wasn't ambient in the prompt. This adds the symmetric human roster so an agent knows who it works for/with (and who can approve what) without a tool round-trip.

## What

`buildCompanyMd` now appends a **"Your team — the people in this workspace"** block:

```
# Your team — the people in this workspace

The humans you work for and with. Roles set who can approve what: **owner** approves anything,
**admin** approves most, **member** runs only assigned agents. Use `ask` to get a decision or
sign-off from the right person; `directory_lookup` returns this same list with more on how to
reach each one (Slack/Discord/email).

- alice (admin) — alice@instapods.com
- bob (member) — bob@instapods.com
```

- Lists each member: name, **role** (so the agent knows who can approve), email, and any linked Slack/Discord ids.
- **Capped at 30 members** — past that it degrades to a one-line pointer to `directory_lookup`, so a large org doesn't bloat every prompt.

## Verification

Rendered the block through the real `buildCompanyMd` against an isolated home (output above is the actual render). Typecheck clean, build clean, **governance conformance 44/44**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)