### PR TITLE
Slack: talk inside a thread — continue the same conversation (v0.54.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.54.0] — 2026-07-08
+### Added
+- **Talk to an agent inside a Slack thread.** A follow-up message in a thread the bot already replied
+  in now **continues the same conversation** instead of being treated as a brand-new trigger (which
+  answered a plain "ok, now do X" with the `/agent` help list). The socket resolves the most recent
+  session bound to that thread and spawns a continuation run that **resumes the same claude transcript**
+  (`claude --resume`), so the agent keeps full context; its `slack_reply` lands back in the same thread.
+  If the bound agent is still working the previous turn, the bot posts a short "still on it — I'll pick
+  this up next" note and drops the duplicate (no overlapping runs on one thread).
+### Changed
+- Headless chat/automation runs now **pin their claude session id** (`--session-id`) so they can be
+  resumed later — the backbone of the thread-continuity above. New `term_sessions.claude_session_id`
+  column (NULL for older/non-claude runs, which fall back to a fresh spawn).
+### Note
+- Requires the Slack app to receive thread replies: subscribe to `message.channels` (and
+  `message.groups`/`message.im`/`message.mpim` as needed) and keep the bot in the channel. `app_mention`
+  alone only delivers explicit @mentions, not plain in-thread replies.
+
 ## [0.53.2] — 2026-07-08
 ### Fixed
 - **Agent library modal now scrolls.** The catalog list overflowed the dialog instead of scrolling

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,15 @@ Key modules:
   `getMemberByEmail`; unmapped → company identity). A leading bot-mention (`<@BOTID>`) is stripped before
   routing so the `/agent` prefix parses. The bot posts an immediate in-thread ack (replies thread on
   `thread_ts ?? ts`, so a mention starts a thread); the agent replies via its own Slack egress tools (the
-  Composio company Slackbot). The socket re-dials when tokens change; uses the Node 22+ global `WebSocket`
+  Composio company Slackbot). **Thread continuity:** a follow-up message inside a thread already bound to a
+  session (`slack_threads`) continues THAT conversation instead of re-triggering — `dispatch` calls
+  `Automations.continueSlackThread` (finds the newest session for `channel`+`thread_ts` via
+  `TerminalManager.sessionForSlackThread`, then spawns a run that `claude --resume`s the SAME transcript,
+  keeping context; a still-busy agent gets a "pick this up next" note, no overlapping run). This needs the
+  pinned claude id — headless runs now launch with `--session-id $CLAUDE_SESSION_ID` (stored in
+  `term_sessions.claude_session_id`). Caveat: plain in-thread replies only reach the socket if the Slack app
+  subscribes to `message.channels`/etc. AND the bot is in-channel (`app_mention` covers only @mentions). The
+  socket re-dials when tokens change; uses the Node 22+ global `WebSocket`
   (no `ws` dep). Slack here is INGRESS-native; Composio remains the webhook ingress lane.
 - `src/edge/discord-socket.ts` + `src/connectors/discord.ts` — **native Discord via the Gateway**: a
   one-for-one mirror of the Slack path. One company bot (single `Bot …` token in Settings → Integrations)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.53.2",
