### PR TITLE
Branding: per-tenant accent color + favicon (Settings → Theme) (v0.71.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.71.0] — 2026-07-09
+### Added
+- **Per-tenant console branding (Settings → Theme).** Give each tenant an **accent colour** and a
+  **favicon badge** (an emoji or 1–3 initials) so several tenants running in parallel — even across
+  machines — are distinguishable at a glance. The accent tints the sidebar strip, active nav item and
+  focus rings; the badge is rendered client-side into an SVG data-URI favicon (no uploads, no
+  storage), so the browser-tab icon differs per tenant. Branding is served from a **public**
+  `GET /api/branding` so the login screen and tab favicon are already themed before sign-in, and it
+  even tints the magic-link accept page. Owner/admin edits via `GET`/`PUT /api/settings/branding`
+  (stored in the per-tenant `settings` table under `ui_branding`, audited `settings.branding.updated`);
+  applies live without a reload. Foreground colours are auto-chosen (black/white by luminance) so text
+  stays readable on any accent.
+
 ## [0.70.0] — 2026-07-09
 ### Changed
 - **Stopping a session retires its open approvals too.** The v0.69.0 stop-cascade for questions now

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.70.0",
+      "version": "0.71.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -10,7 +10,7 @@
  * so adding more instance-level settings later is just another key.
  */
 import { Db } from '../state/db';
-import { EnrichPattern, MemoryConfig, Recommendation, RuntimeTuning, sanitizeRuntimeTuning } from '../types';
+import { Branding, EnrichPattern, MemoryConfig, Recommendation, RuntimeTuning, sanitizeBranding, sanitizeRuntimeTuning } from '../types';
 
 const COMPANY_KEY = 'company_md';
 const COMPOSIO_KEY = 'composio_api_key';
@@ -27,6 +27,7 @@ const LEARNED_APPLY_KEY = 'learned_guidance_apply'; // 'off' to stop injecting (
 const RECOMMENDATIONS_KEY = 'learned_recommendations'; // { open: Recommendation[], dismissed: string[] }
 const GOVERNANCE_KEY = 'governance_thresholds'; // numeric caps the never-tier policy rules read (JSON GovernanceThresholds)
 const ENRICH_PATTERNS_KEY = 'enrich_patterns'; // operator regex→boolean-fact rules the enricher applies (JSON EnrichPattern[])
+const BRANDING_KEY = 'ui_branding'; // per-tenant web-console accent colour + favicon badge (JSON Branding)
 
 /** Numeric governance caps the policy's never-tier rules reference by name (e.g. `$moneyCapUsd`).
  *  Live-editable in Settings → Governance; resolved at classify time by the policy engine. */
