### PR TITLE
Notifications: one global recipient resolver (Audience + resolveRecipients) (v0.63.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.63.1] — 2026-07-09
+### Changed
+- **One global recipient resolver for notifications.** "Who is the receiver of a notification?" was
+  re-derived in each of the three DM notifiers (approvals, questions, task-overdue), each with its own
+  owner→admins fallback chain and its own copy of the identity-map DM loop. Introduced a single
+  `Audience` vocabulary + `resolveRecipients` (`src/governance/recipients.ts`) — `approvers` (by level),
+  `admins` (the escalation tier), `member`, and `sessionOwner` (a run's `run_as`, else a member spawner)
+  — and a shared `deliverDM` helper. The notifiers now declare WHO should hear about a thing and never
+  hand-resolve members. Pure refactor: recipient sets and audit lines are unchanged (verified against
+  the old logic). Groundwork for routing session-less notifications (e.g. Tasks) to the right person.
+
 ## [0.63.0] — 2026-07-09
 ### Added
 - **Ownership guard on automation delete/edit.** Admins and members can now only delete or edit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,7 +284,11 @@ Conventions when touching the DB:
   **Audit** page. Approval cards also DM whoever can approve them via Slack/Discord
   (`TerminalManager.setApprovalNotifier` → `notifyApprovers` → identity map → `dmUser`; audited `approval.notified`).
   Agent **questions** get the same out-of-band ping (`setQuestionNotifier` → `notifyQuestionAsked` → the
-  run-as human, else owner/admins; audited `question.notified`), so a blocking `ask` isn't missed. And a
+  run-as human, else owner/admins; audited `question.notified`), so a blocking `ask` isn't missed. **Who
+  receives an out-of-band notification is resolved in ONE place** — `resolveRecipients(os, audience)` in
+  `src/governance/recipients.ts` (the `Audience` vocabulary: `approvers`/`admins`/`member`/`sessionOwner`);
+  every notifier declares an audience and shares `deliverDM` (identity-map → `dmUser`) rather than
+  re-deriving members. And a
   chat-triggered run mirrors its completion/question/approval back into the Slack/Discord thread it came
   from (`setChatMirror` → `slack.reply`/`discord.reply` over the `slack_threads`/`discord_threads` bindings;
   no-op for non-chat runs) — read/dismiss on the shared feed are **per-member** (`message_state` join).

--- a/docs/inbox-plan.md
+++ b/docs/inbox-plan.md
@@ -194,7 +194,12 @@ always-rule for owner sign-off (mirrors `skill_propose`).
 - `src/terminal.ts` — `listMessages` / `sessionInbox` / `toMessage`; `askQuestion` / `report` /
   `progress`; the `gate` (approval cards); the `approvalNotifier` / `questionNotifier` / `chatMirror`
   sinks; `markRead` / `markAllRead` / `dismissMessage` / `dismissAllMessages`.
