### PR TITLE
Inbox: question DMs, close the chat loop, per-member read/dismiss (v0.39.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.39.0] — 2026-07-08
+### Added
+- **Questions ping the human out-of-band.** When an agent `ask`s a question it no longer sits silently in
+  the console until its ~1h poll times out: a new **question notifier** DMs the person the run acts for
+  (its `run_as`, else the spawning member; a pure automation falls back to owner/admins) on their linked
+  Slack/Discord account — the question-side twin of the existing approval notifier. Audited `question.notified`.
+- **The chat loop closes.** A Slack/Discord-triggered run now mirrors its **completion, questions, and
+  approval gates back into the thread it was triggered from**, instead of only the console Inbox — the
+  person who @mentioned the agent sees the outcome where they asked. Best-effort via a new `chatMirror`
+  sink over the existing `slack_threads`/`discord_threads` bindings; a no-op for non-chat runs. The agent's
+  own `slack_reply`/`discord_reply` still work for finer replies.
+### Changed
+- **Inbox read + dismiss are now per-member.** The feed is shared (every owner/admin sees the same rows),
+  so a single `dismissed_at` column meant one admin dismissing an item hid it for everyone, and unread was
+  a browser-local `localStorage` timestamp that didn't sync across a member's devices. Both now live in a
+  new `message_state(message_id, member_id, read_at, dismissed_at)` join keyed to the viewer: each member
+  has their own read-line and dismissed set, server-backed. Legacy global `messages.dismissed_at` is still
+  honored as a dismissed-for-all fallback. New routes `POST /api/messages/:id/read` and `/api/messages/read-all`.
+
 ## [0.38.0] — 2026-07-08
 ### Added
 - **Files shortcut from a session.** The live terminal's top-right toolbar grows a **Files** button next to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,6 +261,11 @@ Conventions when touching the DB:
   surfaced read-only at `GET /api/audit` (owner/admin; filter by session/type/principal) + the console
   **Audit** page. Approval cards also DM whoever can approve them via Slack/Discord
   (`TerminalManager.setApprovalNotifier` → `notifyApprovers` → identity map → `dmUser`; audited `approval.notified`).
+  Agent **questions** get the same out-of-band ping (`setQuestionNotifier` → `notifyQuestionAsked` → the
+  run-as human, else owner/admins; audited `question.notified`), so a blocking `ask` isn't missed. And a
+  chat-triggered run mirrors its completion/question/approval back into the Slack/Discord thread it came
+  from (`setChatMirror` → `slack.reply`/`discord.reply` over the `slack_threads`/`discord_threads` bindings;
+  no-op for non-chat runs) — read/dismiss on the shared feed are **per-member** (`message_state` join).
 
 ## Team / roles / login
 

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -18,7 +18,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `kb_write` | `POST /api/kb/write` | `KbStore.write` | W | versioned; author `agent:<id>` |
 | `kb_history` | `GET /api/kb/history` | `KbStore.history` | R | newest-first revisions |
 | `kb_revert` | `POST /api/kb/revert` | `KbStore.revert` | W | itself a new revision; audited `kb.reverted` |
-| `ask` | `POST /api/ask` + poll | questions | W (blocking) | blocks ~1h polling for the human answer |
+| `ask` | `POST /api/ask` + poll | questions | W (blocking) | blocks ~1h polling for the human answer; DMs the run-as human out-of-band (`question.notified`) + mirrors to the chat thread so it isn't missed |
 | `check_inbox` | `GET /api/inbox` | `TerminalManager.sessionInbox` | R | non-blocking pull of this session's feed |
 | `report` | `POST /api/report` | messages | W | `outcome` enum |
 | `update` | `POST /api/update` | messages | W | non-blocking progress note |
@@ -100,7 +100,10 @@ future tightening could classify agent creation through Policy for workspaces th
 - **Episodic self-query.** Memory is semantic-only; an agent can't query its own past runs
   (`/api/runs` exists but is member-gated). "Have I done this before, how did it go?"
 - **`ask` rigidity.** Timeout hardcoded ~1h; no `timeoutSeconds` and no non-blocking ask-then-collect
