### PR TITLE
Skills: duplicate an installed skill (v0.49.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+
+## [0.49.0] — 2026-07-08
+### Added
+- **Duplicate an installed skill.** Each skill in the library (Skills page) now has a **Duplicate**
+  action next to Edit/Delete: it deep-copies the skill's folder (SKILL.md + any supporting files)
+  under a new name, strips the managed/proposed markers, and rewrites the copy's frontmatter `name:`
+  so it lists and invokes as `/newName`. Handy for forking a bundled or installed playbook before
+  tweaking it. Assignments are **not** carried over — a copy defaults to all agents, like a fresh
+  install. Owner/admin only; audited `skill.duplicated`. New store method `SkillsStore.duplicate` +
+  route `POST /api/skills/:name/duplicate`.
 ### Docs
 - Embed an architecture diagram at the top of `docs/ARCHITECTURE.md`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.48.0",
+      "version": "0.49.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.48.0",
+  "version": "0.49.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/skills.ts
+++ b/src/governance/skills.ts
@@ -168,6 +168,34 @@ export class SkillsStore {
     return this.read(name)!;
   }
 
+  /**
+   * Duplicate an existing library skill under a NEW name: a deep copy of its folder (SKILL.md + any
+   * supporting files), minus the managed/proposed markers, with the new name written into the copy's
+   * frontmatter so it lists + invokes as `/newName`. Assignments are NOT carried over — a fresh copy
+   * defaults to all agents, exactly like a freshly installed skill. Throws on a bad/unknown source, a
+   * bad new name, or a name that already exists. Returns the new skill's detail.
+   */
+  duplicate(name: string, newName: string): SkillDetail {
+    if (!this.dir) throw new Error('a data home is required to duplicate skills');
+    if (!validSkillName(name)) throw new Error('invalid skill name');
+    const target = newName.trim().toLowerCase();
+    if (!validSkillName(target)) throw new Error('name must be lowercase letters, digits and hyphens (2–40 chars, starting with a letter)');
+    const src = path.join(this.dir, name);
+    if (!fs.existsSync(path.join(src, 'SKILL.md'))) throw new Error(`skill "${name}" not found`);
+    const dest = path.join(this.dir, target);
+    if (fs.existsSync(dest)) throw new Error(`a skill named "${target}" already exists`);
+    fs.mkdirSync(dest, { recursive: true });
+    // Skip markers so a copy of a managed/proposed skill lands as a plain, published, editable one.
+    fs.cpSync(src, dest, {
+      recursive: true,
+      filter: (s) => ![MARKER, PROPOSED_MARKER, 'node_modules'].includes(path.basename(s)),
+    });
+    // Rewrite the frontmatter `name:` to the new folder name so the two copies don't collide on it.
+    const file = path.join(dest, 'SKILL.md');
+    fs.writeFileSync(file, renameFrontmatter(fs.readFileSync(file, 'utf8'), target));
+    return this.read(target)!;
+  }
+
   /** Overwrite an existing skill's SKILL.md. Returns the updated detail, or undefined if unknown. */
   save(name: string, content: string): SkillDetail | undefined {
     if (!this.dir || !validSkillName(name)) return undefined;
@@ -441,6 +469,21 @@ function readProposal(marker: string): SkillProposal | undefined {
   } catch {
     return { at: 0 }; // a truthy proposal even if the marker was empty/corrupt — still "proposed"
   }
+}
+
+/**
+ * Rewrite the frontmatter `name:` of a SKILL.md to `name` (leaving the rest untouched). If there's no
+ * frontmatter, or no `name:` line in it, the text is returned unchanged — the folder name is what the
+ * CLI actually keys on, so this is a best-effort cosmetic fix so the two copies don't share a `name:`.
+ */
+function renameFrontmatter(text: string, name: string): string {
+  if (!text.startsWith('---')) return text;
+  const end = text.indexOf('\n---', 3);
+  if (end === -1) return text;
+  const head = text.slice(0, end);
+  const rest = text.slice(end);
+  const rewritten = head.replace(/^(\s*name\s*:).*$/m, `$1 ${name}`);
+  return rewritten + rest;
 }
 
 /** Wrap a raw Markdown body in a minimal `name`/`description` frontmatter header. */

--- a/src/server.ts
+++ b/src/server.ts
@@ -2261,6 +2261,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.published', data: { skill: name } });
     return sendJson(res, 200, { ok: true, skill: os.skills.get(name) });
   }
