### PR TITLE
Slack: warm resident thread sessions — one session/thread, fast follow-ups (v0.57.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.59.0] — 2026-07-08
+### Added
+- **Warm, resident Slack thread sessions — one session per thread, fast follow-ups.** A Slack thread now
+  runs a single long-lived agent session kept alive between turns, instead of cold-starting a fresh
+  `claude -p` (and a new Sessions row) for every reply. The first message spawns an interactive claude that
+  stays warm; each follow-up is **delivered by typing into the running session** (tmux send-keys) — no
+  reload of MCP servers / transcript, so replies come back fast. It stays **one row per thread** (no more
+  new entry per reply), and the session is attachable from the console like any other. Unattended, so it
+  runs with `--dangerously-skip-permissions` — the PreToolUse gate hook still governs every side effect.
+- **Configurable idle keep-alive (default 30 min).** Settings → Integrations → "Keep Slack threads warm
+  for N minutes". An idle reaper frees the held claude after the window; a later reply **revives the same
+  row**, resuming the transcript (context preserved) and seeded with the new message. `0` disables
+  residence (every reply cold-starts). Backed by new `term_sessions.resident` / `last_activity` columns.
+- **Meaningful session titles for Slack/Discord threads.** A thread session is now titled from the first
+  message (e.g. "why is pod X down?") instead of a generic "Chat → agent".
+### Changed
+- Thread continuity no longer spawns a per-reply run; `continueSlackThread` **delivers** to the live
+  session or **revives** the reaped one. (Discord threads still cold-spawn per message for now.)
+
 ## [0.58.0] — 2026-07-08
 ### Added
 - **Sessions grid view shows the last-updated time too.** Each card now displays its relative "updated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.58.0",
+      "version": "0.59.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -193,6 +193,15 @@ export type FireResult =
 
 const MAX_PAYLOAD_CHARS = 4000; // keep webhook payloads from flooding the task prompt
 
+/** A concise, human session title from a chat message — the meaningful label for a Slack/Discord thread
+ *  session (vs a generic "Chat → agent"). Strips a leading `/agent` prefix + mention tokens, collapses
+ *  whitespace, and trims to ~60 chars. Falls back to "Chat → <agent>" when the message is empty. */
+export function chatTitle(text: string, agentId: string): string {
+  const clean = (text || '').replace(/^\s*\/[A-Za-z0-9][\w-]*\s*/, '').replace(/<@[^>]+>/g, '').replace(/\s+/g, ' ').trim();
+  if (!clean) return `Chat → ${agentId}`;
+  return clean.length > 60 ? `${clean.slice(0, 59).trimEnd()}…` : clean;
+}
+
 // Bounds for agent-scheduled one-shot tasks (`type: 'once'`). A scheduled run is a time-shift of work
 // the agent is already authorized to do, so it needs no fresh approval — but it is bounded so an agent
 // can't schedule into the far future or pile up unbounded pending runs.