-  (partially mitigated now by `check_inbox`).
+  (partially mitigated now by `check_inbox`). The question now DMs the run-as human + mirrors to the chat
+  thread on ask, but there's still **no server-side timeout/escalation**: if the agent's poll gives up, the
+  `questions` row stays `pending` forever and a late answer reaches a run that already moved on. No reminder
+  on stale approvals/questions either — tracked as a follow-up (inbox batch 2).
 - **Cross-agent artifact/KB read of file contents.** `artifacts_list` returns metadata only and is
   scoped to the agent's own outputs; reading a sibling agent's published file back has no tool.
 - **No generic "perform capability" tool** — by design. Effects flow through real tools + the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.38.0",
+      "version": "0.39.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.38.0",
+  "version": "0.39.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1249,6 +1249,18 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, dismissed: tm.dismissAllMessages(me) });
   }
 
+  // Mark every message the viewer can see as read (per-member) — clears the unread badge.
+  if (method === 'POST' && p === '/api/messages/read-all') {
+    return sendJson(res, 200, { ok: true, read: tm.markAllRead(me) });
+  }
+
+  // Mark one message read for this member (per-member state; the shared feed is unaffected for others).
+  const readMatch = p.match(/^\/api\/messages\/([\w-]+)\/read$/);
+  if (method === 'POST' && readMatch) {
+    const ok = tm.markRead(readMatch[1], me);
+    return sendJson(res, ok ? 200 : 404, ok ? { ok: true } : { error: 'unknown message' });
+  }
+
   // Dismiss a message from the inbox (soft hide; the row is kept for audit). Same visibility rule as
   // the feed; a pending approval/question can't be dismissed (resolve/answer it instead).
   const dismissMatch = p.match(/^\/api\/messages\/([\w-]+)\/dismiss$/);

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -394,6 +394,19 @@ function migrate(db: Db): void {
       agent TEXT NOT NULL,
       PRIMARY KEY (skill, agent)
     );
