### PR TITLE
systemd: KillMode=process so a restart no longer kills agent sessions (v0.72.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.72.1] — 2026-07-09
+### Fixed
+- **Restarting the server no longer kills running agent sessions on Linux/systemd** (the
+  ExpressTech/InstaWP boxes). Sessions run in a tmux server that daemonises out of node's process
+  tree, so a restart is meant to leave them alive and re-adopt them via the persistent
+  `<home>/tmux.sock` — which is exactly what happens on macOS/launchd. But the systemd unit shipped
+  `KillMode=mixed`: on stop, systemd SIGKILLs the **entire cgroup**, and a double-fork escapes the
+  process tree but **not** the cgroup, so every `systemctl restart` took the tmux server (and all live
+  sessions) down with it — they resurfaced as `crashed`. `agent-os.service` now uses
+  `KillMode=process`, so systemd signals only the main node process and leaves the tmux server (and its
+  sessions) running for the fresh process to re-adopt. **Deploy note:** the live unit files on each box
+  must be updated too (`agent-os.service` on ExpressTech, `agent-os-instawp` on the jump-server), then
+  `systemctl daemon-reload` + one restart.
+
 ## [0.72.0] — 2026-07-09
 ### Fixed
 - **Stopping a session from the terminal no longer auto-resumes it.** When you Stop a session, ttyd

--- a/agent-os.service
+++ b/agent-os.service
@@ -17,7 +17,16 @@ Environment=PORT=3010
 Environment=PATH=/home/vikas/.local/bin:/home/vikas/.nvm/versions/node/v22.22.0/bin:/usr/bin:/usr/local/bin
 ExecStart=/home/vikas/.nvm/versions/node/v22.22.0/bin/node dist/cli.js serve
 ExecReload=/bin/kill -HUP $MAINPID
-KillMode=mixed
+# KillMode=process (NOT mixed/control-group): on stop/restart, systemd signals ONLY the main node
+# process and leaves the rest of the cgroup alone. Agent sessions run in a tmux server that daemonises
+# out of node's process tree — but a double-fork escapes the process tree, NOT the cgroup, so a
+# cgroup-wide kill (mixed/control-group) SIGKILLs the tmux server on every restart and every live agent
+# session dies (they resurface as `crashed`). This is the Linux-only session-loss bug macOS/launchd
+# never had (launchd has no cgroups). With `process`, the tmux server survives a restart and the fresh
+# node process re-adopts the still-live sessions via the persistent <home>/tmux.sock. Trade-off (intended,
+# and matches macOS): a full `stop` that stays down leaves sessions running orphaned until the service
+# returns. ttyd/Slack/etc. are still reaped explicitly by the SIGINT handler (registry.stopAll).
+KillMode=process
 KillSignal=SIGINT
 TimeoutStopSec=10
 SyslogIdentifier=agent-os

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.72.0",
+      "version": "0.72.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.72.0",
+  "version": "0.72.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
## Problem

On the Linux/systemd boxes (ExpressTech, InstaWP), every `systemctl restart agent-os` terminated all **running agent sessions** — they resurfaced as `crashed`. macOS/launchd never had this.

## Root cause

Agent sessions run inside a **tmux server** started with `tmux … new-session -d`, which daemonises (double-fork) out of node's process tree. The design relies on that: on boot AgentOS doesn't re-spawn sessions, it polls the persistent `<home>/tmux.sock` and **re-adopts** whatever tmux sessions are still alive (`src/terminal.ts` liveness sweep). Node's own shutdown (`registry.stopAll`) never touches tmux.

The unit shipped **`KillMode=mixed`**: on stop, systemd SIGKILLs the **entire cgroup**. A double-fork escapes the *process tree* but **not** the *cgroup* — so the daemonised tmux server (and every session in it) went down with each restart. launchd has no cgroups, so the same daemonised tmux server survives on macOS.

## Fix

`agent-os.service` → **`KillMode=process`**: systemd signals only the main node process and leaves the rest of the cgroup (the tmux server + its sessions) running, so the fresh process re-adopts them via the persistent socket — matching macOS behaviour. `KillSignal=SIGINT` stays, so the SIGINT handler still reaps ttyd/Slack/Discord/automations.

Trade-off (intended, matches macOS): a full `stop` that stays down leaves sessions running orphaned until the service returns.

## Deploy note

The repo file is only the template. The **live unit files on each box** must be updated + reloaded:
- ExpressTech: `agent-os.service`
- jump-server (InstaWP): `agent-os-instawp`

Then `systemctl daemon-reload` + one restart.

## Test

`npm run build` clean; `npm run test:governance` → 45/45 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)