### PR TITLE
Host governance (Phase 2b): egress parsing + net.connect/ssh.exec + netMode (v0.77.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.77.0] — 2026-07-10
+### Added
+- **Host governance (Phase 2b) — agents' SSH / internal-network / DB reaches are now gated by policy.**
+  With **Settings → Governance → "Govern host access"** on (owner-only, off by default), the gate parses
+  an agent's shell egress (`ssh`, `curl`, `psql`, `wget`, `nc`, …), extracts the destination host, and
+  reclassifies `shell.exec` → **`net.connect`** / **`ssh.exec`** so the policy can gate it: a reach to a
+  host that isn't a granted [Host connection](./docs/host-connections-plan.md) (or is internal-looking —
+  private IPs, `.internal`) pauses for approval; a host with posture **never** is refused; an
+  unparseable host (a variable/pipe) escalates rather than slips through. Per-agent **`netMode`** (agent
+  config): `open` (default — public-internet egress runs freely, only internal/listed hosts are governed)
+  or `allowlist` (lockdown — any un-granted reach pauses). New policy caps `net.connect`/`ssh.exec` rules.
+  Best-effort command parsing — a governance + audit layer, **not** a firewall (see
+  `docs/host-connections-plan.md` §2). Phase 2d (kernel egress enforcement) remains future work.
+
 ## [0.76.0] — 2026-07-10
 ### Changed
 - **Automations speak human, not cron.** The Automations list now renders a schedule as friendly prose

--- a/config/policy/default.policy.json
+++ b/config/policy/default.policy.json
@@ -1,6 +1,6 @@
 {
-  "id": "default@v2",
-  "description": "What your agents may do on their own vs. what needs a human. The rule of thumb: LOCAL, reversible work runs freely (editing files, running shell, calling connectors); only OUTWARD-FACING or IRREVERSIBLE effects pause. never = refused outright regardless of who approves (irreversible: destructive ops, spend over $moneyCapUsd, bulk deletes over $bulkDeleteCount — both caps live in Settings → Governance). ask = pauses for the named approver (external email, granting a new OAuth connection). Everything else allows.",
+  "id": "default@v3",
+  "description": "What your agents may do on their own vs. what needs a human. The rule of thumb: LOCAL, reversible work runs freely (editing files, running shell, calling connectors); only OUTWARD-FACING or IRREVERSIBLE effects pause. never = refused outright regardless of who approves (irreversible: destructive ops, spend over $moneyCapUsd, bulk deletes over $bulkDeleteCount — both caps live in Settings → Governance; a host marked posture=never). ask = pauses for the named approver (external email, granting a new OAuth connection, reaching a host that isn't granted). Everything else allows. Host rules (net.connect/ssh.exec) only fire when host governance is enabled in Settings → Governance.",
   "default": { "action": "allow" },
   "rules": [
     { "match": { "capability": "*", "when": { "arg": "destructive", "op": "eq", "value": true } }, "action": "never" },
@@ -11,6 +11,16 @@
 
     { "match": { "capability": "secret.put" }, "action": "ask", "approver": "admin" },
 
-    { "match": { "capability": "connector.connect" }, "action": "ask", "approver": "owner" }
+    { "match": { "capability": "connector.connect" }, "action": "ask", "approver": "owner" },
+
+    { "match": { "capability": "ssh.exec", "when": { "arg": "hostPosture", "op": "eq", "value": "never" } }, "action": "never" },
+    { "match": { "capability": "ssh.exec", "when": { "arg": "hostUnknown", "op": "eq", "value": true } }, "action": "ask", "approver": "owner" },
+    { "match": { "capability": "ssh.exec", "when": { "arg": "hostAllowed", "op": "eq", "value": false } }, "action": "ask", "approver": "owner" },
+    { "match": { "capability": "ssh.exec", "when": { "arg": "hostPosture", "op": "eq", "value": "ask" } }, "action": "ask", "approver": "owner" },
+
+    { "match": { "capability": "net.connect", "when": { "arg": "hostPosture", "op": "eq", "value": "never" } }, "action": "never" },
+    { "match": { "capability": "net.connect", "when": { "arg": "hostUnknown", "op": "eq", "value": true } }, "action": "ask", "approver": "admin" },
+    { "match": { "capability": "net.connect", "when": { "arg": "hostAllowed", "op": "eq", "value": false } }, "action": "ask", "approver": "admin" },
+    { "match": { "capability": "net.connect", "when": { "arg": "hostPosture", "op": "eq", "value": "ask" } }, "action": "ask", "approver": "admin" }
   ]
 }

--- a/docs/host-connections-plan.md
+++ b/docs/host-connections-plan.md
@@ -1,9 +1,14 @@
 # Host / Network Connections — Phase 2 of the access model (scoping plan)
 
