### PR TITLE
Governance: explicit riskClass + human reason on every decision (v0.62.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.62.2] — 2026-07-09
+### Added
+- **Explicit risk class on every decision.** A policy `Decision` now carries a first-class
+  `riskClass` — 🟢 green (allow) / 🟡 yellow (admin approval) / 🔴 red (owner approval) / ⛔ deny — so
+  the four buckets the gate already used are now a named, legible signal instead of something each
+  consumer re-derived from the approver level. The engine also builds a human `reason` that names the
+  *condition* that tripped the rule (e.g. `deleteCount > 25`, `destructive`, `connector.connect`) rather
+  than "matched rule 3". The class + reason are surfaced on the **inbox approval card** (a coloured
+  RED/YELLOW badge + a "why:" line), the **approver DM** (Slack/Discord), the **chat-thread mirror**, and
+  the **audit trail** (`gate.decision`). Additive and backward-compatible — pre-`riskClass` rows fall back
+  to the approver level (head→yellow, owner→red).
+
 ## [0.62.1] — 2026-07-09
 ### Fixed
 - **Inbox action cards preserve line breaks in agent prose.** Question, notification, and approval bodies

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.62.1",
+  "version": "0.62.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.62.1",
+      "version": "0.62.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.62.1",
+  "version": "0.62.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/policy.ts
+++ b/src/governance/policy.ts
@@ -11,7 +11,7 @@
  * Policy decides. It does not record (that's Audit) and does not run the approval
  * workflow (that's Approvals).
  */
-import { ActionAttempt, ApprovalLevel, Decision, PolicyEngine, RunContext } from '../types';
+import { ActionAttempt, ApprovalLevel, Decision, PolicyEngine, RunContext, riskClassForLevel } from '../types';
 
 type Op = 'gt' | 'gte' | 'lt' | 'lte' | 'eq' | 'ne';
 export type PolicyAction = 'allow' | 'ask' | 'never';
@@ -42,6 +42,25 @@ const OPS = ['gt', 'gte', 'lt', 'lte', 'eq', 'ne'];
 /** `admin` approves at the internal `head` level; `owner` at `owner`. (See canApprove in types.ts.) */
 function toLevel(approver: Approver | undefined): ApprovalLevel {
   return approver === 'owner' ? 'owner' : 'head';
+}
+
+const OP_PHRASE: Record<Op, string> = { gt: '>', gte: '≥', lt: '<', lte: '≤', eq: '=', ne: '≠' };
+
+/**
+ * The human `reason` a decision carries — names the rule + the CONDITION that tripped it, so an approver
+ * reads *why*, not "matched rule 3". A `when` clause becomes a legible fact ("deleteCount > 25", or just
+ * "destructive" for a `== true` boolean); no clause → the bare capability; no rule → the default.
+ */
+function describeMatch(rule: PolicyRule | undefined, thresholds: Record<string, number>): string {
+  if (!rule) return 'default policy (no rule matched)';
+  const cap = rule.match.capability === '*' ? 'any action' : rule.match.capability;
+  const w = rule.match.when;
+  if (!w) return cap;
+  const resolved = resolveValue(w.value, thresholds);
+  const val = resolved === undefined ? w.value : resolved;
+  // A boolean flag reads cleaner as the flag name alone (`destructive`, not `destructive = true`).
+  if ((w.op === 'eq' && val === true) || (w.op === 'ne' && val === false)) return `${cap}: ${w.arg}`;
+  return `${cap}: ${w.arg} ${OP_PHRASE[w.op]} ${val}`;
 }
 
 /** Validate one outcome block (a rule or the document default). Returns an error message, or null. */
@@ -202,17 +221,17 @@ export class JsonPolicyEngine implements PolicyEngine {
       return true;
     });
     const outcome: PolicyOutcome = rule ?? this.doc.default;
-    const why = rule
-      ? `matched rule "${rule.match.capability}" → ${outcome.action}`
-      : `no rule matched → default ${outcome.action}`;
+    const reason = describeMatch(rule, thresholds);
 
     switch (outcome.action) {
       case 'allow':
-        return { effect: 'allow' };
+        return { effect: 'allow', riskClass: 'green', reason };
       case 'never':
-        return { effect: 'deny', reason: why };
-      case 'ask':
-        return { effect: 'approve', level: toLevel(outcome.approver), reason: why };
+        return { effect: 'deny', riskClass: 'deny', reason };
+      case 'ask': {
+        const level = toLevel(outcome.approver);
+        return { effect: 'approve', level, riskClass: riskClassForLevel(level), reason };
+      }
     }
   }
 }

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -218,9 +218,10 @@ export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmU
   const approvers = os.team.listMembers().filter((m) => m.status === 'active' && canApprove(m.role, notice.level));
   if (!approvers.length) return;
   // Plain text + backticks render fine in both Slack mrkdwn and Discord markdown (no */** ambiguity).
