### PR TITLE
Automations: a Runs list per automation — see every firing (v0.41.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.40.0] — 2026-07-08
+## [0.41.0] — 2026-07-08
+### Added
+- **Automation Runs — see every time an automation fired.** Each automation card on the Automations page
+  grows a **Runs** toggle that lists the sessions that automation has spawned, newest first — status dot
+  (live / done / stopped / crashed), timestamp, and the run-as/provenance label, each row one click into
+  its session terminal. Backed by a new `GET /api/automations/:id/runs` route (`tm.listRunsFor` filters
+  `listSessions` by provenance `automation:<id>`, so runs carry live status + the same per-viewer
+  visibility as `/api/sessions`: owner/admin see all, a member sees runs of automations they can view).
+  Closes the gap where an automation's history lived only in the audit log — the automation row still
+  tracks just `lastFiredAt`/`lastSessionId`; the full run list is now reconstructed from the session rows
+  that carry the `automation:<id>` provenance.
 ### Added
 - **"Always approve" — teach policy from the inbox.** An approval card grows an owner-only **Always**
   button next to Approve/Reject: it approves the current attempt **and** writes a persistent `allow` rule

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.40.0",
+      "version": "0.41.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.40.0",
+  "version": "0.41.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1118,6 +1118,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const r = autos.fire(a, { guard: false }); // explicit human action — no pile-up guard
     return sendJson(res, 200, r);
   }