-- `src/tenant-registry.ts` — wires the sinks: `notifyApprovers`, `notifyQuestionAsked`, chat mirror.
+- `src/tenant-registry.ts` — wires the sinks: `notifyApprovers`, `notifyQuestionAsked`,
+  `notifyTaskOverdue`, chat mirror. Each declares an **`Audience`** and calls the shared `deliverDM`.
+- `src/governance/recipients.ts` — the **global recipient resolver**: `Audience`
+  (`approvers`/`admins`/`member`/`sessionOwner`) → `resolveRecipients(os, audience): Member[]`. The one
+  answer to "who receives this," consulted by every out-of-band notifier (and the intended basis for a
+  session-less card's visibility — §4/§7 of the tasks work).
 - `src/server.ts` — the `/api/messages*`, `/api/ask`, `/api/approvals/:id`, `/api/questions/:id` routes.
 - `src/state/db.ts` — `messages`, `questions`, `approvals`, `message_state` schema.
 - `src/governance/policy.ts` — the rule engine "Always approve" will write into.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.63.0",
+      "version": "0.63.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/recipients.ts
+++ b/src/governance/recipients.ts
@@ -1,0 +1,57 @@
+/**
+ * Recipient routing — the single global answer to "who is the receiver of a notification?".
+ *
+ * Before this module the logic was re-derived in every notifier (approvals, questions, task-overdue),
+ * each with its own owner→admins fallback chain and its own copy of the identity-map DM loop. An
+ * `Audience` is the one vocabulary every push (Slack/Discord DM) and — see `docs/inbox-plan.md` — every
+ * inbox card's visibility resolves through, so recipient policy lives in ONE place. `resolveRecipients`
+ * turns an intent (`{kind:'approvers', level}`, `{kind:'member', id}`, …) into the concrete member set;
+ * callers state WHO should hear about a thing, never how to find them.
+ */
+import type { AgentOS } from '../kernel';
+import { Member, ApprovalLevel, canApprove } from '../types';
+
+/**
+ * The routing INTENT of a notification. A notifier declares one of these instead of hand-resolving a
+ * member set; `resolveRecipients` expands it.
+ * - `member`        — one named person (a task's owner/assignee, a run's human).
+ * - `approvers`     — everyone who `canApprove(role, level)` (the approval-card audience).
+ * - `admins`        — active owners + admins; the shared escalation/fallback tier.
+ * - `sessionOwner`  — the human a run acts for: its `run_as`, else a member who spawned it (empty for a
+ *                     pure automation/task/chat spawn, whose provenance is prefixed `x:`).
+ */
+export type Audience =
+  | { kind: 'member'; id: string }
+  | { kind: 'approvers'; level: ApprovalLevel }
+  | { kind: 'admins' }
+  | { kind: 'sessionOwner'; id: string };
+
+/**
+ * Resolve an {@link Audience} to the concrete members who should receive the notification. Pure over
+ * `os.team` (+ `os.db` for a session's provenance). The `admins`/`approvers` tiers are limited to
+ * `active` members (an invited-but-not-accepted account can't act); a directly-named `member`/
+ * `sessionOwner` is returned as-is when found, matching the pre-refactor behavior (it may still carry a
+ * linked chat handle worth DMing). Callers apply their own fallback by resolving a second audience when
+ * this returns empty — see `deliverDM` callers in `tenant-registry.ts`.
+ */
+export function resolveRecipients(os: AgentOS, audience: Audience): Member[] {
+  switch (audience.kind) {
+    case 'member': {
+      const m = os.team.getMember(audience.id);
+      return m ? [m] : [];
+    }
+    case 'admins':
+      return os.team.listMembers().filter((m) => m.status === 'active' && (m.role === 'owner' || m.role === 'admin'));
+    case 'approvers':
+      return os.team.listMembers().filter((m) => m.status === 'active' && canApprove(m.role, audience.level));
+    case 'sessionOwner': {
+      const row = os.db
+        .prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?')
+        .get<{ spawned_by: string | null; run_as: string | null }>(audience.id);
+      let m = row?.run_as ? os.team.getMember(row.run_as) : undefined;
+      // A console-spawned run's provenance IS a member id (automation:/task:/chat: spawns are prefixed).
+      if (!m && row?.spawned_by && !row.spawned_by.includes(':')) m = os.team.getMember(row.spawned_by);
+      return m ? [m] : [];
+    }
+  }
+}

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -18,7 +18,8 @@ import { TerminalManager, ApprovalNotice, QuestionNotice } from './terminal';
 import { Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
-import { canApprove, Task } from './types';
+import { Member, Task } from './types';
+import { resolveRecipients } from './governance/recipients';
 import { controlHome, resolvePaths, resolveTenantPaths } from './home';
 import { TenantRecord, TenantStore } from './state/control';
 
@@ -210,12 +211,32 @@ export class TenantRegistry {
 }
 
 /**
+ * Deliver one text to a resolved member set over each member's linked Slack/Discord account (identity
+ * map), best-effort. The single copy of the identity-map DM loop the three notifiers used to inline;
+ * returns the delivered-DM count for the caller's audit line. Recipient resolution is NOT done here —
+ * callers pass an already-resolved set (see {@link resolveRecipients}) so WHO and HOW-to-reach stay
+ * separate concerns.
+ */
+async function deliverDM(slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, os: AgentOS, recipients: Member[], text: string): Promise<number> {
+  let dms = 0;
+  for (const m of recipients) {
+    const ids = os.team.externalIdsFor(m.id);
+    const slackId = ids.find((i) => i.provider === 'slack')?.externalId;
+    const discordId = ids.find((i) => i.provider === 'discord')?.externalId;
+    if (slackId && (await slack.dmUser(slackId, text)).ok) dms++;
+    if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
+  }
+  return dms;
+}
+
+/**
  * DM everyone who can approve a freshly-raised approval, on their linked Slack/Discord account. Best-
- * effort: resolves approvers by `canApprove(role, level)`, looks up each one's chat handle in the
- * identity map, and DMs them. Off the gate's hot path (the caller fires-and-forgets). Audited once.
+ * effort: the approvers set comes from the {@link resolveRecipients} `approvers` audience
+ * (`canApprove(role, level)`); `deliverDM` reaches them via the identity map. Off the gate's hot path
+ * (the caller fires-and-forgets). Audited once.
  */
 export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: ApprovalNotice): Promise<void> {
-  const approvers = os.team.listMembers().filter((m) => m.status === 'active' && canApprove(m.role, notice.level));
+  const approvers = resolveRecipients(os, { kind: 'approvers', level: notice.level });
   if (!approvers.length) return;
   // Plain text + backticks render fine in both Slack mrkdwn and Discord markdown (no */** ambiguity).
   const dot = notice.riskClass === 'red' ? '🔴' : '🟡';
@@ -223,70 +244,42 @@ export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmU
     `${dot} ${notice.riskClass.toUpperCase()} approval needed — \`${notice.capability}\` (${notice.level}) requested by agent ${notice.agent}.` +
     (notice.reason ? `\nwhy: ${notice.reason}` : '') +
     `\nOpen the Agent OS console → Inbox to approve or reject.`;
-  let dms = 0;
-  for (const m of approvers) {
-    const ids = os.team.externalIdsFor(m.id);
-    const slackId = ids.find((i) => i.provider === 'slack')?.externalId;
-    const discordId = ids.find((i) => i.provider === 'discord')?.externalId;
-    if (slackId && (await slack.dmUser(slackId, text)).ok) dms++;
-    if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
-  }
+  const dms = await deliverDM(slack, discord, os, approvers, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'approval.notified', data: { capability: notice.capability, level: notice.level, approvers: approvers.length, dms } });
 }
 
 /**
  * DM the human a blocking agent question is waiting on, on their linked Slack/Discord account — the
- * question-side twin of {@link notifyApprovers}. Targets the member the run acts for (its `run_as`, or
- * the member who spawned it); if the run has no human owner (a pure automation), falls back to the
- * owner/admins so the question still reaches someone. Best-effort, off the ask hot path. Audited once.
+ * question-side twin of {@link notifyApprovers}. Targets the `sessionOwner` audience (the run's `run_as`,
+ * else a member who spawned it); if the run has no human owner (a pure automation), falls back to the
+ * `admins` audience so the question still reaches someone. Best-effort, off the ask hot path. Audited once.
  */
 export async function notifyQuestionAsked(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: QuestionNotice): Promise<void> {
-  const row = os.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(notice.sessionId);
-  let owner = row?.run_as ? os.team.getMember(row.run_as) : undefined;
-  // A console-spawned run's provenance IS a member id (automation:/task:/chat: spawns are prefixed).
-  if (!owner && row?.spawned_by && !row.spawned_by.includes(':')) owner = os.team.getMember(row.spawned_by);
-  const targets = owner
-    ? [owner]
-    : os.team.listMembers().filter((m) => m.status === 'active' && (m.role === 'owner' || m.role === 'admin'));
+  let targets = resolveRecipients(os, { kind: 'sessionOwner', id: notice.sessionId });
+  if (!targets.length) targets = resolveRecipients(os, { kind: 'admins' });
   if (!targets.length) return;
   const text =
     `❓ Agent ${notice.agent} is waiting on your answer:\n${notice.prompt}` +
     `\nOpen the Agent OS console → Inbox to reply.`;
-  let dms = 0;
-  for (const m of targets) {
-    const ids = os.team.externalIdsFor(m.id);
-    const slackId = ids.find((i) => i.provider === 'slack')?.externalId;
-    const discordId = ids.find((i) => i.provider === 'discord')?.externalId;
-    if (slackId && (await slack.dmUser(slackId, text)).ok) dms++;
-    if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
-  }
+  const dms = await deliverDM(slack, discord, os, targets, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'question.notified', data: { agent: notice.agent, targets: targets.length, dms } });
 }
 
 /**
  * DM the owner of a task that just passed its due date, on their linked Slack/Discord account — the
- * deadline-side sibling of {@link notifyQuestionAsked}. Targets the task `owner` (the member it runs as);
- * an owner-less task falls back to the owner/admins so the miss still reaches someone. Best-effort, fired
- * once per task from the scheduler sweep (the once-guard lives in the DB). Audited.
+ * deadline-side sibling of {@link notifyQuestionAsked}. Targets the task `owner` (the `member` audience);
+ * an owner-less (or deleted-owner) task falls back to the `admins` audience so the miss still reaches
+ * someone. Best-effort, fired once per task from the scheduler sweep (the once-guard lives in the DB).
  */
 export async function notifyTaskOverdue(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, task: Task): Promise<void> {
-  const owner = task.owner ? os.team.getMember(task.owner) : undefined;
-  const targets = owner
-    ? [owner]
-    : os.team.listMembers().filter((m) => m.status === 'active' && (m.role === 'owner' || m.role === 'admin'));
+  let targets = task.owner ? resolveRecipients(os, { kind: 'member', id: task.owner }) : [];
+  if (!targets.length) targets = resolveRecipients(os, { kind: 'admins' });
   if (!targets.length) return;
   const due = task.dueAt ? new Date(task.dueAt).toISOString().slice(0, 10) : 'its deadline';
   const text =
     `⏰ Task overdue — \`${task.title}\` (${task.id}) passed ${due} and is still ${task.status}.` +
     `\nOpen the Agent OS console → Tasks to reprioritise, reassign, or extend it.`;
-  let dms = 0;
-  for (const m of targets) {
-    const ids = os.team.externalIdsFor(m.id);
-    const slackId = ids.find((i) => i.provider === 'slack')?.externalId;
-    const discordId = ids.find((i) => i.provider === 'discord')?.externalId;
-    if (slackId && (await slack.dmUser(slackId, text)).ok) dms++;
-    if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
-  }
+  const dms = await deliverDM(slack, discord, os, targets, text);
   os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.overdue.notified', data: { id: task.id, targets: targets.length, dms } });
 }
 


