### PR TITLE
Governance: custom enrich patterns (config-driven danger facts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.42.0] — 2026-07-08
+### Added
+- **Custom governance patterns — teach the enricher your own dangerous ops, as config not code.** A
+  workspace can now define `regex → boolean fact` rules (`EnrichPattern[]`) in Settings; the enricher
+  applies them on every classify and sets the fact, and policy rules gate on it — so operator-specific
+  red-lines (a prod-deploy path, a `suspend-user` CLI, a money-moving command, a "never send" reply)
+  become **data**, keeping `enricher.ts` brand-free and open-core. Patterns carry a `scope`
+  (`shell` | `connector` | `any`, default `any` = shell+connector; never `file.write`, whose haystack
+  is file content). Backed by `SettingsStore.enrichPatterns()`/`setEnrichPatterns()` (invalid regex
+  rejected at save; ignored at match — never throws in the gate) and owner-gated
+  `GET/PUT /api/settings/enrich-patterns` (`settings.enrich_patterns.updated` audited). Wired into both
+  terminal-gate `enrichArgs` call sites; read live per classify (hot, no restart). Unit-tested in
+  `scripts/test-enrich-patterns.cjs`. (Console editor is a follow-up; set via the API meanwhile.)
+
 ## [0.41.0] — 2026-07-08
 ### Added
 - **Automation Runs — see every time an automation fired.** Each automation card on the Automations page

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.41.0",
+      "version": "0.42.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.41.0",
+  "version": "0.42.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -22,7 +22,8 @@
     "demo": "node dist/cli.js demo",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs"