+  const autoRuns = p.match(/^\/api\/automations\/([\w-]+)\/runs$/);
+  if (method === 'GET' && autoRuns) {
+    const a = autos.get(autoRuns[1]);
+    if (!a) return sendJson(res, 404, { error: 'not found' });
+    // Runs = every session this automation spawned (provenance `automation:<id>`). Visibility follows
+    // the same rule as /api/sessions — the caller sees only what they're allowed to.
+    return sendJson(res, 200, { runs: tm.listRunsFor(`automation:${a.id}`, me) });
+  }
   const autoMatch = p.match(/^\/api\/automations\/([\w-]+)$/);
   if (autoMatch && (method === 'PATCH' || method === 'DELETE')) {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -338,6 +338,16 @@ export class TerminalManager {
   }
 
   /**
+   * The runs a given trigger spawned — every session whose provenance is `spawnedBy` (e.g.
+   * `automation:<id>`), newest first. Reuses `listSessions` so each run carries live status /
+   * resumable / label and the SAME per-viewer visibility rules: owner/admin see all, a member sees
+   * only runs of automations they can view (via `canViewRow`).
+   */
+  listRunsFor(spawnedBy: string, viewer?: Member): Session[] {
+    return this.listSessions(viewer).filter((s) => s.spawnedBy === spawnedBy);
+  }
+
+  /**
    * Session ids that have a persisted launch env (`session-<id>.env`) — i.e. an interactive session
    * the ttyd attach wrapper can resurrect via `claude --resume` (see `writeEnvFile`/`terminal/attach.sh`).
    * Headless runs write no env file, so they're absent (and correctly report `resumable:false`). One

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2943,6 +2943,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
   const [items, setItems] = useState<Automation[] | null>(null)
   const [busy, setBusy] = useState('')
   const [hint, setHint] = useState('')
+  const [openRuns, setOpenRuns] = useState<string | null>(null) // automation id whose Runs list is expanded
   // create form
   const [name, setName] = useState('')
   const [agentId, setAgentId] = useState(agents[0]?.id ?? '')
@@ -3016,6 +3017,10 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
                   {a.hookUrl && <div className="mt-2 w-full max-w-xl"><CopyLink link={a.hookUrl} /></div>}
                 </div>
                 <div className="flex shrink-0 items-center gap-2">
+                  <Button size="sm" variant="ghost" onClick={() => setOpenRuns((cur) => (cur === a.id ? null : a.id))} title="show past runs of this automation">
+                    <HistoryIcon className="mr-1 h-3.5 w-3.5" />Runs
+                    <ChevronDown className={`ml-1 h-3.5 w-3.5 transition-transform ${openRuns === a.id ? 'rotate-180' : ''}`} />
+                  </Button>
                   <Button size="sm" variant="secondary" disabled={busy === a.id} onClick={() => runNow(a)} title="fire once now">
                     <Play className="mr-1 h-3.5 w-3.5" />Run now
                   </Button>
@@ -3038,6 +3043,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
                   )}
                 </div>
               </CardContent>
+              {openRuns === a.id && <AutomationRuns id={a.id} onOpen={onOpen} />}
             </Card>
           ))}
         </div>
@@ -3123,6 +3129,36 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
             </CardContent>
           </Card>
         </section>
+      )}
+    </div>
+  )
+}
+
+/** The past runs of one automation — every session it spawned (provenance `automation:<id>`), newest
+ *  first. Loaded lazily when the card's Runs row is expanded. Each row opens its session terminal, so a
+ *  fired run is one click from its transcript/output. Visibility is server-gated (same as /api/sessions). */
+function AutomationRuns({ id, onOpen }: { id: string; onOpen: (tmux: string, title: string) => void }) {
+  const [runs, setRuns] = useState<Session[] | null>(null)
+  useEffect(() => { api.automationRuns(id).then((r) => setRuns(r.runs ?? [])) }, [id])
+  return (
+    <div className="border-t bg-muted/30 px-4 py-3">
+      {!runs ? (
+        <div className="text-xs text-muted-foreground">Loading runs…</div>
+      ) : runs.length === 0 ? (
+        <div className="text-xs text-muted-foreground">No runs yet — this automation hasn't fired.</div>
+      ) : (
+        <div className="space-y-0.5">
+          {runs.map((s) => (
+            <button key={s.id} onClick={() => onOpen(s.tmux, s.agent + ' · ' + s.id)} title={s.spawnedByLabel ? `started by ${s.spawnedByLabel}` : undefined}
+              className="flex w-full items-center gap-2 rounded px-1.5 py-1 text-left text-xs hover:bg-muted">
+              <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusDot(s)}`} />
+              <span className="w-14 shrink-0 text-muted-foreground">{statusLabel(s)}</span>
+              <Clock className="h-3 w-3 shrink-0 text-muted-foreground/50" />
+              <span className="shrink-0 text-muted-foreground">{new Date(s.createdAt).toLocaleString()}</span>
+              {s.spawnedByLabel && <span className="ml-auto min-w-0 truncate text-muted-foreground/60">{s.spawnedByLabel}</span>}
+            </button>
+          ))}
+        </div>
       )}
     </div>
   )

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -680,6 +680,7 @@ export const api = {
     call<Automation & { error?: string }>('PATCH', '/api/automations/' + id, patch),
   deleteAutomation: (id: string) => call<{ ok: boolean }>('DELETE', '/api/automations/' + id),
   runAutomation: (id: string) => call<{ ok: boolean; sessionId?: string; reason?: string; error?: string }>('POST', `/api/automations/${id}/run`),
+  automationRuns: (id: string) => call<{ runs: Session[]; error?: string }>('GET', `/api/automations/${id}/runs`),
 
   memory: (agent: string, q = '', limit = 50, scope: 'all' | 'agent' | 'tenant' = 'all') =>
     call<{ memories: MemoryRecord[] }>('GET', `/api/memory?agent=${encodeURIComponent(agent)}&q=${encodeURIComponent(q)}&limit=${limit}&scope=${scope}`),


### PR DESCRIPTION
## What

Answers "when an automation runs, do we track and show the Runs somewhere?" — previously **no** dedicated view; run history lived only in the audit log. This adds a first-class Runs list.

Each automation card on the **Automations** page grows a **Runs** toggle that lists every session that automation has spawned, newest first:
- status dot (live / done / stopped / crashed) + status word
- fired-at timestamp
- run-as / provenance label
- each row is one click into its session terminal

## How

- **`GET /api/automations/:id/runs`** (`src/server.ts`) — 404 for unknown id, else `{ runs: Session[] }`.
- **`TerminalManager.listRunsFor(spawnedBy, viewer)`** (`src/terminal.ts`) — reuses `listSessions` filtered by provenance `automation:<id>`, so each run carries live status / resumable / label **and the same per-viewer visibility as `/api/sessions`**: owner/admin see all, a member sees only runs of automations they can view.
- **Web** (`web/src/App.tsx`, `web/src/lib/api.ts`) — a lazy-loaded `AutomationRuns` panel + `api.automationRuns(id)`.

No schema change — runs are reconstructed from the `term_sessions` rows that already carry the `automation:<id>` provenance. The automation row still tracks only `lastFiredAt`/`lastSessionId`.

## Verification

- `npm run typecheck` ✓, `cd web && npm run build` ✓, `npm run test:governance` → 44/44 ✓
- End-to-end against an isolated home: created a real automation → `GET …/runs` returns `200 {"runs":[]}`; unknown id → `404`; unauthenticated → `401` (route is behind the member-auth gate, as intended).

🤖 Generated with [Claude Code](https://claude.com/claude-code)