### PR TITLE
Automations: headless runs surface their transcript instead of a dead terminal (v0.47.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.48.0] — 2026-07-08
+### Added
+- **See what a finished headless run did — no more dead terminal.** A headless automation runs
+  `claude -p` and exits, so its tmux pane is gone; opening the session later showed an empty, broken
+  terminal even though the full transcript was already captured on disk (`claude-launch.sh` tee's it to
+  `<home>/connectors/session-<id>.log`, 0600). The session view now detects an ended, non-resumable run
+  (headless/crashed — interactive ended sessions stay resumable and keep the normal attach/resume path)
+  and renders that captured transcript read-only instead of attaching a dead pane. New authz-gated
+  `GET /api/sessions/:id/transcript` (same `canViewSession` check as attach; tails the last 512KB of a
+  long run) + `api.sessionTranscript`.
+### Changed
+- **"Run Now" on a headless automation lands on the sessions list, not a terminal.** Firing a headless
+  automation used to navigate straight into a terminal that dies moments later. It now refreshes and
+  drops the operator on the Sessions list where the new run appears; interactive automations still open
+  the attachable TUI as before. (Both paths already ran headless correctly — this is purely where the UI
+  takes you afterward.)
+
 ## [0.47.0] — 2026-07-08
 ### Added
 - **Files shortcut on the agent detail page.** An agent's page (`#/agents/<id>`) now has a **Files**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1311,6 +1311,25 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const summary = [...byPrim.values()].sort((a, b) => b.count - a.count || a.primitive.localeCompare(b.primitive));
     return sendJson(res, 200, { events, summary, total: events.length });
   }
+  // A finished headless run has no live tmux to attach to, but claude-launch.sh tee'd its full `-p`
+  // transcript to <home>/connectors/session-<id>.log. Serve that (same authz as attach) so the console
+  // can show what the run did instead of a dead terminal. Tail the last 512KB of a long run.
+  const transcriptMatch = p.match(/^\/api\/sessions\/([\w-]+)\/transcript$/);
+  if (method === 'GET' && transcriptMatch) {
+    const id = transcriptMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to view this session' });
+    if (!os.paths) return sendJson(res, 404, { error: 'no transcript' });
+    const file = path.join(os.paths.connectors, `session-${id}.log`);
+    try {
+      const buf = fs.readFileSync(file);
+      const CAP = 512 * 1024;
+      const text = buf.length > CAP ? '…(earlier output truncated)\n' + buf.subarray(buf.length - CAP).toString('utf8') : buf.toString('utf8');
+      return sendJson(res, 200, { text });
+    } catch {
+      return sendJson(res, 404, { error: 'no transcript' });
+    }
+  }
   // Prepare a browser attach: authz, then (under the flag) ensure the member's ttyd is up. Returns
   // the iframe URL — the shared /terminal/?arg=… (flag off) or per-member /terminal/<space>/?arg=… (on).
   const attachMatch = p.match(/^\/api\/sessions\/([\w-]+)\/attach$/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -716,7 +716,7 @@ function Console({ me }: { me: Member }) {
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} />}
           {route === 'connectors' && <ConnectorsPage me={me} />}
           {route === 'team' && <TeamPage me={me} />}
-          {route === 'automations' && <AutomationsPage me={me} agents={state?.agents ?? []} onOpen={openTerminal} />}
+          {route === 'automations' && <AutomationsPage me={me} agents={state?.agents ?? []} onOpen={openTerminal} nav={nav} />}
           {route === 'tasks' && <TasksPage me={me} agents={state?.agents ?? []} onOpen={openTerminal} />}
           {route === 'memory' && <MemoryPage agents={state?.agents ?? []} me={me} />}
           {route === 'kb' && <KnowledgeBasePage me={me} />}
