### PR TITLE
Tasks: board UX, due dates, and drawer polish (v0.60.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.60.0] — 2026-07-09
+### Added
+- **Tasks board — a real board, not a form.** The Tasks page gains drag-and-drop between columns (drop a
+  card to change its status), a **Board ⇄ List** view toggle (the list is sortable by priority / due date /
+  updated), and a **filter bar**: My tasks / All, by assignee, by label, by priority, and an **Overdue**
+  quick filter. Priority now shows as a colored left edge on each card, and the board **auto-refreshes**
+  (~5s) so an agent closing its own loop moves the card without a manual reload.
+- **Task due dates end-to-end.** A task can carry a soft deadline: set it on the create form or in the
+  detail drawer (and via the `task_create`/`task_update` MCP tools with a `due` ISO date). Cards and list
+  rows show a relative badge ("Due today", "3d overdue") with amber/red tone. When a task passes its
+  deadline and is still open, the scheduler DMs its owner **once** on their linked Slack/Discord account
+  (owner-less → owner/admins), audited `task.overdue` / `task.overdue.notified`.
+- **Drawer polish.** The task body now renders as **markdown** and the title + body are **inline-editable**;
+  assignees, owners, and activity authors show **real member names** (and agents by name) instead of raw
+  ids; tasks can be assigned to **humans**, not only agents; and deleting a task now takes a **confirm**.
+
 ## [0.59.0] — 2026-07-08
 ### Added
 - **Warm, resident Slack thread sessions — one session per thread, fast follow-ups.** A Slack thread now

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -30,11 +30,11 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `list_capabilities` | `GET /api/agent/policy` | policy preview | R | |
 | `policy_check` | `POST /api/agent/policy/check` | policy preview | R | dry-run, no side effects |
 | `directory_lookup` | `GET /api/agent/directory` | `TeamStore` | R | people + their chat identities |
-| `task_create` | `POST /api/tasks/create` | `TaskStore.create` | W | files a unit of work; author `agent:<id>`; owner = run-as (delegation passthrough); `mode` headless/interactive for the dispatched run |
+| `task_create` | `POST /api/tasks/create` | `TaskStore.create` | W | files a unit of work; author `agent:<id>`; owner = run-as (delegation passthrough); `mode` headless/interactive for the dispatched run; optional `due` (ISO date) soft deadline |
 | `task_list` | `GET /api/tasks/list` | `TaskStore.list` | R | `assignee:"me"` → self; board query/FTS |
 | `task_get` | `GET /api/tasks/get` | `TaskStore.withEvents` | R | task + full activity timeline |
 | `task_claim` | `POST /api/tasks/claim` | `TaskStore.claim` | W | atomic take (→ doing); loses if already claimed |
-| `task_update` | `POST /api/tasks/update` | `TaskStore.update` | W | status/note/reassign; closes a dispatched loop |
+| `task_update` | `POST /api/tasks/update` | `TaskStore.update` | W | status/note/reassign/reprioritise/`due` (ISO date, or "" to clear); closes a dispatched loop |
 | `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
 | `agent_update` | `POST /api/agents/update` | `AgentOS.registerAgent` + `AgentRevisions.commit` | W | **self-only** (edits the caller's OWN manifest/CLAUDE.md — a body `id` must equal the session's agent); user-home agents only; snapshots a revision; audited `agent.config.updated` |
 | `agent_history` | `POST /api/agents/history` | `AgentRevisions.list` | R | the caller's own listing revisions (rev/author/summary/date), newest first |

--- a/docs/tasks-plan.md
+++ b/docs/tasks-plan.md
@@ -476,6 +476,16 @@ session spawned and the pile-up guard blocks a second). **Isolate `AGENT_OS_HOME
 
 ## 9. Future (not v1)
 
+> **Update (2026-07-09, v0.60.0): board UX + due dates shipped.** The "Richer board" and part of
+> "Dependencies & scheduling" below are now real: the console board has drag-and-drop, a Board⇄List toggle,
+> a filter bar (My/assignee/label/priority/overdue), a per-member "my tasks" lens, rendered-markdown +
+> inline-editable bodies, real member/agent names, and human assignees. **Due dates** are wired end-to-end
+> — `due_at` set on create/edit and via `task_create`/`task_update` (`due` ISO date), relative due/overdue
+> badges, list sort-by-due, and a scheduler **overdue sweep** that DMs the task owner once (owner-less →
+> owner/admins; audited `task.overdue` / `task.overdue.notified`). Still open below: **blocked_by
+> dependencies**, projects/epics/swimlanes, a burndown, pool auto-assignment, agent-triggered dispatch,
+> the policy brake, and the recurring-task Automation.
+
 - **Pool auto-assignment.** Route unassigned `auto_dispatch` tasks to a workspace **default worker agent**
   (or a small pool), so a human can drop tasks on the board with no assignee and the fleet picks them up.
   This is the agent-spawns-agent frontier Automations also parks — needs a concurrency budget + a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.59.0",
+      "version": "0.60.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -12,6 +12,7 @@ import { randomBytes, randomUUID } from 'crypto';
 import { AgentOS } from '../kernel';
 import { Db } from '../state/db';
 import { TerminalManager } from '../terminal';
+import { Task } from '../types';
 
 // ── minimal cron (5 fields: minute hour day-of-month month day-of-week) ──────────
 // Supports: * , a-b , */n , a-b/n , lists. dow 0-7 (7 ≡ 0 = Sunday).
@@ -237,6 +238,10 @@ export class Automations {
   ) {
     this.db = os.db;
   }
