### PR TITLE
Terminal help modal: match the light dialog theme (v0.77.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.77.2] — 2026-07-10
+### Fixed
+- **Terminal "Using the terminal" help modal now matches the (light) dialog theme.** It was styled for a
+  dark surface (`text-neutral-300` on white), so the descriptions rendered washed-out and the key chips
+  looked heavy. Switched to the app's semantic tokens (`text-muted-foreground` / `bg-muted` /
+  `border-border` / `text-foreground`) so it reads correctly.
+
 ## [0.77.1] — 2026-07-10
 ### Fixed
 - **Terminal copy works over plain HTTP again.** The new first-party `<Xterm>` (v0.75.0) copied via

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.77.1",
+  "version": "0.77.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.77.1",
+      "version": "0.77.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.77.1",
+  "version": "0.77.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1204,15 +1204,15 @@ function TerminalHelpModal({ open, onClose }: { open: boolean; onClose: () => vo
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
       <DialogContent className="max-w-lg">
         <DialogHeader><DialogTitle className="flex items-center gap-2"><TerminalSquare className="h-4 w-4" /> Using the terminal</DialogTitle></DialogHeader>
-        <div className="divide-y divide-neutral-800">
+        <div className="divide-y divide-border">
           {rows.map((r) => (
             <div key={r.keys} className="flex items-baseline gap-3 py-2">
-              <kbd className="shrink-0 whitespace-nowrap rounded border border-neutral-700 bg-neutral-800 px-1.5 py-0.5 font-mono text-[11px] text-neutral-200">{r.keys}</kbd>
-              <span className="text-sm text-neutral-300">{r.desc}</span>
+              <kbd className="shrink-0 whitespace-nowrap rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[11px] text-foreground">{r.keys}</kbd>
+              <span className="text-sm text-muted-foreground">{r.desc}</span>
             </div>
           ))}
         </div>
-        <p className="text-xs text-neutral-500">This is a live tmux session — closing the tab leaves it running; reopen it any time to reattach.</p>
+        <p className="text-xs text-muted-foreground">This is a live tmux session — closing the tab leaves it running; reopen it any time to reattach.</p>
       </DialogContent>
     </Dialog>
   )


### PR DESCRIPTION
The v0.75.0 "Using the terminal" help modal was styled for a dark surface (`text-neutral-300` on white, heavy dark key chips), so on the app's light Dialog the descriptions rendered washed-out. Switched to semantic tokens (`text-muted-foreground`/`bg-muted`/`border-border`/`text-foreground`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)