### PR TITLE
Auth: self-service sign-in recovery + sliding sessions (v0.65.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.65.0] — 2026-07-09
+### Added
+- **Self-service sign-in recovery — no admin needed to get back in.** The login screen gains an
+  **"Email me a link"** field: a member who lost their session (new device, cleared cookies, expired
+  window) enters their email and the server mints a fresh 7-day magic-link and delivers it out-of-band —
+  DM'd to their linked **Slack/Discord** (identity map) and written to **server.log** (the always-
+  available fallback, matching how the owner-seed link is surfaced). New public route
+  `POST /api/auth/request-link`; **neutral response** always (`{ ok: true }` whether or not the email is
+  a real member — no account enumeration); rate-limited per email + client IP (3 / 15 min). Closes the
+  gap where the ONLY way into the portal was an owner/admin-minted token. Audited
+  `auth.link.requested` / `auth.link.notified`.
+### Changed
+- **Sliding login sessions — active users stop getting logged out at the hard 30-day mark.**
+  `TeamStore.resolveSession` now bumps the 30-day expiry on activity (throttled to ≤1 DB write/day/
+  session), and `GET /api/auth/me` re-stamps the `aos_sid` cookie on every app load (the SPA calls it on
+  mount) so the browser cookie never lapses either. A daily-active user now stays signed in indefinitely;
+  the fixed-30-day cutoff only bites a genuinely idle session. The one-time invite/magic-link semantics
+  are unchanged (single-use, 7-day TTL).
+
 ## [0.64.0] — 2026-07-09
 ### Added
 - **Task lifecycle → Inbox notifications, routed to the right person.** Creating, (re)assigning, or

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -323,10 +323,21 @@ in `src/types.ts` and `TeamStore.canRun()`.
   the provenance rule (automation creator + owner/admin). So a chat-triggered run is owned by the
   automation for provenance yet acts as — and is visible to — the member who sent the message.
 - **Auth in `server.ts`:** public routes are the app/assets, `/health`, `/accept`, `/hooks/<id>`
-  (webhooks carry their own secret key), `/api/auth/me`, `/api/auth/logout`; every other `/api/*`
-  requires a session (else 401). Role gates: approvals → `canApprove`; spawn → `canRun`;
-  team/connector/automation mutations → owner/admin (role changes & member removal → owner only).
-  Resolver identity is the member's email, not the old hardcoded `console-user`.
+  (webhooks carry their own secret key), `/api/auth/me`, `/api/auth/logout`, `/api/auth/request-link`
+  (self-service recovery — see below); every other `/api/*` requires a session (else 401). Role gates:
+  approvals → `canApprove`; spawn → `canRun`; team/connector/automation mutations → owner/admin (role
+  changes & member removal → owner only). Resolver identity is the member's email, not the old hardcoded
+  `console-user`.
+- **Getting in without an admin (self-service recovery).** Login is still invite-token / magic-link, but
+  a member who lost their session no longer needs an owner to mint a fresh one: the login screen's
+  **"Email me a link"** posts to public `POST /api/auth/request-link`, which mints a fresh 7-day
+  magic-link for the known member and delivers it out-of-band — DM'd to their linked Slack/Discord
+  (`notifyLoginLink` in `tenant-registry.ts` → `deliverDM`, identity map) AND written to `server.log`
+  (the always-available fallback). The response is **always neutral** (`{ ok: true }` regardless of
+  whether the email is a real member — no account enumeration) and rate-limited per email + client IP
+  (`allowLinkRequest`, 3 / 15 min). Sessions **slide**: `resolveSession` bumps the 30-day expiry on
+  activity (≤1 write/day) and `/api/auth/me` re-stamps the cookie on each app load, so an active user
+  never hits the hard cutoff. Owner recovery of last resort is still the CLI (`agent-os login-link`).
 - Generated links (invites, webhook URLs) are built from the request's `Host` + `X-Forwarded-Proto`
   headers at read time. The cookie is `HttpOnly; SameSite=Lax`, 30 days.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.64.0",
