### PR TITLE
Context: fix session-launch injection + recall preamble, self-improve + native-chat steer (v0.52.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.52.0] — 2026-07-08
+### Added
+- **Agents get a "what you already know" head start.** New **Settings → Memory → Session preload**
+  toggle (off by default): when on, each new session's system prompt is seeded with the agent's most
+  salient memories (its own + tenant-shared, ranked by importance then recency-of-use, top N configurable
+  1–25), so a cold run isn't blind instead of relying on it to call `recall`. Backed by a new
+  `MemoryConfig.preload`; the preamble reads the local `memories` ledger directly and is best-effort
+  (never blocks a launch), never leaks another agent's private memories.
+- **Agents are told to self-improve.** The OS operating notes now teach the memory-vs-CLAUDE.md
+  distinction: `remember` a per-task fact, `agent_update` your own standing instructions (CLAUDE.md) when
+  a recurring gap in your setup shows up, and when to do both.
+- **Native Slack/Discord steer.** When a workspace has native Slack/Discord configured, the prompt now
+  tells the agent to reach for the built-in `slack_*`/`discord_*` tools first (they post as the company
+  bot) and fall back to a Composio action only when no native tool covers the need — per-platform, only
+  listed when actually configured.
+### Changed
+- **Every OS-owned MCP tool is now friction-free in interactive sessions.** `claude-launch.sh` pre-allowed
+  only 17 of the 34 OS tools by name, so the rest (`revise`/`forget`/`update`/`check_inbox`/`schedule`/
+  `agent_*`/`secret_*`/…) prompted for permission mid-task even though the gate hook already governs them.
+  Replaced the partial list with the `mcp__agentos` server wildcard (covers present + future tools; real
+  governance stays server-side).
+- Brought the `discord_dm` tool description to parity with `slack_dm` (was a terse one-liner), and
+  trimmed the `remember`/`kb_write` descriptions that duplicated the operating notes.
+- New `npm run test:context` — an isolated harness asserting exactly what a session receives at launch
+  (system prompt, MCP tool list + conditional gating, recall preamble scoping, the allow-list wildcard).
+
 ## [0.51.0] — 2026-07-08
 ### Added
 - **An agent library you install from — and the built-in fleet is now data, not code.** A workspace

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.51.0",
+      "version": "0.52.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -23,7 +23,8 @@
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
     "test:governance": "node scripts/governance-conformance.cjs",
