### PR TITLE
Chat: agents can DM anyone + post to any channel — Slack + Discord (v0.45.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.45.0] — 2026-07-08
+### Added
+- **Agents can proactively DM anyone and post to any channel — Slack + Discord.** Until now the only
+  outbound chat tools (`slack_reply`/`discord_reply`) posted back to the *triggering* thread, so an agent
+  could only speak where it was spoken to. Four new native egress tools change that: `slack_send` /
+  `discord_send` post to ANY channel, and `slack_dm` / `discord_dm` DM ANY person — off-thread and
+  unattended (e.g. a cron automation posting a daily summary or nudging a teammate). Slack resolves a
+  channel by **id or name** (auto-joining a public channel the bot isn't in on `not_in_channel`) and a
+  recipient by **Slack user id or email** (`users.lookupByEmail`); Discord takes channel/user **ids**
+  (no email lookup exists). Exposed to **any** session whenever that platform is configured
+  (`SLACK_EGRESS`/`DISCORD_EGRESS`), not just chat-triggered ones. Audit-only posture — every send/DM is
+  audited (`slack.send`/`slack.dm`/`discord.send`/`discord.dm`, plus `.failed`) but not policy-gated,
+  matching `slack_reply`. New connector helpers (`lookupUserByEmail`/`lookupChannelByName`/`joinChannel`
+  in `connectors/slack.ts`), `SlackSocket.sendToChannel`/`dmMember` + `DiscordSocket.sendToChannel`/
+  `dmMember`, and session-secret-gated loopback routes `POST /api/agent/{slack,discord}/{send,dm}`.
+
 ## [0.44.1] — 2026-07-08
 ### Fixed
 - **Creating a new agent now lands on the agents list with that agent selected**, instead of jumping

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,8 +199,12 @@ Key modules:
   reversible revision (`src/state/agent-revisions.ts`, the KB-style rollback backbone; no agent can edit
   another agent). Plus
   `directory_lookup` (team/identity-map
-  search), `list_capabilities`/`policy_check` (policy preview), and `slack_reply`/`discord_reply` when
-  chat-triggered. Each tool is a session-secret-gated loopback call to an `/api/*` route that sits BEFORE
+  search), `list_capabilities`/`policy_check` (policy preview), `slack_reply`/`discord_reply` when
+  chat-triggered, and **proactive egress** `slack_send`/`slack_dm`/`discord_send`/`discord_dm` (exposed
+  whenever that platform is configured — `SLACK_EGRESS`/`DISCORD_EGRESS`) to post to ANY channel (by
+  id/name, auto-joining public Slack channels) or DM ANY person (Slack: user id / email; Discord: user
+  id), off-thread and unattended; audit-only (`slack.send`/`slack.dm`/`discord.send`/`discord.dm`), no
+  policy gate — same posture as `slack_reply`. Each tool is a session-secret-gated loopback call to an `/api/*` route that sits BEFORE
   the member-auth gate. Canonical tool↔route↔store matrix + the governance notes:
   `docs/agent-mcp-tools.md`. See also `docs/memory-layer-plan.md`.
 - `src/state/kb.ts` — the **Knowledge Base plane** (`os.kb`): the shared, tenant-wide *living* wiki agents

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -44,8 +44,12 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `secret_list` | `GET /api/agent/secret/list` | `TerminalManager.listSecrets` | R | shared (`*`) secret KEYS + metadata only, never values |
 | `slack_reply` | `POST /api/agent/slack/reply` | SlackSocket | W | only when `SLACK_REPLY=1` (chat-triggered) |
 | `discord_reply` | `POST /api/agent/discord/reply` | DiscordSocket | W | only when `DISCORD_REPLY=1` (chat-triggered) |
+| `slack_send` | `POST /api/agent/slack/send` | `SlackSocket.sendToChannel` | W | proactive post to any channel by id/name; auto-joins public channels; audited `slack.send`; only when `SLACK_EGRESS=1` (Slack configured) |
+| `slack_dm` | `POST /api/agent/slack/dm` | `SlackSocket.dmMember` | W | proactive DM by Slack user id or email; audited `slack.dm`; only when `SLACK_EGRESS=1` |
+| `discord_send` | `POST /api/agent/discord/send` | `DiscordSocket.sendToChannel` | W | proactive post to any channel by id; audited `discord.send`; only when `DISCORD_EGRESS=1` (Discord configured) |
+| `discord_dm` | `POST /api/agent/discord/dm` | `DiscordSocket.dmMember` | W | proactive DM by Discord user id; audited `discord.dm`; only when `DISCORD_EGRESS=1` |
 
