### PR TITLE
Updater: don't block self-update on untracked files (v0.42.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 dist/
-data/
+# The local data home at repo root — a directory when running from ./data, OR a symlink to a data home
+# kept outside the checkout (the deploy convention). No trailing slash, so a `data` SYMLINK matches too
+# (a `data/` pattern would miss it → shows as untracked → falsely blocks self-update).
+/data
 .env
 *.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.42.1] — 2026-07-08
+### Fixed
+- **Self-update no longer blocks on untracked files.** The updater flagged the tree "dirty" whenever
+  `git status --porcelain` reported anything, including *untracked* files — but untracked files never
+  break a `git pull --ff-only` (only modified tracked files do). On a live box that always includes the
+  `data` home symlink, `*.log`, and stray docs, so the update button and the manual `wt.sh sync` deploy
+  path both refused with "commit or stash them first" when nothing was actually in the way. The dirty
+  check now passes `--untracked-files=no` (`hasTrackedChanges()` in `src/edge/updater.ts`); if an incoming
+  commit ever collides with an untracked path, `git pull --ff-only` still aborts cleanly and we surface it.
+- **`.gitignore` now ignores a `data` symlink at the repo root, not just a `data/` directory.** The deploy
+  convention symlinks the data home (kept outside the checkout) in as `data`; the trailing-slash `data/`
+  pattern only matched a directory, so the symlink showed as untracked and tripped the check above. Changed
+  to `/data`.
+
 ## [0.42.0] — 2026-07-08
 ### Added
 - **Next-fire timing on the Automations page.** Each cron automation now shows **when it fires next** —

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/vmini/Projects/agent-os/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.42.0",
+      "version": "0.42.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.42.0",
+  "version": "0.42.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/updater.ts
+++ b/src/edge/updater.ts
@@ -15,6 +15,11 @@
  * the caller gets the log; the service manager (launchd/systemd) respawns the process, so bouncing the
  * process we're running in is safe. Override the restart with `AOS_RESTART_CMD` (or the label/unit env).
  *
+ * "Dirty" here means modified/staged TRACKED files only (`--untracked-files=no`) — untracked files never
+ * break an ff-only pull, and a live box always has some (the `data` home symlink, logs, stray docs). If an
+ * incoming commit ever did collide with an untracked path, `git pull --ff-only` aborts cleanly and we
+ * surface its error, so pre-blocking on untracked files would only produce false "can't update" states.
+ *
  * The git repo is process-wide (shared by every tenant in a multi-tenant runtime), so the cache is a
  * module-level singleton rather than per-tenant.
  */
@@ -37,7 +42,8 @@ export interface UpdateStatus {
   /** The checked-out branch and its tracking ref (e.g. `main` / `origin/main`). */
   branch: string;
   upstream: string;
-  /** Uncommitted changes present — an ff-only apply would fail, so the UI disables the button. */
+  /** TRACKED files modified/staged — an ff-only apply would fail, so the UI disables the button.
+   *  Untracked files (the `data` home symlink, logs, stray docs) are deliberately NOT counted. */
   dirty: boolean;
   /** ms epoch of the last successful `git fetch`. */
   checkedAt: number;
@@ -61,6 +67,11 @@ function git(args: string[], timeout = 30_000): { ok: boolean; out: string; err:
   return { ok: r.status === 0, out: (r.stdout || '').trim(), err: (r.stderr || '').trim() };
 }
 
+/** True only when TRACKED files are modified/staged — untracked files don't block an ff-only pull. */
+function hasTrackedChanges(): boolean {
+  return git(['status', '--porcelain', '--untracked-files=no']).out.length > 0;
+}
+
 let cache: UpdateStatus | null = null;
 let inflight: Promise<UpdateStatus> | null = null;
 
@@ -79,7 +90,7 @@ async function doCheck(): Promise<UpdateStatus> {
   const remote = upstream.split('/')[0] || 'origin';
 
   const fetched = git(['fetch', '--quiet', remote], 60_000);
-  const dirty = git(['status', '--porcelain']).out.length > 0;
+  const dirty = hasTrackedChanges();
 
   let behind = 0;
   const rl = git(['rev-list', '--count', `HEAD..${upstream}`]);
@@ -136,8 +147,8 @@ export async function applyUpdate(tenant: string): Promise<ApplyResult> {
     return r.status === 0;
   };
 
-  if (git(['status', '--porcelain']).out.length > 0)
-    return { ok: false, steps, restarting: false, error: 'working tree has uncommitted changes — commit or stash on the box first' };
+  if (hasTrackedChanges())
+    return { ok: false, steps, restarting: false, error: 'tracked files have uncommitted changes — commit or stash them on the box first' };
 
   if (!run('git pull --ff-only', 'git', ['pull', '--ff-only'])) return { ok: false, steps, restarting: false, error: 'git pull failed' };
   // --include=dev is mandatory: the build step below needs `tsc` (a devDependency), and the service


### PR DESCRIPTION
## Problem
The instapods box couldn't run **Software update** — the console showed *"The box has uncommitted changes — commit or stash them before updating."* But there were **no** modified tracked files. The two things git flagged were both **untracked**:

- `data` — a **symlink** to the data home (`~/agent-os-data/instapods`), linked into the checkout by convention. `.gitignore` had `data/`, and a trailing-slash pattern only matches a *directory*, so the symlink showed as untracked.
- `docs/task-dependencies-plan.md` — a stray planning doc.

Neither breaks a `git pull --ff-only`. The updater's dirty check just used `git status --porcelain`, which counts untracked files, so it pre-emptively refused. The manual `wt.sh sync` → build → kickstart deploy path hits the same wall.

## Fix
- `hasTrackedChanges()` (`src/edge/updater.ts`) runs `git status --porcelain --untracked-files=no`; used by both the `checkForUpdate` `dirty` flag and the `applyUpdate` guard. Untracked files no longer block. If an incoming commit ever collides with an untracked path, `git pull --ff-only` still aborts cleanly and the updater surfaces the error — strictly better than a false pre-block.
- `.gitignore`: `data/` → `/data`, so a `data` **symlink** at the repo root is ignored, not just a directory.

## Validation
- `npm run typecheck` ✓ · `npm run build` ✓ · `npm run test:governance` → 44/44 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)