### PR TITLE
Sessions: a Files shortcut in the terminal toolbar → the agent's folder (v0.37.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.38.0] — 2026-07-08
+### Added
+- **Files shortcut from a session.** The live terminal's top-right toolbar grows a **Files** button next to
+  "Attach image": it jumps to the Files browser opened straight at the running agent's own folder
+  (`agents/<id>`) — a one-click way to inspect what the agent is reading and writing. `FilesPage` now honours
+  a deep link (`#/files/<path>`) and falls back to the home root (with a hint) when the folder isn't under
+  the data home (e.g. a bundled agent).
+
 ## [0.37.0] — 2026-07-08
 ### Added
 - **Procedural skills — the fleet drafts its own skills (`skill_propose`, Lever 6 of the learning loop).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -710,7 +710,7 @@ function Console({ me }: { me: Member }) {
           {route === 'memory' && <MemoryPage agents={state?.agents ?? []} me={me} />}
           {route === 'kb' && <KnowledgeBasePage me={me} />}
           {route === 'skills' && <SkillsPage />}
-          {route === 'files' && <FilesPage />}
+          {route === 'files' && <FilesPage initialDir={detail} />}
           {route === 'artifacts' && <ArtifactsPage me={me} initialId={artifactFocus} />}
           {route === 'audit' && <AuditPage />}
           {route === 'docs' && <DocsPage selected={detail} onSelect={(slug) => nav('docs', slug)} />}
@@ -1190,15 +1190,28 @@ function ImageDropZone({ session, children, onActivity }: { session?: Session; c
           onClick={() => setFontSize((s) => Math.min(FONT_MAX, s + 1))}
         >A+</button>
       </div>
-      {/* 📎 attach button — opens a file picker; always works regardless of focus */}
-      <label
-        className="absolute right-2 top-2 z-10 flex cursor-pointer items-center gap-1 rounded bg-neutral-800/90 px-2 py-1 text-xs text-neutral-200 shadow hover:bg-neutral-700"
-        title="attach an image to this session (or drag-drop / paste one onto the terminal)"
-      >
-        <ImageIcon className="h-3.5 w-3.5" /> Attach image
-        <input type="file" accept="image/*" className="hidden"
-          onChange={(e) => { const f = e.target.files?.[0]; if (f) void upload(f); e.currentTarget.value = '' }} />
-      </label>
+      {/* top-right session toolbar: browse the agent's folder + attach an image */}
+      <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5">
+        {session?.agent && (
+          <button
+            type="button"
+            className="flex items-center gap-1 rounded bg-neutral-800/90 px-2 py-1 text-xs text-neutral-200 shadow hover:bg-neutral-700"
+            title="browse this agent's folder in Files"
+            onClick={() => { window.location.hash = '/files/' + encodeURIComponent('agents/' + session.agent) }}
+          >
+            <FolderTree className="h-3.5 w-3.5" /> Files
+          </button>
+        )}
+        {/* 📎 attach button — opens a file picker; always works regardless of focus */}
+        <label
+          className="flex cursor-pointer items-center gap-1 rounded bg-neutral-800/90 px-2 py-1 text-xs text-neutral-200 shadow hover:bg-neutral-700"
+          title="attach an image to this session (or drag-drop / paste one onto the terminal)"
+        >
+          <ImageIcon className="h-3.5 w-3.5" /> Attach image
+          <input type="file" accept="image/*" className="hidden"
+            onChange={(e) => { const f = e.target.files?.[0]; if (f) void upload(f); e.currentTarget.value = '' }} />
+        </label>
+      </div>
       {/* drag overlay — raised ON TOP of the iframe (z-30, interactive) only while a file-drag is in
           progress, so it catches the drop the iframe would otherwise swallow */}
       {drag && (
@@ -1760,7 +1773,7 @@ const fmtSize = (n: number): string =>
 /** Browse + edit files in the instance's data home. The server confines every path to the
  *  home root; navigation (folders/breadcrumb) + a text editor, plus upload (button or drag-drop),
  *  download, new-folder and delete. */
-function FilesPage() {
+function FilesPage({ initialDir }: { initialDir?: string }) {
   const [dir, setDir] = useState('')
   const [listing, setListing] = useState<DirListing | null>(null)
   const [openPath, setOpenPath] = useState<string | null>(null)
@@ -1772,14 +1785,23 @@ function FilesPage() {
   const fileInput = useRef<HTMLInputElement>(null)
   const dragDepth = useRef(0)
 
-  const loadDir = (rel: string) => {
+  const loadDir = (rel: string, fallbackHome = false) => {
     setHint('')
     api.files.list(rel).then((d) => {
-      if (d.error) return setHint('⚠ ' + d.error)
+      if (d.error) {
+        // A deep link to a folder that doesn't exist (e.g. a bundled agent living outside the
+        // data home) still lands somewhere useful — drop to the home root and explain.
+        if (fallbackHome && rel) {
+          api.files.list('').then((r) => { if (!r.error) { setListing(r); setDir(r.path) } })
+          return setHint(`⚠ ${rel}: ${d.error}`)
+        }
+        return setHint('⚠ ' + d.error)
+      }
       setListing(d); setDir(d.path)
     })
   }
-  useEffect(() => { loadDir('') }, [])
+  // Open the deep-linked folder (`#/files/<path>`) on mount / when the link changes; '' = home root.
+  useEffect(() => { loadDir(initialDir || '', true) }, [initialDir])
   const reload = () => loadDir(dir)
 
   const join = (name: string) => (dir ? `${dir}/${name}` : name)


### PR DESCRIPTION
## What

Adds a **Files** button to the live terminal's top-right toolbar, next to **Attach image**. Clicking it opens the Files browser deep-linked straight to the running agent's own folder (`agents/<id>`) — a one-click way to inspect what the agent is reading and writing.

## How

- **`ImageDropZone`** — the attach button + the new Files button are now grouped in one top-right toolbar container. The Files button sets `window.location.hash = '/files/' + encodeURIComponent('agents/' + session.agent)` (the established cross-component nav pattern in this file). Only shown when `session.agent` is known.
- **`FilesPage`** now accepts an `initialDir` prop sourced from the hash-route detail (`#/files/<path>`), and opens it on mount / when the link changes. If the folder can't be listed (e.g. a bundled agent living outside the data home), it falls back to the home root and shows a hint.
- **Router** already supported `#/files/<detail>`; the render call now threads `detail` through: `<FilesPage initialDir={detail} />`.

Agents live at `<home>/agents/<id>` (confirmed against the live data home), and the Files viewer is rooted at the data home — so `agents/<id>` is the correct relative path.

## Test

- `cd web && npm run build` ✅
- `npx tsc --noEmit` (web) ✅

UI-only change (web console) — no server restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)