-> **Status: scoping (2026-07-09).** This is a design plan, not shipped work. It builds on the north-star
-> [`access-model.md`](./access-model.md) and depends on the governance decision layer described in
-> [`governance-model.md`](./governance-model.md). Several load-bearing choices are still open — see
-> **§7 Open decisions**; they change the shape of the build and are the user's to make before code.
+> **Status: 2a + 2b shipped (2026-07-10).** Decisions in §7 are resolved. **Phase 2a** (the `hosts`
+> table + Connections UI) shipped in v0.73.0. **Phase 2b** (the governance engine — egress parsing,
+> `net.connect`/`ssh.exec` reclassification, `netMode`, the master switch) shipped behind
+> **Settings → Governance → "Govern host access"** (off by default). Implementation:
+> `src/governance/host-match.ts` (parsing + matching), the `isShell` host block in
+> `src/governance/enricher.ts`, the reclassification in `TerminalManager.gate` (`src/terminal.ts`),
+> and the `net.connect`/`ssh.exec` rules in `config/policy/default.policy.json`. **Phase 2d** (kernel
+> egress enforcement under uid-isolation) remains future work. Builds on the north-star
+> [`access-model.md`](./access-model.md) and the decision layer [`governance-model.md`](./governance-model.md).
 
 ## 1. Goal
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.76.0",
+      "version": "0.77.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.76.0",
+  "version": "0.77.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/governance-conformance.cjs
+++ b/scripts/governance-conformance.cjs
@@ -36,9 +36,15 @@ for (const c of fixture.decisions) {
   const engine = new JsonPolicyEngine(policyDoc);
   const thresholds = c.thresholds || fixture.thresholdsDefault;
   engine.setThresholds(() => thresholds);
-  const args = enrichArgs(c.capability, c.args, c.orgDomains || [], c.workdir);
+  const args = enrichArgs(c.capability, c.args, c.orgDomains || [], c.workdir, c.patterns || [], c.hostGrants || null);
   // Mirror tm.gate: an email send is reclassified to its own capability so the recipient-aware rules apply.
-  const capability = args.emailSend === true ? 'email.send' : c.capability;
+  let capability = args.emailSend === true ? 'email.send' : c.capability;
+  // Mirror tm.gate host reclassification (Phase 2b): shell.exec → net.connect/ssh.exec per netMode.
+  if (c.hostGrants && args.netEgress === true) {
+    const netMode = c.netMode === 'allowlist' ? 'allowlist' : 'open';
+    const govern = netMode === 'allowlist' ? true : (args.hostUnknown === true || args.hostInternal === true || args.hostListed === true);
+    if (govern) capability = args.netProtocol === 'ssh' ? 'ssh.exec' : 'net.connect';
+  }
   const got = tag(engine.classify({ capabilityId: capability, args, reasoning: '' }, ctx));
   if (got === c.expect) pass++;
   else failures.push(`decision  ✗ ${c.name}\n            expected ${c.expect}, got ${got}  (facts: destructive=${args.destructive} risky=${args.risky} amountUsd=${args.amountUsd} deleteCount=${args.deleteCount})`);

--- a/src/governance/enricher.ts
+++ b/src/governance/enricher.ts
@@ -29,6 +29,7 @@
  */
 import * as path from 'node:path';
 import { ApprovalLevel, EnrichPattern, Role, canApprove } from '../types';
+import { computeHostFacts, type HostGrant } from './host-match';
 
 const DESTRUCTIVE: RegExp[] = [
   /\bdrop\s+(database|table|schema)\b/i,
@@ -104,6 +105,7 @@ export function enrichArgs(
   orgDomains: string[] = [],
   workdir?: string,
   patterns: EnrichPattern[] = [],
+  hostGrants?: HostGrant[] | null,
 ): Record<string, unknown> {
   const tool = typeof args.tool === 'string' ? args.tool : '';
   const input = (args.input && typeof args.input === 'object' ? args.input : args) as Record<string, unknown>;
@@ -196,7 +198,19 @@ export function enrichArgs(
     emailExternal = args.emailExternal === true || emailRecipients.length === 0 || externalCount > 0;
   }
 
+  // Host egress (Phase 2b): when host governance is ON, the caller passes the agent's granted host
+  // matchers (an array, possibly empty; `null`/undefined = feature off). For a shell command we parse
+  // the egress target and surface netEgress/host/hostAllowed/hostUnknown/hostPosture so the gate can
+  // reclassify shell.exec → net.connect/ssh.exec and the policy can gate on the host. Parsing is
+  // best-effort + fail-loud (host-match.ts) — never a firewall.
+  let hostFacts: Record<string, unknown> | undefined;
+  if (hostGrants && isShell && command) {
+    const hf = computeHostFacts(command, hostGrants);
+    if (hf.netEgress) hostFacts = hf as unknown as Record<string, unknown>;
+  }
+
   const facts: Record<string, unknown> = { ...args, destructive, risky };
+  if (hostFacts) Object.assign(facts, hostFacts);
   if (outsideWorkdir !== undefined) facts.outsideWorkdir = outsideWorkdir;
   if (amountUsd !== undefined) facts.amountUsd = amountUsd;
   if (deleteCount !== undefined) facts.deleteCount = deleteCount;

--- a/src/governance/host-match.ts
+++ b/src/governance/host-match.ts
@@ -1,0 +1,232 @@
+/**
+ * Host egress extraction + matching — the parsing core of Phase 2b (docs/host-connections-plan.md).
+ *
+ * Two pure concerns, kept out of enricher.ts so they're independently unit-tested:
+ *   1. extractEgress(command)  — does this Bash command reach out to a host, and to WHICH host?
+ *   2. hostMatches / isInternalHost — does a host match a granted matcher, and does it *look* internal?
+ *
+ * Guiding principle (from the plan): **parse conservatively, fail loud.** We are NOT a shell
+ * interpreter. We detect the common egress forms; when a command clearly reaches out but we can't
+ * pin the host (a variable, a subshell, a pipe), we return `unknown: true` so the caller can ESCALATE
+ * rather than wave it through. Over-escalation is acceptable; a silent false-allow is not.
+ *
+ * This is best-effort policy-layer governance, not a firewall (see the plan's §2 "honest constraint").
+ */
+
+/** The host-row protocol vocabulary (matches src/hosts/hosts.ts HostProtocol). Finer wire protocols
+ *  (mysql/redis/mongo/nc) collapse to 'any' — matching is primarily by host, protocol only narrows. */
+export type EgressProtocol = 'ssh' | 'http' | 'postgres' | 'any';
+
+export interface Egress {
+  /** The command contains an outbound-connection verb (ssh/curl/psql/…). */
+  egress: boolean;
+  /** The extracted destination host (lowercased, no port), when we could pin it. */
+  host?: string;
+  port?: number;
+  protocol?: EgressProtocol;
+  /** Egress was detected but the host couldn't be extracted (variable/pipe/opaque) → caller should escalate. */
+  unknown: boolean;
+}
+
+// Outbound-connection verbs → the protocol they imply. Word-boundary matched so `sync`≠`nc`, `func`≠`nc`.
+const EGRESS_VERBS: { re: RegExp; protocol: EgressProtocol }[] = [
+  { re: /\bssh\b/i, protocol: 'ssh' },
+  { re: /\bscp\b/i, protocol: 'ssh' },
+  { re: /\bsftp\b/i, protocol: 'ssh' },
+  { re: /\brsync\b/i, protocol: 'ssh' },
+  { re: /\bcurl\b/i, protocol: 'http' },
+  { re: /\bwget\b/i, protocol: 'http' },
+  { re: /\bpsql\b/i, protocol: 'postgres' },
+  { re: /\bpg_dump\b/i, protocol: 'postgres' },
+  { re: /\bmysql\b/i, protocol: 'any' },
+  { re: /\bmongosh?\b/i, protocol: 'any' },
+  { re: /\bredis-cli\b/i, protocol: 'any' },
+  { re: /\bncat\b/i, protocol: 'any' },
+  { re: /\bnc\b/i, protocol: 'any' },
+  { re: /\btelnet\b/i, protocol: 'any' },
+];
+
+const SCHEME_PROTOCOL: Record<string, EgressProtocol> = {
+  http: 'http', https: 'http', postgres: 'postgres', postgresql: 'postgres',
+};
+
+/** Split a URL authority (`user:pass@host:port`) into host + port, dropping any credentials. */
+function parseAuthority(authority: string): { host: string; port?: number } {
+  let a = authority.trim();
+  const at = a.lastIndexOf('@');
+  if (at >= 0) a = a.slice(at + 1); // drop user[:pass]@
+  // Bracketed IPv6 [::1]:port
+  const v6 = a.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (v6) return { host: v6[1].toLowerCase(), port: v6[2] ? Number(v6[2]) : undefined };
+  const m = a.match(/^([^:/]+)(?::(\d+))?/);
+  if (!m) return { host: '' };
+  return { host: m[1].toLowerCase(), port: m[2] ? Number(m[2]) : undefined };
+}
+
+/** A token that looks like a bare host or host:port (not a flag, not a URL, not an obvious file/glob). */
+function looksLikeHost(tok: string): boolean {
+  if (!tok || tok.startsWith('-')) return false;
+  if (/[$`(){}*!\\]/.test(tok)) return false; // variable/subshell/glob → not a pinnable host
+  const hostPart = tok.replace(/:\d+$/, '').replace(/:.*/, ''); // strip :port or scp/ssh :path
+  // an IPv4 or a dotted/hyphenated hostname or a single label
+  return /^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$/i.test(hostPart) && /[a-z0-9]/i.test(hostPart);
+}
+
+/**
+ * Does this Bash command reach out to a host, and which one? Best-effort; `unknown:true` when egress
+ * is clear but the host isn't pinnable. Only the FIRST target is extracted (v1).
+ */
+export function extractEgress(command: string): Egress {
+  const cmd = (command || '').trim();
+  if (!cmd) return { egress: false, unknown: false };
+  const verb = EGRESS_VERBS.find((v) => v.re.test(cmd));
+  if (!verb) return { egress: false, unknown: false };
+
+  // 1. URL form (curl/wget/psql/redis/mongo): scheme://[user:pass@]host[:port]/…
+  const url = cmd.match(/\b([a-z][a-z0-9+.-]*):\/\/([^\s'"`|;&<>]+)/i);
+  if (url) {
+    const scheme = url[1].toLowerCase();
+    const { host, port } = parseAuthority(url[2]);
+    if (host && !/[$`{}]/.test(host)) {
+      return { egress: true, host, port, protocol: SCHEME_PROTOCOL[scheme] ?? verb.protocol, unknown: false };
+    }
+  }
+
+  // 2. Explicit host flag: -h HOST | --host HOST | --host=HOST | -h=HOST (psql/mysql/redis-cli/mongo/nc).
+  const flag = cmd.match(/(?:^|\s)(?:-h|--host)[=\s]+([^\s'"`|;&<>]+)/i);
+  if (flag && looksLikeHost(flag[1])) {
+    const host = flag[1].replace(/:\d+$/, '').toLowerCase();
+    const portM = flag[1].match(/:(\d+)$/);
+    return { egress: true, host, port: portM ? Number(portM[1]) : undefined, protocol: verb.protocol, unknown: false };
+  }
+
+  // 3. user@host token (ssh/scp/sftp/rsync). Also plain `host:path` for scp/rsync.
+  const userAt = cmd.match(/(?:^|\s)([a-z0-9._-]+)@([a-z0-9][a-z0-9.-]*)(?::(\d+))?(?:\s|:|$)/i);
+  if (userAt && verb.protocol === 'ssh') {
+    return { egress: true, host: userAt[2].toLowerCase(), port: userAt[3] ? Number(userAt[3]) : undefined, protocol: 'ssh', unknown: false };
+  }
+
+  // 4. ssh/telnet positional host: the first non-flag, non-verb token that looks like a host.
+  if (verb.protocol === 'ssh' || verb.re.source.includes('telnet') || verb.re.source.includes('\\bnc')) {
+    const tokens = cmd.split(/\s+/);
+    let seenVerb = false;
+    for (const raw of tokens) {
+      const t = raw.replace(/^['"]|['"]$/g, '');
+      if (!seenVerb) { if (EGRESS_VERBS.some((v) => v.re.test(t))) seenVerb = true; continue; }
+      if (t.startsWith('-')) continue; // an option
+      if (/^\d+$/.test(t)) continue;   // a bare port (nc host port) handled by the token before it
+      if (looksLikeHost(t)) {
+        const host = t.replace(/:\d+$/, '').replace(/:.*/, '').toLowerCase();
+        const portM = t.match(/:(\d+)$/);
+        return { egress: true, host, port: portM ? Number(portM[1]) : undefined, protocol: verb.protocol, unknown: false };
+      }
+      // a token that isn't a flag and isn't a host (a variable, a quoted string) → stop guessing.
+      break;
+    }
+  }
+
+  // Egress verb present but no host pinned → fail loud.
+  return { egress: true, unknown: true, protocol: verb.protocol };
+}
+
+// ── matching ────────────────────────────────────────────────────────────────────────
+
+const escapeRe = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+function ipv4ToInt(ip: string): number | null {
+  const parts = ip.split('.');
+  if (parts.length !== 4) return null;
+  let n = 0;
+  for (const p of parts) {
+    if (!/^\d{1,3}$/.test(p)) return null;
+    const o = Number(p);
+    if (o > 255) return null;
+    n = n * 256 + o;
+  }
+  return n >>> 0;
+}
+
+function cidrMatch(host: string, cidr: string): boolean {
+  const [net, bitsStr] = cidr.split('/');
+  const bits = Number(bitsStr);
+  const hostInt = ipv4ToInt(host);
+  const netInt = ipv4ToInt(net);
+  if (hostInt === null || netInt === null || !Number.isInteger(bits) || bits < 0 || bits > 32) return false;
+  if (bits === 0) return true;
+  const mask = bits === 32 ? 0xffffffff : (~((1 << (32 - bits)) - 1)) >>> 0;
+  return (hostInt & mask) === (netInt & mask);
+}
+
+/** Does `host` match a granted host matcher — an exact host, a `*.wildcard`, a CIDR, or `host:port`?
+ *  Port in the matcher is ignored for host comparison in v1 (the host is the blast-radius unit). */
+export function hostMatches(host: string, matcher: string): boolean {
+  const h = (host || '').toLowerCase().replace(/\.$/, '').replace(/:\d+$/, '');
+  const m = (matcher || '').trim().toLowerCase();
+  if (!h || !m) return false;
+  if (m.includes('/') && ipv4ToInt(h) !== null) return cidrMatch(h, m);
+  const mHost = m.replace(/:\d+$/, '');
+  if (mHost.includes('*')) {
+    const re = new RegExp('^' + mHost.split('*').map(escapeRe).join('.*') + '$');
+    return re.test(h);
+  }
+  return h === mHost;
+}
+
+/** True if `host` looks internal/sensitive: private/loopback/link-local IPs, localhost, a bare
+ *  single-label hostname, or an internal TLD (.internal/.local/.lan/.corp/.home/.intranet). Public
+ *  FQDNs (api.stripe.com) are NOT internal — they stay ungoverned under netMode 'open'. */
+export function isInternalHost(host: string): boolean {
+  const h = (host || '').toLowerCase().replace(/\.$/, '').replace(/:\d+$/, '');
+  if (!h) return false;
+  if (h === 'localhost' || h === '::1' || h.startsWith('[::1')) return true;
+  const ip = ipv4ToInt(h);
+  if (ip !== null) {
+    return cidrMatch(h, '10.0.0.0/8') || cidrMatch(h, '172.16.0.0/12') || cidrMatch(h, '192.168.0.0/16')
+      || cidrMatch(h, '127.0.0.0/8') || cidrMatch(h, '169.254.0.0/16');
+  }
+  if (/\.(internal|local|lan|corp|home|intranet)$/.test(h)) return true;
+  // A bare single-label hostname (no dots) — resolves via internal DNS / an ssh-config alias, not a public FQDN.
+  if (!h.includes('.')) return true;
+  return false;
+}
+
+// ── fact computation (what the enricher merges in) ────────────────────────────────────
+
+/** A granted host row, reduced to what matching needs. */
+export interface HostGrant { match: string; protocol: EgressProtocol; posture: 'allow' | 'ask' | 'never' }
+
+/** The host facts an enriched attempt carries (all optional; absent when the command isn't egress). */
+export interface HostFacts {
+  netEgress: boolean;
+  netProtocol?: EgressProtocol;
+  host?: string;
+  hostUnknown?: boolean;   // egress but host not pinnable → escalate
+  hostInternal?: boolean;  // private/loopback/internal-TLD/bare-hostname
+  hostListed?: boolean;    // matches an enabled granted host row
+  hostAllowed?: boolean;   // === hostListed (explicitly granted); the policy fact
+  hostPosture?: 'allow' | 'ask' | 'never'; // the matched row's default tier
+}
+
+/** Does a grant apply to this egress? Host must match; protocol narrows (row 'any' or wire 'any' → any). */
+function grantApplies(host: string, wire: EgressProtocol, g: HostGrant): boolean {
+  if (!hostMatches(host, g.match)) return false;
+  return g.protocol === 'any' || wire === 'any' || g.protocol === wire;
+}
+
+/**
+ * Compute host facts for a Bash command against the agent's granted hosts. Pure. The govern/reclassify
+ * decision (which uses netMode) stays with the caller (gate()); this only reports what the command IS.
+ */
+export function computeHostFacts(command: string, grants: HostGrant[]): HostFacts {
+  const e = extractEgress(command);
+  if (!e.egress) return { netEgress: false };
+  const facts: HostFacts = { netEgress: true, netProtocol: e.protocol };
+  if (e.unknown || !e.host) { facts.hostUnknown = true; facts.hostAllowed = false; return facts; }
+  facts.host = e.host;
+  facts.hostInternal = isInternalHost(e.host);
+  const wire = e.protocol ?? 'any';
+  const match = grants.find((g) => grantApplies(e.host as string, wire, g));
+  if (match) { facts.hostListed = true; facts.hostAllowed = true; facts.hostPosture = match.posture; }
+  else { facts.hostListed = false; facts.hostAllowed = false; }
+  return facts;
+}

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -26,6 +26,7 @@ const LEARNED_GUIDANCE_KEY = 'learned_guidance'; // distilled imperatives inject
 const LEARNED_APPLY_KEY = 'learned_guidance_apply'; // 'off' to stop injecting (default on once guidance exists)
 const RECOMMENDATIONS_KEY = 'learned_recommendations'; // { open: Recommendation[], dismissed: string[] }
 const GOVERNANCE_KEY = 'governance_thresholds'; // numeric caps the never-tier policy rules read (JSON GovernanceThresholds)
+const HOST_GOV_KEY = 'host_governance_enabled'; // master switch for Phase 2b host-egress governance ('1'|'0')
 const ENRICH_PATTERNS_KEY = 'enrich_patterns'; // operator regex→boolean-fact rules the enricher applies (JSON EnrichPattern[])
 const BRANDING_KEY = 'ui_branding'; // per-tenant web-console accent colour + favicon badge (JSON Branding)
 
@@ -362,6 +363,18 @@ export class SettingsStore {
     };
     this.set(GOVERNANCE_KEY, JSON.stringify(next), by);
     return next;
+  }
+
+  // ── host-egress governance master switch (Phase 2b — docs/host-connections-plan.md) ──
+  // OFF by default: registering hosts (Phase 2a) is inert until an admin flips this on, so the new
+  // gate behaviour (parsing ssh/curl targets, reclassifying to net.connect/ssh.exec) can bake safely.
+  hostGovernanceEnabled(): boolean {
+    return this.getRow(HOST_GOV_KEY)?.value === '1';
+  }
+
+  setHostGovernanceEnabled(on: boolean, by?: string): boolean {
+    this.set(HOST_GOV_KEY, on ? '1' : '0', by);
+    return on;
   }
 
   // ── custom governance patterns (operator regex → boolean fact the enricher sets) ──

--- a/src/hosts/hosts.ts
+++ b/src/hosts/hosts.ts
@@ -185,4 +185,17 @@ export class HostStore {
   listForConsole(viewerId: string, isAdmin: boolean): Host[] {
     return this.list().filter((h) => h.scope !== 'personal' || h.shared || isAdmin || h.ownerMemberId === viewerId);
   }
+
+  /**
+   * The ENABLED host grants that apply to a session running as `memberId` — org hosts (everyone) +
+   * shared personal + that member's own personal. Mirrors ConnectorStore.boundTo. Reduced to the
+   * matcher shape the enricher's host-fact computation needs (Phase 2b). Undefined member (system/
+   * automation spawn) sees org + shared only.
+   */
+  grantsFor(memberId?: string): { match: string; protocol: HostProtocol; posture: HostPosture }[] {
+    return this.list()
+      .filter((h) => h.enabled)
+      .filter((h) => h.scope !== 'personal' || h.shared || (!!memberId && h.ownerMemberId === memberId))
+      .map((h) => ({ match: h.match, protocol: h.protocol, posture: h.posture }));
+  }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2032,7 +2032,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!ag?.dir) return sendJson(res, 404, { error: 'agent not found or has no folder' });
     if (ag.runtime !== 'claude-code') return sendJson(res, 400, { error: 'runtime tuning applies to claude-code agents only' });
     if (method === 'GET') {
-      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, category: ag.category, icon: ag.icon });
+      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, netMode: ag.netMode ?? 'open', category: ag.category, icon: ag.icon });
     }
     const b = await readBody(req);
     const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
