### PR TITLE
Host connections: hosts table + /api/hosts CRUD + Host UI (v0.73.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.73.0] — 2026-07-09
+### Added
+- **Host connections — a new "Host" shape on the Connections page.** You can now register the hosts
+  your agents reach — an SSH box, an internal service, a database — as first-class connections:
+  name, a match pattern (hostname / wildcard / CIDR / `host:port`), protocol, an optional
+  Secrets-vault credential (`secret:KEY`), and a default posture (allow / ask / never). Same
+  org/personal/shared ownership and owner-admin management as MCP connectors; a `hosts` table +
+  `/api/hosts` CRUD back it. **Phase 2a of the access model** (`docs/host-connections-plan.md`) —
+  this is the registry + UI only; the gate does **not** govern reaches to these hosts yet (that's
+  Phase 2b), and the UI says so.
+
 ## [0.72.3] — 2026-07-09
 ### Fixed
 - **A naturally-finished session no longer auto-resurrects either** (follow-up to v0.72.0, which fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.72.3",
+  "version": "0.73.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.72.3",
+      "version": "0.73.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.72.3",
+  "version": "0.73.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/hosts/hosts.ts
+++ b/src/hosts/hosts.ts
@@ -1,0 +1,188 @@
+/**
+ * Host connections — the "Host" shape of the access model (docs/host-connections-plan.md).
+ *
+ * A Host connection names a reachable destination an agent may talk to — an SSH box, an internal HTTP
+ * service, a database — as a first-class, governed thing instead of opaque Bash text. This file is
+ * **Phase 2a**: the store + data model only. The governance that reads these rows (host-extraction in
+ * the enricher, the `net.connect`/`ssh.exec` reclassification, the allow-list check) is Phase 2b, and
+ * credential injection at launch is Phase 2c — neither is wired yet, so a host here is inert data.
+ *
+ * Deliberately mirrors ConnectorStore: same org/personal/shared ownership model, same console-listing
+ * filter, same redaction-before-the-browser posture. See src/connectors/connectors.ts.
+ */
+import { Db } from '../state/db';
+
+export type HostScope = 'org' | 'personal';
+export type HostProtocol = 'ssh' | 'http' | 'postgres' | 'any';
+/** The default governance tier for reaching this host (Phase 2b turns these into policy outcomes). */
+export type HostPosture = 'allow' | 'ask' | 'never';
+
+export interface Host {
+  id: string;
+  name: string;
+  /** Destination matcher: a hostname glob (`*.internal.example.com`), CIDR (`10.0.0.0/8`), or exact
+   *  `host[:port]`. Stored in the DB column `pattern` (`match` is a SQLite keyword). */
+  match: string;
+  protocol: HostProtocol;
+  /** A vault reference (`secret:KEY`) to an SSH key / password, injected at launch in Phase 2c. '' if none. */
+  credential: string;
+  posture: HostPosture;
+  enabled: boolean;
+  scope: HostScope;
+  ownerMemberId?: string;
+  shared: boolean;
+  createdAt: number;
+}
+
+export interface AddHostInput {
+  name: string;
+  match: string;
+  protocol?: HostProtocol;
+  credential?: string;
+  posture?: HostPosture;
+  scope?: HostScope;
+  ownerMemberId?: string;
+}
+
+interface HostRow {
+  id: string;
+  name: string;
+  pattern: string;
+  protocol: string;
+  credential: string;
+  posture: string;
+  enabled: number;
+  scope: string | null;
+  owner_member_id: string | null;
+  shared: number | null;
+  created_at: number;
+}
+
+const PROTOCOLS: HostProtocol[] = ['ssh', 'http', 'postgres', 'any'];
+const POSTURES: HostPosture[] = ['allow', 'ask', 'never'];
+const asProtocol = (v: unknown): HostProtocol => (PROTOCOLS as string[]).includes(v as string) ? (v as HostProtocol) : 'any';
+const asPosture = (v: unknown): HostPosture => (POSTURES as string[]).includes(v as string) ? (v as HostPosture) : 'ask';
+
+function toHost(r: HostRow): Host {
+  return {
+    id: r.id,
+    name: r.name,
+    match: r.pattern,
+    protocol: asProtocol(r.protocol),
+    credential: r.credential || '',
+    posture: asPosture(r.posture),
+    enabled: !!r.enabled,
+    scope: r.scope === 'personal' ? 'personal' : 'org',
+    ownerMemberId: r.owner_member_id ?? undefined,
+    shared: !!r.shared,
+    createdAt: r.created_at,
+  };
+}
+
+function slug(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'host';
+}
+
+/** Strip a raw credential VALUE before sending to the browser: a `secret:KEY` vault reference is a
+ *  safe pointer (kept), but a pasted raw value is masked. Mirrors connectors' `redact`. */
+export function redactHost(h: Host): Host {
+  const credential = h.credential.startsWith('secret:') ? h.credential : h.credential ? '••••' : '';
+  return { ...h, credential };
+}
+
+export class HostStore {
+  constructor(private readonly db: Db) {}
+
+  list(): Host[] {
+    return this.db.prepare('SELECT * FROM hosts ORDER BY created_at').all<HostRow>().map(toHost);
+  }
+
+  get(id: string): Host | undefined {
+    const r = this.db.prepare('SELECT * FROM hosts WHERE id = ?').get<HostRow>(id);
+    return r ? toHost(r) : undefined;
+  }
+
+  add(input: AddHostInput): Host {
+    const name = (input.name || '').trim();
+    const match = (input.match || '').trim();
+    if (!name) throw new Error('a name is required');
+    if (!match) throw new Error('a host match (hostname, CIDR, or host:port) is required');
+
+    // Ownership: personal hosts must name their owner; org hosts never carry one. Same as connectors.
+    const scope: HostScope = input.scope === 'personal' ? 'personal' : 'org';
+    if (scope === 'personal' && !input.ownerMemberId) throw new Error('a personal host requires an owner');
+    const ownerMemberId = scope === 'personal' ? input.ownerMemberId : undefined;
+
+    const existing = new Set(this.db.prepare('SELECT id FROM hosts').all<{ id: string }>().map((r) => r.id));
+    const base = slug(name);
+    let id = base;
+    for (let n = 2; existing.has(id); n++) id = `${base}-${n}`;
+
+    const host: Host = {
+      id,
+      name,
+      match,
+      protocol: asProtocol(input.protocol),
+      credential: (input.credential || '').trim(),
+      posture: asPosture(input.posture),
+      enabled: true,
+      scope,
+      ownerMemberId,
+      shared: false,
+      createdAt: Date.now(),
+    };
+    this.db
+      .prepare('INSERT INTO hosts (id, name, pattern, protocol, credential, posture, enabled, scope, owner_member_id, shared, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(host.id, host.name, host.match, host.protocol, host.credential, host.posture, 1, host.scope, host.ownerMemberId ?? null, 0, host.createdAt);
+    return host;
+  }
+
+  /** Edit the mutable fields of a host in place (name/match/protocol/credential/posture). Scope and
+   *  ownership are immutable — recreate to move a host between org and personal. */
+  update(id: string, patch: Partial<Pick<Host, 'name' | 'match' | 'protocol' | 'credential' | 'posture'>>): Host | undefined {
+    const h = this.get(id);
+    if (!h) return undefined;
+    const name = patch.name !== undefined ? patch.name.trim() : h.name;
+    const match = patch.match !== undefined ? patch.match.trim() : h.match;
+    const protocol = patch.protocol !== undefined ? asProtocol(patch.protocol) : h.protocol;
+    const posture = patch.posture !== undefined ? asPosture(patch.posture) : h.posture;
+    const credential = patch.credential !== undefined ? patch.credential.trim() : h.credential;
+    if (!name) throw new Error('a name is required');
+    if (!match) throw new Error('a host match is required');
+    this.db
+      .prepare('UPDATE hosts SET name = ?, pattern = ?, protocol = ?, credential = ?, posture = ? WHERE id = ?')
+      .run(name, match, protocol, credential, posture, id);
+    return this.get(id);
+  }
+
+  setEnabled(id: string, enabled: boolean): Host | undefined {
+    const res = this.db.prepare('UPDATE hosts SET enabled = ? WHERE id = ?').run(enabled ? 1 : 0, id);
+    return res.changes ? this.get(id) : undefined;
+  }
+
+  /** Share (or un-share) a PERSONAL host with the whole team. No-op (undefined) for org hosts. */
+  setShared(id: string, shared: boolean): Host | undefined {
+    const h = this.get(id);
+    if (!h || h.scope !== 'personal') return undefined;
+    this.db.prepare('UPDATE hosts SET shared = ? WHERE id = ?').run(shared ? 1 : 0, id);
+    return this.get(id);
+  }
+
+  remove(id: string): boolean {
+    return this.db.prepare('DELETE FROM hosts WHERE id = ?').run(id).changes > 0;
+  }
+
+  /** Delete a member's PERSONAL hosts (their own stored credentials) when the member is removed, so
+   *  their secrets don't outlive the account. Org hosts are untouched. Returns the removed ids. */
+  removeByOwner(memberId: string): string[] {
+    const rows = this.db.prepare("SELECT id FROM hosts WHERE scope = 'personal' AND owner_member_id = ?").all(memberId) as Array<{ id: string }>;
+    this.db.prepare("DELETE FROM hosts WHERE scope = 'personal' AND owner_member_id = ?").run(memberId);
+    return rows.map((r) => r.id);
+  }
+
+  /** What the viewer may see: every org host + shared personal + their own personal. Mirrors
+   *  ConnectorStore.listForConsole. */
+  listForConsole(viewerId: string, isAdmin: boolean): Host[] {
+    return this.list().filter((h) => h.scope !== 'personal' || h.shared || isAdmin || h.ownerMemberId === viewerId);
+  }
+}

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -22,6 +22,7 @@ import {
 import { createMemoryProvider } from './memory';
 import { CapabilityRegistry } from './capabilities/registry';
 import { ConnectorStore } from './connectors/connectors';
+import { HostStore } from './hosts/hosts';
 import { Gateway } from './gateway/gateway';
 import { InMemoryAuditSink, JsonlAuditSink, SqliteAuditSink, TeeAuditSink } from './governance/audit';
 import { InMemoryBudgetLedger } from './governance/budget';
@@ -94,6 +95,8 @@ export class AgentOS {
   readonly agents = new Map<string, AgentManifest>();
   /** User-registered connectors (MCP servers) the claude-code runtime exposes to agents. */
   readonly connectors: ConnectorStore;
+  /** Host connections — governed reachable destinations (SSH / internal HTTP / DB). See host-connections-plan.md. */
+  readonly hosts: HostStore;
   /**
    * Persistent agent memory (recall across sessions). SQLite by default; libsql/automem optional.
    * Mutable so Settings → Memory can hot-swap the backend live (new requests use the new provider).
@@ -114,6 +117,7 @@ export class AgentOS {
     this.db = openDb(opts.paths?.db ?? ':memory:');
     this.secrets = new SqliteSecretsVault(this.db, resolveMasterKey(opts.paths?.home), new EnvSecretsVault());
     this.connectors = new ConnectorStore(this.db);
+    this.hosts = new HostStore(this.db);
     this.approvals = new SqliteApprovals(this.db);
     this.team = new TeamStore(this.db);
     this.settings = new SettingsStore(this.db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
 import { CATALOG, redact } from './connectors/connectors';
+import { redactHost, type HostProtocol, type HostPosture } from './hosts/hosts';
 import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUserId, initiateConnection, verifyComposioWebhook, parseComposioEvent } from './connectors/composio';
 import { JsonPolicyEngine, PolicyDocument, validatePolicyDocument, withAlwaysAllow } from './governance/policy';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
@@ -1235,8 +1236,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // Close the residue loophole: a removed member's PERSONAL connectors (their own credentials) must
     // not outlive the account. Sessions, invites and assignment grants were cleared in removeMember.
     const connectorsRemoved = os.connectors.removeByOwner(teamMember[1]).length;
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'member.removed', data: { member: teamMember[1], connectorsRemoved } });
-    return sendJson(res, 200, { ...out, connectorsRemoved });
+    const hostsRemoved = os.hosts.removeByOwner(teamMember[1]).length;
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'member.removed', data: { member: teamMember[1], connectorsRemoved, hostsRemoved } });
+    return sendJson(res, 200, { ...out, connectorsRemoved, hostsRemoved });
   }
   const teamAssign = p.match(/^\/api\/team\/assignments\/([\w.-]+)$/);
   if (method === 'PUT' && teamAssign) {
@@ -2879,6 +2881,79 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       }
       const updated = os.connectors.setEnabled(id, !!b.enabled);
       return sendJson(res, updated ? 200 : 404, updated ? redact(updated) : { error: 'not found' });
+    }
+  }
+
+  // ── host connections (Host shape of the access model — docs/host-connections-plan.md, Phase 2a) ──
+  // Governed reachable destinations (SSH / internal HTTP / DB). Same org/personal/shared ownership +
+  // auth as connectors. The governance that reads these rows is Phase 2b (not wired yet).
+  if (method === 'GET' && p === '/api/hosts') {
+    return sendJson(res, 200, { hosts: os.hosts.listForConsole(me.id, isAdmin(me)).map(redactHost) });
+  }
+  if (method === 'POST' && p === '/api/hosts') {
+    const b = await readBody(req);
+    // Company (org) hosts are owner/admin-managed; personal ones any member adds for themselves.
+    const scope = b.scope === 'personal' ? 'personal' : 'org';
+    if (scope === 'org' && !isAdmin(me)) return sendJson(res, 403, { error: 'only an owner or admin can add a company host' });
+    try {
+      const created = os.hosts.add({
+        name: b.name ? String(b.name) : '',
+        match: b.match ? String(b.match) : '',
+        protocol: b.protocol ? (b.protocol as HostProtocol) : undefined,
+        credential: b.credential ? String(b.credential) : undefined,
+        posture: b.posture ? (b.posture as HostPosture) : undefined,
+        // The owner is always the caller — never trust a client-supplied owner id.
+        scope,
+        ownerMemberId: scope === 'personal' ? me.id : undefined,
+      });
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'host.added', data: { host: created.id, scope, match: created.match, protocol: created.protocol } });
+      return sendJson(res, 200, redactHost(created));
+    } catch (e) {
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  const hostMatch = p.match(/^\/api\/hosts\/([\w-]+)$/);
+  if (hostMatch) {
+    const id = hostMatch[1];
+    const h = os.hosts.get(id);
+    if (!h) return sendJson(res, 404, { error: 'not found' });
+    // Org hosts: owner/admin only. Personal: the owner, or an owner/admin (oversight). Same as connectors.
+    const canManage = isAdmin(me) || (h.scope === 'personal' && h.ownerMemberId === me.id);
+    if (!canManage) return sendJson(res, 403, { error: 'not allowed to manage this host' });
+    if (method === 'DELETE') {
+      const ok = os.hosts.remove(id);
+      if (ok) os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'host.removed', data: { host: id } });
+      return sendJson(res, ok ? 200 : 404, { ok });
+    }
+    if (method === 'PATCH') {
+      const b = await readBody(req);
+      try {
+        // Share/un-share a personal host with the team.
+        if (typeof b.shared === 'boolean') {
+          if (h.scope !== 'personal') return sendJson(res, 400, { error: 'only personal hosts can be shared' });
+          const updated = os.hosts.setShared(id, b.shared);
+          if (updated) os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'host.shared', data: { host: id, shared: b.shared } });
+          return sendJson(res, updated ? 200 : 404, updated ? redactHost(updated) : { error: 'not found' });
+        }
+        // Enable/disable.
+        if (typeof b.enabled === 'boolean') {
+          const updated = os.hosts.setEnabled(id, b.enabled);
+          return sendJson(res, updated ? 200 : 404, updated ? redactHost(updated) : { error: 'not found' });
+        }
+        // Edit fields. A blank credential means "leave as-is" (the browser only ever sees a redacted
+        // value, so echoing it back must NOT overwrite the stored secret ref).
+        const patch: Record<string, unknown> = {};
+        if (typeof b.name === 'string') patch.name = b.name;
+        if (typeof b.match === 'string') patch.match = b.match;
+        if (typeof b.protocol === 'string') patch.protocol = b.protocol as HostProtocol;
+        if (typeof b.posture === 'string') patch.posture = b.posture as HostPosture;
+        if (typeof b.credential === 'string' && b.credential.trim() !== '') patch.credential = b.credential;
+        const updated = os.hosts.update(id, patch);
+        if (updated) os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'host.updated', data: { host: id, match: updated.match, protocol: updated.protocol } });
+        return sendJson(res, updated ? 200 : 404, updated ? redactHost(updated) : { error: 'not found' });
+      } catch (e) {
+        return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+      }
     }
   }
 

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -95,6 +95,24 @@ function migrate(db: Db): void {
       created_at  INTEGER NOT NULL
     );
 
+    -- Host connections — reachable destinations (SSH box / internal HTTP / DB) an agent may talk to,
+    -- as a first-class governed thing (docs/host-connections-plan.md). Phase 2a stores them; the
+    -- governance that reads them (net.connect/ssh.exec + allow-list) is Phase 2b. Mirrors connectors'
+    -- org/personal/shared ownership. Column is "pattern" (match is a SQLite keyword) = destination matcher.
+    CREATE TABLE IF NOT EXISTS hosts (
+      id          TEXT PRIMARY KEY,
+      name        TEXT NOT NULL,
+      pattern     TEXT NOT NULL,                 -- hostname glob | CIDR | host[:port]
+      protocol    TEXT NOT NULL DEFAULT 'any',   -- ssh | http | postgres | any
+      credential  TEXT NOT NULL DEFAULT '',      -- vault ref (secret:KEY); injected at launch in Phase 2c
+      posture     TEXT NOT NULL DEFAULT 'ask',   -- allow | ask | never (default tier for reaching this host)
+      enabled     INTEGER NOT NULL DEFAULT 1,    -- 0 | 1
+      scope       TEXT NOT NULL DEFAULT 'org',   -- org (company-wide) | personal (one member's own)
+      owner_member_id TEXT,                      -- the owning member (personal scope only; NULL for org)
+      shared      INTEGER NOT NULL DEFAULT 0,    -- a personal host shared with the whole team
+      created_at  INTEGER NOT NULL
+    );
+
     -- Terminal-native agent sessions (each a tmux shell).
     CREATE TABLE IF NOT EXISTS term_sessions (
       id         TEXT PRIMARY KEY,

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -13,7 +13,7 @@
  * tools exist and who they belong to. Extracted into its own file to keep App.tsx from growing.
  */
 import { useEffect, useState, type ReactNode } from 'react'
-import { Plug, Globe, Plus, Trash2, X, Search, Building2, User as UserIcon, ExternalLink } from 'lucide-react'
+import { Plug, Globe, Plus, Trash2, X, Search, Building2, User as UserIcon, ExternalLink, Server, SquareTerminal, Database, Pencil } from 'lucide-react'
 import type { IconType } from 'react-icons'
 import {
   SiGmail, SiGithub, SiGoogledrive, SiDiscord, SiResend, SiHetzner, SiNotion, SiLinear,
@@ -28,6 +28,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '
 import {
   api, type Member, type CatalogEntry, type Connector, type ConnectorScope, type AddConnectorReq,
   type IntegrationsOverview, type ConnectionsResp,
+  type Host, type HostProtocol, type HostPosture, type AddHostReq,
 } from '@/lib/api'
 
 // ── brand icons ────────────────────────────────────────────────────────────────────
@@ -78,8 +79,13 @@ function hueOf(name: string): number {
 function BrandIcon({ name, box = 36 }: { name: string; box?: number }) {
   const key = brandKey(name)
   const tile = 'inline-flex shrink-0 items-center justify-center rounded-lg'
-  if (key === 'custom' || key === 'customremote') {
-    const Glyph = key === 'customremote' ? Globe : Plug
+  // Non-brand glyphs: the custom-MCP escape hatches + the host-connection protocols (Server/terminal/db).
+  const GLYPH: Record<string, typeof Plug> = {
+    custom: Plug, customremote: Globe, host: Server, network: Server, ssh: SquareTerminal,
+    http: Globe, postgres: Database,
+  }
+  if (GLYPH[key]) {
+    const Glyph = GLYPH[key]
     return (
       <span className={`${tile} border bg-muted text-muted-foreground`} style={{ width: box, height: box }}>
         <Glyph style={{ width: box * 0.5, height: box * 0.5 }} />
@@ -411,9 +417,51 @@ function NativeRow({ name, title, s, isAdmin }: {
   )
 }
 
-function ConnectedList({ me, connectors, ov, conns, busy, onToggle, onRemove, onShare, onDisconnectComposio }: {
+/** A single Host connection row — a governed reachable destination (SSH / internal HTTP / DB). Phase
+ *  2a is display + manage only; the gate doesn't read these yet (Phase 2b). */
+function HostRow({ h, me, busy, onToggle, onRemove, onShare, onEdit }: {
+  h: Host; me: Member | null; busy: string
+  onToggle: (id: string, enabled: boolean) => void
+  onRemove: (id: string) => void
+  onShare: (id: string, shared: boolean) => void
+  onEdit: (h: Host) => void
+}) {
+  const isAdmin = isAdminRole(me)
+  const canManage = isAdmin || (h.scope === 'personal' && h.ownerMemberId === me?.id)
+  const canShare = h.scope === 'personal' && canManage
+  const proto = h.protocol === 'any' ? 'any' : h.protocol
+  const detail = `${proto} · ${h.match}${h.credential ? ` · ${h.credential}` : ''}`
+  const postureTone = h.posture === 'never' ? 'warn' : h.posture === 'allow' ? 'ok' : 'muted'
+  return (
+    <Row
+      name={h.protocol === 'any' ? 'host' : h.protocol}
+      title={h.name}
+      subtitle={detail}
+      badges={
+        <>
+          {statusBadge(h.enabled ? 'enabled' : 'disabled', h.enabled ? 'ok' : 'muted')}
+          {statusBadge(h.posture, postureTone)}
+          {h.scope === 'personal' && h.shared && statusBadge('shared with team', 'ok')}
+        </>
+      }
+      right={canManage ? (
+        <>
+          <Button size="icon" variant="ghost" className="h-8 w-8" disabled={busy === h.id} onClick={() => onEdit(h)} title="edit"><Pencil className="h-4 w-4" /></Button>
+          {canShare && (
+            <Button size="sm" variant="outline" disabled={busy === h.id} onClick={() => onShare(h.id, !h.shared)}>{h.shared ? 'Unshare' : 'Share'}</Button>
+          )}
+          <Button size="sm" variant="outline" disabled={busy === h.id} onClick={() => onToggle(h.id, !h.enabled)}>{h.enabled ? 'Disable' : 'Enable'}</Button>
+          <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" disabled={busy === h.id} onClick={() => onRemove(h.id)} title="remove"><Trash2 className="h-4 w-4" /></Button>
+        </>
+      ) : undefined}
+    />
+  )
+}
+
+function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRemove, onShare, onDisconnectComposio, onToggleHost, onRemoveHost, onShareHost, onEditHost }: {
   me: Member | null
   connectors: Connector[]
+  hosts: Host[]
   ov: IntegrationsOverview | null
   conns: ConnectionsResp | null
   busy: string
@@ -421,6 +469,10 @@ function ConnectedList({ me, connectors, ov, conns, busy, onToggle, onRemove, on
   onRemove: (id: string) => void
   onShare: (id: string, shared: boolean) => void
   onDisconnectComposio: (id: string, scope: 'company' | 'personal', label: string) => void
+  onToggleHost: (id: string, enabled: boolean) => void
+  onRemoveHost: (id: string) => void
+  onShareHost: (id: string, shared: boolean) => void
+  onEditHost: (h: Host) => void
 }) {
   const isAdmin = isAdminRole(me)
   const [filter, setFilter] = useState<'all' | 'company' | 'mine'>('all')
@@ -429,16 +481,19 @@ function ConnectedList({ me, connectors, ov, conns, busy, onToggle, onRemove, on
   // apps come from /api/connections (carries each connection's distinguishing name), not the overview.
   const orgConnectors = connectors.filter((c) => c.scope === 'org' || (c.scope === 'personal' && c.shared))
   const companyApps = conns?.company ?? []
-  // Mine = the viewer's own personal connectors + their own Composio apps.
+  const orgHosts = hosts.filter((h) => h.scope === 'org' || (h.scope === 'personal' && h.shared))
+  // Mine = the viewer's own personal connectors + their own Composio apps + their own hosts.
   const myConnectors = connectors.filter((c) => c.scope === 'personal' && c.ownerMemberId === me?.id)
   const myApps = conns?.mine ?? []
+  const myHosts = hosts.filter((h) => h.scope === 'personal' && h.ownerMemberId === me?.id)
 
-  const companyCount = orgConnectors.length + companyApps.length + 2 // +2 for the native bot rows
-  const mineCount = myConnectors.length + myApps.length
+  const companyCount = orgConnectors.length + companyApps.length + orgHosts.length + 2 // +2 for the native bot rows
+  const mineCount = myConnectors.length + myApps.length + myHosts.length
   const showCompany = filter === 'all' || filter === 'company'
   const showMine = filter === 'all' || filter === 'mine'
 
   const cardProps = { me, busy, onToggle, onRemove, onShare }
+  const hostProps = { me, busy, onToggle: onToggleHost, onRemove: onRemoveHost, onShare: onShareHost, onEdit: onEditHost }
 
   return (
     <section className="space-y-4">
@@ -466,6 +521,7 @@ function ConnectedList({ me, connectors, ov, conns, busy, onToggle, onRemove, on
             <ComposioRow key={a.id} app={a} canRemove={isAdmin} busy={busy === a.id} onRemove={() => onDisconnectComposio(a.id, 'company', a.toolkit)} />
           ))}
           {orgConnectors.map((c) => <ConnectorRow key={c.id} c={c} {...cardProps} />)}
+          {orgHosts.map((h) => <HostRow key={h.id} h={h} {...hostProps} />)}
         </div>
       )}
 
@@ -485,6 +541,7 @@ function ConnectedList({ me, connectors, ov, conns, busy, onToggle, onRemove, on
             <ComposioRow key={a.id} app={a} canRemove busy={busy === a.id} onRemove={() => onDisconnectComposio(a.id, 'personal', a.toolkit)} />
           ))}
           {myConnectors.map((c) => <ConnectorRow key={c.id} c={c} {...cardProps} />)}
+          {myHosts.map((h) => <HostRow key={h.id} h={h} {...hostProps} />)}
         </div>
       )}
     </section>
@@ -637,14 +694,100 @@ function AddConnectorDialog({ me, template, scope, onClose, onAdded }: { me: Mem
   )
 }
 
+// ── add/edit a host connection ───────────────────────────────────────────────────────────
+const HOST_PROTOCOLS: { value: HostProtocol; label: string }[] = [
+  { value: 'any', label: 'Any' }, { value: 'ssh', label: 'SSH' }, { value: 'http', label: 'HTTP' }, { value: 'postgres', label: 'Postgres' },
+]
+const HOST_POSTURES: { value: HostPosture; label: string }[] = [
+  { value: 'allow', label: 'Allow' }, { value: 'ask', label: 'Ask' }, { value: 'never', label: 'Never' },
+]
+
+function AddHostDialog({ me, host, scope, onClose, onSaved }: {
+  me: Member | null; host?: Host | null; scope: ConnectorScope; onClose: () => void; onSaved: () => void
+}) {
+  const editing = !!host
+  const isAdmin = isAdminRole(me)
+  const [name, setName] = useState(host?.name ?? '')
+  const [match, setMatch] = useState(host?.match ?? '')
+  const [protocol, setProtocol] = useState<HostProtocol>(host?.protocol ?? 'any')
+  const [posture, setPosture] = useState<HostPosture>(host?.posture ?? 'ask')
+  const [credential, setCredential] = useState('') // never prefilled (redacted); blank on edit = keep existing
+  const [chosenScope, setChosenScope] = useState<ConnectorScope>(host?.scope ?? scope)
+  const [hint, setHint] = useState('')
+  const [busy, setBusy] = useState(false)
+
+  const submit = async () => {
+    setBusy(true); setHint('')
+    const body: AddHostReq = { name: name.trim(), match: match.trim(), protocol, posture }
+    if (credential.trim()) body.credential = credential.trim()
+    if (!editing) body.scope = isAdmin ? chosenScope : 'personal'
+    const res = editing ? await api.updateHost(host!.id, body) : await api.addHost(body)
+    setBusy(false)
+    if (res && 'error' in res) return setHint('⚠ ' + res.error)
+    onSaved()
+  }
+
+  return (
+    <Dialog open onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <BrandIcon name={protocol === 'any' ? 'host' : protocol} box={24} /> {editing ? 'Edit host' : 'Add a host'}
+            <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{chosenScope === 'personal' ? 'personal · only you' : 'company · whole team'}</Badge>
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <p className="text-xs text-muted-foreground">
+            A <b>host</b> is a reachable destination — an SSH box, an internal service, a database — your agents may talk to.
+            <span className="text-foreground"> Not yet enforced:</span> this registers the destination and its credential; the
+            gate begins governing reaches to it in a later update.
+          </p>
+
+          <Field label="Name"><Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Prod database" /></Field>
+
+          <Field label="Host match" help="A hostname (db.internal.example.com), a wildcard (*.internal.example.com), a CIDR (10.0.0.0/8), or host:port.">
+            <Input value={match} onChange={(e) => setMatch(e.target.value)} placeholder="db.prod.internal:5432" className="font-mono text-xs" />
+          </Field>
+
+          <Field label="Protocol"><Segmented value={protocol} onChange={setProtocol} options={HOST_PROTOCOLS} /></Field>
+
+          <Field label="Default posture" help="allow = reach freely · ask = pause for approval · never = always refuse. Takes effect once host governance ships.">
+            <Segmented value={posture} onChange={setPosture} options={HOST_POSTURES} />
+          </Field>
+
+          <Field label="Credential" help="Optional. A Secrets-vault reference (secret:KEY) to an SSH key or password, injected at launch. Leave blank for none.">
+            <Input value={credential} onChange={(e) => setCredential(e.target.value)} placeholder={editing && host?.credential ? `${host.credential} (saved) — type to replace` : 'secret:SSH_KEY'} className="font-mono text-xs" />
+          </Field>
+
+          {isAdmin && !editing && (
+            <Field label="Scope" help={chosenScope === 'personal' ? 'Only loads in sessions you start.' : 'Available to every agent in the workspace.'}>
+              <Segmented value={chosenScope} onChange={setChosenScope} options={[{ value: 'org', label: 'Company · whole team' }, { value: 'personal', label: 'Personal · only me' }]} />
+            </Field>
+          )}
+        </div>
+
+        <DialogFooter>
+          {hint && <span className="mr-auto self-center font-mono text-xs text-destructive">{hint}</span>}
+          <Button variant="ghost" onClick={onClose}>Cancel</Button>
+          <Button onClick={submit} disabled={busy || !name.trim() || !match.trim()}><Server className="mr-1 h-4 w-4" />{editing ? 'Save' : 'Add host'}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 // ── page ─────────────────────────────────────────────────────────────────────────────
 export function ConnectorsPage({ me }: { me: Member | null }) {
   const [connectors, setConnectors] = useState<Connector[]>([])
   const [catalog, setCatalog] = useState<CatalogEntry[]>([])
+  const [hosts, setHosts] = useState<Host[]>([])
   const [ov, setOv] = useState<IntegrationsOverview | null>(null)
   const [conns, setConns] = useState<ConnectionsResp | null>(null)
   const [adding, setAdding] = useState<{ template: CatalogEntry; scope: ConnectorScope } | null>(null)
   const [showAdd, setShowAdd] = useState(false)
+  // A host being added (null host + a default scope) or edited (the host).
+  const [hostForm, setHostForm] = useState<{ host: Host | null; scope: ConnectorScope } | null>(null)
   const [busy, setBusy] = useState('')
 
   const loadConnectors = () =>
@@ -652,9 +795,10 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
       setConnectors(Array.isArray(d?.connectors) ? d.connectors : [])
       setCatalog(Array.isArray(d?.catalog) ? d.catalog : [])
     }).catch(() => {})
+  const loadHosts = () => api.hosts().then((d) => setHosts(Array.isArray(d?.hosts) ? d.hosts : [])).catch(() => {})
   const loadOverview = () => api.integrationsOverview().then(setOv).catch(() => {})
   const loadConnections = () => api.connections().then(setConns).catch(() => {})
-  const reloadAll = () => { loadConnectors(); loadOverview(); loadConnections() }
+  const reloadAll = () => { loadConnectors(); loadHosts(); loadOverview(); loadConnections() }
   useEffect(() => { reloadAll() }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
   const withBusy = async (id: string, fn: () => Promise<unknown>) => {
@@ -663,6 +807,16 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
   const toggle = (id: string, enabled: boolean) => withBusy(id, () => api.toggleConnector(id, enabled))
   const remove = (id: string) => withBusy(id, () => api.deleteConnector(id))
   const share = (id: string, shared: boolean) => withBusy(id, () => api.shareConnector(id, shared))
+
+  const withHostBusy = async (id: string, fn: () => Promise<unknown>) => {
+    setBusy(id); await fn(); await loadHosts(); setBusy('')
+  }
+  const toggleHost = (id: string, enabled: boolean) => withHostBusy(id, () => api.toggleHost(id, enabled))
+  const shareHost = (id: string, shared: boolean) => withHostBusy(id, () => api.shareHost(id, shared))
+  const removeHost = (id: string) => {
+    if (!window.confirm('Remove this host connection?')) return
+    withHostBusy(id, () => api.deleteHost(id))
+  }
 
   const disconnectComposio = async (id: string, scope: 'company' | 'personal', label: string) => {
     const who = scope === 'company' ? 'the whole company' : 'yourself'
@@ -679,13 +833,15 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
   return (
     <div className="max-w-4xl space-y-6">
       <p className="text-sm text-muted-foreground">
-        <b>Connections</b> are the tools your claude-code agents can reach. <b>Company</b> connections are shared by
-        every agent; <b>your</b> connections only load in sessions you start. The keys that power them live under
-        the <b>Creds</b> tab. Every call still passes the gate, so risky actions land in the Inbox for approval.
+        <b>Connections</b> are what your claude-code agents can reach — tool <b>integrations</b> (MCP servers &amp; apps)
+        and <b>hosts</b> (SSH boxes, internal services, databases). <b>Company</b> connections are shared by every
+        agent; <b>your</b> connections only load in sessions you start. The keys that power them live under the
+        <b> Creds</b> tab. Every call still passes the gate, so risky actions land in the Inbox for approval.
       </p>
 
       {!showAdd && (
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={() => setHostForm({ host: null, scope: isAdminRole(me) ? 'org' : 'personal' })}><Server className="mr-1 h-4 w-4" />Add a host</Button>
           <Button onClick={() => setShowAdd(true)}><Plus className="mr-1 h-4 w-4" />Add an integration</Button>
         </div>
       )}
@@ -703,6 +859,7 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
       <ConnectedList
         me={me}
         connectors={connectors}
+        hosts={hosts}
         ov={ov}
         conns={conns}
         busy={busy}
@@ -710,6 +867,10 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
         onRemove={remove}
         onShare={share}
         onDisconnectComposio={disconnectComposio}
+        onToggleHost={toggleHost}
+        onRemoveHost={removeHost}
+        onShareHost={shareHost}
+        onEditHost={(h) => setHostForm({ host: h, scope: h.scope })}
       />
 
       {adding && (
@@ -719,6 +880,16 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
           scope={adding.scope}
           onClose={() => setAdding(null)}
           onAdded={async () => { setAdding(null); reloadAll() }}
+        />
+      )}
+
+      {hostForm && (
+        <AddHostDialog
+          me={me}
+          host={hostForm.host}
+          scope={hostForm.scope}
+          onClose={() => setHostForm(null)}
+          onSaved={async () => { setHostForm(null); loadHosts() }}
         />
       )}
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -402,6 +402,32 @@ export interface AddConnectorReq {
   scope?: ConnectorScope
 }
 
+// ── Host connections (the "Host" shape — docs/host-connections-plan.md, Phase 2a) ──
+export type HostProtocol = 'ssh' | 'http' | 'postgres' | 'any'
+export type HostPosture = 'allow' | 'ask' | 'never'
+export interface Host {
+  id: string
+  name: string
+  match: string                 // hostname glob | CIDR | host[:port]
+  protocol: HostProtocol
+  credential: string            // redacted: a `secret:KEY` ref, '••••' (raw, masked), or ''
+  posture: HostPosture
+  enabled: boolean
+  scope: ConnectorScope         // org | personal (same ownership model as connectors)
+  ownerMemberId?: string
+  shared: boolean
+  createdAt: number
+}
+export interface HostsResp { hosts: Host[] }
+export interface AddHostReq {
+  name: string
+  match: string
+  protocol?: HostProtocol
+  credential?: string
+  posture?: HostPosture
+  scope?: ConnectorScope
+}
+
 export interface MemoryRecord {
   id: string
   tenant: string
@@ -920,4 +946,11 @@ export const api = {
   deleteConnector: (id: string) => call<{ ok: boolean }>('DELETE', '/api/connectors/' + id),
   toggleConnector: (id: string, enabled: boolean) => call<Connector>('PATCH', '/api/connectors/' + id, { enabled }),
   shareConnector: (id: string, shared: boolean) => call<Connector>('PATCH', '/api/connectors/' + id, { shared }),
+
+  hosts: () => call<HostsResp>('GET', '/api/hosts'),
+  addHost: (h: AddHostReq) => call<Host | { error: string }>('POST', '/api/hosts', h),
+  updateHost: (id: string, patch: Partial<AddHostReq>) => call<Host | { error: string }>('PATCH', '/api/hosts/' + id, patch),
+  toggleHost: (id: string, enabled: boolean) => call<Host>('PATCH', '/api/hosts/' + id, { enabled }),
+  shareHost: (id: string, shared: boolean) => call<Host>('PATCH', '/api/hosts/' + id, { shared }),
+  deleteHost: (id: string) => call<{ ok: boolean }>('DELETE', '/api/hosts/' + id),
 }


### PR DESCRIPTION
**Phase 2a** of the access-model reframe (`docs/host-connections-plan.md`): register the hosts an agent reaches — an SSH box, an internal service, a database — as **first-class connections**, the **Host** shape Phase 1 deferred.

## What's here
- **`hosts` table + `HostStore`** (`src/hosts/hosts.ts`) mirroring `ConnectorStore`: org/personal/shared ownership, console-listing filter, redaction. Column is `pattern` (`match` is a SQLite keyword) → mapped to the TS `match` field.
- **`/api/hosts`** `GET`/`POST` + `/:id` `PATCH`/`DELETE` in `server.ts` with the **same admin/owner authz as connectors**. A raw credential is masked in responses (only `secret:KEY` refs are echoed); a blank credential on edit preserves the stored ref.
- **Wired `os.hosts` into the kernel**; personal hosts cascade-delete on member removal.
- **Web:** a Host shape on the Connections page — `HostRow`s in the Company/Mine groups, an Add-a-host / edit dialog (name, match pattern, protocol, `secret:KEY` credential, default posture allow/ask/never, scope), plus `api.ts` client methods + types.

## Scope / verification
- **Registry + UI only** — the gate does **not** govern reaches to these hosts yet (that's Phase 2b); the add dialog says so explicitly. No enricher/policy changes.
- **Verified:** `HostStore` unit checks (migration, `pattern`↔`match`, redaction, ownership, validation, cascade) + **16 end-to-end HTTP route/auth checks** (member 403 on org / 200 on personal, redaction over the wire, blank-credential preservation, enable/disable, share, share-org rejection, delete, 404). `tsc` + `vite` clean; governance CI 45/45. Not yet click-tested in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)