### PR TITLE
Approvals: retire pending approvals when a session ends (v0.70.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.70.0] — 2026-07-09
+### Changed
+- **Stopping a session retires its open approvals too.** The v0.69.0 stop-cascade for questions now
+  extends to pending **approvals**: when a session is stopped (or crashes, or is idle-reaped), its
+  pending approval cards are cancelled (new `cancelled` status) — the agent blocked on the gate is
+  gone, so approving would only clear an effect no one will perform. Cancelling settles the gateway's
+  decision as *denied* (a still-suspended gate unblocks and the effect is blocked), the gate-hook's
+  status poll returns `deny`, and the orphaned "Needs you" card drops into the dismissable Activity
+  feed (labelled *cancelled*, not a rejection).
+### Fixed
+- **`deleteSession` no longer leaks approval rows.** Permanently deleting a session now cancels its
+  pending approvals (settling any waiter) and removes its `approvals` rows, matching how it already
+  cascades messages and questions.
+
 ## [0.69.0] — 2026-07-09
 ### Added
 - **Dismiss an agent question from the Inbox.** A pending question card now has a **Dismiss** button

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.69.0",
+      "version": "0.70.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.69.0",
+  "version": "0.70.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/approvals.ts
+++ b/src/governance/approvals.ts
@@ -49,6 +49,19 @@ export class InMemoryApprovals implements Approvals {
     }
   }
 
+  cancel(id: string, by: string): boolean {
+    const req = this.items.get(id);
+    if (!req || req.status !== 'pending') return false;
+    req.status = 'cancelled';
+    req.resolvedBy = by;
+    const waiter = this.waiters.get(id);
+    if (waiter) {
+      waiter(false); // deny — the gated effect must not proceed
+      this.waiters.delete(id);
+    }
+    return true;
+  }
+
   pending(tenant?: string): ApprovalRequest[] {
     return [...this.items.values()].filter(
       (r) => r.status === 'pending' && (!tenant || r.tenant === tenant),
@@ -65,7 +78,7 @@ interface ApprovalRow {
   args: string;
   reasoning: string | null;
   reason: string;
-  status: 'pending' | 'approved' | 'rejected';
+  status: 'pending' | 'approved' | 'rejected' | 'cancelled';
   resolved_by: string | null;
   created_at: number;
 }
@@ -130,8 +143,21 @@ export class SqliteApprovals implements Approvals {
     }
   }
 
-  /** Map a request id to its current status — for the gate hook (allow | deny | pending). */
-  statusOf(id: string): 'pending' | 'approved' | 'rejected' | undefined {
+  cancel(id: string, by: string): boolean {
+    const row = this.db.prepare('SELECT status FROM approvals WHERE id = ?').get<{ status: string }>(id);
+    if (!row || row.status !== 'pending') return false;
+    this.db.prepare("UPDATE approvals SET status = 'cancelled', resolved_by = ? WHERE id = ?").run(by, id);
+    const waiter = this.waiters.get(id);
+    if (waiter) {
+      waiter(false); // deny — the gated effect must not proceed
+      this.waiters.delete(id);
+    }
+    return true;
+  }
+
+  /** Map a request id to its current status — for the gate hook (allow | deny | pending). A `cancelled`
+   *  row falls through to deny below, so a still-polling gate-hook stops waiting and the effect is blocked. */
+  statusOf(id: string): 'pending' | 'approved' | 'rejected' | 'cancelled' | undefined {
     return this.db.prepare('SELECT status FROM approvals WHERE id = ?').get<{ status: ApprovalRow['status'] }>(id)?.status;
   }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -360,8 +360,9 @@ export class TerminalManager {
           // only place to capture what the run did before it died. Outcome 'crashed'; idempotent, so
           // repeated polls won't write twice; skipped if the session did no real work.
           this.writeEpisode(r.id, r.agent, 'crashed');
-          // A crashed agent can't answer anything it asked — retire its open questions like a clean stop.
+          // A crashed agent can't answer or act — retire its open questions + approvals like a clean stop.
           this.cancelPendingQuestions(r.id, 'system');
+          this.cancelPendingApprovals(r.id, 'system');
         }
       }
     }
@@ -855,6 +856,7 @@ export class TerminalManager {
         this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
         this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), r.id);
         this.cancelPendingQuestions(r.id, 'system');