+
+  /** Best-effort sink DMed once when a task passes its due date (wired in the tenant registry). */
+  private overdueNotifier?: (task: Task) => void;
+  setOverdueNotifier(fn: (task: Task) => void): void { this.overdueNotifier = fn; }
 
   // ── CRUD ───────────────────────────────────────────────────────────────────────
   list(): Automation[] {
@@ -673,6 +678,25 @@ export class Automations {
       this.fire(a, { guard: true });
     }
     this.dispatchTasks();
+    this.sweepOverdue(now);
+  }
+
+  /**
+   * The deadline half of the tick: DM the owner of each newly-overdue task, exactly once. The once-guard
+   * lives in the DB (`markOverdueNotified`), so a restart never re-alarms. Wrapped so a bad row never
+   * kills the scheduler; a no-op when no overdue notifier is wired.
+   */
+  private sweepOverdue(now: Date): void {
+    if (!this.overdueNotifier) return;
+    try {
+      for (const t of this.os.tasks.overdue(this.os.tenant, now.getTime())) {
+        if (!this.os.tasks.markOverdueNotified(t.id)) continue;
+        this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'system', type: 'task.overdue', data: { id: t.id, title: t.title, dueAt: t.dueAt ?? null } });
+        try { this.overdueNotifier(t); } catch { /* notifier best-effort */ }
+      }
+    } catch {
+      // never let the overdue sweep take down the automation scheduler
+    }
   }
 
   /**

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -524,6 +524,7 @@ const TOOLS = [
         parentId: { type: 'string', description: 'Parent task id, to file this as a sub-task.' },
         autoDispatch: { type: 'boolean', description: 'If true and assigned to an agent, the board auto-spawns a session to work it. Default false.' },
         mode: { type: 'string', enum: ['headless', 'interactive'], description: 'How a dispatched session runs: "headless" (default — works to completion then exits) or "interactive" (an attachable TUI a human drives).' },
+        due: { type: 'string', description: 'Optional soft deadline as an ISO date, e.g. "2026-07-15" or "2026-07-15T17:00:00Z".' },
       },
       required: ['title'],
     },
@@ -588,6 +589,7 @@ const TOOLS = [
         assignee: { type: 'string', description: 'Reassign: "agent:<id>", a member id, "me", or null to unassign.' },
         priority: { type: 'number', minimum: 0, maximum: 3, description: '0 urgent … 3 low.' },
         labels: { type: 'array', items: { type: 'string' }, description: 'Replace the label set.' },
+        due: { type: 'string', description: 'Set a soft deadline as an ISO date (e.g. "2026-07-15"), or "" / null to clear it.' },
       },
       required: ['id'],
     },
@@ -1100,6 +1102,14 @@ async function unschedule(args: Record<string, unknown>): Promise<string> {
 interface TaskLite { id: string; title: string; status: string; priority: number; assignee?: string; labels?: string[]; body?: string }
 interface TaskEventLite { kind: string; body?: string; author: string; createdAt: number }
 
+/** Parse an agent-supplied `due` (ISO date/datetime) → epoch ms. '' / null → null (clear). undefined → undefined (leave). */
+function parseDue(due: unknown): number | null | undefined {
+  if (due === undefined) return undefined;
+  if (due === null || (typeof due === 'string' && !due.trim())) return null;
+  const ms = Date.parse(String(due));
+  return Number.isFinite(ms) ? ms : undefined;
+}
+
 async function taskCreate(args: Record<string, unknown>): Promise<string> {
   const title = String(args.title ?? '').trim();
   if (!title) return 'A task needs a title.';
@@ -1115,6 +1125,7 @@ async function taskCreate(args: Record<string, unknown>): Promise<string> {
       parentId: args.parentId !== undefined ? String(args.parentId) : undefined,
       autoDispatch: args.autoDispatch === true,
       mode: args.mode === 'interactive' ? 'interactive' : undefined,
+      dueAt: parseDue(args.due),
     }),
   });
   const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
@@ -1295,6 +1306,7 @@ async function taskUpdate(args: Record<string, unknown>): Promise<string> {
       assignee: args.assignee === null ? null : (args.assignee !== undefined ? String(args.assignee) : undefined),
       priority: typeof args.priority === 'number' ? args.priority : undefined,
       labels: Array.isArray(args.labels) ? args.labels.map(String) : undefined,
+      dueAt: parseDue(args.due),
     }),
   });
   const d = (await res.json()) as { ok?: boolean; task?: TaskLite; error?: string };

--- a/src/server.ts
+++ b/src/server.ts
@@ -877,6 +877,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         parentId: typeof b.parentId === 'string' ? b.parentId : undefined,
         mode: b.mode === 'interactive' ? 'interactive' : 'headless',
         autoDispatch: b.autoDispatch === true || b.autoDispatch === 'true',
+        dueAt: typeof b.dueAt === 'number' && Number.isFinite(b.dueAt) ? b.dueAt : undefined,
         createdBy: `agent:${agent}`,
       });
       os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: 'task.created', data: { id: task.id, title: task.title, assignee: task.assignee ?? null } });
@@ -932,6 +933,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       priority: typeof b.priority === 'number' ? b.priority : undefined,
       labels: Array.isArray(b.labels) ? b.labels.map(String) : undefined,
       mode: b.mode === 'headless' || b.mode === 'interactive' ? b.mode : undefined,
+      dueAt: b.dueAt === null ? null : (typeof b.dueAt === 'number' && Number.isFinite(b.dueAt) ? b.dueAt : undefined),
       note: typeof b.note === 'string' ? b.note : undefined,
       by: `agent:${agent}`,
     });
@@ -1587,6 +1589,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         parentId: typeof b.parentId === 'string' ? b.parentId : undefined,
         mode: b.mode === 'interactive' ? 'interactive' : 'headless',
         autoDispatch: b.autoDispatch === true,
