### PR TITLE
Sessions: filter the session list by owner (run-as) (v0.53.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.53.0] — 2026-07-08
+### Added
+- **Filter the sessions list by owner.** The Sessions filter bar gained an **Owner** dropdown that
+  narrows to the member a run acts as (run-as identity) — so you can see just your own sessions, or
+  everything a given teammate's automations/tasks/chats spawned. Options are the distinct owners
+  present (shown by name), and the dropdown only appears when more than one owner exists. Backed by a
+  new `runAsLabel` on the session API (the run-as member's display name), which the search box now
+  matches too.
+
 ## [0.52.0] — 2026-07-08
 ### Added
 - **Agents get a "what you already know" head start.** New **Settings → Memory → Session preload**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -136,6 +136,9 @@ export interface Session {
    *  chat-triggered run is spawned by `task:`/`automation:` but runs as (and is owned by) a member,
    *  so the console keys "my sessions" off this too. */
   runAs?: string;
+  /** Human-readable owner: the run-as member's name/email. Undefined when the session has no run-as
+   *  identity (e.g. a company-identity automation run). Drives the sessions-list Owner filter. */
+  runAsLabel?: string;
   createdAt: number;
 }
 
@@ -348,6 +351,7 @@ export class TerminalManager {
       alive: alive ? alive.has(r.tmux) : undefined,
       resumable: resumable.has(r.id),
       spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as),
+      runAsLabel: this.runAsLabel(r.run_as),
     }));
   }
 
@@ -457,6 +461,14 @@ export class TerminalManager {
     if (spawnedBy.startsWith('task:')) return `Task · ${spawnedBy.slice('task:'.length)}${asSuffix}`;
     const m = this.os.team.getMember(spawnedBy);
     return m ? m.name || m.email : spawnedBy;
+  }
+
+  /** The run-as member's display name (name → email), for the sessions-list Owner filter. Undefined
+   *  when the session has no run-as identity or the member no longer exists. */
+  private runAsLabel(runAs: string | null): string | undefined {
+    if (!runAs) return undefined;
+    const m = this.os.team.getMember(runAs);
+    return m ? m.name || m.email : undefined;
   }
 
   /** Is this session's tmux shell still alive? (The automations guard against pile-ups.) */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1345,18 +1345,28 @@ function SessionsPage({
   const [statusFilter, setStatusFilter] = useState<SessionStatusFilter>('all')
   const [agentFilter, setAgentFilter] = useState('all')
   const [sourceFilter, setSourceFilter] = useState<'all' | SessionSource>('all')
+  const [ownerFilter, setOwnerFilter] = useState('all') // run-as member id, or 'all'
   const agentOptions = useMemo(() => [...new Set(sessions.map((s) => s.agent))].sort(), [sessions])
-  const filtersActive = query.trim() !== '' || statusFilter !== 'all' || agentFilter !== 'all' || sourceFilter !== 'all'
-  const clearFilters = () => { setQuery(''); setStatusFilter('all'); setAgentFilter('all'); setSourceFilter('all') }
+  // Distinct run-as owners present, id→label, sorted by label. A session with no run-as identity is
+  // omitted (nothing to key an Owner filter on).
+  const ownerOptions = useMemo(() => {
+    const m = new Map<string, string>()
+    for (const s of sessions) if (s.runAs && s.runAsLabel) m.set(s.runAs, s.runAsLabel)
+    return [...m].map(([id, label]) => ({ id, label })).sort((a, b) => a.label.localeCompare(b.label))
+  }, [sessions])
+  const ownerLabel = (id: string) => (id === 'all' ? 'All owners' : ownerOptions.find((o) => o.id === id)?.label ?? id)
+  const filtersActive = query.trim() !== '' || statusFilter !== 'all' || agentFilter !== 'all' || sourceFilter !== 'all' || ownerFilter !== 'all'
+  const clearFilters = () => { setQuery(''); setStatusFilter('all'); setAgentFilter('all'); setSourceFilter('all'); setOwnerFilter('all') }
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase()
     return sessions.filter((s) =>
       matchesStatus(s, statusFilter) &&
       (agentFilter === 'all' || s.agent === agentFilter) &&
       (sourceFilter === 'all' || sessionSource(s) === sourceFilter) &&
-      (needle === '' || `${s.title} ${s.agent} ${s.id} ${s.task} ${s.spawnedByLabel ?? ''}`.toLowerCase().includes(needle)),
+      (ownerFilter === 'all' || s.runAs === ownerFilter) &&
+      (needle === '' || `${s.title} ${s.agent} ${s.id} ${s.task} ${s.spawnedByLabel ?? ''} ${s.runAsLabel ?? ''}`.toLowerCase().includes(needle)),
     )
-  }, [sessions, query, statusFilter, agentFilter, sourceFilter])
+  }, [sessions, query, statusFilter, agentFilter, sourceFilter, ownerFilter])
 
   // Multi-select for bulk stop/delete. Kept in sync with the live list: ids that vanish (deleted
   // elsewhere, or by our own bulk delete) are pruned so the toolbar count never lies. Select-all and
@@ -1523,6 +1533,17 @@ function SessionsPage({
             ))}
           </SelectContent>
         </Select>
+        {/* Owner (run-as) filter — only when more than one distinct owner exists (a single-owner
+            workspace has nothing to narrow). */}
+        {ownerOptions.length > 1 && (
+          <Select value={ownerFilter} onValueChange={(v) => setOwnerFilter(v ?? 'all')}>
+            <SelectTrigger className="h-8 w-[150px] text-xs"><SelectValue>{(v) => ownerLabel((v ?? 'all') as string)}</SelectValue></SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All owners</SelectItem>
+              {ownerOptions.map((o) => <SelectItem key={o.id} value={o.id}>{o.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
+        )}
         {filtersActive && (
           <Button size="sm" variant="ghost" className="h-8 gap-1 px-2 text-xs text-muted-foreground" onClick={clearFilters}>
             <X className="h-3 w-3" /> Clear filters

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -122,6 +122,9 @@ export interface Session {
   /** The member id this session runs AS (run_as). A task/chat-triggered run is spawnedBy `task:`/
    *  `automation:` but runs as a member — the sidebar keys "my sessions" off this too. */
   runAs?: string
+  /** Human-readable owner: the run-as member's name/email. Undefined when the session has no run-as
+   *  identity. Drives the sessions-list Owner filter. */
+  runAsLabel?: string
   createdAt: number
 }
 export interface AuditEvent {


### PR DESCRIPTION
## What

Follows up the Sessions filter bar with an **Owner** dropdown — narrows to the member a run acts as (its run-as identity). Isolate just your own sessions, or everything a given teammate's automations / tasks / chats spawned.

- Options are the **distinct owners present**, shown by name, sorted.
- The dropdown **only appears when more than one owner exists** (a single-owner workspace has nothing to narrow).
- Backed by a new server-computed **`runAsLabel`** on the session API (the run-as member's name/email, resolved in `listSessions` alongside `spawnedByLabel`). The search box now matches it too, so typing an owner's name works.

## Verify

Drove the running console in Chromium against a seeded scratch DB — 2 members (Owner, alice), 4 sessions split 2/2:

- API now returns `runAsLabel` ("Owner" / "alice")
- Filter bar shows a 4th dropdown **All owners** with options `[All owners, alice, Owner]`
- Owner=alice → "2 of 4", both Alice runs; Owner=Owner → the other 2
- Owner=Owner + Source=Automation → "1 of 4" (combined AND)
- search "alice" → 2 of 4 (owner name is searchable)

Server typecheck + web build clean; governance 44/44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)