### PR TITLE
systemd: PrivateTmp=false so restart-surviving sessions keep a valid /tmp (v0.72.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.72.2] — 2026-07-09
+### Fixed
+- **`PrivateTmp=false` in `agent-os.service` — the other half of the restart-survival fix (v0.72.1).**
+  With `KillMode=process` the tmux server now survives a restart, but the unit still shipped
+  `PrivateTmp=true`, which hands every service *invocation* its own throwaway `/tmp`. On the first
+  restart-after-fix the surviving tmux server stayed pinned to the previous invocation's now-torn-down
+  `/tmp` namespace, so the `claude` CLI's `mkdir /tmp/claude-<uid>` failed with `ENOENT` and the session
+  died anyway (`claude session ended`). `PrivateTmp=false` makes the service share the host's stable
+  `/tmp`, which persists across restarts, so a surviving session keeps a valid `/tmp` — matching
+  macOS/launchd. **Deploy note:** flip `PrivateTmp=true`→`false` in each live unit
+  (`agent-os.service` on ExpressTech, `agent-os-instawp` on the jump-server), `daemon-reload`, then do
+  one clean restart (kill any stale tmux server on the data socket first so no dead-namespace server
+  lingers). Verified on both boxes: a session survives a restart and `/tmp` stays writable.
+
 ## [0.72.1] — 2026-07-09
 ### Fixed
 - **Restarting the server no longer kills running agent sessions on Linux/systemd** (the

--- a/agent-os.service
+++ b/agent-os.service
@@ -35,7 +35,15 @@ RestartSec=10
 
 # Security settings
 NoNewPrivileges=true
-PrivateTmp=true
+# PrivateTmp MUST be false here — it is incompatible with KillMode=process (above). Agent sessions run
+# in a tmux server that we deliberately keep alive across a restart (KillMode=process). PrivateTmp gives
+# each service *invocation* its own throwaway /tmp; on restart systemd tears the old invocation's /tmp
+# down, but the surviving tmux server is still pinned to that now-dead mount namespace — so the `claude`
+# CLI's `mkdir /tmp/claude-<uid>` fails with ENOENT and every session dies on the first restart-after-fix.
+# With PrivateTmp=false the service shares the host's stable /tmp, which persists across restarts, so a
+# surviving session keeps a valid /tmp. (macOS/launchd has no private-tmp/cgroup story — this is the
+# Linux-only pairing needed to match its "sessions survive a restart" behaviour.)
+PrivateTmp=false
 ProtectSystem=strict
 ProtectHome=read-only
 ReadWritePaths=/home/vikas/tools/agent-os/data

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.72.1",
+      "version": "0.72.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.72.1",
+  "version": "0.72.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
Follow-up to #120 (`KillMode=process`, v0.72.1). Discovered when testing that a session actually survives a restart on the live boxes.

## Problem

`KillMode=process` correctly keeps the tmux server (and its agent sessions) alive across a `systemctl restart`. But the unit still shipped **`PrivateTmp=true`**, which gives every service *invocation* its own throwaway `/tmp` (a per-instance mount namespace). On the first restart-after-fix:

- the tmux server survives, but stays pinned to the **previous** invocation's mount namespace;
- systemd tears down that old invocation's private `/tmp`;
- the `claude` CLI's `mkdir /tmp/claude-<uid>` then fails with **`ENOENT`** → `claude session ended`.

So the session survived the process kill only to die on a dangling `/tmp`.

Confirmed on the box via namespaces: the surviving tmux server sat in a stale mnt ns (`4026532824`) distinct from the freshly-restarted node (`…825`), with its own dead private tmpfs.

## Fix

`PrivateTmp=true` → **`false`**. The service now shares the host's stable `/tmp`, which persists across restarts, so a surviving session keeps a valid `/tmp`. This is the Linux pairing needed to match macOS/launchd (no private-tmp/cgroup story there).

Trade-off: agent `/tmp` files are no longer isolated from the rest of the host — acceptable on a dedicated single-tenant droplet, and required for session survival.

## Verified live (both boxes)

On ExpressTech and the jump-server (InstaWP): flipped the live unit, `daemon-reload`, killed the stale tmux server, restarted. Then a test session **survived a restart** and `mkdir /tmp/claude-<uid>` succeeded; `stat` confirms the service `/tmp` is now the same inode as host `/tmp`.

## Test

`npm run build` clean; `npm run test:governance` → 45/45 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)