+
+    -- Per-member inbox state (read + dismiss). The messages feed is SHARED (every owner/admin sees the
+    -- same rows), so read/dismiss can't be a single column on the message — one admin dismissing would
+    -- hide it for all. This join table keys both to (message, member): each viewer has their own
+    -- read-line and their own dismissed set. Legacy global messages.dismissed_at is still honored as a
+    -- dismissed-for-all fallback so pre-migration dismissals don't resurface.
+    CREATE TABLE IF NOT EXISTS message_state (
+      message_id   TEXT NOT NULL,
+      member_id    TEXT NOT NULL,
+      read_at      INTEGER,
+      dismissed_at INTEGER,
+      PRIMARY KEY (message_id, member_id)
+    );
   `);
 
   // Idempotent column additions for the inbox feed (older DBs won't have these).

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { AgentOS, loadAgentOS, readRootConfig, RootConfig } from './kernel';
 import { exampleCapabilities } from './capabilities/examples';
-import { TerminalManager, ApprovalNotice } from './terminal';
+import { TerminalManager, ApprovalNotice, QuestionNotice } from './terminal';
 import { Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
@@ -187,6 +187,12 @@ export class TenantRegistry {
     // Chat approval notifications (M5): when a risky action lands an approval card, DM whoever can
     // approve it — via their linked Slack/Discord account (identity map). Best-effort, off the hot path.
     tm.setApprovalNotifier((notice) => { void notifyApprovers(os, slack, discord, notice); });
+    // Question notifications: when an agent asks the human a question, DM the person the run acts for so
+    // a blocking `ask` doesn't sit unseen until it times out — the question-side twin of the above.
+    tm.setQuestionNotifier((notice) => { void notifyQuestionAsked(os, slack, discord, notice); });
+    // Chat loop: mirror completions/questions/approvals back to the Slack/Discord thread a chat-triggered
+    // run is bound to. Both replies no-op when the session has no bound thread (non-chat runs).
+    tm.setChatMirror((sessionId, text) => { void slack.reply(sessionId, text); void discord.reply(sessionId, text); });
     const ttyd = launchTtyd(paths.tmuxSocket, ttydPort, paths.connectors);
     console.log(`  [tenant:${rec.slug}] home=${paths.home}  ttyd=:${ttydPort}`);
     return { record: rec, os, tm, autos, slack, discord, ttyd, ttydPort, firstLogin: firstLogin ?? undefined };
@@ -222,6 +228,35 @@ export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmU
     if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
   }
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'approval.notified', data: { capability: notice.capability, level: notice.level, approvers: approvers.length, dms } });
+}
+
+/**
+ * DM the human a blocking agent question is waiting on, on their linked Slack/Discord account — the
+ * question-side twin of {@link notifyApprovers}. Targets the member the run acts for (its `run_as`, or
+ * the member who spawned it); if the run has no human owner (a pure automation), falls back to the
+ * owner/admins so the question still reaches someone. Best-effort, off the ask hot path. Audited once.
+ */
+export async function notifyQuestionAsked(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: QuestionNotice): Promise<void> {
+  const row = os.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(notice.sessionId);
+  let owner = row?.run_as ? os.team.getMember(row.run_as) : undefined;
+  // A console-spawned run's provenance IS a member id (automation:/task:/chat: spawns are prefixed).
+  if (!owner && row?.spawned_by && !row.spawned_by.includes(':')) owner = os.team.getMember(row.spawned_by);
+  const targets = owner
+    ? [owner]
+    : os.team.listMembers().filter((m) => m.status === 'active' && (m.role === 'owner' || m.role === 'admin'));
+  if (!targets.length) return;
+  const text =
+    `❓ Agent ${notice.agent} is waiting on your answer:\n${notice.prompt}` +
+    `\nOpen the Agent OS console → Inbox to reply.`;
+  let dms = 0;
+  for (const m of targets) {
+    const ids = os.team.externalIdsFor(m.id);
+    const slackId = ids.find((i) => i.provider === 'slack')?.externalId;
+    const discordId = ids.find((i) => i.provider === 'discord')?.externalId;
+    if (slackId && (await slack.dmUser(slackId, text)).ok) dms++;
+    if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
+  }
+  os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'question.notified', data: { agent: notice.agent, targets: targets.length, dms } });
 }
 
 /** Launch a ttyd bound to one tenant's tmux socket on `ttydPort`. (Moved verbatim from server.ts.) */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -152,6 +152,8 @@ export interface FeedMessage {
   answeredBy?: string;
   /** The session's live display title (joined live from term_sessions) — the inbox's primary heading. */
   sessionTitle?: string;
+  /** Whether the requesting viewer has marked this read (per-member; absent on the agent's own feed). */
+  read?: boolean;
   createdAt: number;
 }
 
@@ -198,6 +200,9 @@ interface MessageRow {
   /** The session's live display title (AI-renamed on report, else the task / automation name) — the
    *  inbox leads with this as the primary heading, with the agent as a secondary line. */
   session_title?: string | null;
+  /** Per-viewer inbox state, joined from message_state for the requesting member (console feed only).
+   *  Absent (key not selected) on the agent's own session inbox. */
+  state_read_at?: number | null;
 }
 
 /** What the approval-notifier sink receives when a risky action lands an approval card. */
@@ -207,6 +212,15 @@ export interface ApprovalNotice {
   capability: string;
   level: ApprovalLevel;
   reason?: string;
+}
+
+/** What the question-notifier sink receives when an agent asks the human a question — so an out-of-band
+ *  channel (Slack/Discord DM) can ping the person the run acts for, the way approvals already ping
+ *  approvers. Without it a blocking `ask` sits unseen in the console until it times out. */
+export interface QuestionNotice {
+  sessionId: string;
+  agent: string;
+  prompt: string;
 }
 
 export class TerminalManager {
@@ -231,6 +245,16 @@ export class TerminalManager {
    *  can ping the approver. Set by the registry once the chat sockets exist; absent = no notifications. */
   private approvalNotifier?: (notice: ApprovalNotice) => void;
   setApprovalNotifier(fn: (notice: ApprovalNotice) => void): void { this.approvalNotifier = fn; }
+  /** Optional sink notified when an agent asks the human a question — mirrors the approval notifier so
+   *  a blocking `ask` pings the run-as member out-of-band instead of sitting unseen. */
+  private questionNotifier?: (notice: QuestionNotice) => void;
+  setQuestionNotifier(fn: (notice: QuestionNotice) => void): void { this.questionNotifier = fn; }
+  /** Optional sink that mirrors an inbox-worthy event (completion, question, approval) back to the
+   *  Slack/Discord thread a chat-triggered session is bound to, so the human who pinged the agent in
+   *  chat sees the outcome there instead of having to switch to the console. No-op for non-chat runs
+   *  (the sink resolves no bound thread). Set by the registry once the chat sockets exist. */
+  private chatMirror?: (sessionId: string, text: string) => void;
+  setChatMirror(fn: (sessionId: string, text: string) => void): void { this.chatMirror = fn; }
 
   constructor(
     private readonly os: AgentOS,
@@ -424,21 +448,60 @@ export class TerminalManager {
     // Approval messages take their live status from the approvals table, so the inbox stays
     // correct even after a restart (when the in-memory resolution waiter is gone). We also pull each
     // message's session `spawned_by` so the inbox can be scoped per member (owner/admin see all).
+    // Read/dismiss are PER-MEMBER (message_state join keyed to the viewer): the feed is shared, so one
+    // admin dismissing must not hide the row for another. Legacy global `messages.dismissed_at` is still
+    // honored as a dismissed-for-all fallback. With no viewer (demo), state joins to nothing.
+    const viewerId = viewer?.id ?? '';
     const rows = this.db
       .prepare(
         `SELECT m.*, a.status AS approval_status, a.reason AS approval_reason, a.resolved_by AS approval_resolved_by,
                 q.status AS question_status, q.answer AS question_answer, q.answered_by AS question_answered_by,