@@ -2044,16 +2044,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // everything else.
     const prompts = 'examplePrompts' in b ? sanitizeExamplePrompts(b.examplePrompts) : ag.examplePrompts;
     const shellSecrets = 'shellSecrets' in b ? sanitizeShellSecrets(b.shellSecrets) : ag.shellSecrets;
+    // netMode is governance-sensitive (only owner/admin reach this route; a self-editing agent CANNOT
+    // change it). 'allowlist' locks the agent to its granted hosts; anything else → 'open'. Undefined
+    // ('open') is left off the manifest to keep it clean.
+    const netMode = 'netMode' in b ? (b.netMode === 'allowlist' ? 'allowlist' : 'open') : ag.netMode;
     const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
     const icon = 'icon' in b ? sanitizeIcon(b.icon) : ag.icon;
     const description = 'description' in b ? String(b.description ?? '').trim() : ag.description;
-    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, category, icon };
+    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, netMode: netMode === 'open' ? undefined : netMode, category, icon };
     const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     os.registerAgent(next);
     const rev = os.agentRevisions.commit(os.tenant, ag.id, before, manifestToSnapshot(next, before.claudeMd), 'edited config', me.email);
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, category, shellSecrets: shellSecrets ?? [], rev } });
-    return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, category, icon });
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.config.updated', data: { agent: ag.id, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, category, shellSecrets: shellSecrets ?? [], netMode: netMode ?? 'open', rev } });
+    return sendJson(res, 200, { ok: true, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, netMode: netMode ?? 'open', category, icon });
   }
 
   // ── agent config revision history + revert (owner/admin) — the human rollback for a self-editing agent ──