@@ -233,6 +234,33 @@ export class SettingsStore {
   setRuntimeDefaults(tuning: RuntimeTuning, by?: string): RuntimeTuning {
     this.set(RUNTIME_DEFAULTS_KEY, JSON.stringify(tuning), by);
     return this.runtimeDefaults();
+  }
+
+  // ── UI branding ──────────────────────────────────────────────────────────────────
+  // Per-tenant accent colour + favicon badge for the web console, so several tenants running side by
+  // side are distinguishable at a glance. Display-only (no secrets) → served unauthenticated via
+  // GET /api/branding so the client themes itself even before login. Empty/missing → default look.
+
+  /** The stored branding (accent colour + badge), or `{}` when none saved. */
+  branding(): Branding {
+    const raw = this.getRow(BRANDING_KEY)?.value;
+    if (!raw) return {};
+    try {
+      return sanitizeBranding(JSON.parse(raw) as Record<string, unknown>);
+    } catch {
+      return {};
+    }
+  }
+
+  /** Who last changed the branding. */
+  brandingMeta(): { updatedAt?: number; updatedBy?: string } {
+    const row = this.getRow(BRANDING_KEY);
+    return { updatedAt: row?.updated_at, updatedBy: row?.updated_by ?? undefined };
+  }
+
+  setBranding(b: Branding, by?: string): Branding {
+    this.set(BRANDING_KEY, JSON.stringify(sanitizeBranding(b)), by);
+    return this.branding();
   }
 
   // ── self-learning (Dreaming) cadence ─────────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,7 +28,7 @@ import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument, withAlwaysAll
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
 import { parseBundle } from './governance/bundle-import';
-import { AgentManifest, ApprovalRequest, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
+import { AgentManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
 import { AgentConfigSnapshot } from './state/agent-revisions';
 
 /** Settings → Memory view: stored backend config with secrets redacted to `…Set` booleans. */
@@ -285,7 +285,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const token = url.searchParams.get('token') || '';
     const peek = os.team.peekToken(token);
     if (!peek) return redirect(res, '/?login=invalid');
-    return sendHtml(res, 200, acceptLandingHtml(peek.email, token));
+    return sendHtml(res, 200, acceptLandingHtml(peek.email, token, os.settings.branding().accentColor));
   }
   if (method === 'POST' && p === '/accept') {
     const accepted = os.team.acceptToken(url.searchParams.get('token') || '');
@@ -307,6 +307,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     res.writeHead(200, headers);
     res.end(JSON.stringify({ member: m }));
     return;
+  }
+  // Per-tenant console branding (accent colour + favicon badge). PUBLIC + display-only (no secrets):
+  // the SPA fetches this on mount — before any session exists — so the login screen and the browser-tab
+  // favicon are already tenant-coloured. `tenantName` lets the favicon fall back to the tenant's initial.
+  if (method === 'GET' && p === '/api/branding') {
+    const b = os.settings.branding();
+    return sendJson(res, 200, { tenant: os.tenant, tenantName: os.tenantName, accentColor: b.accentColor, badge: b.badge });
   }
   // Self-service recovery: a member who lost their session (new device, cleared cookies, expired
   // window) asks for a fresh sign-in link WITHOUT needing an admin to mint one. Public + neutral: we
@@ -2072,6 +2079,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, ...saved });
   }
 
+  // ── UI branding (per-tenant accent colour + favicon badge) — owner/admin edits ──
+  // The public read is GET /api/branding (above the member gate); this is the admin editor surface.
+  if (method === 'GET' && p === '/api/settings/branding') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { ...os.settings.branding(), ...os.settings.brandingMeta() });
+  }
+  if (method === 'PUT' && p === '/api/settings/branding') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req);
+    const saved = os.settings.setBranding(sanitizeBranding(b as Partial<Record<keyof Branding, unknown>>), me.email);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.branding.updated', data: { ...saved } });
+    return sendJson(res, 200, { ok: true, ...saved });
+  }
+
   // ── governance thresholds (the numeric caps the never-tier policy rules read) ──
   if (method === 'GET' && p === '/api/settings/governance') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
@@ -3328,14 +3349,29 @@ function sendHtml(res: http.ServerResponse, status: number, html: string): void 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]!));
 }
+/** Black or white — whichever reads better on the given `#rrggbb` background (WCAG relative luminance). */
+function readableOn(hex: string): '#000' | '#fff' {
+  const n = parseInt(hex.slice(1), 16);
+  const [r, g, b] = [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((v) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+  });
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b > 0.4 ? '#000' : '#fff';
+}
 /**
  * The interstitial shown by GET /accept. A plain confirm page — no auto-submit — so a link
  * preview / mail-scanner that renders it never consumes the token; only the "Continue" POST does.
  * Self-contained (no app bundle) and theme-aware so it works before the SPA/session exists.
  */