+        dueAt: typeof b.dueAt === 'number' && Number.isFinite(b.dueAt) ? b.dueAt : undefined,
         createdBy: me.id,
       });
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'task.created', data: { id: task.id, title: task.title, assignee: task.assignee ?? null } });
@@ -1601,11 +1604,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (taskId && method === 'PATCH') {
     const b = await readBody(req);
     const task = os.tasks.update(taskId[1], {
+      title: typeof b.title === 'string' ? b.title : undefined,
+      body: typeof b.body === 'string' ? b.body : undefined,
       status: typeof b.status === 'string' ? (b.status as TaskStatus) : undefined,
       assignee: b.assignee === null ? null : (typeof b.assignee === 'string' ? b.assignee : undefined),
       priority: typeof b.priority === 'number' ? b.priority : undefined,
       labels: Array.isArray(b.labels) ? b.labels.map(String) : undefined,
       mode: b.mode === 'headless' || b.mode === 'interactive' ? b.mode : undefined,
+      dueAt: b.dueAt === null ? null : (typeof b.dueAt === 'number' && Number.isFinite(b.dueAt) ? b.dueAt : undefined),
       note: typeof b.note === 'string' ? b.note : undefined,
       by: me.id,
     });

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -34,6 +34,8 @@ interface EventRow {
 
 const TERMINAL: ReadonlySet<TaskStatus> = new Set<TaskStatus>(['done', 'cancelled']);
 const STATUSES: readonly TaskStatus[] = ['todo', 'doing', 'blocked', 'done', 'cancelled'];
+/** Sentinel body for the one-time "went overdue" event that dedupes the overdue notification. */
+const OVERDUE_MARK = '⏰ went overdue';
 
 export class TaskStore {
   constructor(private readonly db: Db) {}
@@ -117,6 +119,16 @@ export class TaskStore {
     const sets: string[] = [];
     const vals: unknown[] = [];
 
+    if (input.title !== undefined && input.title.trim() && input.title.trim() !== t.title) {
+      sets.push('title = ?'); vals.push(input.title.trim());
+    }
+    if (input.body !== undefined && input.body !== t.body) {
+      sets.push('body = ?'); vals.push(input.body);
+    }
+    if (input.dueAt !== undefined && (input.dueAt ?? null) !== (t.dueAt ?? null)) {
+      sets.push('due_at = ?'); vals.push(input.dueAt ?? null);
+      this.addEvent(id, 'status', input.dueAt ? `due ${new Date(input.dueAt).toISOString().slice(0, 10)}` : 'due date cleared', input.by);
+    }
     if (input.status && input.status !== t.status && STATUSES.includes(input.status)) {
       sets.push('status = ?'); vals.push(input.status);
       this.addEvent(id, 'status', `${t.status}→${input.status}`, input.by);
@@ -184,6 +196,28 @@ export class TaskStore {
       if (r.status in out) out[r.status] = r.n;
     }
     return out;
+  }
+
+  /** Open tasks past their due date — the source for the overdue notification sweep. Soonest-due first. */
+  overdue(tenant: string, now: number): Task[] {
+    return this.db
+      .prepare(`SELECT * FROM tasks WHERE tenant = ? AND due_at IS NOT NULL AND due_at < ?
+                 AND status NOT IN ('done','cancelled') ORDER BY due_at`)
+      .all<TaskRow>(tenant, now)
+      .map(toTask);
+  }
+
+  /**
+   * Record a one-time overdue marker in the activity log; returns true only the FIRST time so the sweep
+   * DMs the owner exactly once (not every tick). The marker also shows in the timeline as "went overdue".
+   */
+  markOverdueNotified(id: string): boolean {
+    const existing = this.db
+      .prepare(`SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'status' AND body = ? LIMIT 1`)
+      .get<{ 1: number }>(id, OVERDUE_MARK);
+    if (existing) return false;
+    this.addEvent(id, 'status', OVERDUE_MARK, 'system');
+    return true;
   }
 
   /** Tasks eligible for auto-dispatch: todo, assigned to an agent, auto_dispatch on. Priority-first. */

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -18,7 +18,7 @@ import { TerminalManager, ApprovalNotice, QuestionNotice } from './terminal';
 import { Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
-import { canApprove } from './types';
+import { canApprove, Task } from './types';
 import { controlHome, resolvePaths, resolveTenantPaths } from './home';
 import { TenantRecord, TenantStore } from './state/control';
 
@@ -193,6 +193,9 @@ export class TenantRegistry {
     // Chat loop: mirror completions/questions/approvals back to the Slack/Discord thread a chat-triggered
     // run is bound to. Both replies no-op when the session has no bound thread (non-chat runs).
     tm.setChatMirror((sessionId, text) => { void slack.reply(sessionId, text); void discord.reply(sessionId, text); });
+    // Deadline notifications: when a task passes its due date, DM its owner (the human it runs as) once,
+    // so a missed deadline surfaces off the board. Owner-less → owner/admins. Mirrors the question path.
+    autos.setOverdueNotifier((task) => { void notifyTaskOverdue(os, slack, discord, task); });
     const ttyd = launchTtyd(paths.tmuxSocket, ttydPort, paths.connectors);
     console.log(`  [tenant:${rec.slug}] home=${paths.home}  ttyd=:${ttydPort}`);
     return { record: rec, os, tm, autos, slack, discord, ttyd, ttydPort, firstLogin: firstLogin ?? undefined };
@@ -257,6 +260,33 @@ export async function notifyQuestionAsked(os: AgentOS, slack: Pick<SlackSocket, 
     if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
   }
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'question.notified', data: { agent: notice.agent, targets: targets.length, dms } });
+}
+
+/**
+ * DM the owner of a task that just passed its due date, on their linked Slack/Discord account — the
+ * deadline-side sibling of {@link notifyQuestionAsked}. Targets the task `owner` (the member it runs as);
+ * an owner-less task falls back to the owner/admins so the miss still reaches someone. Best-effort, fired
+ * once per task from the scheduler sweep (the once-guard lives in the DB). Audited.
+ */
+export async function notifyTaskOverdue(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, task: Task): Promise<void> {
+  const owner = task.owner ? os.team.getMember(task.owner) : undefined;
+  const targets = owner
+    ? [owner]
+    : os.team.listMembers().filter((m) => m.status === 'active' && (m.role === 'owner' || m.role === 'admin'));
+  if (!targets.length) return;
+  const due = task.dueAt ? new Date(task.dueAt).toISOString().slice(0, 10) : 'its deadline';
+  const text =
+    `⏰ Task overdue — \`${task.title}\` (${task.id}) passed ${due} and is still ${task.status}.` +
+    `\nOpen the Agent OS console → Tasks to reprioritise, reassign, or extend it.`;
+  let dms = 0;
+  for (const m of targets) {
+    const ids = os.team.externalIdsFor(m.id);
+    const slackId = ids.find((i) => i.provider === 'slack')?.externalId;
+    const discordId = ids.find((i) => i.provider === 'discord')?.externalId;
+    if (slackId && (await slack.dmUser(slackId, text)).ok) dms++;
+    if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
+  }
+  os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.overdue.notified', data: { id: task.id, targets: targets.length, dms } });
 }
 
 /** Launch a ttyd bound to one tenant's tmux socket on `ttydPort`. (Moved verbatim from server.ts.) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -611,11 +611,14 @@ export interface TaskCreateInput {
 }
 
 export interface TaskUpdateInput {
+  title?: string;
+  body?: string;
   status?: TaskStatus;
   assignee?: string | null; // null clears the assignee
   priority?: number;
   labels?: string[];
   mode?: 'headless' | 'interactive';
+  dueAt?: number | null; // epoch ms soft deadline; null clears it
   note?: string; // free-text comment → appended as a task_event
   by: string; // author (member id | 'agent:<id>')
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3008,8 +3008,43 @@ const PRIORITY_LABEL = ['Urgent', 'High', 'Normal', 'Low']
 // Base UI's Select.Value shows the raw value unless the root gets an items map (value → label).
 const PRIORITY_ITEMS: Record<string, string> = Object.fromEntries(PRIORITY_LABEL.map((l, i) => [String(i), l]))
 const priorityTone = (p: number) => ['text-red-600', 'text-amber-600', 'text-muted-foreground', 'text-muted-foreground/70'][p] ?? 'text-muted-foreground'
+// A colored left edge so priority reads at a glance on a dense board (urgent red → low none).
+const priorityBorder = (p: number) => ['border-l-red-500', 'border-l-amber-500', 'border-l-transparent', 'border-l-transparent'][p] ?? 'border-l-transparent'
+
+/** Friendly name for a task principal: agent id, member name, or a system/automation actor. */
+function principalLabel(id: string | undefined, members: Member[]): string {
+  if (!id) return 'Unassigned'
+  if (id === 'system') return 'System'
+  if (id.startsWith('agent:')) return id.slice('agent:'.length)
+  if (id.startsWith('automation:')) return 'Automation'
+  return members.find((m) => m.id === id)?.name || members.find((m) => m.id === id)?.email || id
+}
+
+/** Due-date presentation: a short relative label + tone, and whether it's overdue (open tasks only). */
+function dueMeta(dueAt: number | undefined, status: TaskStatus): { label: string; overdue: boolean; soon: boolean } | null {
+  if (!dueAt) return null
+  const open = status !== 'done' && status !== 'cancelled'
+  const day = 86_400_000
+  const startOfToday = new Date(); startOfToday.setHours(0, 0, 0, 0)
+  const days = Math.round((new Date(dueAt).setHours(0, 0, 0, 0) - startOfToday.getTime()) / day)
+  const overdue = open && days < 0
+  const soon = open && days >= 0 && days <= 1
+  let label: string
+  if (days < 0) label = `${-days}d overdue`
+  else if (days === 0) label = 'Due today'
+  else if (days === 1) label = 'Due tomorrow'
+  else if (days <= 7) label = `Due in ${days}d`
+  else label = new Date(dueAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+  return { label, overdue, soon }
+}
+/** epoch ms → yyyy-mm-dd for a <input type="date">. */
+const toDateInput = (ms?: number) => (ms ? new Date(ms - new Date().getTimezoneOffset() * 60000).toISOString().slice(0, 10) : '')
+/** yyyy-mm-dd (local) → epoch ms at local midnight, or null when cleared. */
+const fromDateInput = (v: string): number | null => (v ? new Date(v + 'T00:00:00').getTime() : null)
 
 function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; onOpen: (tmux: string, title: string) => void }) {
+  const [members, setMembers] = useState<Member[]>([])
+  useEffect(() => { api.team().then((r) => setMembers(r.members ?? [])).catch(() => {}) }, [])
   const [tasks, setTasks] = useState<Task[] | null>(null)
   const [counts, setCounts] = useState<Record<TaskStatus, number>>({ todo: 0, doing: 0, blocked: 0, done: 0, cancelled: 0 })
   const [q, setQ] = useState('')
@@ -3017,17 +3052,41 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
   const [detail, setDetail] = useState<{ task: Task; events: TaskEvent[] } | null>(null)
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
+  // view + filters
+  const [view, setView] = useState<'board' | 'list'>('board')
+  const [mine, setMine] = useState(false)
+  const [fAssignee, setFAssignee] = useState('') // '' = all
+  const [fLabel, setFLabel] = useState('')
+  const [fPriority, setFPriority] = useState('') // '' = all
+  const [fOverdue, setFOverdue] = useState(false)
+  const [sort, setSort] = useState<'priority' | 'due' | 'updated'>('priority')
+  // drag-and-drop
+  const [dragId, setDragId] = useState<string | null>(null)
+  const [dragOverCol, setDragOverCol] = useState<TaskStatus | null>(null)
   // create form
   const [showNew, setShowNew] = useState(false)
   const [title, setTitle] = useState('')
   const [body, setBody] = useState('')
-  const [assignee, setAssignee] = useState('') // '' = unassigned, else 'agent:<id>'
+  const [assignee, setAssignee] = useState('') // '' = unassigned, else 'agent:<id>' or member id
   const [priority, setPriority] = useState(2)
   const [autoDispatch, setAutoDispatch] = useState(false)
   const [mode, setMode] = useState<'headless' | 'interactive'>('headless')
+  const [due, setDue] = useState('')
+  // drawer inline edit
+  const [editing, setEditing] = useState(false)
+  const [eTitle, setETitle] = useState('')
+  const [eBody, setEBody] = useState('')
+  const [confirmDel, setConfirmDel] = useState(false)
 
   const isAdmin = me.role === 'owner' || me.role === 'admin'
   const chatAgents = agents.filter((a) => a.runtime === 'claude-code')
+  // Assignee options: agents (delegation) + humans. Base UI's SelectValue needs a value→label map.
+  const assigneeItems: Record<string, string> = {
+    none: 'Unassigned',
+    ...Object.fromEntries(chatAgents.map((a) => [`agent:${a.id}`, `🤖 ${a.id}`])),
+    ...Object.fromEntries(members.map((m) => [m.id, `👤 ${m.name || m.email}`])),
+  }
+  const nameOf = (id?: string) => principalLabel(id, members)
 
   const load = async () => {
     const r = await api.tasks(q)
@@ -3035,17 +3094,40 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
     if (r.counts) setCounts(r.counts)
   }
   useEffect(() => { load() }, [q])
+  // Live refresh so an agent closing its own loop moves the card without a manual reload. Pause while a
+  // form/inline-edit is open so it can't clobber unsaved text.
+  useEffect(() => {
+    const paused = () => showNew || editing
+    const t = setInterval(() => { if (!paused()) load() }, 5000)
+    return () => clearInterval(t)
+  }, [q, showNew, editing])
   useEffect(() => {
     if (!selId) { setDetail(null); return }
+    if (editing) return // don't overwrite an in-progress edit on a background refresh
     api.task(selId).then((r) => { if (r.task) setDetail({ task: r.task, events: r.events ?? [] }) })
-  }, [selId, tasks])
+  }, [selId, tasks, editing])
+  useEffect(() => { setEditing(false); setConfirmDel(false) }, [selId]) // fresh drawer per selection
+
+  // Client-side filtering over the (≤500) board — cheap, and keeps the lens shareable via UI state.
+  const labelsPresent = [...new Set((tasks ?? []).flatMap((t) => t.labels))].sort()
+  const assigneesPresent = [...new Set((tasks ?? []).map((t) => t.assignee).filter(Boolean) as string[])]
+  const visible = (tasks ?? []).filter((t) => {
+    if (mine && t.assignee !== me.id) return false
+    if (fAssignee && t.assignee !== fAssignee) return false
+    if (fLabel && !t.labels.includes(fLabel)) return false
+    if (fPriority !== '' && t.priority !== Number(fPriority)) return false
+    if (fOverdue && !dueMeta(t.dueAt, t.status)?.overdue) return false
+    return true
+  })
+  const filterActive = mine || fAssignee || fLabel || fPriority !== '' || fOverdue
+  const clearFilters = () => { setMine(false); setFAssignee(''); setFLabel(''); setFPriority(''); setFOverdue(false) }
 
   const create = async () => {
     setHint('')
-    const req: AddTaskReq = { title, body: body || undefined, assignee: assignee || undefined, priority, mode, autoDispatch: autoDispatch && assignee.startsWith('agent:') }
+    const req: AddTaskReq = { title, body: body || undefined, assignee: assignee || undefined, priority, mode, autoDispatch: autoDispatch && assignee.startsWith('agent:'), dueAt: fromDateInput(due) ?? undefined }
     const r = await api.addTask(req)
     if (r.error) return setHint('⚠ ' + r.error)
-    setTitle(''); setBody(''); setAssignee(''); setAutoDispatch(false); setPriority(2); setMode('headless'); setShowNew(false)
+    setTitle(''); setBody(''); setAssignee(''); setAutoDispatch(false); setPriority(2); setMode('headless'); setDue(''); setShowNew(false)
     load()
   }
   const patch = async (id: string, b: Parameters<typeof api.patchTask>[1]) => { setBusy(true); await api.patchTask(id, b); await load(); setBusy(false) }
@@ -3057,22 +3139,99 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
     await load()
     if (r.sessionId) onOpen('aos-' + r.sessionId, 'Task · ' + t.title)
   }