+        this.cancelPendingApprovals(r.id, 'system');
         this.audit(r.id, r.agent, 'chat.reaped', { idleMin: timeoutMin });
       } catch { /* one bad row must not stop the sweep */ }
     }
@@ -1415,7 +1417,7 @@ export class TerminalManager {
     const status = this.os.approvals.statusOf(id);
     if (status === 'approved') return 'allow';
     if (status === 'pending') return 'pending';
-    return 'deny'; // rejected or unknown
+    return 'deny'; // rejected, cancelled, or unknown
   }
 
   private addMessage(m: Omit<FeedMessage, 'id' | 'createdAt'>): void {
@@ -1498,6 +1500,22 @@ export class TerminalManager {
     if (!pending.length) return 0;
     this.db.prepare("UPDATE questions SET status = 'cancelled', answered_by = ?, answered_at = ? WHERE run_id = ? AND status = 'pending'").run(by, Date.now(), sessionId);
     for (const q of pending) this.audit(sessionId, by, 'question.cancelled', { questionId: q.id, reason: 'session ended' });
+    return pending.length;
+  }
+
+  /**
+   * Cancel every pending approval for a session — the sibling of {@link cancelPendingQuestions}, run
+   * when the session stops/crashes/is reaped. The agent blocked on the gate is gone, so an owner
+   * approving now would gate an effect no one will ever perform. `Approvals.cancel` marks the row
+   * `cancelled` and settles the waiter as denied; the card leaves "Needs you" and becomes a dismissable
+   * Activity row. Returns how many were cancelled.
+   */
+  private cancelPendingApprovals(sessionId: string, by: string): number {
+    const pending = this.os.approvals.pending(this.os.tenant).filter((a) => a.runId === sessionId);
+    for (const a of pending) {
+      this.os.approvals.cancel(a.id, by);
+      this.audit(sessionId, by, 'approval.cancelled', { approvalId: a.id, reason: 'session ended' });
+    }
     return pending.length;
   }
 
@@ -1733,9 +1751,10 @@ export class TerminalManager {
     this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
     if (r.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.clearNotifications(sessionId);
-    // The agent that asked is now dead — no one can answer its open questions. Cancel them so they leave
-    // "Needs you" and become dismissable, rather than hanging forever as unanswerable prompts.
+    // The agent that asked is now dead — no one can answer its open questions or act on its approvals.
+    // Cancel both so they leave "Needs you" and become dismissable, rather than hanging forever.
     this.cancelPendingQuestions(sessionId, by);
+    this.cancelPendingApprovals(sessionId, by);
     // Halting kills the tmux shell, so the launcher's `markEnded` never fires — capture the episode
     // here instead so the work done (the audit stream) is remembered. Outcome 'stopped'; skipped if the
     // session did nothing worth remembering.
@@ -1755,8 +1774,11 @@ export class TerminalManager {
     if (!r) return false;
     this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
     this.removeSessionFiles(sessionId);
+    // Settle any in-memory approval waiter (deny) before the rows go, so a still-suspended gate unblocks.
+    this.cancelPendingApprovals(sessionId, by);
     this.db.prepare('DELETE FROM messages WHERE session_id = ?').run(sessionId);
     this.db.prepare('DELETE FROM questions WHERE run_id = ?').run(sessionId);
+    this.db.prepare('DELETE FROM approvals WHERE run_id = ?').run(sessionId);
     this.db.prepare('DELETE FROM term_sessions WHERE id = ?').run(sessionId);
     this.audit(sessionId, by, 'session.deleted', { tmux: r.tmux, agent: r.agent });
     return true;

--- a/src/types.ts
+++ b/src/types.ts
@@ -225,7 +225,7 @@ export interface ApprovalRequest {
   level: ApprovalLevel;
   attempt: ActionAttempt;
   reason: string;
-  status: 'pending' | 'approved' | 'rejected';
+  status: 'pending' | 'approved' | 'rejected' | 'cancelled';
   createdAt: number;
   resolvedBy?: string;
 }
@@ -237,6 +237,10 @@ export interface Approvals {
     decision: Promise<boolean>;
   };
   resolve(id: string, approved: boolean, by: string): void;
+  /** Cancel a still-pending request (the session it gated ended, so no one can decide). Settles the
+   *  waiter as denied so a live gateway/gate-hook unblocks, and marks the row `cancelled`. Returns
+   *  whether a pending request was actually cancelled. */
+  cancel(id: string, by: string): boolean;
   pending(tenant?: string): ApprovalRequest[];
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2088,10 +2088,14 @@ function FeedItem({ m, onOpen, onOpenArtifact, onOpenTask, onDismiss, unread }: 
     verb = 'published'; detail = m.body
     badge = meta.filename ? <Badge variant="outline" className="max-w-[40%] px-1.5 py-0 text-[10px] font-normal">{meta.filename}</Badge> : null
   } else if (m.type === 'approval') {
+    // cancelled = the session ended before a human decided — a neutral "never ran", not a rejection.
+    const cancelledA = m.status === 'cancelled'
     Icon = m.status === 'approved' ? CheckCircle2 : XCircle
-    iconCls = m.status === 'approved' ? 'text-emerald-600' : 'text-red-600'
-    verb = <>{m.title}{m.resolvedBy && <span className="text-muted-foreground"> · by {m.resolvedBy}</span>}</>
-    badge = <Badge variant={m.status === 'approved' ? 'default' : 'destructive'} className="px-1.5 py-0 text-[10px]">{m.status}</Badge>
+    iconCls = m.status === 'approved' ? 'text-emerald-600' : cancelledA ? 'text-muted-foreground' : 'text-red-600'
+    verb = <>{m.title}{m.resolvedBy && !cancelledA && <span className="text-muted-foreground"> · by {m.resolvedBy}</span>}</>
+    badge = cancelledA
+      ? <Badge variant="outline" className="px-1.5 py-0 text-[10px] font-normal text-muted-foreground">cancelled</Badge>
+      : <Badge variant={m.status === 'approved' ? 'default' : 'destructive'} className="px-1.5 py-0 text-[10px]">{m.status}</Badge>
   } else if (m.type === 'question') {
     Icon = HelpCircle; iconCls = 'text-sky-600'
     const cancelled = m.status === 'cancelled'


### PR DESCRIPTION
## Problem
Follow-up to #115 (questions). Pending **approvals** had the same orphaning gap: when a session was stopped, its approval card stayed live in "Needs you" forever. No one could act on it (the agent blocked on the gate is dead), and approving would only gate an effect that will never be performed. `deleteSession` also leaked: it cascaded messages/questions but left `approvals` rows behind.

## Fix
Extend the v0.69.0 stop-cascade to approvals, via a new `Approvals.cancel(id, by)` and one new `cancelled` status:

- **Stop cascade.** `stopSession` — plus the crash sweep and idle reaper — now cancel the session's pending approvals. `cancel()` marks the row `cancelled` **and settles the gateway's `decision` promise as denied**, so a still-suspended gate unblocks and the effect is blocked (not silently allowed). `gateStatus` maps `cancelled` → `deny`, so a still-polling gate-hook stops waiting. The card leaves "Needs you" and becomes a dismissable Activity row labelled **cancelled** (neutral — it's a "never ran", not a rejection).
- **`deleteSession` leak fixed.** It now cancels (settling any waiter) and deletes the session's `approvals` rows, matching the existing messages/questions cascade.

No new HTTP route: a *live* approval already has an Approve/**Reject** pair, and denying a pending approval is rightly approver-gated — so this only needs to handle the orphaned-after-stop case, which is system-triggered.

## Wiring
- `cancelled` added to `ApprovalRequest.status`, both `Approvals` impls (`SqliteApprovals` + `InMemoryApprovals`), and `statusOf`.
- `TerminalManager.cancelPendingApprovals(sessionId, by)`, audited `approval.cancelled`, called from the three lifecycle paths + `deleteSession`.
- Web `FeedItem` renders a cancelled approval with a muted "cancelled" badge instead of a red rejection.

## Verification
- `typecheck`, web build, `test:governance` → 45/45.
- Isolated in-process script: a pending approval whose gateway awaits its `decision` promise — after `stopSession`, `statusOf` = `cancelled`, `gateStatus` = `deny`, the **decision promise resolves `false`** (gateway unblocks, effect denied), `pending()` drops it, and the mirrored inbox card is `cancelled` and `dismissMessage` → `ok`. `cancel` after a real `resolve` is a no-op (can't clobber a genuine decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)