### PR TITLE
Docs: embed architecture diagram in ARCHITECTURE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+### Docs
+- Embed an architecture diagram at the top of `docs/ARCHITECTURE.md`.
 
 ## [0.48.0] — 2026-07-08
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,8 @@
 > Open-core: the **mechanisms** (kernel, governance, observability) are generic and shippable; the
 > **agents, policies, connectors, and data** are brand-private plugins.
 
+![Agent OS architecture](https://share.instawp.com/CFWZ1myP)
+
 ---
 
 ## 1. What this is, and the one idea that holds it together


### PR DESCRIPTION
Embeds the shared architecture image at the top of `docs/ARCHITECTURE.md` (the central overview doc — there's no docs index). Docs-only, no version bump; CHANGELOG `Unreleased` note added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)