-                ts.spawned_by AS session_spawned_by, ts.run_as AS session_run_as, ts.title AS session_title
+                ts.spawned_by AS session_spawned_by, ts.run_as AS session_run_as, ts.title AS session_title,
+                ms.read_at AS state_read_at
          FROM messages m
          LEFT JOIN approvals a ON m.approval_id = a.id
          LEFT JOIN questions q ON m.question_id = q.id
          LEFT JOIN term_sessions ts ON m.session_id = ts.id
-         WHERE m.dismissed_at IS NULL
+         LEFT JOIN message_state ms ON ms.message_id = m.id AND ms.member_id = ?
+         WHERE m.dismissed_at IS NULL AND ms.dismissed_at IS NULL
          ORDER BY m.created_at DESC`,
       )
-      .all<MessageRow>();
+      .all<MessageRow>(viewerId);
     const visible = viewer ? rows.filter((r) => this.canViewRow(r.session_spawned_by ?? null, r.session_run_as ?? null, viewer)) : rows;
     return visible.map(toMessage);
+  }
+
+  /** Mark one message read for a member (per-member; idempotent upsert). Visibility-guarded like the
+   *  feed — you can only touch a message you can see. Returns false if it's not found or not yours. */
+  markRead(id: string, viewer: Member): boolean {
+    const row = this.db
+      .prepare('SELECT ts.spawned_by AS sb, ts.run_as AS ra FROM messages m LEFT JOIN term_sessions ts ON m.session_id = ts.id WHERE m.id = ?')
+      .get<{ sb: string | null; ra: string | null }>(id);
+    if (!row) return false;
+    if (!this.canViewRow(row.sb, row.ra, viewer)) return false;
+    this.upsertState(id, viewer.id, 'read_at');
+    return true;
+  }
+
+  /** Mark every message the viewer can currently see as read (per-member). Returns how many were touched. */
+  markAllRead(viewer: Member): number {
+    let n = 0;
+    for (const m of this.listMessages(viewer)) {
+      if (m.read) continue;
+      this.upsertState(m.id, viewer.id, 'read_at');
+      n++;
+    }
+    return n;
+  }
+
+  /** Upsert a per-member message_state timestamp column (read_at | dismissed_at) to now. */
+  private upsertState(messageId: string, memberId: string, col: 'read_at' | 'dismissed_at'): void {
+    this.db
+      .prepare(
+        `INSERT INTO message_state (message_id, member_id, ${col}) VALUES (?, ?, ?)
+         ON CONFLICT(message_id, member_id) DO UPDATE SET ${col} = excluded.${col}`,
+      )
+      .run(messageId, memberId, Date.now());
   }
 
   /** The inbox feed for ONE session — what the agent itself can read back (answers to questions it
@@ -482,7 +545,7 @@ export class TerminalManager {
       (row.type === 'approval' && (row.approval_status ?? 'pending') === 'pending') ||
       (row.type === 'question' && (row.question_status ?? 'pending') === 'pending');
     if (stillWaiting) return 'pending';
-    this.db.prepare('UPDATE messages SET dismissed_at = ? WHERE id = ?').run(Date.now(), id);
+    this.upsertState(id, viewer.id, 'dismissed_at'); // per-member hide — the row stays for others + audit
     return 'ok';
   }
 
@@ -492,28 +555,16 @@ export class TerminalManager {
    * human (pending approval/question) — those are left in place. Returns how many were hidden.
    */
   dismissAllMessages(viewer: Member): number {
-    const rows = this.db
-      .prepare(
-        `SELECT m.id, m.type, a.status AS approval_status, q.status AS question_status,
-                ts.spawned_by AS session_spawned_by, ts.run_as AS session_run_as
-         FROM messages m
-         LEFT JOIN approvals a ON m.approval_id = a.id
-         LEFT JOIN questions q ON m.question_id = q.id
-         LEFT JOIN term_sessions ts ON m.session_id = ts.id
-         WHERE m.dismissed_at IS NULL`,
-      )
-      .all<{ id: string; type: FeedMessage['type']; approval_status: string | null; question_status: string | null; session_spawned_by: string | null; session_run_as: string | null }>();
-    const now = Date.now();
-    const stmt = this.db.prepare('UPDATE messages SET dismissed_at = ? WHERE id = ?');
+    // Reuse the feed (already visibility-scoped + per-member-dismiss filtered) and hide each dismissible
+    // row for THIS viewer. Waiting items (pending approval/question, open notifications) stay put.
     let n = 0;
-    for (const r of rows) {
-      if (!this.canViewRow(r.session_spawned_by ?? null, r.session_run_as ?? null, viewer)) continue;
+    for (const m of this.listMessages(viewer)) {
       const stillWaiting =
-        (r.type === 'approval' && (r.approval_status ?? 'pending') === 'pending') ||
-        (r.type === 'question' && (r.question_status ?? 'pending') === 'pending') ||
-        r.type === 'notification';
+        (m.type === 'approval' && (m.status ?? 'pending') === 'pending') ||
+        (m.type === 'question' && (m.status ?? 'pending') === 'pending') ||
+        m.type === 'notification';
       if (stillWaiting) continue;
-      stmt.run(now, r.id);
+      this.upsertState(m.id, viewer.id, 'dismissed_at');
       n++;
     }
     return n;
@@ -921,6 +972,9 @@ export class TerminalManager {
     this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability });
     // Out-of-band ping (Slack/Discord DM to whoever can approve) — best-effort, never blocks the gate.
     try { this.approvalNotifier?.({ sessionId, agent, capability, level: decision.level, reason: decision.reason }); } catch { /* notifications are advisory */ }
+    // If the run was triggered from chat, surface the gate in that thread too (the approver DM reaches
+    // the approver; this reaches everyone watching the thread). No-op for non-chat runs.
+    try { this.chatMirror?.(sessionId, `🔔 ${agent} needs approval — \`${capability}\` (${decision.level}).\nOpen the Agent OS console → Inbox to approve or reject.`); } catch { /* advisory */ }
 
     // The message + gate status are derived from the approvals table at read time, so all this
     // waiter has to do is leave an audit trail. (It won't fire across a restart — that's fine.)
