### PR TITLE
Sessions: show the updated time on grid cards too (v0.58.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.58.0] — 2026-07-08
+### Added
+- **Sessions grid view shows the last-updated time too.** Each card now displays its relative "updated
+  N ago" next to who started it, matching the list view's Updated column (which was already there).
+
 ## [0.57.0] — 2026-07-08
 ### Added
 - **Sessions list: an "Updated" column you can sort by.** Sessions now track a `updated_at` timestamp

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.57.0",
+      "version": "0.58.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1692,7 +1692,10 @@ function SessionsPage({
                   {waiting.has(s.id) && <WaitingBell className="h-3.5 w-3.5" />}
                 </div>
                 <div className="mt-1 truncate text-xs text-muted-foreground">{s.agent} · {statusLabel(s)} · <span className="font-mono">{s.id}</span></div>
-                <div className="mt-1"><StartedBy label={s.spawnedByLabel} /></div>
+                <div className="mt-1 flex items-center justify-between gap-2">
+                  <StartedBy label={s.spawnedByLabel} />
+                  <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
+                </div>
               </button>
               <div className="mt-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                 {canResume(s) && (


### PR DESCRIPTION
## What

The "Updated" recency lived only in the list view's column. This adds the same relative **"updated N ago"** to each **grid card**, on the started-by row (right-aligned opposite who started it), so recency is visible in both layouts.

## Verify

Drove the grid view in Chromium against a seeded scratch DB (3 sessions with distinct `updated_at`) — cards showed "17s ago / 2m ago / 42s ago", aligned opposite the StartedBy label. Web build clean; governance 44/44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)