### PR TITLE
Tasks: word-wrap the task description body (v0.62.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.62.2] — 2026-07-09
+### Fixed
+- **Word-wrap the task description.** Long lines and preformatted/code blocks in a task body now wrap
+  (and long unbroken tokens break) inside the detail modal instead of stretching the width — scoped to the
+  task description so the shared markdown styles (KB, artifacts) are unchanged.
+
 ## [0.62.1] — 2026-07-09
 ### Fixed
 - **Tasks board responsiveness + a roomier detail modal.** The task detail modal was capped too narrow

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.62.1",
+  "version": "0.62.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.62.1",
+      "version": "0.62.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.62.1",
+  "version": "0.62.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3382,7 +3382,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
             ) : (
               <div className="space-y-3.5">
                 <div className="font-mono text-xs text-muted-foreground">{detail.task.id}{detail.task.owner ? ` · as ${nameOf(detail.task.owner)}` : ''}</div>
-                {detail.task.body && <div className="max-h-56 overflow-y-auto rounded-md border bg-muted/30 p-3 text-sm"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{detail.task.body}</ReactMarkdown></div>}
+                {detail.task.body && <div className="max-h-56 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap [&_pre]:break-words"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{detail.task.body}</ReactMarkdown></div>}
 
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                   <Field label="Status">


### PR DESCRIPTION
Long lines and preformatted/code blocks in a task description stretched the modal width instead of wrapping.

- The task body container now wraps: `break-words` on the container and `[&_pre]:whitespace-pre-wrap [&_pre]:break-words` so preformatted/code blocks wrap (and long unbroken tokens break) rather than forcing horizontal width.
- Scoped to the task description only — the shared `mdComponents` (used by KB + artifacts) are unchanged, so code blocks there still scroll as before.

Web-only. `cd web && npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)