@@ -1139,6 +1193,11 @@ export class TerminalManager {
       .run(id, sessionId, this.os.tenant, agent, prompt, 'pending', Date.now());
     this.addMessage({ type: 'question', sessionId, agent, title: `Question — ${agent}`, body: prompt, status: 'pending', questionId: id });
     this.audit(sessionId, agent, 'question.asked', { questionId: id, prompt });
+    // Out-of-band ping (like approvals): DM the person the run acts for so a blocking `ask` doesn't sit
+    // unseen in the console. And if the run was triggered from chat, mirror the question into that
+    // thread. Both best-effort, off the hot path.
+    try { this.questionNotifier?.({ sessionId, agent, prompt }); } catch { /* notifications are advisory */ }
+    try { this.chatMirror?.(sessionId, `❓ ${agent} needs your input:\n${prompt}\n\nAnswer in the Agent OS console → Inbox.`); } catch { /* advisory */ }
     return { id };
   }
 
@@ -1184,6 +1243,11 @@ export class TerminalManager {
     if (this.hasCompleted(sessionId)) return;
     this.clearNotifications(sessionId);
     this.addMessage({ type: 'completed', sessionId, agent, title: `Completed — ${agent}`, body: summary || '(no summary)', status: 'open', outcome });
+    // Close the chat loop: a chat-triggered run's completion goes back to the thread the human pinged
+    // from, not just the console. No-op for non-chat runs. The agent's own `slack_reply`/`discord_reply`
+    // still work for finer-grained replies; this guarantees the outcome lands even if it never called them.
+    const mark = outcome === 'success' ? '✅' : outcome === 'failure' ? '❌' : '☑️';
+    try { this.chatMirror?.(sessionId, `${mark} ${agent} finished (${outcome}).\n${summary || '(no summary)'}`); } catch { /* advisory */ }
     // Rename the session from the agent's own summary — an AI-written label that reflects what the run
     // actually did, replacing the provisional title (the task text / automation name set at spawn).
     // Claude Code's internal /resume summaries aren't available for governed sessions (headless `-p`
@@ -1628,6 +1692,9 @@ function toMessage(r: MessageRow): FeedMessage {
     resolvedBy: r.type === 'approval' ? r.approval_resolved_by ?? undefined : undefined,
     answeredBy: r.type === 'question' ? r.question_answered_by ?? undefined : undefined,
     sessionTitle: r.session_title ?? undefined,
+    // read is per-member: present only when the console feed joined message_state for the viewer.
+    // The agent's own session inbox doesn't select it (key absent) → left undefined.
+    read: 'state_read_at' in r ? r.state_read_at != null : undefined,
     createdAt: r.created_at,
   };
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1477,7 +1477,6 @@ function SessionsPage({
 }
 
 // ── Inbox ──────────────────────────────────────────────────────────────────────
-const SEEN_KEY = 'aos_inbox_seen'
 /** An item needs the human: an unresolved approval, an unanswered question, or a session that fired a
  *  Notification (Claude is blocked waiting on a permission prompt / idle input). */
 const isActionRequired = (m: Msg): boolean =>
@@ -1518,9 +1517,12 @@ function MsgHeading({ m, children }: { m: Msg; children?: ReactNode }) {
 }
 
 function InboxPage({ messages, me, onOpen, onOpenArtifact }: { messages: Msg[]; me: Member; onOpen: (tmux: string, title: string) => void; onOpenArtifact: (id: string) => void }) {
-  const [seen, setSeen] = useState<number>(() => Number(localStorage.getItem(SEEN_KEY) || 0))
+  // Read state is now PER-MEMBER + server-backed (m.read): it syncs across this member's devices/tabs
+  // and one admin marking read no longer touches another's badge. `readIds` optimistically bridges the
+  // gap until the next poll reflects the server truth.
+  const [readIds, setReadIds] = useState<Set<string>>(() => new Set())
   // Optimistically hide dismissed items; roll back on error. The server filters them from the next
-  // poll anyway, so the set just bridges the gap until then.
+  // poll anyway (per-member now), so the set just bridges the gap until then.
   const [dismissed, setDismissed] = useState<Set<string>>(() => new Set())
   const dismiss = async (id: string) => {
     setDismissed((s) => new Set(s).add(id))
@@ -1536,10 +1538,14 @@ function InboxPage({ messages, me, onOpen, onOpenArtifact }: { messages: Msg[]; 
     const r = await api.dismissAllMessages()
     if (r.error) { setDismissed((s) => { const n = new Set(s); ids.forEach((id) => n.delete(id)); return n }); alert(r.error) }
   }
-  const unread = activity.filter((m) => m.createdAt > seen).length
-  const markRead = () => {
-    const latest = messages.reduce((mx, m) => Math.max(mx, m.createdAt), seen)
-    localStorage.setItem(SEEN_KEY, String(latest)); setSeen(latest)
+  const isUnread = (m: Msg): boolean => !m.read && !readIds.has(m.id)
+  const unread = activity.filter(isUnread).length
+  const markRead = async () => {
+    const ids = activity.filter(isUnread).map((m) => m.id)
+    if (ids.length === 0) return
+    setReadIds((s) => { const n = new Set(s); ids.forEach((id) => n.add(id)); return n })
+    const r = await api.markAllRead()
+    if (r.error) { setReadIds((s) => { const n = new Set(s); ids.forEach((id) => n.delete(id)); return n }); alert(r.error) }
   }
 
   if (messages.length === 0)
@@ -1572,7 +1578,7 @@ function InboxPage({ messages, me, onOpen, onOpenArtifact }: { messages: Msg[]; 
           <div className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">No activity yet.</div>
         ) : (
           <div className="divide-y divide-border/60 overflow-hidden rounded-lg border">
-            {activity.map((m) => <FeedItem key={m.id} m={m} onOpen={onOpen} onOpenArtifact={onOpenArtifact} onDismiss={dismiss} unread={m.createdAt > seen} />)}
+            {activity.map((m) => <FeedItem key={m.id} m={m} onOpen={onOpen} onOpenArtifact={onOpenArtifact} onDismiss={dismiss} unread={isUnread(m)} />)}
           </div>
         )}
       </section>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -274,6 +274,8 @@ export interface Msg {
   answeredBy?: string
   /** The session's live display name — the inbox leads with this; `agent` is the secondary line. */
   sessionTitle?: string
+  /** Whether THIS member has marked the message read (per-member, server-backed). */
+  read?: boolean
   createdAt: number
 }
 
@@ -650,6 +652,8 @@ export const api = {
   answerQuestion: (id: string, answer: string) => call<{ ok: boolean; error?: string }>('POST', '/api/questions/' + id, { answer }),
   dismissMessage: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/dismiss`),
   dismissAllMessages: () => call<{ ok: boolean; dismissed?: number; error?: string }>('POST', '/api/messages/dismiss-all'),
+  markRead: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/read`),
+  markAllRead: () => call<{ ok: boolean; read?: number; error?: string }>('POST', '/api/messages/read-all'),
 
   team: () => call<TeamResp>('GET', '/api/team'),
   audit: (f: { session?: string; type?: string; principal?: string; limit?: number } = {}) => {


### PR DESCRIPTION
## Why

An audit of the inbox across the stack found the spine is solid — one `messages` feed with live-joined approval/question status that self-heals across restarts, `canViewRow` visibility (provenance + run-as), agent `check_inbox` + MCP write tools. The weakness is all at the **edges: the inbox is a well-built passive store with weak *push*.** Items land correctly; getting a human or agent to *notice* them in time is the consistent gap. This PR closes the three sharpest ones.

## What

**1. Questions ping the human out-of-band.** `askQuestion` now fires a `questionNotifier` — the twin of the existing approval notifier — that DMs the person the run acts for (`run_as`, else the spawning member; a pure automation → owner/admins) on their linked Slack/Discord account. Previously an agent's blocking `ask` sat silently in the console until its ~1h poll timed out. Audited `question.notified`.

**2. The chat loop closes.** A Slack/Discord-triggered run now mirrors its **completion, questions, and approval gates back into the thread it was triggered from**, not just the console Inbox — the person who @mentioned the agent sees the outcome where they asked. New `chatMirror` sink over the existing `slack_threads`/`discord_threads` bindings; a no-op for non-chat runs. The agent's own `slack_reply`/`discord_reply` still work for finer replies.

**3. Inbox read + dismiss are per-member.** The feed is shared (every owner/admin sees the same rows), so a single `dismissed_at` column meant one admin dismissing hid the row for everyone, and unread was a browser-local `localStorage` timestamp that didn't sync across a member's devices. Both now live in a new `message_state(message_id, member_id, read_at, dismissed_at)` join keyed to the viewer, server-backed. Legacy global `messages.dismissed_at` stays honored as a dismissed-for-all fallback. New routes `POST /api/messages/:id/read` and `/api/messages/read-all`.

## Not in this PR (batch 2 follow-ups)

Server-side question timeout/escalation (a late answer still reaches a run that gave up), stale-approval reminders/digests, and real-time push (SSE) over the 1.5s polling. Documented in `docs/agent-mcp-tools.md`.

## Validation

`npm run typecheck` · `cd web && npm run build` · `npm run test:governance` (44/44) · `npm run demo`, plus isolated smoke tests (scratch `AGENT_OS_HOME`) proving per-member read/dismiss isolation across two members and that the notifier/mirror sinks fire with the right payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)