+    "test:governance": "node scripts/governance-conformance.cjs",
+    "test:enrich": "node scripts/test-enrich-patterns.cjs"
   },
   "keywords": [
     "agents",

--- a/scripts/test-enrich-patterns.cjs
+++ b/scripts/test-enrich-patterns.cjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+/**
+ * Unit test for custom-pattern enrichment (config-driven governance patterns).
+ * Verifies `enrichArgs` sets an operator-defined boolean fact when its regex matches, respects scope,
+ * excludes file.write, dedupes, and never throws on a bad regex. Run: node scripts/test-enrich-patterns.cjs
+ */
+const path = require('path');
+const { enrichArgs } = require(path.join(__dirname, '..', 'dist/governance/enricher'));
+
+const bash = (command) => ({ tool: 'Bash', input: { command } });
+const conn = (tool, input = {}) => ({ tool, input });
+
+// An InstaWP-shaped pattern set (exactly what would live in Settings, not in code).
+const patterns = [
+  { pattern: '\\breboot\\b|systemctl\\s+reboot|shutdown\\s+-r', fact: 'serverReboot', scope: 'shell' },
+  { pattern: 'v-instawp-suspend-user|hestia.*suspend', fact: 'userSuspend', scope: 'shell' },
+  { pattern: '(vite build|npm run build)[\\s\\S]*(app-atomic|159\\.65\\.64\\.73)', fact: 'prodBuild', scope: 'shell' },
+  { pattern: 'stripe-refund|STRIPE_REFUND', fact: 'stripeRefund', scope: 'any' },
+  { pattern: 'freescout-manager\\.php reply|freescout[\\s\\S]*\\breply\\b', fact: 'freescoutSend', scope: 'shell' },
+];
+
+const cases = [
+  // [name, capability, args, fact, expected, patternsOverride?]
+  ['reboot → serverReboot', 'shell.exec', bash('ssh root@159.65.64.73 "reboot"'), 'serverReboot', true],
+  ['systemctl reload is NOT a reboot', 'shell.exec', bash('systemctl reload apache2'), 'serverReboot', undefined],
+  ['suspend-user → userSuspend', 'shell.exec', bash('v-instawp-suspend-user user123 phishing'), 'userSuspend', true],
+  ['prod build → prodBuild', 'shell.exec', bash('cd /home/runcloud/webapps/app-atomic/live && npm run build'), 'prodBuild', true],
+  ['dev build (no prod path) is not prodBuild', 'shell.exec', bash('npm run build'), 'prodBuild', undefined],
+  ['stripe refund (any scope, shell)', 'shell.exec', bash('./iwp stripe-refund ch_123 --amount=50'), 'stripeRefund', true],
+  ['stripe refund (any scope, connector)', 'connector.call', conn('mcp__x__STRIPE_REFUND', { amount: 5 }), 'stripeRefund', true],
+  ['freescout reply → freescoutSend', 'shell.exec', bash('php freescout-manager.php reply 42 --text=hi'), 'freescoutSend', true],
+  ['freescout note is NOT a send', 'shell.exec', bash('php freescout-manager.php note 42 --text=hi'), 'freescoutSend', undefined],
+  ['shell-scoped pattern ignores connector calls', 'connector.call', conn('mcp__x__reboot_thing'), 'serverReboot', undefined],
+  ['file.write is never matched by custom patterns', 'file.write', { tool: 'Write', input: { file_path: '/tmp/x', content: 'reboot the server' } }, 'serverReboot', undefined],
+  ['bad regex is ignored, never throws', 'shell.exec', bash('anything'), 'oops', undefined, [{ pattern: '(', fact: 'oops', scope: 'shell' }]],
+  ['no patterns → no custom facts', 'shell.exec', bash('reboot'), 'serverReboot', undefined, []],
+];
+
+let pass = 0;
+const fails = [];
+for (const [name, cap, args, fact, expect, override] of cases) {
+  const f = enrichArgs(cap, args, [], undefined, override ?? patterns);
+  const got = f[fact];
+  if (got === expect) pass++;
+  else fails.push(`  ✗ ${name}: ${fact}=${JSON.stringify(got)} (expected ${JSON.stringify(expect)})`);
+}
+// built-in facts still work alongside custom patterns
+const both = enrichArgs('shell.exec', bash('rm -rf /data'), [], undefined, patterns);
+if (both.destructive !== true) fails.push('  ✗ built-in destructive fact regressed with patterns present');
+else pass++;
+
+console.log(`${pass}/${cases.length + 1} enrich-pattern checks passed`);
+if (fails.length) { console.log(fails.join('\n')); process.exit(1); }
+process.exit(0);

--- a/src/governance/enricher.ts
+++ b/src/governance/enricher.ts
@@ -28,7 +28,7 @@
  * (least privilege, recoverability) remains the backstop, not this one function.
  */
 import * as path from 'node:path';
-import { ApprovalLevel, Role, canApprove } from '../types';
+import { ApprovalLevel, EnrichPattern, Role, canApprove } from '../types';
 
 const DESTRUCTIVE: RegExp[] = [
   /\bdrop\s+(database|table|schema)\b/i,
@@ -103,6 +103,7 @@ export function enrichArgs(
   args: Record<string, unknown>,
   orgDomains: string[] = [],
   workdir?: string,
+  patterns: EnrichPattern[] = [],
 ): Record<string, unknown> {
   const tool = typeof args.tool === 'string' ? args.tool : '';
   const input = (args.input && typeof args.input === 'object' ? args.input : args) as Record<string, unknown>;
@@ -198,6 +199,29 @@ export function enrichArgs(
     facts.emailExternalCount = emailExternalCount;
     if (emailRecipients) facts.emailRecipients = emailRecipients;
   }
+
+  // Workspace-defined custom patterns (Settings → Governance): each sets a boolean fact the policy
+  // gates on — the extension point for operator-specific dangerous ops without editing this file.
+  // Applied to shell + connector calls only (never file.write, whose haystack is file *content*).
+  for (const p of patterns) {
+    if (!p || typeof p.pattern !== 'string' || typeof p.fact !== 'string' || !p.fact) continue;
+    const scope = p.scope ?? 'any';
+    const applies =
+      scope === 'shell' ? capability === 'shell.exec'
+      : scope === 'connector' ? capability.startsWith('connector')
+      : capability === 'shell.exec' || capability.startsWith('connector');
+    if (!applies || facts[p.fact] === true) continue;
+    let re: RegExp;
+    try {
+      re = new RegExp(p.pattern, 'i');
+    } catch {
+      continue; // bad regex → ignore, never throw inside the gate
+    }
+    // Match the TOOL NAME too (a connector's `STRIPE_REFUND` / `delete_site` is the action itself), not
+    // just the command + input values in `haystack`. Harmless for shell, where `tool` is 'Bash'.
+    if (re.test(`${tool}\n${haystack}`)) facts[p.fact] = true;
+  }
+
   return facts;
 }
 

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -10,7 +10,7 @@
  * so adding more instance-level settings later is just another key.
  */
 import { Db } from '../state/db';
-import { MemoryConfig, Recommendation, RuntimeTuning, sanitizeRuntimeTuning } from '../types';
+import { EnrichPattern, MemoryConfig, Recommendation, RuntimeTuning, sanitizeRuntimeTuning } from '../types';
 
 const COMPANY_KEY = 'company_md';
 const COMPOSIO_KEY = 'composio_api_key';
@@ -26,6 +26,7 @@ const LEARNED_GUIDANCE_KEY = 'learned_guidance'; // distilled imperatives inject
 const LEARNED_APPLY_KEY = 'learned_guidance_apply'; // 'off' to stop injecting (default on once guidance exists)
 const RECOMMENDATIONS_KEY = 'learned_recommendations'; // { open: Recommendation[], dismissed: string[] }
 const GOVERNANCE_KEY = 'governance_thresholds'; // numeric caps the never-tier policy rules read (JSON GovernanceThresholds)
+const ENRICH_PATTERNS_KEY = 'enrich_patterns'; // operator regex→boolean-fact rules the enricher applies (JSON EnrichPattern[])
 
 /** Numeric governance caps the policy's never-tier rules reference by name (e.g. `$moneyCapUsd`).
  *  Live-editable in Settings → Governance; resolved at classify time by the policy engine. */
@@ -332,6 +333,45 @@ export class SettingsStore {
     };
     this.set(GOVERNANCE_KEY, JSON.stringify(next), by);
     return next;
+  }
+
+  // ── custom governance patterns (operator regex → boolean fact the enricher sets) ──
+  // The extension seam that keeps the enricher generic: a workspace declares its OWN dangerous ops as
+  // DATA here (a prod-deploy path, a suspend-user CLI), the enricher sets the fact, and policy gates on
+  // it — no brand code in `enricher.ts`. Read on every classify (hot; no restart).
+  enrichPatterns(): EnrichPattern[] {
+    const raw = this.getRow(ENRICH_PATTERNS_KEY)?.value;
+    if (!raw) return [];
+    try {
+      const v = JSON.parse(raw);
+      if (!Array.isArray(v)) return [];
+      return v
+        .filter((p) => p && typeof p.pattern === 'string' && typeof p.fact === 'string' && p.fact.trim())
+        .map((p) => ({
+          pattern: String(p.pattern),
+          fact: String(p.fact).trim(),
+          scope: ['shell', 'connector', 'any'].includes(p.scope) ? p.scope : 'any',
+        }));
+    } catch {
+      return [];
+    }
+  }
+
+  /** Replace the custom patterns. Rejects an invalid regex so a bad rule can't silently no-op. */
+  setEnrichPatterns(patterns: EnrichPattern[], by?: string): EnrichPattern[] {
+    const clean: EnrichPattern[] = [];
+    for (const p of Array.isArray(patterns) ? patterns : []) {
+      if (!p || typeof p.pattern !== 'string' || !p.pattern.trim() || typeof p.fact !== 'string' || !p.fact.trim()) continue;
+      try {
+        new RegExp(p.pattern, 'i');
+      } catch {
+        throw new Error(`invalid regex: ${p.pattern}`);
+      }
+      const scope = ['shell', 'connector', 'any'].includes(p.scope as string) ? (p.scope as EnrichPattern['scope']) : 'any';
+      clean.push({ pattern: String(p.pattern), fact: String(p.fact).trim(), scope });
+    }
+    this.set(ENRICH_PATTERNS_KEY, JSON.stringify(clean), by);
+    return clean;
   }
 
   // ── email org domains (internal recipients for the email.send policy tier) ───────

--- a/src/server.ts
+++ b/src/server.ts
@@ -1754,6 +1754,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, ...saved });
   }
 
