### PR TITLE
Sessions: add a sortable "Updated" column (last status change) (v0.57.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.57.0] — 2026-07-08
+### Added
+- **Sessions list: an "Updated" column you can sort by.** Sessions now track a `updated_at` timestamp
+  that bumps on every status transition (report / end / stop / resume / crash). The list view shows it
+  as a relative "Updated" column (e.g. "3m ago") that's sortable like the others, so you can surface
+  the most-recently-active runs, not just the newest-created. Persisted in the URL sort param; existing
+  rows backfill to their creation time.
+
 ## [0.56.1] — 2026-07-08
 ### Changed
 - **No "On it — continuing this thread" ack on a Slack thread follow-up.** The continuation's own

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.56.1",
+  "version": "0.57.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.56.1",
+      "version": "0.57.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.56.1",
+  "version": "0.57.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -476,6 +476,12 @@ function migrate(db: Db): void {
   // and non-claude runs → those can't be resumed and fall back to a fresh spawn.
   addColumn(db, 'term_sessions', 'claude_session_id', 'TEXT');
 
+  // Last-touched timestamp: bumped on every status transition (report/end/stop/resume/crash) so the
+  // sessions list can sort by recent activity, not just creation. Backfilled to created_at for existing
+  // rows; the UPDATE is idempotent (only touches NULLs) so it's a no-op after the first boot.
+  addColumn(db, 'term_sessions', 'updated_at', 'INTEGER');
+  db.exec('UPDATE term_sessions SET updated_at = created_at WHERE updated_at IS NULL');
+
   // Session status vocabulary widened: running|idle → running|done|stopped|crashed. Legacy terminal
   // rows collapsed every non-running end state into 'idle'; we can't retro-classify how they actually
   // ended, so map them to the benign 'done'. Idempotent — after the first boot there are no 'idle' rows.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -140,6 +140,9 @@ export interface Session {
    *  identity (e.g. a company-identity automation run). Drives the sessions-list Owner filter. */
   runAsLabel?: string;
   createdAt: number;