### PR DESCRIPTION
## Why

Before this, **"who is the receiver of a notification?"** had no single answer. It was re-derived in each of the three out-of-band notifiers — approvals, questions, task-overdue — every one with its own owner→admins fallback chain and its own copy of the identity-map → `dmUser` loop. And anything not born from a session (e.g. a **Task**) had nowhere to route, because inbox visibility is inferred from a session's provenance.

This PR lands the routing primitive (step 1 of 2). Task create/update notifications build on it next.

## What

- **New `src/governance/recipients.ts`** — one `Audience` vocabulary + `resolveRecipients(os, audience): Member[]`:
  - `approvers` (by level) · `admins` (the escalation tier) · `member` (a named person) · `sessionOwner` (a run's `run_as`, else a member spawner).
- **`tenant-registry.ts`** — the three notifiers now *declare an audience* and share a single `deliverDM` helper (the identity-map DM loop, deduped). They no longer hand-resolve members.

## Behavior

Pure refactor — **recipient sets and audit lines are unchanged**. Verified the resolver against the old logic across 10 cases (approvers by level, admins/active filter, member found/invited/missing, sessionOwner via run_as / member-spawner / pure-automation / dangling run_as).

## Verification

- `npm run typecheck` ✅
- `npm run build` ✅
- `npm run test:governance` → 45/45 ✅
- targeted resolver test → 10/10 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)