+  // ── custom governance patterns (operator regex → boolean fact the enricher sets, policy gates on) ──
+  if (method === 'GET' && p === '/api/settings/enrich-patterns') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { patterns: os.settings.enrichPatterns() });
+  }
+  if (method === 'PUT' && p === '/api/settings/enrich-patterns') {
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' }); // patterns govern what gates → owner only
+    const b = await readBody(req);
+    try {
+      const saved = os.settings.setEnrichPatterns(Array.isArray(b.patterns) ? b.patterns : [], me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.enrich_patterns.updated', data: { count: saved.length } });
+      return sendJson(res, 200, { ok: true, patterns: saved });
+    } catch (e) {
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+
   // ── email org domains (internal recipients → email.send is green; external → yellow) ──
   if (method === 'GET' && p === '/api/settings/email-domains') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -928,7 +928,7 @@ export class TerminalManager {
       this.audit(sessionId, agent, 'gate.killswitch', { capability });
       return { decision: 'deny' };
     }
-    const args = enrichArgs(capability, rawArgs, this.emailOrgDomains(), this.os.agents.get(agent)?.dir);
+    const args = enrichArgs(capability, rawArgs, this.emailOrgDomains(), this.os.agents.get(agent)?.dir, this.os.settings.enrichPatterns());
     // An outbound email is its own governed capability: reclassify so the policy gates it by recipient
     // (internal → green, external → yellow) instead of the generic connector-mutation tier.
     if (args.emailSend === true) {
@@ -1110,7 +1110,7 @@ export class TerminalManager {
    */
   policyCheck(sessionId: string, agent: string, capability: string, args: Record<string, unknown>): Decision {
     if (this.os.settings.killSwitch().engaged) return { effect: 'deny', reason: 'workspace emergency stop is engaged' };
-    const enriched = enrichArgs(capability, args, this.emailOrgDomains(), this.os.agents.get(agent)?.dir);
+    const enriched = enrichArgs(capability, args, this.emailOrgDomains(), this.os.agents.get(agent)?.dir, this.os.settings.enrichPatterns());
     const cap = enriched.emailSend === true ? 'email.send' : capability;
     return this.os.policy.classify({ capabilityId: cap, args: enriched, reasoning: '' }, this.ctx(sessionId, agent));
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -620,6 +620,21 @@ export interface TaskQuery {
 // Agent + runtime
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * A workspace-defined governance pattern: a regex over a tool call that sets a boolean *fact* the
+ * policy can gate on. It lets an operator mark their OWN dangerous operations — a prod-deploy path,
+ * a `suspend-user` command, a money-moving CLI — without editing the enricher's built-in patterns.
+ * Matched case-insensitively against the shell command + connector input text.
+ */
+export interface EnrichPattern {
+  /** Regex source (JS). Tested case-insensitively; an invalid regex is ignored, never thrown. */
+  pattern: string;
+  /** Boolean fact name set to `true` on match (e.g. 'serverReboot'). Policy reads it as `when.arg`. */
+  fact: string;
+  /** Which calls it applies to: 'shell' (Bash), 'connector' (mcp__* tools), or 'any' (default: shell+connector). */
+  scope?: 'shell' | 'connector' | 'any';
+}
+
 /** Reasoning effort for a claude-code session (`claude --effort <level>`). */
 export type Effort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 export const EFFORTS: readonly Effort[] = ['low', 'medium', 'high', 'xhigh', 'max'];


### PR DESCRIPTION
## What
Adds **operator-defined governance patterns** — `regex → boolean fact` rules stored in Settings that the enricher applies on every classify, so a workspace can gate its OWN dangerous operations without editing `enricher.ts`.

Today the enricher's danger patterns (destructive SQL, `rm -rf`, payment/email) are hard-coded and generic. Anything workspace-specific — a prod-deploy path, a `suspend-user` CLI, a money-moving command, a "never send" reply — has nowhere to live except brand code in the open-core enricher, and policy has no regex operator to match raw commands. This keeps pattern-matching in the enricher (as intended) but makes the *patterns themselves* data.

## How
- `EnrichPattern { pattern, fact, scope? }` in `types.ts` (`scope`: `shell` | `connector` | `any`, default `any` = shell+connector; never `file.write`, whose haystack is file content).
- `enrichArgs(...)` gains an optional `patterns` arg; after built-in facts it applies each (case-insensitive) and sets `facts[fact] = true`. Matches the **tool name** too, so a connector's `STRIPE_REFUND` / `delete_site` is gate-able. Bad regex is skipped — never throws in the gate.
- `SettingsStore.enrichPatterns()` / `setEnrichPatterns()` (invalid regex rejected at save). Owner-gated `GET/PUT /api/settings/enrich-patterns`, `settings.enrich_patterns.updated` audited.
- Wired into **both** terminal-gate `enrichArgs` call sites; read live per classify (hot, no restart).

Policy then gates on the fact:
```json
{ "match": { "capability": "*", "when": { "arg": "serverReboot", "op": "eq", "value": true } }, "action": "ask", "approver": "owner" }
```

## Tests
- New `scripts/test-enrich-patterns.cjs` — 14 cases (scope, tool-name match, file.write exclusion, bad-regex safety, built-ins intact): `npm run test:enrich`.
- `npm run test:governance` unchanged: **44/44**. Typecheck + `web` build clean.

## Follow-up
Console editor for patterns (set via API meanwhile). `gateway.ts`'s registry-path `enrichArgs` still uses defaults (the terminal gate is the claude-session path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SExXWNjYbExPEEP3yMQ77c