### PR TITLE
CLI: tenant remove respects AGENT_OS_TENANT, not just cfg.tenant (v0.32.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.32.2] — 2026-07-07
+### Fixed
+- **`agent-os tenant remove` now respects `AGENT_OS_TENANT`.** The remove guard (and the login-URL
+  branch) compared the slug against `cfg.tenant` only, while `TenantRegistry` resolves the default/apex as
+  `AGENT_OS_TENANT || cfg.tenant`. In a process-per-tenant deployment that overrides the seed (e.g.
+  `AGENT_OS_TENANT=expresstech` with a config default of `instapods`), this got it backwards: the CLI
+  refused to remove the stale config-default tenant and would have guarded the wrong (real apex) one. Both
+  now resolve the default the same way as the registry.
+
 ## [0.32.1] — 2026-07-07
 ### Fixed
 - **Browser terminal: auto-reconnect instead of dying on a dropped WebSocket.** ttyd was launched with

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.32.1",
+      "version": "0.32.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.32.1",
+  "version": "0.32.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -128,8 +128,13 @@ function tenants(rest: string[]): void {
   const cfg = readRootConfig(configPath, baseDir);
   const store = new TenantStore(path.join(controlHome(baseDir, cfg), 'control.db'));
   const port = Number(process.env.PORT) || 3010;
+  // Resolve the default/apex slug the SAME way TenantRegistry does (AGENT_OS_TENANT overrides the config
+  // `tenant`). In process-per-tenant with an override (e.g. AGENT_OS_TENANT=expresstech), the apex is the
+  // override, not cfg.tenant — so a stale cfg-default tenant left in the control plane must be removable,
+  // and the real apex must be the one that's guarded. Comparing against cfg.tenant alone got this backwards.
+  const defaultTenant = process.env.AGENT_OS_TENANT || cfg.tenant;
   const loginUrl = (slug: string, token: string): string =>
-    slug === cfg.tenant
+    slug === defaultTenant
       ? `http://localhost:${port}/accept?token=${token}`
       : cfg.baseDomain
         ? `https://${slug}.${cfg.baseDomain}/accept?token=${token}`
@@ -181,7 +186,7 @@ function tenants(rest: string[]): void {
       process.exitCode = 1;
       return;
     }
-    if (slug === cfg.tenant) {
+    if (slug === defaultTenant) {
       console.log('cannot remove the default tenant.');
       process.exitCode = 1;
       return;


### PR DESCRIPTION
## Problem
`agent-os tenant` resolved the default/apex tenant as **`cfg.tenant`** (the config-file value) in both the `remove` guard and the login-URL branch, but `TenantRegistry` resolves it as **`process.env.AGENT_OS_TENANT || cfg.tenant`**.

In a process-per-tenant deployment that overrides the seed — e.g. `AGENT_OS_TENANT=expresstech` with a config default of `instapods` — this got it backwards:
- `tenant remove instapods` (the stale config-default, now just a nested tenant) was **refused** with "cannot remove the default tenant."
- The real apex (`expresstech`) would **not** have been guarded.

Hit live on the expresstech deployment when trying to drop a leftover `instapods` tenant.

## Fix
Resolve `defaultTenant = process.env.AGENT_OS_TENANT || cfg.tenant` once and use it for both the remove guard and the login-URL host — matching `TenantRegistry.defaultSlug`.

## Test
- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run test:governance` → 44/44 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)