### PR TITLE
Agents: one-shot bundle importer + Files folder upload (v0.46.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.46.0] — 2026-07-08
+### Added
+- **One-shot agent import — the importer behind the "Import into AOS" doc.** The doc described a portable
+  "AOS bundle" (`agent.json` + `CLAUDE.md` + `skills/` as files, `memory.jsonl` + `knowledge/` as
+  replayable data) but shipped no importer — the operator was told to have the agent replay its own
+  memory by hand. Now **Agents → Import bundle** (owner/admin) takes the whole `.zip` and reconstructs
+  the agent in one step: writes + live-registers the agent folder, installs skills into the global
+  library, and **replays** every memory line (`os.memory.store`, `"shared": true` → tenant-wide) and
+  knowledge page (`os.kb.write`, authored as the agent) through the same stores an agent writes to.
+  Bundle files may sit at the archive root or under a single `<agent-id>/` wrapper (both work). Recoverable
+  issues (a malformed memory line, a name-clashing skill) become **warnings**, never a failed import;
+  omitted manifest fields get safe defaults (`principal`/`policyContext`/`budget`). New pure parser
+  `src/governance/bundle-import.ts` (reuses the skill uploader's zip + grouping), `POST /api/agents/import`
+  (raw zip, `agent.imported` audited), and `api.importAgentBundle`. Doc updated to lead with the importer.
+- **Upload a whole folder in the Files browser.** Alongside **Upload** (files), a new **Upload folder**
+  button uses the OS folder picker (`webkitdirectory`) and recreates the folder's subtree under the
+  current directory — `/api/files/upload` now accepts a `rel` (the file's `webkitRelativePath`) and
+  `mkdir -p`s intermediate directories, with each path segment sanitised and re-checked against the data
+  home (double-guarded against traversal, like every Files route).
+
 ## [0.45.0] — 2026-07-08
 ### Added
 - **Agents can proactively DM anyone and post to any channel — Slack + Discord.** Until now the only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.45.0",
+      "version": "0.46.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/bundle-import.ts
+++ b/src/governance/bundle-import.ts
@@ -1,0 +1,150 @@
+/**
+ * Import an agent from an "AOS bundle" — the standard folder format documented in
+ * `web/src/docs/import-into-aos.md`. A bundle is the losslessly-portable form of an agent: its manifest
+ * + instructions + skills as files (which AOS stores as files anyway), plus its memory and knowledge as
+ * replayable data (which AOS stores in SQLite, so they can't just be dropped on disk).
+ *
+ * This module is the PURE parser: it turns an uploaded `.zip` into a validated `ParsedBundle`. It does
+ * no I/O and touches no stores — the server route applies the result (writes the agent folder, installs
+ * skills, replays memories + KB pages). Keeping parse/apply split means the parser is trivially testable
+ * and the route owns every side effect + audit line.
+ *
+ * Zero-dependency: it reuses the same hand-rolled `unzip` (and skill grouping) the skill uploader uses.
+ */
+import { unzip, isNoise, groupSkillsFromEntries, ZipEntry, ExtractedSkill } from './skill-zip';
+import { MemoryType } from '../types';
+
+/** One replayable memory line from `memory.jsonl` (see the bundle doc's format). */
+export interface BundleMemory {
+  content: string;
+  tags?: string[];
+  importance?: number;
+  shared?: boolean;
+  type?: MemoryType;
+  metadata?: Record<string, unknown>;
+}
+
+/** One replayable KB page from `knowledge/<section>/<slug>.md`. */
+export interface BundleKnowledge {
+  section: string;
+  slug: string;
+  title?: string;
+  body: string;
+}
+
+/** A fully parsed, ready-to-apply bundle. `manifest` is the raw parsed `agent.json` (route validates it). */
+export interface ParsedBundle {
+  agentId: string;
+  manifest: Record<string, unknown>;
+  claudeMd: string;
+  memories: BundleMemory[];
+  skills: ExtractedSkill[];
+  knowledge: BundleKnowledge[];
+  /** Non-fatal issues (a bad memory line, a knowledge file with no name) — surfaced to the operator. */
+  warnings: string[];
+}
+
+const AGENT_MANIFEST = 'agent.json';
+
+/** First markdown H1 in a doc, if any — used as a KB page title when the file leads with one. */
+function firstHeading(body: string): string | undefined {
+  for (const line of body.split(/\r?\n/)) {
+    const m = line.match(/^#\s+(.+?)\s*$/);
+    if (m) return m[1];
+    if (line.trim()) break; // stop at the first non-blank, non-heading line
+  }
+  return undefined;
+}
+
+/** Lowercase-hyphen a path segment into a url-safe KB section/slug (mirrors the KB store's normSeg). */
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/\.md$/, '').replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+/**
+ * Parse an uploaded bundle `.zip` into a `ParsedBundle`. Throws only on a fatally malformed bundle (not a
+ * zip, or no `agent.json`); recoverable problems become `warnings`. The bundle's files may sit at the
+ * archive root OR under a single `<agent-id>/` wrapper folder — we locate the `agent.json` and treat its
+ * directory as the bundle root, so both shapes (and a stray wrapper) work.
+ */
+export function parseBundle(buf: Buffer): ParsedBundle {
+  const entries = unzip(buf).filter((e) => !isNoise(e.name) && e.name.length > 0);
+  const warnings: string[] = [];
+
+  // The bundle root is the directory holding agent.json (the shallowest, if a stray copy exists deeper).
+  const manifestEntry = entries
+    .filter((e) => e.name === AGENT_MANIFEST || e.name.endsWith('/' + AGENT_MANIFEST))
+    .sort((a, b) => a.name.split('/').length - b.name.split('/').length)[0];
+  if (!manifestEntry) throw new Error('bundle is missing agent.json — it is not an AOS bundle');
+  const root = manifestEntry.name === AGENT_MANIFEST ? '' : manifestEntry.name.slice(0, -AGENT_MANIFEST.length);
+
+  // Everything we care about is under the root prefix; rebase each entry's name to root-relative.
+  const rel = (e: ZipEntry): string | null => (e.name.startsWith(root) ? e.name.slice(root.length) : null);
+  const relEntries = entries
+    .map((e) => ({ rel: rel(e), data: e.data }))
+    .filter((e): e is { rel: string; data: Buffer } => e.rel !== null && e.rel.length > 0);
+
+  let manifest: Record<string, unknown>;
+  try {
+    manifest = JSON.parse(manifestEntry.data.toString('utf8')) as Record<string, unknown>;
+  } catch {
+    throw new Error('bundle agent.json is not valid JSON');
+  }
+
+  const claudeMd = relEntries.find((e) => e.rel === 'CLAUDE.md')?.data.toString('utf8') ?? '';
+  if (!claudeMd.trim()) warnings.push('bundle has no CLAUDE.md — the agent will have empty instructions');
+
+  // agentId: manifest.id wins, then the wrapper folder name, then a placeholder for the operator to fix.
+  const rawId = typeof manifest.id === 'string' && manifest.id.trim() ? manifest.id.trim() : root.replace(/\/$/, '');
+  const agentId = slugify(rawId);
+
+  // memory.jsonl — one JSON object per line; skip (with a warning) any line that isn't valid or lacks content.
+  const memories: BundleMemory[] = [];
+  const jsonl = relEntries.find((e) => e.rel === 'memory.jsonl');
+  if (jsonl) {
+    const lines = jsonl.data.toString('utf8').split(/\r?\n/);
+    lines.forEach((line, i) => {
+      const t = line.trim();
+      if (!t) return;
+      let obj: Record<string, unknown>;
+      try { obj = JSON.parse(t) as Record<string, unknown>; }
+      catch { warnings.push(`memory.jsonl line ${i + 1}: not valid JSON — skipped`); return; }
+      const content = typeof obj.content === 'string' ? obj.content.trim() : '';
+      if (!content) { warnings.push(`memory.jsonl line ${i + 1}: no "content" — skipped`); return; }
+      memories.push({
+        content,
+        tags: Array.isArray(obj.tags) ? obj.tags.map(String) : undefined,
+        importance: typeof obj.importance === 'number' ? obj.importance : undefined,
+        shared: obj.shared === true,
+        type: typeof obj.type === 'string' ? (obj.type as MemoryType) : undefined,
+        metadata: obj.metadata && typeof obj.metadata === 'object' ? (obj.metadata as Record<string, unknown>) : undefined,
+      });
+    });
+  }
+
+  // skills/ — reuse the exact skill-grouping the uploader uses, rebased under the skills/ subtree.
+  const skillEntries: ZipEntry[] = relEntries
+    .filter((e) => e.rel.startsWith('skills/') && e.rel.length > 'skills/'.length)
+    .map((e) => ({ name: e.rel.slice('skills/'.length), data: e.data }));
+  let skills: ExtractedSkill[] = [];
+  if (skillEntries.length) {
+    try { skills = groupSkillsFromEntries(skillEntries); }
+    catch (e) { warnings.push(`skills/ ignored: ${e instanceof Error ? e.message : String(e)}`); }
+  }
+
+  // knowledge/<section>/<slug>.md — section = first path segment, slug = the rest joined with hyphens.
+  const knowledge: BundleKnowledge[] = [];
+  for (const e of relEntries) {
+    if (!e.rel.startsWith('knowledge/') || !e.rel.endsWith('.md')) continue;
+    const parts = e.rel.slice('knowledge/'.length).split('/').filter(Boolean);
+    if (parts.length === 0) continue;
+    const section = parts.length > 1 ? slugify(parts[0]) : 'general';
+    const slugParts = parts.length > 1 ? parts.slice(1) : parts;
+    const slug = slugify(slugParts.join('-'));
+    if (!section || !slug) { warnings.push(`knowledge/${e.rel.slice('knowledge/'.length)}: no url-safe name — skipped`); continue; }
+    const body = e.data.toString('utf8');
+    knowledge.push({ section, slug, title: firstHeading(body), body });
+  }
+
+  return { agentId, manifest, claudeMd, memories, skills, knowledge, warnings };
+}

--- a/src/governance/skill-zip.ts
+++ b/src/governance/skill-zip.ts
@@ -88,7 +88,7 @@ export function unzip(buf: Buffer): ZipEntry[] {
 }
 
 /** Junk an archiver leaves behind that must never reach the library. */
-function isNoise(name: string): boolean {
+export function isNoise(name: string): boolean {
   return name.startsWith('__MACOSX/') || name.includes('/__MACOSX/') || path.basename(name) === '.DS_Store';
 }
 
@@ -101,7 +101,15 @@ function isNoise(name: string): boolean {
  */
 export function extractSkillsFromZip(buf: Buffer, fallbackName?: string): ExtractedSkill[] {
   const entries = unzip(buf).filter((e) => !isNoise(e.name) && e.name.length > 0);
+  return groupSkillsFromEntries(entries, fallbackName);
+}
 
+/**
+ * Group already-unzipped `ZipEntry`s into install-ready skills. Split out from `extractSkillsFromZip`
+ * so callers that have entries in hand (e.g. an AOS import bundle whose skills live under a `skills/`
+ * subtree) reuse the identical longest-prefix ownership + name-derivation rules without re-parsing a zip.
+ */
+export function groupSkillsFromEntries(entries: ZipEntry[], fallbackName?: string): ExtractedSkill[] {
   // Skill folders = the dirs holding a SKILL.md ('' = archive root). Longest first for prefix matching.
   const skillDirs: string[] = [];
   for (const e of entries) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUse
 import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument, withAlwaysAllow } from './governance/policy';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
+import { parseBundle } from './governance/bundle-import';
 import { AgentManifest, ApprovalRequest, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
 import { AgentConfigSnapshot } from './state/agent-revisions';
 
@@ -1729,6 +1730,89 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, ...diff });
   }
 
+  // ── import an agent from an "AOS bundle" .zip — owner/admin only ──────────────────
+  //    The one-shot, lossless counterpart to the "Import into AOS" doc: a bundle carries the agent's
+  //    files (manifest + CLAUDE.md + skills) AND its non-file state (memory.jsonl, knowledge/) so we
+  //    replay the latter through the SAME stores an agent would (os.memory.store / os.kb.write). Raw
+  //    zip bytes in the body. The agent's brain lands on disk + registers live (no rescan needed);
+  //    memories/KB pages replay under the imported agent's identity. Recoverable issues → `warnings`.
+  if (method === 'POST' && p === '/api/agents/import') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (!os.paths) return sendJson(res, 400, { error: 'importing agents requires a data home' });
+    const buf = await readRawBuffer(req);
+    if (buf.length === 0) return sendJson(res, 400, { error: 'empty upload' });
+    let bundle;
+    try { bundle = parseBundle(buf); }
+    catch (e) { return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) }); }
+    const warnings = [...bundle.warnings];
+
+    const id = bundle.agentId;
+    if (!/^[a-z][a-z0-9-]{1,39}$/.test(id)) return sendJson(res, 400, { error: `bundle agent id "${id}" is invalid (need lowercase letters, digits and hyphens, 2–40 chars, starting with a letter)` });
+    if (os.agents.get(id)) return sendJson(res, 409, { error: `an agent named "${id}" already exists` });
+    const folder = path.join(os.paths.userAgents, id);
+    if (fs.existsSync(folder)) return sendJson(res, 409, { error: `folder "${id}" already exists in the agents home` });
+
+    // Rebuild the manifest from safe defaults + the bundle's declared fields (principal/policy/budget
+    // are always OS-assigned; a bad model/effort is a warning, not a failed import).
+    const m = bundle.manifest;
+    const { tuning, error: tErr } = sanitizeRuntimeTuning(m);
+    if (tErr) warnings.push(`runtime tuning ignored: ${tErr}`);
+    const examplePrompts = sanitizeExamplePrompts((m as { examplePrompts?: unknown }).examplePrompts);
+    const category = sanitizeCategory((m as { category?: unknown }).category);
+    const icon = sanitizeIcon((m as { icon?: unknown }).icon);
+    const shellSecrets = sanitizeShellSecrets((m as { shellSecrets?: unknown }).shellSecrets);
+    const manifest: AgentManifest = {
+      id,
+      version: typeof m.version === 'string' && m.version ? m.version : '1.0.0',
+      description: typeof m.description === 'string' ? m.description.trim() : '',
+      ...(category ? { category } : {}),
+      principal: `svc-${id}`,
+      policyContext: 'default@v1',
+      runtime: 'claude-code',
+      ...(tErr ? {} : tuning),
+      ...(examplePrompts ? { examplePrompts } : {}),
+      ...(shellSecrets ? { shellSecrets } : {}),
+      ...(icon ? { icon } : {}),
+      budget: { usdCap: 2.0, tokenCap: 400000, wallClockMs: 1800000 },
+    };
+    fs.mkdirSync(folder, { recursive: true });
+    fs.writeFileSync(path.join(folder, 'agent.json'), JSON.stringify(manifest, null, 2) + '\n');
+    fs.writeFileSync(path.join(folder, 'CLAUDE.md'), bundle.claudeMd);
+    os.registerAgent({ ...manifest, dir: folder });
+
+    // Skills → the global library (skip a same-named existing one rather than failing the import).
+    let skillsInstalled = 0;
+    for (const s of bundle.skills) {
+      try { os.skills.installFiles(s.name, s.files); skillsInstalled++; }
+      catch (e) { warnings.push(`skill "${s.name}" not installed: ${e instanceof Error ? e.message : String(e)}`); }
+    }
+
+    // Memory → replay each line under the imported agent (shared lines publish tenant-wide).
+    let memoriesReplayed = 0;
+    for (const mem of bundle.memories) {
+      try {
+        await os.memory.store({
+          tenant: os.tenant, agentId: id, content: mem.content, tags: mem.tags,
+          type: mem.type, importance: mem.importance, metadata: mem.metadata,
+          scope: mem.shared ? 'tenant' : 'agent',
+        });
+        memoriesReplayed++;
+      } catch (e) { warnings.push(`memory not replayed: ${e instanceof Error ? e.message : String(e)}`); }
+    }
+
+    // Knowledge → replay each page into the shared KB, authored as the imported agent.
+    let knowledgeReplayed = 0;
+    for (const k of bundle.knowledge) {
+      try {
+        os.kb.write({ tenant: os.tenant, section: k.section, slug: k.slug, title: k.title, body: k.body, author: `agent:${id}` });
+        knowledgeReplayed++;
+      } catch (e) { warnings.push(`knowledge "${k.section}/${k.slug}" not replayed: ${e instanceof Error ? e.message : String(e)}`); }
+    }
+
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.imported', data: { agent: id, dir: folder, skills: skillsInstalled, memories: memoriesReplayed, knowledge: knowledgeReplayed, warnings: warnings.length } });
+    return sendJson(res, 200, { ok: true, id, skills: skillsInstalled, memories: memoriesReplayed, knowledge: knowledgeReplayed, warnings });
+  }
+
   // ── duplicate an agent: deep-copy its folder under a NEW id — owner/admin only ──
   //    A clone is a FRESH agent (its own id + `svc-<id>` principal), so it starts clean: none of
   //    the source's runtime history rides along (no memories, sessions, assignments, automations,
