### PR TITLE
Slack: drop the thread-continuation ack + widen the in-app manifest (v0.55.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.56.1] — 2026-07-08
+### Changed
+- **No "On it — continuing this thread" ack on a Slack thread follow-up.** The continuation's own
+  `slack_reply` is the feedback; an "On it…" line before every answer was just noise in a back-and-forth.
+  The `busy` note (message deferred while the agent is still working the previous turn) still posts, since
+  there the user would otherwise see nothing.
+- **In-app Slack manifest now includes the `message.*` events.** Settings → Integrations → the Slack setup
+  manifest (and the create-from-manifest deep link) now requests `message.channels`/`message.groups`/
+  `message.im`/`message.mpim` plus the matching `*:history` scopes (and `channels:read`/`channels:join`/
+  `groups:read`/`im:write`) — so a **plain reply inside a thread** reaches the bot, not just @mentions.
+  The setup copy now reminds you to invite the bot to the channel (`message.channels` only fires where it's
+  a member). Existing apps: reinstall after adding the scopes/events.
+
 ## [0.56.0] — 2026-07-08
 ### Added
 - **Sort the sessions list by column.** The list (table) view's column headings — Session, Agent, ID,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.56.0",
+      "version": "0.56.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -177,11 +177,12 @@ export class SlackSocket {
         type: 'trigger.slack',
         data: { eventType: ev.eventType, channel: ev.channel, thread: true, continued: cont.status, runAs: runAsMember ?? null },
       });
-      const note =
-        cont.status === 'resumed'
-          ? ':robot_face: On it — continuing this thread.'
-          : ':hourglass_flowing_sand: Still working on your previous message — I’ll pick this up next.';
-      await postMessage(this.os.settings.slackBotToken(), ev.channel, note, ev.threadTs);
+      // No ack for a resumed turn — the agent's own `slack_reply` is the feedback, and an "On it…" line
+      // before every follow-up answer is just noise in a back-and-forth thread. Only the `busy` case
+      // posts a note, since there the message is deferred and the user would otherwise see nothing.
+      if (cont.status === 'busy') {
+        await postMessage(this.os.settings.slackBotToken(), ev.channel, ':hourglass_flowing_sand: Still working on your previous message — I’ll pick this up next.', ev.threadTs);
+      }
       return;
     }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2598,18 +2598,33 @@ function CopyBlock({ text, label = 'Copy' }: { text: string; label?: string }) {
 }
 
 // The Slack app manifest (JSON — https://docs.slack.dev/reference/app-manifest/). Enables Socket Mode
-// (no public URL), the bot scopes the OS needs, and the two events we route. Pasted into the manifest
+// (no public URL), the bot scopes the OS needs, and the events we route. Pasted into the manifest
 // editor, or pre-filled via the create-app deep link below (?new_app=1&manifest_json=…).
+//
+// The `message.*` events (+ their `*:history` scopes) are what let a plain in-thread reply reach the
+// bot — without them Slack only delivers explicit `app_mention`s, so a thread follow-up never arrives
+// and thread-continuity can't fire. `channels:read`/`groups:read` back channel-name lookup, `channels:join`
+// lets the bot auto-join a public channel to post, and `im:write` opens DMs.
 const SLACK_MANIFEST_OBJ = {
   display_information: { name: 'Agent OS' },
   features: { bot_user: { display_name: 'Agent OS', always_online: true } },
   oauth_config: {
     scopes: {
-      bot: ['app_mentions:read', 'chat:write', 'users:read', 'users:read.email', 'im:history', 'im:read'],
+      bot: [
+        'app_mentions:read',
+        'chat:write',
+        'channels:read', 'channels:join', 'channels:history',
+        'groups:read', 'groups:history',
+        'im:write', 'im:history',
+        'mpim:history',
+        'users:read', 'users:read.email',
+      ],
     },
   },
   settings: {
-    event_subscriptions: { bot_events: ['app_mention', 'message.im'] },
+    event_subscriptions: {
+      bot_events: ['app_mention', 'message.channels', 'message.groups', 'message.im', 'message.mpim'],
+    },
     interactivity: { is_enabled: false },
     socket_mode_enabled: true,
     token_rotation_enabled: false,
@@ -2656,8 +2671,10 @@ function SlackSetupGuide() {
             <li>The status badge above flips to <strong className="text-emerald-600">connected</strong> within a second or two. Then add a <strong>Slack message</strong> automation on the Automations page.</li>
           </ol>
           <p className="border-t pt-2">
-            The manifest already enables <strong>Socket Mode</strong> and subscribes to <code className="text-[11px]">app_mention</code> +
-            <code className="text-[11px]"> message.im</code> — nothing else to configure. No request URL or public endpoint is needed; the server dials out to Slack.
+            The manifest already enables <strong>Socket Mode</strong> and subscribes to <code className="text-[11px]">app_mention</code> plus the
+            <code className="text-[11px]"> message.*</code> events — so plain replies inside a thread reach the bot too (not just @mentions),
+            which is what lets it keep a conversation going. Remember to <strong>invite the bot to the channel</strong> — <code className="text-[11px]">message.channels</code> only
+            fires where it's a member. No request URL or public endpoint is needed; the server dials out to Slack.
           </p>
         </div>
       )}
@@ -6461,7 +6478,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
               className="font-mono text-xs"
             />
           </Field>
-          <Field label="Bot token" help="OAuth & Permissions → Bot User OAuth Token. Scopes: app_mentions:read, chat:write, users:read, users:read.email, im:history.">
+          <Field label="Bot token" help="OAuth & Permissions → Bot User OAuth Token. Scopes: app_mentions:read, chat:write, channels:read/join/history, groups:read/history, im:write/history, mpim:history, users:read, users:read.email.">
             <Input
               type="password"
               value={botTok}


### PR DESCRIPTION
Two quick follow-ups to the v0.54.0 Slack thread-continuity feature, both from live testing on the instawp deploy.

## 1. No "On it — continuing this thread." ack
A resumed turn used to post `:robot_face: On it — continuing this thread.` before the agent answered. In a back-and-forth thread that's two bot messages per turn — noise. The agent's own `slack_reply` **is** the feedback, so the resumed ack is dropped. The `busy` note (message deferred while the agent is still working the previous turn) still posts, since there the user would otherwise see nothing.

## 2. In-app Slack manifest now covers plain thread replies
Settings → Integrations → the Slack setup manifest (and the *Create Slack app* deep link) only requested `app_mention` + `message.im`, so a plain reply typed **inside a thread** never reached the bot — only @mentions did. Updated the manifest to request:
- **events:** `app_mention`, `message.channels`, `message.groups`, `message.im`, `message.mpim`
- **scopes:** added `channels:read/join/history`, `groups:read/history`, `im:write/history`, `mpim:history` (kept `app_mentions:read`, `chat:write`, `users:read`, `users:read.email`)

Setup copy now notes you must **invite the bot to the channel** (`message.channels` only fires where it's a member), and the bot-token scope hint matches. Existing apps: reinstall after adding scopes/events.

## Not in this PR
The bigger asks from the same session — **one Sessions entry per thread** and **keeping the session warm ~30 min for fast replies** — are a single redesign (a long-lived warm session per thread that follow-ups are fed into, rather than a cold `claude -p --resume` per reply). Tracking that separately.

## Verification
`npm run typecheck`, `npm run build`, `cd web && npm run build`, `npm run test:governance` (44/44) — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)