### PR TITLE
Docs: cross-link access-model.md from governance-model + PILLARS

### DIFF
--- a/docs/PILLARS.md
+++ b/docs/PILLARS.md
@@ -10,6 +10,10 @@ as the **chat-channels v1** work landed, **§4 Team** (added the `member_identit
 were updated. All other grades + narratives still hold. Live v1 milestone tracker:
 `docs/v1-mvp-scope.md`.
 
+**Cross-cutting:** how agents are *granted* reach — the relationship between §3 Connectors, §5 Policy,
+and §8 Secrets — is mapped in [`access-model.md`](./access-model.md) (`Creds → Connections →
+Capabilities`), the taxonomy north-star that sits beside [`governance-model.md`](./governance-model.md).
+
 - ✅ **Working** — usable end-to-end today
 - 🟡 **Partial** — core exists, meaningful gaps remain
 - 🌱 **Seed** — interface/reference impl only, nothing real wired

--- a/docs/governance-model.md
+++ b/docs/governance-model.md
@@ -10,6 +10,12 @@ update this doc if a principle itself moves.
 The one invariant restated: **every side effect an agent has on the world passes through a single
 mediated gateway.** Everything below is what that gateway must actually do to be worth having.
 
+> **Companion — [`access-model.md`](./access-model.md).** This doc is the *decision* (given an action,
+> allow / pause / deny). How an agent is *granted* reach in the first place — connectors, creds,
+> shell/host access — is the **access model** (`Creds → Connections → Capabilities`). Access is
+> upstream of governance: every external Connection there names a capability that *this* decision
+> function then consumes.
+
 ---
 
 ## The core reframing


### PR DESCRIPTION
Follow-up to #105 (the access-model north-star). Makes it discoverable from the two docs it sits beside.

- **`governance-model.md`** — adds a "companion" callout after the invariant: this doc is the *decision* (allow/pause/deny); `access-model.md` is how reach is *granted* (Creds → Connections → Capabilities), upstream of governance.
- **`PILLARS.md`** — adds a cross-cutting note tying §3 Connectors / §5 Policy / §8 Secrets to the access-model taxonomy.

Docs only, additive one-liners, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)