@@ -2343,18 +2427,25 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     }
 
     // Upload (create/overwrite a file). Raw bytes in the body; target dir in `path`, name in `name`.
+    // Folder upload: pass `rel` = the file's path WITHIN the dropped folder (its browser
+    // `webkitRelativePath`, e.g. `runbooks/escalation.md`); intermediate directories are created so a
+    // whole nested tree lands in one call-per-file. `rel` wins over `name` when present; each segment is
+    // sanitised and the resolved target is re-checked against the home so it can't escape.
     if (method === 'POST' && p === '/api/files/upload') {
       const dirRel = url.searchParams.get('path') || '';
-      const name = path.basename(url.searchParams.get('name') || '');
-      if (!name || name === '.' || name === '..') return sendJson(res, 400, { error: 'invalid file name' });
+      const rawRel = url.searchParams.get('rel') || '';
+      // Sanitise into safe segments (drop '', '.', '..'); `rel` may carry subdirs, `name` never does.
+      const segs = (rawRel || url.searchParams.get('name') || '')
+        .split('/').map((s) => s.trim()).filter((s) => s && s !== '.' && s !== '..');
+      if (segs.length === 0) return sendJson(res, 400, { error: 'invalid file name' });
       const dir = safeResolve(root, dirRel);
       if (!dir) return sendJson(res, 400, { error: 'path escapes the data home' });
       try { if (!fs.statSync(dir).isDirectory()) return sendJson(res, 400, { error: 'not a directory' }); }
       catch { return sendJson(res, 404, { error: 'directory not found' }); }
-      const file = safeResolve(root, dirRel ? `${dirRel}/${name}` : name);
+      const file = safeResolve(root, [dirRel, ...segs].filter(Boolean).join('/'));
       if (!file) return sendJson(res, 400, { error: 'path escapes the data home' });
       const buf = await readRawBuffer(req);
-      try { fs.writeFileSync(file, buf); }
+      try { fs.mkdirSync(path.dirname(file), { recursive: true }); fs.writeFileSync(file, buf); }
       catch (e) { return sendJson(res, 500, { error: `write failed: ${(e as Error).message}` }); }
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'file.uploaded', data: { path: relOf(root, file), bytes: buf.length } });
       return sendJson(res, 200, { ok: true, path: relOf(root, file) });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -461,6 +461,17 @@ function Console({ me }: { me: Member }) {
     if (r.errors.length) parts.push(`Skipped (bad agent.json): ${r.errors.map((e) => e.folder).join(', ')}`)
     alert(parts.length ? parts.join('\n') : 'No changes — the agents folder already matches.')
   }
