### PR TITLE
Agents: duplicate an agent — deep-copy a definition under a new id (v0.32.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.32.0] — 2026-07-07
+
+### Added
+- **Duplicate an agent — deep-copy a definition under a new id.** The Agents page gains a **Copy**
+  action (owner/admin, any claude-code agent) that clones the whole agent folder (`agent.json` +
+  `CLAUDE.md` + any sibling files) into `<home>/agents/<new-id>/`, rewriting `id`/`principal` from
+  the authoritative in-memory manifest. The clone is a **fresh** agent with its own id, so none of
+  the source's runtime history rides along (no memories, sessions, assignments, automations, skill
+  scoping, artifacts, audit) — which is exactly why duplicate is the safe answer to "rename an
+  agent" (a new id owns new references instead of orphaning the old ones). The **source** may be a
+  read-only bundled example — a clean way to customise a built-in — while only the **destination**
+  must live under the data home. New `POST /api/agents/:id/duplicate` route (admin-gated), audited
+  as `agent.duplicated`.
+
 ## [0.31.0] — 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.31.0",
+      "version": "0.32.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1504,6 +1504,37 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, ...diff });
   }
 
+  // ── duplicate an agent: deep-copy its folder under a NEW id — owner/admin only ──
+  //    A clone is a FRESH agent (its own id + `svc-<id>` principal), so it starts clean: none of
+  //    the source's runtime history rides along (no memories, sessions, assignments, automations,
+  //    skill scoping, artifacts, audit). That's the whole point of duplicate vs. an id-rename — a
+  //    new id owns new references instead of orphaning the old ones. The SOURCE may be a built-in
+  //    example (customise a read-only bundled agent); only the DESTINATION must live under the data
+  //    home. Everything in the folder (agent.json + CLAUDE.md + any sibling files) is copied, then
+  //    agent.json is rewritten with the new id/principal from the authoritative in-memory manifest.
+  const agentDup = p.match(/^\/api\/agents\/([\w.-]+)\/duplicate$/);
+  if (method === 'POST' && agentDup) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (!os.paths) return sendJson(res, 400, { error: 'duplicating agents requires a data home' });
+    const b = await readBody(req);
+    const srcId = agentDup[1];
+    const src = os.agents.get(srcId);
+    if (!src?.dir) return sendJson(res, 404, { error: `unknown agent "${srcId}"` });
+    if (src.runtime !== 'claude-code') return sendJson(res, 400, { error: 'only claude-code agents can be duplicated' });
+    const newId = String(b.newId || `${srcId}-copy`).trim().toLowerCase();
+    if (!/^[a-z][a-z0-9-]{1,39}$/.test(newId)) return sendJson(res, 400, { error: 'id must be lowercase letters, digits and hyphens (2–40 chars, starting with a letter)' });
+    if (os.agents.get(newId)) return sendJson(res, 409, { error: `an agent named "${newId}" already exists` });
+    const folder = path.join(os.paths.userAgents, newId);
+    if (fs.existsSync(folder)) return sendJson(res, 409, { error: `folder "${newId}" already exists in the agents home` });
+    fs.cpSync(src.dir, folder, { recursive: true });
+    const next: AgentManifest = { ...src, id: newId, principal: `svc-${newId}` };
+    const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
+    fs.writeFileSync(path.join(folder, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
+    os.registerAgent({ ...next, dir: folder });
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.duplicated', data: { agent: newId, from: srcId, dir: folder } });
+    return sendJson(res, 200, { ok: true, id: newId });
+  }
+
   // ── delete a user-created agent: deregister + remove its folder — owner/admin only ──
   //    Only agents that live UNDER the data home can be deleted; the bundled examples that
   //    ship with the software are read-only (they'd reappear on restart anyway).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -438,6 +438,14 @@ function Console({ me }: { me: Member }) {
     if (r.error) { alert(r.error); return }
     await refreshState()
   }
+  const duplicateAgent = async (id: string) => {
+    const newId = prompt(`Duplicate "${id}" as a new agent. Enter an id for the copy:`, `${id}-copy`)
+    if (newId == null) return
+    const r = await api.duplicateAgent(id, newId.trim().toLowerCase())
+    if (r.error || !r.id) { alert(r.error ?? 'could not duplicate agent'); return }
+    await refreshState()
+    openAgent(r.id) // jump into the clone's settings to tweak it
+  }
   const openAgent = (id: string) => nav('agent', id)
   // Sync the registry with the agents folder on disk — picks up folders added/edited/removed
   // outside the console (git pull, scp, another agent) without a server restart.
