### PR TITLE
Terminal: copy falls back to execCommand on plain HTTP (v0.77.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.77.1] — 2026-07-10
+### Fixed
+- **Terminal copy works over plain HTTP again.** The new first-party `<Xterm>` (v0.75.0) copied via
+  `navigator.clipboard`, which browsers expose only in secure contexts (https / localhost) — so on a
+  console served over plain http on a tailnet host, select-to-copy / ⌘-C / OSC 52 silently did nothing.
+  Copy now falls back to a hidden-textarea `execCommand('copy')` inside the user gesture (the same
+  technique ttyd used), so it works in insecure contexts too.
+
 ## [0.77.0] — 2026-07-10
 ### Added
 - **Host governance (Phase 2b) — agents' SSH / internal-network / DB reaches are now gated by policy.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.77.0",
+  "version": "0.77.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.77.0",
+      "version": "0.77.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.77.0",
+  "version": "0.77.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/Xterm.tsx
+++ b/web/src/Xterm.tsx
@@ -31,6 +31,26 @@ const S_PREFS = 50 // '2'
 
 const enc = new TextEncoder()
 
+/** Write text to the clipboard in BOTH secure and insecure contexts. `navigator.clipboard` only exists
+ *  on https/localhost — but the console is often served over plain http on a tailnet host, where it's
+ *  undefined. Fall back to a hidden-textarea `execCommand('copy')` (the same trick ttyd used), which
+ *  works in insecure contexts as long as we're inside a user gesture (mouse-up / key-down). */
+function writeClipboard(text: string): Promise<void> {
+  if (navigator.clipboard?.writeText) return navigator.clipboard.writeText(text)
+  return new Promise((resolve, reject) => {
+    try {
+      const ta = document.createElement('textarea')
+      ta.value = text
+      ta.style.cssText = 'position:fixed;top:0;left:0;opacity:0;pointer-events:none'
+      document.body.appendChild(ta)
+      ta.focus(); ta.select()
+      const ok = document.execCommand('copy')
+      document.body.removeChild(ta)
+      ok ? resolve() : reject(new Error('execCommand copy failed'))
+    } catch (e) { reject(e) }
+  })
+}
+
 /** Console-matched dark theme (neutral-950 bg, geist-ish selection). */
 export const AOS_THEME: ITheme = {
   background: '#0a0a0a',
@@ -126,7 +146,7 @@ export function Xterm({
     // We're in the app's own document (no iframe), so navigator.clipboard just works.
     const copySelection = () => {
       const sel = term.getSelection()
-      if (sel) navigator.clipboard?.writeText(sel).then(() => cbs.current.onCopy?.(), () => {})
+      if (sel) writeClipboard(sel).then(() => cbs.current.onCopy?.(), () => {})
     }
     const paste = async () => {
       try { const t = await navigator.clipboard?.readText(); if (t) send(C_INPUT + t) } catch { /* denied */ }
@@ -135,7 +155,7 @@ export function Xterm({
     // drops it; we honour it, so highlighting inside the TUI lands on the OS clipboard with no modifier.
     term.parser.registerOscHandler(52, (data) => {
       const b64 = data.split(';')[1] ?? ''
-      try { navigator.clipboard?.writeText(atob(b64)).then(() => cbs.current.onCopy?.(), () => {}) } catch { /* bad payload */ }
+      try { writeClipboard(atob(b64)).then(() => cbs.current.onCopy?.(), () => {}) } catch { /* bad payload */ }
       return true
     })
     // Cmd/Ctrl+C copies the selection (and ONLY when there is one — otherwise ^C passes through as


### PR DESCRIPTION
Patch on the v0.75.0 first-party `<Xterm>` terminal.

**Problem:** copy used `navigator.clipboard`, which browsers expose only in **secure contexts** (https / localhost). The instapods console is served over plain **http** on the tailnet host, so select-to-copy, ⌘-C and OSC 52 silently did nothing there.

**Fix:** `writeClipboard()` falls back to a hidden-textarea `document.execCommand('copy')` inside the user gesture (the same technique the old ttyd iframe used), so copy works in insecure contexts too. Native ⌘-V paste already works in insecure contexts via xterm.

> Note: `npm run test:governance` currently reports 7 failures on `main` — all in the **host-governance** capabilities (`net.connect`/`ssh.exec`/egress) from the 0.76/0.77 host-connections work, unrelated to and untouched by this patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)