### PR TITLE
Agents self-improve their own listing + CLAUDE.md, reversibly (v0.43.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.43.0] — 2026-07-08
+### Added
+- **Agents can improve their own listing — reversibly.** An agent can now refine its OWN description,
+  starter prompts, category, icon, runtime tuning, and CLAUDE.md system prompt via `agent_update`, inspect
+  its edit history with `agent_history`, and roll back a bad self-edit with `agent_revert` (all self-only —
+  the target is always the calling session's agent). This is the self-improvement loop: when an agent
+  notices a recurring gap in its instructions, it can fix it, and the change takes effect on its next
+  session. Safety is **reversibility, not an approval gate** (like the Knowledge Base): every edit — by the
+  agent OR a human console edit — snapshots a full revision into a new `agent_revisions` table
+  (`src/state/agent-revisions.ts`), so any change is auditable (`agent.config.updated` /
+  `agent.config.reverted`) and one-click revertable from the console **agent page → Revision history**
+  panel. Two new MCP tools (`agent_history`, `agent_revert`) → 33 always-on tools; new console routes
+  `GET /api/agents/:id/revisions` + `POST /api/agents/:id/revert` (owner/admin).
+### Changed
+- **`agent_update` is now self-only.** It previously took the target agent id from the request body, so
+  any agent could rewrite any other editable agent's prompt/tuning with no approval — a side effect that
+  skipped the gate. The target is now always the calling session's agent (a supplied `id` must match it).
+  Agents can still *create* other agents with `agent_create`; they just can't silently edit each other.
+  Humans edit any agent from the console as before.
+
 ## [0.42.0] — 2026-07-08
 ### Added
 - **Next-fire timing on the Automations page.** Each cron automation now shows **when it fires next** —

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 31 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 33 always-on tools
   + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). KB: `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`. Operator/inbox:
   `ask`/`check_inbox`/`report`/`update`/`publish`/`artifacts_list`. Skills: `skill_propose` (draft a
@@ -192,7 +192,12 @@ Key modules:
   headless/interactive; owner = run-as passthrough so a hand-off keeps the accountable human). Secrets
   (shared credential handoff): `secret_put`/`secret_get`/`secret_list` — an agent stores a password/key
   tenant-wide under a KEY (approval-gated `secret.put`; value kept out of audit/approval-card/policy args,
-  encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. Plus
+  encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. Agents
+  (build + self-improve): `agent_create` (spin up a new governed teammate) and the **self-only**
+  `agent_update`/`agent_history`/`agent_revert` — an agent refines its OWN listing (description, starter
+  prompts, tuning) + CLAUDE.md system prompt and can roll back a bad self-edit; every change snapshots a
+  reversible revision (`src/state/agent-revisions.ts`, the KB-style rollback backbone; no agent can edit
+  another agent). Plus
   `directory_lookup` (team/identity-map
   search), `list_capabilities`/`policy_check` (policy preview), and `slack_reply`/`discord_reply` when
   chat-triggered. Each tool is a session-secret-gated loopback call to an `/api/*` route that sits BEFORE

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -36,14 +36,16 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `task_claim` | `POST /api/tasks/claim` | `TaskStore.claim` | W | atomic take (→ doing); loses if already claimed |
 | `task_update` | `POST /api/tasks/update` | `TaskStore.update` | W | status/note/reassign; closes a dispatched loop |
 | `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
-| `agent_update` | `POST /api/agents/update` | `AgentOS.registerAgent` | W | rewrites manifest (+CLAUDE.md); user-home agents only; audited `agent.config.updated` |
+| `agent_update` | `POST /api/agents/update` | `AgentOS.registerAgent` + `AgentRevisions.commit` | W | **self-only** (edits the caller's OWN manifest/CLAUDE.md — a body `id` must equal the session's agent); user-home agents only; snapshots a revision; audited `agent.config.updated` |
+| `agent_history` | `POST /api/agents/history` | `AgentRevisions.list` | R | the caller's own listing revisions (rev/author/summary/date), newest first |
+| `agent_revert` | `POST /api/agents/revert` | `AgentRevisions` + `AgentOS.registerAgent` | W | **self-only**; restores a prior revision (description/prompts/tuning/CLAUDE.md), records the revert as a new revision; audited `agent.config.reverted` |
 | `secret_put` | `POST /api/agent/secret/put` | `TerminalManager.putSecret` | W | shared-scope (`*`) vault write; **approval-gated** (policy `secret.put`, blocks until decided); value NEVER in audit/approval-card/policy args; audited `secret.put` (key only); `updated_by=agent:<id>` |
 | `secret_get` | `POST /api/agent/secret/get` | `TerminalManager.getSecret` | R | returns plaintext to caller; allow+audit (a policy `deny`/`ask` on `secret.get` refuses — reads never hang); audited `secret.get` (key + found, never value) |
 | `secret_list` | `GET /api/agent/secret/list` | `TerminalManager.listSecrets` | R | shared (`*`) secret KEYS + metadata only, never values |
 | `slack_reply` | `POST /api/agent/slack/reply` | SlackSocket | W | only when `SLACK_REPLY=1` (chat-triggered) |
 | `discord_reply` | `POST /api/agent/discord/reply` | DiscordSocket | W | only when `DISCORD_REPLY=1` (chat-triggered) |
 
-31 always-on tools + 2 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+33 always-on tools + 2 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 
@@ -74,17 +76,26 @@ scheduler `tick()` fires it once when due, then disables it. Recurring (cron) sc
 human-only. A future tightening could classify `schedule` through Policy for workspaces that want
 sign-off on deferred runs.
 
-### `agent_create` / `agent_update` — governance model
+### `agent_create` / `agent_update` / `agent_history` / `agent_revert` — governance model
 
-These are the **agent-author's** build tools (the default *System* agent provisioned by
-`src/edge/agent-author.ts`), though — like the Tasks tools — they're the general **delegation surface**
+`agent_create` is the **agent-author's** build tool (the default *System* agent provisioned by
+`src/edge/agent-author.ts`), though — like the Tasks tools — it's the general **delegation surface**
 available to any agent. Creating an agent **definition escalates nothing**: the new agent still passes
 every side effect through the gate, and only a **human** can run or assign it (spawn is role-gated). So
-they follow the same **auto-apply + audited** posture as `kb_write` / `task_create` — no approval card —
-emitting `agent.created` / `agent.config.updated` with `principal: agent:<id>`. Guards: strict id
-validation + collision check on create; `agent_update` only touches agents that live under the data home
-(the read-only bundled examples can't be edited) and rewrites only the fields the caller supplied. A
-future tightening could classify agent creation through Policy for workspaces that want sign-off.
+it follows the same **auto-apply + audited** posture as `kb_write` / `task_create` — no approval card —
+emitting `agent.created` with `principal: agent:<id>`. Guard: strict id validation + collision check.
+
+`agent_update` / `agent_history` / `agent_revert` are the **self-improvement** loop — an agent refining
+its OWN listing (description, starter prompts, category, icon, tuning) and CLAUDE.md system prompt when it
+notices a recurring gap. They are **self-only**: the target is always the calling session's agent (a body
+`id` must equal it), so **no agent can rewrite another agent's prompt or tuning** — that cross-agent side
+effect would skip the gate. A human edits any agent from the console. Safety here is not an approval card
+but **reversibility** (like the KB): every edit — by the agent or a human console edit — snapshots a full
+revision into `agent_revisions` (`src/state/agent-revisions.ts`), so any change is auditable
+(`agent.config.updated` / `agent.config.reverted`) and one-click / one-tool revertable; the console
+**agent page → Revision history** panel is the human rollback. `agent_update` only touches agents under the
+data home (bundled examples can't be edited) and rewrites only the fields the caller supplied. A future
+tightening could classify CLAUDE.md/model self-edits through Policy for workspaces that want sign-off.
 
 ## Remaining gaps (not yet exposed)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.42.0",
+      "version": "0.43.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.42.0",
+  "version": "0.43.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -32,6 +32,7 @@ import { SkillsStore } from './governance/skills';
 import { Db, openDb } from './state/db';
 import { ArtifactStore } from './state/artifacts';
 import { KbStore } from './state/kb';
+import { AgentRevisions } from './state/agent-revisions';
 import { TaskStore } from './state/tasks';
 import { StubIdentity } from './governance/identity';
 import { InMemoryIdempotencyStore } from './gateway/idempotency';
@@ -80,6 +81,8 @@ export class AgentOS {
   readonly artifacts: ArtifactStore;
   /** The company knowledge base — the shared, living wiki agents + humans co-author (revision-chained). */
   readonly kb: KbStore;
+  /** Revision history for every agent's config/CLAUDE.md — the rollback backbone for self-editing agents. */
+  readonly agentRevisions: AgentRevisions;
   /** The shared work queue — durable tasks humans + agents create, claim, and drain (auto-dispatchable). */
   readonly tasks: TaskStore;
   readonly identity = new StubIdentity();
@@ -118,6 +121,7 @@ export class AgentOS {
     this.skills = new SkillsStore(opts.paths?.skills, this.db, opts.paths?.bundledSkills);
     this.artifacts = new ArtifactStore(this.db, opts.paths?.artifacts);
     this.kb = new KbStore(this.db, opts.paths?.kb);
+    this.agentRevisions = new AgentRevisions(this.db);
     this.tasks = new TaskStore(this.db); // db-only (structured state, no on-disk mirror — see tasks-plan.md §Decision 2)
     this.memory = createMemoryProvider(opts.memory ?? { backend: 'sqlite' }, this.db);
 

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -555,23 +555,45 @@ const TOOLS = [
   {
     name: 'agent_update',
     description:
-      'Refine an existing agent: pass its id plus only the fields you want to change (its CLAUDE.md, ' +
-      'description, category, model, effort, example prompts, or icon). Re-registers it live so the next ' +
-      'session uses the new values. Prefer this over creating a near-duplicate when an agent nearly fits.',
+      'Improve YOUR OWN listing — pass only the fields you want to change (your CLAUDE.md system prompt, ' +
+      'description, category, model, effort, example prompts, or icon). This is how you self-improve: when ' +
+      "you notice a recurring gap in your instructions or a better way to describe what you do, refine it " +
+      'here. Takes effect on your next session. Every edit is snapshotted — inspect them with agent_history ' +
+      'and undo with agent_revert. You can only edit yourself (the id defaults to you); a human edits others.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
       properties: {
-        id: { type: 'string', description: 'The id of the agent to edit.' },
-        description: { type: 'string', description: 'New one-line description.' },
-        claudeMd: { type: 'string', description: "Replacement CLAUDE.md (the agent's system prompt)." },
+        id: { type: 'string', description: 'Optional — defaults to you. Must be your own id; you cannot edit another agent.' },
+        description: { type: 'string', description: 'New one-line description of what you do.' },
+        claudeMd: { type: 'string', description: "Replacement CLAUDE.md (your full system prompt). Send the complete new text, not a diff." },
         category: { type: 'string', description: 'New grouping label (empty string clears it → Uncategorized).' },
         model: { type: 'string', description: 'Model override (empty string clears → inherit the workspace default).' },
         effort: { type: 'string', enum: ['low', 'medium', 'high', 'xhigh', 'max'], description: 'Reasoning-effort override.' },
-        examplePrompts: { type: 'array', items: { type: 'string' }, description: 'Replacement starter prompts.' },
+        examplePrompts: { type: 'array', items: { type: 'string' }, description: 'Replacement starter prompts shown on your spawn card.' },
         icon: { type: 'string', description: 'New lucide icon name (or raw <svg>).' },
       },
-      required: ['id'],
+    },
+  },
+  {
+    name: 'agent_history',
+    description:
+      'List the revision history of your own listing (description, starter prompts, CLAUDE.md, tuning) — ' +
+      'newest first, each with a rev number, who made it, and a one-line summary. Use this to find a good ' +
+      'revision to roll back to after a self-edit that made things worse.',
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+  },
+  {
+    name: 'agent_revert',
+    description:
+      "Undo a self-edit: roll YOUR OWN listing back to a prior revision (get the number from " +
+      'agent_history). Restores that revision\'s description, starter prompts, tuning, and CLAUDE.md, and ' +
+      'records the revert as a new revision (so it too is reversible). Takes effect on your next session.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { rev: { type: 'number', description: 'The revision number to restore (from agent_history).' } },
+      required: ['rev'],
     },
   },
   {
@@ -1002,13 +1024,13 @@ async function agentCreate(args: Record<string, unknown>): Promise<string> {
   });
   const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
   if (!d.ok) return `Could not create the agent: ${d.error ?? 'unknown error'}`;
-  return `Created agent "${d.id}". It's live in the console now (grouped under ${args.category ? String(args.category) : 'Uncategorized'}); a human can run or assign it. Use agent_update "${d.id}" to refine it.`;
+  return `Created agent "${d.id}". It's live in the console now (grouped under ${args.category ? String(args.category) : 'Uncategorized'}); a human can run or assign it, and refine it from its console page. (agent_update only edits your own listing, not other agents.)`;
 }
 
 async function agentUpdate(args: Record<string, unknown>): Promise<string> {
-  const id = String(args.id ?? '').trim().toLowerCase();
-  if (!id) return 'Which agent? (id is required).';
-  // Only forward fields the caller actually supplied, so an unset field is left untouched server-side.
+  // Self-only: an agent refines its OWN listing. Default the target to this session's agent; the server
+  // rejects any other id. Every change is snapshotted (see agent_history / agent_revert) so it's reversible.
+  const id = String(args.id ?? AGENT).trim().toLowerCase();
   const body: Record<string, unknown> = { session: SESSION, id };
   for (const k of ['description', 'claudeMd', 'category', 'model', 'effort', 'icon'] as const) {
     if (args[k] !== undefined) body[k] = String(args[k]);
@@ -1019,9 +1041,36 @@ async function agentUpdate(args: Record<string, unknown>): Promise<string> {
     headers: H({ 'content-type': 'application/json' }),
     body: JSON.stringify(body),
   });
-  const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
+  const d = (await res.json()) as { ok?: boolean; id?: string; rev?: number | null; error?: string };
   if (!d.ok) return `Could not update the agent: ${d.error ?? 'unknown error'}`;
-  return `Updated agent "${id}". The next session it runs will use the new configuration.`;
+  return `Updated your listing "${id}"${d.rev ? ` (saved as rev ${d.rev} — revert with agent_revert)` : ''}. The next session you run will use it.`;
+}
+
+async function agentHistory(): Promise<string> {
+  const res = await fetch(AOS_URL + '/api/agents/history', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION }),
+  });
+  const d = (await res.json()) as { ok?: boolean; revisions?: Array<{ rev: number; author: string; summary: string | null; createdAt: number; description: string; claudeChars: number }>; error?: string };
+  if (!d.ok) return `Could not read history: ${d.error ?? 'unknown error'}`;
+  if (!d.revisions?.length) return 'No revisions yet — your listing has not been edited.';
+  return 'Your listing revisions (newest first):\n' + d.revisions
+    .map((r) => `  rev ${r.rev} · ${new Date(r.createdAt).toISOString().slice(0, 16).replace('T', ' ')} · ${r.author}${r.summary ? ` — ${r.summary}` : ''}`)
+    .join('\n') + '\n\nUse agent_revert { rev } to roll back to one.';
+}
+
+async function agentRevert(args: Record<string, unknown>): Promise<string> {
+  const rev = Number(args.rev);
+  if (!Number.isInteger(rev) || rev < 1) return 'Which revision? Pass rev (a positive integer from agent_history).';
+  const res = await fetch(AOS_URL + '/api/agents/revert', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, rev }),
+  });
+  const d = (await res.json()) as { ok?: boolean; toRev?: number; rev?: number | null; error?: string };
+  if (!d.ok) return `Could not revert: ${d.error ?? 'unknown error'}`;
+  return `Reverted your listing to rev ${d.toRev}${d.rev ? ` (recorded as rev ${d.rev})` : ''}. The next session you run will use it.`;
 }
 
 // ── Secrets vault: shared credential handoff (value stays out of every durable plane) ─────────────