+  // Duplicate an installed skill under a new name — a deep copy (markers stripped, assignments reset
+  // to all-agents). Owner/admin only. MUST precede the generic /api/skills/:name route (the trailing
+  // /duplicate keeps them distinct, but keep it grouped with the other sub-path routes).
+  const skillDup = p.match(/^\/api\/skills\/([\w.-]+)\/duplicate$/);
+  if (method === 'POST' && skillDup) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (!os.skills.enabled) return sendJson(res, 400, { error: 'duplicating skills requires a data home' });
+    const from = skillDup[1];
+    const b = await readBody(req);
+    try {
+      const s = os.skills.duplicate(from, String(b.name ?? ''));
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.duplicated', data: { skill: s.name, from } });
+      return sendJson(res, 200, { ok: true, skill: s });
+    } catch (e) {
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
+  }
   // The bundled catalog — skills that ship with the software, installable into this tenant's library.
   // MUST precede the generic /api/skills/:name route below (else "catalog" reads as a skill name).
   if (method === 'GET' && p === '/api/skills/catalog') {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4647,6 +4647,15 @@ function SkillCard({ s, agents, onChanged }: { s: SkillSummary; agents: string[]
     if (!r.ok || r.error) return setHint('⚠ ' + (r.error || 'failed'))
     onChanged()
   }
+  const duplicate = async () => {
+    const to = prompt(`Duplicate "${s.name}" as a new skill. Enter a name for the copy:`, `${s.name}-copy`)
+    if (!to) return
+    setBusy(true); setHint('')
+    const r = await api.duplicateSkill(s.name, to.trim().toLowerCase())
+    setBusy(false)
+    if (!r.ok || r.error) return setHint('⚠ ' + (r.error || 'could not duplicate skill'))
+    setHint(`duplicated as "${r.skill?.name ?? to}"`); setTimeout(() => setHint(''), 2500); onChanged()
+  }
   const openAssign = () => { setSel(s.agents); setAssigning((v) => !v); setHint('') }
   const toggle = (id: string) => setSel((cur) => cur.includes(id) ? cur.filter((x) => x !== id) : [...cur, id])
   // "Specific" with nothing checked = every agent (an empty assignment), so guard against that footgun.
@@ -4696,6 +4705,7 @@ function SkillCard({ s, agents, onChanged }: { s: SkillSummary; agents: string[]
           <div className="flex shrink-0 items-center opacity-0 transition-opacity group-hover:opacity-100">
             <Button size="icon" variant="ghost" className="h-7 w-7 text-muted-foreground" title="assign to agents" onClick={openAssign}><Bot className="h-3.5 w-3.5" /></Button>
             <Button size="icon" variant="ghost" className="h-7 w-7 text-muted-foreground" title="edit" onClick={editing ? () => setEditing(false) : open}><Pencil className="h-3.5 w-3.5" /></Button>
+            <Button size="icon" variant="ghost" className="h-7 w-7 text-muted-foreground" title="duplicate — deep-copy this skill under a new name (assignments reset to all agents)" disabled={busy} onClick={duplicate}><Copy className="h-3.5 w-3.5" /></Button>
             <Button size="icon" variant="ghost" className="h-7 w-7 text-destructive" title="delete" disabled={busy} onClick={remove}><Trash2 className="h-3.5 w-3.5" /></Button>
           </div>
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -788,6 +788,8 @@ export const api = {
   saveSkill: (name: string, content: string) =>
     call<{ ok: boolean; skill?: SkillDetail; error?: string }>('PUT', '/api/skills/' + encodeURIComponent(name), { content }),
   deleteSkill: (name: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/skills/' + encodeURIComponent(name)),
+  duplicateSkill: (name: string, newName: string) =>
+    call<{ ok: boolean; skill?: SkillDetail; error?: string }>('POST', '/api/skills/' + encodeURIComponent(name) + '/duplicate', { name: newName }),
   publishSkill: (name: string) =>
     call<{ ok: boolean; skill?: SkillDetail; error?: string }>('POST', '/api/skills/' + encodeURIComponent(name) + '/publish'),
   setSkillAgents: (name: string, agents: string[]) =>


### PR DESCRIPTION
## What

Adds a **Duplicate** action to every skill in the library (Skills page), next to Edit/Delete.

Duplicating deep-copies the skill's whole folder (SKILL.md + any supporting files) under a new name, then:
- strips the `.aos-managed` / `.aos-proposed` markers so the copy lands as a plain, published, editable skill;
- rewrites the copy's frontmatter `name:` to the new folder name so the two copies don't collide and it invokes as `/newName`.

Assignments are **not** carried over — a copy defaults to all agents, exactly like a freshly installed skill. Owner/admin only; audited `skill.duplicated`.

Good for forking a bundled or installed playbook before tweaking it.

## Layers
- **Store:** `SkillsStore.duplicate(name, newName)` + a `renameFrontmatter` helper (`src/governance/skills.ts`).
- **Route:** `POST /api/skills/:name/duplicate` (`src/server.ts`) — owner/admin, `{ name: newName }` body.
- **API:** `api.duplicateSkill(name, newName)` (`web/src/lib/api.ts`).
- **UI:** a `Copy` icon button in `SkillCard` that prompts for the new name (`web/src/App.tsx`).

## Validation
- `npm run build` + `cd web && npm run build` clean.
- `npm run test:governance` → 44/44.
- Isolated-home functional test of `duplicate`: extra files copied, markers stripped, frontmatter `name:` rewritten, and the three error paths (duplicate name / missing source / bad new name) all throw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)