@@ -690,7 +698,7 @@ function Console({ me }: { me: Member }) {
         </div>
 
         <div className={`min-h-0 flex-1 ${fullBleed ? '' : 'overflow-y-auto p-6'}`}>
-          {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onRescan={rescanAgents} />}
+          {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onDuplicate={duplicateAgent} onRescan={rescanAgents} />}
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); openAgent(id) }} />}
           {route === 'sessions' && <SessionsPage sessions={sessions} waiting={waiting} selected={selected} onOpen={openTerminal} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} />}
@@ -732,7 +740,7 @@ function NavItem({ icon, label, active, badge, onClick }: { icon: ReactNode; lab
  *  Settings (CLAUDE.md + runtime), delete it, or create a new one — all the catalog actions,
  *  just scoped to the chosen agent instead of a grid of cards. */
 function AgentsPage({
-  me, agents, selected, onSelect, run, onEdit, onNew, onDelete, onRescan,
+  me, agents, selected, onSelect, run, onEdit, onNew, onDelete, onDuplicate, onRescan,
 }: {
   me: Member
   agents: AgentInfo[]
@@ -742,6 +750,7 @@ function AgentsPage({
   onEdit: (id: string) => void
   onNew: () => void
   onDelete: (id: string) => void
+  onDuplicate: (id: string) => void
   onRescan: () => Promise<void>
 }) {
   const canEdit = me.role === 'owner' || me.role === 'admin'
@@ -829,6 +838,11 @@ function AgentsPage({
           {canEdit && agent.runtime === 'claude-code' && (
             <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0 text-muted-foreground" onClick={() => onEdit(agent.id)} title="agent settings — runtime tuning, starter prompts, CLAUDE.md">
               <SlidersHorizontal className="h-4 w-4" />
+            </Button>
+          )}
+          {canEdit && agent.runtime === 'claude-code' && (
+            <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0 text-muted-foreground" onClick={() => onDuplicate(agent.id)} title="duplicate agent — deep-copy its definition under a new id (fresh, no history carried over)">
+              <Copy className="h-4 w-4" />
             </Button>
           )}
           {canEdit && agent.deletable && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -690,6 +690,7 @@ export const api = {
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),
+  duplicateAgent: (id: string, newId: string) => call<{ ok: boolean; id?: string; error?: string }>('POST', `/api/agents/${encodeURIComponent(id)}/duplicate`, { newId }),
   rescanAgents: () => call<{ ok: boolean; added: string[]; updated: string[]; removed: string[]; errors: { folder: string; error: string }[]; error?: string }>('POST', '/api/agents/rescan'),
   agentClaude: (id: string) => call<{ agent: string; runtime: string; exists: boolean; content: string; error?: string }>('GET', `/api/agents/${encodeURIComponent(id)}/claude`),
   saveAgentClaude: (id: string, content: string) => call<{ ok: boolean; error?: string }>('PUT', `/api/agents/${encodeURIComponent(id)}/claude`, { content }),


### PR DESCRIPTION
## What

Adds **Duplicate agent** — a Copy action on the Agents page (owner/admin, any claude-code agent) that deep-copies an agent's whole folder (`agent.json` + `CLAUDE.md` + any sibling files) into `<home>/agents/<new-id>/`, rewriting `id`/`principal` from the authoritative in-memory manifest.

## Why

Came out of a "can I rename an agent's id?" question. The id is a soft foreign key spread across ~14 DB columns plus `agent:<id>` / `svc-<id>` / `chat:<id>` prefixes, with no rename primitive and no cascade — a bare rename orphans assignments, automations, memories, secrets, skill scoping, tasks, artifacts and audit. **Duplicate sidesteps all of that**: the clone is a fresh agent with its own id, so new references attach to the new id instead of orphaning the old ones. None of the source's runtime history rides along (no memories, sessions, assignments, automations, skill scoping, artifacts, audit) — a clone starts clean.

Bonus: the **source** may be a read-only bundled example, so this doubles as a clean way to customise a built-in agent; only the **destination** must live under the data home.

## Changes

- `POST /api/agents/:id/duplicate` (admin-gated) — deep-copy via `fs.cpSync`, rewrite `agent.json`, `registerAgent`, audit `agent.duplicated`. Default new id is `<id>-copy`.
- `api.duplicateAgent(id, newId)` client method.
- Agents page: **Copy** button in the composer action row (next to Edit/Delete); prompts for the new id, then jumps into the clone's settings.

## Verification

- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` (44/44) all pass.
- Isolated in-process server test (ephemeral `AGENT_OS_HOME`) drives the real HTTP route with an owner cookie — 14/14 checks: happy path, registry + on-disk `agent.json` id/principal rewrite, `dir` not persisted, CLAUDE.md + sibling-file deep copy, source untouched, default `<id>-copy`, collision 409, bad-id 400, unknown-source 404, unauthenticated 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Gi4VvZ9agC9kWoL13tXMp