@@ -1267,6 +1316,8 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'task_update' ? await taskUpdate(args)
         : name === 'agent_create' ? await agentCreate(args)
         : name === 'agent_update' ? await agentUpdate(args)
+        : name === 'agent_history' ? await agentHistory()
+        : name === 'agent_revert' ? await agentRevert(args)
         : name === 'secret_put' ? await secretPut(args)
         : name === 'secret_get' ? await secretGet(args)
         : name === 'secret_list' ? await secretList()

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument, withAlwaysAll
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
 import { AgentManifest, ApprovalRequest, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
+import { AgentConfigSnapshot } from './state/agent-revisions';
 
 /** Settings → Memory view: stored backend config with secrets redacted to `…Set` booleans. */
 interface EmbeddingsView { provider: 'openai' | 'ollama'; url: string; model: string; dimensions?: number; apiKeySet: boolean }
@@ -53,6 +54,40 @@ const WEB_DIST = path.resolve(__dirname, '../web/dist');
  *  can't tell them apart from a hand-authored agent — and homes provisioned before this flag existed
  *  carry no marker in their on-disk manifests. */
 const BUILT_IN_AGENT_IDS = new Set<string>([...GENERALIST_IDS, AGENT_AUTHOR_ID, CONSOLIDATOR_ID]);
+
+/** The full editable state of an agent, from its manifest + on-disk CLAUDE.md — the unit revisions snapshot. */
+function manifestToSnapshot(ag: AgentManifest, claudeMd: string): AgentConfigSnapshot {
+  return {
+    description: ag.description ?? '',
+    category: ag.category, icon: ag.icon,
+    model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode,
+    examplePrompts: ag.examplePrompts ?? [], shellSecrets: ag.shellSecrets ?? [],
+    claudeMd,
+  };
+}
+
+/** Read the agent's current on-disk snapshot (manifest fields + CLAUDE.md), to record as the "before". */
+function readAgentSnapshot(ag: AgentManifest): AgentConfigSnapshot {
+  const file = ag.dir ? path.join(ag.dir, 'CLAUDE.md') : '';
+  const claudeMd = file && fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+  return manifestToSnapshot(ag, claudeMd);
+}
+
+/** Re-apply a full snapshot to disk (agent.json + CLAUDE.md) and re-register — the shared revert primitive. */
+function applyAgentSnapshot(os: AgentOS, ag: AgentManifest, snap: AgentConfigSnapshot): AgentManifest {
+  const next: AgentManifest = {
+    ...ag,
+    description: snap.description, category: snap.category, icon: snap.icon,
+    model: snap.model, effort: snap.effort, permissionMode: snap.permissionMode,
+    examplePrompts: snap.examplePrompts.length ? snap.examplePrompts : undefined,
+    shellSecrets: snap.shellSecrets.length ? snap.shellSecrets : undefined,
+  };
+  const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
+  fs.writeFileSync(path.join(ag.dir!, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
+  fs.writeFileSync(path.join(ag.dir!, 'CLAUDE.md'), snap.claudeMd);
+  os.registerAgent(next);
+  return next;
+}
 
 /** Agents available for terminal sessions = whatever manifests this instance loaded.
  *  `deletable` = lives under the data home (user-created), so it can be removed; the bundled
@@ -910,7 +945,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!agent) return sendJson(res, 404, { error: 'unknown session' });
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     if (!os.paths) return sendJson(res, 200, { ok: false, error: 'editing agents requires a data home' });
-    const id = String(b.id || '').trim().toLowerCase();
+    // Self-only: an agent edits ITS OWN listing. The target is the session's agent, never a body id —
+    // no agent can rewrite another agent's prompt/tuning (that side effect would skip the gate). A
+    // human edits any agent from the console (the owner/admin routes below).
+    const id = agent;
+    if (b.id !== undefined && String(b.id).trim().toLowerCase() !== id)
+      return sendJson(res, 200, { ok: false, error: `you can only edit your own listing ("${id}"), not "${String(b.id).trim().toLowerCase()}"` });
     const ag = os.agents.get(id);
     if (!ag?.dir) return sendJson(res, 200, { ok: false, error: `unknown agent "${id}"` });
     if (ag.runtime !== 'claude-code') return sendJson(res, 200, { ok: false, error: 'only claude-code agents can be edited' });
@@ -919,6 +959,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return sendJson(res, 200, { ok: false, error: 'built-in agents cannot be edited' });
     const { tuning, error: tErr } = sanitizeRuntimeTuning({ model: 'model' in b ? b.model : ag.model, effort: 'effort' in b ? b.effort : ag.effort });
     if (tErr) return sendJson(res, 200, { ok: false, error: tErr });
+    const before = readAgentSnapshot(ag);
     // Only fields present in the body are changed; everything else is preserved.
     const description = 'description' in b ? String(b.description ?? '').trim() : ag.description;
     const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
@@ -930,8 +971,42 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     if ('claudeMd' in b) fs.writeFileSync(path.join(ag.dir, 'CLAUDE.md'), String(b.claudeMd ?? ''));
     os.registerAgent(next);
-    os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: 'agent.config.updated', data: { agent: id, model: tuning.model, effort: tuning.effort, category, claudeMd: 'claudeMd' in b, by: `agent:${agent}` } });
-    return sendJson(res, 200, { ok: true, id });
+    const after = manifestToSnapshot(next, 'claudeMd' in b ? String(b.claudeMd ?? '') : before.claudeMd);
+    const rev = os.agentRevisions.commit(os.tenant, id, before, after, 'agent self-edit', `agent:${agent}`);
+    os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: 'agent.config.updated', data: { agent: id, model: tuning.model, effort: tuning.effort, category, claudeMd: 'claudeMd' in b, rev, by: `agent:${agent}` } });
+    return sendJson(res, 200, { ok: true, id, rev });
+  }
+  // Agent reads its OWN revision history (self-scoped) — pick a rev to revert to.
+  if (method === 'POST' && p === '/api/agents/history') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const revisions = os.agentRevisions.list(agent).map((r) => ({
+      rev: r.rev, author: r.author, summary: r.summary, createdAt: r.createdAt,
+      description: r.description, claudeChars: r.claudeMd.length,
+    }));
+    return sendJson(res, 200, { ok: true, agent, revisions });
+  }
+  // Agent reverts ITS OWN listing to a prior revision (self-scoped) — the rollback for a bad self-edit.
+  if (method === 'POST' && p === '/api/agents/revert') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    if (!os.paths) return sendJson(res, 200, { ok: false, error: 'editing agents requires a data home' });
+    const ag = os.agents.get(agent);
+    if (!ag?.dir) return sendJson(res, 200, { ok: false, error: `unknown agent "${agent}"` });
+    const rev = Number(b.rev);
+    const target = os.agentRevisions.get(agent, rev);
+    if (!target) return sendJson(res, 200, { ok: false, error: `no revision ${b.rev} for "${agent}"` });
+    const before = readAgentSnapshot(ag);
+    const next = applyAgentSnapshot(os, ag, target);
+    const newRev = os.agentRevisions.commit(os.tenant, agent, before, manifestToSnapshot(next, target.claudeMd), `revert to rev ${rev}`, `agent:${agent}`);
+    os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: 'agent.config.reverted', data: { agent, toRev: rev, rev: newRev, by: `agent:${agent}` } });
+    return sendJson(res, 200, { ok: true, id: agent, toRev: rev, rev: newRev });
   }
 
   // Every other /api/* route requires a logged-in member.
@@ -1686,9 +1761,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return sendJson(res, 200, { agent: ag.id, runtime: ag.runtime, exists: fs.existsSync(file), content });
     }
     const b = await readBody(req);
-    fs.writeFileSync(file, String(b.content ?? ''));
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.claude.updated', data: { agent: ag.id, bytes: String(b.content ?? '').length } });
-    return sendJson(res, 200, { ok: true });
+    const before = readAgentSnapshot(ag);
+    const content = String(b.content ?? '');
+    fs.writeFileSync(file, content);
+    const rev = os.agentRevisions.commit(os.tenant, ag.id, before, manifestToSnapshot(ag, content), 'edited CLAUDE.md', me.email);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.claude.updated', data: { agent: ag.id, bytes: content.length, rev } });
+    return sendJson(res, 200, { ok: true, rev });
   }
 
   // ── per-agent runtime tuning (model / effort / permission-mode) — owner/admin only ──
@@ -1707,6 +1785,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const b = await readBody(req);
     const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
     if (tErr) return sendJson(res, 400, { error: tErr });
+    const before = readAgentSnapshot(ag);
     // Replace the tuning fields wholesale (sanitize already dropped empties to undefined → those
     // become "inherit"). Starter prompts + shell secrets + category + icon are only touched when the
     // body carries the field (a tuning-only save from the runtime card leaves them as-is). Preserve
@@ -1720,8 +1799,34 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     os.registerAgent(next);
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, category, shellSecrets: shellSecrets ?? [] } });
+    const rev = os.agentRevisions.commit(os.tenant, ag.id, before, manifestToSnapshot(next, before.claudeMd), 'edited config', me.email);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, category, shellSecrets: shellSecrets ?? [], rev } });
     return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, category, icon });
+  }
+
+  // ── agent config revision history + revert (owner/admin) — the human rollback for a self-editing agent ──
+  const agentRevs = p.match(/^\/api\/agents\/([\w.-]+)\/revisions$/);
+  if (agentRevs && method === 'GET') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const ag = os.agents.get(agentRevs[1]);
+    if (!ag) return sendJson(res, 404, { error: 'agent not found' });
+    return sendJson(res, 200, { agent: ag.id, revisions: os.agentRevisions.list(ag.id) });
+  }
+  const agentRevert = p.match(/^\/api\/agents\/([\w.-]+)\/revert$/);
+  if (agentRevert && method === 'POST') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const ag = os.agents.get(agentRevert[1]);
+    if (!ag?.dir) return sendJson(res, 404, { error: 'agent not found or has no folder' });
+    if (ag.runtime !== 'claude-code') return sendJson(res, 400, { error: 'only claude-code agents can be reverted' });
+    const b = await readBody(req);
+    const rev = Number(b.rev);
+    const target = os.agentRevisions.get(ag.id, rev);
+    if (!target) return sendJson(res, 404, { error: `no revision ${b.rev} for "${ag.id}"` });
+    const before = readAgentSnapshot(ag);
+    const next = applyAgentSnapshot(os, ag, target);
+    const newRev = os.agentRevisions.commit(os.tenant, ag.id, before, manifestToSnapshot(next, target.claudeMd), `revert to rev ${rev}`, me.email);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.reverted', data: { agent: ag.id, toRev: rev, rev: newRev } });
+    return sendJson(res, 200, { ok: true, id: ag.id, toRev: rev, rev: newRev });
   }
 
   // ── workspace runtime defaults (the fleet-wide model/effort/permission fallback) — owner/admin only ──

--- a/src/state/agent-revisions.ts
+++ b/src/state/agent-revisions.ts
@@ -1,0 +1,137 @@
+/**
+ * Agent config revision history — the rollback backbone for a self-editing agent.
+ *
+ * An agent can refine its own "listing" (description, starter prompts, category, icon, tuning) and its
+ * CLAUDE.md system prompt via the `agent_update` MCP tool; humans do the same from the console. Neither
+ * path is approval-gated — like the KB, safety comes from **reversibility**: every edit snapshots the
+ * full prior + new state here, so any change (by the agent or a human) is auditable and one-click
+ * revertable. Nothing the agent does to itself is ever truly lost.
+ *
+ * This store is DB-only (a snapshot is pure structured state). The manifest itself still lives on disk
+ * (`agent.json` + `CLAUDE.md`); the server writes those files and calls `commit` to record the version.
+ */
+import { randomUUID } from 'crypto';
+import { Db } from './db';
+import { Effort, PermissionMode } from '../types';
+
+/** The full editable surface of an agent — everything a revert must restore. */
+export interface AgentConfigSnapshot {
+  description: string;
+  category?: string;
+  icon?: string;
+  model?: string;
+  effort?: Effort;
+  permissionMode?: PermissionMode;
+  examplePrompts: string[];
+  shellSecrets: string[];
+  claudeMd: string;
+}
+
+/** A committed snapshot with its revision metadata. */
+export interface AgentRevision extends AgentConfigSnapshot {
+  id: string;
+  rev: number;
+  summary: string | null;
+  author: string;
+  createdAt: number;
+}
+
+interface RevRow {
+  id: string; tenant: string; agent_id: string; rev: number;
+  description: string; category: string | null; icon: string | null;
+  model: string | null; effort: string | null; permission_mode: string | null;
+  example_prompts: string; shell_secrets: string; claude_md: string;
+  summary: string | null; author: string; created_at: number;
+}
+
+function toRevision(r: RevRow): AgentRevision {
+  return {
+    id: r.id, rev: r.rev,
+    description: r.description,
+    category: r.category ?? undefined,
+    icon: r.icon ?? undefined,
+    model: r.model ?? undefined,
+    effort: (r.effort as Effort) ?? undefined,
+    permissionMode: (r.permission_mode as PermissionMode) ?? undefined,
+    examplePrompts: safeArray(r.example_prompts),
+    shellSecrets: safeArray(r.shell_secrets),
+    claudeMd: r.claude_md,
+    summary: r.summary, author: r.author, createdAt: r.created_at,
+  };
+}
+
+function safeArray(json: string): string[] {
+  try { const v = JSON.parse(json); return Array.isArray(v) ? v.map(String) : []; } catch { return []; }
+}
+
+/** Two snapshots are equal when every tracked field matches (so a no-op save records nothing). */
+function sameSnapshot(a: AgentConfigSnapshot, b: AgentConfigSnapshot): boolean {
+  return a.description === b.description
+    && (a.category ?? '') === (b.category ?? '')
+    && (a.icon ?? '') === (b.icon ?? '')
+    && (a.model ?? '') === (b.model ?? '')
+    && (a.effort ?? '') === (b.effort ?? '')
+    && (a.permissionMode ?? '') === (b.permissionMode ?? '')
+    && JSON.stringify(a.examplePrompts ?? []) === JSON.stringify(b.examplePrompts ?? [])
+    && JSON.stringify(a.shellSecrets ?? []) === JSON.stringify(b.shellSecrets ?? [])
+    && a.claudeMd === b.claudeMd;
+}
+
+export class AgentRevisions {
+  constructor(private readonly db: Db) {}
+
+  /** All revisions for an agent, newest first. */
+  list(agentId: string): AgentRevision[] {
+    return this.db
+      .prepare('SELECT * FROM agent_revisions WHERE agent_id = ? ORDER BY rev DESC')
+      .all<RevRow>(agentId)
+      .map(toRevision);
+  }
+
+  /** One revision by number, or null. */
+  get(agentId: string, rev: number): AgentRevision | null {
+    const r = this.db
+      .prepare('SELECT * FROM agent_revisions WHERE agent_id = ? AND rev = ?')
+      .get<RevRow>(agentId, rev);
+    return r ? toRevision(r) : null;
+  }
+
+  /**
+   * Record an edit. `before` is the on-disk state just replaced, `after` the new state. On the FIRST
+   * tracked edit we seed a baseline revision from `before` (so pre-feature state stays recoverable),
+   * then append `after`. A no-op edit (after === latest) records nothing. Returns the new rev, or null
+   * when nothing changed.
+   */
+  commit(tenant: string, agentId: string, before: AgentConfigSnapshot, after: AgentConfigSnapshot, summary: string, author: string): number | null {
+    const now = Date.now();
+    const maxRev = this.maxRev(agentId);
+    let rev = maxRev;
+    if (rev === 0) {
+      this.insert(tenant, agentId, 1, before, 'baseline — captured before the first tracked edit', 'system', now);
+      rev = 1;
+    }
+    if (sameSnapshot(before, after)) return null;
+    rev += 1;
+    this.insert(tenant, agentId, rev, after, summary, author, now);
+    return rev;
+  }
+
+  private maxRev(agentId: string): number {
+    const r = this.db.prepare('SELECT COALESCE(MAX(rev), 0) AS m FROM agent_revisions WHERE agent_id = ?').get<{ m: number }>(agentId);
+    return r?.m ?? 0;
+  }
+
+  private insert(tenant: string, agentId: string, rev: number, s: AgentConfigSnapshot, summary: string, author: string, ts: number): void {
+    this.db
+      .prepare(`INSERT INTO agent_revisions
+        (id, tenant, agent_id, rev, description, category, icon, model, effort, permission_mode, example_prompts, shell_secrets, claude_md, summary, author, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
+      .run(
+        randomUUID().slice(0, 8), tenant, agentId, rev,
+        s.description, s.category ?? null, s.icon ?? null,
+        s.model ?? null, s.effort ?? null, s.permissionMode ?? null,
+        JSON.stringify(s.examplePrompts ?? []), JSON.stringify(s.shellSecrets ?? []), s.claudeMd,
+        summary || null, author, ts,
+      );
+  }
+}

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -312,6 +312,30 @@ function migrate(db: Db): void {
     );
     CREATE INDEX IF NOT EXISTS idx_kb_rev_page ON kb_revisions(page_id, rev);
 
+    -- Agent config revision history: every prior version of an agent's "listing" (description, starter
+    -- prompts, CLAUDE.md system prompt, tuning). Append-only full snapshots — the rollback + audit
+    -- backbone that makes a self-editing agent safe (safety = reversibility, like the KB above).
+    CREATE TABLE IF NOT EXISTS agent_revisions (
+      id              TEXT PRIMARY KEY,
+      tenant          TEXT NOT NULL,
+      agent_id        TEXT NOT NULL,
+      rev             INTEGER NOT NULL,
+      description     TEXT NOT NULL,
+      category        TEXT,
+      icon            TEXT,
+      model           TEXT,
+      effort          TEXT,
+      permission_mode TEXT,
+      example_prompts TEXT NOT NULL,          -- JSON string[]
+      shell_secrets   TEXT NOT NULL,          -- JSON string[]
+      claude_md       TEXT NOT NULL,          -- full CLAUDE.md snapshot
+      summary         TEXT,                   -- one-line "what changed"
+      author          TEXT NOT NULL,          -- member email | agent:<id> | system
+      created_at      INTEGER NOT NULL,
+      UNIQUE(agent_id, rev)
+    );
+    CREATE INDEX IF NOT EXISTS idx_agent_rev ON agent_revisions(agent_id, rev);
+
     -- FTS5 over title+tags+body for ranked search (mirrors memories_fts).
     CREATE VIRTUAL TABLE IF NOT EXISTS kb_fts USING fts5(
       title, tags, body, content='kb_pages', content_rowid='rowid'

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
 import { ConnectorsPage } from '@/connectors'
 import { docPages } from '@/docs'
 
@@ -3933,6 +3933,8 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
   const [loaded, setLoaded] = useState(false)
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
+  // Bumped after a revert so both the tuning card (remounted via key) and the CLAUDE.md below re-fetch.
+  const [revBump, setRevBump] = useState(0)
   const info = agents.find((a) => a.id === agentId)
 
   useEffect(() => {
@@ -3941,7 +3943,7 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
       if (r.error) { setHint('⚠ ' + r.error); return }
       setContent(r.content ?? ''); setSaved(r.content ?? ''); setLoaded(true)
     }).catch(() => {})
-  }, [agentId])
+  }, [agentId, revBump])
 
   const dirty = content !== saved
   const save = async () => {
@@ -3963,7 +3965,7 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
         system prompt: its role, conventions, and how it should use its tools (including when to
         <span className="font-mono text-xs"> recall</span>/<span className="font-mono text-xs">remember</span>). Applied on the agent's next session.
       </p>
-      {info?.runtime === 'claude-code' && <AgentTuningCard agentId={agentId} onSaved={onSaved} />}
+      {info?.runtime === 'claude-code' && <AgentTuningCard key={revBump} agentId={agentId} onSaved={onSaved} />}
       <Card>
         <CardContent className="space-y-3 p-4">
           {!loaded && !hint ? (
@@ -3984,7 +3986,54 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
           )}
         </CardContent>
       </Card>
+      {info?.runtime === 'claude-code' && <AgentRevisionsCard agentId={agentId} onReverted={() => { setRevBump((n) => n + 1); onSaved?.() }} />}
     </div>
+  )
+}
+
+/** Revision history for an agent's listing + CLAUDE.md — the human rollback for a self-editing agent.
+ *  Every edit (by the agent via agent_update, or a human here) snapshots a full version; revert restores
+ *  one and records a new revision, so nothing is ever lost. */
+function AgentRevisionsCard({ agentId, onReverted }: { agentId: string; onReverted: () => void }) {
+  const [revs, setRevs] = useState<AgentRevision[] | null>(null)
+  const [open, setOpen] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [hint, setHint] = useState('')
+  const load = () => api.agentRevisions(agentId).then((r) => { if (!r.error) setRevs(r.revisions) }).catch(() => {})
+  useEffect(() => { setRevs(null); setOpen(false); setHint('') }, [agentId])
+  useEffect(() => { if (open && revs === null) load() }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+  const revert = async (rev: number) => {
+    if (!window.confirm(`Revert ${agentId} to rev ${rev}?\n\nThis restores that revision's description, starter prompts, tuning, and CLAUDE.md, and records a new revision (so it too is reversible).`)) return
+    setBusy(true); setHint('')
+    const r = await api.agentRevert(agentId, rev)
+    setBusy(false)
+    if (r.error || !r.ok) return setHint('⚠ ' + (r.error ?? 'failed'))
+    setHint(`reverted to rev ${rev}`); load(); onReverted(); setTimeout(() => setHint(''), 2500)
+  }
+  return (
+    <Card>
+      <CardContent className="space-y-2 p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 text-xs font-medium"><HistoryIcon className="h-3.5 w-3.5" /> Revision history</div>
+          <div className="flex items-center gap-3">
+            {hint && <span className="font-mono text-[11px] text-muted-foreground">{hint}</span>}
+            <Button size="sm" variant="outline" onClick={() => setOpen((v) => !v)}>{open ? 'Hide' : 'Show'}</Button>
+          </div>
+        </div>
+        {open && (
+          revs === null ? <div className="text-xs text-muted-foreground">Loading…</div>
+          : revs.length === 0 ? <div className="text-xs text-muted-foreground">No revisions yet — edits to this agent's listing or CLAUDE.md (by the agent itself or a human) will show up here.</div>
+          : <div className="space-y-1">
+              {revs.map((rv) => (
+                <div key={rv.id} className="flex items-center justify-between gap-2 rounded px-2 py-1 text-xs hover:bg-muted/50">
+                  <span className="min-w-0 flex-1 truncate"><span className="font-mono">rev {rv.rev}</span> · {new Date(rv.createdAt).toLocaleString()} · {rv.author}{rv.summary ? ` — ${rv.summary}` : ''}</span>
+                  {rv.rev !== revs[0].rev && <button className="shrink-0 text-muted-foreground underline hover:text-foreground disabled:opacity-50" disabled={busy} onClick={() => revert(rv.rev)}>revert</button>}
+                </div>
+              ))}
+            </div>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -208,6 +208,23 @@ export interface KbRevision {
   createdAt: number
 }
 
+export interface AgentRevision {
+  id: string
+  rev: number
+  description: string
+  category?: string
+  icon?: string
+  model?: string
+  effort?: Effort
+  permissionMode?: PermissionMode
+  examplePrompts: string[]
+  shellSecrets: string[]
+  claudeMd: string
+  summary?: string | null
+  author: string
+  createdAt: number
+}
+
 export type TaskStatus = 'todo' | 'doing' | 'blocked' | 'done' | 'cancelled'
 export interface Task {
   id: string
@@ -733,6 +750,8 @@ export const api = {
   saveAgentClaude: (id: string, content: string) => call<{ ok: boolean; error?: string }>('PUT', `/api/agents/${encodeURIComponent(id)}/claude`, { content }),
   agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),
   saveAgentConfig: (id: string, patch: RuntimeTuning & { description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string }) => call<{ ok: boolean; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string } & RuntimeTuning>('PUT', `/api/agents/${encodeURIComponent(id)}/config`, patch),
+  agentRevisions: (id: string) => call<{ agent: string; revisions: AgentRevision[]; error?: string }>('GET', `/api/agents/${encodeURIComponent(id)}/revisions`),
+  agentRevert: (id: string, rev: number) => call<{ ok: boolean; id?: string; toRev?: number; rev?: number; error?: string }>('POST', `/api/agents/${encodeURIComponent(id)}/revert`, { rev }),
   runtimeDefaults: () => call<RuntimeTuning & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/runtime-defaults'),
   saveRuntimeDefaults: (tuning: RuntimeTuning) => call<{ ok: boolean; error?: string } & RuntimeTuning>('PUT', '/api/settings/runtime-defaults', tuning),
 


### PR DESCRIPTION
## What

Agents can now **improve their own listing** — the self-improvement loop the OS was missing. An agent refines its OWN description, starter prompts, category, icon, runtime tuning, and CLAUDE.md system prompt via `agent_update`, inspects its edit history with `agent_history`, and rolls back a bad self-edit with `agent_revert`. All **self-only**: the target is always the calling session's agent. Changes apply on the agent's next session.

Turns out the write mechanism mostly existed (`agent_update` already wrote `agent.json`/`CLAUDE.md`). This PR makes it *safe* and *reversible*, and closes a governance hole.

## Safety model — reversibility, not an approval gate

Mirrors the Knowledge Base: every edit — by the agent OR a human console edit — snapshots a full revision into a new `agent_revisions` table (`src/state/agent-revisions.ts`). Any change is auditable (`agent.config.updated` / `agent.config.reverted`) and one-click revertable from the console **agent page → Revision history** panel. Nothing an agent does to itself is ever lost.

## Governance hole closed

`agent_update` previously took the target `id` from the request body, so **any agent could rewrite any other editable agent's prompt/tuning with zero approval** — a side effect that skipped the gate. It's now self-only (a supplied `id` must equal the session's agent). Agents still *create* others via `agent_create`; they just can't silently edit each other. Humans edit any agent from the console as before.

## Surface

- **MCP tools:** `agent_update` (now self-scoped), + new `agent_history` / `agent_revert` → 33 always-on tools.
- **Loopback routes:** `POST /api/agents/history`, `POST /api/agents/revert` (session-scoped, self-only).
- **Console routes:** `GET /api/agents/:id/revisions`, `POST /api/agents/:id/revert` (owner/admin).
- **Store:** `agent_revisions` table + `AgentRevisions` (`commit` seeds a pre-edit baseline on first tracked edit, skips no-ops; `list`/`get`).
- **Console UI:** Revision history panel on the agent page; a revert remounts the tuning card + reloads CLAUDE.md.

## Verification

- `npm run typecheck` → clean; backend build → clean; `web` tsc -b + vite build → clean.
- Governance conformance: **44/44**.
- Isolated **store unit test** (baseline seeding, no-op skip, per-agent isolation, revert read) → all pass.
- Ephemeral-server **route smoke test**: loopback self routes present (404 on bad session), console routes gated (401 without a member).

🤖 Generated with [Claude Code](https://claude.com/claude-code)