### PR TITLE
Inbox: dismiss agent questions + retire them when a session ends (v0.69.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.69.0] — 2026-07-09
+### Added
+- **Dismiss an agent question from the Inbox.** A pending question card now has a **Dismiss** button
+  next to Reply. It cancels the question (new `cancelled` status) so it leaves "Needs you" — and a
+  still-live agent's blocking `ask` unblocks and proceeds instead of waiting out its poll timeout.
+### Changed
+- **Stopping a session retires its open questions.** When a session is stopped (or crashes, or is
+  idle-reaped), the agent that asked is gone and no one can answer — so its pending questions are now
+  cancelled automatically. The orphaned "Needs you" cards drop into the dismissable Activity feed
+  (labelled *dismissed*) instead of hanging forever as unanswerable prompts.
+
 ## [0.68.0] — 2026-07-09
 ### Changed
 - **Connectors → Connections, with a Creds sub-tab.** The **Connectors** page is now **Connections**,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.68.0",
+      "version": "0.69.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.68.0",
+  "version": "0.69.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -756,6 +756,7 @@ async function ask(args: Record<string, unknown>): Promise<string> {
     const r = await fetch(`${AOS_URL}/api/ask/${id}`);
     const d = (await r.json()) as { status?: string; answer?: string };
     if (d.status === 'answered') return d.answer || '(the operator gave no answer)';
+    if (d.status === 'cancelled') return 'The operator dismissed this question without answering. Proceed using your best judgement, or ask again if you are still blocked.';
   }
   return 'No answer yet (timed out waiting on the operator). Proceed using your best judgement or ask again.';
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1475,6 +1475,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, ok ? 200 : 409, ok ? { ok: true } : { error: 'already answered or not found' });
   }
 
+  // Dismiss a pending question without answering it (the inbox "dismiss" on a question card). Cancels
+  // the question — it leaves "Needs you" and a still-live agent's blocking `ask` unblocks. Same
+  // visibility gate as answering.
+  const cancelQMatch = p.match(/^\/api\/questions\/([\w-]+)\/cancel$/);
+  if (method === 'POST' && cancelQMatch) {
+    if (!tm.canViewQuestion(cancelQMatch[1], me)) return sendJson(res, 403, { error: 'not allowed to dismiss this question' });
+    const ok = tm.cancelQuestion(cancelQMatch[1], me.email);
+    return sendJson(res, ok ? 200 : 409, ok ? { ok: true } : { error: 'already resolved or not found' });
+  }
+
   // ── memory (console: browse / curate an agent's persistent memory) ───────────
   if (method === 'GET' && p === '/api/memory/health') return sendJson(res, 200, await os.memory.health());
   // The learning-system Overview: pipeline counts + a recent learning-activity feed. Owner/admin —

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -153,7 +153,7 @@ export interface FeedMessage {
   agent: string;
   title: string;
   body: string;
-  status: 'open' | 'pending' | 'approved' | 'rejected' | 'answered';
+  status: 'open' | 'pending' | 'approved' | 'rejected' | 'answered' | 'cancelled';
   approvalId?: string;
   capability?: string;
   args?: unknown;
@@ -360,6 +360,8 @@ export class TerminalManager {
           // only place to capture what the run did before it died. Outcome 'crashed'; idempotent, so
           // repeated polls won't write twice; skipped if the session did no real work.
           this.writeEpisode(r.id, r.agent, 'crashed');
+          // A crashed agent can't answer anything it asked — retire its open questions like a clean stop.
+          this.cancelPendingQuestions(r.id, 'system');
         }
       }
     }
@@ -852,6 +854,7 @@ export class TerminalManager {
       try {
         this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
         this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), r.id);
+        this.cancelPendingQuestions(r.id, 'system');
         this.audit(r.id, r.agent, 'chat.reaped', { idleMin: timeoutMin });
       } catch { /* one bad row must not stop the sweep */ }
     }
@@ -1471,11 +1474,40 @@ export class TerminalManager {
     return true;
   }
 
