### PR TITLE
Terminal: natural exits + idle-reaps stay down, not auto-resurrected (v0.72.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.72.3] — 2026-07-09
+### Fixed
+- **A naturally-finished session no longer auto-resurrects either** (follow-up to v0.72.0, which fixed
+  it for the Stop button). When claude exits on its own, the launcher normally holds the pane on a
+  "press [r] to resume" prompt — but if that pane dies (a detached/idle `read` bailing out, seen on the
+  Linux boxes), ttyd's silent auto-reconnect re-ran `attach.sh` and `claude --resume`d the finished
+  session back to life. `markEnded` now drops the same stay-stopped sentinel as a manual stop (inert
+  while the holding pane lives, decisive if it dies); a deliberate re-open or **Resume** clears it. The
+  idle reaper does the same, so a reaped resident session stays reaped instead of un-reaping itself on
+  a still-open tab (a later Slack reply still revives it).
+
 ## [0.72.2] — 2026-07-09
 ### Fixed
 - **`PrivateTmp=false` in `agent-os.service` — the other half of the restart-survival fix (v0.72.1).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.72.2",
+  "version": "0.72.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.72.2",
+      "version": "0.72.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.72.2",
+  "version": "0.72.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -860,6 +860,10 @@ export class TerminalManager {
         this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), r.id);
         this.cancelPendingQuestions(r.id, 'system');
         this.cancelPendingApprovals(r.id, 'system');
+        // A reaped session must stay reaped — otherwise ttyd's reconnect on the still-open tab would
+        // resurrect it and defeat the reap. A later Slack reply still revives it (a fresh session), and a
+        // deliberate console re-open clears the block.
+        this.blockResume(r.id);
         this.audit(r.id, r.agent, 'chat.reaped', { idleMin: timeoutMin });
       } catch { /* one bad row must not stop the sweep */ }
     }
@@ -1683,6 +1687,12 @@ export class TerminalManager {
     if (!s) return;
     if (s.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'done', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.clearNotifications(sessionId);
+    // claude exited on its own. The launcher normally holds the pane on a "press [r] to resume" prompt,
+    // but if that pane dies (an idle/detached `read` bailing out), ttyd's silent auto-reconnect would
+    // re-run attach.sh and `claude --resume` the finished session back to life. Drop the same stay-stopped
+    // sentinel as a manual stop — inert while the holding pane lives, decisive if it doesn't. A deliberate
+    // re-open/Resume clears it.
+    this.blockResume(sessionId);
     // Distil the session into one durable memory for the agent — the `report` (a 'completed' card) has
     // already landed by now if the agent left one, so writeEpisode prefers it; otherwise it summarises
     // the audit stream. Best-effort + idempotent; never blocks the end signal.
@@ -1778,11 +1788,15 @@ export class TerminalManager {
     return this.os.paths ? path.join(this.os.paths.connectors, `session-${sessionId}.stopped`) : null;
   }
 
-  /** Mark a session as deliberately stopped so the ttyd attach wrapper won't `claude --resume` it. */
+  /** Mark a session as "do not auto-resurrect" so the ttyd attach wrapper (attach.sh) won't
+   *  `claude --resume` it the next time its dead pane triggers a silent reconnect. Only a session with a
+   *  persisted launch env is resurrectable, so there's nothing to block otherwise — skip it (a headless
+   *  run leaves no env and would only litter the dir). A deliberate re-open clears it via `allowResume`. */
   private blockResume(sessionId: string): void {
     const p = this.stopMarkerPath(sessionId);
-    if (!p) return;
-    try { this.ensureSecureDir(this.os.paths!.connectors); fs.writeFileSync(p, '', { mode: 0o600 }); } catch { /* best-effort */ }
+    if (!p || !this.os.paths) return;
+    if (!fs.existsSync(path.join(this.os.paths.connectors, `session-${sessionId}.env`))) return;
+    try { this.ensureSecureDir(this.os.paths.connectors); fs.writeFileSync(p, '', { mode: 0o600 }); } catch { /* best-effort */ }
   }
 
   /** Clear the stop sentinel — a human deliberately re-opened/resumed this session, so let attach.sh


### PR DESCRIPTION
## Problem
Follow-up to #119 (v0.72.0), which stopped the **Stop** button from bouncing a session back to life. A session that finishes **on its own** had the same hole.

When claude exits, the launcher deliberately holds the pane on a `press [r] to resume, [q] to close` prompt (so ttyd doesn't loop "Reconnecting", and so it never drops to an ungoverned shell). But on the Linux boxes that holding pane dies — a detached/idle `read` bails out — the tmux session goes away, ttyd's silent auto-reconnect re-runs `attach.sh`, and with no stay-stopped sentinel it `claude --resume`s the finished session. Result: a session you watched finish comes back to life.

## Fix
Mirror the stop fix to the graceful-exit path:
- `markEnded` (claude exited cleanly) now drops the same `session-<id>.stopped` sentinel. It's **inert while the holding pane is alive** (attach.sh only consults it when the tmux session is actually gone) and **decisive if the pane dies** — attach.sh then plain-attaches instead of resurrecting.
- `reapIdleResidents` does the same, so a reaped resident session stays reaped rather than un-reaping itself on a still-open tab. (A later Slack reply still revives it — that path spawns a fresh session, not a ttyd resurrection.)
- A deliberate re-open (`attachUrl`) or **Resume** (`allowResume`) clears the sentinel, so on-demand resume still works.
- `blockResume` now no-ops unless the session has a persisted launch env — a headless run isn't resurrectable, so there's nothing to block and no `.stopped` litter for automation runs.

Net guarantee across #119 + this: **a dead pane never resurrects on its own — stop, natural exit, or idle-reap — only a deliberate console open/Resume brings it back.**

## Verification
- `typecheck`, build, `test:governance` → 45/45.
- Isolated node run: an interactive natural-exit writes the sentinel and `attachUrl` clears it; a headless (no-env) exit writes none; an idle-reaped resident ends up `stopped` **and** blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)