-33 always-on tools + 2 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+33 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 
@@ -105,9 +109,6 @@ tightening could classify CLAUDE.md/model self-edits through Policy for workspac
   missing is **synchronous** delegation (an agent blocking on another's result) and an agent-triggered
   `task_dispatch` (today agents `claim` into their own session; direct spawn stays human/tick-only). Both
   still want budget attribution + recursion-depth limiting before they ship (`docs/tasks-plan.md` §9).
-- **Proactive person-to-person DM.** `directory_lookup` finds a teammate's Slack/Discord id and the
-  server has `dmUser` (the approval notifier path), but the only outbound chat tools (`slack_reply`/
-  `discord_reply`) post to the *triggering* thread. An agent can't DM a specific person off-thread.
 - **Episodic self-query.** Memory is semantic-only; an agent can't query its own past runs
   (`/api/runs` exists but is member-gated). "Have I done this before, how did it go?"
 - **`ask` rigidity.** Timeout hardcoded ~1h; no `timeoutSeconds` and no non-blocking ask-then-collect

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.44.1",
+      "version": "0.45.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.44.1",
+  "version": "0.45.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -76,6 +76,67 @@ export async function openDmChannel(botToken: string, userId: string): Promise<{
   }
 }
 
+/** Resolve an email → its Slack user id, so an agent can DM a person it only knows by email. Uses
+ *  `users.lookupByEmail` (needs the `users:read.email` scope). Returns `{ error }` (never throws). */
+export async function lookupUserByEmail(botToken: string, email: string): Promise<{ user: string } | { error: string }> {
+  if (!botToken || !email) return { error: 'missing token or email' };
+  try {
+    const res = await fetch(`${SLACK_API}/users.lookupByEmail?email=${encodeURIComponent(email)}`, {
+      headers: { authorization: `Bearer ${botToken}` },
+    });
+    const j: any = await res.json().catch(() => ({}));
+    if (j?.ok && j.user?.id) return { user: String(j.user.id) };
+    return { error: String(j?.error || `users.lookupByEmail failed (${res.status})`) };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'users.lookupByEmail failed' };
+  }
+}
+
+/** Resolve a channel NAME (e.g. `general`, leading `#` optional) → its channel id, so an agent can
+ *  post to a channel it knows by name. Walks `conversations.list` (public + private) with a bounded
+ *  number of pages. Returns `{ error }` when not found / on failure (never throws). */
+export async function lookupChannelByName(botToken: string, name: string): Promise<{ channel: string } | { error: string }> {
+  if (!botToken || !name) return { error: 'missing token or channel name' };
+  const want = name.trim().replace(/^#/, '').toLowerCase();
+  let cursor = '';
+  try {
+    for (let page = 0; page < 10; page++) { // ≤10 pages × 1000 = 10k channels, plenty for a workspace
+      const qs = new URLSearchParams({ types: 'public_channel,private_channel', exclude_archived: 'true', limit: '1000' });
+      if (cursor) qs.set('cursor', cursor);
+      const res = await fetch(`${SLACK_API}/conversations.list?${qs.toString()}`, {
+        headers: { authorization: `Bearer ${botToken}` },
+      });
+      const j: any = await res.json().catch(() => ({}));
+      if (!j?.ok) return { error: String(j?.error || `conversations.list failed (${res.status})`) };
+      const hit = (j.channels || []).find((c: any) => String(c?.name || '').toLowerCase() === want);
+      if (hit?.id) return { channel: String(hit.id) };
+      cursor = String(j.response_metadata?.next_cursor || '');
+      if (!cursor) break;
+    }
+    return { error: `no channel named "${want}"` };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'conversations.list failed' };
+  }
+}
+
+/** Best-effort join a public channel so the bot can post into it (`chat.postMessage` fails with
+ *  `not_in_channel` otherwise). No-op-ish for private channels (returns the error). Never throws. */
+export async function joinChannel(botToken: string, channelId: string): Promise<{ ok: true } | { error: string }> {
+  if (!botToken || !channelId) return { error: 'missing token or channel' };
+  try {
+    const res = await fetch(`${SLACK_API}/conversations.join`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${botToken}`, 'content-type': 'application/json; charset=utf-8' },
+      body: JSON.stringify({ channel: channelId }),
+    });
+    const j: any = await res.json().catch(() => ({}));
+    if (j?.ok) return { ok: true };
+    return { error: String(j?.error || `conversations.join failed (${res.status})`) };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'conversations.join failed' };
+  }
+}
+
 /** Resolve a Slack user id (e.g. `U123`) to their profile email — the join key for member run-as.
  *  Returns '' on any error/missing email (the dispatcher then falls back to the company identity). */
 export async function lookupUserEmail(botToken: string, userId: string): Promise<string> {

--- a/src/edge/discord-socket.ts
+++ b/src/edge/discord-socket.ts
@@ -280,6 +280,52 @@ export class DiscordSocket {
     return { ok: true };
   }
 
+  /**
+   * Native egress: post to ANY channel by id. Unlike `reply` this is not bound to the triggering
+   * message — it lets an agent proactively message a channel (e.g. a cron posting a daily summary).
+   * Discord has no email/name lookup, so the caller supplies a channel id. Audited as `discord.send`.
+   */
+  async sendToChannel(sessionId: string, channelId: string, text: string): Promise<{ ok: true } | { ok: false; error: string }> {
+    const token = this.os.settings.discordBotToken();
+    if (!token) return { ok: false, error: 'discord not configured' };
+    const body = (text || '').trim();
+    if (!body) return { ok: false, error: 'empty message' };
+    const channel = (channelId || '').trim();
+    if (!channel) return { ok: false, error: 'channel is required' };
+    const res = await postMessage(token, channel, body);
+    if ('error' in res) {
+      this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'discord', type: 'discord.send.failed', data: { channel, error: res.error } });
+      return { ok: false, error: res.error };
+    }
+    this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'discord', type: 'discord.send', data: { channel, id: res.id, chars: body.length } });
+    return { ok: true };
+  }
+
+  /**
+   * Native egress: DM a person by their Discord user id (Discord exposes no email lookup, so the id is
+   * the only handle). Opens the DM channel then posts. Audited as `discord.dm`. Returns ok / a reason.
+   */
+  async dmMember(sessionId: string, to: string, text: string): Promise<{ ok: true } | { ok: false; error: string }> {
+    const token = this.os.settings.discordBotToken();
+    if (!token) return { ok: false, error: 'discord not configured' };
+    const body = (text || '').trim();
+    if (!body) return { ok: false, error: 'empty message' };
+    const userId = (to || '').trim();
+    if (!userId) return { ok: false, error: 'recipient is required' };
+    const ch = await openDmChannel(token, userId);
+    if ('error' in ch) {
+      this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'discord', type: 'discord.dm.failed', data: { to: userId, error: ch.error } });
+      return { ok: false, error: ch.error };
+    }
+    const res = await postMessage(token, ch.channel, body);
+    if ('error' in res) {
+      this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'discord', type: 'discord.dm.failed', data: { to: userId, error: res.error } });
+      return { ok: false, error: res.error };
+    }
+    this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'discord', type: 'discord.dm', data: { to: userId, id: res.id, chars: body.length } });
+    return { ok: true };
+  }
+
   /** DM a Discord user (by their Discord user id) — best-effort, used for approval notifications.
    *  Returns ok / a reason; never throws. No-op when Discord isn't configured. */
   async dmUser(discordUserId: string, text: string): Promise<{ ok: true } | { ok: false; error: string }> {

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -16,7 +16,7 @@
  */
 import { AgentOS } from '../kernel';
 import { Automations } from './automations';
-import { lookupBotUserId, lookupUserEmail, openDmChannel, openSocketConnection, parseSlackEvent, postMessage } from '../connectors/slack';
+import { joinChannel, lookupBotUserId, lookupChannelByName, lookupUserByEmail, lookupUserEmail, openDmChannel, openSocketConnection, parseSlackEvent, postMessage } from '../connectors/slack';
 
 const RECONNECT_MIN_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
@@ -212,6 +212,72 @@ export class SlackSocket {
     }
     this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'slack', type: 'slack.reply', data: { channel: row.channel, ts: res.ts, chars: body.length } });
     return { ok: true };
+  }
+
+  /**
+   * Native egress: post to ANY channel by id (`C…`/`G…`) or by name (`general` / `#general`). Unlike
+   * `reply` this is not bound to the triggering thread — it lets an agent proactively message a channel
+   * (e.g. a cron automation posting a daily summary). Public channels the bot isn't in are auto-joined
+   * on `not_in_channel` and the post retried once. Audited as `slack.send`. Returns ok / a reason.
+   */
+  async sendToChannel(sessionId: string, channelRef: string, text: string): Promise<{ ok: true } | { ok: false; error: string }> {
+    const token = this.os.settings.slackBotToken();
+    if (!token) return { ok: false, error: 'slack not configured' };
+    const body = (text || '').trim();
+    if (!body) return { ok: false, error: 'empty message' };
+    const ref = (channelRef || '').trim().replace(/^#/, '');
+    if (!ref) return { ok: false, error: 'channel is required' };
+    // Slack channel/group ids look like C/G/D + base32; anything else is treated as a channel name.
+    let channel = ref;
+    if (!/^[CGD][A-Z0-9]{6,}$/.test(ref)) {
+      const found = await lookupChannelByName(token, ref);
+      if ('error' in found) return this.sendFailed(sessionId, ref, `channel "${ref}" not found: ${found.error}`);
+      channel = found.channel;
+    }
+    let res = await postMessage(token, channel, body);
+    if ('error' in res && res.error === 'not_in_channel') {
+      await joinChannel(token, channel); // best-effort; retry once whether or not the join reported ok
+      res = await postMessage(token, channel, body);
+    }
+    if ('error' in res) return this.sendFailed(sessionId, channel, res.error);
+    this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'slack', type: 'slack.send', data: { channel, ts: res.ts, chars: body.length } });
+    return { ok: true };
+  }
+
+  private sendFailed(sessionId: string, channel: string, error: string): { ok: false; error: string } {
+    this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'slack', type: 'slack.send.failed', data: { channel, error } });
+    return { ok: false, error };
+  }
+
+  /**
+   * Native egress: DM a person by their Slack user id (`U…`) or by email (resolved via
+   * `users.lookupByEmail`). Opens the DM channel then posts. Lets an agent reach anyone in the
+   * workspace, not just the triggering thread. Audited as `slack.dm`. Returns ok / a reason.
+   */
+  async dmMember(sessionId: string, to: string, text: string): Promise<{ ok: true } | { ok: false; error: string }> {
+    const token = this.os.settings.slackBotToken();
+    if (!token) return { ok: false, error: 'slack not configured' };
+    const body = (text || '').trim();
+    if (!body) return { ok: false, error: 'empty message' };
+    const ref = (to || '').trim();
+    if (!ref) return { ok: false, error: 'recipient is required' };
+    let userId = ref;
+    if (ref.includes('@')) {
+      const found = await lookupUserByEmail(token, ref);
+      if ('error' in found) return this.dmFailed(sessionId, ref, `no Slack user for ${ref}: ${found.error}`);
+      userId = found.user;
+    }
+    const ch = await openDmChannel(token, userId);
+    if ('error' in ch) return this.dmFailed(sessionId, userId, ch.error);
+    const res = await postMessage(token, ch.channel, body);
+    if ('error' in res) return this.dmFailed(sessionId, userId, res.error);
+    this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'slack', type: 'slack.dm', data: { to: userId, ts: res.ts, chars: body.length } });
+    return { ok: true };
+  }
+
+  private dmFailed(sessionId: string, to: string, error: string): { ok: false; error: string } {
+    this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'slack', type: 'slack.dm.failed', data: { to, error } });
+    return { ok: false, error };
   }
 
   /** DM a Slack user (by their Slack user id) — best-effort, used for approval notifications.

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -68,6 +68,71 @@ const DISCORD_REPLY_TOOL = {
   },
 };
 
+// Native proactive egress — offered to ANY session when the workspace has Slack/Discord configured
+// (SLACK_EGRESS / DISCORD_EGRESS = '1'), not just chat-triggered ones. Unlike the reply tools these
+// are NOT thread-bound: the agent names a channel or person, so it can message anyone / anywhere.
+const SLACK_EGRESS = process.env.SLACK_EGRESS === '1';
+const DISCORD_EGRESS = process.env.DISCORD_EGRESS === '1';
+
+const SLACK_SEND_TOOL = {
+  name: 'slack_send',
+  description:
+    'Post a message to a Slack channel (any channel, not just the one that triggered you). Use this to ' +
+    'proactively message a channel — announcements, summaries, alerts. For replying to the thread that ' +
+    'triggered you, prefer slack_reply.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      channel: { type: 'string', description: 'Channel id (e.g. C0123ABCD) or name (e.g. "general" / "#general"). Names are resolved to ids; the bot auto-joins public channels it is not in.' },
+      text: { type: 'string', description: 'The message to post (Slack mrkdwn supported).' },
+    },
+    required: ['channel', 'text'],
+  },
+};
+
+const SLACK_DM_TOOL = {
+  name: 'slack_dm',
+  description:
+    'Send a direct message to a person in Slack. Reach anyone in the workspace — teammate updates, ' +
+    'nudges, one-to-one answers.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      to: { type: 'string', description: 'The recipient: a Slack user id (e.g. U0123ABCD) or their email address (resolved to their Slack account).' },
+      text: { type: 'string', description: 'The message to send (Slack mrkdwn supported).' },
+    },
+    required: ['to', 'text'],
+  },
+};
+
+const DISCORD_SEND_TOOL = {
+  name: 'discord_send',
+  description:
+    'Post a message to a Discord channel (any channel, not just the one that triggered you). Use this ' +
+    'to proactively message a channel. For replying where you were triggered, prefer discord_reply.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      channel: { type: 'string', description: 'The Discord channel id to post into.' },
+      text: { type: 'string', description: 'The message to post (Discord markdown supported).' },
+    },
+    required: ['channel', 'text'],
+  },
+};
+
+const DISCORD_DM_TOOL = {
+  name: 'discord_dm',
+  description: 'Send a direct message to a person in Discord by their user id.',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      to: { type: 'string', description: 'The recipient Discord user id.' },
+      text: { type: 'string', description: 'The message to send (Discord markdown supported).' },
+    },
+    required: ['to', 'text'],
+  },
+};
+
 const TOOLS = [
   {
     name: 'recall',
@@ -716,6 +781,62 @@ async function discordReply(args: Record<string, unknown>): Promise<string> {
   return d.ok ? 'Posted to Discord.' : `Could not post to Discord: ${d.error ?? 'unknown error'}`;
 }
 
+async function slackSend(args: Record<string, unknown>): Promise<string> {
+  const channel = String(args.channel ?? '').trim();
+  const text = String(args.text ?? '').trim();
+  if (!channel) return 'A channel (id or name) is required.';
+  if (!text) return 'Nothing to post (text is required).';
+  const res = await fetch(AOS_URL + '/api/agent/slack/send', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, channel, text }),
+  });
+  const d = (await res.json()) as { ok?: boolean; error?: string };
+  return d.ok ? `Posted to Slack channel ${channel}.` : `Could not post to Slack: ${d.error ?? 'unknown error'}`;
+}
+
+async function slackDm(args: Record<string, unknown>): Promise<string> {
+  const to = String(args.to ?? '').trim();
+  const text = String(args.text ?? '').trim();
+  if (!to) return 'A recipient (Slack user id or email) is required.';
+  if (!text) return 'Nothing to send (text is required).';
+  const res = await fetch(AOS_URL + '/api/agent/slack/dm', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, to, text }),
+  });
+  const d = (await res.json()) as { ok?: boolean; error?: string };
+  return d.ok ? `DM sent to ${to}.` : `Could not DM on Slack: ${d.error ?? 'unknown error'}`;
+}
+
+async function discordSend(args: Record<string, unknown>): Promise<string> {
+  const channel = String(args.channel ?? '').trim();
+  const text = String(args.text ?? '').trim();
+  if (!channel) return 'A channel id is required.';
+  if (!text) return 'Nothing to post (text is required).';
+  const res = await fetch(AOS_URL + '/api/agent/discord/send', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, channel, text }),
+  });
+  const d = (await res.json()) as { ok?: boolean; error?: string };
+  return d.ok ? `Posted to Discord channel ${channel}.` : `Could not post to Discord: ${d.error ?? 'unknown error'}`;
+}
+
+async function discordDm(args: Record<string, unknown>): Promise<string> {
+  const to = String(args.to ?? '').trim();
+  const text = String(args.text ?? '').trim();
+  if (!to) return 'A recipient Discord user id is required.';
+  if (!text) return 'Nothing to send (text is required).';
+  const res = await fetch(AOS_URL + '/api/agent/discord/dm', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, to, text }),
+  });
+  const d = (await res.json()) as { ok?: boolean; error?: string };
+  return d.ok ? `DM sent to ${to}.` : `Could not DM on Discord: ${d.error ?? 'unknown error'}`;
+}
+
 async function report(args: Record<string, unknown>): Promise<string> {
   const res = await fetch(AOS_URL + '/api/report', {
     method: 'POST',
@@ -1276,7 +1397,13 @@ async function handle(req: JsonRpc): Promise<void> {
   if (method && method.startsWith('notifications/')) return;
 
   if (method === 'tools/list') {
-    send({ jsonrpc: '2.0', id, result: { tools: [...TOOLS, ...(SLACK_REPLY ? [SLACK_REPLY_TOOL] : []), ...(DISCORD_REPLY ? [DISCORD_REPLY_TOOL] : [])] } });
+    send({ jsonrpc: '2.0', id, result: { tools: [
+      ...TOOLS,
+      ...(SLACK_REPLY ? [SLACK_REPLY_TOOL] : []),
+      ...(DISCORD_REPLY ? [DISCORD_REPLY_TOOL] : []),
+      ...(SLACK_EGRESS ? [SLACK_SEND_TOOL, SLACK_DM_TOOL] : []),
+      ...(DISCORD_EGRESS ? [DISCORD_SEND_TOOL, DISCORD_DM_TOOL] : []),
+    ] } });
     return;
   }
 
@@ -1301,6 +1428,10 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'skill_propose' ? await skillPropose(args)
         : name === 'slack_reply' ? await slackReply(args)
         : name === 'discord_reply' ? await discordReply(args)
+        : name === 'slack_send' ? await slackSend(args)
+        : name === 'slack_dm' ? await slackDm(args)
+        : name === 'discord_send' ? await discordSend(args)
+        : name === 'discord_dm' ? await discordDm(args)
         : name === 'list_capabilities' ? await listCapabilities()
         : name === 'policy_check' ? await policyCheck(args)
         : name === 'directory_lookup' ? await directoryLookup(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -698,6 +698,47 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const out = await discord.reply(session, String(b.text || ''));
     return sendJson(res, out.ok ? 200 : 400, out.ok ? { ok: true } : { ok: false, error: out.error });
   }
+  // native Slack egress (proactive): post to any channel by id/name. Not thread-bound — the agent
+  // supplies the channel. Audited as `slack.send`. Available to any session when Slack is configured.
+  if (method === 'POST' && p === '/api/agent/slack/send') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    if (!slack) return sendJson(res, 503, { error: 'slack not available' });
+    const out = await slack.sendToChannel(session, String(b.channel || ''), String(b.text || ''));
+    return sendJson(res, out.ok ? 200 : 400, out.ok ? { ok: true } : { ok: false, error: out.error });
+  }
+  // native Slack egress (proactive): DM a person by Slack user id or email. Audited as `slack.dm`.
+  if (method === 'POST' && p === '/api/agent/slack/dm') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    if (!slack) return sendJson(res, 503, { error: 'slack not available' });
+    const out = await slack.dmMember(session, String(b.to || ''), String(b.text || ''));
+    return sendJson(res, out.ok ? 200 : 400, out.ok ? { ok: true } : { ok: false, error: out.error });
+  }
+  // native Discord egress (proactive): post to any channel by id. Audited as `discord.send`.
+  if (method === 'POST' && p === '/api/agent/discord/send') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    if (!discord) return sendJson(res, 503, { error: 'discord not available' });
+    const out = await discord.sendToChannel(session, String(b.channel || ''), String(b.text || ''));
+    return sendJson(res, out.ok ? 200 : 400, out.ok ? { ok: true } : { ok: false, error: out.error });
+  }
+  // native Discord egress (proactive): DM a person by Discord user id. Audited as `discord.dm`.
+  if (method === 'POST' && p === '/api/agent/discord/dm') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    if (!discord) return sendJson(res, 503, { error: 'discord not available' });
+    const out = await discord.dmMember(session, String(b.to || ''), String(b.text || ''));
+    return sendJson(res, out.ok ? 200 : 400, out.ok ? { ok: true } : { ok: false, error: out.error });
+  }
   // launcher signal that the claude process exited (→ completion fallback + mark idle).
   if (method === 'POST' && p === '/api/ended') {
     const b = await readBody(req);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -866,8 +866,16 @@ export class TerminalManager {
       args: [this.memoryMcp],
       // SLACK_REPLY / DISCORD_REPLY: '1' makes the agentos server expose the native `slack_reply` /
       // `discord_reply` tool — only for chat-triggered sessions (which have a bound thread/channel),
-      // so other agents aren't cluttered by it.
-      env: { AOS_URL: this.baseUrl, AOS_TENANT: this.os.tenant, SESSION: sessionId, AGENT: agent, AOS_SECRET: secret, ...(slackReply ? { SLACK_REPLY: '1' } : {}), ...(discordReply ? { DISCORD_REPLY: '1' } : {}) },
+      // so other agents aren't cluttered by it. SLACK_EGRESS / DISCORD_EGRESS: '1' expose the proactive
+      // `slack_send`/`slack_dm` (and Discord equivalents) whenever the workspace has that platform
+      // configured — any session can message a channel/person, not just chat-triggered ones.
+      env: {
+        AOS_URL: this.baseUrl, AOS_TENANT: this.os.tenant, SESSION: sessionId, AGENT: agent, AOS_SECRET: secret,
+        ...(slackReply ? { SLACK_REPLY: '1' } : {}),
+        ...(discordReply ? { DISCORD_REPLY: '1' } : {}),
+        ...(this.os.settings.slackConfigured() ? { SLACK_EGRESS: '1' } : {}),
+        ...(this.os.settings.discordConfigured() ? { DISCORD_EGRESS: '1' } : {}),
+      },
     };
     return JSON.stringify(config, null, 2);
   }


### PR DESCRIPTION
## What

Agents were confined to `slack_reply`/`discord_reply` — they could only post back to the **thread that triggered them**. This adds four native **proactive** egress tools so an agent can reach anyone, anywhere:

| Tool | Does |
|---|---|
| `slack_send` / `discord_send` | Post to **any channel** |
| `slack_dm` / `discord_dm` | **DM any person** |

Use cases: a cron automation posting a daily summary to `#ops`, an agent nudging a teammate directly, an alert fired into a channel no one asked in.

## How it resolves recipients

- **Slack channel** — by id (`C…`) *or* name (`general` / `#general`, via `conversations.list`). Auto-joins a public channel the bot isn't in on `not_in_channel`, then retries once.
- **Slack DM** — by Slack user id (`U…`) *or* email (`users.lookupByEmail`).
- **Discord** — channel/user **ids** (Discord exposes no email lookup).

## Governance

Exposed to **any** session whenever that platform is configured (`SLACK_EGRESS`/`DISCORD_EGRESS`), not just chat-triggered ones — so proactive/unattended posting works. **Audit-only** posture (`slack.send`/`slack.dm`/`discord.send`/`discord.dm`, plus `.failed`), no policy gate — matching the existing `slack_reply`. Routes sit before the member-auth gate, session-secret gated.

## Shape

- `connectors/slack.ts`: `lookupUserByEmail`, `lookupChannelByName`, `joinChannel`
- `SlackSocket.sendToChannel` / `dmMember`; `DiscordSocket.sendToChannel` / `dmMember`
- Routes `POST /api/agent/{slack,discord}/{send,dm}`
- MCP tools + handlers in `memory/memory-mcp.ts`; `SLACK_EGRESS`/`DISCORD_EGRESS` wired in `terminal.ts`
- Docs (`agent-mcp-tools.md` — closes the "proactive person-to-person DM" gap), CLAUDE.md, CHANGELOG, version → 0.45.0

## Verified

- `npm run typecheck` + `npm run build` clean
- MCP `tools/list` exposes the 4 new tools under the env flags (39 total)
- All 4 routes return **404 unknown-session** (present, before the auth gate) on an ephemeral server
- `npm run test:governance` → 44/44 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)