### PR TITLE
Connections: rename Connectors → Connections + fold Integrations into a Creds sub-tab (v0.68.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.68.0] — 2026-07-09
+### Changed
+- **Connectors → Connections, with a Creds sub-tab.** The **Connectors** page is now **Connections**,
+  and the workspace platform-credential editor (Composio key, Slack/Discord tokens, chat-router
+  toggle) moved out of **Settings → Integrations** into a **Creds** sub-tab on the same page — so
+  "what an agent can reach" and "the keys that power it" live in one place (`#/connectors/creds`).
+  The Settings → Integrations tab is gone; all prose/links now point to **Connections → Creds**. Creds
+  stays owner/admin-only, as before. UI-only — no API, schema, or data change. First step of the
+  access-model reframe (`docs/access-model.md`).
+
 ## [0.67.0] — 2026-07-09
 ### Added
 - **Edit an existing automation.** Each automation card gains an **Edit** button (owner or creator)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.67.0",
+      "version": "0.68.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.67.0",
+  "version": "0.68.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -779,7 +779,7 @@ function Console({ me }: { me: Member }) {
               {(me.role === 'owner' || me.role === 'admin') && (
                 <NavItem icon={<Sparkles className="h-4 w-4" />} label="Skills" active={route === 'skills'} onClick={() => nav('skills')} />
               )}