+  const dot = notice.riskClass === 'red' ? '🔴' : '🟡';
   const text =
-    `🔔 Approval needed — \`${notice.capability}\` (${notice.level}) requested by agent ${notice.agent}.` +
-    (notice.reason ? `\n${notice.reason}` : '') +
+    `${dot} ${notice.riskClass.toUpperCase()} approval needed — \`${notice.capability}\` (${notice.level}) requested by agent ${notice.agent}.` +
+    (notice.reason ? `\nwhy: ${notice.reason}` : '') +
     `\nOpen the Agent OS console → Inbox to approve or reject.`;
   let dms = 0;
   for (const m of approvers) {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -13,7 +13,7 @@ import * as path from 'path';
 import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
-import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, Role, RunContext, resolveRuntimeTuning } from './types';
+import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval } from './governance/enricher';
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
@@ -157,6 +157,9 @@ export interface FeedMessage {
   capability?: string;
   args?: unknown;
   level?: string;
+  /** For 'approval' messages: the explicit risk bucket (yellow = admin, red = owner) — the legible
+   *  severity signal the card badges. Derived from `level` on read. */
+  riskClass?: RiskClass;
   /** Who/what spawned the session (member id | `automation:<id>`) — for 'task' provenance. */
   source?: string;
   /** Links a 'question' message to its row; the answer derives live from it. */
@@ -232,6 +235,7 @@ export interface ApprovalNotice {
   agent: string;
   capability: string;
   level: ApprovalLevel;
+  riskClass: 'yellow' | 'red';
   reason?: string;
 }
 
@@ -1130,7 +1134,7 @@ export class TerminalManager {
       const emailDenial = this.emailIdentityDenial(sessionId, rawArgs);
       if (emailDenial) {
         this.audit(sessionId, agent, 'gate.email.blocked', { capability, reason: emailDenial, recipients: args.emailRecipients ?? [] });
-        this.audit(sessionId, agent, 'gate.decision', { capability, decision: { effect: 'deny', reason: emailDenial } });
+        this.audit(sessionId, agent, 'gate.decision', { capability, decision: { effect: 'deny', riskClass: 'deny', reason: emailDenial } });
         return { decision: 'deny' };
       }
     }
@@ -1172,10 +1176,11 @@ export class TerminalManager {
     });
     this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability });
     // Out-of-band ping (Slack/Discord DM to whoever can approve) — best-effort, never blocks the gate.
-    try { this.approvalNotifier?.({ sessionId, agent, capability, level: decision.level, reason: decision.reason }); } catch { /* notifications are advisory */ }
+    try { this.approvalNotifier?.({ sessionId, agent, capability, level: decision.level, riskClass: decision.riskClass, reason: decision.reason }); } catch { /* notifications are advisory */ }
     // If the run was triggered from chat, surface the gate in that thread too (the approver DM reaches
     // the approver; this reaches everyone watching the thread). No-op for non-chat runs.
