### PR TITLE
Agents: Files shortcut on the agent detail page (v0.47.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.47.0] — 2026-07-08
+### Added
+- **Files shortcut on the agent detail page.** An agent's page (`#/agents/<id>`) now has a **Files**
+  button (next to the back-to-Agents link) that opens the Files browser scoped to that agent's folder
+  (`#/files/agents/<id>`), so you can jump straight into its `agent.json`/`CLAUDE.md`/skills. Shown only
+  for agents that live under the data home (`deletable`) — bundled examples live outside it and aren't
+  browsable there; the existing deep-link fallback already drops to the home root for anything missing.
+
 ## [0.46.0] — 2026-07-08
 ### Added
 - **One-shot agent import — the importer behind the "Import into AOS" doc.** The doc described a portable

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3995,9 +3995,19 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
 
   return (
     <div className="max-w-3xl space-y-4">
-      <button onClick={() => { window.location.hash = '/agents' }} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
-        <ArrowLeft className="h-3.5 w-3.5" /> Agents
-      </button>
+      <div className="flex items-center justify-between gap-2">
+        <button onClick={() => { window.location.hash = '/agents' }} className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+          <ArrowLeft className="h-3.5 w-3.5" /> Agents
+        </button>
+        {/* Open the Files browser scoped to this agent's folder (only for agents that live under the
+            data home — bundled examples live outside it and aren't browsable here). */}
+        {info?.deletable && (
+          <Button size="sm" variant="outline" className="h-7 gap-1 px-2 text-xs" title="browse this agent's files"
+            onClick={() => { window.location.hash = '/files/' + encodeURIComponent('agents/' + agentId) }}>
+            <FolderTree className="h-3.5 w-3.5" /> Files
+          </Button>
+        )}
+      </div>
       <p className="text-sm text-muted-foreground">
         <span className="font-medium text-foreground">{agentId}</span>
         {info && <RuntimeBadge runtime={info.runtime} />} — this agent's <span className="font-mono text-xs">CLAUDE.md</span> is its


### PR DESCRIPTION
## What

Adds a **Files** button to the agent detail page (`#/agents/<id>`), next to the back-to-Agents link. It opens the Files browser scoped to that agent's folder (`#/files/agents/<id>`) — so from an agent like `influencer-marketing` you can jump straight into its `agent.json` / `CLAUDE.md` / skills.

- Reuses the existing deep-link pattern already used from session rows (`#/files/` + `encodeURIComponent('agents/' + id)`).
- Shown only for agents that live under the data home (`deletable`) — bundled examples live outside it and aren't browsable in the home-rooted Files page. (The Files deep-link fallback already drops to the home root for anything missing, so it's safe either way.)

## Testing

- `cd web && npm run build` — clean.
- `npm run test:governance` — **44/44 passed**.
- Confirmed `~/agent-os-data/instapods/agents/influencer-marketing/` exists under the home, so it's `deletable` and the button shows for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)