### PR TITLE
Fix: stop tracking node_modules symlink; ignore symlinks by name (v0.42.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-node_modules/
+# No trailing slash on node_modules/data: `scripts/wt.sh` symlinks node_modules into each worktree, and
+# the deploy convention symlinks the data home in as `data`. A `foo/` pattern matches only a DIRECTORY, so
+# a SYMLINK named node_modules/data slips through → shows as untracked → and (once) got committed by a
+# stray `git add -A`, breaking every checkout that pulled it. Match name-only so symlinks are ignored too.
+/node_modules
 dist/
-# The local data home at repo root — a directory when running from ./data, OR a symlink to a data home
-# kept outside the checkout (the deploy convention). No trailing slash, so a `data` SYMLINK matches too
-# (a `data/` pattern would miss it → shows as untracked → falsely blocks self-update).
 /data
 .env
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.42.2] — 2026-07-08
+### Fixed
+- **Stop tracking the `node_modules` symlink (regression from 0.42.1) + harden `.gitignore`.** `scripts/wt.sh`
+  symlinks `node_modules` into each worktree, and the `node_modules/` ignore pattern (trailing slash) matches
+  only a *directory* — so the symlink slipped past the ignore and a `git add -A` committed it to the repo. Any
+  checkout that pulled it had its real `node_modules` replaced by a self-referential symlink, breaking dependency
+  resolution until `npm install`. Untracked the symlink (`git rm --cached node_modules`) and changed the ignore
+  patterns for both worktree/deploy symlinks — `node_modules/` → `/node_modules` and (from 0.42.1) `data/` →
+  `/data` — to name-only so a *symlink* is ignored too, not just a directory.
+
 ## [0.42.1] — 2026-07-08
 ### Fixed
 - **Self-update no longer blocks on untracked files.** The updater flagged the tree "dirty" whenever

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/vmini/Projects/agent-os/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.42.1",
+      "version": "0.42.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.42.1",
+  "version": "0.42.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
## Regression from #72
`scripts/wt.sh` symlinks `node_modules` into each worktree. The `.gitignore` pattern `node_modules/` (trailing slash) matches only a **directory**, so the *symlink* named `node_modules` was not ignored — and a `git add -A` in the worktree committed it (mode 120000) into #72. Every checkout that pulled main then had its real `node_modules` replaced by a **self-referential symlink** (`node_modules → .../node_modules`), breaking dependency resolution until `npm install`.

## Fix
- `git rm --cached node_modules` — stop tracking the symlink.
- `.gitignore`: `node_modules/` → `/node_modules`, and `data/` → `/data` (same class of bug — the deploy convention symlinks the data home in as `data`). Name-only patterns ignore a **symlink** too, not just a directory, so `wt.sh`'s node_modules and the data-home symlink can never be committed again.

## Recovery
Checkouts that already pulled #72 (incl. the live box) recover by ff-syncing this commit — which deletes the tracked symlink — then `npm install`.

## Validation
- `npm run build` ✓ · `npm run test:governance` → 44/44 ✓ · staged diff is exactly `.gitignore`, `CHANGELOG.md`, `package*.json`, and the `node_modules` deletion (no `-A`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)