@@ -2112,7 +2116,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   // ── governance thresholds (the numeric caps the never-tier policy rules read) ──
   if (method === 'GET' && p === '/api/settings/governance') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    return sendJson(res, 200, { ...os.settings.governanceThresholds(), ...os.settings.governanceMeta() });
+    return sendJson(res, 200, { ...os.settings.governanceThresholds(), hostGovernanceEnabled: os.settings.hostGovernanceEnabled(), ...os.settings.governanceMeta() });
   }
   if (method === 'PUT' && p === '/api/settings/governance') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
@@ -2121,8 +2125,15 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       { moneyCapUsd: Number(b.moneyCapUsd), bulkDeleteCount: Number(b.bulkDeleteCount), emailBulkCap: Number(b.emailBulkCap) },
       me.email,
     );
+    // Host-egress governance master switch (owner-only, since it changes WHAT gates). Only touched when
+    // the field is present, so a thresholds-only save leaves it unchanged.
+    if (typeof b.hostGovernanceEnabled === 'boolean') {
+      if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required to change host governance' });
+      os.settings.setHostGovernanceEnabled(b.hostGovernanceEnabled, me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.host_governance.updated', data: { enabled: b.hostGovernanceEnabled } });
+    }
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.governance.updated', data: { ...saved } });
-    return sendJson(res, 200, { ok: true, ...saved });
+    return sendJson(res, 200, { ok: true, ...saved, hostGovernanceEnabled: os.settings.hostGovernanceEnabled() });
   }
 
   // ── custom governance patterns (operator regex → boolean fact the enricher sets, policy gates on) ──

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1170,7 +1170,15 @@ export class TerminalManager {
       this.audit(sessionId, agent, 'gate.killswitch', { capability });
       return { decision: 'deny' };
     }
-    const args = enrichArgs(capability, rawArgs, this.emailOrgDomains(), this.os.agents.get(agent)?.dir, this.os.settings.enrichPatterns());
+    // Host-egress governance (Phase 2b): OFF unless the workspace switch is on. When on, pass the
+    // agent's granted host matchers (org + shared + the session's run-as member's personal) so the
+    // enricher can parse the egress target and compute host facts. `null` = feature off.
+    let hostGrants: { match: string; protocol: 'ssh' | 'http' | 'postgres' | 'any'; posture: 'allow' | 'ask' | 'never' }[] | null = null;
+    if (this.os.settings.hostGovernanceEnabled()) {
+      const runAs = this.db.prepare('SELECT run_as FROM term_sessions WHERE id = ?').get<{ run_as: string | null }>(sessionId)?.run_as ?? undefined;
+      hostGrants = this.os.hosts.grantsFor(runAs);
+    }
+    const args = enrichArgs(capability, rawArgs, this.emailOrgDomains(), this.os.agents.get(agent)?.dir, this.os.settings.enrichPatterns(), hostGrants);
     // An outbound email is its own governed capability: reclassify so the policy gates it by recipient
     // (internal → green, external → yellow) instead of the generic connector-mutation tier.
     if (args.emailSend === true) {
@@ -1183,6 +1191,21 @@ export class TerminalManager {
         this.audit(sessionId, agent, 'gate.email.blocked', { capability, reason: emailDenial, recipients: args.emailRecipients ?? [] });
         this.audit(sessionId, agent, 'gate.decision', { capability, decision: { effect: 'deny', riskClass: 'deny', reason: emailDenial } });
         return { decision: 'deny' };
+      }
+    }
+    // Host egress reclassification (Phase 2b): shell.exec → net.connect / ssh.exec when this command
+    // reaches a host we should govern. netMode decides scope: 'allowlist' (lockdown) governs ALL
+    // egress; 'open' (default) governs only internal-looking, explicitly-listed, or unpinnable-host
+    // reaches — public-internet egress stays plain shell.exec. Host facts (hostAllowed/hostUnknown/
+    // hostPosture) ride along in `args` for the net.* policy rules.
+    if (hostGrants && args.netEgress === true) {
+      const netMode = this.os.agents.get(agent)?.netMode === 'allowlist' ? 'allowlist' : 'open';
+      const govern = netMode === 'allowlist'
+        ? true
+        : (args.hostUnknown === true || args.hostInternal === true || args.hostListed === true);
+      if (govern) {
+        capability = args.netProtocol === 'ssh' ? 'ssh.exec' : 'net.connect';
+        this.audit(sessionId, agent, 'gate.net.reclassified', { capability, host: (args.host as string) ?? null, netMode, hostAllowed: args.hostAllowed === true, hostUnknown: args.hostUnknown === true });
       }
     }
     const attempt: ActionAttempt = { capabilityId: capability, args, reasoning };