-    try { this.chatMirror?.(sessionId, `🔔 ${agent} needs approval — \`${capability}\` (${decision.level}).\nOpen the Agent OS console → Inbox to approve or reject.`); } catch { /* advisory */ }
+    const dot = decision.riskClass === 'red' ? '🔴' : '🟡';
+    try { this.chatMirror?.(sessionId, `${dot} ${agent} needs approval — \`${capability}\` (${decision.riskClass.toUpperCase()} · ${decision.level}).\n_why: ${decision.reason}_\nOpen the Agent OS console → Inbox to approve or reject.`); } catch { /* advisory */ }
 
     // The message + gate status are derived from the approvals table at read time, so all this
     // waiter has to do is leave an audit trail. (It won't fire across a restart — that's fine.)
@@ -1237,7 +1242,7 @@ export class TerminalManager {
           level: decision.level,
         });
         this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability: 'secret.put' });
-        try { this.approvalNotifier?.({ sessionId, agent, capability: 'secret.put', level: decision.level, reason: decision.reason }); } catch { /* advisory */ }
+        try { this.approvalNotifier?.({ sessionId, agent, capability: 'secret.put', level: decision.level, riskClass: decision.riskClass, reason: decision.reason }); } catch { /* advisory */ }
         const approved = await settle;
         this.audit(sessionId, agent, 'approval.resolved', { approvalId: req.id, approved });
         if (!approved) return { status: 'denied', detail: `approval rejected (${decision.level})` };