+  // Import an agent from an "AOS bundle" .zip (see the Docs → "Import into AOS" page): writes the agent
+  // and replays its memory/knowledge/skills in one shot, then lands on the new agent.
+  const importAgent = async (file: File): Promise<void> => {
+    const r = await api.importAgentBundle(file)
+    if (!r.ok || r.error) { alert(r.error || 'Import failed'); return }
+    await refreshState()
+    if (r.id) nav('agents', r.id)
+    const bits = [`Imported "${r.id}"`, `${r.skills ?? 0} skill(s), ${r.memories ?? 0} memory(ies), ${r.knowledge ?? 0} KB page(s)`]
+    if (r.warnings?.length) bits.push('', 'Warnings:', ...r.warnings.map((w) => '• ' + w))
+    alert(bits.join('\n'))
+  }
   // Attending to a session → clear its "waiting" bell, same as Dismiss. Optimistically drop the open
   // notifications from state so the icon/tab/badge update instantly; persist via dismiss. Reads the
   // latest messages from the ref so it's safe to call from the terminal's imperative click listener.
@@ -699,7 +710,7 @@ function Console({ me }: { me: Member }) {
         </div>
 
         <div className={`min-h-0 flex-1 ${fullBleed ? '' : 'overflow-y-auto p-6'}`}>
-          {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onDuplicate={duplicateAgent} onRescan={rescanAgents} />}
+          {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onDuplicate={duplicateAgent} onRescan={rescanAgents} onImport={importAgent} />}
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); nav('agents', id) }} />}
           {route === 'sessions' && <SessionsPage sessions={sessions} waiting={waiting} selected={selected} onOpen={openTerminal} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} />}
