### PR TITLE
Inbox: instant "Needs you" dismiss + dismiss-all (v0.66.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.66.1] — 2026-07-09
+### Fixed
+- **Inbox: dismissing a "Needs you" notification is now instant.** The section rendered
+  `messages.filter(isActionRequired)` without honoring the optimistic `dismissed` set (the Activity
+  feed below it did), so a dismissed notification lingered until the next 1.5s poll dropped it
+  server-side — it felt stuck. It now hides the moment you click.
+- **Inbox: added a "dismiss all" link to the "Needs you" section.** Clears every open waiting
+  notification there in one click (pending approvals/questions are left in place — those must be
+  resolved/answered, and the server refuses to dismiss them anyway).
+
 ## [0.66.0] — 2026-07-09
 ### Added
 - **Close a terminal tab without killing its session.** Each tab in the session switcher now has a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.66.0",
+      "version": "0.66.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1880,8 +1880,22 @@ function InboxPage({ messages, me, onOpen, onOpenArtifact, onOpenTask }: { messa
     const r = await api.dismissMessage(id)
     if (r.error) { setDismissed((s) => { const n = new Set(s); n.delete(id); return n }); alert(r.error) }
   }
-  const action = messages.filter(isActionRequired)
+  // `dismissed` is honored here too so a dismissed notification vanishes INSTANTLY (optimistic), instead
+  // of lingering until the next 1.5s poll drops it server-side — the old code filtered `activity` but not
+  // `action`, which is why dismissing a "Needs you" notification felt stuck.
+  const action = messages.filter((m) => isActionRequired(m) && !dismissed.has(m.id))
   const activity = messages.filter((m) => !isActionRequired(m) && !dismissed.has(m.id))
+  // Only open notifications in "Needs you" are dismissible — pending approvals/questions must be
+  // resolved/answered, not swept away (the server refuses to dismiss them anyway).
+  const dismissableAction = action.filter((m) => m.type === 'notification')
+  const dismissAllAction = async () => {
+    const ids = dismissableAction.map((m) => m.id)
+    if (ids.length === 0) return
+    setDismissed((s) => { const n = new Set(s); ids.forEach((id) => n.add(id)); return n })
+    const results = await Promise.all(ids.map((id) => api.dismissMessage(id)))
+    const failed = ids.filter((_, i) => results[i].error)
+    if (failed.length) { setDismissed((s) => { const n = new Set(s); failed.forEach((id) => n.delete(id)); return n }); alert('Some notifications could not be dismissed') }
+  }
   const dismissAll = async () => {
     const ids = activity.map((m) => m.id)
     if (ids.length === 0) return
@@ -1905,8 +1919,11 @@ function InboxPage({ messages, me, onOpen, onOpenArtifact, onOpenTask }: { messa
   return (
     <div className="mx-auto max-w-2xl space-y-7">
       <section>
-        <div className="mb-2 flex items-center gap-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
-          Needs you {action.length > 0 && <Badge variant="destructive" className="px-1.5 py-0 text-[10px]">{action.length}</Badge>}
+        <div className="mb-2 flex items-center justify-between">
+          <span className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
+            Needs you {action.length > 0 && <Badge variant="destructive" className="px-1.5 py-0 text-[10px]">{action.length}</Badge>}
+          </span>
+          {dismissableAction.length > 0 && <button className="text-[11px] text-muted-foreground underline hover:text-foreground" onClick={dismissAllAction}>dismiss all</button>}
         </div>
         {action.length === 0 ? (
           <div className="rounded-lg border border-dashed p-3 text-center text-xs text-muted-foreground">Nothing waiting on you. 🎉</div>


### PR DESCRIPTION
## Problem
Dismissing a notification in the Inbox **Needs you** section felt like it took forever — the card stayed on screen after clicking **Dismiss**.

## Root cause
`InboxPage` computed the section as `messages.filter(isActionRequired)` **without** the `!dismissed.has(m.id)` guard that the Activity feed right below it uses. So the optimistic `dismissed` state (set on click) never hid the card — it only disappeared on the next 1.5s poll, once the server-side `dismissed_at` write landed and got refetched.

## Fix
- `action` now honors the `dismissed` set → the card hides the instant you click **Dismiss**.
- Added a **dismiss all** link to the "Needs you" header (mirroring Activity's). It clears every open waiting notification at once. Pending approvals/questions are intentionally left in place — those must be resolved/answered, and the server refuses to dismiss them anyway (so it fires per-notification `dismissMessage` calls client-side; no server change).

Frontend-only (`web/src/App.tsx`). No API or store changes.

## Verification
- `cd web && npm run build` ✓
- root `tsc` build ✓
- `npm run test:governance` → 45/45 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)