@@ -443,16 +452,21 @@ export class Automations {
   private spawnChatAgent(
     agentId: string,
     task: string,
-    opts: { runAs?: string; slack?: { channel: string; threadTs: string }; discord?: { channel: string; messageId: string } },
+    opts: { runAs?: string; slack?: { channel: string; threadTs: string }; discord?: { channel: string; messageId: string }; title?: string; resident?: boolean },
   ): FireResult {
-    const s = this.tm.createSession(agentId, `Chat → ${agentId}`, task, `chat:${agentId}`, true, opts.slack, opts.discord, opts.runAs);
+    // `resident` (Slack chat) → a warm interactive session (headless off) kept alive for fast follow-ups;
+    // otherwise the classic one-shot headless run. `title` is the meaningful, message-derived label.
+    const s = this.tm.createSession(
+      agentId, opts.title || `Chat → ${agentId}`, task, `chat:${agentId}`,
+      !opts.resident, opts.slack, opts.discord, opts.runAs, undefined, !!opts.resident,
+    );
     this.os.audit.append({
       ts: Date.now(),
       runId: s.id,
       tenant: this.os.tenant,
       principal: opts.runAs ? `member:${opts.runAs}` : 'chat',
       type: 'chat.routed',
-      data: { agent: agentId, runAs: opts.runAs ?? null, channel: opts.slack?.channel ?? opts.discord?.channel ?? null },
+      data: { agent: agentId, runAs: opts.runAs ?? null, channel: opts.slack?.channel ?? opts.discord?.channel ?? null, resident: !!opts.resident },
     });
     return { ok: true, sessionId: s.id, tmux: s.tmux };
   }
@@ -524,7 +538,7 @@ export class Automations {
     if (sessions.length === 0 && this.os.settings.chatRouterEnabled()) {
       const routed = this.routeChat(event.text);
       if (routed.agentId) {
-        const r = this.spawnChatAgent(routed.agentId, extra, { runAs: runAsMember, slack: { channel: event.channel, threadTs: event.threadTs } });
+        const r = this.spawnChatAgent(routed.agentId, extra, { runAs: runAsMember, slack: { channel: event.channel, threadTs: event.threadTs }, title: chatTitle(event.text, routed.agentId), resident: true });
         if (r.ok) sessions.push(r.sessionId);
       } else {
         reply = routed.help;
@@ -534,55 +548,51 @@ export class Automations {
   }
 
   /**
-   * Thread continuity: a follow-up message inside a Slack thread already bound to a session should
-   * CONTINUE that conversation with the same agent — not re-run the automation/`/agent` router (which
-   * would answer a plain "ok, now do X" with a help list). We find the most recent session bound to the
-   * thread and, if it can be resumed, spawn a new governed run that `--resume`s the SAME claude
-   * transcript (context preserved), bound to the same thread so its `slack_reply` lands back in place.
-   *
-   * Returns the disposition so the socket can post the right ack:
-   *   - `resumed`: a continuation run started (sessionId set).
-   *   - `busy`:    the bound agent is still working the previous turn — the caller posts a "one sec" note
-   *                and drops this message (no overlapping run on the same thread).
-   *   - `none`:    nothing resumable is bound (first mention, or a pre-continuity run) — the caller falls
-   *                through to the normal fireSlack path (fresh spawn / router).
+   * Thread continuity: a follow-up message inside a Slack thread already bound to a session CONTINUES
+   * that conversation with the same agent — not the `/agent` router (which would answer a plain "ok, now
+   * do X" with a help list). We keep ONE warm resident session per thread:
+   *   - **delivered**: the session is live → type the message straight into the running claude (send-keys).
+   *     Fast (no cold reload), and no new Sessions row.
+   *   - **revived**:   the session was reaped/ended (idle) → revive the SAME row, `--resume`ing the claude
+   *     transcript, seeded with the message. Still one row per thread; context preserved.
+   *   - **none**:      nothing resumable is bound (the first message in a thread) → the caller falls through
+   *     to the normal fireSlack path (fresh spawn / router).
+   * The socket posts no ack — the agent's own `slack_reply` is the feedback.
    */
   continueSlackThread(
     event: { channel: string; threadTs: string; actorLabel: string; text: string; raw: unknown },
     runAsMember?: string,
-  ): { status: 'resumed' | 'busy' | 'none'; sessionId?: string } {
+  ): { status: 'delivered' | 'revived' | 'none'; sessionId?: string } {
     if (!event.threadTs) return { status: 'none' };
     const bound = this.tm.sessionForSlackThread(event.channel, event.threadTs);
-    if (!bound || !bound.claudeSessionId) return { status: 'none' }; // unbound or unresumable → fresh spawn
-    if (this.tm.isAlive(bound.sessionId)) return { status: 'busy' };  // still working the previous turn
-    // Continuation identity is whoever sent THIS follow-up (they're the accountable human for this turn),
-    // falling back to the original run-as when the sender is unmapped.
+    if (!bound || !bound.claudeSessionId) return { status: 'none' }; // unbound / unresumable → fresh spawn
+    // Continuation identity is whoever sent THIS follow-up (accountable human for this turn), falling back
+    // to the original run-as when the sender is unmapped.
     const runAs = runAsMember ?? bound.runAs;
-    const extra =
-      `Follow-up from ${event.actorLabel} in the SAME Slack thread — continue the conversation.\n` +
-      `Message:\n${event.text}\n\n` +
-      `Reply with the \`slack_reply\` tool when done (it posts back to this thread). Keep it concise.\n\n` +
-      `Event payload:\n${JSON.stringify(event.raw, null, 2).slice(0, MAX_PAYLOAD_CHARS)}`;
-    const s = this.tm.createSession(
-      bound.agent,
-      `Chat → ${bound.agent} (cont.)`,
-      extra,
-      `chat:${bound.agent}`,
-      true, // headless one-off, resuming the prior transcript
-      { channel: event.channel, threadTs: event.threadTs },
-      undefined,
-      runAs,
-      bound.claudeSessionId,
-    );
-    this.os.audit.append({
-      ts: Date.now(),
-      runId: s.id,
-      tenant: this.os.tenant,
-      principal: runAs ? `member:${runAs}` : 'chat',
-      type: 'chat.resumed',
-      data: { agent: bound.agent, from: bound.sessionId, channel: event.channel, thread: event.threadTs, runAs: runAs ?? null },
+    // The delivered message goes straight into a live TUI — strip a leading `/agent` (a re-mention) so
+    // claude doesn't see it as a slash command, and drop mention tokens.
+    const msg = this.stripChatPrefix(event.text);
+    if (!msg) return { status: 'none' };
+    const emit = (mode: 'delivered' | 'revived') => this.os.audit.append({
+      ts: Date.now(), runId: bound.sessionId, tenant: this.os.tenant,
+      principal: runAs ? `member:${runAs}` : 'chat', type: 'chat.continued',
+      data: { mode, agent: bound.agent, session: bound.sessionId, channel: event.channel, thread: event.threadTs, runAs: runAs ?? null },
     });
-    return { status: 'resumed', sessionId: s.id };
+    // Warm path: live resident session → deliver by typing into it.
+    if (this.tm.deliverToResident(bound.sessionId, msg)) { emit('delivered'); return { status: 'delivered', sessionId: bound.sessionId }; }
+    // Cold path: reaped/ended → revive the SAME row (resume transcript, seeded with the message).
+    if (this.tm.reviveResident(bound.sessionId, msg, runAs)) { emit('revived'); return { status: 'revived', sessionId: bound.sessionId }; }
+    return { status: 'none' };
+  }
+
+  /** Strip a leading `/agent` router prefix (only when it names a known agent) and any `<@…>` mention
+   *  tokens from a follow-up before it's typed into a live claude — so a re-mention doesn't land as a
+   *  slash command. Returns the cleaned message (never undefined). */
+  private stripChatPrefix(text: string): string {
+    const t = (text || '').replace(/<@[^>]+>/g, '').trim();
+    const m = t.match(/^\/([A-Za-z0-9][\w-]*)\s+([\s\S]*)$/);
+    if (m && this.os.agents.has(m[1])) return m[2].trim();
+    return t;
   }
 
   /**
@@ -614,7 +624,7 @@ export class Automations {
     if (sessions.length === 0 && this.os.settings.chatRouterEnabled()) {
       const routed = this.routeChat(event.text);
       if (routed.agentId) {
-        const r = this.spawnChatAgent(routed.agentId, extra, { runAs: runAsMember, discord: { channel: event.channel, messageId: event.messageId } });
+        const r = this.spawnChatAgent(routed.agentId, extra, { runAs: runAsMember, discord: { channel: event.channel, messageId: event.messageId }, title: chatTitle(event.text, routed.agentId) });
         if (r.ok) sessions.push(r.sessionId);
       } else {
         reply = routed.help;

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -169,6 +169,8 @@ export class SlackSocket {
       runAsMember,
     );
     if (cont.status !== 'none') {
+      // Handled by the thread's warm session — delivered into the live claude, or revived it. No ack:
+      // the agent's own `slack_reply` is the feedback (continueSlackThread already audited the turn).
       this.os.audit.append({
         ts: Date.now(),
         runId: cont.sessionId ?? '-',
@@ -177,12 +179,6 @@ export class SlackSocket {
         type: 'trigger.slack',
         data: { eventType: ev.eventType, channel: ev.channel, thread: true, continued: cont.status, runAs: runAsMember ?? null },
       });
-      // No ack for a resumed turn — the agent's own `slack_reply` is the feedback, and an "On it…" line
-      // before every follow-up answer is just noise in a back-and-forth thread. Only the `busy` case
-      // posts a note, since there the message is deferred and the user would otherwise see nothing.
-      if (cont.status === 'busy') {
-        await postMessage(this.os.settings.slackBotToken(), ev.channel, ':hourglass_flowing_sand: Still working on your previous message — I’ll pick this up next.', ev.threadTs);
-      }
       return;
     }
 

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -43,6 +43,7 @@ export const DEFAULT_GOVERNANCE_THRESHOLDS: GovernanceThresholds = { moneyCapUsd
 
 const EMAIL_ORG_DOMAINS_KEY = 'email_org_domains'; // internal email domains (JSON string[]); email.send to these is green
 const CHAT_ROUTER_KEY = 'chat_router_enabled'; // generic Slack/Discord `/agent` router fallback ('off' disables)
+const CHAT_IDLE_MIN_KEY = 'chat_idle_timeout_min'; // resident (warm) chat session idle-kill, minutes
 const KILL_SWITCH_KEY = 'kill_switch'; // workspace-wide emergency stop (JSON KillSwitchState)
 
 /** The workspace emergency stop. When engaged, the gate denies EVERY action, fleet-wide, until cleared. */
@@ -420,6 +421,23 @@ export class SettingsStore {
   setChatRouterEnabled(on: boolean, by?: string): boolean {
     this.set(CHAT_ROUTER_KEY, on ? 'on' : 'off', by);
     return this.chatRouterEnabled();
+  }
+
+  /** How long a resident (warm) Slack/Discord thread session is kept alive after its last turn before
+   *  the idle reaper kills it. Default 30 min; clamped to a sane 1 min–24 h. 0 disables residence
+   *  (every reply cold-starts) — an escape hatch, not the default. */
+  chatIdleTimeoutMinutes(): number {
+    const n = Number(this.getRow(CHAT_IDLE_MIN_KEY)?.value);
+    if (!Number.isFinite(n)) return 30; // unset → default
+    if (n <= 0) return 0;               // explicit 0 → residence off
+    return Math.min(Math.max(Math.round(n), 1), 24 * 60);
+  }
+
+  setChatIdleTimeoutMinutes(minutes: number, by?: string): number {
+    const n = Number(minutes);
+    const clamped = !Number.isFinite(n) || n < 0 ? 30 : n === 0 ? 0 : Math.min(Math.max(Math.round(n), 1), 24 * 60);
+    this.set(CHAT_IDLE_MIN_KEY, String(clamped), by);
+    return this.chatIdleTimeoutMinutes();
   }
 
   // ── kill switch (workspace emergency stop) ───────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -207,7 +207,10 @@ export function startServer(port = Number(process.env.PORT) || 3010): http.Serve
 
   // Shared, process-wide upkeep timers — each fans out across every tenant runtime.
   // Idle GC (A5): reclaim idle members' uids/ttyds. No-op under the local backend, so always-on is safe.
-  const reaper = setInterval(() => registry.forEach((rt) => { try { rt.tm.reapIdleSpaces(); } catch { /* never let the sweep crash */ } }), 60_000);
+  const reaper = setInterval(() => registry.forEach((rt) => {
+    try { rt.tm.reapIdleSpaces(); } catch { /* never let the sweep crash */ }
+    try { rt.tm.reapIdleResidents(); } catch { /* warm-chat idle reaper — never let it crash the sweep */ }
+  }), 60_000);
   reaper.unref?.();
   // Memory upkeep + self-learning: hourly check per tenant; each is a no-op unless that tenant opted in.
   const lastMaint = new Map<string, number>();
@@ -2130,6 +2133,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (discordTouched && discord) void discord.restart();
     // Generic `/agent` chat router toggle (Slack + Discord fallback when no automation matches).
     if (typeof b.chatRouter === 'boolean') os.settings.setChatRouterEnabled(b.chatRouter, me.email);
+    // Warm (resident) Slack thread session idle-kill, minutes (0 = disable residence → cold replies).
+    if (b.chatIdleTimeoutMin !== undefined && Number.isFinite(Number(b.chatIdleTimeoutMin))) os.settings.setChatIdleTimeoutMinutes(Number(b.chatIdleTimeoutMin), me.email);
     return sendJson(res, 200, { ok: true, removedSlackAutomations, removedDiscordAutomations, ...integrationsView(os) });
   }
   // Live Slack Socket-Mode connection status (owner/admin) — for the Integrations panel.
@@ -3044,6 +3049,7 @@ function integrationsView(os: AgentOS): {
   slack: { appToken: boolean; botToken: boolean; configured: boolean };
   discord: { botToken: boolean; configured: boolean };
   chatRouter: boolean;
+  chatIdleTimeoutMin: number;
   updatedAt?: number;
   updatedBy?: string;
 } {
@@ -3056,6 +3062,7 @@ function integrationsView(os: AgentOS): {
     slack: { appToken: slack.appToken, botToken: slack.botToken, configured: os.settings.slackConfigured() },
     discord: { botToken: discord.botToken, configured: os.settings.discordConfigured() },
     chatRouter: os.settings.chatRouterEnabled(),
+    chatIdleTimeoutMin: os.settings.chatIdleTimeoutMinutes(),
     updatedAt: meta.updatedAt,
     updatedBy: meta.updatedBy,
   };

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -482,6 +482,15 @@ function migrate(db: Db): void {
   addColumn(db, 'term_sessions', 'updated_at', 'INTEGER');
   db.exec('UPDATE term_sessions SET updated_at = created_at WHERE updated_at IS NULL');
 
+  // Resident (warm) chat session: an INTERACTIVE claude kept alive after it answers so a thread
+  // follow-up is delivered by typing into it (tmux send-keys) — fast, and one session row per thread
+  // instead of a fresh cold run per reply. The idle reaper kills these after the configured timeout.
+  // 0 for normal one-shot runs.
+  addColumn(db, 'term_sessions', 'resident', 'INTEGER NOT NULL DEFAULT 0');
+  // Last time a resident session saw a turn (spawn or a delivered follow-up) — the idle-reaper clock.
+  // NULL for non-resident rows (never reaped on idle).
+  addColumn(db, 'term_sessions', 'last_activity', 'INTEGER');
+
   // Session status vocabulary widened: running|idle → running|done|stopped|crashed. Legacy terminal
   // rows collapsed every non-running end state into 'idle'; we can't retro-classify how they actually
   // ended, so map them to the benign 'done'. Idempotent — after the first boot there are no 'idle' rows.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -638,7 +638,7 @@ export class TerminalManager {
    * the automations pile-up guard releases. Interactive (the default, e.g. manual spawns) opens a
    * normal attachable TUI that stays live until closed.
    */
-  createSession(agent: string, title: string, task: string, spawnedBy?: string, headless = false, slack?: { channel: string; threadTs: string }, discord?: { channel: string; messageId: string }, runAs?: string, resumeClaudeId?: string): Session {
+  createSession(agent: string, title: string, task: string, spawnedBy?: string, headless = false, slack?: { channel: string; threadTs: string }, discord?: { channel: string; messageId: string }, runAs?: string, resumeClaudeId?: string, resident = false): Session {
     const id = randomUUID().slice(0, 8);
     const tmux = `aos-${id}`;
     // The claude conversation this run drives. A fresh run mints a new id (pinned via `--session-id`);
@@ -658,8 +658,8 @@ export class TerminalManager {
     const secret = randomBytes(24).toString('hex');
     const session: Session = { id, agent, title, task, tmux, status: 'running', createdAt: Date.now(), updatedAt: Date.now() };
     this.db
-      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
-      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, claudeSessionId, session.createdAt, session.createdAt);
+      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, resident, last_activity, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, claudeSessionId, resident ? 1 : 0, resident ? session.createdAt : null, session.createdAt, session.createdAt);
     // No spawn card — the Inbox is a feed of agent-authored signals (progress / questions / approvals /
     // completions / artifacts), not a session lifecycle log. A run that never speaks stays off the feed
     // and lives only on the Sessions page.
@@ -682,68 +682,140 @@ export class TerminalManager {
     const runtime = manifest?.runtime ?? 'mock';
     // Audit records BOTH provenance and the run-as principal — when they differ (a trigger acting as
     // a member), the trail shows what fired it AND whose identity it used.
-    this.audit(id, agent, 'session.created', { tmux, task, runtime, dir: manifest?.dir, headless, spawnedBy: spawnedBy ?? null, runAs: actingMember ?? null });
+    this.audit(id, agent, 'session.created', { tmux, task, runtime, dir: manifest?.dir, headless, resident, spawnedBy: spawnedBy ?? null, runAs: actingMember ?? null });
 
     if (runtime === 'claude-code' && manifest?.dir) {
-      // Real claude in the agent's own folder, governed by the gate hook. Memory and connectors
-      // are delivered PURELY as MCP tools (recall/remember) via the per-session `.mcp.json` — the
-      // orchestrator injects nothing into the prompt. When/whether to recall or remember is the
-      // agent's own decision, guided by its CLAUDE.md and the tools' own descriptions.
-      const env = this.sessionEnv(id, agent, task, secret);
-      // Build the per-session connector + company payloads once (Composio is minted here).
-      const mcpJson = this.buildMcpConfigJson(id, agent, actingMember, secret, !!slack?.channel, !!discord?.channel);
-      const companyMd = this.buildCompanyMd(agent);
-      this.materializeSkills(id, agent, manifest.dir);
-      if (headless) env.HEADLESS = '1';
-      env.AGENT_DIR = manifest.dir;
-      env.HOOK = this.hook;
-      // No OS sandbox env: the gate hook (PreToolUse) is the sole authority for governed side effects
-      // (it emits an authoritative permissionDecision per Bash/write/connector call, which bypasses
-      // Claude's own permission engine), so we don't wrap the shell in Seatbelt/bubblewrap. Real OS
-      // containment, where wanted, is the Linux uid-isolation path.
-      // Per-agent model / effort / permission-mode, each falling back to the workspace default. The
-      // launcher (claude-launch.sh) turns these into `--model` / `--effort` / `--permission-mode`
-      // (permission-mode on the INTERACTIVE lane only — headless keeps --dangerously-skip-permissions;
-      // it only tunes the fallback for tools the gate hook doesn't decide, and defaults to `auto`).
-      // Resolved here (not in bash) so the resume env file captures the exact values a reconnect re-uses.
-      const tuning = resolveRuntimeTuning(manifest, this.os.settings.runtimeDefaults());
-      if (tuning.model) env.CLAUDE_MODEL = tuning.model;
-      if (tuning.effort) env.CLAUDE_EFFORT = tuning.effort;
-      if (tuning.permissionMode) env.CLAUDE_PERMISSION_MODE = tuning.permissionMode;
-      this.audit(id, agent, 'session.tuning', { model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode });
-      // A stable claude session id we choose (vs letting claude mint its own), so a stopped session
-      // can be resumed in-place with `claude --resume <id>` when the user reconnects in the browser —
-      // and so a chat-thread follow-up can resume the SAME conversation. When `resumeClaudeId` is set
-      // (a thread follow-up), reuse the prior run's id and tell the launcher to `--resume` it; even the
-      // headless lane then continues the transcript instead of starting fresh.
-      env.CLAUDE_SESSION_ID = claudeSessionId;
-      if (resumeClaudeId) env.RESUME = '1';
-
-      // The agent's opt-in shell secrets (vault keys → shell env vars, e.g. GH_TOKEN for `gh`). Done
-      // here so both isolation lanes and the resurrect env file (writeEnvFile below) carry them.
-      this.injectShellSecrets(env, agent, manifest, id);
-
-      if (this.uidIsolation) {
-        // Flag on: the launcher writes the files INTO the member's home (member-readable), copies the
-        // agent dir to a per-member working copy (AGENT_DIR override), and sets MCP_CONFIG/COMPANY_FILE/
-        // LOG_DIR itself — the app dir is unreadable/unwritable by the member uid.
-        this.backend.spawn(this.spaceFor(actingMember ?? spawnedBy), { sessionId: id, agent, tmuxName: tmux, env, argv: ['bash', this.launcher], files: { mcp: mcpJson || undefined, company: companyMd || undefined }, agentSrc: manifest.dir });
-      } else {
-        // Flag off: materialise into the app's connectors dir (the session runs as the app uid, so it
-        // can read them), set the env, and persist the launch context so the ttyd attach wrapper can
-        // resurrect a dead session (terminal/attach.sh). Headless automation runs aren't resumable.
-        const mcpFile = this.writeSessionFile(id, 'mcp.json', mcpJson);
-        if (mcpFile) env.MCP_CONFIG = mcpFile;
-        const companyFile = this.writeSessionFile(id, 'company.md', companyMd);
-        if (companyFile) env.COMPANY_FILE = companyFile;
-        if (headless) env.LOG_DIR = this.os.paths?.connectors ?? '/tmp';
-        if (!headless) this.writeEnvFile(id, env);
-        this.backend.spawn(this.spaceFor(actingMember ?? spawnedBy), { sessionId: id, agent, tmuxName: tmux, env, argv: ['bash', this.launcher] });
-      }
+      this.launchClaudeCode({ id, agent, task, secret, actingMember, spawnedBy, hasSlack: !!slack?.channel, hasDiscord: !!discord?.channel, headless, resident, resume: !!resumeClaudeId, claudeSessionId });
     } else {
       this.backend.spawn(this.spaceFor(actingMember ?? spawnedBy), { sessionId: id, agent, tmuxName: tmux, env: this.sessionEnv(id, agent, task, secret), argv: ['bash', this.runner] });
     }
     return session;
+  }
+
+  /**
+   * Spawn the claude-code runtime for a session row (in its agent folder, governed by the gate hook).
+   * Factored out of `createSession` so `reviveResident` can re-launch the SAME row (same id/tmux/secret/
+   * claude id) after the warm session was reaped — with `resume: true` it continues the transcript.
+   * Memory + connectors are delivered purely as MCP tools via the per-session `.mcp.json`; the
+   * orchestrator injects nothing into the prompt.
+   */
+  private launchClaudeCode(o: {
+    id: string; agent: string; task: string; secret: string;
+    actingMember?: string; spawnedBy?: string; hasSlack: boolean; hasDiscord: boolean;
+    headless: boolean; resident: boolean; resume: boolean; claudeSessionId: string;
+  }): void {
+    const manifest = this.os.agents.get(o.agent);
+    if (!manifest?.dir) return;
+    const tmux = `aos-${o.id}`;
+    const env = this.sessionEnv(o.id, o.agent, o.task, o.secret);
+    // Build the per-session connector + company payloads once (Composio is minted here).
+    const mcpJson = this.buildMcpConfigJson(o.id, o.agent, o.actingMember, o.secret, o.hasSlack, o.hasDiscord);
+    const companyMd = this.buildCompanyMd(o.agent);
+    this.materializeSkills(o.id, o.agent, manifest.dir);
+    if (o.headless) env.HEADLESS = '1';
+    // Resident (warm) chat session: the launcher's RESIDENT lane keeps an interactive claude alive so
+    // thread follow-ups are delivered by send-keys (see deliverToResident / reviveResident).
+    if (o.resident) env.RESIDENT = '1';
+    env.AGENT_DIR = manifest.dir;
+    env.HOOK = this.hook;
+    // No OS sandbox env: the gate hook (PreToolUse) is the sole authority for governed side effects, so
+    // we don't wrap the shell in Seatbelt/bubblewrap. Real OS containment is the Linux uid-isolation path.
+    // Per-agent model / effort / permission-mode fall back to the workspace default; the launcher maps
+    // them onto `--model`/`--effort`/`--permission-mode` (permission-mode on the interactive lane only).
+    const tuning = resolveRuntimeTuning(manifest, this.os.settings.runtimeDefaults());
+    if (tuning.model) env.CLAUDE_MODEL = tuning.model;
+    if (tuning.effort) env.CLAUDE_EFFORT = tuning.effort;
+    if (tuning.permissionMode) env.CLAUDE_PERMISSION_MODE = tuning.permissionMode;
+    this.audit(o.id, o.agent, 'session.tuning', { model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode });
+    // A stable claude session id we choose (vs letting claude mint its own), so a stopped session can be
+    // resumed in-place with `claude --resume <id>`. `resume` continues that transcript (a thread
+    // follow-up or a console reconnect) instead of starting fresh.
+    env.CLAUDE_SESSION_ID = o.claudeSessionId;
+    if (o.resume) env.RESUME = '1';
+    // The agent's opt-in shell secrets (vault keys → shell env vars, e.g. GH_TOKEN for `gh`).
+    this.injectShellSecrets(env, o.agent, manifest, o.id);
+    if (this.uidIsolation) {
+      // Flag on: the launcher writes the files INTO the member's home and sets MCP_CONFIG/COMPANY_FILE itself.
+      this.backend.spawn(this.spaceFor(o.actingMember ?? o.spawnedBy), { sessionId: o.id, agent: o.agent, tmuxName: tmux, env, argv: ['bash', this.launcher], files: { mcp: mcpJson || undefined, company: companyMd || undefined }, agentSrc: manifest.dir });
+    } else {
+      // Flag off: materialise into the app's connectors dir and persist the launch context so the ttyd
+      // attach wrapper can resurrect a dead session. Headless automation runs write no resurrect env.
+      const mcpFile = this.writeSessionFile(o.id, 'mcp.json', mcpJson);
+      if (mcpFile) env.MCP_CONFIG = mcpFile;
+      const companyFile = this.writeSessionFile(o.id, 'company.md', companyMd);
+      if (companyFile) env.COMPANY_FILE = companyFile;
+      if (o.headless) env.LOG_DIR = this.os.paths?.connectors ?? '/tmp';
+      if (!o.headless) this.writeEnvFile(o.id, env);
+      this.backend.spawn(this.spaceFor(o.actingMember ?? o.spawnedBy), { sessionId: o.id, agent: o.agent, tmuxName: tmux, env, argv: ['bash', this.launcher] });
+    }
+  }
+
+  /**
+   * Deliver a thread follow-up to a LIVE resident chat session by typing it into the running claude
+   * (tmux send-keys) — the warm, fast path (no cold reload). Bumps the idle clock. Returns false when
+   * the session isn't a live resident or the keystrokes couldn't be delivered (caller then revives).
+   */
+  deliverToResident(sessionId: string, text: string): boolean {
+    const row = this.db.prepare('SELECT tmux, status, resident, run_as, spawned_by FROM term_sessions WHERE id = ?')
+      .get<{ tmux: string; status: string; resident: number; run_as: string | null; spawned_by: string | null }>(sessionId);
+    if (!row || !row.resident || row.status !== 'running') return false;
+    if (!this.isAlive(sessionId)) return false;
+    const body = (text || '').replace(/\r?\n+/g, ' ').trim(); // one-line: a stray newline would submit early
+    if (!body) return false;
+    const ok = this.backend.injectText(this.spaceFor(row.run_as ?? row.spawned_by), row.tmux, body, true);
+    if (ok) {
+      this.db.prepare('UPDATE term_sessions SET last_activity = ?, updated_at = ? WHERE id = ?').run(Date.now(), Date.now(), sessionId);
+      const agent = this.sessionAgent(sessionId) ?? '';
+      this.audit(sessionId, agent, 'chat.delivered', { chars: body.length });
+    }
+    return ok;
+  }
+
+  /**
+   * Revive a reaped/ended resident chat session IN PLACE: flip the row back to running and re-launch the
+   * claude-code runtime under the SAME id/tmux/claude-session, resuming the transcript and seeded with the
+   * new message. Keeps ONE session row per thread across idle gaps (no new list entry). Returns false if
+   * the session can't be revived (unknown, still alive, or non-resumable).
+   */
+  reviveResident(sessionId: string, text: string, runAs?: string): boolean {
+    const row = this.db.prepare('SELECT agent, secret, claude_session_id, run_as, spawned_by, status FROM term_sessions WHERE id = ?')
+      .get<{ agent: string; secret: string | null; claude_session_id: string | null; run_as: string | null; spawned_by: string | null; status: string }>(sessionId);
+    if (!row || !row.claude_session_id) return false;
+    if (this.isAlive(sessionId)) return false; // caller should have delivered instead
+    const body = (text || '').trim();
+    if (!body) return false;
+    const actingMember = runAs ?? row.run_as ?? undefined;
+    const hasSlack = !!this.db.prepare('SELECT 1 FROM slack_threads WHERE session_id = ?').get(sessionId);
+    const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
+    this.db.prepare("UPDATE term_sessions SET status = 'running', resident = 1, task = ?, run_as = ?, last_activity = ?, updated_at = ? WHERE id = ?")
+      .run(body, actingMember ?? row.run_as ?? null, Date.now(), Date.now(), sessionId);
+    this.audit(sessionId, row.agent, 'chat.revived', { runAs: actingMember ?? null });
+    this.launchClaudeCode({
+      id: sessionId, agent: row.agent, task: body, secret: row.secret ?? randomBytes(24).toString('hex'),
+      actingMember, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord,
+      headless: false, resident: true, resume: true, claudeSessionId: row.claude_session_id,
+    });
+    return true;
+  }
+
+  /**
+   * Idle reaper: kill resident (warm) chat sessions whose last turn was longer ago than the configured
+   * timeout (Settings → Integrations; default 30 min). Frees the held claude process + MCP servers; the
+   * thread's row stays (status → stopped) so a later reply revives it. `timeoutMin = 0` disables residence
+   * → reap everything resident. Run from the process-wide 60s sweep in server.ts. Never throws.
+   */
+  reapIdleResidents(): void {
+    const timeoutMin = this.os.settings.chatIdleTimeoutMinutes();
+    const cutoff = timeoutMin > 0 ? Date.now() - timeoutMin * 60_000 : Date.now() + 1; // 0 → reap all now
+    const rows = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent FROM term_sessions WHERE resident = 1 AND status = 'running' AND COALESCE(last_activity, created_at) < ?")
+      .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string }>(cutoff);
+    for (const r of rows) {
+      try {
+        this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
+        this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), r.id);
+        this.audit(r.id, r.agent, 'chat.reaped', { idleMin: timeoutMin });
+      } catch { /* one bad row must not stop the sweep */ }
+    }
   }
 
   /** `{ AOS_URL, SESSION, AGENT, TASK_B64, AOS_SECRET }` — the base env every runner/launcher inherits. */

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -232,9 +232,36 @@ if [ "${HEADLESS:-}" = "1" ]; then
   exit 0
 fi
 
-# INTERACTIVE lane only (the headless branch above already exited). Add the permission mode here — NOT
-# in COMMON_ARGS — so it never touches the headless `-p --dangerously-skip-permissions` run. Defaults to
-# `auto` if the env is unset (e.g. resuming a session launched before this knob existed).
+if [ "${RESIDENT:-}" = "1" ]; then
+  # RESIDENT (warm chat) lane: an INTERACTIVE claude that STAYS ALIVE after it answers, so a Slack/Discord
+  # thread follow-up is delivered by typing into this very pane (tmux send-keys) — fast, no cold reload of
+  # MCP servers / transcript. Unattended (no human to answer prompts), so --dangerously-skip-permissions —
+  # the SAME PreToolUse gate hook still runs and still BLOCKS risky Bash for inbox approval under the flag.
+  # Seeded with the first message ($TASK); RESUME=1 continues a prior transcript, still seeded with the new
+  # message. The OS keeps it warm and the idle reaper kills it after the configured timeout. On an abnormal
+  # exit (crash/quit) the pane just ends → the row goes done and the next follow-up revives it fresh (no
+  # ungoverned holding shell, matching the interactive lane's security stance).
+  export CLAUDE_CODE_NO_FLICKER=1
+  export CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1
+  RES_ARGS=(--dangerously-skip-permissions "${COMMON_ARGS[@]}")
+  dim "resident warm chat session — unattended (gate hook still governs); kept warm for fast follow-ups"
+  echo
+  if [ "${RESUME:-}" = "1" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+    notify_resumed
+    claude --resume "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" "$TASK" \
+      || claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" "$TASK"
+  elif [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+    claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" "$TASK"
+  else
+    claude "${RES_ARGS[@]}" "$TASK"
+  fi
+  notify_ended
+  exit 0
+fi
+
+# INTERACTIVE lane only (the headless/resident branches above already exited). Add the permission mode
+# here — NOT in COMMON_ARGS — so it never touches the headless `-p --dangerously-skip-permissions` run.
+# Defaults to `auto` if the env is unset (e.g. resuming a session launched before this knob existed).
 COMMON_ARGS+=(--permission-mode "${CLAUDE_PERMISSION_MODE:-auto}")
 dim "permission mode: ${CLAUDE_PERMISSION_MODE:-auto} (gate hook still governs every side effect)"
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6348,6 +6348,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
   const [discord, setDiscord] = useState<IntegrationsResp['discord']>({ botToken: false, configured: false })
   const [discordState, setDiscordState] = useState<DiscordStatus | null>(null)
   const [chatRouter, setChatRouter] = useState(true)
+  const [chatIdle, setChatIdle] = useState(30)
   const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
   const [key, setKey] = useState('')
   const [wh, setWh] = useState('')
@@ -6367,6 +6368,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
     setSlack(r.slack ?? SLACK_DEFAULT)
     setDiscord(r.discord ?? DISCORD_DEFAULT)
     if (typeof r.chatRouter === 'boolean') setChatRouter(r.chatRouter)
+    if (typeof r.chatIdleTimeoutMin === 'number') setChatIdle(r.chatIdleTimeoutMin)
     setMeta({ updatedAt: r.updatedAt, updatedBy: r.updatedBy })
   }
   const loadStatus = () => {
@@ -6381,7 +6383,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
     loadStatus()
   }, [])
 
-  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; chatRouter?: boolean }, label: string) => {
+  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }, label: string) => {
     setBusy(true); setHint('')
     const r = await api.saveIntegrations(body)
     setBusy(false)
@@ -6542,6 +6544,29 @@ function IntegrationsSettings({ me }: { me: Member }) {
               help list of available agents. Runs go through the same gate + run-as as everything else. No per-agent automation needed.
             </span>
           </label>
+
+          {/* Warm (resident) Slack thread session: how long to keep a thread's claude alive between turns
+              so follow-ups reply fast. The idle reaper kills it after this many minutes; a later reply
+              revives it (context preserved). 0 disables residence (every reply cold-starts). */}
+          <div className="flex flex-wrap items-center gap-2 rounded-md border bg-muted/20 p-3 text-xs">
+            <span className="font-medium text-foreground">Keep Slack threads warm for</span>
+            <Input
+              type="number"
+              min={0}
+              max={1440}
+              value={chatIdle}
+              disabled={busy}
+              onChange={(e) => setChatIdle(Number(e.target.value))}
+              onBlur={() => save({ chatIdleTimeoutMin: chatIdle }, 'warm-thread timeout saved')}
+              className="h-7 w-20 text-xs"
+            />
+            <span>minutes.</span>
+            <span className="text-muted-foreground">
+              A Slack thread keeps ONE live agent session this long between messages, so follow-ups reply fast (no
+              cold reload). After the idle window it's reaped; the next reply revives it with full context. <code className="text-[11px]">0</code> = off (every reply cold-starts).
+            </span>
+          </div>
+
           <DiscordSetupGuide />
           <Field label="Bot token" help="Discord Developer Portal → your app → Bot → Reset/Copy Token. Enable the MESSAGE CONTENT privileged intent on the same page.">
             <Input

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -567,6 +567,8 @@ export interface IntegrationsResp {
   discord: { botToken: boolean; configured: boolean }
   /** Generic `/agent` chat router: when on, an unmatched Slack/Discord message reaches any agent by name. */
   chatRouter: boolean
+  /** Warm (resident) Slack thread session idle-kill, minutes. 0 = residence off (every reply cold-starts). */
+  chatIdleTimeoutMin: number
   updatedAt?: number
   updatedBy?: string
   error?: string
@@ -804,7 +806,7 @@ export const api = {
   disconnectApp: (body: { id: string; scope: 'company' | 'personal' }) =>
     call<{ ok?: boolean; error?: string }>('POST', '/api/connections/disconnect', body),
   integrations: () => call<IntegrationsResp>('GET', '/api/settings/integrations'),
-  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; chatRouter?: boolean }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
+  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
   slackStatus: () => call<SlackStatus>('GET', '/api/settings/slack/status'),
   discordStatus: () => call<DiscordStatus>('GET', '/api/settings/discord/status'),
 


### PR DESCRIPTION
Redesigns Slack thread continuity from live testing feedback: replies were slow (each turn cold-started `claude -p --resume`, reloading MCP servers + transcript), every reply created a **new Sessions row**, and thread sessions had generic titles.

## Now: one warm, resident session per thread
- **First mention** spawns an *interactive* claude via a new **RESIDENT launcher lane** that stays alive after it answers. Unattended → `--dangerously-skip-permissions`; the PreToolUse gate hook still governs every side effect (risky Bash still blocks for approval).
- **Follow-up** is **delivered into the running session** by typing it in (`tmux send-keys`, via the existing `injectText` used for image paths) — no reload, so it replies fast. **One row per thread**, attachable from the console like any session.
- **Idle keep-alive**, configurable (default **30 min**, Settings → Integrations → "Keep Slack threads warm for N minutes"). An idle reaper frees the held claude; a later reply **revives the same row**, `--resume`ing the transcript (context preserved) seeded with the new message. `0` disables residence (cold every reply).
- **Meaningful titles**: a thread session is titled from the first message (e.g. "why is pod X down?") instead of "Chat → agent".

## Shape
- `term_sessions.resident` + `last_activity` columns; `settings.chat_idle_timeout_min`.
- `createSession(..., resident)`; extracted `TerminalManager.launchClaudeCode` so revive re-launches the same row; new `deliverToResident` / `reviveResident` / `reapIdleResidents` (wired into the existing process-wide 60s sweep in `server.ts`).
- `continueSlackThread` now **delivers** (live) or **revives** (reaped) instead of spawning a per-reply run; no ack (the agent's `slack_reply` is the feedback). A leading `/agent` re-mention is stripped before it's typed in (so it isn't seen as a slash command).
- Settings API + web field.

## Scope / follow-ups
- **Discord** threads still cold-spawn per message (no continuity/residence yet) — a mirror can follow.
- Residence is scoped to the Slack `/agent` chat-router path; configured `slack` automations stay one-shot headless.

## Verification
- `npm run typecheck`, `npm run build`, `cd web && npm run build`, `npm run test:governance` (44/44) — all clean.
- `bash -n` on the launcher; isolated DB test confirms the reaper selects exactly the idle *resident + running* rows (not fresh, not non-resident, not stopped), and the migration adds both columns.
- `claude --resume <id> "<prompt>"` verified to seed a new prompt while preserving context (basis for revive/first-turn seeding).
- Full end-to-end Slack test on the instawp droplet after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)