@@ -741,7 +752,7 @@ function NavItem({ icon, label, active, badge, onClick }: { icon: ReactNode; lab
  *  Settings (CLAUDE.md + runtime), delete it, or create a new one — all the catalog actions,
  *  just scoped to the chosen agent instead of a grid of cards. */
 function AgentsPage({
-  me, agents, selected, onSelect, run, onEdit, onNew, onDelete, onDuplicate, onRescan,
+  me, agents, selected, onSelect, run, onEdit, onNew, onDelete, onDuplicate, onRescan, onImport,
 }: {
   me: Member
   agents: AgentInfo[]
@@ -753,10 +764,20 @@ function AgentsPage({
   onDelete: (id: string) => void
   onDuplicate: (id: string) => void
   onRescan: () => Promise<void>
+  onImport: (file: File) => Promise<void>
 }) {
   const canEdit = me.role === 'owner' || me.role === 'admin'
   const [rescanning, setRescanning] = useState(false)
   const rescan = async () => { setRescanning(true); try { await onRescan() } finally { setRescanning(false) } }
+  const [importing, setImporting] = useState(false)
+  const importInput = useRef<HTMLInputElement>(null)
+  const pickBundle = async (files: FileList | null) => {
+    const file = files?.[0]
+    if (!file) return
+    if (!file.name.toLowerCase().endsWith('.zip')) { alert('Pick an AOS bundle .zip'); return }
+    setImporting(true)
+    try { await onImport(file) } finally { setImporting(false); if (importInput.current) importInput.current.value = '' }
+  }
   const [task, setTask] = useState('')
   const [hint, setHint] = useState('')
   const [busy, setBusy] = useState(false)
@@ -806,7 +827,11 @@ function AgentsPage({
         <p className="text-sm text-muted-foreground">{canEdit ? 'No agents yet — create one to get started.' : 'No agents assigned to you.'}</p>
         {canEdit && (
           <div className="flex items-center gap-2">
+            <input ref={importInput} type="file" accept=".zip,application/zip" className="hidden" onChange={(e) => pickBundle(e.target.files)} />
             <Button size="sm" className="gap-1" onClick={onNew}><Plus className="h-4 w-4" /> New agent</Button>
+            <Button size="sm" variant="outline" className="gap-1" onClick={() => importInput.current?.click()} disabled={importing} title="import an agent from an AOS bundle .zip">
+              <Upload className={'h-4 w-4' + (importing ? ' animate-pulse' : '')} /> {importing ? 'Importing…' : 'Import bundle'}
+            </Button>
             <Button size="sm" variant="outline" className="gap-1" onClick={rescan} disabled={rescanning} title="pick up agents added to the agents folder on disk">
               <RefreshCw className={'h-4 w-4' + (rescanning ? ' animate-spin' : '')} /> Rescan folder
             </Button>
@@ -899,7 +924,9 @@ function AgentsPage({
           </div>
           {canEdit && (
             <>
+              <input ref={importInput} type="file" accept=".zip,application/zip" className="hidden" onChange={(e) => pickBundle(e.target.files)} />
               <Button size="icon" variant="ghost" className="h-8 w-8 text-muted-foreground" onClick={onNew} title="new agent"><Plus className="h-4 w-4" /></Button>
+              <Button size="icon" variant="ghost" className="h-8 w-8 text-muted-foreground" onClick={() => importInput.current?.click()} disabled={importing} title="import an agent from an AOS bundle .zip"><Upload className={'h-4 w-4' + (importing ? ' animate-pulse' : '')} /></Button>
               <Button size="icon" variant="ghost" className="h-8 w-8 text-muted-foreground" onClick={rescan} disabled={rescanning} title="rescan the agents folder — pick up agents added on disk without a restart"><RefreshCw className={'h-4 w-4' + (rescanning ? ' animate-spin' : '')} /></Button>
             </>
           )}
@@ -1809,6 +1836,7 @@ function FilesPage({ initialDir }: { initialDir?: string }) {
   const [hint, setHint] = useState('')
   const [dragging, setDragging] = useState(false)
   const fileInput = useRef<HTMLInputElement>(null)
+  const folderInput = useRef<HTMLInputElement>(null)
   const dragDepth = useRef(0)
 
   const loadDir = (rel: string, fallbackHome = false) => {
@@ -1852,10 +1880,14 @@ function FilesPage({ initialDir }: { initialDir?: string }) {
   const uploadFiles = async (files: FileList | File[]) => {
     const list = Array.from(files)
     if (!list.length) return
-    setBusy(true); setHint(`uploading ${list.length} file${list.length === 1 ? '' : 's'}…`)
+    // A folder pick (webkitdirectory) or a directory drag sets `webkitRelativePath` (e.g.
+    // "runbooks/escalation.md") — forward it so the whole tree is recreated under `dir`.
+    const withRel = list.map((f) => ({ f, rel: (f as File & { webkitRelativePath?: string }).webkitRelativePath || '' }))
+    const foldered = withRel.some((x) => x.rel.includes('/'))
+    setBusy(true); setHint(`uploading ${list.length} ${foldered ? 'item' : 'file'}${list.length === 1 ? '' : 's'}…`)
     let ok = 0; let err = ''
-    for (const f of list) {
-      const r = await api.files.upload(dir, f)
+    for (const { f, rel } of withRel) {
+      const r = await api.files.upload(dir, f, rel || undefined)
       if (r.error) err = r.error; else ok++
     }
     setBusy(false)
@@ -1937,7 +1969,14 @@ function FilesPage({ initialDir }: { initialDir?: string }) {
           <Button size="sm" variant="outline" className="h-7 gap-1 px-2 text-xs" onClick={() => fileInput.current?.click()} disabled={busy}>
             <Upload className="h-3.5 w-3.5" /> Upload
           </Button>
+          <Button size="sm" variant="outline" className="h-7 gap-1 px-2 text-xs" onClick={() => folderInput.current?.click()} disabled={busy} title="upload a whole folder (its subfolders are recreated here)">
+            <FolderPlus className="h-3.5 w-3.5" /> Upload folder
+          </Button>
           <input ref={fileInput} type="file" multiple className="hidden"
+            onChange={(e) => { if (e.target.files) void uploadFiles(e.target.files); e.currentTarget.value = '' }} />
+          {/* webkitdirectory = OS folder picker; each File carries a webkitRelativePath the server rebuilds under `dir`. */}
+          <input ref={folderInput} type="file" multiple className="hidden"
+            {...({ webkitdirectory: '', directory: '' } as Record<string, string>)}
             onChange={(e) => { if (e.target.files) void uploadFiles(e.target.files); e.currentTarget.value = '' }} />
         </div>
       </div>

--- a/web/src/docs/import-into-aos.md
+++ b/web/src/docs/import-into-aos.md
@@ -2,7 +2,7 @@
 
 Bringing an agent over from another system (a raw Claude Code project, a CrewAI/LangGraph agent, a folder of prompts, a custom harness)? This page gives you a **master prompt** to paste into that agent. It briefs the agent on what Agent OS is and has it emit a **bundle** — a small, standard folder — that drops straight into AOS.
 
-The trick: the bundle mirrors how AOS actually stores things, so the file parts need **no importer at all**.
+The trick: the bundle mirrors how AOS actually stores things. On the **Agents** page, **Import bundle** takes the whole `.zip` and reconstructs the agent in one shot — files land on disk, and the parts that *aren't* files (memory, knowledge) are replayed through the same stores an agent writes to. Or, if you prefer, drop the files in by hand — see **Finishing the import** below.
 
 ## How an AOS agent is stored (why the bundle looks the way it does)
 
@@ -14,7 +14,7 @@ The trick: the bundle mirrors how AOS actually stores things, so the file parts 
 | **Memory** | SQLite (`memories` table) | ❌ needs replay/import |
 | **Knowledge** | SQLite + `data/kb/…` | ❌ needs replay/import |
 
-So an agent's *brain* (manifest + instructions + skills) is pure files — copy them in, hit **Rescan** on the Agents page, and the agent exists. Its *memory* isn't files, so the bundle carries it as `memory.jsonl` that gets replayed in (see **Finishing the import** below).
+So an agent's *brain* (manifest + instructions + skills) is pure files — the importer drops them in (or you can copy them in and hit **Rescan**). Its *memory* and *knowledge* aren't files, so the bundle carries them as `memory.jsonl` + `knowledge/` and the importer **replays** them through AOS's own `remember`/`kb_write` paths — the same thing a human would do by hand, done losslessly in one step.
 
 **Never put in a bundle:** secrets/API keys/tokens, absolute filesystem paths, or the auto-generated `.claude/aos-settings.json` and materialized `.claude/skills/` — AOS regenerates those at launch for its own environment.
 
@@ -130,14 +130,15 @@ Produce the bundle now.
 
 ## Finishing the import (operator side)
 
-Once you have the bundle folder:
+Zip the bundle folder and, on the **Agents** page, click **Import bundle** (owner/admin) — or `POST /api/agents/import` with the raw `.zip` bytes. In one shot the importer:
 
-1. **Agent brain — drop in + rescan (no code):**
-   - Copy `agent.json` and `CLAUDE.md` into `data/agents/<agent-id>/`.
-   - Copy each `skills/<name>/` into the global `data/skills/<name>/`.
-   - On the **Agents** page click **Rescan** (or `POST /api/agents/rescan`). The agent appears.
-   - Open it, set its **budget, model, and assignments**, and review the `CLAUDE.md` for anything that still assumes the old environment. Wire any credentials it needs via **Connectors**, not in the file.
+- writes `agent.json` + `CLAUDE.md` into `data/agents/<agent-id>/` and registers the agent **live** (no rescan needed);
+- installs each `skills/<name>/` into the global library;
+- **replays** every `memory.jsonl` line via the same store `remember` uses (a `"shared": true` line publishes tenant-wide);
+- **replays** each `knowledge/<section>/<slug>.md` into the KB, authored as the agent.
 
-2. **Memory — replay:** memory lives in SQLite, so it isn't a drop-in file. The simplest path with no new code: run the agent once and tell it *"Read the memory.jsonl in your folder and `remember` each line with its tags, importance, and shared flag."* It replays its own memory through the standard tool. (A one-shot bulk importer would make this lossless — see below.)
+It reports how many memories / KB pages / skills came in, plus any **warnings** (a malformed memory line, a skill whose name is already taken — skipped, never fatal). Safe defaults are assigned for anything the bundle omits (`principal`, `policyContext`, `budget`).
 
-3. **Knowledge — replay:** same idea — have the agent `kb_write` each `knowledge/<section>/<slug>.md`, or paste them into the **Knowledge** page yourself.
+Afterward, open the agent and set its **budget, model, and assignments**, skim the `CLAUDE.md` for anything that still assumes the old environment, and wire any credentials it needs via **Connectors** — never in the file.
+
+**Doing it by hand instead?** The files are drop-in: copy `agent.json` + `CLAUDE.md` into `data/agents/<agent-id>/` and each `skills/<name>/` into `data/skills/<name>/`, then **Rescan**. For the non-file parts, run the agent once and tell it *"read `memory.jsonl` in your folder and `remember` each line"* / *"`kb_write` each file under `knowledge/`"* — the same replay the importer automates.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -809,6 +809,15 @@ export const api = {
     })
     return res.json()
   },
+  /** Import an agent from an "AOS bundle" .zip — writes the agent + replays its memory/knowledge/skills. */
+  importAgentBundle: async (file: File): Promise<{ ok: boolean; id?: string; skills?: number; memories?: number; knowledge?: number; warnings?: string[]; error?: string }> => {
+    const res = await fetch('/api/agents/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/zip' },
+      body: file,
+    })
+    return res.json()
+  },
 
   policy: () => call<PolicyResp>('GET', '/api/policy'),
   savePolicy: (document: PolicyDocument) => call<{ ok: boolean; document?: PolicyDocument; error?: string }>('PUT', '/api/policy', { document }),
@@ -823,9 +832,14 @@ export const api = {
     rename: (from: string, to: string) => call<{ ok: boolean; path?: string; error?: string }>('POST', '/api/files/rename', { from, to }),
     /** Direct URL to a file's bytes as an attachment (for download links). */
     downloadUrl: (path: string) => `/api/files/download?path=${encodeURIComponent(path)}`,
-    /** Upload raw bytes into `dir` under `name` (drag-drop / picker). */
-    upload: async (dir: string, file: File): Promise<{ ok: boolean; path?: string; error?: string }> => {
+    /**
+     * Upload raw bytes into `dir` under `name` (drag-drop / picker). Pass `rel` = the file's path within
+     * a dropped folder (its `webkitRelativePath`) to recreate the folder tree server-side; intermediate
+     * directories are created for you.
+     */
+    upload: async (dir: string, file: File, rel?: string): Promise<{ ok: boolean; path?: string; error?: string }> => {
       const qs = `path=${encodeURIComponent(dir)}&name=${encodeURIComponent(file.name)}`
+        + (rel ? `&rel=${encodeURIComponent(rel)}` : '')
       const r = await fetch(`/api/files/upload?${qs}`, { method: 'POST', credentials: 'same-origin', body: file })
       try { return await r.json() } catch { return { ok: r.ok, error: r.ok ? undefined : `upload failed (${r.status})` } }
     },


### PR DESCRIPTION
## What

Two console additions.

### 1. The agent bundle importer (the thing behind the "Import into AOS" doc)

The docs page described a portable **AOS bundle** — `agent.json` + `CLAUDE.md` + `skills/` as files, `memory.jsonl` + `knowledge/` as replayable data — but we never shipped the importer. The doc told operators to *run the agent and have it replay its own memory by hand*. Now there's a real one-shot importer:

**Agents → Import bundle** (owner/admin) takes the whole `.zip` and:
- writes + **live-registers** the agent folder (no rescan needed);
- installs each `skills/<name>/` into the global library;
- **replays** every `memory.jsonl` line via `os.memory.store` (a `"shared": true` line publishes tenant-wide);
- **replays** each `knowledge/<section>/<slug>.md` via `os.kb.write`, authored as the agent.

The bundle's files may sit at the archive root **or** under a single `<agent-id>/` wrapper — both work (we locate `agent.json` and treat its dir as the root). Recoverable problems (a malformed memory line, a name-clashing skill) become **warnings**, never a failed import; anything the manifest omits gets safe defaults (`principal`/`policyContext`/`budget`).

- New **pure parser** `src/governance/bundle-import.ts` (reuses the skill uploader's `unzip` + skill grouping, now exported from `skill-zip.ts`).
- `POST /api/agents/import` (raw zip bytes; `agent.imported` audited) + `api.importAgentBundle`.
- Doc rewritten to lead with the importer (manual drop-in kept as the fallback).

### 2. Upload a folder in the Files browser

Alongside **Upload** (files), a new **Upload folder** button uses the OS folder picker (`webkitdirectory`) and recreates the folder's subtree under the current directory. `/api/files/upload` now accepts a `rel` param (the file's `webkitRelativePath`) and `mkdir -p`s intermediate directories — each segment sanitised and re-checked against the data home (double-guarded against traversal, like every Files route).

## Testing

- `npm run typecheck`, `cd web && npm run build` — clean.
- `npm run test:governance` — **44/44 passed**.
- End-to-end: built a real bundle `.zip` (with a wrapper folder, a shared + private memory, a bad JSONL line, a skill, a knowledge page) → `parseBundle` returns the right agentId/claudeMd/memories/skills/knowledge + the expected two warnings.
- Applied the parsed bundle against an **isolated `AGENT_OS_HOME`**: agent registered, skill on disk, shared memory recalled by query, KB page written + read back with `agent:<id>` author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)