+  "version": "0.54.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.53.2",
+      "version": "0.54.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.53.2",
+  "version": "0.54.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -534,6 +534,58 @@ export class Automations {
   }
 
   /**
+   * Thread continuity: a follow-up message inside a Slack thread already bound to a session should
+   * CONTINUE that conversation with the same agent — not re-run the automation/`/agent` router (which
+   * would answer a plain "ok, now do X" with a help list). We find the most recent session bound to the
+   * thread and, if it can be resumed, spawn a new governed run that `--resume`s the SAME claude
+   * transcript (context preserved), bound to the same thread so its `slack_reply` lands back in place.
+   *
+   * Returns the disposition so the socket can post the right ack:
+   *   - `resumed`: a continuation run started (sessionId set).
+   *   - `busy`:    the bound agent is still working the previous turn — the caller posts a "one sec" note
+   *                and drops this message (no overlapping run on the same thread).
+   *   - `none`:    nothing resumable is bound (first mention, or a pre-continuity run) — the caller falls
+   *                through to the normal fireSlack path (fresh spawn / router).
+   */
+  continueSlackThread(
+    event: { channel: string; threadTs: string; actorLabel: string; text: string; raw: unknown },
+    runAsMember?: string,
+  ): { status: 'resumed' | 'busy' | 'none'; sessionId?: string } {
+    if (!event.threadTs) return { status: 'none' };
+    const bound = this.tm.sessionForSlackThread(event.channel, event.threadTs);
+    if (!bound || !bound.claudeSessionId) return { status: 'none' }; // unbound or unresumable → fresh spawn
+    if (this.tm.isAlive(bound.sessionId)) return { status: 'busy' };  // still working the previous turn
+    // Continuation identity is whoever sent THIS follow-up (they're the accountable human for this turn),
+    // falling back to the original run-as when the sender is unmapped.
+    const runAs = runAsMember ?? bound.runAs;
+    const extra =
+      `Follow-up from ${event.actorLabel} in the SAME Slack thread — continue the conversation.\n` +
+      `Message:\n${event.text}\n\n` +
+      `Reply with the \`slack_reply\` tool when done (it posts back to this thread). Keep it concise.\n\n` +
+      `Event payload:\n${JSON.stringify(event.raw, null, 2).slice(0, MAX_PAYLOAD_CHARS)}`;
+    const s = this.tm.createSession(
+      bound.agent,
+      `Chat → ${bound.agent} (cont.)`,
+      extra,
+      `chat:${bound.agent}`,
+      true, // headless one-off, resuming the prior transcript
+      { channel: event.channel, threadTs: event.threadTs },
+      undefined,
+      runAs,
+      bound.claudeSessionId,
+    );
+    this.os.audit.append({
+      ts: Date.now(),
+      runId: s.id,
+      tenant: this.os.tenant,
+      principal: runAs ? `member:${runAs}` : 'chat',
+      type: 'chat.resumed',
+      data: { agent: bound.agent, from: bound.sessionId, channel: event.channel, thread: event.threadTs, runAs: runAs ?? null },
+    });
+    return { status: 'resumed', sessionId: s.id };
+  }
+
+  /**
    * Inbound native Discord message (Gateway; the bot was @-mentioned or DMed). The exact analogue of
    * `fireSlack`: fire every enabled `discord` automation whose `filter` matches the event type or
    * channel ('' / '*' = any). `runAsMember` runs the session AS that member; absent → the company

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -160,6 +160,31 @@ export class SlackSocket {
     // (and the `/agent` router prefix) starts clean, matching the Discord path.
     const text = (ev.text || '').replace(new RegExp(`^\\s*<@${this.botUserId}>\\s*`), '').trim();
 
+    // Thread continuity: if this message lands inside a thread already bound to a session, continue THAT
+    // conversation (resume the same agent + transcript) instead of treating it as a fresh trigger — so
+    // a plain "ok, now do X" in the thread keeps talking to the agent rather than hitting the /agent
+    // router's help list. Only the FIRST message in a thread (nothing bound yet) falls through below.
+    const cont = this.autos.continueSlackThread(
+      { channel: ev.channel, threadTs: ev.threadTs, actorLabel, text, raw: ev.raw },
+      runAsMember,
+    );
+    if (cont.status !== 'none') {
+      this.os.audit.append({
+        ts: Date.now(),
+        runId: cont.sessionId ?? '-',
+        tenant: this.os.tenant,
+        principal: runAsMember ? `member:${runAsMember}` : 'slack',
+        type: 'trigger.slack',
+        data: { eventType: ev.eventType, channel: ev.channel, thread: true, continued: cont.status, runAs: runAsMember ?? null },
+      });
+      const note =
+        cont.status === 'resumed'
+          ? ':robot_face: On it — continuing this thread.'
+          : ':hourglass_flowing_sand: Still working on your previous message — I’ll pick this up next.';
+      await postMessage(this.os.settings.slackBotToken(), ev.channel, note, ev.threadTs);
+      return;
+    }
+
     const result = this.autos.fireSlack(
       {
         eventType: ev.eventType,

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -470,6 +470,12 @@ function migrate(db: Db): void {
   // NULL → identity falls back to memberOf(spawned_by). Older rows predate it → NULL (no change).
   addColumn(db, 'term_sessions', 'run_as', 'TEXT');
 
+  // The claude conversation id we pin this run to (`claude --session-id`), so a later run can RESUME
+  // the SAME transcript (`claude --resume`) and keep context — the backbone of chat-thread continuity
+  // (a Slack/Discord follow-up in a bound thread continues the same conversation). NULL for older rows
+  // and non-claude runs → those can't be resumed and fall back to a fresh spawn.
+  addColumn(db, 'term_sessions', 'claude_session_id', 'TEXT');
+
   // Session status vocabulary widened: running|idle → running|done|stopped|crashed. Legacy terminal
   // rows collapsed every non-running end state into 'idle'; we can't retro-classify how they actually
   // ended, so map them to the benign 'done'. Idempotent — after the first boot there are no 'idle' rows.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -480,6 +480,26 @@ export class TerminalManager {
     if (!alive) return true; // launcher backend: can't poll; the row says running, so treat as alive
     return alive.has(r.tmux);
   }
+
+  /**
+   * The MOST RECENT session bound to a Slack thread (`channel` + `thread_ts`), for thread continuity:
+   * a follow-up message in a thread resumes THAT run's agent + claude conversation. Returns the agent,
+   * its run-as, and the pinned `claudeSessionId` needed to `--resume`. Undefined when nothing is bound
+   * (the first mention — the thread isn't bound yet) or the newest run predates the claude-id column
+   * (unresumable → the caller falls back to a fresh spawn).
+   */
+  sessionForSlackThread(channel: string, threadTs: string): { sessionId: string; agent: string; runAs?: string; claudeSessionId?: string } | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT t.id AS id, t.agent AS agent, t.run_as AS runAs, t.claude_session_id AS claudeSessionId
+           FROM slack_threads s JOIN term_sessions t ON t.id = s.session_id
+          WHERE s.channel = ? AND s.thread_ts = ?
+          ORDER BY t.created_at DESC LIMIT 1`,
+      )
+      .get<{ id: string; agent: string; runAs: string | null; claudeSessionId: string | null }>(channel, threadTs);
+    if (!row) return undefined;
+    return { sessionId: row.id, agent: row.agent, runAs: row.runAs ?? undefined, claudeSessionId: row.claudeSessionId ?? undefined };
+  }
   listMessages(viewer?: Member): FeedMessage[] {
     // Approval messages take their live status from the approvals table, so the inbox stays
     // correct even after a restart (when the in-memory resolution waiter is gone). We also pull each
@@ -612,9 +632,13 @@ export class TerminalManager {
    * the automations pile-up guard releases. Interactive (the default, e.g. manual spawns) opens a
    * normal attachable TUI that stays live until closed.
    */
-  createSession(agent: string, title: string, task: string, spawnedBy?: string, headless = false, slack?: { channel: string; threadTs: string }, discord?: { channel: string; messageId: string }, runAs?: string): Session {
+  createSession(agent: string, title: string, task: string, spawnedBy?: string, headless = false, slack?: { channel: string; threadTs: string }, discord?: { channel: string; messageId: string }, runAs?: string, resumeClaudeId?: string): Session {
     const id = randomUUID().slice(0, 8);
     const tmux = `aos-${id}`;
+    // The claude conversation this run drives. A fresh run mints a new id (pinned via `--session-id`);
+    // a thread follow-up passes the PRIOR run's id so the launcher `--resume`s the same transcript and
+    // keeps context. Persisted on the row so a later follow-up can look it up (see sessionForSlackThread).
+    const claudeSessionId = resumeClaudeId || randomUUID();
     // P2 — provenance vs identity:
     //   `spawnedBy`     = what TRIGGERED this run (an `automation:<id>` or the console member). Stays
     //                     provenance: drives the inbox source label, the audit principal, isolation
@@ -628,8 +652,8 @@ export class TerminalManager {
     const secret = randomBytes(24).toString('hex');
     const session: Session = { id, agent, title, task, tmux, status: 'running', createdAt: Date.now() };
     this.db
-      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
-      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, session.createdAt);
+      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, claudeSessionId, session.createdAt);
     // No spawn card — the Inbox is a feed of agent-authored signals (progress / questions / approvals /
     // completions / artifacts), not a session lifecycle log. A run that never speaks stays off the feed
     // and lives only on the Sessions page.
@@ -682,8 +706,12 @@ export class TerminalManager {
       if (tuning.permissionMode) env.CLAUDE_PERMISSION_MODE = tuning.permissionMode;
       this.audit(id, agent, 'session.tuning', { model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode });
       // A stable claude session id we choose (vs letting claude mint its own), so a stopped session
-      // can be resumed in-place with `claude --resume <id>` when the user reconnects in the browser.
-      env.CLAUDE_SESSION_ID = randomUUID();
+      // can be resumed in-place with `claude --resume <id>` when the user reconnects in the browser —
+      // and so a chat-thread follow-up can resume the SAME conversation. When `resumeClaudeId` is set
+      // (a thread follow-up), reuse the prior run's id and tell the launcher to `--resume` it; even the
+      // headless lane then continues the transcript instead of starting fresh.
+      env.CLAUDE_SESSION_ID = claudeSessionId;
+      if (resumeClaudeId) env.RESUME = '1';
 
       // The agent's opt-in shell secrets (vault keys → shell env vars, e.g. GH_TOKEN for `gh`). Done
       // here so both isolation lanes and the resurrect env file (writeEnvFile below) carry them.

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -215,7 +215,19 @@ if [ "${HEADLESS:-}" = "1" ]; then
   ( umask 077; : > "$LOG" ) 2>/dev/null || true
   dim "headless run — transcript → $LOG. This pane closes when the task completes."
   echo
-  claude -p "$TASK" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG"
+  # Pin the run to CLAUDE_SESSION_ID (`--session-id`) so a later chat-thread follow-up can `--resume`
+  # the SAME transcript and keep context. RESUME=1 (a thread follow-up) resumes it, seeding the new
+  # message as the next turn; if the resume fails (no persisted transcript) fall back to a fresh run so
+  # the user still gets an answer (context lost, but no dead end). No id set → mint-your-own as before.
+  if [ "${RESUME:-}" = "1" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+    dim "resuming claude session $CLAUDE_SESSION_ID (thread follow-up) …"
+    claude -p "$TASK" --resume "$CLAUDE_SESSION_ID" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG" \
+      || claude -p "$TASK" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG"
+  elif [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+    claude -p "$TASK" --session-id "$CLAUDE_SESSION_ID" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG"
+  else
+    claude -p "$TASK" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG"
+  fi
   notify_ended
   exit 0
 fi


### PR DESCRIPTION
## Problem
Talking **inside a Slack thread** didn't work. When you @mention the bot it spawns a session, binds the thread (`slack_threads`: session → channel + thread_ts), and replies in-thread. But that binding was **egress-only** — looked up by `session_id` to know where to post. A **reply in the thread** had no reverse path back to its session, so `dispatch → fireSlack` treated it as brand-new: with no `/agent` prefix it hit the `routeChat` help list ("👋 Address an agent with `/<agent>`…") instead of continuing the conversation.

## Fix — thread continuity
`SlackSocket.dispatch` now checks continuity **before** the normal trigger path:
- `Automations.continueSlackThread` finds the **newest** session bound to `(channel, thread_ts)` via `TerminalManager.sessionForSlackThread`.
- If resumable, it spawns a continuation run that **`claude --resume`s the SAME transcript** — full context preserved — bound to the same thread so `slack_reply` posts back in place. Ack: *"On it — continuing this thread."*
- If the bound agent is **still working** the previous turn (`isAlive`), the bot posts *"Still working on your previous message — I'll pick this up next"* and drops the duplicate (no overlapping runs on one thread).
- First message in a thread (nothing bound yet) falls through to the existing `fireSlack`/router path unchanged.

## Backbone
Headless chat/automation runs previously ran `claude -p` with **no** `--session-id`, so their claude conversation id was never captured — nothing to resume. Now they launch with `--session-id $CLAUDE_SESSION_ID`, persisted in a new **`term_sessions.claude_session_id`** column (NULL for older/non-claude rows → fresh-spawn fallback). `createSession` gains an optional `resumeClaudeId` that reuses the prior id and sets `RESUME=1`, and the launcher's headless lane resumes it (with a fresh-run fallback if the transcript is missing).

## Operational note
Plain in-thread replies only reach the socket if the Slack app subscribes to `message.channels` (and `message.groups`/`message.im`/`message.mpim` as needed) and the bot is in-channel. `app_mention` alone delivers only explicit @mentions. (Re-@mentioning in the thread also resumes, since its `thread_ts` matches the binding.)

## Verification
- `npm run typecheck`, `npm run build`, `cd web && npm run build` — clean.
- `npm run test:governance` — 44/44 ✓.
- Isolated DB test: new column present; `sessionForSlackThread` join returns the **newest** binding with correct `claude_session_id`/`run_as`; unbound thread → undefined.

Discord has the same gap (egress-only `discord_threads`); this PR scopes to Slack as reported — a Discord mirror can follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)