--- a/src/types.ts
+++ b/src/types.ts
@@ -720,6 +720,11 @@ export interface AgentManifest extends RuntimeTuning {
    *  vault secret reaches the interactive shell — connectors get theirs via the MCP bag — so it's
    *  deliberately explicit per agent. Undefined/empty → nothing is exported. */
   shellSecrets?: string[];
+  /** Host-egress governance posture (Phase 2b — docs/host-connections-plan.md). Only takes effect when
+   *  workspace host governance is enabled. `'open'` (default): public-internet egress stays plain
+   *  shell.exec; only internal-looking or explicitly-listed hosts are governed. `'allowlist'` (lockdown):
+   *  ANY detected egress to a host not in this agent's grants pauses/denies. Undefined → 'open'. */
+  netMode?: 'open' | 'allowlist';
   /** The agent's visual icon. Either a built-in library id (a lucide icon name like `"Bot"`) or a raw
    *  custom `<svg>…</svg>` markup string the user uploaded. Undefined → the console falls back to a
    *  default glyph. Purely cosmetic. Rendered in an `<img>` so inline SVG can't execute scripts. */

--- a/test/governance/conformance.json
+++ b/test/governance/conformance.json
@@ -1,61 +1,965 @@
 {
   "_about": "Golden governance fixture: the single source of truth for what the gate decides. `decisions` feed enrichArgs() → JsonPolicyEngine.classify() (the brain tm.gate uses); `context` feed autoClearsApproval(). Run with `node scripts/governance-conformance.cjs` (exits non-zero on any mismatch). Add a case here before changing the enricher or the default policy.",
-  "thresholdsDefault": { "moneyCapUsd": 500, "bulkDeleteCount": 25, "emailBulkCap": 10 },
-
+  "thresholdsDefault": {
+    "moneyCapUsd": 500,
+    "bulkDeleteCount": 25,
+    "emailBulkCap": 10
+  },
   "decisions": [
-    { "name": "bash read is allowed", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "ls -la /var/www" } }, "expect": "allow" },
-    { "name": "bash deploy runs freely (risky ≠ destructive; no longer gated)", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "npm run deploy:prod" } }, "expect": "allow" },
-    { "name": "rm -rf data is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "rm -rf /var/lib/data" } }, "expect": "never" },
-
-    { "name": "file write inside the agent folder is allowed", "capability": "file.write", "workdir": "/data/agents/support", "args": { "tool": "Edit", "input": { "file_path": "/data/agents/support/notes.md", "old_string": "a", "new_string": "b" } }, "expect": "allow" },
-    { "name": "file write via a relative path is inside → allowed", "capability": "file.write", "workdir": "/data/agents/support", "args": { "tool": "Write", "input": { "file_path": "sub/out.txt", "content": "hi" } }, "expect": "allow" },
-    { "name": "file write OUTSIDE the folder now runs freely (local, reversible — not a side effect on the world)", "capability": "file.write", "workdir": "/data/agents/support", "args": { "tool": "Write", "input": { "file_path": "/Users/x/.claude/settings.json", "content": "x" } }, "expect": "allow" },
-    { "name": "path traversal out of the folder now runs freely", "capability": "file.write", "workdir": "/data/agents/support", "args": { "tool": "Edit", "input": { "file_path": "../other/secret", "old_string": "a", "new_string": "b" } }, "expect": "allow" },
-    { "name": "file write with no visible path now runs freely", "capability": "file.write", "workdir": "/data/agents/support", "args": { "tool": "Write", "input": { "content": "opaque" } }, "expect": "allow" },
-    { "name": "file content that mentions DROP TABLE is NOT destructive (judged by path)", "capability": "file.write", "workdir": "/data/agents/support", "args": { "tool": "Write", "input": { "file_path": "/data/agents/support/migration.sql", "content": "DROP TABLE users; DELETE FROM accounts;" } }, "expect": "allow" },
-    { "name": "notebook edit inside the folder is allowed", "capability": "file.write", "workdir": "/data/agents/support", "args": { "tool": "NotebookEdit", "input": { "notebook_path": "/data/agents/support/run.ipynb", "new_source": "print(1)" } }, "expect": "allow" },
-    { "name": "lowercase drop database is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "psql -c \"drop database production\"" } }, "expect": "never" },
-    { "name": "TRUNCATE is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "mysql -e 'TRUNCATE TABLE users'" } }, "expect": "never" },
-    { "name": "delete from with no where is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "psql -c \"delete from sessions\"" } }, "expect": "never" },
-    { "name": "delete from with where is risky, not destructive → runs freely", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "psql -c \"delete from sessions where id=1\"" } }, "expect": "allow" },
-    { "name": "terraform destroy is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "terraform destroy -auto-approve" } }, "expect": "never" },
-    { "name": "force push is never", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "git push --force origin main" } }, "expect": "never" },
-    { "name": "destructive phrase in the DESCRIPTION does not gate a benign command (classify on command only)", "capability": "shell.exec", "args": { "tool": "Bash", "input": { "command": "gh run list --repo acme/docs --limit 1", "description": "check the deploy after we rm -rf the old build" } }, "expect": "allow" },
-
-    { "name": "connector read is allowed", "capability": "connector.call", "args": { "tool": "mcp__instawp__list_sites", "input": {} }, "expect": "allow" },
-    { "name": "connector send (risky mutation) now runs freely", "capability": "connector.call", "args": { "tool": "mcp__slack__SLACK_SEND_MESSAGE", "input": { "text": "hi" } }, "expect": "allow" },
-    { "name": "delete_site is never (by name)", "capability": "connector.call", "args": { "tool": "mcp__instawp__delete_site", "input": { "site_id": 5 } }, "expect": "never" },
-    { "name": "db_query DROP TABLE is never (argument-aware — the closed hole)", "capability": "connector.call", "args": { "tool": "mcp__instawp__db_query", "input": { "sql": "DROP TABLE wp_posts" } }, "expect": "never" },
-    { "name": "execute_php with rm -rf is never", "capability": "connector.call", "args": { "tool": "mcp__site__execute_php", "input": { "code": "shell_exec('rm -rf /var/www')" } }, "expect": "never" },
-    { "name": "db_query SELECT is just a read-ish call", "capability": "connector.call", "args": { "tool": "mcp__instawp__db_query", "input": { "sql": "SELECT * FROM wp_posts LIMIT 10" } }, "expect": "allow" },
-
-    { "name": "refund under cap now runs freely (only over-cap spend is never)", "capability": "connector.call", "args": { "tool": "mcp__stripe__REFUND_CHARGE", "input": { "amount": 200 } }, "expect": "allow" },
-    { "name": "refund over cap → never", "capability": "connector.call", "args": { "tool": "mcp__stripe__REFUND_CHARGE", "input": { "amount": 600 } }, "expect": "never" },
-    { "name": "explicit amount_usd over cap → never", "capability": "connector.call", "args": { "tool": "mcp__billing__charge_customer", "input": { "amount_usd": 1000 } }, "expect": "never" },
-
-    { "name": "bulk delete over cap → never", "capability": "connector.call", "args": { "tool": "mcp__instawp__delete_content", "input": { "ids": [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26] } }, "expect": "never" },
-    { "name": "small delete under cap now runs freely (only over-cap bulk delete is never)", "capability": "connector.call", "args": { "tool": "mcp__instawp__delete_content", "input": { "ids": [1,2,3] } }, "expect": "allow" },
-
-    { "name": "company connection management → owner", "capability": "connector.connect", "args": { "tool": "mcp__composio-company__GMAIL_MANAGE_CONNECTION", "input": {} }, "expect": "ask:owner" },
-
-    { "name": "email to internal domain → allowed (green)", "capability": "connector.call", "orgDomains": ["acme.com"], "args": { "tool": "mcp__composio__GMAIL_SEND_EMAIL", "input": { "recipient_email": "cfo@acme.com", "subject": "hi", "body": "x" } }, "expect": "allow" },
-    { "name": "email to external domain → approval (yellow)", "capability": "connector.call", "orgDomains": ["acme.com"], "args": { "tool": "mcp__composio__GMAIL_SEND_EMAIL", "input": { "recipient_email": "someone@outside.com" } }, "expect": "ask:head" },
-    { "name": "email mixed internal+external → approval", "capability": "connector.call", "orgDomains": ["acme.com"], "args": { "tool": "mcp__gmail__send_email", "input": { "to": ["a@acme.com", "b@out.com"] } }, "expect": "ask:head" },
-    { "name": "email with unparseable recipients → external (safe default)", "capability": "connector.call", "orgDomains": ["acme.com"], "args": { "tool": "mcp__composio__GMAIL_SEND_EMAIL", "input": { "subject": "no to field" } }, "expect": "ask:head" },
-    { "name": "email with no org domains configured → all external", "capability": "connector.call", "args": { "tool": "mcp__composio__GMAIL_SEND_EMAIL", "input": { "to": "cfo@acme.com" } }, "expect": "ask:head" },
-    { "name": "bulk external send → admin (external email always asks; no separate bulk tier now)", "capability": "connector.call", "orgDomains": ["acme.com"], "args": { "tool": "mcp__composio__GMAIL_SEND_EMAIL", "input": { "to": ["a@x.com","b@x.com","c@x.com","d@x.com","e@x.com","f@x.com","g@x.com","h@x.com","i@x.com","j@x.com","k@x.com"] } }, "expect": "ask:head" },
-    { "name": "external send at cap stays yellow (not bulk)", "capability": "connector.call", "orgDomains": ["acme.com"], "args": { "tool": "mcp__composio__GMAIL_SEND_EMAIL", "input": { "to": ["a@x.com","b@x.com","c@x.com","d@x.com","e@x.com","f@x.com","g@x.com","h@x.com","i@x.com","j@x.com"] } }, "expect": "ask:head" },
-    { "name": "many INTERNAL recipients is not bulk-external → green", "capability": "connector.call", "orgDomains": ["acme.com"], "args": { "tool": "mcp__composio__GMAIL_SEND_EMAIL", "input": { "to": ["a@acme.com","b@acme.com","c@acme.com","d@acme.com","e@acme.com","f@acme.com","g@acme.com","h@acme.com","i@acme.com","j@acme.com","k@acme.com","l@acme.com"] } }, "expect": "allow" },
-    { "name": "slack send stays a connector call (not email) → runs freely", "capability": "connector.call", "orgDomains": ["acme.com"], "args": { "tool": "mcp__slack__SLACK_SEND_MESSAGE", "input": { "text": "hi" } }, "expect": "allow" }
+    {
+      "name": "bash read is allowed",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "ls -la /var/www"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "bash deploy runs freely (risky ≠ destructive; no longer gated)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "npm run deploy:prod"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "rm -rf data is never",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "rm -rf /var/lib/data"
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "file write inside the agent folder is allowed",
+      "capability": "file.write",
+      "workdir": "/data/agents/support",
+      "args": {
+        "tool": "Edit",
+        "input": {
+          "file_path": "/data/agents/support/notes.md",
+          "old_string": "a",
+          "new_string": "b"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "file write via a relative path is inside → allowed",
+      "capability": "file.write",
+      "workdir": "/data/agents/support",
+      "args": {
+        "tool": "Write",
+        "input": {
+          "file_path": "sub/out.txt",
+          "content": "hi"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "file write OUTSIDE the folder now runs freely (local, reversible — not a side effect on the world)",
+      "capability": "file.write",
+      "workdir": "/data/agents/support",
+      "args": {
+        "tool": "Write",
+        "input": {
+          "file_path": "/Users/x/.claude/settings.json",
+          "content": "x"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "path traversal out of the folder now runs freely",
+      "capability": "file.write",
+      "workdir": "/data/agents/support",
+      "args": {
+        "tool": "Edit",
+        "input": {
+          "file_path": "../other/secret",
+          "old_string": "a",
+          "new_string": "b"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "file write with no visible path now runs freely",
+      "capability": "file.write",
+      "workdir": "/data/agents/support",
+      "args": {
+        "tool": "Write",
+        "input": {
+          "content": "opaque"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "file content that mentions DROP TABLE is NOT destructive (judged by path)",
+      "capability": "file.write",
+      "workdir": "/data/agents/support",
+      "args": {
+        "tool": "Write",
+        "input": {
+          "file_path": "/data/agents/support/migration.sql",
+          "content": "DROP TABLE users; DELETE FROM accounts;"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "notebook edit inside the folder is allowed",
+      "capability": "file.write",
+      "workdir": "/data/agents/support",
+      "args": {
+        "tool": "NotebookEdit",
+        "input": {
+          "notebook_path": "/data/agents/support/run.ipynb",
+          "new_source": "print(1)"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "lowercase drop database is never",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "psql -c \"drop database production\""
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "TRUNCATE is never",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "mysql -e 'TRUNCATE TABLE users'"
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "delete from with no where is never",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "psql -c \"delete from sessions\""
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "delete from with where is risky, not destructive → runs freely",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "psql -c \"delete from sessions where id=1\""
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "terraform destroy is never",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "terraform destroy -auto-approve"
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "force push is never",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "git push --force origin main"
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "destructive phrase in the DESCRIPTION does not gate a benign command (classify on command only)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "gh run list --repo acme/docs --limit 1",
+          "description": "check the deploy after we rm -rf the old build"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "connector read is allowed",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__instawp__list_sites",
+        "input": {}
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "connector send (risky mutation) now runs freely",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__slack__SLACK_SEND_MESSAGE",
+        "input": {
+          "text": "hi"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "delete_site is never (by name)",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__instawp__delete_site",
+        "input": {
+          "site_id": 5
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "db_query DROP TABLE is never (argument-aware — the closed hole)",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__instawp__db_query",
+        "input": {
+          "sql": "DROP TABLE wp_posts"
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "execute_php with rm -rf is never",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__site__execute_php",
+        "input": {
+          "code": "shell_exec('rm -rf /var/www')"
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "db_query SELECT is just a read-ish call",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__instawp__db_query",
+        "input": {
+          "sql": "SELECT * FROM wp_posts LIMIT 10"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "refund under cap now runs freely (only over-cap spend is never)",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__stripe__REFUND_CHARGE",
+        "input": {
+          "amount": 200
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "refund over cap → never",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__stripe__REFUND_CHARGE",
+        "input": {
+          "amount": 600
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "explicit amount_usd over cap → never",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__billing__charge_customer",
+        "input": {
+          "amount_usd": 1000
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "bulk delete over cap → never",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__instawp__delete_content",
+        "input": {
+          "ids": [
+            1,
+            2,
+            3,
+            4,
+            5,
+            6,
+            7,
+            8,
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+            17,
+            18,
+            19,
+            20,
+            21,
+            22,
+            23,
+            24,
+            25,
+            26
+          ]
+        }
+      },
+      "expect": "never"
+    },
+    {
+      "name": "small delete under cap now runs freely (only over-cap bulk delete is never)",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__instawp__delete_content",
+        "input": {
+          "ids": [
+            1,
+            2,
+            3
+          ]
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "company connection management → owner",
+      "capability": "connector.connect",
+      "args": {
+        "tool": "mcp__composio-company__GMAIL_MANAGE_CONNECTION",
+        "input": {}
+      },
+      "expect": "ask:owner"
+    },
+    {
+      "name": "email to internal domain → allowed (green)",
+      "capability": "connector.call",
+      "orgDomains": [
+        "acme.com"
+      ],
+      "args": {
+        "tool": "mcp__composio__GMAIL_SEND_EMAIL",
+        "input": {
+          "recipient_email": "cfo@acme.com",
+          "subject": "hi",
+          "body": "x"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "email to external domain → approval (yellow)",
+      "capability": "connector.call",
+      "orgDomains": [
+        "acme.com"
+      ],
+      "args": {
+        "tool": "mcp__composio__GMAIL_SEND_EMAIL",
+        "input": {
+          "recipient_email": "someone@outside.com"
+        }
+      },
+      "expect": "ask:head"
+    },
+    {
+      "name": "email mixed internal+external → approval",
+      "capability": "connector.call",
+      "orgDomains": [
+        "acme.com"
+      ],
+      "args": {
+        "tool": "mcp__gmail__send_email",
+        "input": {
+          "to": [
+            "a@acme.com",
+            "b@out.com"
+          ]
+        }
+      },
+      "expect": "ask:head"
+    },
+    {
+      "name": "email with unparseable recipients → external (safe default)",
+      "capability": "connector.call",
+      "orgDomains": [
+        "acme.com"
+      ],
+      "args": {
+        "tool": "mcp__composio__GMAIL_SEND_EMAIL",
+        "input": {
+          "subject": "no to field"
+        }
+      },
+      "expect": "ask:head"
+    },
+    {
+      "name": "email with no org domains configured → all external",
+      "capability": "connector.call",
+      "args": {
+        "tool": "mcp__composio__GMAIL_SEND_EMAIL",
+        "input": {
+          "to": "cfo@acme.com"
+        }
+      },
+      "expect": "ask:head"
+    },
+    {
+      "name": "bulk external send → admin (external email always asks; no separate bulk tier now)",
+      "capability": "connector.call",
+      "orgDomains": [
+        "acme.com"
+      ],
+      "args": {
+        "tool": "mcp__composio__GMAIL_SEND_EMAIL",
+        "input": {
+          "to": [
+            "a@x.com",
+            "b@x.com",
+            "c@x.com",
+            "d@x.com",
+            "e@x.com",
+            "f@x.com",
+            "g@x.com",
+            "h@x.com",
+            "i@x.com",
+            "j@x.com",
+            "k@x.com"
+          ]
+        }
+      },
+      "expect": "ask:head"
+    },
+    {
+      "name": "external send at cap stays yellow (not bulk)",
+      "capability": "connector.call",
+      "orgDomains": [
+        "acme.com"
+      ],
+      "args": {
+        "tool": "mcp__composio__GMAIL_SEND_EMAIL",
+        "input": {
+          "to": [
+            "a@x.com",
+            "b@x.com",
+            "c@x.com",
+            "d@x.com",
+            "e@x.com",
+            "f@x.com",
+            "g@x.com",
+            "h@x.com",
+            "i@x.com",
+            "j@x.com"
+          ]
+        }
+      },
+      "expect": "ask:head"
+    },
+    {
+      "name": "many INTERNAL recipients is not bulk-external → green",
+      "capability": "connector.call",
+      "orgDomains": [
+        "acme.com"
+      ],
+      "args": {
+        "tool": "mcp__composio__GMAIL_SEND_EMAIL",
+        "input": {
+          "to": [
+            "a@acme.com",
+            "b@acme.com",
+            "c@acme.com",
+            "d@acme.com",
+            "e@acme.com",
+            "f@acme.com",
+            "g@acme.com",
+            "h@acme.com",
+            "i@acme.com",
+            "j@acme.com",
+            "k@acme.com",
+            "l@acme.com"
+          ]
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "slack send stays a connector call (not email) → runs freely",
+      "capability": "connector.call",
+      "orgDomains": [
+        "acme.com"
+      ],
+      "args": {
+        "tool": "mcp__slack__SLACK_SEND_MESSAGE",
+        "input": {
+          "text": "hi"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "host-gov OFF: internal ssh is plain shell (allow)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "ssh deploy@box.prod.internal uptime"
+        }
+      },
+      "expect": "allow"
+    },
+    {
+      "name": "open: public egress stays shell.exec (allow)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl https://api.stripe.com/v1/charges"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "open",
+      "expect": "allow"
+    },
+    {
+      "name": "open: internal unlisted → net.connect ask admin",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl http://172.16.5.5/admin"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "open",
+      "expect": "ask:head"
+    },
+    {
+      "name": "open: listed CIDR posture ask → net.connect ask admin",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl http://10.0.4.4/status"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "open",
+      "expect": "ask:head"
+    },
+    {
+      "name": "open: listed allowed db host (posture allow) → allow",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "psql -h db.internal -U app"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "open",
+      "expect": "allow"
+    },
+    {
+      "name": "open: listed ssh host posture ask → ssh.exec ask owner",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "ssh deploy@web.prod.internal"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "open",
+      "expect": "ask:owner"
+    },
+    {
+      "name": "open: host posture never → net.connect never",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl http://blocked.internal/x"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "open",
+      "expect": "never"
+    },
+    {
+      "name": "open: unknown host (variable) → ssh.exec ask owner",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "ssh $TARGET uptime"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "open",
+      "expect": "ask:owner"
+    },
+    {
+      "name": "open: destructive over ssh still denied (never wins)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "ssh deploy@box.prod.internal 'rm -rf /data'"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "open",
+      "expect": "never"
+    },
+    {
+      "name": "allowlist: public egress now governed → net.connect ask admin",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl https://api.stripe.com/v1/x"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "allowlist",
+      "expect": "ask:head"
+    },
+    {
+      "name": "allowlist: granted host still allowed",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "psql -h db.internal -U app"
+        }
+      },
+      "hostGrants": [
+        {
+          "match": "*.prod.internal",
+          "protocol": "ssh",
+          "posture": "ask"
+        },
+        {
+          "match": "db.internal",
+          "protocol": "any",
+          "posture": "allow"
+        },
+        {
+          "match": "blocked.internal",
+          "protocol": "any",
+          "posture": "never"
+        },
+        {
+          "match": "10.0.0.0/8",
+          "protocol": "any",
+          "posture": "ask"
+        }
+      ],
+      "netMode": "allowlist",
+      "expect": "allow"
+    },
+    {
+      "name": "open: empty grants, internal reach → ask admin",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl http://192.168.1.9/x"
+        }
+      },
+      "hostGrants": [],
+      "netMode": "open",
+      "expect": "ask:head"
+    }
   ],
-
   "context": [
-    { "name": "owner attended clears head", "level": "head", "ctx": { "initiatorRole": "owner", "attended": true }, "expectAutoClear": true },
-    { "name": "admin attended clears head", "level": "head", "ctx": { "initiatorRole": "admin", "attended": true }, "expectAutoClear": true },
-    { "name": "owner attended clears owner", "level": "owner", "ctx": { "initiatorRole": "owner", "attended": true }, "expectAutoClear": true },
-    { "name": "admin attended CANNOT clear owner", "level": "owner", "ctx": { "initiatorRole": "admin", "attended": true }, "expectAutoClear": false },
-    { "name": "member attended cannot clear head", "level": "head", "ctx": { "initiatorRole": "member", "attended": true }, "expectAutoClear": false },
-    { "name": "owner UNattended (automation) cannot clear", "level": "head", "ctx": { "initiatorRole": "owner", "attended": false }, "expectAutoClear": false },
-    { "name": "no initiator role cannot clear", "level": "head", "ctx": { "initiatorRole": null, "attended": true }, "expectAutoClear": false }
+    {
+      "name": "owner attended clears head",
+      "level": "head",
+      "ctx": {
+        "initiatorRole": "owner",
+        "attended": true
+      },
+      "expectAutoClear": true
+    },
+    {
+      "name": "admin attended clears head",
+      "level": "head",
+      "ctx": {
+        "initiatorRole": "admin",
+        "attended": true
+      },
+      "expectAutoClear": true
+    },
+    {
+      "name": "owner attended clears owner",
+      "level": "owner",
+      "ctx": {
+        "initiatorRole": "owner",
+        "attended": true
+      },
+      "expectAutoClear": true
+    },
+    {
+      "name": "admin attended CANNOT clear owner",
+      "level": "owner",
+      "ctx": {
+        "initiatorRole": "admin",
+        "attended": true
+      },
+      "expectAutoClear": false
+    },
+    {
+      "name": "member attended cannot clear head",
+      "level": "head",
+      "ctx": {
+        "initiatorRole": "member",
+        "attended": true
+      },
+      "expectAutoClear": false
+    },
+    {
+      "name": "owner UNattended (automation) cannot clear",
+      "level": "head",
+      "ctx": {
+        "initiatorRole": "owner",
+        "attended": false
+      },
+      "expectAutoClear": false
+    },
+    {
+      "name": "no initiator role cannot clear",
+      "level": "head",
+      "ctx": {
+        "initiatorRole": null,
+        "attended": true
+      },
+      "expectAutoClear": false
+    }
   ]
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4776,6 +4776,8 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
   const [savedIcon, setSavedIcon] = useState<string | undefined>(undefined)
   const [secrets, setSecrets] = useState('')
   const [savedSecrets, setSavedSecrets] = useState('')
+  const [netMode, setNetMode] = useState<'open' | 'allowlist'>('open')
+  const [savedNetMode, setSavedNetMode] = useState<'open' | 'allowlist'>('open')
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
 
@@ -4787,17 +4789,18 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
       const p = (r.examplePrompts ?? []).join('\n')
       const c = r.category ?? ''
       const s = (r.shellSecrets ?? []).join(' ')
-      setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon); setSecrets(s); setSavedSecrets(s)
+      const nm = r.netMode === 'allowlist' ? 'allowlist' : 'open'
+      setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon); setSecrets(s); setSavedSecrets(s); setNetMode(nm); setSavedNetMode(nm)
     }).catch(() => {})
   }, [agentId])
 
-  const dirty = JSON.stringify(tuning) !== JSON.stringify(saved) || description !== savedDescription || prompts !== savedPrompts || category !== savedCategory || icon !== savedIcon || secrets !== savedSecrets
+  const dirty = JSON.stringify(tuning) !== JSON.stringify(saved) || description !== savedDescription || prompts !== savedPrompts || category !== savedCategory || icon !== savedIcon || secrets !== savedSecrets || netMode !== savedNetMode
   const save = async () => {
     setBusy(true); setHint('')
     const examplePrompts = prompts.split('\n').map((s) => s.trim()).filter(Boolean)
     const shellSecrets = secrets.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean)
     // Always send `icon` (empty string clears it → server drops the manifest key).
-    const r = await api.saveAgentConfig(agentId, { ...tuning, description: description.trim(), examplePrompts, shellSecrets, category: category.trim(), icon: icon ?? '' })
+    const r = await api.saveAgentConfig(agentId, { ...tuning, description: description.trim(), examplePrompts, shellSecrets, netMode, category: category.trim(), icon: icon ?? '' })
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
     const t: RuntimeTuning = { model: r.model, effort: r.effort }
@@ -4805,7 +4808,8 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
     const p = (r.examplePrompts ?? []).join('\n')
     const c = r.category ?? ''
     const s = (r.shellSecrets ?? []).join(' ')
-    setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon); setSecrets(s); setSavedSecrets(s); setHint('saved — applies on the next session'); setTimeout(() => setHint(''), 2500)
+    const nm = r.netMode === 'allowlist' ? 'allowlist' : 'open'
+    setTuning(t); setSaved(t); setDescription(d); setSavedDescription(d); setPrompts(p); setSavedPrompts(p); setCategory(c); setSavedCategory(c); setIcon(r.icon); setSavedIcon(r.icon); setSecrets(s); setSavedSecrets(s); setNetMode(nm); setSavedNetMode(nm); setHint('saved — applies on the next session'); setTimeout(() => setHint(''), 2500)
     onSaved?.()
   }
 
@@ -4834,6 +4838,14 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
           <label className="text-xs font-medium">Shell secrets</label>
           <Input value={secrets} onChange={(e) => setSecrets(e.target.value)} className="font-mono text-sm" placeholder="e.g. GH_TOKEN  (space/comma separated env-var names)" />
           <p className="text-[11px] text-muted-foreground">Vault keys exported as env vars into this agent's shell (so CLIs like <span className="font-mono">gh</span> authenticate). Store the value in <span className="font-medium">Settings → Secrets</span> (key = the name here; set its principal to <span className="font-mono">{agentId}</span> for a per-agent value, or leave tenant-wide). Resolved at launch, audited per key.</p>
+        </div>
+        <div className="space-y-1">
+          <label className="text-xs font-medium">Host access mode</label>
+          <select value={netMode} onChange={(e) => setNetMode(e.target.value === 'allowlist' ? 'allowlist' : 'open')} className="w-full rounded-md border bg-background px-2 py-1.5 text-sm">
+            <option value="open">Open — govern only internal / listed hosts (default)</option>
+            <option value="allowlist">Allowlist — lock to granted Host connections only</option>
+          </select>
+          <p className="text-[11px] text-muted-foreground">Only applies when <span className="font-medium">host governance</span> is on (Settings → Governance). <span className="font-mono">Open</span>: public-internet egress runs freely; internal-looking or listed <a href="#/connectors" className="underline hover:text-foreground">hosts</a> are gated. <span className="font-mono">Allowlist</span>: any reach to a host not granted to this agent pauses for approval.</p>
         </div>
         <div className="flex items-center gap-3">
           <Button size="sm" onClick={save} disabled={busy || !dirty}>{dirty ? 'Save' : 'Saved'}</Button>
@@ -6324,15 +6336,27 @@ function GovernanceSettings({ me }: { me: Member }) {
   const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
+  const [hostGov, setHostGov] = useState(false)
+  const [hostBusy, setHostBusy] = useState(false)
   const canEdit = me.role === 'owner' || me.role === 'admin'
+  const isOwner = me.role === 'owner'
 
   useEffect(() => {
     api.governance().then((r) => {
       if (r.error) return
       const v = { moneyCapUsd: r.moneyCapUsd, bulkDeleteCount: r.bulkDeleteCount }
-      setT(v); setSaved(v); setMeta({ updatedAt: r.updatedAt, updatedBy: r.updatedBy })
+      setT(v); setSaved(v); setMeta({ updatedAt: r.updatedAt, updatedBy: r.updatedBy }); setHostGov(!!r.hostGovernanceEnabled)
     }).catch(() => {})
   }, [])
+
+  const toggleHostGov = async () => {
+    setHostBusy(true)
+    const next = !hostGov
+    const r = await api.saveGovernance({ ...saved, hostGovernanceEnabled: next })
+    setHostBusy(false)
+    if (r.error) return setHint('⚠ ' + r.error)
+    setHostGov(!!r.hostGovernanceEnabled)
+  }
 
   const dirty = JSON.stringify(t) !== JSON.stringify(saved)
   const save = async () => {
@@ -6370,6 +6394,26 @@ function GovernanceSettings({ me }: { me: Member }) {
             {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
             {!hint && meta.updatedBy && <span className="text-[11px] text-muted-foreground">last set by {meta.updatedBy}</span>}
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <label className="flex items-start gap-3">
+            <input type="checkbox" className="mt-1" checked={hostGov} disabled={!isOwner || hostBusy} onChange={toggleHostGov} />
+            <span className="text-sm">
+              <span className="font-medium">Govern host access (SSH / internal network / databases)</span>
+              <span className="ml-2 rounded bg-muted px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-muted-foreground">beta</span>
+              <p className="mt-1 text-xs text-muted-foreground">
+                When on, an agent's shell reaches to a <a href="#/connectors" className="underline hover:text-foreground">Host connection</a> —
+                or to any internal-looking host (private IPs, <span className="font-mono">.internal</span>) — are classified as
+                <span className="font-mono"> net.connect</span>/<span className="font-mono">ssh.exec</span> and gated by policy (unlisted or
+                unrecognised hosts pause for approval; a host set to <em>never</em> is refused). Public-internet egress stays ungoverned unless an
+                agent is set to <span className="font-mono">allowlist</span> mode. Best-effort command parsing — a governance + audit layer, not a
+                firewall. Owner-only.
+              </p>
+            </span>
+          </label>
         </CardContent>
       </Card>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -835,15 +835,15 @@ export const api = {
   rescanAgents: () => call<{ ok: boolean; added: string[]; updated: string[]; removed: string[]; errors: { folder: string; error: string }[]; error?: string }>('POST', '/api/agents/rescan'),
   agentClaude: (id: string) => call<{ agent: string; runtime: string; exists: boolean; content: string; error?: string }>('GET', `/api/agents/${encodeURIComponent(id)}/claude`),
   saveAgentClaude: (id: string, content: string) => call<{ ok: boolean; error?: string }>('PUT', `/api/agents/${encodeURIComponent(id)}/claude`, { content }),
-  agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),
-  saveAgentConfig: (id: string, patch: RuntimeTuning & { description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string }) => call<{ ok: boolean; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; category?: string; icon?: string } & RuntimeTuning>('PUT', `/api/agents/${encodeURIComponent(id)}/config`, patch),
+  agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; netMode?: 'open' | 'allowlist'; category?: string; icon?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),
+  saveAgentConfig: (id: string, patch: RuntimeTuning & { description?: string; examplePrompts?: string[]; shellSecrets?: string[]; netMode?: 'open' | 'allowlist'; category?: string; icon?: string }) => call<{ ok: boolean; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; netMode?: 'open' | 'allowlist'; category?: string; icon?: string } & RuntimeTuning>('PUT', `/api/agents/${encodeURIComponent(id)}/config`, patch),
   agentRevisions: (id: string) => call<{ agent: string; revisions: AgentRevision[]; error?: string }>('GET', `/api/agents/${encodeURIComponent(id)}/revisions`),
   agentRevert: (id: string, rev: number) => call<{ ok: boolean; id?: string; toRev?: number; rev?: number; error?: string }>('POST', `/api/agents/${encodeURIComponent(id)}/revert`, { rev }),
   runtimeDefaults: () => call<RuntimeTuning & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/runtime-defaults'),
   saveRuntimeDefaults: (tuning: RuntimeTuning) => call<{ ok: boolean; error?: string } & RuntimeTuning>('PUT', '/api/settings/runtime-defaults', tuning),
 
-  governance: () => call<GovernanceThresholds & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/governance'),
-  saveGovernance: (t: GovernanceThresholds) => call<{ ok: boolean; error?: string } & GovernanceThresholds>('PUT', '/api/settings/governance', t),
+  governance: () => call<GovernanceThresholds & { hostGovernanceEnabled?: boolean; updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/governance'),
+  saveGovernance: (t: GovernanceThresholds & { hostGovernanceEnabled?: boolean }) => call<{ ok: boolean; error?: string; hostGovernanceEnabled?: boolean } & GovernanceThresholds>('PUT', '/api/settings/governance', t),
 
   // Per-tenant console branding (accent colour + favicon badge).
   branding: () => call<Branding & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/branding'),


### PR DESCRIPTION
**Phase 2b** of the access-model reframe — the governance engine that makes Host connections (Phase 2a) *actually govern*. Behind **Settings → Governance → "Govern host access"** (owner-only, **off by default**).

## What it does
When on, the gate parses an agent's shell egress (`ssh`/`scp`/`rsync`/`curl`/`wget`/`psql`/`mysql`/`nc`/`telnet`/`redis-cli`/…), extracts the destination host, and reclassifies `shell.exec` → **`net.connect`** / **`ssh.exec`** so policy can gate it:
- reach to a host that isn't a granted Host connection **or** is internal-looking (private IPs, `.internal`/`.local`, bare hostnames) → **pause for approval**;
- a host whose posture is **never** → **refused**;
- an **unparseable** host (variable/pipe/subshell) → **escalates** (fail-loud), never slips through;
- per-agent **`netMode`**: `open` (default — public-internet egress runs free, only internal/listed hosts governed) or `allowlist` (lockdown — any un-granted reach pauses). `netMode` is owner/admin-set only — **a self-editing agent can't loosen its own lockdown**.

## Pieces
- `src/governance/host-match.ts` — pure egress extraction + host matching (glob / CIDR / `host:port`) + `isInternalHost` + `computeHostFacts`.
- `enricher.ts` — new `isShell` host block, gated on a `hostGrants` param (`null` = feature off).
- `terminal.ts gate()` — fetch flag + run-as grants → `enrichArgs` → reclassify (audited `gate.net.reclassified`).
- `AgentManifest.netMode`; `HostStore.grantsFor(member)`; `settings.hostGovernanceEnabled` + `/api/settings/governance` wiring.
- `config/policy/default.policy.json` — `net.connect`/`ssh.exec` rules (unknown/unlisted → ask, posture never → deny).
- UI: a **Govern host access** toggle (Settings → Governance) + a **Host access mode** select on the agent config.

## Honest scope
Best-effort command parsing — a **governance + audit layer, not a firewall** (`docs/host-connections-plan.md` §2). Kernel-level egress enforcement is **Phase 2d** (future, uid-isolation).

## Verification
- `host-match` **39** unit checks (extraction across ssh/url/-h/positional/unknown; glob+CIDR matching; internal heuristic).
- governance conformance **57/57** — **12 new host cases** pinning the full enrich→reclassify→policy chain (off/open/allowlist × listed/unlisted/internal/public/unknown/never/destructive).
- gate-seam **9** checks (settings flag + `grantsFor` ownership/enabled filtering).
- `tsc` + `vite` clean. Not yet browser-clicked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)