+  /**
+   * Cancel a single pending question (the inbox "dismiss" on a question card). Flips it to `cancelled`
+   * so the card leaves "Needs you" and becomes a dismissable Activity row — and, since `questionStatus`
+   * now reports `cancelled`, a still-live agent's blocking `ask` poll unblocks and proceeds instead of
+   * waiting out the hour. No-op unless the question exists and is still pending.
+   */
+  cancelQuestion(id: string, by: string): boolean {
+    const q = this.db.prepare('SELECT run_id, status FROM questions WHERE id = ?').get<{ run_id: string; status: string }>(id);
+    if (!q || q.status !== 'pending') return false;
+    this.db.prepare("UPDATE questions SET status = 'cancelled', answered_by = ?, answered_at = ? WHERE id = ?").run(by, Date.now(), id);
+    this.audit(q.run_id, by, 'question.cancelled', { questionId: id });
+    return true;
+  }
+
+  /**
+   * Cancel every pending question for a session — called when the session stops/crashes/is reaped, so the
+   * agent that asked is gone and no one can answer. Leaves the orphaned "Needs you" cards as dismissable
+   * `cancelled` Activity rows instead of live prompts that can never be resolved. Returns how many flipped.
+   */
+  private cancelPendingQuestions(sessionId: string, by: string): number {
+    const pending = this.db.prepare("SELECT id FROM questions WHERE run_id = ? AND status = 'pending'").all<{ id: string }>(sessionId);
+    if (!pending.length) return 0;
+    this.db.prepare("UPDATE questions SET status = 'cancelled', answered_by = ?, answered_at = ? WHERE run_id = ? AND status = 'pending'").run(by, Date.now(), sessionId);
+    for (const q of pending) this.audit(sessionId, by, 'question.cancelled', { questionId: q.id, reason: 'session ended' });
+    return pending.length;
+  }
+
   /** Question status + answer for the polling ask-human MCP tool. */
