### PR TITLE
Inbox: preserve line breaks in agent question/approval prose (v0.62.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.62.1] — 2026-07-09
+### Fixed
+- **Inbox action cards preserve line breaks in agent prose.** Question, notification, and approval bodies
+  now render with `whitespace-pre-line`, so an agent's multi-line question or description keeps its
+  paragraph/list breaks instead of collapsing into one run-on paragraph.
+
 ## [0.62.0] — 2026-07-09
 ### Added
 - **Task detail is a shareable permalink.** Opening a task now updates the URL to `#/tasks/<id>`, and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1924,7 +1924,7 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
         <Bell className="mt-0.5 h-4 w-4 shrink-0 text-indigo-600" />
         <div className="min-w-0 flex-1">
           <MsgHeading m={m}><span className="shrink-0 text-indigo-600">· waiting for you</span></MsgHeading>
-          <div className="mt-1 break-words text-xs text-muted-foreground">{m.body}</div>
+          <div className="mt-1 whitespace-pre-line break-words text-xs text-muted-foreground">{m.body}</div>
         </div>
         {time}
         <div className="flex shrink-0 gap-1">
@@ -1956,7 +1956,7 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
             </MsgHeading>
             <div className="mt-1 break-words text-sm font-medium">{m.title}</div>
             {m.policyReason && <div className="mt-0.5 break-words text-xs text-muted-foreground"><span className="text-amber-700">why:</span> {m.policyReason}</div>}
-            {m.body && <div className="mt-0.5 break-words text-xs text-muted-foreground">{m.body}</div>}
+            {m.body && <div className="mt-0.5 whitespace-pre-line break-words text-xs text-muted-foreground">{m.body}</div>}
             <div className="mt-1 break-all font-mono text-[10px] text-muted-foreground/80">{JSON.stringify(m.args ?? {})}</div>
           </div>
           {time}
@@ -1986,7 +1986,7 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
         <HelpCircle className="mt-0.5 h-4 w-4 shrink-0 text-sky-600" />
         <div className="min-w-0 flex-1">
           <MsgHeading m={m}><span className="shrink-0 text-sky-600">· asks</span></MsgHeading>
-          <div className="mt-1 break-words text-sm">{m.body}</div>
+          <div className="mt-1 whitespace-pre-line break-words text-sm">{m.body}</div>
         </div>
         <button className="shrink-0 pt-0.5 text-[11px] text-muted-foreground underline hover:text-foreground" onClick={open}>open</button>
         {time}


### PR DESCRIPTION
## What

Inbox action cards (question, notification, approval) rendered the agent's body text with `break-words text-sm` but no whitespace handling — so a multi-line question or description collapsed into one run-on paragraph.

## Fix

Add `whitespace-pre-line` to the three action-card bodies in `web/src/App.tsx`, preserving the agent's newlines (paragraphs, bullet lists) while still collapsing incidental spaces and wrapping long lines. Read-only Activity feed rows stay single-line/truncated by design.

Web-only change — rebuild `web/dist` and reload; no server restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)