+  /** Last time the session's status changed (report/end/stop/resume/crash); = createdAt until the
+   *  first transition. Lets the sessions list sort by recent activity, not just creation. */
+  updatedAt: number;
 }
 
 export interface FeedMessage {
@@ -187,6 +190,7 @@ interface SessionRow {
   spawned_by: string | null;
   run_as: string | null;
   created_at: number;
+  updated_at: number;
 }
 interface MessageRow {
   id: string;
@@ -335,8 +339,10 @@ export class TerminalManager {
       const cutoff = Date.now() - 10_000;
       for (const r of rows) {
         if (r.status === 'running' && !alive.has(r.tmux) && r.created_at < cutoff) {
-          this.db.prepare("UPDATE term_sessions SET status = 'crashed' WHERE id = ?").run(r.id);
+          const crashedAt = Date.now();
+          this.db.prepare("UPDATE term_sessions SET status = 'crashed', updated_at = ? WHERE id = ?").run(crashedAt, r.id);
           r.status = 'crashed';
+          r.updated_at = crashedAt; // keep the in-memory row in sync so this same response isn't stale
           // A crash fires no end signal (no `report`/`markEnded`/`stopSession`), so this sweep is the
           // only place to capture what the run did before it died. Outcome 'crashed'; idempotent, so
           // repeated polls won't write twice; skipped if the session did no real work.
@@ -650,10 +656,10 @@ export class TerminalManager {
     // Per-session bearer (0d): exported into the session env and required on the loopback agent
     // endpoints, so one session's runtime can't gate/recall/report AS another by forging its id.
     const secret = randomBytes(24).toString('hex');
-    const session: Session = { id, agent, title, task, tmux, status: 'running', createdAt: Date.now() };
+    const session: Session = { id, agent, title, task, tmux, status: 'running', createdAt: Date.now(), updatedAt: Date.now() };
     this.db
-      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
-      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, claudeSessionId, session.createdAt);
+      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, claudeSessionId, session.createdAt, session.createdAt);
     // No spawn card — the Inbox is a feed of agent-authored signals (progress / questions / approvals /
     // completions / artifacts), not a session lifecycle log. A run that never speaks stays off the feed
     // and lives only on the Sessions page.
@@ -1377,8 +1383,8 @@ export class TerminalManager {
     // never persists one), so the agent's report is the reliable source. Skip when empty so a good
     // title isn't blanked.
     const aiTitle = titleFromSummary(summary);
-    if (aiTitle) this.db.prepare("UPDATE term_sessions SET title = ?, status = 'done' WHERE id = ?").run(aiTitle, sessionId);
-    else this.db.prepare("UPDATE term_sessions SET status = 'done' WHERE id = ?").run(sessionId);
+    if (aiTitle) this.db.prepare("UPDATE term_sessions SET title = ?, status = 'done', updated_at = ? WHERE id = ?").run(aiTitle, Date.now(), sessionId);
+    else this.db.prepare("UPDATE term_sessions SET status = 'done', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.audit(sessionId, agent, 'session.reported', { outcome, summary });
     // Deliberate semantic memory — the agent's note to its future self. Higher importance than an
     // auto-episode (0.7 vs 0.5), private to this agent (broadly-useful facts go via `remember` shared).
@@ -1490,7 +1496,7 @@ export class TerminalManager {
   markEnded(sessionId: string): void {
     const s = this.db.prepare('SELECT agent, status FROM term_sessions WHERE id = ?').get<{ agent: string; status: string }>(sessionId);
     if (!s) return;
-    if (s.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'done' WHERE id = ?").run(sessionId);
+    if (s.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'done', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.clearNotifications(sessionId);
     // Distil the session into one durable memory for the agent — the `report` (a 'completed' card) has
     // already landed by now if the agent left one, so writeEpisode prefers it; otherwise it summarises
@@ -1507,7 +1513,7 @@ export class TerminalManager {
   markResumed(sessionId: string): void {
     const s = this.db.prepare('SELECT agent, status FROM term_sessions WHERE id = ?').get<{ agent: string; status: string }>(sessionId);
     if (!s || s.status === 'running') return;
-    this.db.prepare("UPDATE term_sessions SET status = 'running' WHERE id = ?").run(sessionId);
+    this.db.prepare("UPDATE term_sessions SET status = 'running', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     // No "Resumed" card — reconnecting is lifecycle noise, not something the operator needs in the feed.
     this.audit(sessionId, s.agent, 'session.resumed', {});
   }
@@ -1561,7 +1567,7 @@ export class TerminalManager {
     const r = this.db.prepare('SELECT agent, tmux, status, spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ agent: string; tmux: string; status: string; spawned_by: string | null; run_as: string | null }>(sessionId);
     if (!r) return false;
     this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
-    if (r.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'stopped' WHERE id = ?").run(sessionId);
+    if (r.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.clearNotifications(sessionId);
     // Halting kills the tmux shell, so the launcher's `markEnded` never fires — capture the episode
     // here instead so the work done (the audit stream) is remembered. Outcome 'stopped'; skipped if the
@@ -1787,7 +1793,7 @@ function titleFromSummary(summary: string): string {
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, createdAt: r.created_at };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -72,9 +72,9 @@ const SESSION_SOURCE_LABELS: Record<'all' | SessionSource, string> =
   { all: 'All sources', member: 'Member', automation: 'Automation', task: 'Task', chat: 'Chat' }
 
 /** Sortable columns of the sessions list. `created` is the default (newest first — the server order). */
-type SessionSortKey = 'created' | 'title' | 'agent' | 'id' | 'startedBy' | 'status'
+type SessionSortKey = 'created' | 'title' | 'agent' | 'id' | 'startedBy' | 'status' | 'updated'
 type SortDir = 'asc' | 'desc'
-const SESSION_SORT_KEYS: SessionSortKey[] = ['created', 'title', 'agent', 'id', 'startedBy', 'status']
+const SESSION_SORT_KEYS: SessionSortKey[] = ['created', 'title', 'agent', 'id', 'startedBy', 'status', 'updated']
 /** Status ordering for the Status-column sort: live → done → stopped → crashed. */
 const statusRank = (s: Session): number =>
   isLive(s) ? 0 : s.status === 'done' ? 1 : s.status === 'stopped' ? 2 : s.status === 'crashed' ? 3 : 4
@@ -87,6 +87,7 @@ const compareSessions = (a: Session, b: Session, key: SessionSortKey): number =>
     case 'id': return a.id.localeCompare(b.id)
     case 'startedBy': return (a.spawnedByLabel ?? '').localeCompare(b.spawnedByLabel ?? '')
     case 'status': return statusRank(a) - statusRank(b)
+    case 'updated': return a.updatedAt - b.updatedAt
   }
 }
 
@@ -1725,6 +1726,7 @@ function SessionsPage({
               {sortHead('agent', 'Agent', 'hidden w-32 shrink-0 sm:flex')}
               {sortHead('id', 'ID', 'hidden w-20 shrink-0 md:flex')}
               {sortHead('startedBy', 'Started by', 'w-40 shrink-0')}
+              {sortHead('updated', 'Updated', 'w-20 shrink-0')}
               {sortHead('status', 'Status', 'w-16 shrink-0')}
             </div>
             <span className="w-32 shrink-0" aria-hidden />
@@ -1745,6 +1747,7 @@ function SessionsPage({
                 <span className="hidden w-32 shrink-0 truncate text-xs text-muted-foreground sm:block">{s.agent}</span>
                 <span className="hidden w-20 shrink-0 truncate font-mono text-xs text-muted-foreground md:block" title={s.id}>{s.id}</span>
                 <StartedBy label={s.spawnedByLabel} className="w-40 shrink-0" />
+                <span className="w-20 shrink-0 text-xs tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
                 <span className="w-16 shrink-0 text-xs text-muted-foreground">{statusLabel(s)}</span>
               </button>
               <div className="flex w-32 shrink-0 items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -126,6 +126,9 @@ export interface Session {
    *  identity. Drives the sessions-list Owner filter. */
   runAsLabel?: string
   createdAt: number
+  /** Last time the session's status changed (report/end/stop/resume/crash); = createdAt until the
+   *  first transition. Sortable "Updated" column on the sessions list. */
+  updatedAt: number
 }
 export interface AuditEvent {
   id: number


### PR DESCRIPTION
## What

Sessions only tracked `created_at`, so the list could sort by creation but not by **recent activity**. This adds a **last-updated** timestamp and surfaces it as a sortable column.

- New `updated_at` column on `term_sessions` (migration; existing rows **backfill to `created_at`**, idempotent).
- Bumped on **every status transition** — `report` / `markEnded` / `stopSession` / `markResumed`, and the liveness-sweep **crash** path.
- Exposed as `updatedAt` on the session API; shown in the **list view** as a relative **"Updated"** column ("3m ago"), **sortable** like the others and **persisted in the URL** sort param.

## Verify

Drove the running console + API against a seeded scratch DB:

- migration adds the column; API returns `updatedAt` distinct from `createdAt`
- **status-transition bump**: a running session stopped via `POST /api/sessions/:id/stop` → `updatedAt` jumped from an old value to ≈now
- caught + fixed a staleness bug: the crash sweep bumped the DB but not the in-memory row, so `toSession` returned a stale `updatedAt` that same response — now syncs `r.updated_at`
- UI: "Updated" column renders "22s ago / 3m ago / 10m ago", sorts both directions (order flips correctly), reload of `?sort=updated` restores order + caret

Server build + web build clean; governance 44/44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)