### PR TITLE
Sessions: default sort to most-recently-updated (v0.61.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.61.0] — 2026-07-09
+### Changed
+- **Sessions now default to most-recently-active first.** The sessions list's default sort switched
+  from newest-*created* to newest-*updated* (last status change), so the sessions you've most recently
+  touched surface at the top. Still overridable per column, and the default stays omitted from the URL.
+
 ## [0.60.0] — 2026-07-09
 ### Added
 - **Tasks board — a real board, not a form.** The Tasks page gains drag-and-drop between columns (drop a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.60.0",
+      "version": "0.61.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.60.0",
+  "version": "0.61.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -71,10 +71,12 @@ const SESSION_STATUS_LABELS: Record<SessionStatusFilter, string> =
 const SESSION_SOURCE_LABELS: Record<'all' | SessionSource, string> =
   { all: 'All sources', member: 'Member', automation: 'Automation', task: 'Task', chat: 'Chat' }
 
-/** Sortable columns of the sessions list. `created` is the default (newest first — the server order). */
+/** Sortable columns of the sessions list. `updated` is the default (most recently active first); it's
+ *  the omitted value in the URL, so a clean `#/sessions` shows the freshest sessions on top. */
 type SessionSortKey = 'created' | 'title' | 'agent' | 'id' | 'startedBy' | 'status' | 'updated'
 type SortDir = 'asc' | 'desc'
 const SESSION_SORT_KEYS: SessionSortKey[] = ['created', 'title', 'agent', 'id', 'startedBy', 'status', 'updated']
+const DEFAULT_SORT_KEY: SessionSortKey = 'updated'
 /** Status ordering for the Status-column sort: live → done → stopped → crashed. */
 const statusRank = (s: Session): number =>
   isLive(s) ? 0 : s.status === 'done' ? 1 : s.status === 'stopped' ? 2 : s.status === 'crashed' ? 3 : 4
@@ -105,7 +107,7 @@ const parseSessionFilters = (qs: string): SessionFilters => {
     agent: p.get('agent') ?? 'all',
     source: (source in SESSION_SOURCE_LABELS ? source : 'all') as 'all' | SessionSource,
     owner: p.get('owner') ?? 'all',
-    sortKey: (SESSION_SORT_KEYS.includes(sort as SessionSortKey) ? sort : 'created') as SessionSortKey,
+    sortKey: (SESSION_SORT_KEYS.includes(sort as SessionSortKey) ? sort : DEFAULT_SORT_KEY) as SessionSortKey,
     sortDir: (p.get('dir') === 'asc' ? 'asc' : 'desc') as SortDir,
   }
 }
@@ -117,7 +119,7 @@ const sessionFiltersToParams = (f: SessionFilters): Record<string, string> => {
   if (f.agent !== 'all') p.agent = f.agent
   if (f.source !== 'all') p.source = f.source
   if (f.owner !== 'all') p.owner = f.owner
-  if (f.sortKey !== 'created') p.sort = f.sortKey
+  if (f.sortKey !== DEFAULT_SORT_KEY) p.sort = f.sortKey
   if (f.sortDir !== 'desc') p.dir = f.sortDir
   return p
 }


### PR DESCRIPTION
## What

Switches the sessions list's **default sort** from newest-*created* to newest-*updated* (last status change), so the sessions you've most recently touched surface at the top. Still overridable by clicking any column; the default key is now the omitted value in the URL, so a clean `#/sessions` carries no sort param.

## Verify

Drove the console in Chromium against a seeded scratch DB (3 sessions where created-order ≠ updated-order):

- clean `#/sessions` → order = updated-desc `[Created-first Updated-last, Middle, Created-last Updated-first]`
- URL stays clean (no `?sort` for the default)
- the Updated column shows the active caret on load

Web build clean; governance 44/44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)