### PR TITLE
Secrets: agents share credentials via the vault — secret_put/get/list (v0.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.35.0] — 2026-07-08
+### Added
+- **Agents can share credentials through the secrets vault — without the value ever touching a durable
+  plane.** Three new always-on MCP tools give the fleet an A2A credential-handoff path: `secret_put`
+  stores a password / API key / token in the vault under a KEY, `secret_get` fetches it back read-once,
+  and `secret_list` shows the available keys (metadata only). Agents pass the key **name** to each other
+  (in a task, message, or report) and never the raw value. Design invariant: the plaintext lives only in
+  the encrypted vault row and the live `secret_get` response — it is deliberately kept out of the audit
+  trail, the approval card, and the policy args (all of which persist), so a secret can't leak through the
+  governance planes. Storing is **approval-gated**: `secret.put` classifies as `ask`/admin in the default
+  policy and blocks the call until a human approves (auto-cleared when an owner/admin is already attending
+  the run, per governance P5). Reads are allow+audit (a workspace can tighten a specific key to `deny`).
+  Scope is **shared/tenant-wide** (any agent can read a stored key) — the pragmatic choice for a trusted
+  fleet; agent-written keys surface on the console **Secrets** page stamped `updated_by = agent:<id>` for
+  human oversight/rotation. Backed by `TerminalManager.putSecret/getSecret/listSecrets` +
+  `/api/agent/secret/{put,get,list}` loopback routes (session-secret gated). Not yet done: generic
+  cross-plane redaction (scrubbing a value out of memory/KB/inbox if an agent ignores the read-once
+  guidance) — tracked as a follow-up.
+
 ## [0.34.1] — 2026-07-08
 ### Changed
 - **Settings → Integrations: one Composio card.** The separate "Composio API key" and "Composio webhook

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,14 +175,17 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 27 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 30 always-on tools
   + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). KB: `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`. Operator/inbox:
   `ask`/`check_inbox`/`report`/`update`/`publish`/`artifacts_list`. Scheduling: `schedule`/`unschedule`
   (one-shot deferred self-run via a `type:'once'` automation). Tasks (shared work queue):
   `task_create`/`task_list`/`task_get`/`task_claim`/`task_update` (file/claim/drain durable work; an
   agent-assigned `autoDispatch` task spawns a governed session — the A2A delegation path; per-task `mode`
-  headless/interactive; owner = run-as passthrough so a hand-off keeps the accountable human). Plus
+  headless/interactive; owner = run-as passthrough so a hand-off keeps the accountable human). Secrets
+  (shared credential handoff): `secret_put`/`secret_get`/`secret_list` — an agent stores a password/key
+  tenant-wide under a KEY (approval-gated `secret.put`; value kept out of audit/approval-card/policy args,
+  encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. Plus
   `directory_lookup` (team/identity-map
   search), `list_capabilities`/`policy_check` (policy preview), and `slack_reply`/`discord_reply` when
   chat-triggered. Each tool is a session-secret-gated loopback call to an `/api/*` route that sits BEFORE

--- a/config/policy/default.policy.json
+++ b/config/policy/default.policy.json
@@ -9,6 +9,8 @@
 
     { "match": { "capability": "email.send", "when": { "arg": "emailExternal", "op": "eq", "value": true } }, "action": "ask", "approver": "admin" },
 
+    { "match": { "capability": "secret.put" }, "action": "ask", "approver": "admin" },
+
     { "match": { "capability": "connector.connect" }, "action": "ask", "approver": "owner" }
   ]
 }

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -36,12 +36,30 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `task_update` | `POST /api/tasks/update` | `TaskStore.update` | W | status/note/reassign; closes a dispatched loop |
 | `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
 | `agent_update` | `POST /api/agents/update` | `AgentOS.registerAgent` | W | rewrites manifest (+CLAUDE.md); user-home agents only; audited `agent.config.updated` |
+| `secret_put` | `POST /api/agent/secret/put` | `TerminalManager.putSecret` | W | shared-scope (`*`) vault write; **approval-gated** (policy `secret.put`, blocks until decided); value NEVER in audit/approval-card/policy args; audited `secret.put` (key only); `updated_by=agent:<id>` |
+| `secret_get` | `POST /api/agent/secret/get` | `TerminalManager.getSecret` | R | returns plaintext to caller; allow+audit (a policy `deny`/`ask` on `secret.get` refuses — reads never hang); audited `secret.get` (key + found, never value) |
+| `secret_list` | `GET /api/agent/secret/list` | `TerminalManager.listSecrets` | R | shared (`*`) secret KEYS + metadata only, never values |
 | `slack_reply` | `POST /api/agent/slack/reply` | SlackSocket | W | only when `SLACK_REPLY=1` (chat-triggered) |
 | `discord_reply` | `POST /api/agent/discord/reply` | DiscordSocket | W | only when `DISCORD_REPLY=1` (chat-triggered) |
 
-27 always-on tools + 2 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+30 always-on tools + 2 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
+
+### `secret_put` / `secret_get` — the shared credential handoff
+
+The A2A way to pass a password/API key/token between agents **without the value ever touching a
+durable plane**. Agent A `secret_put`s a value under a KEY (stored tenant-wide, encrypted at rest);
+it tells agent B the key NAME (in a task/message/report — a handle, never the value); B `secret_get`s
+it and uses it read-once. The design invariant: the plaintext lives only in the vault row and the
+live `secret_get` response — it is deliberately kept out of `gate.attempt`/audit, the approval card,
+and the policy args (all of which persist). `secret_put` is **approval-gated** (`secret.put` → `ask`
+admin in the default policy) and blocks the call until a human decides, unless an owner/admin is
+already attending the run (governance P5 auto-clear). `secret_get`/`secret_list` are allow+audit.
+Because the scope is shared (tenant-wide `*`), any agent can read any stored key — only put things
+meant for the team, and manage/rotate them from the console **Secrets** page (agent-written keys show
+`updated_by = agent:<id>`). Not yet done: generic cross-plane redaction (scrubbing a leaked value out
+of memory/KB/inbox if an agent ignores the read-once guidance) — tracked as a follow-up.
 
 ### `schedule` — governance model
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.34.1",
+      "version": "0.35.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.34.1",
+  "version": "0.35.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/secrets.ts
+++ b/src/edge/secrets.ts
@@ -1,7 +1,11 @@
 /**
  * Secrets vault — stores/injects credentials, namespaced by tenant + principal so
  * brands are isolated. This is the VAULT, not the Identity (who acts). Capabilities
- * read secrets inside the gateway boundary; agents never see raw keys.
+ * read secrets inside the gateway boundary; connectors get theirs via `secret:` refs.
+ * Agents can also read/write the SHARED (tenant-wide `*`) scope directly via the
+ * governed `secret_get`/`secret_put` MCP tools (writes approval-gated) — the A2A
+ * credential-handoff path — but the plaintext value is deliberately kept out of every
+ * durable plane (audit, approval card, policy args); only the KEY is ever recorded.
  *
  * Env lookup order:  <TENANT>__<PRINCIPAL>__<KEY>  →  <TENANT>__<KEY>  →  <KEY>
  * (principal/tenant upper-cased, non-alphanumerics → underscore)

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -551,6 +551,53 @@ const TOOLS = [
       required: ['id'],
     },
   },
+  {
+    name: 'secret_put',
+    description:
+      'Store a credential (password, API key, token, connection string) in the shared secrets vault so ' +
+      'ANOTHER agent — or a later run of yourself — can use it, without ever putting the raw value in a ' +
+      'message, memory, task, or report. This is how you hand a secret to a teammate: you store it here ' +
+      'under a KEY, then tell them the key NAME (e.g. "I saved it as PROD_DB_URL") — never the value. The ' +
+      'value is encrypted at rest and is NOT recorded in the audit trail. Storing a secret is a governed, ' +
+      'approval-gated action: this call BLOCKS until a human approves it (unless an approver is already ' +
+      'attending your run). Keys are shared tenant-wide, so any agent can secret_get them — only store ' +
+      'things that are meant to be shared with the team.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        key: { type: 'string', description: 'The handle other agents will fetch by — a letter/underscore then letters, digits or underscores, e.g. "PROD_DB_URL", "STRIPE_KEY". This name is safe to share in messages.' },
+        value: { type: 'string', description: 'The secret value itself. Encrypted at rest; never logged. Do NOT repeat this value anywhere else (messages, memory, reports) — pass the key name instead.' },
+        reasoning: { type: 'string', description: 'One line for the approver: what this credential is and why you are storing it.' },
+      },
+      required: ['key', 'value'],
+    },
+  },
+  {
+    name: 'secret_get',
+    description:
+      'Fetch a shared credential from the vault by its key (the handle another agent told you, e.g. ' +
+      '"PROD_DB_URL"). Returns the plaintext value for you to USE — then use it directly (in the command, ' +
+      'the request, the config) and do NOT echo it back into any durable place: not a memory, not a ' +
+      'report, not a task update, not the knowledge base. Treat it as read-once. The read is audited by ' +
+      'key, never by value.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        key: { type: 'string', description: 'The secret key/handle to fetch, e.g. "PROD_DB_URL".' },
+      },
+      required: ['key'],
+    },
+  },
+  {
+    name: 'secret_list',
+    description:
+      'List the shared secret KEYS available in the vault (handles + when/who last set them) — metadata ' +
+      'only, never the values. Use it to discover what credentials the team has already shared before you ' +
+      'store a duplicate or ask a human, then secret_get the one you need.',
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+  },
 ];
 
 function send(msg: JsonRpc): void {
@@ -938,6 +985,51 @@ async function agentUpdate(args: Record<string, unknown>): Promise<string> {
   return `Updated agent "${id}". The next session it runs will use the new configuration.`;
 }
 
+// ── Secrets vault: shared credential handoff (value stays out of every durable plane) ─────────────
+async function secretPut(args: Record<string, unknown>): Promise<string> {
+  const key = String(args.key ?? '').trim();
+  const value = args.value != null ? String(args.value) : '';
+  if (!key) return 'A secret needs a key (the handle other agents fetch by, e.g. PROD_DB_URL).';
+  if (!value) return 'A secret needs a value to store.';
+  const res = await fetch(AOS_URL + '/api/agent/secret/put', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, key, value, reasoning: args.reasoning != null ? String(args.reasoning) : undefined }),
+  });
+  const d = (await res.json()) as { status?: string; detail?: string; error?: string };
+  if (d.error) return `Could not store the secret: ${d.error}`;
+  if (d.status === 'stored') return `Stored secret "${key}" in the shared vault. Hand it off by NAME — tell the other agent to secret_get "${key}". Never paste the value into a message, memory, or report.`;
+  if (d.status === 'denied') return `Storing "${key}" was not approved${d.detail ? `: ${d.detail}` : ''}.`;
+  return `Could not store the secret${d.detail ? `: ${d.detail}` : ''}.`;
+}
+
+async function secretGet(args: Record<string, unknown>): Promise<string> {
+  const key = String(args.key ?? '').trim();
+  if (!key) return 'Which secret? Pass its key/handle, e.g. secret_get "PROD_DB_URL".';
+  const res = await fetch(AOS_URL + '/api/agent/secret/get', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, key }),
+  });
+  const d = (await res.json()) as { status?: string; value?: string; detail?: string; error?: string };
+  if (d.error) return `Could not read the secret: ${d.error}`;
+  if (d.status === 'ok') return `${d.value}\n\n(Use this value directly — do not store or echo it into a memory, report, task, or the knowledge base.)`;
+  if (d.status === 'denied') return `Reading "${key}" is not allowed${d.detail ? `: ${d.detail}` : ''}.`;
+  return `No secret named "${key}" is in the vault. Check secret_list, or ask the agent/human who has it to secret_put it.`;
+}
+
+async function secretList(): Promise<string> {
+  const u = new URL(AOS_URL + '/api/agent/secret/list');
+  u.searchParams.set('session', SESSION);
+  const res = await fetch(u, { headers: H() });
+  const d = (await res.json()) as { secrets?: Array<{ key: string; updatedAt: number; updatedBy?: string }>; error?: string };
+  if (d.error) return `Could not list secrets: ${d.error}`;
+  const rows = d.secrets ?? [];
+  if (!rows.length) return 'The shared vault has no secrets yet. Use secret_put to add one the team can share.';
+  return 'Shared vault keys (metadata only — use secret_get to fetch a value):\n' +
+    rows.map((s) => `• ${s.key}${s.updatedBy ? ` — set by ${s.updatedBy}` : ''}`).join('\n');
+}
+
 async function taskList(args: Record<string, unknown>): Promise<string> {
   const u = new URL(AOS_URL + '/api/tasks/list');
   u.searchParams.set('session', SESSION);
@@ -1135,6 +1227,9 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'task_update' ? await taskUpdate(args)
         : name === 'agent_create' ? await agentCreate(args)
         : name === 'agent_update' ? await agentUpdate(args)
+        : name === 'secret_put' ? await secretPut(args)
+        : name === 'secret_get' ? await secretGet(args)
+        : name === 'secret_list' ? await secretList()
         : `unknown tool: ${name}`;
       send({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text }] } });
     } catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUse
 import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument } from './governance/policy';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
-import { AgentManifest, ApprovalRequest, EmbeddingsConfig, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
+import { AgentManifest, ApprovalRequest, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
 
 /** Settings → Memory view: stored backend config with secrets redacted to `…Set` booleans. */
 interface EmbeddingsView { provider: 'openai' | 'ollama'; url: string; model: string; dimensions?: number; apiKeySet: boolean }
@@ -391,6 +391,43 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!capability) return sendJson(res, 400, { error: 'capability is required' });
     const args = b.args && typeof b.args === 'object' ? (b.args as Record<string, unknown>) : {};
     return sendJson(res, 200, { decision: tm.policyCheck(String(b.session), agent, capability, args) });
+  }
+
+  // ── Secrets vault, agent-facing (loopback, session-scoped) — the A2A credential-handoff path ──
+  // Shared-scope model: writes land tenant-wide (`*`) so any agent can read them; the value NEVER
+  // touches audit/approval-card/policy args (see TerminalManager.putSecret/getSecret). `put` is
+  // approval-gated (policy `secret.put`) and BLOCKS this request until the human decides; `get`/`list`
+  // are allow+audit reads. Agents pass key HANDLES to each other, never the raw value.
+  if (method === 'POST' && p === '/api/agent/secret/put') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const key = String(b.key || '').trim();
+    const value = b.value != null ? String(b.value) : '';
+    if (!ENV_NAME.test(key) || key.length > 64) return sendJson(res, 400, { error: 'key must be a letter/underscore then letters, digits or underscores, ≤64 chars (e.g. PROD_DB_URL)' });
+    if (!value) return sendJson(res, 400, { error: 'value is required' });
+    const reasoning = String(b.reasoning || `store shared secret ${key}`);
+    const out = await tm.putSecret(session, agent, key, value, reasoning);
+    return sendJson(res, 200, out);
+  }
+  if (method === 'POST' && p === '/api/agent/secret/get') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const key = String(b.key || '').trim();
+    if (!key) return sendJson(res, 400, { error: 'key is required' });
+    return sendJson(res, 200, tm.getSecret(session, agent, key));
+  }
+  if (method === 'GET' && p === '/api/agent/secret/list') {
+    const session = url.searchParams.get('session') || '';
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    return sendJson(res, 200, { secrets: tm.listSecrets() });
   }
 
   if (method === 'GET' && p === '/api/memory/recall') {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -924,6 +924,115 @@ export class TerminalManager {
   }
 
   /**
+   * Agent-facing vault WRITE (the `secret_put` MCP tool) — the A2A credential-handoff primitive.
+   * Stores a credential under the SHARED (tenant-wide `*`) scope so any agent in the tenant can later
+   * `secret_get` it. Approval-gated through the SAME machinery as {@link gate}: policy classifies
+   * `secret.put`, and unless an attended approver clears it, a human must approve before the value is
+   * written. Crucially, the plaintext value lives ONLY in this call's memory + the encrypted vault
+   * row — it is NEVER passed to the policy args, the approval card, or the audit trail (all of which
+   * persist), so a secret cannot leak through the governance planes. Only the KEY is ever recorded.
+   * Resolves once the write is settled (stored / denied / errored); like {@link gate} the waiter does
+   * not survive a server restart (the agent simply retries).
+   */
+  async putSecret(
+    sessionId: string,
+    agent: string,
+    key: string,
+    value: string,
+    reasoning: string,
+  ): Promise<{ status: 'stored' | 'denied' | 'error'; detail?: string }> {
+    if (this.os.settings.killSwitch().engaged) {
+      this.audit(sessionId, agent, 'gate.killswitch', { capability: 'secret.put', key });
+      return { status: 'denied', detail: 'workspace emergency stop is engaged' };
+    }
+    // Gate on the KEY only — the value is deliberately absent from classify/audit/the approval card.
+    const attempt: ActionAttempt = { capabilityId: 'secret.put', args: { key }, reasoning };
+    const decision: Decision = this.os.policy.classify(attempt, this.ctx(sessionId, agent));
+    this.audit(sessionId, agent, 'gate.attempt', { capability: 'secret.put', args: { key }, reasoning });
+    this.audit(sessionId, agent, 'gate.decision', { capability: 'secret.put', decision });
+    if (decision.effect === 'deny') return { status: 'denied', detail: decision.reason };
+    if (decision.effect === 'approve') {
+      // Attended owner/admin clears their own write without a self-addressed card (governance P5).
+      const approver = this.attendedApprover(sessionId, decision.level);
+      if (approver) {
+        this.audit(sessionId, agent, 'approval.auto_approved', { capability: 'secret.put', level: decision.level, by: approver.email, reason: decision.reason });
+      } else {
+        const { req, decision: settle } = this.os.approvals.request({
+          runId: sessionId,
+          tenant: this.os.tenant,
+          level: decision.level,
+          attempt,
+          reason: decision.reason,
+        });
+        this.addMessage({
+          type: 'approval',
+          sessionId,
+          agent,
+          title: `Approval needed — store secret "${key}"`,
+          body: reasoning,
+          status: 'pending',
+          approvalId: req.id,
+          capability: 'secret.put',
+          args: { key },
+          level: decision.level,
+        });
+        this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability: 'secret.put' });
+        try { this.approvalNotifier?.({ sessionId, agent, capability: 'secret.put', level: decision.level, reason: decision.reason }); } catch { /* advisory */ }
+        const approved = await settle;
+        this.audit(sessionId, agent, 'approval.resolved', { approvalId: req.id, approved });
+        if (!approved) return { status: 'denied', detail: `approval rejected (${decision.level})` };
+      }
+    }
+    // green (allow) or approved → write the encrypted row under the shared tenant-wide principal.
+    try {
+      this.os.secrets.set(this.os.tenant, key, value, { principal: '*', updatedBy: `agent:${agent}` });
+      this.audit(sessionId, agent, 'secret.put', { key, principal: '*' });
+      return { status: 'stored' };
+    } catch (e) {
+      return { status: 'error', detail: e instanceof Error ? e.message : String(e) };
+    }
+  }
+
+  /**
+   * Agent-facing vault READ (the `secret_get` MCP tool). Under the shared-scope model any agent in the
+   * tenant may read a shared secret, so this is allow-and-audit — but it still runs the policy
+   * `classify` so a workspace CAN tighten a specific key to `deny` (a non-allow outcome refuses rather
+   * than silently returning; reads must never hang on an approval card). The plaintext is returned to
+   * the CALLER only; the audit records the key + whether it resolved, never the value. Widens the
+   * agent-scoped principal to the tenant-wide `*` inside the vault, so an agent reads its own value
+   * first, then the shared one.
+   */
+  getSecret(
+    sessionId: string,
+    agent: string,
+    key: string,
+  ): { status: 'ok' | 'denied' | 'missing'; value?: string; detail?: string } {
+    if (this.os.settings.killSwitch().engaged) return { status: 'denied', detail: 'workspace emergency stop is engaged' };
+    const decision = this.os.policy.classify({ capabilityId: 'secret.get', args: { key }, reasoning: '' }, this.ctx(sessionId, agent));
+    if (decision.effect !== 'allow') {
+      const reason = decision.effect === 'deny' ? decision.reason : 'reading this secret requires approval, which reads do not support';
+      this.audit(sessionId, agent, 'secret.get.denied', { key, reason });
+      return { status: 'denied', detail: reason };
+    }
+    const value = this.os.secrets.getSync(this.os.tenant, agent, key);
+    this.audit(sessionId, agent, 'secret.get', { key, found: value !== undefined });
+    if (value === undefined) return { status: 'missing' };
+    return { status: 'ok', value };
+  }
+
+  /**
+   * Agent-facing vault LISTING (the `secret_list` MCP tool): the shared (tenant-wide `*`) secret KEYS
+   * an agent can `secret_get`, as metadata only — never values. Scoped to the shared principal so it
+   * surfaces exactly the handoff namespace, not other principals' member-scoped key names.
+   */
+  listSecrets(): Array<{ key: string; updatedAt: number; updatedBy?: string }> {
+    return this.os.secrets
+      .list(this.os.tenant)
+      .filter((s) => s.principal === '*')
+      .map((s) => ({ key: s.key, updatedAt: s.updatedAt, updatedBy: s.updatedBy }));
+  }
+
+  /**
    * Dry-run the policy for a hypothetical attempt — the SAME brain the gate uses, but pure: no
    * approval card, no audit, no side effect. Lets an agent learn ahead of time whether an action is
    * allowed / needs approval / denied (via the policy_check + list_capabilities MCP tools), so it can

--- a/src/types.ts
+++ b/src/types.ts
@@ -719,7 +719,7 @@ export function sanitizeExamplePrompts(input: unknown): string[] | undefined {
 /** Valid POSIX-ish env var / vault key name: a letter or underscore, then letters/digits/underscores.
  *  A `shellSecrets` entry is used verbatim as both the vault key and the exported shell variable, so
  *  it must satisfy this or the shell can't reference it. */
-const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
+export const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /** Normalize a `shellSecrets` payload (from an API body or config file): coerce to an array of
  *  trimmed strings, drop anything that isn't a valid env-var name, dedupe (order-preserving), cap


### PR DESCRIPTION
## What

Lets agents hand credentials to each other through the **secrets vault** instead of pasting passwords/API keys into messages, memory, or reports. Three new always-on MCP tools:

- **`secret_put(key, value)`** — store a credential under a KEY (shared/tenant-wide, encrypted at rest). **Approval-gated.**
- **`secret_get(key)`** — fetch the plaintext back, read-once.
- **`secret_list()`** — the available keys + metadata (never values).

Agents pass the key **name** ("I saved it as `PROD_DB_URL`") to each other — never the value.

## The design invariant

The plaintext value lives **only** in the encrypted vault row and the live `secret_get` response. It is deliberately kept out of every durable plane:

- not in the audit trail (`gate.attempt`/`secret.put` log the **key only**),
- not on the approval card,
- not in the policy args.

So a stored secret can't leak through the governance planes.

## Governance

- `secret_put` classifies as **`ask`/admin** in the default policy and **blocks the call until a human approves** — auto-cleared only when an owner/admin is already attending the run (governance P5).
- `secret_get` / `secret_list` are **allow + audit**; a workspace can tighten a specific key to `deny`.
- **Scope is shared/tenant-wide** — any agent can read a stored key. The pragmatic choice for a trusted fleet; agent-written keys show up on the console **Secrets** page stamped `updated_by = agent:<id>` so humans can see/rotate them.

## Changes

- `src/terminal.ts` — `putSecret` / `getSecret` / `listSecrets`, reusing the existing gate/approval machinery.
- `src/server.ts` — `/api/agent/secret/{put,get,list}` loopback routes (session-secret gated, before the member-auth gate).
- `src/memory/memory-mcp.ts` — the three tool schemas + handlers (30 always-on tools now).
- `config/policy/default.policy.json` — gate `secret.put` as `ask`/admin.
- `src/types.ts` — export `ENV_NAME` for vault-key validation.
- Docs: `docs/agent-mcp-tools.md` matrix + governance note; `CLAUDE.md`; `secrets.ts` header.

## Verification

`npm run typecheck` ✓, `npm run build` ✓, `npm run test:governance` → 44/44 ✓. Two isolated in-process tests (scratch `AGENT_OS_HOME`):

1. store → read-back → missing-key → list (with `agent:<id>` stamp); **the value never appears in the audit JSONL**.
2. gate engages: an unattended run goes **pending**, stores nothing until approved, and a **rejection → `denied` + vault untouched**.

## Not in this PR (follow-up)

Generic **cross-plane redaction** — scrubbing a leaked value out of memory/KB/inbox if an agent ignores the read-once guidance. The MVP relies on the new code never persisting a value + explicit tool guidance; deferred rather than shipping a fragile value-matching regex that gives false confidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)