### PR TITLE
Tasks: audience-routed Inbox notifications on create/assign/status (v0.64.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.64.0] — 2026-07-09
+### Added
+- **Task lifecycle → Inbox notifications, routed to the right person.** Creating, (re)assigning, or
+  changing a task's status now lands an inbox card for the human it concerns and DMs them on their
+  linked Slack/Discord account: a **new/reassigned** task → its human **assignee** ("assigned to you");
+  a task going **blocked** or **done** → its **owner**. Agent-assigned and self-made changes stay quiet
+  (an agent-owned task announces itself by dispatching a session; nobody is notified of their own
+  action). Fires on **every** mutation path — console, agent `task_*` MCP tools, and the auto-dispatcher
+  — because the sink lives on `TaskStore`, not the routes.
+- **Explicit recipient routing on the inbox feed (`audience`).** A message row can now name its
+  **audience** (`audience_kind`/`audience_id`) instead of always inheriting visibility from its session's
+  provenance — the mechanism that lets a **session-less** card (a task notification) reach exactly the
+  right member. `canViewMessageRow` resolves the audience via the same `resolveRecipients` used to DM, so
+  a card is visible to precisely whom it would be pinged (owner/admin still see all); rows without an
+  audience are unchanged. Task cards use a `task:<id>` session sentinel and deep-link to the board.
+
 ## [0.63.1] — 2026-07-09
 ### Changed
 - **One global recipient resolver for notifications.** "Who is the receiver of a notification?" was

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,8 +232,12 @@ Key modules:
   agent **closes its own loop** with `task_update(done)`. This is the **A2A delegation path** (support→coding
   = a task assigned to `agent:<id>`; run-as passthrough keeps the accountable human). Agent tools
   `task_create`/`task_list`/`task_get`/`task_claim`/`task_update` (author/assignee server-derived); console
-  **Tasks** Kanban board (primary nav, under Agents). §9 futures: pool auto-assignment, agent-triggered
-  `task_dispatch`, a policy brake on dispatch. See `docs/tasks-plan.md`.
+  **Tasks** Kanban board (primary nav, under Agents). A `TaskStore` notifier (`setNotifier`, wired in
+  tenant-registry like `setOverdueNotifier`) fires on create/(re)assign/status so **every** mutation path
+  (console, MCP, dispatcher) lands an **audience-addressed Inbox card + DM** for the right human —
+  assignee on create/assign, owner on blocked/done — via `notifyTaskEvent` → `postTaskCard` +
+  `resolveRecipients`/`deliverDM` (agent-assigned & self-actions stay quiet). §9 futures: pool
+  auto-assignment, agent-triggered `task_dispatch`, a policy brake on dispatch. See `docs/tasks-plan.md`.
 - `src/edge/dreaming.ts` — the **self-learning ("Dreaming")** engine: a periodic deterministic pass that
   reflects on recent episodes + outcomes + friction, **compounds** them into `settings: dreaming_state`,
   emits a living KB page + a tenant-shared memory Insight, and **closes the loop** — distilled guidance is
