### PR TITLE
Automations: next-fire timing + collapse the New-automation form (v0.42.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.42.0] — 2026-07-08
+### Added
+- **Next-fire timing on the Automations page.** Each cron automation now shows **when it fires next** —
+  "next in 3h · <local time>" — computed by a new `nextCronRun(expr)` helper (`src/edge/automations.ts`,
+  the forward companion to `cronMatches`: scans minute-by-minute from the next whole minute, null for an
+  impossible expression like Feb 30) and surfaced as `nextRunAt` on the automation view. A disabled cron
+  reads "paused — won't fire"; event triggers (webhook/slack/discord) read "fires on … — no schedule";
+  last-fired is now the compact "last fired 2h ago".
+### Changed
+- **Automations UX: the New-automation form is collapsed behind a button.** The page led with a permanent
+  form; now a **New automation** button sits in the Configured header and reveals the form on demand (with
+  a Cancel, and auto-collapse on create), so the page opens on the list of what's configured — the runs,
+  schedules, and next-fire timings — instead of an empty form.
+
 ## [0.41.0] — 2026-07-08
 ### Added
 - **Automation Runs — see every time an automation fired.** Each automation card on the Automations page

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -75,6 +75,26 @@ export function cronMatches(spec: CronSpec, d: Date): boolean {
   return domOk || dowOk;
 }
 
+/**
+ * The next time (epoch ms) a 5-field cron expression fires at or after `from` (default now). Minute-
+ * grained to match the scheduler tick, and scanned forward from the NEXT whole minute (a match in the
+ * current minute has already fired or is firing). Returns null if nothing matches within ~13 months — a
+ * defensive bound (a valid cron always fires within a year; an impossible combo like `0 0 30 2 *`,
+ * Feb 30, never does). Cheap enough to call per-automation on a list render: worst case ≈ a year of
+ * minute steps of Set lookups, and real schedules resolve in far fewer.
+ */
+export function nextCronRun(expr: string, from: Date = new Date()): number | null {
+  const spec = parseCron(expr);
+  const d = new Date(from.getTime());
+  d.setSeconds(0, 0);
+  d.setMinutes(d.getMinutes() + 1); // start at the next whole minute
+  const limit = d.getTime() + 400 * 86_400_000;
+  for (let t = d.getTime(); t <= limit; t += 60_000) {
+    if (cronMatches(spec, new Date(t))) return t;
+  }
+  return null;
+}
+
 // ── the automation object ─────────────────────────────────────────────────────────
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
 import { TerminalManager, AGENT_OS_OPERATING_NOTES } from './terminal';
 import { classifyActivity, clipText, ActivityCategory, ActivityEffect } from './state/session-activity';
-import { Automation, Automations } from './edge/automations';
+import { Automation, Automations, nextCronRun } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
 import { DreamingEngine } from './edge/dreaming';
@@ -2599,7 +2599,18 @@ function automationView(a: Automation, req: http.IncomingMessage, admin: boolean
   return {
     ...rest,
     hookUrl: admin && a.type === 'webhook' && secret ? hookUrlFor(req, a.id, secret) : undefined,
+    // When it fires next: an enabled cron computes its next matching minute; a pending one-shot carries
+    // its scheduled runAt. Event triggers (webhook/slack/discord) have no schedule, so it stays absent.
+    nextRunAt: nextRunAtFor(a),
   };
+}
+function nextRunAtFor(a: Automation): number | undefined {
+  if (!a.enabled) return undefined;
+  if (a.type === 'cron' && a.schedule) {
+    try { return nextCronRun(a.schedule) ?? undefined; } catch { return undefined; }
+  }
+  if (a.type === 'once' && a.runAt) return a.runAt;
+  return undefined;
 }
 function hookUrlFor(req: http.IncomingMessage, id: string, secret: string): string {
   const proto = String(req.headers['x-forwarded-proto'] || 'http').split(',')[0];

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1497,6 +1497,16 @@ function timeAgo(ts: number): string {
   return `${Math.floor(d / 7)}w`
 }
 
+/** Compact "in 3h" / "in 2d" for a future timestamp — the forward-looking companion to timeAgo. */
+function timeUntil(ts: number): string {
+  const s = Math.max(0, Math.floor((ts - Date.now()) / 1000))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60); if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60); if (h < 24) return `${h}h`
+  const d = Math.floor(h / 24); if (d < 7) return `${d}d`
+  return `${Math.floor(d / 7)}w`
+}
+
 /** The inbox heading for a message: the session's live display name, falling back to the agent id if a
  *  run hasn't been named yet. Every card leads with this; the agent is shown as a secondary line. */
 const sessionName = (m: Msg): string => (m.sessionTitle || '').trim() || m.agent
