### PR TITLE
Terminal: a stopped session no longer auto-resurrects on ttyd reconnect (v0.72.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.72.0] — 2026-07-09
+### Fixed
+- **Stopping a session from the terminal no longer auto-resumes it.** When you Stop a session, ttyd
+  (auto-reconnect on) silently re-dialled the moment the pane's tmux died, re-running the attach
+  wrapper — which `claude --resume`d the session straight back to life ("reconnected… resumes").
+  Most visible on the Linux boxes (ExpressTech/InstaWP), where the local backend + `attach.sh` drive
+  the terminal. `stopSession` now drops a per-session `.stopped` sentinel that `terminal/attach.sh`
+  checks before resurrecting: a silent auto-reconnect stays disconnected, while a **deliberate**
+  re-open (opening the terminal, or the **Resume** button → new `POST /api/sessions/:id/resume`) lifts
+  the block so resume still works on demand. The sentinel is cleared on any deliberate attach and
+  removed with the session's files on delete.
+
 ## [0.71.0] — 2026-07-09
 ### Added
 - **Per-tenant console branding (Settings → Theme).** Give each tenant an **accent colour** and a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.71.0",
+      "version": "0.72.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1430,6 +1430,17 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
     return sendJson(res, 200, { ok: tm.stopSession(id, me.email) });
   }