-    "test:enrich": "node scripts/test-enrich-patterns.cjs"
+    "test:enrich": "node scripts/test-enrich-patterns.cjs",
+    "test:context": "node scripts/context-injection-test.cjs"
   },
   "keywords": [
     "agents",

--- a/scripts/context-injection-test.cjs
+++ b/scripts/context-injection-test.cjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/*
+ * Context-injection conformance test — verifies EXACTLY what an agent receives at session launch:
+ *   1. The assembled system prompt (buildCompanyMd): operating notes, the self-improvement subsection,
+ *      the conditional native-Slack/Discord steer, and the launch-time recall preamble (Settings→Memory).
+ *   2. The OS-owned MCP tool list actually advertised by dist/memory/memory-mcp.js (always-on set +
+ *      the conditional slack/discord tools), and the discord_dm description parity fix.
+ *   3. The launch script's permission pre-allow uses the `mcp__agentos` wildcard (no partial list).
+ *
+ * Runs fully isolated: AGENT_OS_HOME points at a throwaway scratch dir (see the CLAUDE.md warning —
+ * a bare loadAgentOS() would otherwise write into the LIVE ./data home). No server, no tmux, no claude.
+ *
+ * Usage:  node scripts/context-injection-test.cjs        (build first: npm run build)
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-ctx-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+// Keep the vault master key inside the scratch home too (a stray secret.key in ./data would leak).
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0,
+  fail = 0;
+const ok = (name) => {
+  pass++;
+  console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+};
+const bad = (name, detail) => {
+  fail++;
+  console.log(`  \x1b[31m✗ ${name}\x1b[0m${detail ? `\n      ${detail}` : ''}`);
+};
+const assert = (cond, name, detail) => (cond ? ok(name) : bad(name, detail));
+
+async function main() {
+  const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+  const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+
+  const aos = loadAgentOS();
+  // A peer agent so the fleet roster has something, and OUR agent under test.
+  aos.agents.set('peer', { id: 'peer', runtime: 'claude-code', description: 'A peer agent', category: 'ops', dir: path.join(HOME, 'agents/peer') });
+  aos.agents.set('tester', { id: 'tester', runtime: 'claude-code', description: 'The agent under test', dir: path.join(HOME, 'agents/tester') });
+
+  const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+  const build = (agent) => tm.buildCompanyMd(agent); // private, but reachable from JS
+
+  console.log('\n\x1b[1m1) System prompt assembly (buildCompanyMd)\x1b[0m');
+
+  // --- default (no chat configured, preload off) ---
+  const base = build('tester');
+  assert(base.includes('# You are running inside Agent OS'), 'operating notes present');
+  assert(base.includes('a fact (memory) vs. your standing instructions (CLAUDE.md)'), 'self-improvement subsection present');
+  assert(/agent_update\b/.test(base) && /change to how you ALWAYS operate → your CLAUDE\.md/.test(base), 'self-improvement explains agent_update vs remember vs both');
+  assert(base.includes('agent:peer') && !base.includes('agent:tester'), 'fleet roster lists peers, excludes self');
+  assert(!base.includes('Messaging — use the native integration first'), 'no native-messaging block when Slack/Discord unconfigured');
+  assert(!base.includes('What you already know'), 'no recall preamble when preload is off');
+
+  // --- native Slack + Discord configured ---
+  aos.settings.setSlackAppToken('xapp-test');
+  aos.settings.setSlackBotToken('xoxb-test');
+  aos.settings.setDiscordBotToken('bot-test');
+  const chat = build('tester');
+  assert(chat.includes('Messaging — use the native integration first'), 'native-messaging block appears when configured');
+  assert(/\*\*Slack\*\* is native/.test(chat) && /slack_send/.test(chat) && /Do NOT use a Composio Slack action/.test(chat), 'Slack steer: prefer native over Composio');
+  assert(/\*\*Discord\*\* is native/.test(chat) && /discord_send/.test(chat) && /Do NOT use a Composio Discord action/.test(chat), 'Discord steer: prefer native over Composio');
+
+  // Only-Slack: the Discord bullet must NOT appear (never advertise a tool the session lacks).
+  aos.settings.setDiscordBotToken('');
+  const slackOnly = build('tester');
+  assert(/\*\*Slack\*\* is native/.test(slackOnly) && !/\*\*Discord\*\* is native/.test(slackOnly), 'per-platform: only Slack listed when only Slack configured');
+
+  console.log('\n\x1b[1m2) Launch-time recall preamble (Settings → Memory)\x1b[0m');
+
+  // Seed memories: two private to `tester`, one tenant-shared (from a peer), one private to another agent (must NOT leak).
+  await aos.memory.store({ tenant: aos.tenant, agentId: 'tester', content: 'PRIVATE-DEPLOY-GOTCHA restart after build', importance: 0.9 });
+  await aos.memory.store({ tenant: aos.tenant, agentId: 'tester', content: 'low-value note', importance: 0.2 });
+  await aos.memory.store({ tenant: aos.tenant, agentId: 'peer', content: 'SHARED-COMPANY-FACT the db is the tenant boundary', importance: 0.8, scope: 'tenant' });
+  await aos.memory.store({ tenant: aos.tenant, agentId: 'other', content: 'OTHERS-PRIVATE-SECRET should never surface', importance: 0.99 });
+
+  const preloadOff = build('tester');
+  assert(!preloadOff.includes('What you already know'), 'preamble still absent while preload disabled');
+
+  aos.settings.setMemoryConfig({ backend: 'sqlite', preload: { enabled: true, count: 8 } });
+  const preloadOn = build('tester');
+  assert(preloadOn.includes('What you already know — your most salient memories'), 'preamble present when preload enabled');
+  assert(preloadOn.includes('PRIVATE-DEPLOY-GOTCHA'), "preamble includes the agent's own memories");
+  assert(preloadOn.includes('SHARED-COMPANY-FACT'), 'preamble includes tenant-shared memories');
+  assert(!preloadOn.includes('OTHERS-PRIVATE-SECRET'), "preamble does NOT leak another agent's private memories");
+  // Importance ordering: the 0.9 private fact should sort above the 0.2 note (both present, high first).
+  assert(preloadOn.indexOf('PRIVATE-DEPLOY-GOTCHA') < preloadOn.indexOf('low-value note'), 'preamble ranks by importance (high before low)');
+
+  // count clamp
+  aos.settings.setMemoryConfig({ backend: 'sqlite', preload: { enabled: true, count: 1 } });
+  const one = build('tester');
+  const bullets = (one.split('What you already know')[1] || '').split('\n').filter((l) => l.startsWith('- ')).length;
+  assert(bullets === 1, 'preamble honours the count (1 requested → 1 bullet)', `got ${bullets}`);
+
+  console.log('\n\x1b[1m3) OS-owned MCP tool list (dist/memory/memory-mcp.js)\x1b[0m');
+  const always = await mcpTools({});
+  const alwaysNames = always.map((t) => t.name);
+  const EXPECTED_ALWAYS = ['recall', 'remember', 'revise', 'forget', 'kb_search', 'kb_write', 'ask', 'report', 'update', 'publish', 'schedule', 'task_create', 'task_update', 'agent_update', 'secret_put', 'secret_get', 'check_inbox'];
+  const missing = EXPECTED_ALWAYS.filter((n) => !alwaysNames.includes(n));
+  assert(missing.length === 0, `always-on tools all present (${alwaysNames.length} total)`, `missing: ${missing.join(', ')}`);
+  assert(!alwaysNames.some((n) => /slack|discord/.test(n)), 'no slack/discord tools without egress flags');
+
+  const dm = always.find((t) => t.name === 'discord_dm');
+  // discord_dm is conditional, so pull the egress set to check its description parity.
+  const egress = await mcpTools({ SLACK_EGRESS: '1', DISCORD_EGRESS: '1' });
+  const eNames = egress.map((t) => t.name);
+  ['slack_send', 'slack_dm', 'discord_send', 'discord_dm'].forEach((n) => assert(eNames.includes(n), `egress tool ${n} appears with *_EGRESS=1`));
+  const ddm = egress.find((t) => t.name === 'discord_dm');
+  const sdm = egress.find((t) => t.name === 'slack_dm');
+  assert(ddm && /Reach anyone in the workspace/.test(ddm.description), 'discord_dm description brought to parity with slack_dm');
+  assert(ddm && sdm && ddm.description.length >= sdm.description.length * 0.6, 'discord_dm no longer a terse stub', `ddm=${ddm && ddm.description.length} sdm=${sdm && sdm.description.length}`);
+
+  const reply = await mcpTools({ SLACK_REPLY: '1', DISCORD_REPLY: '1' });
+  const rNames = reply.map((t) => t.name);
+  assert(rNames.includes('slack_reply') && rNames.includes('discord_reply'), 'reply tools appear with *_REPLY=1');
+
+  console.log('\n\x1b[1m4) Launch-script permission pre-allow (claude-launch.sh)\x1b[0m');
+  const launch = fs.readFileSync(path.join(ROOT, 'terminal/claude-launch.sh'), 'utf8');
+  assert(/"allow": \["mcp__agentos"\]/.test(launch), 'allow-list uses the mcp__agentos wildcard');
+  assert(!/mcp__agentos__task_update"/.test(launch), 'old partial enumerated allow-list removed');
+
+  console.log(`\n\x1b[1mResult:\x1b[0m ${pass} passed, ${fail} failed\n`);
+  process.exit(fail ? 1 : 0);
+}
+
+/** Spawn the MCP server, initialize, call tools/list, return the tool array. */
+function mcpTools(extraEnv) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('node', [path.join(ROOT, 'dist/memory/memory-mcp.js')], {
+      env: { ...process.env, AOS_URL: 'http://127.0.0.1:0', SESSION: 'test', AGENT: 'tester', AOS_SECRET: 'x', ...extraEnv },
+      stdio: ['pipe', 'pipe', 'inherit'],
+    });
+    let out = '';
+    const timer = setTimeout(() => { child.kill(); reject(new Error('mcp server timeout')); }, 5000);
+    child.stdout.on('data', (d) => {
+      out += d.toString();
+      let nl;
+      while ((nl = out.indexOf('\n')) >= 0) {
+        const line = out.slice(0, nl).trim();
+        out = out.slice(nl + 1);
+        if (!line) continue;
+        let msg;
+        try { msg = JSON.parse(line); } catch { continue; }
+        if (msg.id === 2) { clearTimeout(timer); child.kill(); resolve(msg.result.tools); }
+      }
+    });
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }) + '\n');
+    child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} }) + '\n');
+  });
+}
+
+main()
+  .catch((e) => { console.error(e); fail++; })
+  .finally(() => { try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {} });

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -108,8 +108,9 @@ const SLACK_DM_TOOL = {
 const DISCORD_SEND_TOOL = {
   name: 'discord_send',
   description:
-    'Post a message to a Discord channel (any channel, not just the one that triggered you). Use this ' +
-    'to proactively message a channel. For replying where you were triggered, prefer discord_reply.',
+    'Post a message to a Discord channel (any channel, not just the one that triggered you). Use this to ' +
+    'proactively message a channel — announcements, summaries, alerts. For replying to the message that ' +
+    'triggered you, prefer discord_reply.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -122,7 +123,9 @@ const DISCORD_SEND_TOOL = {
 
 const DISCORD_DM_TOOL = {
   name: 'discord_dm',
-  description: 'Send a direct message to a person in Discord by their user id.',
+  description:
+    'Send a direct message to a person in Discord. Reach anyone in the workspace — teammate updates, ' +
+    'nudges, one-to-one answers.',
   inputSchema: {
     type: 'object',
     properties: {
@@ -156,13 +159,11 @@ const TOOLS = [
   {
     name: 'remember',
     description:
-      'Store a durable memory for your future self. WHEN to write one — the moments worth encoding: you ' +
-      'were SURPRISED (something behaved differently than you expected), you spent real EFFORT figuring ' +
-      'something out, you made a DECISION others will depend on, or you hit a GOTCHA / constraint / root ' +
-      'cause. Skip routine steps, anything already in the knowledge base, and run-specific trivia — ' +
-      'remembering everything is as useless as remembering nothing. Keep each memory one self-contained ' +
-      'fact; add short tags. Set `importance` honestly — it can bias future recall toward what matters. ' +
-      'Got a fact wrong later? Use `revise` to correct it or `forget` to drop it (recall shows each memory\'s id).',
+      'Store a durable memory for your future self — one self-contained fact you\'ll want on a later run ' +
+      '(a gotcha, a root cause, a decision others depend on, something that surprised you or took real ' +
+      'effort). Skip routine steps and run-specific trivia. Add short tags; set `importance` honestly (it ' +
+      'can bias future recall). Correct a fact later with `revise`, or drop it with `forget` (recall shows ' +
+      'each memory\'s id).',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -246,11 +247,10 @@ const TOOLS = [
   {
     name: 'kb_write',
     description:
-      'Create or update a KNOWLEDGE-BASE page — durable, company-wide knowledge others will reuse (a runbook ' +
-      'you followed, a decision and its rationale, a convention, a fact you established). Editing an existing ' +
-      'page is ENCOURAGED — search first (kb_search) and update in place rather than create a duplicate; your ' +
-      'change is versioned and revertable. Use this for shared canonical knowledge, NOT private run notes (use ' +
-      'remember for those).',
+      'Create or update a KNOWLEDGE-BASE page — durable, company-wide knowledge others reuse (a runbook, a ' +
+      'decision + rationale, a convention, an established fact). Search first (kb_search) and edit in place ' +
+      'rather than duplicate; changes are versioned and revertable. Shared canonical knowledge, NOT private ' +
+      'run notes (use remember for those).',
     inputSchema: {
       type: 'object',
       additionalProperties: false,

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument, withAlwaysAll
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
 import { parseBundle } from './governance/bundle-import';
-import { AgentManifest, ApprovalRequest, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
+import { AgentManifest, ApprovalRequest, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
 import { AgentConfigSnapshot } from './state/agent-revisions';
 
 /** Settings → Memory view: stored backend config with secrets redacted to `…Set` booleans. */
@@ -41,6 +41,7 @@ interface MemorySettingsView {
   ranking?: { halfLifeDays?: number; weightByImportance?: boolean; weightByUsage?: boolean };
   maintenance?: { pruneAfterDays?: number; keepImportance?: number; dedupeThreshold?: number; everyHours?: number };
   sharedWrites?: 'open' | 'curated';
+  preload?: { enabled: boolean; count?: number };
   updatedAt?: number;
   updatedBy?: string;
 }
@@ -3092,6 +3093,7 @@ function memoryView(os: AgentOS): MemorySettingsView {
   if (cfg.ranking) view.ranking = { halfLifeDays: cfg.ranking.halfLifeDays, weightByImportance: !!cfg.ranking.weightByImportance, weightByUsage: !!cfg.ranking.weightByUsage };
   if (cfg.maintenance) view.maintenance = { ...cfg.maintenance };
   view.sharedWrites = cfg.sharedWrites === 'curated' ? 'curated' : 'open';
+  if (cfg.preload?.enabled) view.preload = { enabled: true, count: cfg.preload.count ?? 8 };
   return view;
 }
 
@@ -3157,7 +3159,16 @@ function buildMemoryConfig(body: Record<string, any>, prev: MemoryConfig | null)
   const maintenance = parseMaintenance(body.maintenance);
   if (maintenance) cfg.maintenance = maintenance;
   if (body.sharedWrites === 'curated') cfg.sharedWrites = 'curated';
+  const preload = parsePreload(body.preload);
+  if (preload) cfg.preload = preload;
   return cfg;
+}
+
+/** Parse the launch-time recall-preamble control; undefined unless it's explicitly enabled. */
+function parsePreload(pb: any): MemoryPreload | undefined {
+  if (!pb || typeof pb !== 'object' || !pb.enabled) return undefined;
+  const count = Number(pb.count);
+  return { enabled: true, count: Number.isFinite(count) && count > 0 ? Math.min(Math.floor(count), 25) : 8 };
 }
 
 /** Parse the recall-ranking controls; returns undefined when neither knob is on (→ no re-ranking). */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -79,6 +79,20 @@ Other agents run in this workspace and you share state with them. You are a node
   things a plain fact already covers.
 - **The team**: \`directory_lookup\` finds who's on the team and how to reach them (Slack/Discord/email).
 
+## Improve yourself — a fact (memory) vs. your standing instructions (CLAUDE.md)
+You can edit your OWN definition, so keep it current instead of repeating the same mistakes. Know which
+lever to pull:
+- \`remember\` (or \`report\` \`lessons\`) captures a **fact** for your future runs — a gotcha, a root
+  cause, a decision. Reach for it constantly, for the specific things a task teaches you.
+- \`agent_update\` rewrites **your own CLAUDE.md** (your system prompt / standing instructions), plus
+  your description and tuning — your durable **identity and how you always work**. Reach for it when you
+  notice a recurring gap in your own setup: a step you always have to redo, a convention you should
+  always follow, a better description of what you do. It takes effect next session and every edit is
+  reversible (\`agent_history\` / \`agent_revert\`).
+- Often you want **both**: \`remember\` the one-off fact now, AND — if it reveals a standing rule you'll
+  need on every run — fold that rule into your CLAUDE.md with \`agent_update\`. Rule of thumb: a fact
+  about THIS task → memory; a change to how you ALWAYS operate → your CLAUDE.md.
+
 ## Environment notes
 - Links aren't clickable in this terminal: always print any URL the user must open or copy
   (OAuth/connect links etc.) in full as plain text, not only as a markdown label.`;
@@ -814,7 +828,58 @@ export class TerminalManager {
       : members.length > TEAM_CAP
         ? `# Your team\n\n${members.length} people are on the team — use \`directory_lookup\` to find someone by name or email.`
         : '';
-    return [company, AGENT_OS_OPERATING_NOTES, fleet, team, learned].filter(Boolean).join('\n\n');
+    // Native Slack/Discord are wired directly into the OS (they post as the company bot via the
+    // `slack_*`/`discord_*` tools). When a platform is configured, steer the agent to those FIRST —
+    // otherwise a claude reaching for chat defaults to a Composio Slack/Discord action. Only listed
+    // per-platform when actually configured, so we never advertise a tool the session doesn't have.
+    const chatLines: string[] = [];
+    if (this.os.settings.slackConfigured())
+      chatLines.push(
+        '- **Slack** is native — use `slack_send` (any channel), `slack_dm` (any person), and ' +
+          '`slack_reply` (the thread that triggered you). Do NOT use a Composio Slack action for this.',
+      );
+    if (this.os.settings.discordConfigured())
+      chatLines.push(
+        '- **Discord** is native — use `discord_send` (any channel), `discord_dm` (any person), and ' +
+          '`discord_reply` (the message that triggered you). Do NOT use a Composio Discord action for this.',
+      );
+    const messaging = chatLines.length
+      ? '# Messaging — use the native integration first\n\n' +
+        'These channels are wired directly into Agent OS: the built-in tools post as the company bot, ' +
+        'need no channel setup, and are the supported path. Reach for the native tool first; fall back to ' +
+        'a Composio action only if no native tool covers what you need.\n\n' +
+        chatLines.join('\n')
+      : '';
+    // Launch-time recall preamble (Settings → Memory, off by default): seed the prompt with this
+    // agent's most salient memories so a cold session isn't blind, instead of relying on it to call
+    // `recall`. Reads the local `memories` ledger directly (node:sqlite is synchronous) — the same
+    // store recall ranks over. Best-effort: never let a preamble query block a launch.
+    let preamble = '';
+    const preload = this.os.settings.memoryConfig()?.preload;
+    if (preload?.enabled && selfAgent) {
+      const n = Math.max(1, Math.min(Math.floor(preload.count ?? 8), 25));
+      try {
+        const rows = this.db
+          .prepare(
+            `SELECT content FROM memories
+             WHERE tenant = ? AND (scope = 'tenant' OR (scope = 'agent' AND agent_id = ?))
+             ORDER BY COALESCE(importance, 0.5) DESC, COALESCE(last_recalled_at, created_at) DESC
+             LIMIT ?`,
+          )
+          .all<{ content: string }>(this.os.tenant, selfAgent, n);
+        if (rows.length)
+          preamble =
+            '# What you already know — your most salient memories\n\n' +
+            "Surfaced from your persistent memory so you don't start blind. This is a HEAD START, not the " +
+            'whole picture — `recall` for more on any specific topic before non-trivial work.\n\n' +
+            rows.map((r) => `- ${r.content.replace(/\s+/g, ' ').trim()}`).join('\n');
+      } catch {
+        /* preamble is best-effort; a query failure must never block a session launch */
+      }
+    }
+    return [company, AGENT_OS_OPERATING_NOTES, messaging, fleet, team, preamble, learned]
+      .filter(Boolean)
+      .join('\n\n');
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -416,6 +416,19 @@ export interface MemoryConfig {
    * 'curated' — agents' shared writes are downgraded to private; only humans (owner/admin) publish shared.
    */
   sharedWrites?: 'open' | 'curated';
+  /**
+   * Launch-time recall preamble: seed each new session's system prompt with the agent's most salient
+   * memories, so a cold start isn't blind (vs. relying on the agent to call `recall` itself). Off by
+   * default. Reads the local `memories` ledger the same store recall ranks over.
+   */
+  preload?: MemoryPreload;
+}
+
+/** Launch-time recall preamble config (Settings → Memory). See MemoryConfig.preload. */
+export interface MemoryPreload {
+  enabled: boolean;
+  /** How many memories to inject (1..25; default 8). Ranked by importance then recency-of-use. */
+  count?: number;
 }
 
 /**

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -37,9 +37,16 @@ cd "$AGENT_DIR" 2>/dev/null || { red "agent folder not found: $AGENT_DIR"; exec 
 # Wire the gate as a project-local PreToolUse hook. claude inherits AOS_URL/SESSION/AGENT from
 # this shell's env, so the hook can reach the gateway and tag the right session. We regenerate
 # the settings each launch so the hook path is always correct (and portable across machines).
-# Pre-allow the OS-owned tools (memory, ask/report, policy preview) so they're friction-free — they're
-# internal and safe (memory reads/writes only this agent's own namespace; policy_check/list_capabilities
-# are pure dry-runs; all go through the loopback API, which derives identity from the session row).
+# Pre-allow EVERY OS-owned tool so they're friction-free in interactive sessions — a single
+# `mcp__agentos` entry approves all tools that server exposes (present and future: memory, KB, tasks,
+# inbox, schedule, agent_*, secret_*, the conditional slack/discord tools, …). They're internal and
+# safe to pre-allow at Claude's permission layer: every one goes through the loopback API, which derives
+# identity from the session row and enforces the REAL governance server-side (e.g. secret_put still
+# blocks for human approval; memory reads/writes only this agent's own namespace) — so approving them
+# here only silences Claude's own prompt, it does NOT bypass Agent OS policy. The gate hook likewise
+# `exit 0`s mcp__agentos__* (they aren't world side effects), so without this pre-allow the tools NOT
+# on the old explicit list (revise/forget/update/check_inbox/schedule/agent_*/secret_*/…) prompted in
+# interactive sessions. Enumerating a partial list caused exactly that gap; the server name covers all.
 # The Notification hook lives beside the gate hook; derive its path so it's correct on every machine.
 NOTIFY_HOOK="$(dirname "$HOOK")/notify-hook.sh"
 # The Agent OS status line renderer (native claude statusLine) lives beside the hooks too.
@@ -79,7 +86,7 @@ rm -f .claude/settings.json
 cat > .claude/aos-settings.json <<JSON
 {
   "permissions": {
-    "allow": ["mcp__agentos__recall", "mcp__agentos__remember", "mcp__agentos__kb_search", "mcp__agentos__kb_read", "mcp__agentos__kb_write", "mcp__agentos__ask", "mcp__agentos__report", "mcp__agentos__publish", "mcp__agentos__list_capabilities", "mcp__agentos__policy_check", "mcp__agentos__directory_lookup", "mcp__agentos__list_agents", "mcp__agentos__task_create", "mcp__agentos__task_list", "mcp__agentos__task_get", "mcp__agentos__task_claim", "mcp__agentos__task_update"]$DENY_LINE
+    "allow": ["mcp__agentos"]$DENY_LINE
   },
   "hooks": {
     "PreToolUse": [

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5781,6 +5781,8 @@ function MemorySettings({ me }: { me: Member }) {
   const [maintBusy, setMaintBusy] = useState(false)
   const [maintMsg, setMaintMsg] = useState('')
   const [curated, setCurated] = useState(false) // shared-write policy: only humans publish shared
+  const [preloadOn, setPreloadOn] = useState(false) // launch-time recall preamble
+  const [preloadCount, setPreloadCount] = useState('8')
   const apply = (v: MemorySettings) => {
     setView(v)
     setBackend(v.backend)
@@ -5799,6 +5801,8 @@ function MemorySettings({ me }: { me: Member }) {
     if (m?.dedupeThreshold != null) setDedupeThresh(String(m.dedupeThreshold))
     setEveryHours(String(m?.everyHours ?? 24))
     setCurated(v.sharedWrites === 'curated')
+    setPreloadOn(!!v.preload?.enabled)
+    if (v.preload?.count != null) setPreloadCount(String(v.preload.count))
   }
   useEffect(() => { api.memorySettings().then((v) => { if (v.error) return setHint('⚠ ' + v.error); apply(v) }).catch(() => {}) }, [])
 
@@ -5848,12 +5852,13 @@ function MemorySettings({ me }: { me: Member }) {
   const ranking = () => ({ halfLifeDays: Number(halfLife) || 0, weightByImportance: weightImp, weightByUsage: weightUse })
   const maintenance = () => ({ pruneAfterDays: Number(pruneDays) || 0, keepImportance: Number(keepImp), everyHours: Number(everyHours) || 24, ...(dedupeOn ? { dedupeThreshold: Number(dedupeThresh) } : {}) })
   const sharedWrites = (): 'open' | 'curated' => (curated ? 'curated' : 'open')
+  const preload = () => ({ enabled: preloadOn, count: Math.max(1, Math.min(Number(preloadCount) || 8, 25)) })
   const body = (): MemorySettingsReq => {
     if (backend === 'libsql') {
-      return { backend, libsql: { url: url.trim(), ...(authToken.trim() ? { authToken: authToken.trim() } : {}), embeddings: emb() }, ranking: ranking(), maintenance: maintenance(), sharedWrites: sharedWrites() }
+      return { backend, libsql: { url: url.trim(), ...(authToken.trim() ? { authToken: authToken.trim() } : {}), embeddings: emb() }, ranking: ranking(), maintenance: maintenance(), sharedWrites: sharedWrites(), preload: preload() }
     }
-    if (backend === 'automem') return { backend, automem: { endpoint: endpoint.trim(), ...(token.trim() ? { token: token.trim() } : {}) }, sharedWrites: sharedWrites() }
-    return { ...(embedOn ? { backend: 'sqlite', sqlite: { embeddings: emb() } } : { backend: 'sqlite' }), ranking: ranking(), maintenance: maintenance(), sharedWrites: sharedWrites() }
+    if (backend === 'automem') return { backend, automem: { endpoint: endpoint.trim(), ...(token.trim() ? { token: token.trim() } : {}) }, sharedWrites: sharedWrites(), preload: preload() }
+    return { ...(embedOn ? { backend: 'sqlite', sqlite: { embeddings: emb() } } : { backend: 'sqlite' }), ranking: ranking(), maintenance: maintenance(), sharedWrites: sharedWrites(), preload: preload() }
   }
 
   // Run a maintenance pass now (uses the SAVED policy — save first if you just changed the knobs).
@@ -6121,6 +6126,25 @@ function MemorySettings({ me }: { me: Member }) {
           <label className="flex items-center gap-2 text-sm">
             <input type="checkbox" checked={curated} onChange={(e) => setCurated(e.target.checked)} />
             Curated <span className="text-[11px] text-muted-foreground">— agents' shared writes are stored private; only humans publish shared. Off = any agent may publish (audited).</span>
+          </label>
+        </CardContent>
+      </Card>
+
+      {/* Launch-time recall preamble — seed each new session with the agent's most salient memories. */}
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <div>
+            <div className="text-sm font-medium">Session preload</div>
+            <p className="text-xs text-muted-foreground">Inject each agent's most salient memories into its system prompt at launch, so a cold session doesn't start blind (instead of relying on it to call <code className="text-xs">recall</code>). Ranked by importance then recency-of-use; includes the agent's own memories and tenant-shared ones.</p>
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={preloadOn} onChange={(e) => setPreloadOn(e.target.checked)} />
+            Preload memories on launch
+            {preloadOn && (
+              <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+                — top <Input value={preloadCount} onChange={(e) => setPreloadCount(e.target.value)} className="h-6 w-16 font-mono text-xs" /> (1–25)
+              </span>
+            )}
           </label>
         </CardContent>
       </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -421,6 +421,7 @@ export interface MemorySettings {
   ranking?: MemoryRanking
   maintenance?: MemoryMaintenance
   sharedWrites?: 'open' | 'curated'
+  preload?: { enabled: boolean; count?: number }
   health?: MemoryHealth
   /** Rows in the local `memories` ledger vs. the active external store — drives the migrate/clear banner. */
   localCount?: number
@@ -449,6 +450,7 @@ export interface MemorySettingsReq {
   ranking?: MemoryRanking
   maintenance?: MemoryMaintenance
   sharedWrites?: 'open' | 'curated'
+  preload?: { enabled: boolean; count?: number }
 }
 export interface AddMemoryReq {
   agent: string


### PR DESCRIPTION
## Why

An audit of **everything injected into an agent's context at session launch** (system prompt, MCP tool list, skills, settings/hooks, env) surfaced one real permission-friction bug, a description gap, and two missing pieces of guidance. This addresses them and adds a test harness that pins down exactly what a session receives.

## What changed

**Fixes**
- **Allow-list (the friction bug).** `claude-launch.sh` pre-allowed only **17 of 34** OS-owned tools by name. The gate hook `exit 0`s all `mcp__agentos__*` (they aren't world side effects) and emits no decision, so the omitted tools (`revise`/`forget`/`update`/`check_inbox`/`schedule`/`agent_*`/`secret_*`/…) fell back to Claude's own prompt **in interactive sessions**. Replaced the partial list with the `mcp__agentos` server wildcard — covers present + future tools; real governance stays server-side (e.g. `secret_put` still blocks for approval).
- **`discord_dm` description** brought to parity with `slack_dm` (was a terse one-liner); `discord_send` aligned to `slack_send`.
- **Dedup.** Made the OS operating notes the single teaching home and trimmed the `remember`/`kb_write` descriptions that restated them.

**New guidance in the prompt**
- **Self-improvement.** Operating-notes subsection teaching the distinction: `remember` a per-task **fact**, `agent_update` your own **CLAUDE.md** when a recurring setup gap shows up, and when to do **both**.
- **Native Slack/Discord steer.** When a platform is configured, the prompt tells the agent to use the built-in `slack_*`/`discord_*` tools first (they post as the company bot) and fall back to Composio only when no native tool covers the need — per-platform, only listed when actually configured.

**New feature**
- **Settings → Memory → Session preload** (off by default). When on, each new session's system prompt is seeded with the agent's most salient memories (its own + tenant-shared, ranked importance→recency-of-use, top N 1–25), so a cold run isn't blind. New `MemoryConfig.preload`; reads the local `memories` ledger directly, best-effort (never blocks a launch), never leaks another agent's private memories. Wired types → server → web UI.

## Tests
- New **`npm run test:context`** — isolated harness (scratch `AGENT_OS_HOME`, no live data) that renders `buildCompanyMd` and drives the real MCP server over stdio. **28/28**: operating notes + self-improvement subsection, native-messaging steer (both / Slack-only / none), preamble on/off + own-vs-shared scoping + **no cross-agent leak** + importance ordering + count clamp, the 34 always-on tools, conditional egress/reply gating, `discord_dm` parity, wildcard allow-list.
- `npm run test:governance` **44/44**; `npm run typecheck` + `cd web && npm run build` clean.

## Deploy notes
- Allow-list + native-steer + preamble (server/`terminal.ts`) need **build + server restart**.
- The trimmed/parity MCP descriptions need **build + session relaunch** to reach a live session.
- Web toggle: `cd web && npm run build` + reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)