### PR TITLE
Files: a New file button + POST /api/files/create (v0.35.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.36.0] — 2026-07-08
+### Added
+- **Files → New file.** The Files browser grows a **New file** button beside "New folder": it prompts for a
+  name, creates an empty file in the current folder, and opens it straight into the editor. Backed by a new
+  `POST /api/files/create` route that refuses to clobber an existing path (`409`) and audits `file.created`
+  (the existing `/api/files/write` still declines to create files, so this is the dedicated create path).
+
 ## [0.35.0] — 2026-07-08
 ### Added
 - **Agents can share credentials through the secrets vault — without the value ever touching a durable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.35.0",
+      "version": "0.36.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.35.0",
+  "version": "0.36.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2150,6 +2150,24 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return sendJson(res, 200, { ok: true, path: relOf(root, file) });
     }
 
+    // Create a new (empty, or seeded) file. Refuses to clobber an existing path.
+    if (method === 'POST' && p === '/api/files/create') {
+      const b = await readBody(req);
+      const file = safeResolve(root, String(b.path ?? ''));
+      if (!file) return sendJson(res, 400, { error: 'path escapes the data home' });
+      const rel = relOf(root, file);
+      if (rel === '') return sendJson(res, 400, { error: 'invalid file name' });
+      if (fs.existsSync(file)) return sendJson(res, 409, { error: 'a file or folder already exists here' });
+      const parent = path.dirname(file);
+      try { if (!fs.statSync(parent).isDirectory()) return sendJson(res, 400, { error: 'parent is not a directory' }); }
+      catch { return sendJson(res, 404, { error: 'directory not found' }); }
+      const content = String(b.content ?? '');
+      try { fs.writeFileSync(file, content, { flag: 'wx' }); }
+      catch (e) { return sendJson(res, 500, { error: `create failed: ${(e as Error).message}` }); }
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'file.created', data: { path: rel, bytes: content.length } });
+      return sendJson(res, 200, { ok: true, path: rel });
+    }
+
     // Create a folder (recursive; no-op if it already exists).
     if (method === 'POST' && p === '/api/files/mkdir') {
       const b = await readBody(req);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1822,6 +1822,19 @@ function FilesPage() {
     reload()
   }
 
+  const newFile = async () => {
+    const name = prompt('New file name')?.trim()
+    if (!name) return
+    const rel = join(name)
+    setBusy(true); setHint('')
+    const r = await api.files.create(rel)
+    setBusy(false)
+    if (r.error) return setHint('⚠ ' + r.error)
+    reload()
+    // open the fresh (empty) file straight into the editor
+    setOpenPath(rel); setFile({ path: rel, content: '', size: 0 }); setContent('')
+  }
+
   const removeEntry = async (e: FileEntry) => {
     const what = e.type === 'dir' ? 'folder (and everything in it)' : 'file'
     if (!confirm(`Delete ${what} "${e.name}"? This cannot be undone.`)) return
@@ -1863,6 +1876,9 @@ function FilesPage() {
           ))}
         </div>
         <div className="flex items-center gap-1.5">
+          <Button size="sm" variant="outline" className="h-7 gap-1 px-2 text-xs" onClick={newFile} disabled={busy}>
+            <FileIcon className="h-3.5 w-3.5" /> New file
+          </Button>
           <Button size="sm" variant="outline" className="h-7 gap-1 px-2 text-xs" onClick={newFolder} disabled={busy}>
             <FolderPlus className="h-3.5 w-3.5" /> New folder
           </Button>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -782,6 +782,7 @@ export const api = {
     list: (path = '') => call<DirListing>('GET', `/api/files/list?path=${encodeURIComponent(path)}`),
     read: (path: string) => call<FileContent>('GET', `/api/files/read?path=${encodeURIComponent(path)}`),
     write: (path: string, content: string) => call<{ ok: boolean; error?: string }>('PUT', '/api/files/write', { path, content }),
+    create: (path: string, content = '') => call<{ ok: boolean; path?: string; error?: string }>('POST', '/api/files/create', { path, content }),
     mkdir: (path: string) => call<{ ok: boolean; path?: string; error?: string }>('POST', '/api/files/mkdir', { path }),
     remove: (path: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/files/delete?path=${encodeURIComponent(path)}`),
     rename: (from: string, to: string) => call<{ ok: boolean; path?: string; error?: string }>('POST', '/api/files/rename', { from, to }),


### PR DESCRIPTION
## What

The Files browser could create folders and upload files, but had no way to create a **new empty file** — `PUT /api/files/write` deliberately declines to create (`file not found (creating files is disabled)`). This adds the dedicated create path.

- **`src/server.ts`** — new `POST /api/files/create`: resolves the path within the data home, refuses to clobber an existing file/folder (`409`), verifies the parent is a directory, writes with the `wx` flag (fail-if-exists), and audits `file.created`.
- **`web/src/lib/api.ts`** — `api.files.create(path, content?)`.
- **`web/src/App.tsx`** — a **New file** toolbar button beside "New folder": prompts for a name, creates the file in the current folder, reloads the listing, and opens the empty file straight into the editor.

## Test plan

- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 44/44 ✓
- Manual: New file in a folder → appears in listing + opens in editor; creating over an existing name → `409` surfaced as a hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)