-function acceptLandingHtml(email: string, token: string): string {
+function acceptLandingHtml(email: string, token: string, accent?: string): string {
   const safeEmail = escapeHtml(email);
   const action = `/accept?token=${encodeURIComponent(token)}`;
+  // Tenant accent (validated `#rrggbb`): tint the logo chip + Continue button so even the invite
+  // interstitial matches the tenant's console colour. Overrides both light + dark defaults.
+  const brand = accent && /^#[0-9a-fA-F]{6}$/.test(accent)
+    ? `<style>.logo,.card button{background:${accent}!important;color:${readableOn(accent)}!important}
+       .card button:hover{filter:brightness(.92)}</style>`
+    : '';
   return `<!doctype html><html lang="en"><head><meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="robots" content="noindex">
@@ -3366,7 +3402,7 @@ function acceptLandingHtml(email: string, token: string): string {
     button { background: #f3f5f8; color: #0b0d12; }
     button:hover { background: #dfe3e9; }
   }
-</style></head>
+</style>${brand}</head>
 <body><div class="card">
   <div class="logo">A</div>
   <h1>Sign in to Agent OS</h1>

--- a/src/types.ts
+++ b/src/types.ts
@@ -749,6 +749,30 @@ export function sanitizeRuntimeTuning(input: Partial<Record<keyof RuntimeTuning,
   return { tuning };
 }
 
+/** Per-tenant web-console branding — a small visual stamp so several tenants running in parallel
+ *  (even across machines) are distinguishable at a glance: it recolours the sidebar accent and the
+ *  browser-tab favicon, and tints the pre-login screen. Display-only, no secrets — safe to serve
+ *  unauthenticated so the client can theme itself before login. Empty fields → the default look. */
+export interface Branding {
+  /** Accent colour as a 6-digit hex (`#7c3aed`). Undefined/empty → no override (default theme). */
+  accentColor?: string;
+  /** Favicon badge: an emoji (`🟣`) or a 1–3 char initial (`IP`). Undefined → first letter of the
+   *  tenant name is used. Purely cosmetic. */
+  badge?: string;
+}
+
+/** Normalize+validate a branding payload (from an API body): keeps only a well-formed 6-digit hex
+ *  accent (else dropped, not an error — clearing it is valid) and a short badge (≤ 3 chars after
+ *  trimming, so a single emoji or a couple of initials). Never throws; returns a clean object. */
+export function sanitizeBranding(input: Partial<Record<keyof Branding, unknown>>): Branding {
+  const out: Branding = {};
+  const accent = typeof input.accentColor === 'string' ? input.accentColor.trim() : '';
+  if (/^#[0-9a-fA-F]{6}$/.test(accent)) out.accentColor = accent.toLowerCase();
+  const badge = typeof input.badge === 'string' ? [...input.badge.trim()].slice(0, 3).join('') : '';
+  if (badge) out.badge = badge;
+  return out;
+}
+
 /** Normalize a starter-prompts payload (from an API body or config file): coerces to an array of
  *  trimmed, non-empty strings, caps each at 500 chars and the list at 6. Returns undefined when the
  *  result is empty so the manifest stays clean (the card just falls back to its placeholder). */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,6 +12,8 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
+import { type Branding, type PublicBranding } from '@/lib/api'
+import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage } from '@/connectors'
 import { docPages } from '@/docs'
 
@@ -337,12 +339,25 @@ function useHashRoute(): { route: Route; detail: string; query: string; nav: (r:
 export default function App() {
   // undefined = checking, null = not logged in (show Login), Member = authed.
   const [me, setMe] = useState<Member | null | undefined>(undefined)
+  const [accent, setAccent] = useState<string | undefined>(undefined)
   useEffect(() => {
     api.me().then(setMe)
   }, [])
+  // Per-tenant branding — fetched from the PUBLIC endpoint so it themes the login screen + tab favicon
+  // before any session exists. Runs once on mount, independent of auth.
+  useEffect(() => {
+    fetch('/api/branding')
+      .then((r) => r.json() as Promise<PublicBranding>)
+      .then((b) => {
+        applyAccent(b.accentColor)
+        applyFavicon(faviconDataUri(b.accentColor, b.badge, b.tenantName))
+        setAccent(b.accentColor)
+      })
+      .catch(() => {})
+  }, [])
 
   if (me === undefined) return <div className="flex h-screen items-center justify-center text-sm text-muted-foreground">Loading…</div>
-  if (me === null) return <LoginScreen />
+  if (me === null) return <LoginScreen accent={accent} />
   return <Console me={me} />
 }
 
@@ -689,7 +704,9 @@ function Console({ me }: { me: Member }) {
   return (
     <div className="flex h-screen bg-muted/30 text-foreground">
       {sidebarCollapsed && (
-        <aside className="flex w-12 shrink-0 flex-col items-center gap-1 border-r bg-background py-3">
+        <aside className="relative flex w-12 shrink-0 flex-col items-center gap-1 border-r bg-background py-3">
+          {/* Per-tenant accent strip — invisible until a tenant sets a brand colour (var(--brand)). */}
+          <div className="absolute inset-x-0 top-0 h-1" style={{ background: 'var(--brand)' }} />
           <Button size="icon" variant="ghost" className="h-8 w-8 text-muted-foreground" title="expand sidebar" onClick={() => setSidebarCollapsed(false)}>
             <PanelLeftOpen className="h-4 w-4" />
           </Button>
@@ -704,6 +721,8 @@ function Console({ me }: { me: Member }) {
         </aside>
       )}
       <aside className={`${sidebarCollapsed ? 'hidden' : 'flex'} w-72 shrink-0 flex-col border-r bg-background`}>
+        {/* Per-tenant accent strip — invisible until a tenant sets a brand colour (var(--brand)). */}
+        <div className="h-1 shrink-0" style={{ background: 'var(--brand)' }} />
         {/* Top: brand + primary nav (fixed) */}
         <div className="p-4 pb-2">
           <div className="mb-4 flex items-start justify-between">
@@ -2616,7 +2635,10 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
 }
 
 // ── Login ────────────────────────────────────────────────────────────────────────
-function LoginScreen() {
+function LoginScreen({ accent }: { accent?: string }) {
+  // Tenant accent (when set) tints the primary Sign-in button so even the pre-login screen is
+  // identifiable across several tenants; falls back to the default primary styling otherwise.
+  const brandStyle = accent ? { backgroundColor: accent, color: readableOn(accent) } : undefined
   const [value, setValue] = useState('')
   const [email, setEmail] = useState('')
   const [sent, setSent] = useState(false)
@@ -2651,7 +2673,7 @@ function LoginScreen() {
           <Field label="Magic link or token">
             <Input value={value} onChange={(e) => setValue(e.target.value)} placeholder="https://…/accept?token=…" onKeyDown={(e) => e.key === 'Enter' && go()} />
           </Field>
-          <Button className="mt-4 w-full" onClick={go} disabled={!value.trim()}>Sign in</Button>
+          <Button className="mt-4 w-full" style={brandStyle} onClick={go} disabled={!value.trim()}>Sign in</Button>
 
           <div className="my-4 flex items-center gap-3 text-xs text-muted-foreground">
             <div className="h-px flex-1 bg-border" />lost your link?<div className="h-px flex-1 bg-border" />
@@ -5863,8 +5885,8 @@ function AuditPage() {
   )
 }
 
-type SettingsTab = 'company' | 'runtime' | 'secrets' | 'memory' | 'policy' | 'governance' | 'system'
-const SETTINGS_TABS: SettingsTab[] = ['company', 'runtime', 'secrets', 'memory', 'policy', 'governance', 'system']
+type SettingsTab = 'company' | 'runtime' | 'theme' | 'secrets' | 'memory' | 'policy' | 'governance' | 'system'
+const SETTINGS_TABS: SettingsTab[] = ['company', 'runtime', 'theme', 'secrets', 'memory', 'policy', 'governance', 'system']
 
 // The active sub-tab is a URL detail (`#/settings/<tab>`) so a refresh / shared link lands on the same
 // tab. `tab` is the raw detail from the router; `onTab` writes it back into the hash.
@@ -5877,6 +5899,7 @@ function SettingsPage({ me, state, tab: tabParam, onTab }: { me: Member; state: 
       <div className="flex w-48 shrink-0 flex-col gap-1 rounded-lg border bg-background p-1 self-start [&_button]:text-left">
         <TabButton on={tab === 'company'} onClick={() => setTab('company')}>Company context</TabButton>
         <TabButton on={tab === 'runtime'} onClick={() => setTab('runtime')}>Runtime defaults</TabButton>
+        <TabButton on={tab === 'theme'} onClick={() => setTab('theme')}>Theme</TabButton>
         <TabButton on={tab === 'secrets'} onClick={() => setTab('secrets')}>Secrets</TabButton>
         <TabButton on={tab === 'memory'} onClick={() => setTab('memory')}>Memory backend</TabButton>
         <TabButton on={tab === 'governance'} onClick={() => setTab('governance')}>Governance</TabButton>
@@ -5886,6 +5909,7 @@ function SettingsPage({ me, state, tab: tabParam, onTab }: { me: Member; state: 
       <div className="min-w-0 flex-1">
         {tab === 'company' ? <CompanySettings me={me} />
           : tab === 'runtime' ? <RuntimeDefaultsSettings me={me} />
+          : tab === 'theme' ? <ThemeSettings me={me} state={state} />
           : tab === 'secrets' ? <SecretsSettings me={me} />
           : tab === 'memory' ? <MemorySettings me={me} />
           : tab === 'governance' ? <GovernanceSettings me={me} />
@@ -7137,6 +7161,124 @@ function CompanySettings({ me }: { me: Member }) {
             <Button onClick={save} disabled={busy || !dirty}>
               {dirty ? 'Save' : 'Saved'}
             </Button>
+            {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
+            {meta.updatedAt && (
+              <span className="ml-auto text-[11px] text-muted-foreground">
+                last updated {new Date(meta.updatedAt).toLocaleString()}{meta.updatedBy ? ` by ${meta.updatedBy}` : ''}
+              </span>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+/** Settings → Theme — the per-tenant accent colour + favicon badge, so several tenants running in
+ *  parallel are distinguishable at a glance (sidebar strip, browser-tab favicon, login screen). */
+function ThemeSettings({ me, state }: { me: Member; state: StateResp | null }) {
+  const isAdmin = me.role === 'owner' || me.role === 'admin'
+  const [accent, setAccent] = useState('')      // '' = no accent (default theme)
+  const [badge, setBadge] = useState('')
+  const [saved, setSaved] = useState<Branding>({})
+  const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
+  const [busy, setBusy] = useState(false)
+  const [hint, setHint] = useState('')
+
+  useEffect(() => {
+    api.branding().then((b) => {
+      if (b.error) return setHint('⚠ ' + b.error)
+      setAccent(b.accentColor ?? ''); setBadge(b.badge ?? '')
+      setSaved({ accentColor: b.accentColor, badge: b.badge }); setMeta({ updatedAt: b.updatedAt, updatedBy: b.updatedBy })
+    }).catch(() => {})
+  }, [])
+
+  const validHex = /^#[0-9a-fA-F]{6}$/.test(accent)
+  const cur: Branding = { accentColor: validHex ? accent.toLowerCase() : undefined, badge: badge.trim() || undefined }
+  const dirty = cur.accentColor !== saved.accentColor || cur.badge !== saved.badge
+  const tenantName = state?.tenantName || state?.tenant
+  const previewFavicon = faviconDataUri(cur.accentColor, cur.badge, tenantName)
+
+  const save = async () => {
+    setBusy(true); setHint('')
+    const r = await api.saveBranding(cur)
+    setBusy(false)
+    if (r.error) return setHint('⚠ ' + r.error)
+    setSaved({ accentColor: r.accentColor, badge: r.badge }); setMeta({ updatedAt: Date.now(), updatedBy: me.email })
+    // Go live immediately — no reload — for this browser.
+    applyAccent(r.accentColor); applyFavicon(faviconDataUri(r.accentColor, r.badge, tenantName))
+    setAccent(r.accentColor ?? ''); setBadge(r.badge ?? '')
+    setHint('saved'); setTimeout(() => setHint(''), 1500)
+  }
+  const clear = () => { setAccent(''); setBadge('') }
+
+  if (!isAdmin) return <div className="text-sm text-muted-foreground">Owner or admin access required.</div>
+
+  return (
+    <div className="max-w-3xl space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Give this tenant a <strong>colour + favicon badge</strong> so it's instantly recognisable when you're
+        running several consoles side by side. The accent tints the sidebar strip, active nav item and focus
+        rings; the badge becomes the browser-tab favicon. Applies to <strong>this tenant only</strong>. Leave
+        the colour blank for the default look.
+      </p>
+
+      <Card>
+        <CardContent className="space-y-4 p-4">
+          <div className="flex flex-wrap items-end gap-5">
+            <Field label="Accent colour">
+              <div className="flex items-center gap-2">
+                <input
+                  type="color"
+                  value={validHex ? accent : '#7c3aed'}
+                  onChange={(e) => setAccent(e.target.value)}
+                  className="h-9 w-12 cursor-pointer rounded border bg-background p-0.5"
+                  aria-label="accent colour"
+                />
+                <Input
+                  value={accent}
+                  onChange={(e) => setAccent(e.target.value.trim())}
+                  placeholder="#7c3aed"
+                  className="w-32 font-mono text-xs"
+                />
+              </div>
+            </Field>
+            <Field label="Favicon badge" help="An emoji or 1–3 letters. Blank → the tenant's initial.">
+              <Input
+                value={badge}
+                onChange={(e) => setBadge(e.target.value)}
+                placeholder={tenantName ? tenantName.charAt(0).toUpperCase() : '🟣'}
+                className="w-28"
+              />
+            </Field>
+          </div>
+
+          {accent && !validHex && <div className="text-xs text-amber-600">Enter a 6-digit hex colour like <span className="font-mono">#7c3aed</span> (or clear it).</div>}
+
+          {/* Live preview — favicon tile + a mock sidebar showing the accent strip and active nav item. */}
+          <div className="flex flex-wrap items-center gap-5 rounded-lg border bg-muted/30 p-4">
+            <div className="flex flex-col items-center gap-1">
+              <img src={previewFavicon} alt="favicon preview" className="h-12 w-12 rounded-[10px] shadow-sm" />
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">favicon</span>
+            </div>
+            <div className="w-44 overflow-hidden rounded-md border bg-background">
+              <div className="h-1" style={{ background: cur.accentColor || 'transparent' }} />
+              <div className="p-2">
+                <div className="mb-1.5 text-[11px] font-semibold">⚙️ {tenantName || 'Agent OS'}</div>
+                <div
+                  className="rounded px-2 py-1 text-[11px] font-medium"
+                  style={cur.accentColor ? { background: cur.accentColor, color: readableOn(cur.accentColor) } : { background: 'var(--sidebar-primary)', color: 'var(--sidebar-primary-foreground)' }}
+                >Inbox</div>
+                <div className="px-2 py-1 text-[11px] text-muted-foreground">Agents</div>
+                <div className="px-2 py-1 text-[11px] text-muted-foreground">Tasks</div>
+              </div>
+            </div>
+            <span className="text-[10px] uppercase tracking-wider text-muted-foreground">sidebar</span>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Button onClick={save} disabled={busy || !dirty}>{dirty ? 'Save' : 'Saved'}</Button>
+            {(accent || badge) && <Button variant="ghost" onClick={clear} disabled={busy}>Clear</Button>}
             {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
             {meta.updatedAt && (
               <span className="ml-auto text-[11px] text-muted-foreground">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -81,6 +81,10 @@
     --sidebar-accent-foreground: oklch(0.205 0 0);
     --sidebar-border: oklch(0.922 0 0);
     --sidebar-ring: oklch(0.708 0 0);
+    /* Per-tenant accent, driven at runtime by applyAccent() in lib/branding.ts. Transparent by
+       default so the sidebar brand strip is invisible until a tenant sets an accent colour. */
+    --brand: transparent;
+    --brand-foreground: currentColor;
 }
 
 .dark {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -551,6 +551,19 @@ export interface CompanySettings {
   error?: string
 }
 
+/** Per-tenant web-console branding — accent colour + favicon badge. Display-only. */
+export interface Branding {
+  /** Accent colour as `#rrggbb`; empty/undefined → default theme. */
+  accentColor?: string
+  /** Favicon badge: an emoji or a 1–3 char initial; undefined → tenant initial. */
+  badge?: string
+}
+/** The public GET /api/branding payload (served unauthenticated so the login screen themes too). */
+export interface PublicBranding extends Branding {
+  tenant: string
+  tenantName?: string
+}
+
 /** A stored secret's identity + provenance — the value is NEVER returned by the API. */
 export interface SecretMeta {
   principal: string
@@ -801,6 +814,10 @@ export const api = {
 
   governance: () => call<GovernanceThresholds & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/governance'),
   saveGovernance: (t: GovernanceThresholds) => call<{ ok: boolean; error?: string } & GovernanceThresholds>('PUT', '/api/settings/governance', t),
+
+  // Per-tenant console branding (accent colour + favicon badge).
+  branding: () => call<Branding & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/branding'),
+  saveBranding: (b: Branding) => call<{ ok: boolean; error?: string } & Branding>('PUT', '/api/settings/branding', b),
 
   // Secrets vault — metadata only on the way out; values only ever travel inbound.
   secrets: () => call<{ secrets: SecretMeta[]; error?: string }>('GET', '/api/secrets'),

--- a/web/src/lib/branding.ts
+++ b/web/src/lib/branding.ts
@@ -1,0 +1,85 @@
+/**
+ * Per-tenant console branding — apply an accent colour + favicon badge at runtime.
+ *
+ * The accent recolours the sidebar's active-item + focus rings and a thin brand strip (via a small
+ * set of CSS custom properties layered over `index.css`); it deliberately does NOT touch `--primary`,
+ * so buttons/text contrast across the rest of the app is never at risk. The favicon is generated
+ * client-side as an SVG data-URI (no uploads, no server storage) so several tenants are
+ * distinguishable both in the sidebar and in the browser-tab strip.
+ *
+ * Everything here is idempotent and reversible: passing an empty accent clears the overrides so the
+ * `index.css` defaults win again.
+ */
+
+/** Black or white — whichever reads better on the given `#rrggbb` background (WCAG luminance). */
+export function readableOn(hex: string): '#000000' | '#ffffff' {
+  const n = parseInt(hex.slice(1), 16)
+  const chan = [(n >> 16) & 255, (n >> 8) & 255, n & 255].map((v) => {
+    const s = v / 255
+    return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4
+  })
+  const lum = 0.2126 * chan[0] + 0.7152 * chan[1] + 0.0722 * chan[2]
+  return lum > 0.4 ? '#000000' : '#ffffff'
+}
+
+const VALID = /^#[0-9a-fA-F]{6}$/
+
+/** CSS vars we drive from the accent — cleared together when the accent is removed. */
+const ACCENT_VARS = ['--brand', '--brand-foreground', '--sidebar-primary', '--sidebar-primary-foreground', '--sidebar-ring', '--ring'] as const
+
+/** Set (or clear) the accent CSS custom properties on <html>. Invalid/empty hex → clear to defaults. */
+export function applyAccent(hex?: string): void {
+  const root = document.documentElement
+  if (!hex || !VALID.test(hex)) {
+    for (const v of ACCENT_VARS) root.style.removeProperty(v)
+    return
+  }
+  const fg = readableOn(hex)
+  root.style.setProperty('--brand', hex)
+  root.style.setProperty('--brand-foreground', fg)
+  root.style.setProperty('--sidebar-primary', hex)
+  root.style.setProperty('--sidebar-primary-foreground', fg)
+  root.style.setProperty('--sidebar-ring', hex)
+  root.style.setProperty('--ring', hex)
+}
+
+/** The badge glyph: an explicit emoji/initials, else the tenant name's first letter, else "•". */
+export function badgeGlyph(badge?: string, tenantName?: string): string {
+  const b = (badge ?? '').trim()
+  if (b) return b
+  const first = (tenantName ?? '').trim().charAt(0).toUpperCase()
+  return first || '•'
+}
+
+/** Build an SVG favicon data-URI: a rounded square filled with the accent, centred glyph on top.
+ *  With no accent, falls back to a neutral dark tile so the tab still gets a per-tenant initial. */
+export function faviconDataUri(hex: string | undefined, badge?: string, tenantName?: string): string {
+  const bg = hex && VALID.test(hex) ? hex : '#0b0d12'
+  const fg = readableOn(bg)
+  const glyph = badgeGlyph(badge, tenantName)
+  // Shrink the font for multi-char initials so 2–3 letters still fit the 64px tile.
+  const size = [...glyph].length >= 3 ? 26 : [...glyph].length === 2 ? 32 : 40
+  const svg =
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">` +
+    `<rect width="64" height="64" rx="14" fill="${bg}"/>` +
+    `<text x="32" y="33" font-size="${size}" text-anchor="middle" dominant-baseline="central" ` +
+    `font-family="-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif" font-weight="700" fill="${fg}">` +
+    `${escapeXml(glyph)}</text></svg>`
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`
+}
+
+/** Point the tab favicon at `uri` (creating the <link rel="icon"> if the page lacks one). */
+export function applyFavicon(uri: string): void {
+  let link = document.querySelector<HTMLLinkElement>('link[rel="icon"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.rel = 'icon'
+    document.head.appendChild(link)
+  }
+  link.type = 'image/svg+xml'
+  link.href = uri
+}
+
+function escapeXml(s: string): string {
+  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&apos;' }[c]!))
+}


### PR DESCRIPTION
## What

Adds **per-tenant web-console branding** — an **accent colour** + a **favicon badge** — so several tenants running in parallel (even across machines) are distinguishable at a glance. Motivated by running 3 tenants side by side and acting in the wrong tab.

Configured under **Settings → Theme** (owner/admin). Applies to **this tenant only** — it lives in the per-tenant `settings` table (`ui_branding`), which is already the tenant boundary, so no schema change and no cross-tenant bleed.

### Scope of the accent (deliberately not a full `--primary` override)
- Thin **accent strip** atop the sidebar + **active nav item** + focus rings
- **Browser-tab favicon** — a client-generated SVG data-URI (rounded square in the accent + an emoji or 1–3 initials; falls back to the tenant's initial). No uploads, no binary storage.
- **Login screen** + the magic-link **accept page** are tinted too (branding is served pre-auth)

Foreground colour on the accent is auto-picked black/white by WCAG luminance, so text stays readable on any colour.

## How
- **types.ts** — `Branding` interface + `sanitizeBranding` (validates `#rrggbb`, caps the badge at 3 code points).
- **SettingsStore** — `branding()` / `setBranding()` / `brandingMeta()` under key `ui_branding` (mirrors `runtimeDefaults`).
- **server.ts** — public `GET /api/branding` (display-only, before the member gate, so the login screen + favicon theme before sign-in); owner/admin `GET`/`PUT /api/settings/branding` (audited `settings.branding.updated`); `acceptLandingHtml` tinted.
- **web/src/lib/branding.ts** (new) — `readableOn`, `applyAccent` (drives `--brand`/`--sidebar-primary`/`--sidebar-ring`/`--ring` + foregrounds), `faviconDataUri`, `applyFavicon`.
- **App.tsx** — mount effect fetches `/api/branding` (auth-independent) → applies accent + favicon; sidebar accent strip (expanded + collapsed); tinted `LoginScreen` button; new **Theme** settings tab (`ThemeSettings`) with a live favicon + sidebar preview, saving live without reload.
- **index.css** — `--brand` defaults to `transparent` so the strip is invisible until a tenant sets a colour.

## Testing
- `npm run build` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → 45/45 ✓
- Store + sanitizer round-trip against an **isolated** `AGENT_OS_HOME` (hex validation/lowercasing, badge cap, meta, bad-value clearing) — all pass.
- Live server on an ephemeral port: `GET /api/branding` → `200 {tenant,tenantName}` unauth; `GET`/`PUT /api/settings/branding` → `401` unauth (present + gated); `/health` → 200.

## Deploy note
The new **public `/api/branding`** route needs a **server restart** to take effect (a stale long-running server 404→falls through to a 401). Web changes just need `cd web && npm run build` + browser reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)