### PR TITLE
Enricher: classify Bash risk on the command, not the description (v0.61.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.61.1] — 2026-07-09
+### Fixed
+- **Bash risk classification no longer reads the `description` field.** The enricher classified a
+  `shell.exec` call's `destructive`/`risky` facts over the whole tool input — including the human-written
+  `description` label. A read-only command whose description happened to mention a gated word (a `gh run
+  list` described as *"Check deploy status"*, or a benign command whose note said *"rm -rf"*) was flagged
+  and, on tenants that gate `risky`/`destructive` shell, funneled a needless approval to the owner (or was
+  outright blocked). Shell calls now classify on the `command` only; connector calls still scan their input
+  values (those are the effect). Regression-pinned in the governance conformance fixture.
+
 ## [0.61.0] — 2026-07-09
 ### Changed
 - **Sessions now default to most-recently-active first.** The sessions list's default sort switched

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.61.0",
+      "version": "0.61.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/enricher.ts
+++ b/src/governance/enricher.ts
@@ -116,15 +116,22 @@ export function enrichArgs(
   // TEXT happens to contain "DROP TABLE" or "rm -rf" is not a destructive DB/shell op. So skip the
   // content scan for it — otherwise the `*` destructive→never rule would wrongly deny a benign edit.
   const isFileWrite = capability === 'file.write';
+  // For a Bash call the effect is the COMMAND itself; the sibling `description` field is a human-written
+  // label ("Check deploy status") that must NOT drive classification. Scanning it flagged benign
+  // read-only commands (a `gh run list` described as a deploy check) as risky and funneled needless
+  // approvals to the owner. So shell.exec classifies on `command` only; connector calls still scan their
+  // input VALUES (those ARE the effect) via `haystack`.
+  const isShell = capability === 'shell.exec';
+  const classifyText = isShell ? command : haystack;
 
   let destructive = args.destructive === true;
   if (!destructive && !isFileWrite) {
-    destructive = DESTRUCTIVE.some((re) => re.test(haystack)) || (!!tool && DESTRUCTIVE_TOOL.test(tool));
+    destructive = DESTRUCTIVE.some((re) => re.test(classifyText)) || (!!tool && DESTRUCTIVE_TOOL.test(tool));
   }
 
   let risky = args.risky === true || destructive;
   if (!risky && !isFileWrite) {
-    if (capability === 'shell.exec') risky = RISKY_SHELL.test(haystack);
+    if (isShell) risky = RISKY_SHELL.test(command);
     else if (capability.startsWith('connector')) risky = !!tool && MUTATION_TOOL.test(tool);
   }
 

--- a/test/governance/conformance.json
+++ b/test/governance/conformance.json
@@ -20,6 +20,7 @@
     { "name": "delete from with where is risky, not destructive → runs freely", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "psql -c \"delete from sessions where id=1\"" } }, "expect": "allow" },
     { "name": "terraform destroy is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "terraform destroy -auto-approve" } }, "expect": "never" },
     { "name": "force push is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "git push --force origin main" } }, "expect": "never" },
+    { "name": "destructive phrase in the DESCRIPTION does not gate a benign command (classify on command only)", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "gh run list --repo acme/docs --limit 1", "description": "check the deploy after we rm -rf the old build" } }, "expect": "allow" },
 
     { "name": "connector read is allowed", "capability": "connector.call", "args": { "tool": "mcp__instawp__list_sites", "input": {} }, "expect": "allow" },
     { "name": "connector send (risky mutation) now runs freely", "capability": "connector.call", "args": { "tool": "mcp__slack__SLACK_SEND_MESSAGE", "input": { "text": "hi" } }, "expect": "allow" },


### PR DESCRIPTION
## Problem

On the **instawp** tenant the owner was getting a flood of approval notifications. Tracing all 19 approvals showed they were only two capabilities — `shell.exec` (risky, 13) and `connector.connect` (6) — and the `shell.exec` ones were almost all **false positives**: read-only / routine `gh` calls (`gh run list`, `gh pr view`, `gh pr merge`).

Root cause: `enrichArgs` computed `destructive`/`risky` over the *entire* tool input — including the Bash `description` field. A read-only `gh run list` described as *"Check deploy status"* was flagged **risky** purely because the label contained "deploy"; a benign command whose description said *"rm -rf …"* would be flagged **destructive** and blocked. The `description` is a human-readable label, not an effect.

## Fix

For `shell.exec`, classify on the `command` only. Connector calls still scan their input **values** (those are the real effect). Minimal, behaviour-preserving for every genuine destructive/risky command.

Before → after (verified):
- `gh run list` desc *"Check deploy status"* → risky **true → false**
- benign command, desc mentions `rm -rf` → destructive **true → false** (was blocked)
- real `rm -rf /var/lib/data` → destructive/risky **still true**

## Tests

`npm run test:governance` — 45/45 pass, including a new regression case pinning "destructive phrase in the description does not gate a benign command".

## Note

Separately, the instawp tenant's live policy was rerouted (`shell.exec`-risky and `connector.connect` `ask` approver **owner → admin**) to spread approval load off the owner immediately — that's a data-home policy edit on the droplet, not part of this repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)