@@ -2944,6 +2954,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
   const [busy, setBusy] = useState('')
   const [hint, setHint] = useState('')
   const [openRuns, setOpenRuns] = useState<string | null>(null) // automation id whose Runs list is expanded
+  const [showForm, setShowForm] = useState(false) // the New-automation form is collapsed until requested
   // create form
   const [name, setName] = useState('')
   const [agentId, setAgentId] = useState(agents[0]?.id ?? '')
@@ -2963,7 +2974,7 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
     setHint('')
     const r = await api.addAutomation({ name, agentId, type, mode, schedule: type === 'cron' ? schedule : undefined, filter: type === 'composio' || type === 'slack' || type === 'discord' ? filter : undefined, task })
     if (r.error) return setHint('⚠ ' + r.error)
-    setName(''); setTask('')
+    setName(''); setTask(''); setShowForm(false)
     load()
   }
   const setItemMode = async (a: Automation, m: 'interactive' | 'headless') => { setBusy(a.id); await api.updateAutomation(a.id, { mode: m }); await load(); setBusy('') }
@@ -2990,70 +3001,16 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
       </p>
 
       <section>
-        <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">Configured</div>
-        {items.length === 0 && <div className="text-sm text-muted-foreground">No automations yet{isAdmin ? ' — create one below.' : '.'}</div>}
-        <div className="space-y-2">
-          {items.map((a) => (
-            <Card key={a.id}>
-              <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <Zap className={`h-4 w-4 shrink-0 ${a.enabled ? 'text-amber-500' : 'text-muted-foreground/40'}`} />
-                    <span className="truncate text-sm font-medium">{a.name}</span>
-                    <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{a.type}</Badge>
-                    <Badge variant="outline" className="px-1.5 py-0 text-[10px]">{a.mode === 'headless' ? 'headless' : 'interactive'}</Badge>
-                    {!a.enabled && <Badge variant="outline" className="px-1.5 py-0 text-[10px]">disabled</Badge>}
-                  </div>
-                  <div className="mt-0.5 text-xs text-muted-foreground">
-                    {a.agentId}
-                    {a.type === 'cron' && <span className="ml-2 font-mono">{a.schedule}</span>}
-                    {(a.type === 'composio' || a.type === 'slack' || a.type === 'discord') && <span className="ml-2 font-mono">{a.filter || 'any event'}</span>}
-                    {a.lastFiredAt ? <span className="ml-2">last fired {new Date(a.lastFiredAt).toLocaleString()}</span> : <span className="ml-2">never fired</span>}
-                  </div>
-                  {a.type === 'cron' && a.mode === 'interactive' && (
-                    <div className="mt-1 text-[11px] text-amber-600">Interactive sessions stay open until closed — this cron won't re-fire while its last run is still running.</div>
-                  )}
-                  <div className="mt-1 truncate text-xs text-muted-foreground">{a.task}</div>
-                  {a.hookUrl && <div className="mt-2 w-full max-w-xl"><CopyLink link={a.hookUrl} /></div>}
-                </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <Button size="sm" variant="ghost" onClick={() => setOpenRuns((cur) => (cur === a.id ? null : a.id))} title="show past runs of this automation">
-                    <HistoryIcon className="mr-1 h-3.5 w-3.5" />Runs
-                    <ChevronDown className={`ml-1 h-3.5 w-3.5 transition-transform ${openRuns === a.id ? 'rotate-180' : ''}`} />
-                  </Button>
-                  <Button size="sm" variant="secondary" disabled={busy === a.id} onClick={() => runNow(a)} title="fire once now">
-                    <Play className="mr-1 h-3.5 w-3.5" />Run now
-                  </Button>
-                  {isAdmin && (
-                    <>
-                      <Select value={a.mode} onValueChange={(v) => v && v !== a.mode && setItemMode(a, v as 'interactive' | 'headless')}>
-                        <SelectTrigger className="h-8 w-32"><SelectValue /></SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="headless">headless</SelectItem>
-                          <SelectItem value="interactive">interactive</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <Button size="sm" variant="outline" disabled={busy === a.id} onClick={() => toggle(a)}>
-                        {a.enabled ? 'Disable' : 'Enable'}
-                      </Button>
-                      <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" disabled={busy === a.id} onClick={() => remove(a)} title="remove">
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </>
-                  )}
-                </div>
-              </CardContent>
-              {openRuns === a.id && <AutomationRuns id={a.id} onOpen={onOpen} />}
-            </Card>
-          ))}
+        <div className="mb-2 flex items-center justify-between gap-2">
+          <div className="text-[11px] uppercase tracking-wider text-muted-foreground">Configured</div>
+          {isAdmin && (
+            <Button size="sm" variant={showForm ? 'ghost' : 'default'} onClick={() => { setShowForm((v) => !v); setHint('') }}>
+              {showForm ? <><X className="mr-1 h-3.5 w-3.5" />Cancel</> : <><Plus className="mr-1 h-3.5 w-3.5" />New automation</>}
+            </Button>
+          )}
         </div>