@@ -265,7 +269,9 @@ Everything the live console touches persists in one SQLite DB per data home, via
 `node:sqlite`** (keeps the zero-dependency stance; `@types/node` v20 lacks the types, so
 `src/state/sqlite.d.ts` declares the subset we use). Tables: `members`, `invites`, `auth_sessions`,
 `assignments`, `member_identities` (external accounts → member, the chat run-as join key; PK
-`(provider, external_id)`), `connectors`, `term_sessions`, `messages` (the inbox feed), `questions`,
+`(provider, external_id)`), `connectors`, `term_sessions`, `messages` (the inbox feed; a row may carry an
+explicit `audience_kind`/`audience_id` to route a session-less card — e.g. a Tasks notification — to a
+member, else visibility falls back to its session's provenance), `questions`,
 `approvals`, `automations`, `slack_threads`, `discord_threads`, `artifacts`, `audit_events`,
 `settings` (key→value: company context,
 runtime defaults, memory config, **self-learning state/guidance/recommendations**, …), `memories`

--- a/docs/inbox-plan.md
+++ b/docs/inbox-plan.md
@@ -43,9 +43,17 @@ Three design choices make it robust:
 | `update` | `update` MCP tool | no | no |
 | `artifact` | `publish` MCP tool | no | no |
 | `skill.proposed` | `skill_propose` MCP tool | no | review (in Skills) |
-| `task` | legacy start rows | no | no |
+| `task` | Tasks lifecycle (`TaskStore` notifier) + legacy start rows | no | no (deep-links to the board) |
 
 The first three are **"Needs you"**; the rest are **"Activity"**.
+
+**Explicit-audience cards (`audience_kind`/`audience_id`).** Most cards inherit their visibility from the
+session that wrote them (`canViewRow` on the session's provenance/run-as). A card can instead **name its
+recipient** via an Audience (`member`/`admins`/`approvers`/`sessionOwner`) — then `canViewMessageRow`
+resolves it through the same `resolveRecipients` used to DM, so the card is visible to exactly whom it
+would be pinged (owner/admin always see all). This is how a **session-less** card reaches the right person:
+a **Tasks** notification has no session, so it carries `audience = {member: assignee|owner}` and a
+`session_id = 'task:<id>'` sentinel. See §4.10.
 
 ---
 
@@ -127,6 +135,15 @@ Approve/reply buttons just `disabled=busy` until the next 1.5s poll (no optimist
 `alert()`. No filter/search/grouping/threading in the feed. **Plan:** optimistic action state +
 toasts; per-agent/per-session grouping; type filter + search.
 
+### 4.10 No global "who receives this?" + Tasks didn't notify — ✅ SHIPPED (v0.63.1 / v0.64.0)
+"Who is the receiver of a notification?" was re-derived in each DM notifier, and anything without a
+session (a **Task**) had nowhere to route — inbox visibility was inferred purely from a session's
+provenance. **Fixed in two steps:** (1) one `Audience` vocabulary + `resolveRecipients`
+(`src/governance/recipients.ts`) is the single answer to "who receives this," consulted by every notifier
+(v0.63.1). (2) Messages gained an explicit `audience` (the pull face of the same resolver), and
+`TaskStore` gained a notifier so create/assign/blocked/done events land an **audience-addressed** inbox
+card + DM for the right human — assignee or owner (v0.64.0). See §4 header for the audience mechanics.
+
 ### 4.9 Agent can't be *pushed* an answer — ⏳ LATER
 An agent only learns its question was answered by polling `ask` or remembering to `check_inbox`. No push,
 no "N new replies since last check" cursor. Partially mitigated by `check_inbox`. **Plan:** an inbox
@@ -183,6 +200,7 @@ always-rule for owner sign-off (mirrors `skill_propose`).
 |---|---|---|
 | **1** | Question DMs · chat loop · per-member read/dismiss | ✅ v0.39.0 |
 | **Always approve** | Learn a policy `allow` from an approval card (§4.4/§5) | ✅ v0.40.0 |
+| **Recipient routing** | Global `Audience`/`resolveRecipients` + explicit-audience cards + Tasks→Inbox (§4.10) | ✅ v0.63.1/v0.64.0 |
 | **2** | Server-side `ask` timeout/expiry · stale-item reminders + escalation | ⏳ |
 | **3** | `since`-cursor + SSE push · feed filter/search/grouping · optimistic UI | ⏳ |
 | **later** | Push answers to the agent · inbox cursor | ⏳ |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.63.1",
+  "version": "0.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.63.1",
+      "version": "0.64.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.63.1",
+  "version": "0.64.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -438,6 +438,11 @@ function migrate(db: Db): void {
   addColumn(db, 'messages', 'question_id', 'TEXT');   // links a 'question' message to its row
   addColumn(db, 'messages', 'outcome', 'TEXT');       // for 'completed' messages: success|failure|partial|unknown
   addColumn(db, 'messages', 'dismissed_at', 'INTEGER'); // when a human dismissed it from the inbox (NULL = visible)
+  // Explicit recipient routing (see docs/inbox-plan.md): when set, the card's visibility is governed by
+  // this Audience (member/admins/approvers/sessionOwner), NOT by its session's provenance — the path a
+  // session-less card (e.g. a Tasks notification, session_id='task:<id>') reaches the right person.
+  addColumn(db, 'messages', 'audience_kind', 'TEXT');  // Audience.kind | NULL = fall back to session visibility
+  addColumn(db, 'messages', 'audience_id', 'TEXT');    // the audience's member id / approval level (kind-dependent)
 
   // Execution mode for automations (older DBs predate it — default preserves their interactive behavior).
   addColumn(db, 'automations', 'mode', "TEXT NOT NULL DEFAULT 'interactive'");

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -37,8 +37,28 @@ const STATUSES: readonly TaskStatus[] = ['todo', 'doing', 'blocked', 'done', 'ca
 /** Sentinel body for the one-time "went overdue" event that dedupes the overdue notification. */
 const OVERDUE_MARK = '⏰ went overdue';
 
+/**
+ * What the {@link TaskStore} notifier sink receives on a meaningful task change. The store stays
+ * db-only and layer-clean — it just fires a domain event; the edge wiring (tenant-registry) decides
+ * whether it merits an inbox card, resolves the receiver via an `Audience`, and DMs them. Mirrors
+ * `Automations.setOverdueNotifier`. `by` is the actor (member id | `agent:<id>`) so the wiring can
+ * suppress self-notification.
+ */
+export interface TaskNotice {
+  task: Task;
+  kind: 'created' | 'assigned' | 'status';
+  by: string;
+  detail?: string;
+}
+
 export class TaskStore {
   constructor(private readonly db: Db) {}
+
+  private notifier?: (n: TaskNotice) => void;
+  /** Register the sink fired on task create / (re)assignment / status change. Best-effort, post-construction
+   *  (wired in tenant-registry once the TerminalManager exists), like the other notifier sinks. */
+  setNotifier(fn: (n: TaskNotice) => void): void { this.notifier = fn; }
+  private notify(n: TaskNotice): void { try { this.notifier?.(n); } catch { /* notifications are advisory */ } }
 
   /** Create a task, log its opening `status` event, and (for a sub-task) `link` it on the parent. */
   create(input: TaskCreateInput): Task {
@@ -59,7 +79,9 @@ export class TaskStore {
       );
     this.addEvent(id, 'status', '→todo', input.createdBy);
     if (input.parentId && this.get(input.parentId)) this.addEvent(input.parentId, 'link', `task:${id}`, input.createdBy);
-    return this.get(id)!;
+    const task = this.get(id)!;
+    this.notify({ task, kind: 'created', by: input.createdBy });
+    return task;
   }
 
   get(id: string): Task | undefined {
@@ -129,12 +151,16 @@ export class TaskStore {
       sets.push('due_at = ?'); vals.push(input.dueAt ?? null);
       this.addEvent(id, 'status', input.dueAt ? `due ${new Date(input.dueAt).toISOString().slice(0, 10)}` : 'due date cleared', input.by);
     }
+    let statusChange: string | undefined;
     if (input.status && input.status !== t.status && STATUSES.includes(input.status)) {
       sets.push('status = ?'); vals.push(input.status);
-      this.addEvent(id, 'status', `${t.status}→${input.status}`, input.by);
+      statusChange = `${t.status}→${input.status}`;
+      this.addEvent(id, 'status', statusChange, input.by);
     }
+    let reassigned = false;
     if (input.assignee !== undefined && (input.assignee ?? null) !== (t.assignee ?? null)) {
       sets.push('assignee = ?'); vals.push(input.assignee ?? null);
+      reassigned = true;
       this.addEvent(id, 'assign', input.assignee ? `→${input.assignee}` : '→unassigned', input.by);
     }
     if (input.priority !== undefined) { sets.push('priority = ?'); vals.push(clampPriority(input.priority)); }
@@ -146,7 +172,13 @@ export class TaskStore {
     sets.push('updated_at = ?'); vals.push(now);
     sets.push('updated_by = ?'); vals.push(input.by);
     this.db.prepare(`UPDATE tasks SET ${sets.join(', ')} WHERE id = ?`).run(...vals, id);
-    return this.get(id)!;
+    const task = this.get(id)!;
+    // Fire the notices AFTER the write so the snapshot reflects the change. Reassignment first (the new
+    // assignee's "assigned to you"), then any status transition (owner's "blocked"/"done"); the edge
+    // wiring filters which merit a card + resolves the receiver.
+    if (reassigned) this.notify({ task, kind: 'assigned', by: input.by });
+    if (statusChange) this.notify({ task, kind: 'status', by: input.by, detail: statusChange });
+    return task;
   }
 
   /**

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -19,7 +19,8 @@ import { Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
 import { Member, Task } from './types';
-import { resolveRecipients } from './governance/recipients';
+import { TaskNotice } from './state/tasks';
+import { Audience, resolveRecipients } from './governance/recipients';
 import { controlHome, resolvePaths, resolveTenantPaths } from './home';
 import { TenantRecord, TenantStore } from './state/control';
 
@@ -197,6 +198,10 @@ export class TenantRegistry {
     // Deadline notifications: when a task passes its due date, DM its owner (the human it runs as) once,
     // so a missed deadline surfaces off the board. Owner-less → owner/admins. Mirrors the question path.
     autos.setOverdueNotifier((task) => { void notifyTaskOverdue(os, slack, discord, task); });
+    // Task lifecycle → Inbox: a create/assign/status change lands an audience-addressed inbox card for
+    // the right human (assignee/owner) — routed via resolveRecipients — and DMs them. Fires for EVERY
+    // mutation path (console, agent MCP, dispatcher) because the sink lives on the store, not the routes.
+    os.tasks.setNotifier((notice) => { void notifyTaskEvent(os, tm, slack, discord, notice); });
     const ttyd = launchTtyd(paths.tmuxSocket, ttydPort, paths.connectors);
     console.log(`  [tenant:${rec.slug}] home=${paths.home}  ttyd=:${ttydPort}`);
     return { record: rec, os, tm, autos, slack, discord, ttyd, ttydPort, firstLogin: firstLogin ?? undefined };
@@ -281,6 +286,51 @@ export async function notifyTaskOverdue(os: AgentOS, slack: Pick<SlackSocket, 'd
     `\nOpen the Agent OS console → Tasks to reprioritise, reassign, or extend it.`;
   const dms = await deliverDM(slack, discord, os, targets, text);
   os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.overdue.notified', data: { id: task.id, targets: targets.length, dms } });
+}
+
+/** Is `who` a human teammate (a member id) rather than an agent (`agent:<id>`) or nobody? */
+function isHumanMember(who: string | undefined): who is string {
+  return !!who && !who.startsWith('agent:');
+}
+
+/**
+ * Map a {@link TaskNotice} to the inbox card it warrants — WHO should hear about it (an {@link Audience})
+ * and the card copy — or `null` when the change doesn't merit a notification. The routing:
+ * - **created / assigned** → the human assignee ("assigned to you"); agent/unassigned tasks notify nobody
+ *   (an agent-owned task announces itself by dispatching a session, not a card).
+ * - **status → blocked** → the owner ("needs you to unblock"); → **done** → the owner ("finished").
+ * Actor-suppression (don't notify yourself) is applied by the caller against `notice.by`.
+ */
+function taskCard(n: TaskNotice): { audience: Audience; title: string; event: string } | null {
+  const t = n.task;
+  if ((n.kind === 'created' || n.kind === 'assigned') && isHumanMember(t.assignee)) {
+    return { audience: { kind: 'member', id: t.assignee }, event: n.kind, title: n.kind === 'created' ? 'New task assigned to you' : 'Task assigned to you' };
+  }
+  if (n.kind === 'status' && isHumanMember(t.owner)) {
+    if (t.status === 'blocked') return { audience: { kind: 'member', id: t.owner }, event: 'blocked', title: 'Task blocked — needs you' };
+    if (t.status === 'done') return { audience: { kind: 'member', id: t.owner }, event: 'done', title: 'Task done' };
+  }
+  return null;
+}
+
+/**
+ * Task lifecycle → Inbox. Writes an audience-addressed inbox card for the human a task change concerns
+ * (assignee/owner) and DMs them on their linked chat account. The card is written SYNCHRONOUSLY (before
+ * the awaited DM) so it's durable even if the process exits right after; the DM is best-effort. Skips
+ * entirely when the change warrants no card or the only recipient is the actor who made it.
+ */
+export async function notifyTaskEvent(os: AgentOS, tm: Pick<TerminalManager, 'postTaskCard'>, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: TaskNotice): Promise<void> {
+  const card = taskCard(notice);
+  if (!card) return;
+  // Resolve the receiver, then drop the actor themselves — nobody needs a card for their own action.
+  const recipients = resolveRecipients(os, card.audience).filter((m) => m.id !== notice.by);
+  if (!recipients.length) return;
+  const t = notice.task;
+  const agentLabel = t.assignee?.startsWith('agent:') ? t.assignee.slice('agent:'.length) : 'tasks';
+  tm.postTaskCard({ taskId: t.id, agent: agentLabel, title: card.title, body: t.title, audience: card.audience, event: card.event });
+  const text = `📋 ${card.title} — \`${t.title}\` (${t.id}).\nOpen the Agent OS console → Tasks.`;
+  const dms = await deliverDM(slack, discord, os, recipients, text);
+  os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.notified', data: { id: t.id, event: card.event, recipients: recipients.length, dms } });
 }
 
 /** Launch a ttyd bound to one tenant's tmux socket on `ttydPort`. (Moved verbatim from server.ts.) */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,6 +15,7 @@ import { Db } from './state/db';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
 import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval } from './governance/enricher';
+import { Audience, resolveRecipients } from './governance/recipients';
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
 import { LauncherSessionBackend, LocalSessionBackend, SessionBackend, SpawnErrorSink } from './edge/session-backend';
@@ -177,6 +178,11 @@ export interface FeedMessage {
   sessionTitle?: string;
   /** Whether the requesting viewer has marked this read (per-member; absent on the agent's own feed). */
   read?: boolean;
+  /** Explicit recipient routing: when set, visibility is governed by this Audience rather than the
+   *  card's session provenance (the path a session-less card — e.g. a Tasks notification — reaches the
+   *  right person). `audienceId` holds the member id / approval level, per `audienceKind`. */
+  audienceKind?: Audience['kind'];
+  audienceId?: string;
   createdAt: number;
 }
 
@@ -227,6 +233,9 @@ interface MessageRow {
   /** Per-viewer inbox state, joined from message_state for the requesting member (console feed only).
    *  Absent (key not selected) on the agent's own session inbox. */
   state_read_at?: number | null;
+  /** Explicit-audience routing columns (NULL = fall back to session visibility). */
+  audience_kind?: string | null;
+  audience_id?: string | null;
 }
 
 /** What the approval-notifier sink receives when a risky action lands an approval card. */
@@ -421,6 +430,32 @@ export class TerminalManager {
     return this.canViewSpawn(spawnedBy, viewer);
   }
 
+  /**
+   * Whether `viewer` may see a message ROW. A card with an explicit `audience_kind` is routed by that
+   * Audience (the pull face of {@link resolveRecipients} — one definition of "receiver" for push and
+   * pull); otherwise it falls back to the card's session provenance (`canViewRow`). Owner/admin see all
+   * either way, keeping parity with `canViewSpawn`.
+   */
+  private canViewMessageRow(r: MessageRow, viewer: Member): boolean {
+    return this.canViewMsg(r.audience_kind ?? null, r.audience_id ?? null, r.session_spawned_by ?? null, r.session_run_as ?? null, viewer);
+  }
+
+  /** Field-level twin of {@link canViewMessageRow} for the read/dismiss/answer guards, which fetch just
+   *  the visibility columns: explicit audience wins, else the session provenance rule. */
+  private canViewMsg(audienceKind: string | null, audienceId: string | null, spawnedBy: string | null, runAs: string | null, viewer: Member): boolean {
+    if (audienceKind) return this.canViewAudience(audienceKind, audienceId, viewer);
+    return this.canViewRow(spawnedBy, runAs, viewer);
+  }
+
+  /** Is `viewer` in the resolved recipient set of an explicit audience? Reuses `resolveRecipients` so a
+   *  card is visible to exactly whom it would have been DMed (owner/admin always, per the platform rule). */
+  private canViewAudience(kind: string, id: string | null, viewer: Member): boolean {
+    if (viewer.role === 'owner' || viewer.role === 'admin') return true;
+    const audience = audienceFromColumns(kind, id);
+    if (!audience) return false;
+    return resolveRecipients(this.os, audience).some((m) => m.id === viewer.id);
+  }
+
   /** Whether `viewer` may see a specific session (resolves its provenance + run-as, then the rule). */
   canViewSession(sessionId: string, viewer: Member): boolean {
     const r = this.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(sessionId);
@@ -533,7 +568,7 @@ export class TerminalManager {
          ORDER BY m.created_at DESC`,
       )
       .all<MessageRow>(viewerId);
-    const visible = viewer ? rows.filter((r) => this.canViewRow(r.session_spawned_by ?? null, r.session_run_as ?? null, viewer)) : rows;
+    const visible = viewer ? rows.filter((r) => this.canViewMessageRow(r, viewer)) : rows;
     return visible.map(toMessage);
   }
 
@@ -541,10 +576,10 @@ export class TerminalManager {
    *  feed — you can only touch a message you can see. Returns false if it's not found or not yours. */
   markRead(id: string, viewer: Member): boolean {
     const row = this.db
-      .prepare('SELECT ts.spawned_by AS sb, ts.run_as AS ra FROM messages m LEFT JOIN term_sessions ts ON m.session_id = ts.id WHERE m.id = ?')
-      .get<{ sb: string | null; ra: string | null }>(id);
+      .prepare('SELECT m.audience_kind AS ak, m.audience_id AS ai, ts.spawned_by AS sb, ts.run_as AS ra FROM messages m LEFT JOIN term_sessions ts ON m.session_id = ts.id WHERE m.id = ?')
+      .get<{ ak: string | null; ai: string | null; sb: string | null; ra: string | null }>(id);
     if (!row) return false;
-    if (!this.canViewRow(row.sb, row.ra, viewer)) return false;
+    if (!this.canViewMsg(row.ak, row.ai, row.sb, row.ra, viewer)) return false;
     this.upsertState(id, viewer.id, 'read_at');
     return true;
   }
@@ -597,16 +632,16 @@ export class TerminalManager {
   dismissMessage(id: string, viewer: Member): 'ok' | 'not_found' | 'forbidden' | 'pending' {
     const row = this.db
       .prepare(
-        `SELECT m.type, a.status AS approval_status, q.status AS question_status, ts.spawned_by AS session_spawned_by, ts.run_as AS session_run_as
+        `SELECT m.type, m.audience_kind, m.audience_id, a.status AS approval_status, q.status AS question_status, ts.spawned_by AS session_spawned_by, ts.run_as AS session_run_as
          FROM messages m
          LEFT JOIN approvals a ON m.approval_id = a.id
          LEFT JOIN questions q ON m.question_id = q.id
          LEFT JOIN term_sessions ts ON m.session_id = ts.id
          WHERE m.id = ?`,
       )
-      .get<{ type: FeedMessage['type']; approval_status: string | null; question_status: string | null; session_spawned_by: string | null; session_run_as: string | null }>(id);
+      .get<{ type: FeedMessage['type']; audience_kind: string | null; audience_id: string | null; approval_status: string | null; question_status: string | null; session_spawned_by: string | null; session_run_as: string | null }>(id);
     if (!row) return 'not_found';
-    if (!this.canViewRow(row.session_spawned_by ?? null, row.session_run_as ?? null, viewer)) return 'forbidden';
+    if (!this.canViewMsg(row.audience_kind ?? null, row.audience_id ?? null, row.session_spawned_by ?? null, row.session_run_as ?? null, viewer)) return 'forbidden';
     const stillWaiting =
       (row.type === 'approval' && (row.approval_status ?? 'pending') === 'pending') ||
       (row.type === 'question' && (row.question_status ?? 'pending') === 'pending');
@@ -1382,12 +1417,32 @@ export class TerminalManager {
 
   private addMessage(m: Omit<FeedMessage, 'id' | 'createdAt'>): void {
     this.db
-      .prepare('INSERT INTO messages (id, type, session_id, agent, title, body, status, approval_id, capability, args, level, source, question_id, outcome, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .prepare('INSERT INTO messages (id, type, session_id, agent, title, body, status, approval_id, capability, args, level, source, question_id, outcome, audience_kind, audience_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
       .run(
         randomUUID().slice(0, 8), m.type, m.sessionId, m.agent, m.title, m.body, m.status,
         m.approvalId ?? null, m.capability ?? null, m.args !== undefined ? JSON.stringify(m.args) : null,
-        m.level ?? null, m.source ?? null, m.questionId ?? null, m.outcome ?? null, Date.now(),
+        m.level ?? null, m.source ?? null, m.questionId ?? null, m.outcome ?? null,
+        m.audienceKind ?? null, m.audienceId ?? null, Date.now(),
       );
+  }
+
+  /**
+   * Post an inbox card for a Tasks event, addressed to an explicit {@link Audience} (the assignee, the
+   * owner, …) rather than to a session's viewers — a task has no session, so it uses the `task:<id>`
+   * sentinel for `session_id` (no matching term_sessions row → visibility is governed entirely by the
+   * audience via `canViewMessageRow`). `args.taskId` deep-links the card to the board. Public so the
+   * tenant-registry wiring (the `os.tasks` notifier) can call it.
+   */
+  postTaskCard(input: { taskId: string; agent: string; title: string; body: string; audience: Audience; event: string }): void {
+    const audienceId = input.audience.kind === 'member' ? input.audience.id
+      : input.audience.kind === 'sessionOwner' ? input.audience.id
+      : input.audience.kind === 'approvers' ? input.audience.level
+      : undefined;
+    this.addMessage({
+      type: 'task', sessionId: `task:${input.taskId}`, agent: input.agent, title: input.title,
+      body: input.body, status: 'open', args: { taskId: input.taskId, event: input.event },
+      audienceKind: input.audience.kind, audienceId,
+    });
   }
 
   // ── session lifecycle → inbox ────────────────────────────────────────────────
@@ -1903,7 +1958,21 @@ function toMessage(r: MessageRow): FeedMessage {
     // read is per-member: present only when the console feed joined message_state for the viewer.
     // The agent's own session inbox doesn't select it (key absent) → left undefined.
     read: 'state_read_at' in r ? r.state_read_at != null : undefined,
+    audienceKind: (r.audience_kind as Audience['kind']) ?? undefined,
+    audienceId: r.audience_id ?? undefined,
     createdAt: r.created_at,
   };
+}
+
+/** Rebuild an {@link Audience} from a message row's two persisted columns (`audience_kind`,
+ *  `audience_id`) — the inverse of how `postTaskCard` flattens it. Unknown/blank kind → null. */
+function audienceFromColumns(kind: string, id: string | null): Audience | null {
+  switch (kind) {
+    case 'member': return id ? { kind: 'member', id } : null;
+    case 'sessionOwner': return id ? { kind: 'sessionOwner', id } : null;
+    case 'admins': return { kind: 'admins' };
+    case 'approvers': return id === 'head' || id === 'owner' ? { kind: 'approvers', level: id } : null;
+    default: return null;
+  }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -809,7 +809,7 @@ function Console({ me }: { me: Member }) {
           {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onDuplicate={duplicateAgent} onRescan={rescanAgents} onImport={importAgent} onRefresh={refreshState} />}
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); nav('agents', id) }} />}
           {route === 'sessions' && <SessionsPage sessions={sessions} waiting={waiting} selected={selected} onOpen={openTerminal} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
-          {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} />}
+          {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} />}
           {route === 'connectors' && <ConnectorsPage me={me} />}
           {route === 'team' && <TeamPage me={me} />}
           {route === 'automations' && <AutomationsPage me={me} agents={state?.agents ?? []} onOpen={openTerminal} nav={nav} />}
@@ -1815,7 +1815,9 @@ function timeUntil(ts: number): string {
 
 /** The inbox heading for a message: the session's live display name, falling back to the agent id if a
  *  run hasn't been named yet. Every card leads with this; the agent is shown as a secondary line. */
-const sessionName = (m: Msg): string => (m.sessionTitle || '').trim() || m.agent
+// A 'task' card has no session — its headline is the event title; everything else leads with the
+// session's live title (falling back to the agent id).
+const sessionName = (m: Msg): string => m.type === 'task' ? (m.title || 'Task') : ((m.sessionTitle || '').trim() || m.agent)
 
 /** Shared two-tier heading: the session name (primary) with the agent id as a secondary line below.
  *  Inline status badges/verb sit on the agent line so the session name always reads as the title. */
@@ -1832,7 +1834,7 @@ function MsgHeading({ m, children }: { m: Msg; children?: ReactNode }) {
   )
 }
 
-function InboxPage({ messages, me, onOpen, onOpenArtifact }: { messages: Msg[]; me: Member; onOpen: (tmux: string, title: string) => void; onOpenArtifact: (id: string) => void }) {
+function InboxPage({ messages, me, onOpen, onOpenArtifact, onOpenTask }: { messages: Msg[]; me: Member; onOpen: (tmux: string, title: string) => void; onOpenArtifact: (id: string) => void; onOpenTask: (id: string) => void }) {
   // Read state is now PER-MEMBER + server-backed (m.read): it syncs across this member's devices/tabs
   // and one admin marking read no longer touches another's badge. `readIds` optimistically bridges the
   // gap until the next poll reflects the server truth.
@@ -1894,7 +1896,7 @@ function InboxPage({ messages, me, onOpen, onOpenArtifact }: { messages: Msg[]; 
           <div className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">No activity yet.</div>
         ) : (
           <div className="divide-y divide-border/60 overflow-hidden rounded-lg border">
-            {activity.map((m) => <FeedItem key={m.id} m={m} onOpen={onOpen} onOpenArtifact={onOpenArtifact} onDismiss={dismiss} unread={isUnread(m)} />)}
+            {activity.map((m) => <FeedItem key={m.id} m={m} onOpen={onOpen} onOpenArtifact={onOpenArtifact} onOpenTask={onOpenTask} onDismiss={dismiss} unread={isUnread(m)} />)}
           </div>
         )}
       </section>
@@ -2007,10 +2009,12 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
 /** One read-only Activity-feed row — completion · artifact · progress update · resolved approval ·
  *  answered question · (legacy) start. Compact, the whole row opens the session (artifacts open the
  *  gallery); the timestamp swaps to a dismiss button on hover. */
-function FeedItem({ m, onOpen, onOpenArtifact, onDismiss, unread }: { m: Msg; onOpen: (tmux: string, title: string) => void; onOpenArtifact?: (id: string) => void; onDismiss?: (id: string) => void; unread?: boolean }) {
+function FeedItem({ m, onOpen, onOpenArtifact, onOpenTask, onDismiss, unread }: { m: Msg; onOpen: (tmux: string, title: string) => void; onOpenArtifact?: (id: string) => void; onOpenTask?: (id: string) => void; onDismiss?: (id: string) => void; unread?: boolean }) {
   const open = () => onOpen('aos-' + m.sessionId, m.agent + ' · ' + m.sessionId)
-  const meta = (m.args ?? {}) as { artifactId?: string; filename?: string }
+  const meta = (m.args ?? {}) as { artifactId?: string; filename?: string; taskId?: string; event?: string }
   const goArtifact = m.type === 'artifact' && meta.artifactId && onOpenArtifact ? () => onOpenArtifact(meta.artifactId!) : null
+  // A 'task' card has no session — it deep-links to the board (its taskId), not a terminal.
+  const goTask = m.type === 'task' && meta.taskId && onOpenTask ? () => onOpenTask(meta.taskId!) : null
 
   let Icon = Clock
   let iconCls = 'text-muted-foreground'
@@ -2050,6 +2054,13 @@ function FeedItem({ m, onOpen, onOpenArtifact, onDismiss, unread }: { m: Msg; on
   } else if (m.type === 'update') {
     Icon = Activity; iconCls = 'text-muted-foreground'
     detail = m.body
+  } else if (m.type === 'task' && meta.taskId) {
+    // A Tasks lifecycle card (assigned to you / blocked / done). Headline = event title (via sessionName);
+    // the muted line carries the task title (m.body). Blocked is highlighted — it needs a human.
+    Icon = ListChecks; iconCls = meta.event === 'blocked' ? 'text-amber-600' : meta.event === 'done' ? 'text-emerald-600' : 'text-sky-600'
+    highlight = meta.event === 'blocked'
+    detail = m.body
+    badge = <Badge variant="outline" className="px-1.5 py-0 text-[10px] font-normal">task</Badge>
   } else {
     // legacy 'task' (started) rows from older runs — kept renderable
     Icon = Rocket; iconCls = 'text-muted-foreground'
@@ -2058,7 +2069,7 @@ function FeedItem({ m, onOpen, onOpenArtifact, onDismiss, unread }: { m: Msg; on
 
   return (
     <div
-      onClick={goArtifact ?? open}
+      onClick={goArtifact ?? goTask ?? open}
       className={`group relative flex cursor-pointer items-start gap-2.5 px-3 py-2 hover:bg-muted/50 ${highlight ? 'bg-amber-50/40' : ''}`}
     >
       <span className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full ${unread ? 'bg-primary' : 'bg-transparent'}`} />


### PR DESCRIPTION
Second of two PRs. Builds on #108 (the `Audience`/`resolveRecipients` primitive) to deliver the feature you originally asked for — **task create/update inbox notifications** — now that there's a global way to find the receiver.

## What

**1. Explicit recipient routing on the feed.** A `messages` row can now name its **audience** (`audience_kind`/`audience_id`) rather than always inheriting visibility from its session's provenance. `canViewMessageRow` resolves the audience through the **same `resolveRecipients` used to DM**, so a card is visible to exactly whom it would be pinged (owner/admin still see all). Audience-less rows behave exactly as before. This is what lets a **session-less** card reach the right person.

**2. Tasks → Inbox.** `TaskStore` gained a `setNotifier` sink (wired in `tenant-registry.ts` like `setOverdueNotifier`) that fires on create / (re)assign / status change. `notifyTaskEvent` posts an audience-addressed card + Slack/Discord DM:

| event | receiver |
|---|---|
| created / reassigned (human assignee) | the **assignee** |
| status → blocked | the **owner** |
| status → done | the **owner** |

Agent-assigned tasks and self-actions stay quiet (an agent-owned task announces itself by dispatching a session; nobody is notified of their own action). Fires on **every** mutation path — console, `task_*` MCP tools, and the auto-dispatcher — because the sink lives on the store, not the routes. Task cards use a `task:<id>` session sentinel (no schema rebuild — `session_id` stays `NOT NULL`) and deep-link to the board.

**3. Console.** `FeedItem` renders a task card (blocked highlighted amber, done green) and clicking it deep-links to the Tasks board.

## Schema

Two additive `addColumn`s on `messages` (`audience_kind`, `audience_id`) — idempotent, backward-compatible. No table rebuild.

## Verification

- `npm run typecheck` · backend `npm run build` · `web && npm run build` ✅
- `npm run test:governance` → 45/45 ✅
- `npm run demo` ✅
- **Isolated integration test (12/12)** on a scratch `AGENT_OS_HOME`: per-viewer routing (assignee sees it, unrelated member doesn't, owner sees all), blocked→owner (not assignee), reassign→new assignee, actor-suppression (self-assigned = no card), agent-assigned = no human card, and `markRead`/`dismiss` audience-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)