-  const remove = async (id: string) => { setBusy(true); await api.deleteTask(id); setSelId(null); await load(); setBusy(false) }
+  const remove = async (id: string) => { setBusy(true); await api.deleteTask(id); setSelId(null); setConfirmDel(false); await load(); setBusy(false) }
+  const onDropTo = async (status: TaskStatus) => {
+    const id = dragId
+    setDragId(null); setDragOverCol(null)
+    const t = tasks?.find((x) => x.id === id)
+    if (!t || !id || t.status === status) return
+    await patch(id, { status })
+  }
+  const startEdit = () => { if (!detail) return; setETitle(detail.task.title); setEBody(detail.task.body); setEditing(true) }
+  const saveEdit = async () => {
+    if (!detail) return
+    setBusy(true)
+    await api.patchTask(detail.task.id, { title: eTitle, body: eBody })
+    setEditing(false); setBusy(false)
+    await load()
+    const r = await api.task(detail.task.id); if (r.task) setDetail({ task: r.task, events: r.events ?? [] })
+  }
 
   if (!tasks) return <div className="text-sm text-muted-foreground">Loading…</div>
+
+  const card = (t: Task) => {
+    const dm = dueMeta(t.dueAt, t.status)
+    return (
+      <div
+        key={t.id}
+        draggable
+        onDragStart={(e) => { e.dataTransfer.effectAllowed = 'move'; setDragId(t.id) }}
+        onDragEnd={() => { setDragId(null); setDragOverCol(null) }}
+        onClick={() => setSelId(t.id)}
+        className={`w-full cursor-pointer rounded-md border border-l-[3px] p-2.5 text-left hover:bg-muted ${priorityBorder(t.priority)} ${selId === t.id ? 'ring-1 ring-primary' : ''} ${dragId === t.id ? 'opacity-50' : ''}`}
+      >
+        <div className="flex items-start justify-between gap-2">
+          <span className={`truncate text-sm font-medium ${t.status === 'cancelled' ? 'line-through opacity-60' : ''}`}>{t.title}</span>
+          <span className={`shrink-0 text-[10px] font-medium ${priorityTone(t.priority)}`}>{PRIORITY_LABEL[t.priority]}</span>
+        </div>
+        <div className="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-muted-foreground">
+          {t.assignee && <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{nameOf(t.assignee)}</Badge>}
+          {t.autoDispatch && <Badge variant="outline" className="px-1.5 py-0 text-[10px]">auto</Badge>}
+          {dm && <span className={`inline-flex items-center gap-0.5 rounded px-1 text-[10px] ${dm.overdue ? 'bg-red-500/15 text-red-600' : dm.soon ? 'text-amber-600' : ''}`}><Clock className="h-2.5 w-2.5" />{dm.label}</span>}
+          {t.labels.map((l) => <Badge key={l} variant="outline" className="px-1.5 py-0 text-[10px]">{l}</Badge>)}
+          <span className="ml-auto font-mono text-[10px] opacity-60">{t.id}</span>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-2">
-        <p className="mr-auto max-w-2xl text-sm text-muted-foreground">
-          The shared work queue humans and agents drain together. Assign a task to an agent (with <strong>auto-dispatch</strong>)
-          and it spawns a governed session that works it and closes its own loop — the safe way for one agent to hand work to another.
+        <p className="mr-auto max-w-xl text-sm text-muted-foreground">
+          The shared work queue humans and agents drain together. Assign to an agent with <strong>auto-dispatch</strong> and it
+          spawns a governed session that works it and closes its own loop.
         </p>
+        <div className="inline-flex overflow-hidden rounded-md border">
+          <button onClick={() => setView('board')} className={`flex items-center gap-1 px-2.5 py-1.5 text-xs ${view === 'board' ? 'bg-muted font-medium' : 'text-muted-foreground'}`}><LayoutGrid className="h-3.5 w-3.5" />Board</button>
+          <button onClick={() => setView('list')} className={`flex items-center gap-1 border-l px-2.5 py-1.5 text-xs ${view === 'list' ? 'bg-muted font-medium' : 'text-muted-foreground'}`}><List className="h-3.5 w-3.5" />List</button>
+        </div>
         <div className="relative">
           <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
-          <Input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search tasks…" className="h-8 w-52 pl-7" />
+          <Input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search tasks…" className="h-8 w-48 pl-7" />
         </div>
         <Button size="sm" onClick={() => setShowNew((v) => !v)}><Plus className="mr-1 h-3.5 w-3.5" />New task</Button>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap items-center gap-2 text-xs">
+        <div className="inline-flex overflow-hidden rounded-md border">
+          <button onClick={() => setMine(false)} className={`px-2.5 py-1 ${!mine ? 'bg-muted font-medium' : 'text-muted-foreground'}`}>All</button>
+          <button onClick={() => setMine(true)} className={`border-l px-2.5 py-1 ${mine ? 'bg-muted font-medium' : 'text-muted-foreground'}`}>My tasks</button>
+        </div>
+        <Select items={{ all: 'Anyone', ...Object.fromEntries(assigneesPresent.map((a) => [a, nameOf(a)])) }} value={fAssignee || 'all'} onValueChange={(v) => setFAssignee(v === 'all' ? '' : v || '')}>
+          <SelectTrigger className="h-7 w-36 text-xs"><SelectValue /></SelectTrigger>
+          <SelectContent><SelectItem value="all">Anyone</SelectItem>{assigneesPresent.map((a) => <SelectItem key={a} value={a}>{nameOf(a)}</SelectItem>)}</SelectContent>
+        </Select>
+        {labelsPresent.length > 0 && (
+          <Select items={{ all: 'Any label', ...Object.fromEntries(labelsPresent.map((l) => [l, l])) }} value={fLabel || 'all'} onValueChange={(v) => setFLabel(v === 'all' ? '' : v || '')}>
+            <SelectTrigger className="h-7 w-32 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent><SelectItem value="all">Any label</SelectItem>{labelsPresent.map((l) => <SelectItem key={l} value={l}>{l}</SelectItem>)}</SelectContent>
+          </Select>
+        )}
+        <Select items={{ all: 'Any priority', ...PRIORITY_ITEMS }} value={fPriority === '' ? 'all' : fPriority} onValueChange={(v) => setFPriority(v === 'all' ? '' : v ?? '')}>
+          <SelectTrigger className="h-7 w-32 text-xs"><SelectValue /></SelectTrigger>
+          <SelectContent><SelectItem value="all">Any priority</SelectItem>{PRIORITY_LABEL.map((l, i) => <SelectItem key={i} value={String(i)}>{l}</SelectItem>)}</SelectContent>
+        </Select>
+        <button onClick={() => setFOverdue((v) => !v)} className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 ${fOverdue ? 'border-red-500 bg-red-500/10 text-red-600' : 'text-muted-foreground'}`}><AlertTriangle className="h-3.5 w-3.5" />Overdue</button>
+        {view === 'list' && (
+          <Select items={{ priority: 'Sort: Priority', due: 'Sort: Due date', updated: 'Sort: Updated' }} value={sort} onValueChange={(v) => v && setSort(v as typeof sort)}>
+            <SelectTrigger className="h-7 w-36 text-xs"><SelectValue /></SelectTrigger>
+            <SelectContent><SelectItem value="priority">Sort: Priority</SelectItem><SelectItem value="due">Sort: Due date</SelectItem><SelectItem value="updated">Sort: Updated</SelectItem></SelectContent>
+          </Select>
+        )}
+        {filterActive && <button onClick={clearFilters} className="text-muted-foreground underline-offset-2 hover:underline">Clear</button>}
+        <span className="ml-auto text-muted-foreground">{visible.length} shown</span>
       </div>
 
       {showNew && (
@@ -3080,13 +3239,14 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
           <CardContent className="space-y-3 p-4">
             <Field label="Title"><Input value={title} onChange={(e) => setTitle(e.target.value)} placeholder="Fix null-deref in billing.ts" /></Field>
             <Field label="Details"><Textarea value={body} onChange={(e) => setBody(e.target.value)} rows={3} placeholder="Context, acceptance criteria — enough for whoever works it." /></Field>
-            <div className="grid grid-cols-3 gap-3">
+            <div className="grid grid-cols-4 gap-3">
               <Field label="Assign to">
-                <Select items={[{ value: 'none', label: 'Unassigned' }, ...chatAgents.map((a) => ({ value: `agent:${a.id}`, label: `agent · ${a.id}` }))]} value={assignee || 'none'} onValueChange={(v) => setAssignee(!v || v === 'none' ? '' : v)}>
+                <Select items={assigneeItems} value={assignee || 'none'} onValueChange={(v) => setAssignee(!v || v === 'none' ? '' : v)}>
                   <SelectTrigger><SelectValue /></SelectTrigger>
                   <SelectContent>
                     <SelectItem value="none">Unassigned</SelectItem>
-                    {chatAgents.map((a) => <SelectItem key={a.id} value={`agent:${a.id}`}>agent · {a.id}</SelectItem>)}
+                    {chatAgents.map((a) => <SelectItem key={a.id} value={`agent:${a.id}`}>🤖 {a.id}</SelectItem>)}
+                    {members.map((m) => <SelectItem key={m.id} value={m.id}>👤 {m.name || m.email}</SelectItem>)}
                   </SelectContent>
                 </Select>
               </Field>
@@ -3096,6 +3256,7 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
                   <SelectContent>{PRIORITY_LABEL.map((l, i) => <SelectItem key={i} value={String(i)}>{l}</SelectItem>)}</SelectContent>
                 </Select>
               </Field>
+              <Field label="Due date"><Input type="date" value={due} onChange={(e) => setDue(e.target.value)} className="h-9" /></Field>
               <Field label="Auto-dispatch">
                 <label className={`flex h-9 items-center gap-2 text-sm ${assignee.startsWith('agent:') ? '' : 'opacity-40'}`}>
                   <input type="checkbox" checked={autoDispatch} disabled={!assignee.startsWith('agent:')} onChange={(e) => setAutoDispatch(e.target.checked)} />
@@ -3123,47 +3284,91 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
       )}
 
       <div className="flex gap-4">
-        <div className="grid flex-1 grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
-          {TASK_COLUMNS.map((col) => {
-            const inCol = tasks.filter((t) => t.status === col.status || (col.status === 'done' && t.status === 'cancelled'))
-            return (
-              <div key={col.status} className="min-w-0">
-                <div className="mb-2 flex items-center justify-between text-[11px] uppercase tracking-wider text-muted-foreground">
-                  <span>{col.label}</span><span>{counts[col.status] + (col.status === 'done' ? counts.cancelled : 0)}</span>
+        {view === 'board' ? (
+          <div className="grid flex-1 grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-4">
+            {TASK_COLUMNS.map((col) => {
+              const inCol = visible.filter((t) => t.status === col.status || (col.status === 'done' && t.status === 'cancelled'))
+              return (
+                <div
+                  key={col.status}
+                  onDragOver={(e) => { e.preventDefault(); if (dragOverCol !== col.status) setDragOverCol(col.status) }}
+                  onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node)) setDragOverCol((c) => (c === col.status ? null : c)) }}
+                  onDrop={() => onDropTo(col.status)}
+                  className={`min-w-0 rounded-md ${dragOverCol === col.status ? 'bg-primary/5 ring-1 ring-primary/40' : ''}`}
+                >
+                  <div className="mb-2 flex items-center justify-between px-1 text-[11px] uppercase tracking-wider text-muted-foreground">
+                    <span>{col.label}</span><span>{counts[col.status] + (col.status === 'done' ? counts.cancelled : 0)}</span>
+                  </div>
+                  <div className="space-y-2 px-1 pb-2">
+                    {inCol.length === 0 && <div className="rounded-md border border-dashed p-3 text-center text-xs text-muted-foreground">{dragOverCol === col.status ? 'Drop here' : '—'}</div>}
+                    {inCol.map(card)}
+                  </div>
                 </div>
-                <div className="space-y-2">
-                  {inCol.length === 0 && <div className="rounded-md border border-dashed p-3 text-center text-xs text-muted-foreground">—</div>}
-                  {inCol.map((t) => (
-                    <button key={t.id} onClick={() => setSelId(t.id)} className={`w-full rounded-md border p-2.5 text-left hover:bg-muted ${selId === t.id ? 'ring-1 ring-primary' : ''}`}>
-                      <div className="flex items-start justify-between gap-2">
-                        <span className={`truncate text-sm font-medium ${t.status === 'cancelled' ? 'line-through opacity-60' : ''}`}>{t.title}</span>
-                        <span className={`shrink-0 text-[10px] font-medium ${priorityTone(t.priority)}`}>{PRIORITY_LABEL[t.priority]}</span>
-                      </div>
-                      <div className="mt-1 flex flex-wrap items-center gap-1 text-[11px] text-muted-foreground">
-                        {t.assignee && <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{t.assignee}</Badge>}
-                        {t.autoDispatch && <Badge variant="outline" className="px-1.5 py-0 text-[10px]">auto</Badge>}
-                        {t.labels.map((l) => <Badge key={l} variant="outline" className="px-1.5 py-0 text-[10px]">{l}</Badge>)}
-                        <span className="ml-auto font-mono text-[10px] opacity-60">{t.id}</span>
-                      </div>
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )
-          })}
-        </div>
+              )
+            })}
+          </div>
+        ) : (
+          <div className="flex-1 overflow-x-auto rounded-md border">
+            <table className="w-full text-sm">
+              <thead className="border-b bg-muted/40 text-[11px] uppercase tracking-wider text-muted-foreground">
+                <tr>
+                  <th className="px-3 py-2 text-left font-medium">Task</th>
+                  <th className="px-3 py-2 text-left font-medium">Status</th>
+                  <th className="px-3 py-2 text-left font-medium">Assignee</th>
+                  <th className="px-3 py-2 text-left font-medium">Priority</th>
+                  <th className="px-3 py-2 text-left font-medium">Due</th>
+                  <th className="px-3 py-2 text-left font-medium">Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[...visible].sort((a, b) => sort === 'priority' ? a.priority - b.priority || b.updatedAt - a.updatedAt
+                  : sort === 'due' ? (a.dueAt ?? Infinity) - (b.dueAt ?? Infinity)
+                  : b.updatedAt - a.updatedAt).map((t) => {
+                  const dm = dueMeta(t.dueAt, t.status)
+                  return (
+                    <tr key={t.id} onClick={() => setSelId(t.id)} className={`cursor-pointer border-b border-l-[3px] last:border-b-0 hover:bg-muted ${priorityBorder(t.priority)} ${selId === t.id ? 'bg-muted' : ''}`}>
+                      <td className="px-3 py-2"><span className={t.status === 'cancelled' ? 'line-through opacity-60' : ''}>{t.title}</span> {t.labels.map((l) => <Badge key={l} variant="outline" className="ml-1 px-1 py-0 text-[10px]">{l}</Badge>)}</td>
+                      <td className="px-3 py-2 capitalize text-muted-foreground">{t.status}</td>
+                      <td className="px-3 py-2 text-muted-foreground">{t.assignee ? nameOf(t.assignee) : '—'}</td>
+                      <td className={`px-3 py-2 text-xs ${priorityTone(t.priority)}`}>{PRIORITY_LABEL[t.priority]}</td>
+                      <td className="px-3 py-2 text-xs">{dm ? <span className={dm.overdue ? 'text-red-600' : dm.soon ? 'text-amber-600' : 'text-muted-foreground'}>{dm.label}</span> : <span className="text-muted-foreground">—</span>}</td>
+                      <td className="px-3 py-2 text-xs text-muted-foreground">{new Date(t.updatedAt).toLocaleDateString()}</td>
+                    </tr>
+                  )
+                })}
+                {visible.length === 0 && <tr><td colSpan={6} className="px-3 py-8 text-center text-sm text-muted-foreground">No tasks match.</td></tr>}
+              </tbody>
+            </table>
+          </div>
+        )}
 
         {detail && (
           <Card className="w-[26rem] shrink-0 self-start">
             <CardContent className="space-y-3.5 p-4">
               <div className="flex items-start justify-between gap-2">
-                <div className="min-w-0">
-                  <div className="text-base font-semibold leading-snug">{detail.task.title}</div>
-                  <div className="mt-0.5 font-mono text-xs text-muted-foreground">{detail.task.id}{detail.task.owner ? ` · as ${detail.task.owner}` : ''}</div>
+                <div className="min-w-0 flex-1">
+                  {editing
+                    ? <Input value={eTitle} onChange={(e) => setETitle(e.target.value)} className="text-base font-semibold" />
+                    : <div className="text-base font-semibold leading-snug">{detail.task.title}</div>}
+                  <div className="mt-0.5 font-mono text-xs text-muted-foreground">{detail.task.id}{detail.task.owner ? ` · as ${nameOf(detail.task.owner)}` : ''}</div>
                 </div>
-                <Button size="icon" variant="ghost" className="h-7 w-7 shrink-0" onClick={() => setSelId(null)}><X className="h-4 w-4" /></Button>
+                <div className="flex shrink-0 items-center gap-0.5">
+                  {!editing && <Button size="icon" variant="ghost" className="h-7 w-7" title="Edit" onClick={startEdit}><Pencil className="h-3.5 w-3.5" /></Button>}
+                  <Button size="icon" variant="ghost" className="h-7 w-7" onClick={() => { setSelId(null); setEditing(false) }}><X className="h-4 w-4" /></Button>
+                </div>
               </div>
-              {detail.task.body && <div className="max-h-48 overflow-y-auto whitespace-pre-wrap rounded-md border bg-muted/30 p-3 text-sm leading-relaxed text-foreground">{detail.task.body}</div>}
+
+              {editing ? (
+                <>
+                  <Field label="Details (markdown)"><Textarea value={eBody} onChange={(e) => setEBody(e.target.value)} rows={8} className="font-mono text-xs" /></Field>
+                  <div className="flex items-center gap-2">
+                    <Button size="sm" disabled={busy || !eTitle.trim()} onClick={saveEdit}><Save className="mr-1 h-3.5 w-3.5" />Save</Button>
+                    <Button size="sm" variant="ghost" onClick={() => setEditing(false)}>Cancel</Button>
+                  </div>
+                </>
+              ) : (
+                detail.task.body && <div className="prose-tasks max-h-56 overflow-y-auto rounded-md border bg-muted/30 p-3 text-sm"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{detail.task.body}</ReactMarkdown></div>
+              )}
 
               <div className="grid grid-cols-2 gap-2">
                 <Field label="Status">
@@ -3179,16 +3384,21 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
                   </Select>
                 </Field>
               </div>
-              <Field label="Assignee">
-                <Select items={[{ value: 'none', label: 'Unassigned' }, ...chatAgents.map((a) => ({ value: `agent:${a.id}`, label: `agent · ${a.id}` })), ...(detail.task.assignee && !detail.task.assignee.startsWith('agent:') ? [{ value: detail.task.assignee, label: detail.task.assignee }] : [])]} value={detail.task.assignee || 'none'} onValueChange={(v) => patch(detail.task.id, { assignee: !v || v === 'none' ? null : v })}>
-                  <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="none">Unassigned</SelectItem>
-                    {chatAgents.map((a) => <SelectItem key={a.id} value={`agent:${a.id}`}>agent · {a.id}</SelectItem>)}
-                    {detail.task.assignee && !detail.task.assignee.startsWith('agent:') && <SelectItem value={detail.task.assignee}>{detail.task.assignee}</SelectItem>}
-                  </SelectContent>
-                </Select>
-              </Field>
+              <div className="grid grid-cols-2 gap-2">
+                <Field label="Assignee">
+                  <Select items={assigneeItems} value={detail.task.assignee || 'none'} onValueChange={(v) => patch(detail.task.id, { assignee: !v || v === 'none' ? null : v })}>
+                    <SelectTrigger className="h-8"><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">Unassigned</SelectItem>
+                      {chatAgents.map((a) => <SelectItem key={a.id} value={`agent:${a.id}`}>🤖 {a.id}</SelectItem>)}
+                      {members.map((m) => <SelectItem key={m.id} value={m.id}>👤 {m.name || m.email}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                </Field>
+                <Field label="Due date">
+                  <Input type="date" value={toDateInput(detail.task.dueAt)} onChange={(e) => patch(detail.task.id, { dueAt: fromDateInput(e.target.value) })} className="h-8" />
+                </Field>
+              </div>
               {(detail.task.assignee || '').startsWith('agent:') && (
                 <Field label="Run mode">
                   <Select items={{ headless: 'Headless — runs to completion, then exits', interactive: 'Interactive — attachable TUI you drive' }} value={detail.task.mode} onValueChange={(v) => v && patch(detail.task.id, { mode: v as 'headless' | 'interactive' })}>
@@ -3226,16 +3436,21 @@ function TasksPage({ me, agents, onOpen }: { me: Member; agents: AgentInfo[]; on
                         <span className="text-[10px] text-muted-foreground">{new Date(e.createdAt).toLocaleString()}</span>
                       </div>
                       {e.body && <div className="mt-1 break-words text-xs leading-relaxed text-foreground">{e.body}</div>}
-                      <div className="mt-0.5 font-mono text-[10px] text-muted-foreground">{e.author}</div>
+                      <div className="mt-0.5 text-[10px] text-muted-foreground">{nameOf(e.author)}</div>
                     </div>
                   ))}
                 </div>
               </div>
 
               {isAdmin && (
-                <Button size="sm" variant="ghost" className="w-full text-destructive" disabled={busy} onClick={() => remove(detail.task.id)}>
-                  <Trash2 className="mr-1 h-3.5 w-3.5" />Delete task
-                </Button>
+                confirmDel
+                  ? <div className="flex items-center gap-2">
+                      <Button size="sm" variant="destructive" className="flex-1" disabled={busy} onClick={() => remove(detail.task.id)}>Confirm delete</Button>
+                      <Button size="sm" variant="ghost" onClick={() => setConfirmDel(false)}>Cancel</Button>
+                    </div>
+                  : <Button size="sm" variant="ghost" className="w-full text-destructive" onClick={() => setConfirmDel(true)}>
+                      <Trash2 className="mr-1 h-3.5 w-3.5" />Delete task
+                    </Button>
               )}
             </CardContent>
           </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -272,6 +272,7 @@ export interface AddTaskReq {
   parentId?: string
   mode?: 'headless' | 'interactive'
   autoDispatch?: boolean
+  dueAt?: number
 }
 
 export interface Msg {
@@ -758,7 +759,7 @@ export const api = {
   tasks: (q = '', status = '') => call<{ tasks: Task[]; counts: Record<TaskStatus, number>; agents: string[] }>('GET', `/api/tasks?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
   task: (id: string) => call<{ task?: Task; events?: TaskEvent[]; error?: string }>('GET', `/api/tasks/${id}`),
   addTask: (b: AddTaskReq) => call<{ ok: boolean; task?: Task; error?: string }>('POST', '/api/tasks', b),
-  patchTask: (id: string, b: { status?: TaskStatus; assignee?: string | null; priority?: number; labels?: string[]; mode?: 'headless' | 'interactive'; note?: string }) => call<{ ok: boolean; task?: Task; error?: string }>('PATCH', `/api/tasks/${id}`, b),
+  patchTask: (id: string, b: { title?: string; body?: string; status?: TaskStatus; assignee?: string | null; priority?: number; labels?: string[]; mode?: 'headless' | 'interactive'; dueAt?: number | null; note?: string }) => call<{ ok: boolean; task?: Task; error?: string }>('PATCH', `/api/tasks/${id}`, b),
   commentTask: (id: string, body: string) => call<{ ok: boolean; task?: Task; error?: string }>('POST', `/api/tasks/${id}/comment`, { body }),
   dispatchTask: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/tasks/${id}/dispatch`),
   deleteTask: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/tasks/${id}`),


### PR DESCRIPTION
Enhances the Tasks plane to be more comprehensive and to feel like a real board.

## Board feel (web)
- **Drag-and-drop** between columns — drop a card to change its status.
- **Board ⇄ List** view toggle; the list is sortable by priority / due date / updated.
- **Filter bar**: My tasks / All, by assignee, by label, by priority, and an **Overdue** quick filter.
- Priority shows as a **colored left edge** on each card; the board **auto-refreshes** (~5s) so an agent closing its own loop moves the card without a reload.

## Due dates (model → server → UI → notify)
- `dueAt` wired through `TaskStore.update`, the create/patch routes, and the `task_create` / `task_update` MCP tools (a `due` ISO date).
- Relative **due / overdue badges** on cards and list rows (amber/red tone); list **sort-by-due**.
- Scheduler **overdue sweep** DMs the task owner **once** on their linked Slack/Discord account (owner-less → owner/admins), with a DB-backed once-guard. Audited `task.overdue` / `task.overdue.notified`.

## Drawer polish (web)
- Body renders as **markdown**; **title + body inline-editable** (PATCH now accepts `title`/`body`).
- **Real member/agent names** for assignee, owner, and activity authors (no more raw ids).
- Tasks assignable to **humans**, not only agents.
- **Confirm-on-delete**.

## Validation
- `npm run typecheck` ✓, `cd web && npm run build` ✓
- `npm run test:governance` → 44/44 ✓
- Isolated in-process store test (due dates, overdue detection + dedupe, done-excluded, timeline events) → 12/12 ✓

Docs: `docs/tasks-plan.md` §9 updated (board UX + due dates shipped), `docs/agent-mcp-tools.md` notes the `due` param. Version bumped to 0.60.0 with CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)