### PR TITLE
test:governance: refuse to run against a stale dist (v0.77.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.77.3] — 2026-07-10
+### Changed
+- **`npm run test:governance` refuses to run against a stale `dist/`.** The conformance suite exercises
+  the compiled `dist/` gate, not `src/`, so running it without rebuilding after a governance edit
+  validates old behaviour — which once made the host-governance rules look like "7 failures" that were
+  really just an un-rebuilt tree. The runner now bails (exit 2) with a "run `npm run build` first"
+  message when `dist/` is missing or older than any `src/*.ts`.
+
 ## [0.77.2] — 2026-07-10
 ### Fixed
 - **Terminal "Using the terminal" help modal now matches the (light) dialog theme.** It was styled for a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.77.2",
+  "version": "0.77.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.77.2",
+      "version": "0.77.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.77.2",
+  "version": "0.77.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/governance-conformance.cjs
+++ b/scripts/governance-conformance.cjs
@@ -9,12 +9,43 @@
  *
  *   npm run build && node scripts/governance-conformance.cjs
  *
- * Exits 0 when every case matches, 1 otherwise (CI-friendly).
+ * Exits 0 when every case matches, 1 on a mismatch, 2 if dist/ is missing or stale (CI-friendly).
  */
 const path = require('path');
 const fs = require('fs');
 
 const ROOT = path.resolve(__dirname, '..');
+
+// Stale-dist guard. This suite exercises the BUILT `dist/` — the same compiled gate the live server
+// runs — NOT `src/`. So if you edit the enricher/policy in src/ and run this WITHOUT rebuilding, you
+// validate the OLD behaviour and get a false result (this exact trap once masked the host-governance
+// rules as "7 failures"). Refuse to run when dist/ is missing or older than any src/*.ts change, and
+// point at the fix. Walk mtimes: the newest src/*.ts must not be newer than the newest dist/*.js.
+function newestMtime(dir, ext) {
+  let newest = 0;
+  const walk = (d) => {
+    for (const e of fs.readdirSync(d, { withFileTypes: true })) {
+      const p = path.join(d, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.name.endsWith(ext)) { const m = fs.statSync(p).mtimeMs; if (m > newest) newest = m; }
+    }
+  };
+  if (fs.existsSync(dir)) walk(dir);
+  return newest;
+}
+const DIST = path.join(ROOT, 'dist');
+const newestDist = newestMtime(DIST, '.js');
+if (newestDist === 0) {
+  console.error('governance-conformance: dist/ not built — run `npm run build` first.');
+  process.exit(2);
+}
+const newestSrc = newestMtime(path.join(ROOT, 'src'), '.ts');
+if (newestSrc > newestDist) {
+  console.error('governance-conformance: STALE dist/ — a src/*.ts is newer than the newest dist/*.js.');
+  console.error('  The suite runs the compiled gate, so a stale build validates old behaviour. Run `npm run build` first.');
+  process.exit(2);
+}
+
 const { enrichArgs, autoClearsApproval } = require(path.join(ROOT, 'dist/governance/enricher'));
 const { JsonPolicyEngine } = require(path.join(ROOT, 'dist/governance/policy'));
 


### PR DESCRIPTION
The governance conformance suite exercises the **compiled `dist/`** gate (the same code the live server runs), not `src/`. So editing the enricher/policy and running `npm run test:governance` **without rebuilding** validates the old behaviour — which recently made the host-governance rules (#130) look like "7 failures" that were really just an un-rebuilt tree.

**Guard:** the runner now walks mtimes and bails (**exit 2**) with a `run \`npm run build\` first` message when `dist/` is missing or any `src/*.ts` is newer than the newest `dist/*.js`. Verified: fresh → pass, stale → refuses, rebuild → pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)