+  // Deliberately resume a stopped session: lift the stop-block so the ttyd attach wrapper resurrects it
+  // (`claude --resume`) on the next reconnect. The actual relaunch happens in attach.sh when the terminal
+  // (re)connects; this just clears the "stay stopped" sentinel. Same per-member gate as stop.
+  const resumeMatch = p.match(/^\/api\/sessions\/([\w-]+)\/resume$/);
+  if (method === 'POST' && resumeMatch) {
+    const id = resumeMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
+    tm.allowResume(id);
+    return sendJson(res, 200, { ok: true });
+  }
   // Permanently delete a session (kill tmux + cascade messages/questions/files) — same gate.
   const sessMatch = p.match(/^\/api\/sessions\/([\w-]+)$/);
   if (method === 'DELETE' && sessMatch) {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -479,6 +479,9 @@ export class TerminalManager {
   async attachUrl(sessionId: string): Promise<string | null> {
     const r = this.db.prepare('SELECT tmux, spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ tmux: string; spawned_by: string | null; run_as: string | null }>(sessionId);
     if (!r) return null;
+    // Opening the terminal is a deliberate act (vs ttyd's silent auto-reconnect, which never fetches an
+    // attach URL) — so lift any prior stop-block and let attach.sh resurrect a stopped session on re-open.
+    this.allowResume(sessionId);
     return this.backend.attachUrl(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
   }
 
@@ -1755,6 +1758,12 @@ export class TerminalManager {
     // Cancel both so they leave "Needs you" and become dismissable, rather than hanging forever.
     this.cancelPendingQuestions(sessionId, by);
     this.cancelPendingApprovals(sessionId, by);
+    // A deliberate stop must STAY stopped. The terminal is likely still open in the browser, and ttyd
+    // (disableReconnect=false) silently re-dials the moment the pane's tmux dies — re-running attach.sh,
+    // which would otherwise `claude --resume` the session straight back to life ("reconnected… resumes").
+    // Drop a sentinel so attach.sh skips resurrection; a deliberate re-open (attachUrl / the Resume
+    // button → /resume) clears it. Auto-reconnect calls neither, so it can't self-revive.
+    this.blockResume(sessionId);
     // Halting kills the tmux shell, so the launcher's `markEnded` never fires — capture the episode
     // here instead so the work done (the audit stream) is remembered. Outcome 'stopped'; skipped if the
     // session did nothing worth remembering.
@@ -1762,6 +1771,26 @@ export class TerminalManager {
     // No "Stopped" card — a human halting a run is lifecycle noise; the audit log records who/when.
     this.audit(sessionId, by, 'session.stopped', { tmux: r.tmux });
     return true;
+  }
+
+  /** Path of a session's "do not auto-resurrect" sentinel (see stopSession / attach.sh). */
+  private stopMarkerPath(sessionId: string): string | null {
+    return this.os.paths ? path.join(this.os.paths.connectors, `session-${sessionId}.stopped`) : null;
+  }
+
+  /** Mark a session as deliberately stopped so the ttyd attach wrapper won't `claude --resume` it. */
+  private blockResume(sessionId: string): void {
+    const p = this.stopMarkerPath(sessionId);
+    if (!p) return;
+    try { this.ensureSecureDir(this.os.paths!.connectors); fs.writeFileSync(p, '', { mode: 0o600 }); } catch { /* best-effort */ }
+  }
+
+  /** Clear the stop sentinel — a human deliberately re-opened/resumed this session, so let attach.sh
+   *  resurrect it again. No-op if it was never stopped. Idempotent. */
+  allowResume(sessionId: string): void {
+    const p = this.stopMarkerPath(sessionId);
+    if (!p) return;
+    try { fs.rmSync(p, { force: true }); } catch { /* best-effort */ }
   }
 
   /**

--- a/terminal/attach.sh
+++ b/terminal/attach.sh
@@ -44,6 +44,15 @@ done
 ID="${NAME#aos-}"
 LAUNCHER="$(cd "$(dirname "$0")" && pwd)/claude-launch.sh"
 ENV_FILE="${AOS_SESSION_DIR:-}/session-$ID.env"
+
+# A DELIBERATE stop (the console Stop button → stopSession) drops a sentinel here. ttyd re-runs us the
+# instant the pane dies (auto-reconnect), so WITHOUT this guard a stopped session would `claude --resume`
+# itself straight back to life. Skip resurrection while the sentinel is present; re-opening the session
+# from the console (attachUrl / the Resume button) clears it, so a deliberate resume still works.
+if [ -n "${AOS_SESSION_DIR:-}" ] && [ -f "${AOS_SESSION_DIR}/session-$ID.stopped" ]; then
+  exec tmux -u -S "$SOCK" attach -t "$NAME"   # fails cleanly (no such session) → ttyd shows disconnected
+fi
+
 if [ -n "${AOS_SESSION_DIR:-}" ] && [ -f "$ENV_FILE" ] && [ -f "$LAUNCHER" ]; then
   # new-session -A: attach if it raced back to life, else create running the resume launcher.
   exec tmux -u -S "$SOCK" new-session -A -s "$NAME" \

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -48,6 +48,14 @@ const statusLabel = (s: Session): string => (isLive(s) && s.status !== 'running'
  *  session is just "open", not "resume". */
 const canResume = (s: Session): boolean => Boolean(s.resumable) && !isLive(s)
 
+/** Resume a stopped session from the console: lift the server-side stop-block, THEN open/focus its
+ *  terminal. A plain stop leaves the block in place so ttyd's silent auto-reconnect can't revive the
+ *  session; a Resume click is the deliberate act that clears it. We clear it explicitly (not just via
+ *  the iframe's attach fetch) because the tab may already be open and not remount. */
+const resumeAndOpen = (s: Session, onOpen: (tmux: string, title: string) => void): void => {
+  void api.resumeSession(s.id).finally(() => onOpen(s.tmux, s.agent + ' · ' + s.id))
+}
+
 /** Coarse provenance category of a session, from its raw `spawnedBy` (`automation:`/`task:`/`chat:`
  *  prefixes, else a member started it directly). Drives the Source filter on the sessions list. */
 type SessionSource = 'member' | 'automation' | 'task' | 'chat'
@@ -1575,7 +1583,7 @@ function SessionsPage({
         {/* per-tab controls — resume (resumable + not live) / stop (running only) + delete, revealed on hover or when active */}
         <span className={`flex items-center gap-1 ${selected.tmux === s.tmux ? '' : 'opacity-0 group-hover/tab:opacity-100'}`}>
           {canResume(s) && (
-            <button className="rounded p-0.5 text-emerald-400 hover:bg-neutral-600 hover:text-emerald-300" onClick={() => onOpen(s.tmux, s.agent + ' · ' + s.id)} title="resume — reopen and continue this session (claude --resume)">
+            <button className="rounded p-0.5 text-emerald-400 hover:bg-neutral-600 hover:text-emerald-300" onClick={() => resumeAndOpen(s, onOpen)} title="resume — reopen and continue this session (claude --resume)">
               <Play className="h-3 w-3" />
             </button>
           )}
@@ -1753,7 +1761,7 @@ function SessionsPage({
               </button>
               <div className="mt-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                 {canResume(s) && (
-                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-emerald-600" onClick={() => onOpen(s.tmux, s.agent + ' · ' + s.id)} title="reopen and continue this session (claude --resume)">
+                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-emerald-600" onClick={() => resumeAndOpen(s, onOpen)} title="reopen and continue this session (claude --resume)">
                     <Play className="h-3 w-3" /> Resume
                   </Button>
                 )}
@@ -1809,7 +1817,7 @@ function SessionsPage({
               </button>
               <div className="flex w-32 shrink-0 items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                 {canResume(s) && (
-                  <Button size="icon" variant="ghost" className="h-7 w-7 text-emerald-600" onClick={() => onOpen(s.tmux, s.agent + ' · ' + s.id)} title="resume — reopen and continue this session (claude --resume)">
+                  <Button size="icon" variant="ghost" className="h-7 w-7 text-emerald-600" onClick={() => resumeAndOpen(s, onOpen)} title="resume — reopen and continue this session (claude --resume)">
                     <Play className="h-3.5 w-3.5" />
                   </Button>
                 )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -712,6 +712,8 @@ export const api = {
   messages: () => call<Msg[]>('GET', '/api/messages'),
   run: (agent: string, task: string) => call<{ id: string; tmux: string; error?: string }>('POST', '/api/sessions', { agent, task }),
   stopSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/stop`),
+  /** Lift the stop-block so a stopped session resurrects (claude --resume) on the next terminal open. */
+  resumeSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/resume`),
   deleteSession: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/sessions/' + id),
   attach: (id: string) => call<{ url?: string; error?: string }>('GET', `/api/sessions/${id}/attach`),
   sessionTranscript: (id: string) => call<{ text?: string; error?: string }>('GET', `/api/sessions/${id}/transcript`),


### PR DESCRIPTION
## Problem
Stopping a session from the terminal top bar could bounce it straight back to life — the terminal shows *"reconnected"* and the agent resumes. Reported on the Linux boxes (ExpressTech especially).

**Root cause:** ttyd runs with `disableReconnect=false` (deliberately, to survive network blips). When `stopSession` kills the pane's tmux, ttyd's client sees the socket drop and **silently re-dials**, re-running `terminal/attach.sh`. That wrapper's job is to resurrect a dead session via `claude --resume` — which is great for a *deliberate* "press Enter to reconnect", but here it fires automatically the instant you stop, reviving the session you just killed.

This only affects the `LocalSessionBackend` + `attach.sh` path (uid-isolation **off**) — i.e. the single-tenant Linux boxes. Under the uid-isolation launcher, attach just re-attaches to live tmux and never resurrects, so it's unaffected.

## Fix
Distinguish a **silent auto-reconnect** from a **deliberate re-open**, using a per-session sentinel:

- `stopSession` drops `session-<id>.stopped` (`blockResume`).
- `terminal/attach.sh` checks it *before* the resurrection branch: present → plain attach (fails cleanly → ttyd shows disconnected), so the session **stays stopped**.
- A deliberate re-open clears it (`allowResume`):
  - `attachUrl()` — every console open fetches the attach URL first; ttyd's internal auto-reconnect never does.
  - new `POST /api/sessions/:id/resume`, which the **Resume** button now calls before opening (covers an already-open tab that won't remount to re-fetch the URL).
- `removeSessionFiles` already globs `session-<id>.*`, so the sentinel is cleaned on delete.

Net: Stop stays stopped; Resume (and any deliberate open) still resurrects on demand; blip-survival is untouched (a blip leaves tmux alive, so attach.sh never reaches the resurrection branch).

## Verification
- `typecheck` (server + web), web build, `test:governance` → 45/45.
- Isolated node run: stop writes the sentinel; `attachUrl` and `allowResume` each clear it.
- Drove `terminal/attach.sh` directly against a mock tmux: **no sentinel → resurrects** (`new-session … RESUME=1 … claude-launch.sh`); **with sentinel → plain attach only**, no resurrection. Script stays bash-3.2/BSD-portable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)