-              <NavItem icon={<Plug className="h-4 w-4" />} label="Connectors" active={route === 'connectors'} onClick={() => nav('connectors')} />
+              <NavItem icon={<Plug className="h-4 w-4" />} label="Connections" active={route === 'connectors'} onClick={() => nav('connectors')} />
               <NavItem icon={<Users className="h-4 w-4" />} label="Team" active={route === 'team'} onClick={() => nav('team')} />
               {(me.role === 'owner' || me.role === 'admin') && (
                 <NavItem icon={<FolderTree className="h-4 w-4" />} label="Files" active={route === 'files'} onClick={() => nav('files')} />
@@ -817,7 +817,7 @@ function Console({ me }: { me: Member }) {
         <div className="flex items-center justify-between border-b px-6 py-4">
           <div className="flex items-center gap-3">
             <h1 className="max-w-[60vw] truncate text-lg font-semibold">
-              {route === 'sessions' && selected ? selected.title : route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connectors' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Artifacts' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'docs' ? 'Docs' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
+              {route === 'sessions' && selected ? selected.title : route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connections' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Artifacts' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'docs' ? 'Docs' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
             </h1>
             {/* When a terminal is open the page fills with the iframe; this pins a way back to the list next to the title. */}
             {route === 'sessions' && selected && (
@@ -833,7 +833,7 @@ function Console({ me }: { me: Member }) {
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); nav('agents', id) }} />}
           {route === 'sessions' && <SessionsPage sessions={sessions} waiting={waiting} selected={selected} hiddenTabs={hiddenTabs} onOpen={openTerminal} onCloseTab={closeTab} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} />}
-          {route === 'connectors' && <ConnectorsPage me={me} />}
+          {route === 'connectors' && <ConnectionsPage me={me} tab={detail} onTab={(t) => nav('connectors', t)} />}
           {route === 'team' && <TeamPage me={me} />}
           {route === 'automations' && <AutomationsPage me={me} agents={state?.agents ?? []} onOpen={openTerminal} nav={nav} />}
           {route === 'tasks' && <TasksPage me={me} agents={state?.agents ?? []} taskId={detail} onOpen={openTerminal} nav={nav} />}
@@ -2153,7 +2153,35 @@ function FeedItem({ m, onOpen, onOpenArtifact, onOpenTask, onDismiss, unread }: 
   )
 }
 
-// Connectors UI lives in ./connectors.tsx (ConnectorsPage imported above).
+// Connectors UI lives in ./connectors.tsx (ConnectorsPage imported above). The "Connections" page
+// wraps it with a **Creds** sub-tab — the workspace platform-credential editor (formerly Settings →
+// Integrations) — so "what an agent can reach" and "the keys that power it" live in one place. The
+// active sub-tab is the hash detail (`#/connectors/creds`), mirroring how SettingsPage tabs work.
+function ConnectionsPage({ me, tab, onTab }: { me: Member | null; tab: string; onTab: (t: 'connected' | 'creds') => void }) {
+  // Creds (the platform-credential editor) is owner/admin-only — as it was under Settings. Members see
+  // only the Connected list, so a stray `#/connectors/creds` falls back rather than showing a dead tab.
+  const isAdmin = me?.role === 'owner' || me?.role === 'admin'
+  const active: 'connected' | 'creds' = tab === 'creds' && isAdmin ? 'creds' : 'connected'
+  return (
+    <div className="max-w-4xl space-y-4">
+      {isAdmin && (
+        <div className="inline-flex gap-1 rounded-lg border bg-background p-1">
+          {([['connected', 'Connected'], ['creds', 'Creds']] as const).map(([v, label]) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => onTab(v)}
+              className={`rounded-md px-3 py-1 text-xs transition-colors ${active === v ? 'bg-primary text-primary-foreground' : 'text-muted-foreground hover:text-foreground'}`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      )}
+      {active === 'creds' && me ? <IntegrationsSettings me={me} /> : <ConnectorsPage me={me} />}
+    </div>
+  )
+}
 function Field({ label, help, children }: { label: string; help?: string; children: ReactNode }) {
   return (
     <div>
@@ -3756,15 +3784,15 @@ function AutomationsPage({ me, agents, onOpen, nav }: { me: Member; agents: Agen
                     <Input disabled value="URL generated after create" />
                   </Field>
                 ) : type === 'slack' ? (
-                  <Field label="Trigger filter" help="Scope to an event type (app_mention / message) or a channel id (e.g. C0123…). Blank = any Slack message the app receives. Needs Slack tokens in Settings → Integrations.">
+                  <Field label="Trigger filter" help="Scope to an event type (app_mention / message) or a channel id (e.g. C0123…). Blank = any Slack message the app receives. Needs Slack tokens in Connections → Creds.">
                     <Input value={filter} onChange={(e) => setFilter(e.target.value)} className="font-mono" placeholder="app_mention  ·  or a channel id  (blank = any)" />
                   </Field>
                 ) : type === 'discord' ? (
-                  <Field label="Trigger filter" help="Scope to an event type (mention / direct_message) or a channel id. Blank = any Discord message the bot receives. Needs a bot token in Settings → Integrations.">
+                  <Field label="Trigger filter" help="Scope to an event type (mention / direct_message) or a channel id. Blank = any Discord message the bot receives. Needs a bot token in Connections → Creds.">
                     <Input value={filter} onChange={(e) => setFilter(e.target.value)} className="font-mono" placeholder="mention  ·  or a channel id  (blank = any)" />
                   </Field>
                 ) : (
-                  <Field label="Trigger filter" help="Composio trigger slug to match — e.g. SLACK_DIRECT_MESSAGE_RECEIVED. Blank = any Composio event. Needs a webhook secret in Settings → Integrations.">
+                  <Field label="Trigger filter" help="Composio trigger slug to match — e.g. SLACK_DIRECT_MESSAGE_RECEIVED. Blank = any Composio event. Needs a webhook secret in Connections → Creds.">
                     <Input value={filter} onChange={(e) => setFilter(e.target.value)} className="font-mono" placeholder="SLACK_DIRECT_MESSAGE_RECEIVED  (blank = any)" />
                   </Field>
                 )}
@@ -5826,8 +5854,8 @@ function AuditPage() {
   )
 }
 
-type SettingsTab = 'company' | 'runtime' | 'integrations' | 'secrets' | 'memory' | 'policy' | 'governance' | 'system'
-const SETTINGS_TABS: SettingsTab[] = ['company', 'runtime', 'integrations', 'secrets', 'memory', 'policy', 'governance', 'system']
+type SettingsTab = 'company' | 'runtime' | 'secrets' | 'memory' | 'policy' | 'governance' | 'system'
+const SETTINGS_TABS: SettingsTab[] = ['company', 'runtime', 'secrets', 'memory', 'policy', 'governance', 'system']
 
 // The active sub-tab is a URL detail (`#/settings/<tab>`) so a refresh / shared link lands on the same
 // tab. `tab` is the raw detail from the router; `onTab` writes it back into the hash.
@@ -5840,7 +5868,6 @@ function SettingsPage({ me, state, tab: tabParam, onTab }: { me: Member; state: 
       <div className="flex w-48 shrink-0 flex-col gap-1 rounded-lg border bg-background p-1 self-start [&_button]:text-left">
         <TabButton on={tab === 'company'} onClick={() => setTab('company')}>Company context</TabButton>
         <TabButton on={tab === 'runtime'} onClick={() => setTab('runtime')}>Runtime defaults</TabButton>
-        <TabButton on={tab === 'integrations'} onClick={() => setTab('integrations')}>Integrations</TabButton>
         <TabButton on={tab === 'secrets'} onClick={() => setTab('secrets')}>Secrets</TabButton>
         <TabButton on={tab === 'memory'} onClick={() => setTab('memory')}>Memory backend</TabButton>
         <TabButton on={tab === 'governance'} onClick={() => setTab('governance')}>Governance</TabButton>
@@ -5850,7 +5877,6 @@ function SettingsPage({ me, state, tab: tabParam, onTab }: { me: Member; state: 
       <div className="min-w-0 flex-1">
         {tab === 'company' ? <CompanySettings me={me} />
           : tab === 'runtime' ? <RuntimeDefaultsSettings me={me} />
-          : tab === 'integrations' ? <IntegrationsSettings me={me} />
           : tab === 'secrets' ? <SecretsSettings me={me} />
           : tab === 'memory' ? <MemorySettings me={me} />
           : tab === 'governance' ? <GovernanceSettings me={me} />
@@ -6816,9 +6842,10 @@ function IntegrationsSettings({ me }: { me: Member }) {
   return (
     <div className="max-w-3xl space-y-4">
       <p className="text-sm text-muted-foreground">
-        Workspace <strong>integration credentials</strong> — stored once and used by your connectors. The
-        <strong> Composio</strong> API key powers Composio-backed connectors: one company key, with each member's
-        apps scoped to their own account (their email is the Composio <code className="text-xs">user_id</code>).
+        <strong>Creds</strong> — the workspace platform credentials stored once and used by your connections. The
+        <strong> Composio</strong> API key powers Composio-backed connections: one company key, with each member's
+        apps scoped to their own account (their email is the Composio <code className="text-xs">user_id</code>). For
+        arbitrary secrets an agent reads at runtime, use the <a href="#/settings/secrets" className="underline hover:text-foreground">Secrets vault</a>.
       </p>
 
       <Card>

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -288,7 +288,7 @@ function AddIntegration({ me, catalog, keySet, onPickTemplate, onConnected, onCl
       {matchedTemplates.length === 0 && matchedApps.length === 0 && (
         <p className="text-xs text-muted-foreground">
           {query ? `No integrations match “${q}”.` : 'No integrations available.'}
-          {!keySet && ' Connecting Composio apps needs a company Composio key (an admin adds it in Settings → Integrations).'}
+          {!keySet && ' Connecting Composio apps needs a company Composio key (an admin adds it in Connections → Creds).'}
         </p>
       )}
       {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
@@ -390,7 +390,7 @@ function ComposioRow({ app, canRemove, busy, onRemove }: {
   )
 }
 
-/** A native chat-bot row (Slack / Discord) — status only; setup lives in Settings → Integrations. */
+/** A native chat-bot row (Slack / Discord) — status only; setup lives in Connections → Creds. */
 function NativeRow({ name, title, s, isAdmin }: {
   name: string; title: string; s?: { configured: boolean; connected: boolean; botUserId: string }; isAdmin: boolean
 }) {
@@ -405,7 +405,7 @@ function NativeRow({ name, title, s, isAdmin }: {
             : statusBadge('not configured')
       }
       right={isAdmin
-        ? <a href="#/settings/integrations" className="inline-flex items-center gap-1 text-[11px] text-muted-foreground underline hover:text-foreground">Settings <ExternalLink className="h-3 w-3" /></a>
+        ? <a href="#/connectors/creds" className="inline-flex items-center gap-1 text-[11px] text-muted-foreground underline hover:text-foreground">Creds <ExternalLink className="h-3 w-3" /></a>
         : <span className="text-[11px] text-muted-foreground">managed by an admin</span>}
     />
   )
@@ -476,7 +476,7 @@ function ConnectedList({ me, connectors, ov, conns, busy, onToggle, onRemove, on
             {conns?.me && <code className="rounded bg-muted px-1.5 py-0.5 text-[10px]" title="your Composio user_id">{conns.me}</code>}
           </div>
           {!conns?.keySet && myConnectors.length === 0 && (
-            <p className="text-xs text-muted-foreground">Connecting your own apps needs a company Composio key (an admin sets it in Settings → Integrations).</p>
+            <p className="text-xs text-muted-foreground">Connecting your own apps needs a company Composio key (an admin sets it in Connections → Creds).</p>
           )}
           {conns?.keySet && myApps.length === 0 && myConnectors.length === 0 && (
             <p className="text-xs text-muted-foreground">You haven’t connected any personal apps or servers yet.</p>
@@ -679,9 +679,9 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
   return (
     <div className="max-w-4xl space-y-6">
       <p className="text-sm text-muted-foreground">
-        Connectors give your claude-code agents real tools. <b>Company</b> integrations are shared by every agent;
-        <b> your</b> connections only load in sessions you start. Every call still passes the gate, so risky actions
-        land in the Inbox for approval.
+        <b>Connections</b> are the tools your claude-code agents can reach. <b>Company</b> connections are shared by
+        every agent; <b>your</b> connections only load in sessions you start. The keys that power them live under
+        the <b>Creds</b> tab. Every call still passes the gate, so risky actions land in the Inbox for approval.
       </p>
 
       {!showAdd && (

--- a/web/src/docs/automations.md
+++ b/web/src/docs/automations.md
@@ -18,7 +18,7 @@ work*; automations answer *when the work starts*.
 | **Discord message** | the bot is @mentioned or DM'd | the same, in a Discord server or DM |
 
 Slack and Discord run over an **outbound** connection, so there's no public URL to expose — set the
-tokens once in **Settings → Integrations**. Webhooks get a secret URL (the key in the link *is* the
+tokens once in **Connections → Creds**. Webhooks get a secret URL (the key in the link *is* the
 auth); treat it like a password.
 
 ## An automated run is still a governed run


### PR DESCRIPTION
**Phase 1 of the access-model reframe** ([`docs/access-model.md`](../blob/main/docs/access-model.md)). Collapses the two surfaces users kept confusing — the **Connectors** page and **Settings → Integrations** — into one **Connections** page.

## What changed
- **Connectors → Connections** (nav label + header title). Internal route id stays `'connectors'` so existing links/bookmarks keep working.
- **Integrations → a "Creds" sub-tab** on the Connections page (`#/connectors/creds`). The workspace platform-credential editor (Composio key + webhook secret, Slack/Discord tokens, `/agent` chat-router toggle, warm-thread timeout) moved out of Settings.
- New `ConnectionsPage` wrapper composes the existing `ConnectorsPage` (**Connected**) and `IntegrationsSettings` (**Creds**) — no cross-file moves, no circular import. Sub-tab is routed by the hash detail, mirroring `SettingsPage`.
- **Creds stays owner/admin-only** (as it was under Settings): members see only the Connected list — no dead tab, and a stray `#/connectors/creds` falls back to Connected.
- Removed the Settings → Integrations tab; relabelled all prose/links (`connectors.tsx`, Automations trigger-filter help, `docs/automations.md`) to **Connections → Creds**; native-bot rows' setup link now points to `#/connectors/creds`.
- Refreshed the Connected + Creds intro copy to the Connections/Creds framing.

## Scope / safety
- **UI-only.** No API, schema, route-id, or data change — the Creds editor still saves to the same `/api/settings/integrations` endpoints.
- **Verified:** `tsc -b` + `vite build` clean. Not yet click-tested in a live browser (relabel + a conditional-render wrapper mirroring the proven SettingsPage tab pattern).
- **Deliberately deferred:** the Tool/Shell/Host **shape facet** from the doc — only Tool-shaped connections have data today, so an empty facet would be vaporware. It lands with Phase 2 (Host/Network as a first-class connection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)