+      "version": "0.65.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.64.0",
+  "version": "0.65.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -214,10 +214,20 @@ export class TeamStore {
   }
   resolveSession(sid: string): Member | undefined {
     if (!sid) return undefined;
+    const now = Date.now();
     const row = this.db
-      .prepare('SELECT member_id FROM auth_sessions WHERE sid = ? AND expires_at > ?')
-      .get<{ member_id: string }>(sid, Date.now());
-    return row ? this.getMember(row.member_id) : undefined;
+      .prepare('SELECT member_id, expires_at FROM auth_sessions WHERE sid = ? AND expires_at > ?')
+      .get<{ member_id: string; expires_at: number }>(sid, now);
+    if (!row) return undefined;
+    // Sliding window: bump the 30-day expiry on activity so a daily-active user never hits the hard
+    // cutoff and gets locked out. Throttled to ≤1 write/day/session (only slide once the row is >1 day
+    // short of a fresh full TTL), so this stays off the per-request hot path. The BROWSER cookie is
+    // re-stamped separately on GET /api/auth/me (see server.ts) — the DB slide alone can't, since the
+    // cookie's Max-Age is fixed at mint time.
+    if (now + SESSION_TTL_MS - row.expires_at > 24 * 60 * 60 * 1000) {
+      this.db.prepare('UPDATE auth_sessions SET expires_at = ? WHERE sid = ?').run(now + SESSION_TTL_MS, sid);
+    }
+    return this.getMember(row.member_id);
   }
   destroySession(sid: string): void {
     this.db.prepare('DELETE FROM auth_sessions WHERE sid = ?').run(sid);

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,7 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import { AgentOS, loadAgentOS } from './kernel';
 import { VERSION } from './version';
-import { TenantRegistry, TenantRuntime } from './tenant-registry';
+import { TenantRegistry, TenantRuntime, notifyLoginLink } from './tenant-registry';
 import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
 import { TerminalManager, AGENT_OS_OPERATING_NOTES } from './terminal';
@@ -296,7 +296,40 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   }
   if (method === 'GET' && p === '/api/auth/me') {
     const m = memberFor(os, req);
-    return m ? sendJson(res, 200, { member: m }) : sendJson(res, 401, { error: 'not authenticated' });
+    if (!m) return sendJson(res, 401, { error: 'not authenticated' });
+    // Sliding session: re-stamp the cookie on every app load (the SPA GETs this on mount) so an active
+    // user's 30-day browser cookie never lapses. Pairs with the DB-side slide in TeamStore.resolveSession
+    // — restamping the cookie alone would outlive the server row, sliding the row alone would outlive the
+    // cookie; both together keep an active user logged in indefinitely.
+    const sid = parseCookies(req)['aos_sid'];
+    const headers: Record<string, string> = { 'content-type': 'application/json; charset=utf-8' };
+    if (sid) headers['set-cookie'] = sessionCookie(sid);
+    res.writeHead(200, headers);
+    res.end(JSON.stringify({ member: m }));
+    return;
+  }
+  // Self-service recovery: a member who lost their session (new device, cleared cookies, expired
+  // window) asks for a fresh sign-in link WITHOUT needing an admin to mint one. Public + neutral: we
+  // ALWAYS return { ok: true } regardless of whether the email is a real member, so this can't be used
+  // to enumerate accounts. A known member gets a fresh 7-day magic-link delivered out-of-band — DM'd to
+  // their linked Slack/Discord (identity map) AND written to server.log (the always-available fallback,
+  // matching how the owner-seed link is surfaced). Rate-limited per email + client IP.
+  if (method === 'POST' && p === '/api/auth/request-link') {
+    const b = await readBody(req);
+    const email = String(b.email || '').trim().toLowerCase();
+    if (email && email.includes('@') && allowLinkRequest(email, req)) {
+      const issued = os.team.issueLoginLink(email); // null when no such member — stays silent
+      if (issued) {
+        const link = linkFor(req, issued.token);
+        let dms = 0;
+        if (slack && discord) dms = await notifyLoginLink(os, slack, discord, issued.member, link);
+        console.log(`[auth] sign-in link requested for ${email} — ${dms} DM(s) sent: ${link}`);
+        os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: email, type: 'auth.link.requested', data: { member: issued.member.id, dms } });
+      } else {
+        os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: email, type: 'auth.link.requested', data: { unknown: true } });
+      }
+    }
+    return sendJson(res, 200, { ok: true });
   }
   if (method === 'POST' && p === '/api/auth/logout') {
     const sid = parseCookies(req)['aos_sid'];
@@ -2977,6 +3010,26 @@ function clearCookie(): string {
 }
 function memberFor(os: AgentOS, req: http.IncomingMessage): Member | undefined {
   return os.team.resolveSession(parseCookies(req)['aos_sid'] || '');
+}
+
+// In-memory throttle for the public /api/auth/request-link route: at most LINK_REQ_MAX attempts per
+// key (email OR client IP) within LINK_REQ_WINDOW_MS. Bounds link-minting + DM spam and slows any
+// enumeration-by-timing. Process-local (fine — this is a per-tenant single process); resets on restart.
+const LINK_REQ_WINDOW_MS = 15 * 60 * 1000;
+const LINK_REQ_MAX = 3;
+const linkReqHits = new Map<string, number[]>();
+function allowLinkRequest(email: string, req: http.IncomingMessage): boolean {
+  const ip = String(req.headers['x-forwarded-for'] || req.socket.remoteAddress || '').split(',')[0].trim();
+  const now = Date.now();
+  let ok = true;
+  for (const key of [`e:${email}`, `ip:${ip}`]) {
+    if (!key.slice(2)) continue; // skip an empty ip
+    const hits = (linkReqHits.get(key) || []).filter((t) => now - t < LINK_REQ_WINDOW_MS);
+    if (hits.length >= LINK_REQ_MAX) ok = false;
+    hits.push(now);
+    linkReqHits.set(key, hits);
+  }
+  return ok;
 }
 
 // ── per-member terminal reverse proxy (Phase A, flag on) ───────────────────────

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -235,6 +235,21 @@ async function deliverDM(slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<Disco
 }
 
 /**
+ * DM a member their own freshly-minted sign-in link, on their linked Slack/Discord account — the
+ * delivery half of the self-service "email me a link" recovery path (server.ts `POST
+ * /api/auth/request-link`). Best-effort; the caller ALSO logs the link to server.log so an owner with
+ * box access can always recover even with no chat identity linked. Returns the delivered-DM count.
+ */
+export async function notifyLoginLink(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, member: Member, link: string): Promise<number> {
+  const text =
+    `🔑 Your Agent OS sign-in link (valid 7 days, single use):\n${link}\n` +
+    `If you didn't request this, you can ignore it — the link is harmless until it's opened.`;
+  const dms = await deliverDM(slack, discord, os, [member], text);
+  os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'auth.link.notified', data: { member: member.id, dms } });
+  return dms;
+}
+
+/**
  * DM everyone who can approve a freshly-raised approval, on their linked Slack/Discord account. Best-
  * effort: the approvers set comes from the {@link resolveRecipients} `approvers` audience
  * (`canApprove(role, level)`); `deliverDM` reaches them via the identity map. Off the gate's hot path

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2531,6 +2531,9 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
 // ── Login ────────────────────────────────────────────────────────────────────────
 function LoginScreen() {
   const [value, setValue] = useState('')
+  const [email, setEmail] = useState('')
+  const [sent, setSent] = useState(false)
+  const [sending, setSending] = useState(false)
   const invalid = /[?&]login=invalid/.test(window.location.href)
   // Accept either a full magic link or a bare token; navigate to the server-side /accept route.
   const go = () => {
@@ -2539,21 +2542,47 @@ function LoginScreen() {
     const token = v.includes('token=') ? v.split('token=')[1].split(/[&\s]/)[0] : v
     window.location.href = '/accept?token=' + encodeURIComponent(token)
   }
+  // Self-service recovery. The server responds neutrally (no account enumeration), so we always show the
+  // same "if that's a member, a link is on its way" confirmation.
+  const requestLink = async () => {
+    if (!email.trim() || sending) return
+    setSending(true)
+    try { await api.requestLink(email.trim()) } catch { /* neutral either way */ }
+    setSending(false)
+    setSent(true)
+  }
   return (
     <div className="flex h-screen items-center justify-center bg-muted/30">
       <Card className="w-full max-w-md">
         <CardContent className="p-6">
           <div className="mb-1 flex items-center gap-2 text-lg font-semibold">⚙️ Agent OS</div>
           <p className="mb-4 text-sm text-muted-foreground">
-            Access is by invite. Paste the magic-link (or token) you were sent to sign in. The
-            workspace owner can mint one from the Team page, or from the box with{' '}
-            <span className="font-mono text-xs">agent-os invite</span>.
+            Access is by invite. Paste the magic-link (or token) you were sent to sign in — or, if you've
+            signed in before, request a fresh link by email below.
           </p>
-          {invalid && <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">That link is invalid or expired — ask for a fresh one.</div>}
+          {invalid && <div className="mb-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">That link is invalid or expired — request a fresh one below.</div>}
           <Field label="Magic link or token">
             <Input value={value} onChange={(e) => setValue(e.target.value)} placeholder="https://…/accept?token=…" onKeyDown={(e) => e.key === 'Enter' && go()} />
           </Field>
           <Button className="mt-4 w-full" onClick={go} disabled={!value.trim()}>Sign in</Button>
+
+          <div className="my-4 flex items-center gap-3 text-xs text-muted-foreground">
+            <div className="h-px flex-1 bg-border" />lost your link?<div className="h-px flex-1 bg-border" />
+          </div>
+
+          {sent ? (
+            <div className="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+              If <span className="font-medium">{email.trim()}</span> is a member, a fresh sign-in link is on its
+              way to their linked Slack/Discord. Ask the workspace owner if nothing arrives.
+            </div>
+          ) : (
+            <>
+              <Field label="Send me a sign-in link">
+                <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} placeholder="you@company.com" onKeyDown={(e) => e.key === 'Enter' && requestLink()} />
+              </Field>
+              <Button variant="outline" className="mt-3 w-full" onClick={requestLink} disabled={!email.trim() || sending}>{sending ? 'Sending…' : 'Email me a link'}</Button>
+            </>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -683,6 +683,9 @@ export const api = {
     return (await res.json()).member as Member
   },
   logout: () => call<{ ok: boolean }>('POST', '/api/auth/logout'),
+  /** Self-service recovery: ask the server to send a fresh sign-in link. Always resolves ok (neutral
+   *  response — a real member is DM'd/logged a link; an unknown email is a silent no-op). */
+  requestLink: (email: string) => call<{ ok: boolean }>('POST', '/api/auth/request-link', { email }),
 
   state: () => call<StateResp>('GET', '/api/state'),
   /** Self-update: check whether the checkout is behind origin (`force` re-runs `git fetch`, owner/admin). */


### PR DESCRIPTION
## Problem

The invite/magic-link is single-use (correct — a scanner's GET can't burn it), but that wasn't the real gap: **the only way into the portal was a token an owner/admin minted for you**, and sessions had a **hard 30-day cutoff with no refresh**. A member who lost their session — new device, cleared cookies, or a session that simply aged out — was locked out until an admin generated a fresh link. There was no self-service door.

## Changes

**Self-service recovery (`POST /api/auth/request-link`, public)**
- Login screen gains an **"Email me a link"** field. A known member gets a fresh 7-day magic-link delivered out-of-band: DM'd to their linked **Slack/Discord** (identity map, new `notifyLoginLink` → `deliverDM`) **and** written to **`server.log`** (always-available fallback, matching how the owner-seed link is surfaced).
- **Neutral response always** (`{ ok: true }` whether or not the email is a real member) — no account enumeration.
- Rate-limited per email + client IP (`allowLinkRequest`, 3 / 15 min).
- Audited `auth.link.requested` / `auth.link.notified`.

**Sliding sessions**
- `TeamStore.resolveSession` bumps the 30-day expiry on activity, throttled to ≤1 DB write/day/session.
- `GET /api/auth/me` re-stamps the `aos_sid` cookie on each app load (the SPA calls it on mount), so the browser cookie never lapses either.
- A daily-active user now stays signed in indefinitely; the hard cutoff only bites a genuinely idle session. One-time invite/magic-link semantics unchanged (single-use, 7-day TTL).

## Verification
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → 45/45 ✓
- Ephemeral-DB smoke tests: unknown email → neutral 200, silent no-op (no log); known email → neutral 200 + fresh link logged; missing email → 200; `/api/auth/me` no-cookie → 401; accept mints `aos_sid`; `/api/auth/me` with cookie → 200 + re-stamped cookie; **token reuse → `/?login=invalid`** (single-use preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)