-        {hint && <div className="mt-2 font-mono text-xs text-destructive">{hint}</div>}
-      </section>
-
-      {isAdmin && (
-        <section>
-          <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">New automation</div>
-          <Card>
+        {isAdmin && showForm && (
+          <Card className="mb-3 border-primary/30">
             <CardContent className="space-y-3 p-4">
               <div className="grid grid-cols-2 gap-3">
                 <Field label="Name"><Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Morning site check" /></Field>
@@ -3122,14 +3079,85 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
               <Field label="Task">
                 <Textarea value={task} onChange={(e) => setTask(e.target.value)} className="min-h-[64px]" placeholder="What should the agent do each time this fires? (Webhook payloads are appended automatically.)" />
               </Field>
-              <div className="flex items-center gap-3">
+              <div className="flex items-center gap-2">
                 <Button onClick={create} disabled={!name.trim() || !task.trim() || !agentId}><Plus className="mr-1 h-4 w-4" />Create</Button>
+                <Button variant="ghost" onClick={() => { setShowForm(false); setHint('') }}>Cancel</Button>
                 {hint && <span className="font-mono text-xs text-destructive">{hint}</span>}
               </div>
             </CardContent>
           </Card>
-        </section>
-      )}
+        )}
+        {items.length === 0 && !showForm && <div className="text-sm text-muted-foreground">No automations yet{isAdmin ? ' — click New automation to create one.' : '.'}</div>}
+        <div className="space-y-2">
+          {items.map((a) => (
+            <Card key={a.id}>
+              <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <Zap className={`h-4 w-4 shrink-0 ${a.enabled ? 'text-amber-500' : 'text-muted-foreground/40'}`} />
+                    <span className="truncate text-sm font-medium">{a.name}</span>
+                    <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{a.type}</Badge>
+                    <Badge variant="outline" className="px-1.5 py-0 text-[10px]">{a.mode === 'headless' ? 'headless' : 'interactive'}</Badge>
+                    {!a.enabled && <Badge variant="outline" className="px-1.5 py-0 text-[10px]">disabled</Badge>}
+                  </div>
+                  <div className="mt-0.5 text-xs text-muted-foreground">
+                    {a.agentId}
+                    {a.type === 'cron' && <span className="ml-2 font-mono">{a.schedule}</span>}
+                    {(a.type === 'composio' || a.type === 'slack' || a.type === 'discord') && <span className="ml-2 font-mono">{a.filter || 'any event'}</span>}
+                  </div>
+                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                    {a.nextRunAt ? (
+                      <span className="inline-flex items-center gap-1 text-emerald-600" title={new Date(a.nextRunAt).toLocaleString()}>
+                        <Clock className="h-3 w-3" />next in {timeUntil(a.nextRunAt)} · {new Date(a.nextRunAt).toLocaleString()}
+                      </span>
+                    ) : a.type === 'cron' && !a.enabled ? (
+                      <span className="text-amber-600">paused — won't fire while disabled</span>
+                    ) : a.type !== 'cron' ? (
+                      <span>fires on {a.type === 'webhook' ? 'webhook' : `${a.type} message`} — no schedule</span>
+                    ) : null}
+                    <span title={a.lastFiredAt ? new Date(a.lastFiredAt).toLocaleString() : undefined}>
+                      {a.lastFiredAt ? `last fired ${timeAgo(a.lastFiredAt)} ago` : 'never fired'}
+                    </span>
+                  </div>
+                  {a.type === 'cron' && a.mode === 'interactive' && (
+                    <div className="mt-1 text-[11px] text-amber-600">Interactive sessions stay open until closed — this cron won't re-fire while its last run is still running.</div>
+                  )}
+                  <div className="mt-1 truncate text-xs text-muted-foreground">{a.task}</div>
+                  {a.hookUrl && <div className="mt-2 w-full max-w-xl"><CopyLink link={a.hookUrl} /></div>}
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <Button size="sm" variant="ghost" onClick={() => setOpenRuns((cur) => (cur === a.id ? null : a.id))} title="show past runs of this automation">
+                    <HistoryIcon className="mr-1 h-3.5 w-3.5" />Runs
+                    <ChevronDown className={`ml-1 h-3.5 w-3.5 transition-transform ${openRuns === a.id ? 'rotate-180' : ''}`} />
+                  </Button>
+                  <Button size="sm" variant="secondary" disabled={busy === a.id} onClick={() => runNow(a)} title="fire once now">
+                    <Play className="mr-1 h-3.5 w-3.5" />Run now
+                  </Button>
+                  {isAdmin && (
+                    <>
+                      <Select value={a.mode} onValueChange={(v) => v && v !== a.mode && setItemMode(a, v as 'interactive' | 'headless')}>
+                        <SelectTrigger className="h-8 w-32"><SelectValue /></SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="headless">headless</SelectItem>
+                          <SelectItem value="interactive">interactive</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <Button size="sm" variant="outline" disabled={busy === a.id} onClick={() => toggle(a)}>
+                        {a.enabled ? 'Disable' : 'Enable'}
+                      </Button>
+                      <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" disabled={busy === a.id} onClick={() => remove(a)} title="remove">
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </CardContent>
+              {openRuns === a.id && <AutomationRuns id={a.id} onOpen={onOpen} />}
+            </Card>
+          ))}
+        </div>
+        {hint && <div className="mt-2 font-mono text-xs text-destructive">{hint}</div>}
+      </section>
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -294,6 +294,9 @@ export interface Automation {
   createdAt: number
   lastFiredAt?: number
   lastSessionId?: string
+  /** When it fires next (epoch ms): computed for an enabled cron, or the pending runAt for a one-shot.
+   *  Absent for event triggers (webhook/slack/discord) and disabled automations. */
+  nextRunAt?: number
   /** Ready-to-paste webhook URL — present for admins on webhook automations only. */
   hookUrl?: string
 }


### PR DESCRIPTION
## What

Two Automations-page (`/#/automations`) improvements requested:

1. **Show when each automation fires next.** Cron automations now show `next in 3h · <local time>` alongside a compact `last fired 2h ago`. Disabled crons read *"paused — won't fire while disabled"*; event triggers (webhook/slack/discord) read *"fires on … — no schedule"*.
2. **Collapse the New-automation form behind a button.** The page used to lead with a permanently-open form. Now a **New automation** button in the Configured header reveals it on demand (Cancel button + auto-collapse on create), so the page opens on the list of what's configured — the runs, schedules, and next-fire timings.

## How

- **`nextCronRun(expr, from?)`** (`src/edge/automations.ts`) — the forward-looking companion to `cronMatches`: scans minute-by-minute from the next whole minute, returns the next matching epoch-ms, or `null` for an impossible expression (e.g. `0 0 30 2 *`, Feb 30).
- **`nextRunAt`** added to the automation view (`src/server.ts` `automationView` → `nextRunAtFor`): an enabled cron's next matching minute, or a pending one-shot's `runAt`; absent for event triggers and disabled automations.
- **Web** (`web/src/App.tsx`, `web/src/lib/api.ts`) — `nextRunAt` on the `Automation` type, a `timeUntil()` helper, the timing row per card, and `showForm` state that gates the (relocated) form above the list.

## Verification

- `npm run typecheck` ✓, `cd web && npm run build` ✓, `npm run test:governance` → 44/44 ✓
- Unit-tested `nextCronRun` across `*/30 * * * *` (→ next :30), `0 9 * * 1-5` (Wed 10:15 → Thu 09:00), `0 * * * *` (→ next hour), the current-minute edge (already-firing minute → next day), and `0 0 30 2 *` (→ null).
- E2E against an isolated home: cron automation → `nextRunAt` set; webhook → undefined; after disabling the cron → `nextRunAt` drops to undefined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)