### PR TITLE
Sessions: an Activity view — see which agent-os primitives a run used (v0.34.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.34.0] — 2026-07-08
+### Added
+- **Session activity — see which agent-os primitives a run used, visually.** Every session card (grid +
+  list) grows an **Activity** button that opens a modal timeline built from the run's audit stream:
+  grouped counts (`Bash ×12 · remember ×3 · ask ×1 · report ×1`) over a chronological feed, each event
+  classified into its OS plane (governed action · operator · memory · knowledge · tasks · scheduling ·
+  agents · approval) with the gate's `allow`/`approve`/`deny` verdict shown as a badge. Backed by a new
+  `GET /api/sessions/:id/activity` route (gated by `canViewSession`, so a member sees the activity of the
+  runs they can attach to — not just owner/admin). Classification lives in a pure, testable
+  `src/state/session-activity.ts`; session plumbing (lifecycle, paired gate halves, secret/skill
+  materialisation) is filtered out so the feed reads as intent, and the one un-audited primitive
+  (progress `update`s) is folded in from the inbox so the timeline is complete. Read-only tools (`recall`,
+  searches, inbox checks) leave no audit trace and so don't appear — called out in the empty state.
+
 ## [0.33.0] — 2026-07-08
 ### Added
 - **Docs: "Import into AOS" console page** — a master-prompt guide for bringing an agent over from

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.33.0",
+      "version": "0.34.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.33.0",
+  "version": "0.34.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -14,6 +14,7 @@ import { TenantRegistry, TenantRuntime } from './tenant-registry';
 import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
 import { TerminalManager, AGENT_OS_OPERATING_NOTES } from './terminal';
+import { classifyActivity, clipText, ActivityCategory, ActivityEffect } from './state/session-activity';
 import { Automation, Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
@@ -1096,6 +1097,41 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!os.team.canRun(me, agent)) return sendJson(res, 403, { error: `you are not assigned to run "${agent}"` });
     const s = tm.createSession(agent, String(b.title || task), task, me.id);
     return sendJson(res, 200, { id: s.id, tmux: s.tmux });
+  }
+  // Session activity: "which agent-os primitives did this run use?" — the session's audit stream,
+  // classified into a chronological timeline + a grouped count summary. Same visibility as the terminal
+  // (canViewSession), so a member sees the activity of the runs they can attach to, not just admins.
+  const activityMatch = p.match(/^\/api\/sessions\/([\w-]+)\/activity$/);
+  if (method === 'GET' && activityMatch) {
+    const id = activityMatch[1];
+    const agent = tm.sessionAgent(id);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to view this session' });
+    const rows = os.db
+      .prepare('SELECT ts, type, data FROM audit_events WHERE tenant = ? AND run_id = ? ORDER BY ts ASC, id ASC')
+      .all<{ ts: number; type: string; data: string }>(os.tenant, id);
+    type Row = { ts: number; category: ActivityCategory; primitive: string; summary: string; effect?: ActivityEffect };
+    const events: Row[] = [];
+    for (const r of rows) {
+      const d = classifyActivity(r.type, safeJson(r.data));
+      if (d) events.push({ ts: r.ts, ...d });
+    }
+    // Progress `update`s are the one primitive not audited (they only write an inbox message) — fold
+    // them in so the timeline is complete.
+    const ups = os.db
+      .prepare("SELECT created_at AS ts, body FROM messages WHERE session_id = ? AND type = 'update' ORDER BY created_at ASC")
+      .all<{ ts: number; body: string }>(id);
+    for (const u of ups) events.push({ ts: u.ts, category: 'operator', primitive: 'update', summary: clipText(u.body) });
+    events.sort((a, b) => a.ts - b.ts);
+    // Grouped count summary (primitive → how many times), most-used first.
+    const byPrim = new Map<string, { primitive: string; category: ActivityCategory; count: number }>();
+    for (const e of events) {
+      const cur = byPrim.get(e.primitive) ?? { primitive: e.primitive, category: e.category, count: 0 };
+      cur.count += 1;
+      byPrim.set(e.primitive, cur);
+    }
+    const summary = [...byPrim.values()].sort((a, b) => b.count - a.count || a.primitive.localeCompare(b.primitive));
+    return sendJson(res, 200, { events, summary, total: events.length });
   }
   // Prepare a browser attach: authz, then (under the flag) ensure the member's ttyd is up. Returns
   // the iframe URL — the shared /terminal/?arg=… (flag off) or per-member /terminal/<space>/?arg=… (on).