@@ -1300,7 +1305,7 @@ export class TerminalManager {
    * string — classify falls back to the ruleset's default outcome for ones with no matching rule.
    */
   policyCheck(sessionId: string, agent: string, capability: string, args: Record<string, unknown>): Decision {
-    if (this.os.settings.killSwitch().engaged) return { effect: 'deny', reason: 'workspace emergency stop is engaged' };
+    if (this.os.settings.killSwitch().engaged) return { effect: 'deny', riskClass: 'deny', reason: 'workspace emergency stop is engaged' };
     const enriched = enrichArgs(capability, args, this.emailOrgDomains(), this.os.agents.get(agent)?.dir, this.os.settings.enrichPatterns());
     const cap = enriched.emailSend === true ? 'email.send' : capability;
     return this.os.policy.classify({ capabilityId: cap, args: enriched, reasoning: '' }, this.ctx(sessionId, agent));
@@ -1885,6 +1890,8 @@ function toMessage(r: MessageRow): FeedMessage {
     capability: r.capability ?? undefined,
     args: r.args ? (JSON.parse(r.args) as unknown) : undefined,
     level: r.level ?? undefined,
+    // Explicit risk bucket for approval cards, derived from the approver level (head→yellow, owner→red).
+    riskClass: r.type === 'approval' && r.level ? riskClassForLevel(r.level as ApprovalLevel) : undefined,
     source: r.source ?? undefined,
     questionId: r.question_id ?? undefined,
     answer: r.question_answer ?? undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,10 +149,21 @@ export interface ActionAttempt {
   reasoning?: string;
 }
 
+/**
+ * A policy decision. Every decision carries an explicit {@link RiskClass} — the single, legible
+ * bucket a human reads ("why am I being asked?") — plus a `reason` naming the rule/condition that put
+ * it there. The class is pinned to the effect: allow→green, approve@head→yellow, approve@owner→red,
+ * deny→deny. It's surfaced on the approval card, the audit trail, and the approver DM.
+ */
 export type Decision =
-  | { effect: 'allow' }
-  | { effect: 'deny'; reason: string }
-  | { effect: 'approve'; level: ApprovalLevel; reason: string };
+  | { effect: 'allow'; riskClass: 'green'; reason: string }
+  | { effect: 'deny'; riskClass: 'deny'; reason: string }
+  | { effect: 'approve'; level: ApprovalLevel; riskClass: 'yellow' | 'red'; reason: string };
+
+/** The risk bucket for an `ask` at a given approval level (yellow = admin/head, red = owner). */
+export function riskClassForLevel(level: ApprovalLevel): 'yellow' | 'red' {
+  return level === 'owner' ? 'red' : 'yellow';
+}
 
 export interface CapabilityResult {
   ok: boolean;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1938,6 +1938,9 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
   // ── Approval (pending) ──
   if (m.type === 'approval') {
     const mayApprove = canApprove(me.role, (m.level ?? 'head') as 'head' | 'owner')
+    // Explicit risk bucket — falls back to level for pre-riskClass rows (head→yellow, owner→red).
+    const rc = m.riskClass ?? (m.level === 'owner' ? 'red' : 'yellow')
+    const approverLabel = m.level === 'owner' ? 'owner' : 'admin'
     const resolve = async (approved: boolean) => { setBusy(true); const r = await api.resolve(m.approvalId!, approved); if (r.error) setBusy(false) }
     // "Always approve" also teaches policy an allow rule for this capability — a policy edit, so owner-only.
     const always = async () => {
@@ -1952,7 +1955,9 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
           <div className="min-w-0 flex-1">
             <MsgHeading m={m}>
-              <Badge variant={m.level === 'owner' ? 'destructive' : 'secondary'} className="px-1.5 py-0 text-[10px]">{m.level === 'owner' ? 'owner' : 'admin'} approval</Badge>
+              {rc === 'red'
+                ? <Badge variant="destructive" className="px-1.5 py-0 text-[10px]">🔴 RED · {approverLabel} approval</Badge>
+                : <Badge className="border-amber-300 bg-amber-100 px-1.5 py-0 text-[10px] text-amber-900 hover:bg-amber-100">🟡 YELLOW · {approverLabel} approval</Badge>}
             </MsgHeading>
             <div className="mt-1 break-words text-sm font-medium">{m.title}</div>
             {m.policyReason && <div className="mt-0.5 break-words text-xs text-muted-foreground"><span className="text-amber-700">why:</span> {m.policyReason}</div>}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -287,6 +287,8 @@ export interface Msg {
   capability?: string
   args?: unknown
   level?: 'head' | 'owner'
+  /** approval: explicit risk bucket (yellow = admin, red = owner) — the card's severity badge. */
+  riskClass?: 'green' | 'yellow' | 'red' | 'deny'
   source?: string
   questionId?: string
   answer?: string


### PR DESCRIPTION
## Why

Follow-up to the notification-overload investigation. The gate already resolved to **four effective buckets** — allow / ask-admin / ask-owner / never — but that was *emergent*: every consumer re-derived the bucket from the approver level, and the decision `reason` was `matched rule "connector.connect" → ask`. So an approver couldn't tell *why* they were being pinged. This makes the four buckets we already have **first-class and legible** — without touching the rule engine's expressiveness.

## What

- **`Decision.riskClass`** — 🟢 green (allow) / 🟡 yellow (admin) / 🔴 red (owner) / ⛔ deny, pinned to the effect (`src/types.ts`, `riskClassForLevel`).
- **Human `reason`** — the policy engine names the *condition* that tripped the rule instead of the rule index:
  - `shell.exec: risky`
  - `connector.connect`
  - `any action: destructive`
  - `any action: deleteCount > 25`  ← resolved threshold, not `$bulkDeleteCount`
- **Surfaced everywhere a human looks**: the inbox approval **card** (coloured RED/YELLOW badge + a "why:" line), the **approver DM** (Slack/Discord), the **chat-thread mirror**, and the **audit** (`gate.decision` now records `riskClass`).

## Verified

```
🟡 YELLOW approve/head   | why: shell.exec: risky
🔴 RED    approve/owner  | why: connector.connect
⛔ DENY   deny           | why: any action: destructive
⛔ DENY   deny           | why: any action: deleteCount > 25
🟢 GREEN  allow          | why: default policy (no rule matched)
```

Governance conformance 45/45; server + web build clean.

## Notes / scope

- **Additive & backward-compatible.** Existing approval rows have no stored `riskClass`; the card falls back to the approver level (head→yellow, owner→red). No DB migration.
- **Does not change any decision** — same rules, same tiers, same routing. This is a legibility layer on top, so it's safe to revert.
- Keeps the fact-based enricher + JSON rule engine underneath (per the design discussion: the value is making the existing buckets explicit, not reducing the classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)