### PR TITLE
Automations: ownership guard on delete/edit (v0.63.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.63.0] — 2026-07-09
+### Added
+- **Ownership guard on automation delete/edit.** Admins and members can now only delete or edit
+  automations **they created**; the owner keeps a break-glass override for anyone's (and for legacy
+  automations with no recorded creator). Prevents one teammate from clobbering another's automation.
+  Enforced server-side on `DELETE`/`PATCH /api/automations/:id` and mirrored in the console — the
+  mode/enable/delete controls are hidden (with a "created by another member" note) on automations you
+  can't manage, via a new `canManage` flag on the automation view.
+
 ## [0.62.2] — 2026-07-09
 ### Fixed
 - **Word-wrap the task description.** Long lines and preformatted/code blocks in a task body now wrap

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.62.2",
+  "version": "0.63.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.62.2",
+      "version": "0.63.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.62.2",
+  "version": "0.63.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1210,7 +1210,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
 
   // ── automations (cron / webhook → spawn agent sessions) ──────────────────────
   if (method === 'GET' && p === '/api/automations') {
-    return sendJson(res, 200, { automations: autos.list().map((a) => automationView(a, req, isAdmin(me))) });
+    return sendJson(res, 200, { automations: autos.list().map((a) => automationView(a, req, isAdmin(me), canManageAuto(me, a))) });
   }
   if (method === 'POST' && p === '/api/automations') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
@@ -1251,6 +1251,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   const autoMatch = p.match(/^\/api\/automations\/([\w-]+)$/);
   if (autoMatch && (method === 'PATCH' || method === 'DELETE')) {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    // Ownership guard: admins/members may only delete or edit automations THEY created; the owner keeps
+    // a break-glass override for anyone's (incl. legacy automations with no recorded creator). Prevents
+    // one teammate clobbering another's automation. `createdBy` is a member id (or `agent:`/`automation`
+    // for machine-created ones — those are owner-only to manage).
+    const existing = autos.get(autoMatch[1]);
+    if (existing && !canManageAuto(me, existing)) {
+      return sendJson(res, 403, { error: 'you can only delete or edit automations you created' });
+    }
     if (method === 'DELETE') {
       const ok = autos.remove(autoMatch[1]);
       return sendJson(res, ok ? 200 : 404, { ok });
@@ -2919,7 +2927,7 @@ function approvalView(a: ApprovalRequest) {
   return { id: a.id, runId: a.runId, level: a.level, capability: a.attempt.capabilityId, args: a.attempt.args, reason: a.reason };
 }
 /** Strip the webhook secret for non-admins; give admins the ready-to-paste hook URL instead. */
-function automationView(a: Automation, req: http.IncomingMessage, admin: boolean) {
+function automationView(a: Automation, req: http.IncomingMessage, admin: boolean, canManage = true) {
   const { secret, ...rest } = a;
   return {
     ...rest,
@@ -2927,7 +2935,15 @@ function automationView(a: Automation, req: http.IncomingMessage, admin: boolean
     // When it fires next: an enabled cron computes its next matching minute; a pending one-shot carries
     // its scheduled runAt. Event triggers (webhook/slack/discord) have no schedule, so it stays absent.
     nextRunAt: nextRunAtFor(a),
+    // Whether THIS caller may delete/edit it — mirrors the server-side guard so the console can hide the
+    // controls (owner override, else creator-only). Machine-created ones (`agent:`/`automation`) → owner-only.
+    canManage,
   };
+}
+/** Server-side ownership guard for automations: owner manages any (break-glass); everyone else only their
+ *  own. Shared by the DELETE/PATCH gate and the list view's `canManage` flag so UI and API never diverge. */
+function canManageAuto(me: Member, a: Automation): boolean {
+  return me.role === 'owner' || a.createdBy === me.id;
 }
 function nextRunAtFor(a: Automation): number | undefined {
   if (!a.enabled) return undefined;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3701,7 +3701,9 @@ function AutomationsPage({ me, agents, onOpen, nav }: { me: Member; agents: Agen
                   <Button size="sm" variant="secondary" disabled={busy === a.id} onClick={() => runNow(a)} title="fire once now">
                     <Play className="mr-1 h-3.5 w-3.5" />Run now
                   </Button>
-                  {isAdmin && (
+                  {/* Manage controls only for automations this member may edit: owner (any) or the creator.
+                      `canManage !== false` keeps them for older payloads without the flag; the server enforces. */}
+                  {isAdmin && a.canManage !== false && (
                     <>
                       <Select value={a.mode} onValueChange={(v) => v && v !== a.mode && setItemMode(a, v as 'interactive' | 'headless')}>
                         <SelectTrigger className="h-8 w-32"><SelectValue /></SelectTrigger>
@@ -3717,6 +3719,9 @@ function AutomationsPage({ me, agents, onOpen, nav }: { me: Member; agents: Agen
                         <Trash2 className="h-4 w-4" />
                       </Button>
                     </>
+                  )}
+                  {isAdmin && a.canManage === false && (
+                    <span className="text-[11px] text-muted-foreground" title="Only the creator or the owner can change this automation">created by another member</span>
                   )}
                 </div>
               </CardContent>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -320,6 +320,11 @@ export interface Automation {
   createdAt: number
   lastFiredAt?: number
   lastSessionId?: string
+  /** Member id (or `agent:`/`automation`) that created it — drives the delete/edit ownership guard. */
+  createdBy?: string
+  /** Whether the current caller may delete/edit it (owner override, else creator-only). Mirrors the API
+   *  guard so the console can hide the controls on automations you didn't create. */
+  canManage?: boolean
   /** When it fires next (epoch ms): computed for an enabled cron, or the pending runAt for a one-shot.
    *  Absent for event triggers (webhook/slack/discord) and disabled automations. */
   nextRunAt?: number


### PR DESCRIPTION
## What

Adds an **ownership guard** so a teammate can't delete (or edit) an automation they didn't create — the exact accident that prompted this: an owner deleting a support automation they mistook for their own.

- **Admins/members** may only `DELETE`/`PATCH` automations where `createdBy === me.id`.
- **Owner** keeps a break-glass override for anyone's automation, and manages legacy automations that predate `createdBy` (null creator → owner-only).
- Enforced server-side in the `DELETE`/`PATCH /api/automations/:id` handler via a shared `canManageAuto(me, a)` helper.
- The same helper feeds a new **`canManage`** flag on the automation view, so the console hides the mode/enable/disable/delete controls (showing a "created by another member" note) on automations you can't manage. UI and API never diverge.

## Verification

- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` (45/45) — all green.
- Isolated end-to-end test against the real HTTP handler (seeded owner + admin, automations with distinct creators): **6/6** — admin blocked (403) from deleting the owner's automation, admin can delete their own (200), owner override works (200), and `canManage` flags resolve correctly per caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)