### PR TITLE
Terminal: auto-reconnect the browser terminal instead of dying on a dropped WebSocket (v0.32.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.32.1] — 2026-07-07
+### Fixed
+- **Browser terminal: auto-reconnect instead of dying on a dropped WebSocket.** ttyd was launched with
+  `disableReconnect=true` (both the per-tenant shared terminal and the Phase-A per-member terminal), so a
+  transient WebSocket blip — laptop sleep, a network hiccup, or CPU starvation on a small box — blanked the
+  terminal permanently until a full page reload, which reads as "the session got killed" even though the
+  tmux-backed agent keeps running. Now reconnect is enabled and ttyd sends a keepalive ping every 30s, so
+  the terminal re-attaches to the live session after a blip (the backend already supports resuming claude
+  in-place on reconnect).
+
 ## [0.32.0] — 2026-07-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.32.0",
+      "version": "0.32.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/launcher.ts
+++ b/src/edge/launcher.ts
@@ -459,7 +459,10 @@ export class LauncherDaemon {
       ...setenv,
       '--',
       'ttyd', '-p', String(port), '-i', '127.0.0.1', '-b', `/terminal/${member}`, '-a', '-W',
-      '-t', 'disableReconnect=true', '-t', 'disableLeaveAlert=true', '-t', 'fontSize=14',
+      // Ping to keep the WS alive through idle proxies, and auto-reattach after a dropped socket — the
+      // tmux session persists so reconnect re-attaches to the live session. See the matching rationale in
+      // tenant-registry.launchTtyd: disableReconnect made a transient blip blank the terminal permanently.
+      '-P', '30', '-t', 'disableReconnect=false', '-t', 'disableLeaveAlert=true', '-t', 'fontSize=14',
       'tmux', '-S', this.sock(member), 'attach', '-t',
     ]);
     return r.ok ? { ok: true, uid: ensured.uid } : { ok: false, error: `ttyd start failed: ${r.err}` };

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -231,7 +231,12 @@ export function launchTtyd(tmuxSocket: string, ttydPort: number, sessionDir: str
     const child = spawn(
       'ttyd',
       ['-p', String(ttydPort), '-i', '127.0.0.1', '-b', '/terminal', '-a', '-W',
-       '-t', 'disableReconnect=true', '-t', 'disableLeaveAlert=true', '-t', 'fontSize=14',
+       // Keep the WS alive through idle proxies (nginx/the app proxy) and auto-reattach after a blip:
+       // the tmux session persists, so on reconnect ttyd re-attaches to the live session (the backend
+       // even resumes claude in-place — see terminal.ts). Leaving disableReconnect on meant a single
+       // dropped socket (laptop sleep, network hiccup, CPU starvation) blanked the terminal until a full
+       // page reload, which reads as "the session got killed" even though the agent is still running.
+       '-P', '30', '-t', 'disableReconnect=false', '-t', 'disableLeaveAlert=true', '-t', 'fontSize=14',
        // Pass-through xterm.js option: while claude has mouse events active (we keep the wheel for
        // in-app scroll via CLAUDE_CODE_DISABLE_MOUSE_CLICKS), xterm.js disables selection unless the
        // user holds the force-selection modifier — on macOS that's Option, and ONLY when this option


### PR DESCRIPTION
## Problem
The browser terminal (ttyd) was launched with **`disableReconnect=true`** in both spots — the per-tenant shared terminal (`tenant-registry.launchTtyd`) and the Phase-A per-member terminal (`launcher.ttydUp`). So a transient WebSocket drop — laptop sleep, a network hiccup, or **CPU starvation on a small box** — blanked the terminal permanently until a full page reload. Because the tmux-backed agent keeps running underneath, this reads to the user as **"the session got killed"** when nothing actually died.

Observed on the expresstech deployment (1-vCPU droplet): sessions recorded `session.ended` with `episode.stored outcome:"success"` — i.e. they completed — while the operator saw the terminal die. Confirmed via cgroup `oom_kill` counters all 0 (not a memory kill).

## Fix
- `disableReconnect=false` → ttyd auto-reattaches after a dropped socket. The tmux session persists, so reconnect re-attaches to the live session (the backend already resumes claude in-place on reconnect — see `terminal.ts`).
- `-P 30` → 30s keepalive ping so idle WebSockets aren't dropped by nginx / the app proxy.

## Test
- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run test:governance` → 44/44 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)