--- a/src/state/session-activity.ts
+++ b/src/state/session-activity.ts
@@ -1,0 +1,140 @@
+/**
+ * Session activity — turn a run's raw audit stream into the human question "which agent-os primitives
+ * did this session use?". Pure classification (audit type + data → a one-line activity descriptor);
+ * the DB read + un-audited `update` folding live in the /api/sessions/:id/activity route in server.ts.
+ *
+ * The categories mirror the OS planes an agent touches: `action` (governed gateway/gate effects — the
+ * external tool calls the gate decided on), `operator` (the human-facing channel: ask/report/update/
+ * publish), `memory`, `knowledge` (KB), `tasks`, `scheduling`, `agents`, `approval`. Anything that is
+ * pure session plumbing (lifecycle, secret/skill materialisation, the paired half of a governed action)
+ * is NOISE and never surfaces as a primitive.
+ */
+
+export type ActivityCategory =
+  | 'action' | 'operator' | 'memory' | 'knowledge' | 'tasks'
+  | 'scheduling' | 'agents' | 'approval' | 'other';
+
+export type ActivityEffect = 'allow' | 'approve' | 'deny' | 'error';
+
+/** One classified primitive-use, sans timestamp (the route stamps `ts` from the audit row). */
+export interface ActivityDescriptor {
+  category: ActivityCategory;
+  /** The primitive the agent used — an OS tool name (`remember`, `ask`, `task_create`) or, for a
+   *  governed effect, the capability id (`Bash`, `email.send`, `mcp__gmail__send`). */
+  primitive: string;
+  /** A one-line human gloss built from the event's data (memory tags, KB slug, task title, …). */
+  summary: string;
+  /** For governed actions/approvals: how the gate classified it (allow/approve/deny) or the outcome. */
+  effect?: ActivityEffect;
+}
+
+/** Session plumbing + the paired/duplicate half of a governed action — not, on their own, a primitive
+ *  the agent "used". Keeping these out is what makes the activity feed read as intent, not machinery. */
+const NOISE = new Set<string>([
+  'session.created', 'session.ended', 'session.resumed', 'session.stopped', 'session.error',
+  'session.tuning', 'session.progress', 'session.notified', 'session.attachment', 'session.deleted',
+  'skills.materialized', 'skills.error',
+  'connector.minted', 'connector.mint.failed', 'connector.secret.unresolved',
+  'shell.secret.injected', 'shell.secret.unresolved',
+  'gate.attempt', 'gate.killswitch', 'episode.stored', 'episode.error', 'lesson.stored', 'lesson.error',
+  'action.attempt', 'policy.decision', 'space.released', 'approval.notified', 'approval.auto_approved',
+  // The human side of the two agent→human channels — a follow-up to the agent's primitive, not one itself.
+  'approval.resolved', 'question.answered',
+]);
+
+/** Category by type-prefix — the fallback for any audited effect not spelled out below. */
+const PREFIX: ReadonlyArray<readonly [string, ActivityCategory]> = [
+  ['memory.', 'memory'], ['kb.', 'knowledge'], ['task.', 'tasks'], ['agent.', 'agents'],
+  ['automation.', 'scheduling'], ['approval.', 'approval'], ['gate.', 'action'], ['action.', 'action'],
+  ['question.', 'operator'], ['artifact.', 'operator'],
+];
+
+const str = (v: unknown): string => (typeof v === 'string' ? v : v == null ? '' : String(v));
+
+/** Collapse whitespace and clip to a feed-friendly length. */
+export function clipText(v: unknown, n = 140): string {
+  const t = str(v).replace(/\s+/g, ' ').trim();
+  return t.length > n ? t.slice(0, n - 1) + '…' : t;
+}
+
+const normEffect = (e: string): ActivityEffect | undefined =>
+  e === 'allow' || e === 'approve' || e === 'deny' || e === 'error' ? e : undefined;
+
+const fmtWhen = (v: unknown): string => {
+  if (typeof v === 'number' && Number.isFinite(v)) {
+    return new Date(v).toISOString().slice(0, 16).replace('T', ' ');
+  }
+  return str(v);
+};
+
+/**
+ * Classify one audit event into an activity descriptor, or `null` if it's noise (and therefore not a
+ * primitive the session used). Pure — no I/O, no clock; the caller supplies `ts`.
+ */
+export function classifyActivity(type: string, data: Record<string, unknown>): ActivityDescriptor | null {
+  if (NOISE.has(type)) return null;
+  const id = () => str(data.id);
+
+  switch (type) {
+    // ── governed external effects — the capability the gate decided on IS the primitive ──
+    case 'gate.decision': {
+      const cap = str(data.capability) || 'action';
+      const d = data.decision as { effect?: string } | undefined;
+      return { category: 'action', primitive: cap, summary: cap, effect: normEffect(str(d?.effect)) };
+    }
+    case 'action.result': {
+      const cap = str(data.capability) || 'action';
+      return { category: 'action', primitive: cap, summary: cap, effect: data.ok === false ? 'error' : 'allow' };
+    }
+    case 'gate.email.blocked':
+      return { category: 'action', primitive: str(data.capability) || 'email.send', summary: clipText(data.reason, 100), effect: 'deny' };
+
+    // ── operator channel (agent ↔ human) ──
+    case 'question.asked':     return { category: 'operator', primitive: 'ask', summary: clipText(data.prompt) };
+    case 'session.reported':   return { category: 'operator', primitive: 'report', summary: `${str(data.outcome) || 'done'} — ${clipText(data.summary, 110)}`.replace(/ — $/, '') };
+    case 'artifact.published': return { category: 'operator', primitive: 'publish', summary: clipText(data.title) || str(data.filename) };
+    case 'artifact.deleted':   return { category: 'operator', primitive: 'artifact_delete', summary: clipText(data.title) || id() };
+
+    // ── memory plane ──
+    case 'memory.stored': {
+      const tags = Array.isArray(data.tags) ? data.tags.map(str).filter(Boolean).join(', ') : '';
+      const scope = str(data.scope);
+      return { category: 'memory', primitive: 'remember', summary: [tags && `[${tags}]`, scope && scope !== 'agent' ? `${scope}-scoped` : '', id() && `#${id()}`].filter(Boolean).join(' ') || 'a fact' };
+    }
+    case 'memory.revised':   return { category: 'memory', primitive: 'revise', summary: id() ? `#${id()}` : '' };
+    case 'memory.forgotten': return { category: 'memory', primitive: 'forget', summary: id() ? `#${id()}` : '' };
+
+    // ── knowledge base ──
+    case 'kb.written':   return { category: 'knowledge', primitive: 'kb_write', summary: `${str(data.section)}/${str(data.slug)}${data.rev ? ` · rev ${str(data.rev)}` : ''}` };
+    case 'kb.reverted':  return { category: 'knowledge', primitive: 'kb_revert', summary: `${str(data.section)}/${str(data.slug)} → rev ${str(data.rev)}` };
+    case 'kb.deleted':   return { category: 'knowledge', primitive: 'kb_delete', summary: `${str(data.section)}/${str(data.slug)}` };
+
+    // ── tasks plane ──
+    case 'task.created':    return { category: 'tasks', primitive: 'task_create', summary: clipText(data.title) || id() };
+    case 'task.claimed':    return { category: 'tasks', primitive: 'task_claim', summary: id() };
+    case 'task.updated':    return { category: 'tasks', primitive: 'task_update', summary: `${id()} → ${str(data.status)}` };
+    case 'task.completed':  return { category: 'tasks', primitive: 'task_update', summary: `${id()} → ${str(data.status) || 'done'}`, effect: 'allow' };
+    case 'task.dispatched': return { category: 'tasks', primitive: 'task_dispatch', summary: id() };
+    case 'task.deleted':    return { category: 'tasks', primitive: 'task_delete', summary: id() };
+
+    // ── scheduling (agent-deferred self-runs) ──
+    case 'automation.scheduled': return { category: 'scheduling', primitive: 'schedule', summary: `${str(data.agent)} @ ${fmtWhen(data.runAt)}`.trim() };
+    case 'automation.cancelled': return { category: 'scheduling', primitive: 'unschedule', summary: id() };
+
+    // ── agent authoring (the A2A / agent-author surface) ──
+    case 'agent.created':        return { category: 'agents', primitive: 'agent_create', summary: str(data.agent) || id() };
+    case 'agent.duplicated':     return { category: 'agents', primitive: 'agent_duplicate', summary: str(data.agent) || id() };
+    case 'agent.config.updated':
+    case 'agent.claude.updated': return { category: 'agents', primitive: 'agent_update', summary: str(data.agent) || id() };
+    case 'agent.deleted':        return { category: 'agents', primitive: 'agent_delete', summary: str(data.agent) || id() };
+
+    // ── approvals the agent triggered (the human resolution is folded away as noise) ──
+    case 'approval.requested':   return { category: 'approval', primitive: 'approval', summary: `${str(data.level)}${data.reason ? ` · ${clipText(data.reason, 90)}` : ''}`.replace(/^ · /, ''), effect: 'approve' };
+
+    default: break;
+  }
+
+  // Anything audited but not spelled out: keep it, categorised by prefix, primitive = the raw type.
+  const cat = PREFIX.find(([pre]) => type.startsWith(pre))?.[1] ?? 'other';
+  return { category: cat, primitive: type, summary: '' };
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,11 +6,12 @@ import remarkGfm from 'remark-gfm'
 import { Button, buttonVariants } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
 import { ConnectorsPage } from '@/connectors'
 import { docPages } from '@/docs'
 
@@ -1245,6 +1246,9 @@ function SessionsPage({
   // toggle so the bar doesn't accrete every past run. The open session always shows even if it ended.
   const [showEnded, setShowEnded] = useState(false)
 
+  // The session whose agent-os primitive activity is open in the modal timeline (null = closed).
+  const [inspect, setInspect] = useState<Session | null>(null)
+
   // Multi-select for bulk stop/delete. Kept in sync with the live list: ids that vanish (deleted
   // elsewhere, or by our own bulk delete) are pruned so the toolbar count never lies.
   const [sel, setSel] = useState<Set<string>>(new Set())
@@ -1402,6 +1406,9 @@ function SessionsPage({
                     <X className="h-3 w-3" /> Stop
                   </Button>
                 )}
+                <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs" onClick={() => setInspect(s)} title="which agent-os primitives this session used">
+                  <Activity className="h-3 w-3" /> Activity
+                </Button>
                 <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-destructive" onClick={() => onDelete(s.id, s.tmux)} title="delete session + its messages/files">
                   <Trash2 className="h-3 w-3" /> Delete
                 </Button>
@@ -1440,6 +1447,9 @@ function SessionsPage({
                     <Square className="h-3.5 w-3.5" />
                   </Button>
                 )}
+                <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => setInspect(s)} title="activity — which agent-os primitives this session used">
+                  <Activity className="h-3.5 w-3.5" />
+                </Button>
                 <Button size="icon" variant="ghost" className="h-7 w-7 text-destructive" onClick={() => onDelete(s.id, s.tmux)} title="delete session + its messages/files">
                   <Trash2 className="h-3.5 w-3.5" />
                 </Button>
@@ -1448,6 +1458,7 @@ function SessionsPage({
           ))}
         </div>
       )}