@@ -1020,9 +1020,22 @@ function StartedBy({ label, className = '' }: { label?: string; className?: stri
 function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux: string; onActivity?: (sid: string) => void }) {
   const [src, setSrc] = useState('')
   const [err, setErr] = useState('')
+  const [transcript, setTranscript] = useState<string | null>(null)
+  // A finished headless run (and a crashed headless run) has no resurrectable pane — never resumable
+  // and no longer live — so attaching would show a dead terminal. Show its captured transcript instead.
+  // Interactive ended sessions stay resumable and keep the normal attach/resume path untouched.
+  const ended = Boolean(session) && !isLive(session!) && !session!.resumable
   useEffect(() => {
     let alive = true
-    setSrc(''); setErr('')
+    setSrc(''); setErr(''); setTranscript(null)
+    if (session?.id && ended) {
+      api.sessionTranscript(session.id).then((r) => {
+        if (!alive) return
+        if (r.text != null) setTranscript(r.text.replace(/\x1b\[[0-9;]*m/g, '')) // strip any stray ANSI color
+        else setErr(r.error || 'no transcript for this session')
+      })
+      return () => { alive = false }
+    }
     if (!session?.id) { setSrc(`/terminal/?arg=${encodeURIComponent(tmux)}`); return }
     api.attach(session.id).then((r) => {
       if (!alive) return
@@ -1030,7 +1043,15 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
       else setErr(r.error || 'could not open terminal')
     })
     return () => { alive = false }
-  }, [session?.id, tmux])
+  }, [session?.id, tmux, ended])
+  if (transcript != null) return (
+    <div className="flex min-h-0 flex-1 flex-col bg-black">
+      <div className="shrink-0 border-b border-neutral-800 px-3 py-1.5 text-xs text-neutral-500">
+        Session ended · headless transcript (read-only)
+      </div>
+      <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-xs leading-relaxed text-neutral-300">{transcript || '(no output captured)'}</pre>
+    </div>
+  )
   if (err) return <div className="flex flex-1 items-center justify-center bg-black text-sm text-red-400">⚠ {err}</div>
   if (!src) return <div className="flex flex-1 items-center justify-center bg-black text-sm text-neutral-500">opening terminal…</div>
   // allow clipboard-write so ttyd's copy-on-select (document.execCommand("copy") on the xterm.js
@@ -2988,7 +3009,7 @@ const TRIGGER_ITEMS: Record<string, string> = {
   composio: 'Composio event',
 }
 
-function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; onOpen: (tmux: string, title: string) => void }) {
+function AutomationsPage({ me, agents, onOpen, nav }: { me: Member; agents: AgentInfo[]; onOpen: (tmux: string, title: string) => void; nav: (r: Route, detail?: string) => void }) {
   const [items, setItems] = useState<Automation[] | null>(null)
   const [busy, setBusy] = useState('')
   const [hint, setHint] = useState('')
@@ -3025,7 +3046,12 @@ function AutomationsPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo
     setBusy('')
     if (!r.ok) return setHint('⚠ ' + (r.reason || r.error || 'failed'))
     await load()
-    if (r.sessionId) onOpen('aos-' + r.sessionId, a.agentId + ' · ' + r.sessionId)
+    // A headless run exits into a dead terminal — don't drop the operator onto it. Send them to the
+    // sessions list where the new run shows up; only interactive runs open the attachable TUI.
+    if (r.sessionId) {
+      if (a.mode === 'headless') nav('sessions')
+      else onOpen('aos-' + r.sessionId, a.agentId + ' · ' + r.sessionId)
+    }
   }
 
   if (!items) return <div className="text-sm text-muted-foreground">Loading…</div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -662,6 +662,7 @@ export const api = {
   stopSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/stop`),
   deleteSession: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/sessions/' + id),
   attach: (id: string) => call<{ url?: string; error?: string }>('GET', `/api/sessions/${id}/attach`),
+  sessionTranscript: (id: string) => call<{ text?: string; error?: string }>('GET', `/api/sessions/${id}/transcript`),
   /** The agent-os primitives this session used — a classified timeline + grouped counts. */
   sessionActivity: (id: string) => call<SessionActivityResp>('GET', `/api/sessions/${id}/activity`),
   /** Upload a pasted/dropped image into a live session; the server saves it in the agent's folder and


### PR DESCRIPTION
## Problem
A headless automation runs `claude -p` and exits, so its tmux pane is gone. That produced two UX gaps:
1. **"Run Now"** navigated the operator straight into a terminal that died moments later.
2. **Opening a finished headless session** showed an empty/broken terminal — even though the full transcript was already captured on disk (`claude-launch.sh` tee's it to `<home>/connectors/session-<id>.log`, 0600).

Both paths already *executed* headless correctly; the gap was purely what the UI showed afterward.

## Changes
- **Run Now → Sessions list.** Firing a headless automation now refreshes and lands on the Sessions list where the new run appears. Interactive automations still open the attachable TUI.
- **Transcript fallback.** `TerminalFrame` detects an ended, non-resumable run (headless/crashed) and renders the captured transcript read-only instead of attaching a dead pane. Interactive ended sessions stay resumable → unchanged attach/resume path (the `!isLive && !resumable` signal cleanly targets headless).
- **New endpoint** `GET /api/sessions/:id/transcript` — same `canViewSession` authz as attach, serves the log file, tails the last 512KB of a long run. Plus `api.sessionTranscript`.

No DB migration.

## Testing
- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 44/44 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)