### PR TITLE
Inbox: "Always approve" learns a policy rule + inbox-plan doc (v0.40.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.40.0] — 2026-07-08
+### Added
+- **"Always approve" — teach policy from the inbox.** An approval card grows an owner-only **Always**
+  button next to Approve/Reject: it approves the current attempt **and** writes a persistent `allow` rule
+  for that capability into the policy override (`POST /api/approvals/:id/always`, hot-reloaded), so future
+  matching attempts pass the gate without a card. The inbox becomes the policy-authoring surface — the
+  place to codify "we've decided this is fine." Safety is by rule **placement**: since `classify` is
+  first-match and the deny guardrails are conditional `never` rules (`destructive` / over-`$moneyCapUsd` /
+  bulk-delete), the new allow is inserted **after** all `never` rules, so a routine attempt stops
+  prompting while a destructive or over-cap attempt of the same capability **still denies**. Owner-only
+  (adding a rule is a policy edit, same guard as `PUT /api/policy`); refuses to shadow an unconditional
+  `never` (approves once, doesn't add the rule); idempotent; audited `policy.rule.added` + `policy.updated`.
+  New `withAlwaysAllow`/`hasHardDeny` helpers in `src/governance/policy.ts`.
+- **`docs/inbox-plan.md`** — the standing inbox audit: the spine, ranked gaps with status, the
+  "Always approve" safety design, and the batch roadmap.
+
 ## [0.39.0] — 2026-07-08
 ### Added
 - **Questions ping the human out-of-band.** When an agent `ask`s a question it no longer sits silently in

--- a/docs/inbox-plan.md
+++ b/docs/inbox-plan.md
@@ -1,0 +1,201 @@
+# The Inbox — audit, gaps, and roadmap
+
+The **Inbox** is the human↔agent message surface: the feed of approvals, questions, completions,
+progress updates, notifications, artifacts, and skill proposals that agents and automations produce and
+humans consume in the console. It is where the governed fleet *talks to people* — the counterpart to the
+gateway (where agents *act on the world*).
+
+This doc is the standing audit of that surface: how it's wired, the gaps found, what's shipped, and the
+roadmap. Update the status tags as reality changes.
+
+---
+
+## 1. The spine (what's solid)
+
+One `messages` table is the feed. Every row is one card. Two consumer surfaces read it:
+
+- **Console** — `GET /api/messages` → `TerminalManager.listMessages(viewer)`, polled every 1.5s. The
+  whole tenant feed, visibility-scoped per member.
+- **Agent** — `GET /api/inbox` → `sessionInbox(sessionId)`, the agent's own session feed (the
+  `check_inbox` MCP tool), so a run can read back answers/approvals/updates on itself.
+
+Three design choices make it robust:
+
+1. **Live status by join, not by copy.** An `approval`/`question` card doesn't store its own resolution
+   — `listMessages` LEFT JOINs the `approvals`/`questions` tables at read time. So the card's status is
+   always the single source of truth, and it **self-heals across a restart** even though the in-memory
+   blocking waiter doesn't survive one. (`toMessage` derives `status` from the joined row.)
+2. **Visibility = provenance + identity.** `canViewRow(spawned_by, run_as, viewer)`: owner/admin see all;
+   a member sees what they spawned, what an automation they own fired, **and** any run that acted *as*
+   them (`run_as`). A chat-triggered run is owned by the automation for provenance yet visible to — and
+   owned by — the person it ran as.
+3. **Per-member state.** Read + dismiss live in a `message_state(message_id, member_id, read_at,
+   dismissed_at)` join keyed to the viewer, not as columns on the shared row (see §4.3).
+
+### Message types
+
+| type | written by | terminal? | needs human? |
+|---|---|---|---|
+| `approval` | the gate (policy → `approve`) | no | **yes** (approve/reject) |
+| `question` | `ask` MCP tool | no | **yes** (answer) |
+| `notification` | Claude `Notification` hook (permission/idle) | no | **yes** (attend) |
+| `completed` | `report` MCP tool | yes | no |
+| `update` | `update` MCP tool | no | no |
+| `artifact` | `publish` MCP tool | no | no |
+| `skill.proposed` | `skill_propose` MCP tool | no | review (in Skills) |
+| `task` | legacy start rows | no | no |
+
+The first three are **"Needs you"**; the rest are **"Activity"**.
+
+---
+
+## 2. Write paths
+
+All agent writes are session-secret-gated loopback calls to `/api/*` routes that sit *before* the
+member-auth gate (`src/memory/memory-mcp.ts` → `src/server.ts` → `TerminalManager`):
+
+- `ask` → `POST /api/ask` → `askQuestion` — **blocking** (~1h client-side poll of `/api/ask/:id`).
+- `report` → `POST /api/report` → `report` — completion + outcome; stores an optional lesson memory.
+- `update` → `POST /api/update` → `progress` — non-blocking progress note (`important` highlights it).
+- `publish` → `POST /api/publish` → `publishArtifact` — snapshots a deliverable.
+- `skill_propose` → `POST /api/skills/propose` — drafts an `.aos-proposed` skill + a card.
+- The **gate** itself writes `approval` cards when policy returns `approve` (`terminal.ts` `gate` /
+  `putSecret`).
+
+---
+
+## 3. Read + resolve paths
+
+- **List:** `GET /api/messages` (console, per-viewer) · `GET /api/inbox` (agent, per-session).
+- **Approve/reject:** `POST /api/approvals/:id` — role-gated by `canApprove(role, level)`.
+- **Answer:** `POST /api/questions/:id` — visibility-gated by `canViewQuestion`.
+- **Read (per-member):** `POST /api/messages/:id/read` · `POST /api/messages/read-all`.
+- **Dismiss (per-member):** `POST /api/messages/:id/dismiss` · `POST /api/messages/dismiss-all` —
+  refuses to dismiss an item still waiting on the human.
+
+---
+
+## 4. Gaps (ranked) and status
+
+The recurring theme of the audit: **the inbox is a well-built passive store with weak *push*.** Items
+land correctly; getting a human or agent to *notice* and *act* on them in time is the consistent
+weakness. Ranked by impact:
+
+### 4.1 Questions notified nobody — ✅ SHIPPED (v0.39.0)
+Approvals DM approvers out-of-band; `ask` did not. A blocking `ask` sat unseen until its ~1h poll timed
+out. **Fixed:** a `questionNotifier` twin DMs the run-as human (else the spawning member; a pure
+automation → owner/admins). Audited `question.notified`.
+
+### 4.2 The chat loop didn't close — ✅ SHIPPED (v0.39.0)
+A Slack/Discord-triggered run's `report`/`ask`/approval went to the console, not back to the thread the
+human was watching. **Fixed:** a `chatMirror` sink mirrors completion, questions, and approval gates
+back into the bound `slack_threads`/`discord_threads` thread; no-op for non-chat runs.
+
+### 4.3 Read/dismiss were inconsistent for a team — ✅ SHIPPED (v0.39.0)
+Unread was a browser-local `localStorage` timestamp (didn't sync across a member's devices); dismiss was
+a **global** column (one admin dismissing hid the row for everyone). **Fixed:** both moved to the
+per-member `message_state` join. Legacy global `dismissed_at` still honored as a dismissed-for-all
+fallback.
+
+### 4.4 "Always approve" — teach the policy from an approval — ✅ SHIPPED (v0.40.0)
+Every approval used to be one-shot: the same capability re-prompted every run, forever. **Fixed:** an
+**"Always approve"** action on the approval card (owner-only) approves *this* attempt **and** writes a
+persistent `allow` rule into the policy override, so future matching attempts pass the gate without a
+card. The inbox becomes the **policy-authoring** surface — the natural place to codify "we've decided
+this is fine." See §5 for the safety design.
+
+### 4.5 No server-side timeout / escalation on stale items — ⏳ BATCH 2
+The agent's `ask` gives up client-side at ~1h, but the `questions` row stays `pending` **forever** — a
+human answering at hour 2 succeeds into a void; the run already moved on. Approvals block the gate hook
+indefinitely. No `timeoutSeconds`, no session-liveness check on answer, no "this run already gave up"
+signal. **Plan:** configurable `ask` timeout; mark the question `expired` when the run dies; on answer,
+check the run is still alive and tell the human if not.
+
+### 4.6 Nothing re-pings or digests stale items — ⏳ BATCH 2
+The approval/question DM fires **once**, best-effort, errors swallowed. If the approver was offline it
+never re-pings; no second-approver escalation; no "N items waiting Nh" digest. **Plan:** a scheduled
+reminder pass (reuse the automations tick) that re-DMs / digests items pending beyond a threshold, with
+escalation to the next approver tier.
+
+### 4.7 Everything polls; nothing scales — ⏳ BATCH 3
+Console re-fetches the **entire** tenant feed every 1.5s (no `since` cursor, no pagination, all held in
+memory); the agent polls `/api/ask` every 2s. Fine now, won't scale. **Plan:** `GET
+/api/messages?since=<ts>` delta + SSE push; virtualize/paginate the feed.
+
+### 4.8 UI friction + no feed tools — ⏳ BATCH 3
+Approve/reply buttons just `disabled=busy` until the next 1.5s poll (no optimistic update); errors are
+`alert()`. No filter/search/grouping/threading in the feed. **Plan:** optimistic action state +
+toasts; per-agent/per-session grouping; type filter + search.
+
+### 4.9 Agent can't be *pushed* an answer — ⏳ LATER
+An agent only learns its question was answered by polling `ask` or remembering to `check_inbox`. No push,
+no "N new replies since last check" cursor. Partially mitigated by `check_inbox`. **Plan:** an inbox
+cursor per session; longer-term, a push channel into the run.
+
+---
+
+## 5. "Always approve" — design detail (§4.4)
+
+**Trigger.** On a pending `approval` card, alongside *Approve* / *Reject*, an **"Always approve"** action
+(shown only to a member who may approve that level).
+
+**Effect** (`POST /api/approvals/:id/always`). Two steps in one call:
+1. Resolve *this* approval as approved (unblocks the waiting run now) — always, even if the rule can't be
+   added, since the run is what's urgent.
+2. Add a persistent **`allow`** rule for the matched **capability** to the policy override, hot-reloaded
+   (`os.policy.update`) so the next matching attempt returns `allow` and never lands a card.
+
+**The safety story is rule *placement*** (`withAlwaysAllow` in `src/governance/policy.ts`). `classify` is
+**first-match**, and the real policy's deny guardrails are *conditional* `never` rules on `*` (`when
+destructive` / `when amountUsd > $moneyCapUsd` / `when deleteCount > $bulkDeleteCount`). So the new
+`allow` rule is inserted **after all `never` rules**, never before them:
+- a routine attempt of the capability now hits the `allow` → no card;
+- a **destructive / over-cap / bulk-delete** attempt of the same capability still hits its conditional
+  `never` first → **stays denied**. "Always approve email.send" stops prompting for ordinary sends but
+  cannot send a destructive or over-budget one.
+
+**Guardrails (non-negotiable).**
+- **Placement preserves every `never`** — the allow goes after the last `never`, so no deny is shadowed
+  (verified by the `withAlwaysAllow` smoke test: destructive/over-cap sends still deny post-rule).
+- **Unconditional `never` refuses** — if a `never` with no `when` matches the capability (an absolute
+  deny), the rule is *not* added; the attempt is still approved once, with a note to the human.
+- **Owner-only** — adding a rule is a policy edit, so it takes the same `me.role === 'owner'` guard as
+  `PUT /api/policy` (an admin may approve once but must not rewrite the ruleset). The button is
+  owner-only in the UI, enforced server-side.
+- **Idempotent** — a second "always approve" of the same capability is a no-op (returns `ruleAdded:false`).
+- **Audited + reversible** — emits `policy.rule.added` (`from: inbox.always_approve`) + `policy.updated`;
+  the rule shows in the console Policy editor where it can be removed.
+
+**Why it belongs in the inbox.** The approval card is the exact moment a human forms the judgment "this
+class of action is fine." Making them re-navigate to a Policy editor to codify it loses the intent. The
+inbox becomes not just where policy *stops* the fleet, but where humans *teach* it — the governance
+analogue of the memory/skill self-learning loop.
+
+**Follow-ups.** v1 keys the rule on the capability id (workspace-wide). Later: narrow by agent or by an
+arg predicate; visually distinguish a learned allow from a hand-authored one; let an admin propose an
+always-rule for owner sign-off (mirrors `skill_propose`).
+
+---
+
+## 6. Roadmap summary
+
+| Batch | Scope | Status |
+|---|---|---|
+| **1** | Question DMs · chat loop · per-member read/dismiss | ✅ v0.39.0 |
+| **Always approve** | Learn a policy `allow` from an approval card (§4.4/§5) | ✅ v0.40.0 |
+| **2** | Server-side `ask` timeout/expiry · stale-item reminders + escalation | ⏳ |
+| **3** | `since`-cursor + SSE push · feed filter/search/grouping · optimistic UI | ⏳ |
+| **later** | Push answers to the agent · inbox cursor | ⏳ |
+
+---
+
+## 7. Key files
+
+- `src/terminal.ts` — `listMessages` / `sessionInbox` / `toMessage`; `askQuestion` / `report` /
+  `progress`; the `gate` (approval cards); the `approvalNotifier` / `questionNotifier` / `chatMirror`
+  sinks; `markRead` / `markAllRead` / `dismissMessage` / `dismissAllMessages`.
+- `src/tenant-registry.ts` — wires the sinks: `notifyApprovers`, `notifyQuestionAsked`, chat mirror.
+- `src/server.ts` — the `/api/messages*`, `/api/ask`, `/api/approvals/:id`, `/api/questions/:id` routes.
+- `src/state/db.ts` — `messages`, `questions`, `approvals`, `message_state` schema.
+- `src/governance/policy.ts` — the rule engine "Always approve" will write into.
+- `web/src/App.tsx` — `InboxPage` / `ActionItem` / `FeedItem`; `web/src/lib/api.ts` — the client.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.39.0",
+      "version": "0.40.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.39.0",
+  "version": "0.40.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/policy.ts
+++ b/src/governance/policy.ts
@@ -91,6 +91,42 @@ function globToRegExp(glob: string): RegExp {
 }
 
 /**
+ * Does an UNCONDITIONAL `never` rule (no `when`) match `capabilityId`? Such a rule is an absolute deny,
+ * and "Always approve" refuses to shadow it. Note that CONDITIONAL nevers (the default policy's
+ * `* when destructive` / `* when amountUsd > cap` / `* when deleteCount > cap`) are deliberately NOT
+ * hard denies here: they're preserved by inserting the new allow AFTER all never rules (see
+ * {@link withAlwaysAllow}), so they still fire for a destructive/over-cap attempt.
+ */
+export function hasHardDeny(doc: PolicyDocument, capabilityId: string): boolean {
+  return doc.rules.some((r) => r.action === 'never' && !r.match.when && globToRegExp(r.match.capability).test(capabilityId));
+}
+
+/**
+ * The "Always approve" learn step: return a NEW document that allows `capabilityId` from now on.
+ *
+ * `classify` is first-match, so placement is the whole safety story. We insert the unconditional `allow`
+ * rule immediately AFTER the last `never` rule — never before it. That keeps every deny guardrail in
+ * force (a destructive or over-cap attempt of this capability still hits its conditional `never`), while
+ * the new allow shadows the `ask` rule that raised the card, so the routine case stops prompting. The
+ * common policy lists nevers first, then asks, so this shadows exactly the intended `ask` and nothing more.
+ * - Refuses (`{ error }`) when an UNCONDITIONAL `never` matches — that's an absolute deny we won't erase.
+ * - Idempotent: if an identical allow rule already exists, returns `added: false`.
+ * Callers persist + hot-reload the returned doc and surface `added`/`error` to the human.
+ */
+export function withAlwaysAllow(doc: PolicyDocument, capabilityId: string): { doc: PolicyDocument; added: boolean } | { error: string } {
+  const cap = capabilityId.trim();
+  if (!cap) return { error: 'no capability to allow' };
+  if (hasHardDeny(doc, cap)) return { error: `"${cap}" is hard-denied by a policy rule and can't be allowed from the inbox — edit policy directly if you really mean to` };
+  const exists = doc.rules.some((r) => r.action === 'allow' && !r.match.when && r.match.capability === cap);
+  if (exists) return { doc, added: false };
+  let insertAt = 0;
+  doc.rules.forEach((r, i) => { if (r.action === 'never') insertAt = i + 1; });
+  const rule: PolicyRule = { match: { capability: cap }, action: 'allow' };
+  const rules = [...doc.rules.slice(0, insertAt), rule, ...doc.rules.slice(insertAt)];
+  return { doc: { ...doc, rules }, added: true };
+}
+
+/**
  * A `when.value` of the form `"$name"` is a reference to a named governance threshold (e.g.
  * `"$moneyCapUsd"`), resolved live from the engine's thresholds provider at classify time. This keeps
  * the numeric caps editable in Settings → Governance without rewriting policy rules. The kernel always

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,7 +25,7 @@ import { AGENT_AUTHOR_ID } from './edge/agent-author';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
 import { CATALOG, redact } from './connectors/connectors';
 import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUserId, initiateConnection, verifyComposioWebhook, parseComposioEvent } from './connectors/composio';
-import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument } from './governance/policy';
+import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument, withAlwaysAllow } from './governance/policy';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
 import { AgentManifest, ApprovalRequest, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
@@ -2516,6 +2516,34 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { events, types });
   }
   if (method === 'GET' && p === '/api/approvals') return sendJson(res, 200, os.approvals.pending(os.tenant).filter((a) => tm.canViewSession(a.runId, me)).map(approvalView));
+  // "Always approve": approve THIS attempt AND teach the policy an `allow` rule for its capability, so
+  // future matching attempts pass the gate without a card. Adding a rule is a POLICY EDIT, so it's
+  // OWNER-ONLY — the same guard as PUT /api/policy (an admin can approve once but must not rewrite the
+  // ruleset to bypass future owner sign-off). The rule is inserted AFTER all `never` rules, so deny
+  // guardrails (destructive / over-cap) stay in force; a capability under an unconditional `never` is
+  // refused (approved once, rule not added, with a note). Audited `policy.rule.added` + `policy.updated`.
+  const alwaysMatch = p.match(/^\/api\/approvals\/([\w-]+)\/always$/);
+  if (method === 'POST' && alwaysMatch) {
+    const ap = os.approvals.get(alwaysMatch[1]);
+    if (!ap) return sendJson(res, 404, { error: 'approval not found' });
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required — “always approve” edits policy' });
+    if (!(os.policy instanceof JsonPolicyEngine)) return sendJson(res, 400, { error: 'active policy engine is not editable' });
+    const cap = ap.attempt.capabilityId;
+    const result = withAlwaysAllow(os.policy.document, cap);
+    // The run is waiting — approve this attempt regardless of whether the durable rule lands.
+    os.approvals.resolve(alwaysMatch[1], true, me.email);
+    if ('error' in result) return sendJson(res, 200, { ok: true, ruleAdded: false, note: result.error });
+    if (result.added) {
+      if (os.paths) {
+        fs.mkdirSync(path.dirname(os.paths.policyOverride), { recursive: true });
+        fs.writeFileSync(os.paths.policyOverride, JSON.stringify(result.doc, null, 2));
+      }
+      os.policy.update(result.doc); // hot reload — gateway + terminal gate share this instance
+      os.audit.append({ ts: Date.now(), runId: ap.runId, tenant: os.tenant, principal: me.email, type: 'policy.rule.added', data: { capability: cap, effect: 'allow', from: 'inbox.always_approve' } });
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'policy.updated', data: { id: result.doc.id, rules: result.doc.rules.length } });
+    }
+    return sendJson(res, 200, { ok: true, ruleAdded: result.added, note: result.added ? undefined : `“${cap}” is already always-allowed` });
+  }
   const apMatch = p.match(/^\/api\/approvals\/([\w-]+)$/);
   if (method === 'POST' && apMatch) {
     const ap = os.approvals.get(apMatch[1]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1623,6 +1623,13 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
   if (m.type === 'approval') {
     const mayApprove = canApprove(me.role, (m.level ?? 'head') as 'head' | 'owner')
     const resolve = async (approved: boolean) => { setBusy(true); const r = await api.resolve(m.approvalId!, approved); if (r.error) setBusy(false) }
+    // "Always approve" also teaches policy an allow rule for this capability — a policy edit, so owner-only.
+    const always = async () => {
+      setBusy(true)
+      const r = await api.alwaysApprove(m.approvalId!)
+      if (r.error) { setBusy(false); alert(r.error) }          // 403/404 — not resolved; leave the card
+      else if (r.ruleAdded === false && r.note) alert(`Approved once — ${r.note}`)  // resolved, rule not added
+    }
     return (
       <div className="rounded-lg border border-amber-300 bg-amber-50/40 px-3 py-2.5">
         <div className="flex items-start gap-2.5">
@@ -1642,6 +1649,9 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
           {mayApprove ? (
             <>
               <Button size="sm" className="h-7 px-2.5 text-xs" disabled={busy} onClick={() => resolve(true)}><Check className="mr-1 h-3.5 w-3.5" />Approve</Button>
+              {me.role === 'owner' && (
+                <Button size="sm" variant="outline" className="h-7 px-2.5 text-xs" disabled={busy} onClick={always} title={`Approve this and stop asking — adds an "allow ${m.capability ?? ''}" rule to policy`}><Shield className="mr-1 h-3.5 w-3.5" />Always</Button>
+              )}
               <Button size="sm" variant="destructive" className="h-7 px-2.5 text-xs" disabled={busy} onClick={() => resolve(false)}><X className="mr-1 h-3.5 w-3.5" />Reject</Button>
             </>
           ) : (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -649,6 +649,8 @@ export const api = {
   attachFile: (id: string, dataB64: string, ext: string) =>
     call<{ ok: boolean; path?: string; error?: string }>('POST', `/api/sessions/${id}/attach-file`, { dataB64, ext }),
   resolve: (id: string, approved: boolean) => call<{ ok: boolean; error?: string }>('POST', '/api/approvals/' + id, { approved }),
+  /** Approve this attempt AND add a persistent policy `allow` rule for its capability (owner-only). */
+  alwaysApprove: (id: string) => call<{ ok: boolean; ruleAdded?: boolean; note?: string; error?: string }>('POST', `/api/approvals/${id}/always`),
   answerQuestion: (id: string, answer: string) => call<{ ok: boolean; error?: string }>('POST', '/api/questions/' + id, { answer }),
   dismissMessage: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/dismiss`),
   dismissAllMessages: () => call<{ ok: boolean; dismissed?: number; error?: string }>('POST', '/api/messages/dismiss-all'),


### PR DESCRIPTION
## Why

Two things: (1) a written-up audit of the inbox — the gaps, what shipped, the roadmap — as a durable `docs/inbox-plan.md`; and (2) the first roadmap item from it: **"Always approve."**

Every approval was one-shot — the same capability re-prompted every run, forever. A human who is sure about the *future* of a class of approvals had no way to say so from where the decision is made. This makes the inbox the **policy-authoring** surface: where humans *teach* the fleet, not just where policy *stops* it.

## What

An approval card grows an owner-only **Always** button (next to Approve/Reject). It approves the current attempt **and** appends a persistent `allow` rule for that capability to the policy override (`POST /api/approvals/:id/always`), hot-reloaded so future matching attempts pass the gate without a card.

### The safety story is rule *placement*

`classify` is **first-match**, and the real policy's deny guardrails are *conditional* `never` rules on `*` (`when destructive` / `when amountUsd > $moneyCapUsd` / `when deleteCount > $bulkDeleteCount`). So `withAlwaysAllow` inserts the new `allow` **after all `never` rules**, never before them:

- a routine attempt of the capability now hits the `allow` → no card;
- a **destructive / over-cap / bulk-delete** attempt of the *same* capability still hits its conditional `never` first → **stays denied**.

"Always approve `email.send`" stops prompting for ordinary external sends but **cannot** send a destructive or over-budget one. (A naive prepend would have silently erased those guardrails — that's the trap this avoids.)

### Guardrails

- **Owner-only** — adding a rule is a policy edit, same guard as `PUT /api/policy` (an admin may approve once but must not rewrite the ruleset). Enforced server-side; the button is owner-only in the UI.
- **Refuses to shadow an unconditional `never`** — approves once, doesn't add the rule, returns a note.
- **Idempotent**; **audited** `policy.rule.added` (`from: inbox.always_approve`) + `policy.updated`; **reversible** from the console Policy editor.

## Validation

`npm run typecheck` · `cd web && npm run build` · `npm run test:governance` (44/44), plus a `withAlwaysAllow` smoke test (13/13) proving the deny-preservation (destructive/over-cap still deny after the rule), the unconditional-never refusal, insert-after-nevers placement, and idempotence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)