+      {inspect && <SessionActivity session={inspect} onClose={() => setInspect(null)} />}
     </div>
   )
 }
@@ -4529,6 +4540,115 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
         </Card>
       </section>
     </div>
+  )
+}
+
+// ── Session activity (which agent-os primitives a run used) ──────────────────────
+/** Per-category visual style for the activity timeline — icon + accent, mirroring the OS planes. */
+const ACTIVITY_STYLE: Record<ActivityEvent['category'], { icon: LucideIcon; label: string; cls: string }> = {
+  action:     { icon: Zap,           label: 'Governed action', cls: 'text-amber-600' },
+  operator:   { icon: MessageSquare, label: 'Operator',        cls: 'text-blue-600' },
+  memory:     { icon: Brain,         label: 'Memory',          cls: 'text-violet-600' },
+  knowledge:  { icon: BookText,      label: 'Knowledge',       cls: 'text-emerald-600' },
+  tasks:      { icon: ListChecks,    label: 'Tasks',           cls: 'text-sky-600' },
+  scheduling: { icon: Clock,         label: 'Scheduling',      cls: 'text-orange-600' },
+  agents:     { icon: Bot,           label: 'Agents',          cls: 'text-pink-600' },
+  approval:   { icon: Shield,        label: 'Approval',        cls: 'text-yellow-600' },
+  other:      { icon: Activity,      label: 'Other',           cls: 'text-muted-foreground' },
+}
+
+const EFFECT_CLS: Record<NonNullable<ActivityEvent['effect']>, string> = {
+  allow:   'border-emerald-500/40 text-emerald-600',
+  approve: 'border-amber-500/40 text-amber-600',
+  deny:    'border-red-500/40 text-red-600',
+  error:   'border-red-500/40 text-red-600',
+}
+
+/** A modal timeline of the agent-os primitives a session used: grouped counts + a chronological feed,
+ *  read from the run's audit stream via /api/sessions/:id/activity. */
+function SessionActivity({ session, onClose }: { session: Session; onClose: () => void }) {
+  const [events, setEvents] = useState<ActivityEvent[]>([])
+  const [summary, setSummary] = useState<ActivitySummaryRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState('')
+  useEffect(() => {
+    let live = true
+    setLoading(true)
+    api.sessionActivity(session.id)
+      .then((r) => { if (!live) return; if (r.error) setError(r.error); else { setEvents(r.events ?? []); setSummary(r.summary ?? []) } })
+      .catch(() => { if (live) setError('Could not load activity') })
+      .finally(() => { if (live) setLoading(false) })
+    return () => { live = false }
+  }, [session.id])
+
+  return (
+    <Dialog open onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="max-h-[85vh] w-full max-w-[calc(100%-2rem)] gap-3 overflow-hidden sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 pr-8">
+            <Activity className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <span className="truncate">{session.title}</span>
+          </DialogTitle>
+          <div className="text-xs text-muted-foreground">
+            {session.agent} · <span className="font-mono">{session.id}</span> · primitives this session used
+          </div>
+        </DialogHeader>
+
+        {/* grouped counts — the "recall ×3 · ask ×1 · report ×1" glance */}
+        {summary.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {summary.map((s) => {
+              const st = ACTIVITY_STYLE[s.category] ?? ACTIVITY_STYLE.other
+              const Icon = st.icon
+              return (
+                <span key={s.primitive} title={st.label} className="inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs">
+                  <Icon className={`h-3 w-3 ${st.cls}`} />
+                  <span className="font-mono">{s.primitive}</span>
+                  <span className="text-muted-foreground">×{s.count}</span>
+                </span>
+              )
+            })}
+          </div>
+        )}
+
+        {/* chronological timeline */}
+        <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border">
+          {loading ? (
+            <div className="p-6 text-sm text-muted-foreground">Loading activity…</div>
+          ) : error ? (
+            <div className="p-6 text-sm text-destructive">{error}</div>
+          ) : events.length === 0 ? (
+            <div className="p-6 text-sm text-muted-foreground">
+              No governed primitives recorded for this session yet. Read-only tools (recall, searches, inbox
+              checks) don't leave an audit trace.
+            </div>
+          ) : (
+            <div className="divide-y">
+              {events.map((e, i) => {
+                const st = ACTIVITY_STYLE[e.category] ?? ACTIVITY_STYLE.other
+                const Icon = st.icon
+                return (
+                  <div key={i} className="flex items-start gap-2.5 px-3 py-2 text-xs">
+                    <span className="w-16 shrink-0 pt-0.5 font-mono text-[11px] text-muted-foreground" title={new Date(e.ts).toLocaleString()}>
+                      {new Date(e.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })}
+                    </span>
+                    <Icon className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${st.cls}`} />
+                    <Badge variant="outline" className="shrink-0 px-1.5 py-0 font-mono text-[10px]">{e.primitive}</Badge>
+                    {e.effect && (
+                      <Badge variant="outline" className={`shrink-0 px-1.5 py-0 text-[10px] ${EFFECT_CLS[e.effect]}`}>{e.effect}</Badge>
+                    )}
+                    <span className="min-w-0 flex-1 break-words text-muted-foreground" title={e.summary}>{e.summary}</span>
+                  </div>
+                )
+              })}
+            </div>
+          )}
+        </div>
+        <div className="text-[11px] text-muted-foreground">
+          {loading ? '' : `${events.length} primitive${events.length === 1 ? '' : 's'} · from the session's audit trail`}
+        </div>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -137,6 +137,27 @@ export interface AuditResp {
   types: string[]
   error?: string
 }
+/** One classified primitive-use in a session's activity timeline (from /api/sessions/:id/activity). */
+export interface ActivityEvent {
+  ts: number
+  category: 'action' | 'operator' | 'memory' | 'knowledge' | 'tasks' | 'scheduling' | 'agents' | 'approval' | 'other'
+  /** OS tool name (remember/ask/task_create…) or, for a governed effect, the capability id. */
+  primitive: string
+  summary: string
+  /** For governed actions/approvals: how the gate classified it, or the outcome. */
+  effect?: 'allow' | 'approve' | 'deny' | 'error'
+}
+export interface ActivitySummaryRow {
+  primitive: string
+  category: ActivityEvent['category']
+  count: number
+}
+export interface SessionActivityResp {
+  events: ActivityEvent[]
+  summary: ActivitySummaryRow[]
+  total: number
+  error?: string
+}
 export interface Artifact {
   id: string
   sessionId: string
@@ -615,6 +636,8 @@ export const api = {
   stopSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/stop`),
   deleteSession: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/sessions/' + id),
   attach: (id: string) => call<{ url?: string; error?: string }>('GET', `/api/sessions/${id}/attach`),
+  /** The agent-os primitives this session used — a classified timeline + grouped counts. */
+  sessionActivity: (id: string) => call<SessionActivityResp>('GET', `/api/sessions/${id}/activity`),
   /** Upload a pasted/dropped image into a live session; the server saves it in the agent's folder and
    *  types the path into the running claude. `dataB64` is base64 (no data: prefix); `ext` e.g. 'png'. */
   attachFile: (id: string, dataB64: string, ext: string) =>


### PR DESCRIPTION
## What

Answers the question **"which agent-os primitives did this session use?"** visually. Each session card (grid + list) gets an **Activity** button that opens a modal timeline:

- **Grouped counts** — `Bash ×12 · remember ×3 · ask ×1 · report ×1` — most-used first.
- **Chronological feed** — each event classified into its OS plane (governed action · operator · memory · knowledge · tasks · scheduling · agents · approval), with the gate's `allow`/`approve`/`deny` verdict as a badge.

Before this, the only way to see a session's primitive usage was the owner/admin-only Audit page, manually filtered by session id — a flat raw-JSON list, no grouping, no timeline.

## How

- **`GET /api/sessions/:id/activity`** (`src/server.ts`) — reads the run's `audit_events`, classifies each row, folds in the one un-audited primitive (progress `update`s, which only write an inbox message), and returns `{ events, summary, total }`. Gated by `canViewSession`, so a member sees the activity of runs they can attach to — not just owner/admin.
- **`src/state/session-activity.ts`** — a pure, testable classifier: audit type + data → `{ category, primitive, summary, effect }`, or `null` for noise. Session plumbing (lifecycle, secret/skill materialisation) and the paired half of a governed action (`gate.attempt`, `approval.resolved`) are filtered so the feed reads as intent, not machinery.
- **`web/src/App.tsx`** — a `SessionActivity` dialog (reuses the existing `Dialog` primitive) + the per-card buttons.
- Read-only tools (`recall`, searches, inbox checks) leave no audit trace and so don't appear — called out in the empty state.

## Testing

- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → 44/44 ✓
- Isolated in-process smoke test (ephemeral `AGENT_OS_HOME`): classifier unit checks (11 mapped + 5 noise-dropped) and the live HTTP endpoint — 401 unauth / 404 unknown / 200 with correct total (7 from 9, 2 noise dropped), `Bash ×2` grouped and sorted first, `approve` effect preserved, chronological ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)