### PR TITLE
Agents: fix the agent library modal not scrolling (v0.53.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.53.2] — 2026-07-08
+### Fixed
+- **Agent library modal now scrolls.** The catalog list overflowed the dialog instead of scrolling
+  (the grid `DialogContent` clipped it with no bounded height on the list). Gave the list its own
+  `max-h-[60vh] overflow-y-auto` so long catalogs scroll within the modal.
+
 ## [0.53.1] — 2026-07-08
 ### Changed
 - **The agent library moved behind a button.** The Agents page no longer shows the library as an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.53.1",
+      "version": "0.53.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.53.1",
+  "version": "0.53.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4400,7 +4400,7 @@ function AgentLibrary({ open, onOpenChange, onInstalled }: { open: boolean; onOp
           <div className="text-xs text-muted-foreground">Ready-made agents bundled with Agent OS. Install one to copy it into your fleet — then edit, tune, assign, or delete it like any other agent.</div>
         </DialogHeader>
         {hint && <div className="font-mono text-xs text-muted-foreground">{hint}</div>}
-        <div className="space-y-2 overflow-y-auto">
+        <div className="max-h-[60vh] space-y-2 overflow-y-auto pr-1">
           {!catalog ? (
             <p className="py-6 text-center text-sm text-muted-foreground">Loading…</p>
           ) : catalog.length === 0 ? (


### PR DESCRIPTION
## What

Fixes the agent library modal not scrolling — the catalog list overflowed the dialog instead of scrolling.

## Cause

`DialogContent` is a CSS `grid` with `overflow-hidden`; the inner list had `overflow-y-auto` but no bounded height, so it grew past the clip instead of scrolling.

## Fix

Gave the list its own `max-h-[60vh] overflow-y-auto pr-1` (same pattern the recommendations/task-body lists use). Web-only, one line.

`cd web && npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)