### PR TITLE
Settings: one Composio card + deep-link connectors settings links (v0.34.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.34.1] — 2026-07-08
+### Changed
+- **Settings → Integrations: one Composio card.** The separate "Composio API key" and "Composio webhook
+  secret" cards are merged into a single **Composio** card (matching how the Slack/Discord cards already
+  group an integration's credentials): API key + optional webhook secret as two fields under one intro,
+  a single Save, and per-credential Remove links (they stay independent — connectors work without a webhook).
+### Fixed
+- **Connectors page links now deep-link to the right settings tab.** The native chat-bot (Slack/Discord)
+  row's "Settings" link and the Secrets-vault reference pointed at the bare `#/settings` (landing on Company
+  context); they now open `#/settings/integrations` and `#/settings/secrets` respectively.
+
 ## [0.34.0] — 2026-07-08
 ### Added
 - **Session activity — see which agent-os primitives a run used, visually.** Every session card (grid +

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5683,7 +5683,17 @@ function IntegrationsSettings({ me }: { me: Member }) {
 
       <Card>
         <CardContent className="space-y-3 p-4">
-          <Field label="Composio API key">
+          <div>
+            <div className="text-sm font-medium">Composio</div>
+            <p className="text-xs text-muted-foreground">
+              The <strong>API key</strong> powers Composio-backed connectors. The optional <strong>webhook secret</strong> lets
+              app events <strong>trigger agents</strong> (Slack message/DM → run an agent): in Composio, create a webhook pointing
+              at <code className="text-xs">{`<this-host>`}/triggers/composio</code>, paste its signing secret
+              (<code className="text-xs">whsec_…</code>) here, then add a <strong>Composio</strong> trigger on the Automations page.
+            </p>
+          </div>
+
+          <Field label="API key">
             <Input
               type="password"
               value={key}
@@ -5691,31 +5701,12 @@ function IntegrationsSettings({ me }: { me: Member }) {
               placeholder={composio.set ? `${composio.hint} (saved) — type a new key to replace` : 'comp_…  (Composio dashboard → Settings → API Keys)'}
               className="font-mono text-xs"
             />
-          </Field>
-          <div className="flex items-center gap-3">
-            <Button onClick={() => save({ composioApiKey: key.trim() }, 'saved')} disabled={busy || !key.trim()}>Save</Button>
-            {composio.set && <Button variant="ghost" onClick={() => save({ composioApiKey: '' }, 'removed')} disabled={busy}>Remove</Button>}
-            {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
-            {meta.updatedAt && (
-              <span className="ml-auto text-[11px] text-muted-foreground">
-                updated {new Date(meta.updatedAt).toLocaleString()}{meta.updatedBy ? ` by ${meta.updatedBy}` : ''}
-              </span>
+            {composio.set && (
+              <button type="button" className="mt-1 text-[11px] text-muted-foreground hover:text-destructive disabled:opacity-50" onClick={() => save({ composioApiKey: '' }, 'removed')} disabled={busy}>Remove key</button>
             )}
-          </div>
-        </CardContent>
-      </Card>
+          </Field>
 
-      <Card>
-        <CardContent className="space-y-3 p-4">
-          <div>
-            <div className="text-sm font-medium">Composio webhook secret</div>
-            <p className="text-xs text-muted-foreground">
-              Lets app events <strong>trigger agents</strong> (Slack message/DM → run an agent). In Composio, create a webhook
-              pointing at <code className="text-xs">{`<this-host>`}/triggers/composio</code>, then paste its signing secret
-              (<code className="text-xs">whsec_…</code>) here. Then add a <strong>Composio</strong> trigger on the Automations page.
-            </p>
-          </div>
-          <Field label="Signing secret">
+          <Field label="Webhook secret" help="Optional — only needed for Composio triggers.">
             <Input
               type="password"
               value={wh}
@@ -5723,10 +5714,22 @@ function IntegrationsSettings({ me }: { me: Member }) {
               placeholder={webhook.set ? '•••• (saved) — type a new secret to replace' : 'whsec_…'}
               className="font-mono text-xs"
             />
+            {webhook.set && (
+              <button type="button" className="mt-1 text-[11px] text-muted-foreground hover:text-destructive disabled:opacity-50" onClick={() => save({ composioWebhookSecret: '' }, 'removed')} disabled={busy}>Remove secret</button>
+            )}
           </Field>
+
           <div className="flex items-center gap-3">
-            <Button onClick={() => save({ composioWebhookSecret: wh.trim() }, 'saved')} disabled={busy || !wh.trim()}>Save</Button>
-            {webhook.set && <Button variant="ghost" onClick={() => save({ composioWebhookSecret: '' }, 'removed')} disabled={busy}>Remove</Button>}
+            <Button
+              onClick={() => save({ ...(key.trim() ? { composioApiKey: key.trim() } : {}), ...(wh.trim() ? { composioWebhookSecret: wh.trim() } : {}) }, 'saved')}
+              disabled={busy || (!key.trim() && !wh.trim())}
+            >Save</Button>
+            {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
+            {meta.updatedAt && (
+              <span className="ml-auto text-[11px] text-muted-foreground">
+                updated {new Date(meta.updatedAt).toLocaleString()}{meta.updatedBy ? ` by ${meta.updatedBy}` : ''}
+              </span>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -405,7 +405,7 @@ function NativeRow({ name, title, s, isAdmin }: {
             : statusBadge('not configured')
       }
       right={isAdmin
-        ? <a href="#/settings" className="inline-flex items-center gap-1 text-[11px] text-muted-foreground underline hover:text-foreground">Settings <ExternalLink className="h-3 w-3" /></a>
+        ? <a href="#/settings/integrations" className="inline-flex items-center gap-1 text-[11px] text-muted-foreground underline hover:text-foreground">Settings <ExternalLink className="h-3 w-3" /></a>
         : <span className="text-[11px] text-muted-foreground">managed by an admin</span>}
     />
   )
@@ -622,7 +622,7 @@ function AddConnectorDialog({ me, template, scope, onClose, onAdded }: { me: Mem
             )}{' '}
             Credentials are stored locally in your data home. Tip: enter{' '}
             <span className="font-mono">secret:KEY</span> (or <span className="font-mono">secret:PRINCIPAL/KEY</span>) to
-            reference an encrypted value from the <a href="#/settings" className="underline hover:text-foreground">Secrets vault</a>{' '}
+            reference an encrypted value from the <a href="#/settings/secrets" className="underline hover:text-foreground">Secrets vault</a>{' '}
             instead of storing the raw credential here — it's decrypted only at session launch.
           </p>
         </div>


### PR DESCRIPTION
## What

- **Settings → Integrations: one Composio card.** Merge the separate "Composio API key" and "Composio webhook secret" cards into a single **Composio** card — matching how the Slack/Discord cards already group an integration's credentials. Two fields (API key + optional webhook secret) under one intro, a single Save, and per-credential Remove links (kept independent: connectors work without a webhook).
- **Fix Connectors page settings links.** The native chat-bot (Slack/Discord) row's "Settings" link and the Secrets-vault reference pointed at the bare `#/settings` (landing on Company context). They now deep-link to `#/settings/integrations` and `#/settings/secrets`.

## Validation

- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 44/44 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)