-  questionStatus(id: string): { status: 'pending' | 'answered'; answer?: string } {
+  questionStatus(id: string): { status: 'pending' | 'answered' | 'cancelled'; answer?: string } {
     const q = this.db.prepare('SELECT status, answer FROM questions WHERE id = ?').get<{ status: string; answer: string | null }>(id);
     if (!q) return { status: 'pending' };
-    return { status: q.status === 'answered' ? 'answered' : 'pending', answer: q.answer ?? undefined };
+    if (q.status === 'answered') return { status: 'answered', answer: q.answer ?? undefined };
+    if (q.status === 'cancelled') return { status: 'cancelled' };
+    return { status: 'pending' };
   }
 
   /** Claude Code fired a Notification — it's blocked waiting on the human (a permission prompt in the
@@ -1701,6 +1733,9 @@ export class TerminalManager {
     this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
     if (r.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.clearNotifications(sessionId);
+    // The agent that asked is now dead — no one can answer its open questions. Cancel them so they leave
+    // "Needs you" and become dismissable, rather than hanging forever as unanswerable prompts.
+    this.cancelPendingQuestions(sessionId, by);
     // Halting kills the tmux shell, so the launcher's `markEnded` never fires — capture the episode
     // here instead so the work done (the audit stream) is remembered. Outcome 'stopped'; skipped if the
     // session did nothing worth remembering.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2037,6 +2037,8 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
 
   // ── Question (pending) ──
   const send = async () => { if (!answer.trim()) return; setBusy(true); const r = await api.answerQuestion(m.questionId!, answer.trim()); if (r.error) setBusy(false) }
+  // Dismiss without answering: cancels the question so it leaves "Needs you" (and unblocks a live agent's `ask`).
+  const dismissQ = async () => { setBusy(true); const r = await api.cancelQuestion(m.questionId!); if (r.error) { setBusy(false); alert(r.error) } }
   return (
     <div className="rounded-lg border border-sky-300 bg-sky-50/40 px-3 py-2.5">
       <div className="flex items-start gap-2.5">
@@ -2051,6 +2053,7 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
       <div className="mt-2 flex gap-1.5">
         <Input value={answer} onChange={(e) => setAnswer(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && send()} placeholder="Type your answer — the agent is waiting…" className="h-8 text-sm" />
         <Button size="sm" className="h-8 px-2.5 text-xs" disabled={busy || !answer.trim()} onClick={send}><Send className="mr-1 h-3.5 w-3.5" />Reply</Button>
+        <Button size="sm" variant="ghost" className="h-8 px-2 text-xs text-muted-foreground" disabled={busy} onClick={dismissQ} title="Dismiss without answering — the agent stops waiting on this">Dismiss</Button>
       </div>
     </div>
   )
@@ -2091,7 +2094,9 @@ function FeedItem({ m, onOpen, onOpenArtifact, onOpenTask, onDismiss, unread }: 
     badge = <Badge variant={m.status === 'approved' ? 'default' : 'destructive'} className="px-1.5 py-0 text-[10px]">{m.status}</Badge>
   } else if (m.type === 'question') {
     Icon = HelpCircle; iconCls = 'text-sky-600'
-    verb = 'asked'; detail = m.body
+    const cancelled = m.status === 'cancelled'
+    verb = cancelled ? 'asked — dismissed unanswered' : 'asked'; detail = m.body
+    if (cancelled) badge = <Badge variant="outline" className="px-1.5 py-0 text-[10px] font-normal text-muted-foreground">dismissed</Badge>
     extra = m.answer ? <div className="mt-1 rounded bg-muted px-2 py-1 text-xs"><span className="text-muted-foreground">{m.answeredBy ? `${m.answeredBy}: ` : 'answer: '}</span>{m.answer}</div> : null
   } else if (isImportant(m)) {
     Icon = AlertTriangle; iconCls = 'text-amber-600'; highlight = true

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -282,7 +282,7 @@ export interface Msg {
   agent: string
   title: string
   body: string
-  status: 'open' | 'pending' | 'approved' | 'rejected' | 'answered'
+  status: 'open' | 'pending' | 'approved' | 'rejected' | 'answered' | 'cancelled'
   approvalId?: string
   capability?: string
   args?: unknown
@@ -712,6 +712,8 @@ export const api = {
   /** Approve this attempt AND add a persistent policy `allow` rule for its capability (owner-only). */
   alwaysApprove: (id: string) => call<{ ok: boolean; ruleAdded?: boolean; note?: string; error?: string }>('POST', `/api/approvals/${id}/always`),
   answerQuestion: (id: string, answer: string) => call<{ ok: boolean; error?: string }>('POST', '/api/questions/' + id, { answer }),
+  /** Dismiss a pending question without answering (cancels it; unblocks a still-live agent's `ask`). */
+  cancelQuestion: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/questions/${id}/cancel`),
   dismissMessage: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/dismiss`),
   dismissAllMessages: () => call<{ ok: boolean; dismissed?: number; error?: string }>('POST', '/api/messages/dismiss-all'),
   markRead: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/read`),


### PR DESCRIPTION
## Problem
If you stop a terminal session, its open agent **questions** stayed live in the Inbox forever. They couldn't be answered (the agent is dead) and the dismiss path explicitly **refuses** pending questions (409). Only a full `deleteSession` cleared them.

## Fix
Two changes, unified by one new question status `cancelled`:

1. **Stop cascade (the primary ask).** `stopSession` — and the crash sweep + idle reaper, which orphan questions the same way — now cancel the session's pending questions. The orphaned "Needs you" cards fall out into the dismissable Activity feed (labelled *dismissed*).
2. **Dismiss button on a question (the alternative ask).** A pending question card gets a **Dismiss** button beside Reply. It cancels just that question. Because `questionStatus` now reports `cancelled`, a still-live agent's blocking `ask` poll **unblocks and proceeds** instead of waiting out the ~1h timeout — a graceful cancel, not a silent hide.

## Wiring
- `TerminalManager.cancelQuestion(id, by)` + private `cancelPendingQuestions(sessionId, by)`; `question.cancelled` audit.
- `questionStatus` and the `FeedMessage`/`Msg` status unions gain `cancelled`.
- Route `POST /api/questions/:id/cancel` (same `canViewQuestion` gate as answering).
- The `ask` MCP poll handles `cancelled`.
- Web: `ActionItem` Dismiss button → `api.cancelQuestion`; `FeedItem` shows a *dismissed* badge for cancelled questions.

## Verification
- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` → 45/45.
- Isolated in-process script: ask→stop flips the question to `cancelled`; direct dismiss cancels it while the session stays `running`; re-cancel is a no-op; a cancelled question is no longer `pending` and `dismissMessage` returns `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)