### PR TITLE
Agents: creating a new agent lands on the list with it selected (v0.44.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.44.1] — 2026-07-08
+### Fixed
+- **Creating a new agent now lands on the agents list with that agent selected**, instead of jumping
+  straight into its edit/settings page. `NewAgentPage`'s `onCreated` navigates to `nav('agents', id)`
+  (agents list, new agent highlighted via the URL detail param) rather than `openAgent(id)`.
+
 ## [0.44.0] — 2026-07-08
 ### Added
 - **Custom governance patterns — teach the enricher your own dangerous ops, as config not code.** A

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.44.0",
+      "version": "0.44.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.44.0",
+  "version": "0.44.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -700,7 +700,7 @@ function Console({ me }: { me: Member }) {
 
         <div className={`min-h-0 flex-1 ${fullBleed ? '' : 'overflow-y-auto p-6'}`}>
           {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onDuplicate={duplicateAgent} onRescan={rescanAgents} />}
-          {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); openAgent(id) }} />}
+          {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); nav('agents', id) }} />}
           {route === 'sessions' && <SessionsPage sessions={sessions} waiting={waiting} selected={selected} onOpen={openTerminal} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} />}
           {route === 'connectors' && <ConnectorsPage me={me} />}


### PR DESCRIPTION
## What

When you create a new agent, the console now returns to the **agents list with that agent selected**, instead of jumping straight into its edit/settings page.

## Why

Requested behavior: after creating an agent you want to see it in context in the list (and it's highlighted), not land on a form.

## Change

`web/src/App.tsx` — `NewAgentPage`'s `onCreated` now calls `nav('agents', id)` (agents list, new agent highlighted via the URL detail param) instead of `openAgent(id)` (which routed to `nav('agent', id)`, the edit page). `AgentsPage` already prioritizes the URL `selected` detail when choosing the highlighted agent, so no other change is needed.

Web-only; no server restart required (server serves `web/dist` off disk).

## Verification

- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` — 44/44 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)