### PR TITLE
Fleet insights skill + actionable Slack egress errors (v0.77.4)

### DIFF
--- a/.claude/skills/fleet-insights/SKILL.md
+++ b/.claude/skills/fleet-insights/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: fleet-insights
+description: Analyze agent sessions across the instapods, instawp, and expresstech tenants to find product-improvement insights and ship the resulting codebase changes as a PR. Use when asked to review fleet/session usage, mine sessions for insights, learn from real usage, or improve agent-os from how the fleet is actually behaving.
+license: MIT
+---
+
+# fleet-insights
+
+Mine real agent-session usage across all three production tenants, turn the friction into
+ranked product insights, then **implement the highest-signal changes and open one PR**. This is a
+**maintainer** skill: it runs from this repo checkout, reads the live tenant databases read-only,
+and improves the agent-os codebase itself. It is NOT a fleet agent — it sees every tenant and edits
+the OS source, which governed in-tenant agents cannot.
+
+Full loop: **collect → analyze → synthesize insights → implement top changes in a worktree → PR.**
+
+## The three tenants (read-only sources)
+
+| Tenant | Host | agent-os.db path | Access |
+|---|---|---|---|
+| **instapods** | this Mac Mini (local) | `~/agent-os-data/instapods/agent-os.db` | direct |
+| **instawp** | jump-server droplet | `~/tools/agent-os/data/agent-os.db` | `ssh vikas@128.199.25.26` |
+| **expresstech** | et droplet | `~/tools/agent-os/data/agent-os.db` | `ssh vikas@143.110.180.186` |
+
+Remote node (nvm, not on non-login PATH): `/home/vikas/.nvm/versions/node/v22.22.0/bin/node`.
+The tenants run **different agent-os versions**, so the collector is schema-defensive — trust it to
+degrade, not to match every column.
+
+> Safety: never write to a live tenant DB. The collector opens read-only and runs SELECT/PRAGMA only.
+> Collected bundles and transcripts may contain **customer data** — keep them in the scratchpad,
+> never commit them, and reason over aggregates + samples, not by pasting raw customer content into
+> code, commits, or PR text.
+
+## Step 1 — Collect
+
+Run `collect.mjs` (in this skill dir) against each tenant into your scratchpad. It emits one JSON
+bundle per tenant (aggregates + qualitative samples). Default window is 30 days; widen with a third
+arg when a box is quiet.
+
+```bash
+SKILL=.claude/skills/fleet-insights
+OUT="$SCRATCHPAD"                 # your session scratchpad dir; make it if unset
+DAYS=30
+
+# instapods — local
+node "$SKILL/collect.mjs" ~/agent-os-data/instapods/agent-os.db instapods $DAYS > "$OUT/instapods.json"
+
+# instawp + expresstech — ship the collector over, run with the box's node, capture JSON
+for H in 128.199.25.26:instawp 143.110.180.186:expresstech; do
+  IP="${H%%:*}"; T="${H##*:}"
+  scp -q "$SKILL/collect.mjs" "vikas@$IP:/tmp/aos-collect.mjs"
+  ssh "vikas@$IP" "/home/vikas/.nvm/versions/node/v22.22.0/bin/node /tmp/aos-collect.mjs ~/tools/agent-os/data/agent-os.db $T $DAYS" > "$OUT/$T.json"
+done
+```
+
+If a box's node lacks `node:sqlite` readOnly (older node), the collector falls back automatically. If
+`ssh` is refused, add your key first (see the deploy notes in memory); do not switch to writing to the DB.
+
+## Step 2 — Read the bundles
+
+Read all three JSON bundles. Each has:
+
+- **`sessions`** — `total`, `byStatus`, `byAgent` (with `crashed`/`stopped`), `provenance`
+  (member/automation/task/chat). High `stopped`/`crashed` ratio for an agent = friction.
+- **`failedSessions`** / **`recentTasks`** — session `id` + truncated `task`; the roster for deep-dives
+  and workflow clustering.
+- **`audit`** — `byType` (volume), `sampleByType` (one raw `data` blob per type so you can see the real
+  JSON shape for this version), `gateDecisions` (`capability → effect × n`), `friction` (errors, budget
+  stops, killswitch, resolved approvals, asks).
+- **`approvals`** — `byCapabilityStatus`: capabilities repeatedly routed to humans.
+- **`questions`** — `byStatus` (`pending` = **unanswered**, agents left blocked) + samples.
+- **`outcomes`** — completion success/partial/failure counts.
+- **`topEpisodes`** — highest-importance (= highest friction/effort) end-of-run recaps, with
+  `outcome`, `salience`, `sessionId`, and `content`. **The qualitative core.**
+- **`topLessons`** — deliberate `report` lessons agents recorded.
+- **`memoryHealth`** — `total`, `neverRecalled`, `avgRecall`. All-never-recalled = the self-learning
+  loop isn't surfacing.
+
+## Step 3 — Deep-dive the highest-signal sessions
+
+Pick the ~5–10 sessions that dominate the friction (failed/stopped, low outcome, high-importance
+episodes with a `failure`/`partial` outcome, or the source of a recurring question). For each, pull
+the real transcript and audit trail:
+
+```bash
+# transcript (headless runs only) — tail the tail, it can be large
+# local:  ~/agent-os-data/instapods/connectors/session-<id>.log
+# remote: ssh vikas@<ip> "tail -c 200000 ~/tools/agent-os/data/connectors/session-<id>.log"
+```
+
+Read the episode `content` and `salience` first (cheap, already in the bundle); only open transcripts
+when you need the actual failure mechanism. You want the *why*, not a log dump.
+
+## Step 4 — Synthesize insights
+
+Cluster across tenants. For each insight capture: **evidence** (counts + which tenants + sample
+session ids), **root-cause hypothesis**, **proposed change** (concrete files/areas), and
+**confidence + risk**. Prioritize signals that recur across ≥2 tenants or dominate one.
+
+Map friction to the agent-os surface it implicates:
+
+- **Repeated approvals for one capability** (`file.write → approve ×N`) → a policy default in
+  `config/policy` / `src/governance/policy.ts`, or an "always approve" affordance gap.
+- **Recurring agent `questions` / many `pending`** → missing context the product should inject
+  (`buildCompanyMd`, agent CLAUDE.md, a starter prompt), or a blocking-`ask` UX gap.
+- **A capability erroring / denied a lot** → a gate/gateway bug (`src/gateway`), a bad policy rule,
+  or a broken MCP tool (`src/memory/memory-mcp.ts`, its `/api/*` handler in `src/server.ts`).
+- **Recurring task/prompt clusters** → a first-class feature, an Automation, or a new **global
+  skill** (`config/skills/<name>/SKILL.md`) so the fleet stops reinventing it.
+- **Crashed/stopped sessions** → launch/terminal robustness (`src/terminal.ts`,
+  `terminal/claude-launch.sh` — mind the bash-3.2/BSD macOS gotchas in CLAUDE.md).
+- **`memoryHealth` all-never-recalled / never-used tools** → recall relevance, injection, or a
+  dead surface to prune. Cross-check `docs/PILLARS.md` maturity before investing.
+- **Automation/chat provenance skew, unattended failures** → `src/edge/automations.ts`.
+
+## Step 5 — Implement the top changes and open a PR (full auto)
+
+Ship the changes that are **well-evidenced and low-risk** (recurring, clear root cause, localized).
+For large/architectural or uncertain insights, **do not** speculatively rewrite — write them up as a
+"Proposed, not implemented" section in the PR body (or an issue) for a human to weigh. Full-auto means
+*ship the safe wins and surface the rest*, not *rewrite the kernel on a hunch*.
+
+Follow the repo's standing workflow (see CLAUDE.md + memory) — **never edit the primary checkout**:
+
+1. `scripts/wt.sh new fleet-insights-<yyyy-mm-dd>` — develop in the worktree, not `/Users/vmini/Projects/agent-os`.
+2. Make the surgical changes. Match surrounding code; keep `src/core` + kernel importing only `src/types.ts`.
+3. Validate: `npm run typecheck` · `cd web && npm run build` · `npm run test:governance` (from repo
+   **root**) · `npm run demo` if you touched governance.
+4. Bump version (minor for a feature, patch for a fix) + move a CHANGELOG line under a new heading.
+5. Commit (with the `Co-Authored-By: Claude Opus 4.8 (1M context)` trailer), push, open **one**
+   consolidated PR with `gh ... --repo vikasprogrammer/agent-os`, then `gh pr merge --squash`.
+
+Batching several branches? Use `scripts/wt.sh integrate` and one PR, per the shared-checkout rule.
+
+## Step 6 — Report
+
+Print (and save to scratchpad) a ranked insights report: for each insight — evidence, hypothesis,
+the change, confidence/risk, and status (**shipped in PR #N** / **proposed**). Lead with the PR link
+and a one-line summary of what changed and why. Note anything you deliberately left un-shipped and why.
+
+## Notes
+
+- The gate `data.decision` is a nested object (`{effect, level, riskClass, reason}`); the collector
+  already extracts `.effect`. Use `sampleByType` to confirm any other field's shape before querying it.
+- instapods also exists as a *seed/nested* tenant on the instawp box (`data/tenants/instapods`) — ignore
+  it; the real instapods is the local Mac Mini DB.
+- Re-run cheaply anytime. This complements the in-tenant Dreaming/consolidation loop (which improves a
+  tenant's *shared memory*); this skill improves the *product*.

--- a/.claude/skills/fleet-insights/collect.mjs
+++ b/.claude/skills/fleet-insights/collect.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+// fleet-insights collector — read-only, zero-dependency (node:sqlite only).
+//
+// Emits ONE JSON bundle (stdout) of quantitative aggregates + qualitative samples
+// for a single tenant's agent-os.db. Progress/warnings go to stderr so the JSON
+// stays clean for `ssh ... > tenant.json`.
+//
+// Usage:  node collect.mjs <db-path> <tenant-label> [sinceDays=30]
+//
+// SAFETY: opens read-only and runs SELECT/PRAGMA only. It never writes, so it is
+// safe against a LIVE database (a second reader sees committed WAL state). The db
+// may be on a different agent-os version than this repo — every query is guarded
+// by table/column existence so an older/newer schema degrades gracefully instead
+// of throwing.
+
+import { DatabaseSync } from 'node:sqlite';
+
+const [dbPath, tenant, sinceDaysRaw] = process.argv.slice(2);
+if (!dbPath || !tenant) {
+  console.error('usage: node collect.mjs <db-path> <tenant-label> [sinceDays=30]');
+  process.exit(2);
+}
+const sinceDays = Number(sinceDaysRaw ?? 30) || 30;
+const windowStart = Date.now() - sinceDays * 86_400_000;
+
+let db;
+try {
+  db = new DatabaseSync(dbPath, { readOnly: true });
+} catch (e) {
+  // Older node:sqlite without the readOnly option — fall back (still SELECT-only).
+  try { db = new DatabaseSync(dbPath); }
+  catch (e2) { console.error(`cannot open ${dbPath}: ${e2.message}`); process.exit(1); }
+}
+
+const warn = (m) => console.error(`[${tenant}] ${m}`);
+const trunc = (s, n = 400) => (s == null ? null : String(s).length > n ? String(s).slice(0, n) + '…' : String(s));
+
+function hasTable(t) {
+  try { return db.prepare("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?").get(t) != null; }
+  catch { return false; }
+}
+function cols(t) {
+  try { return new Set(db.prepare(`PRAGMA table_info(${t})`).all().map((r) => r.name)); }
+  catch { return new Set(); }
+}
+// Run a query, swallow schema errors into a warning + fallback value.
+function safe(label, fn, fallback = null) {
+  try { return fn(); }
+  catch (e) { warn(`${label}: ${e.message}`); return fallback; }
+}
+function all(sql, ...p) { return db.prepare(sql).all(...p); }
+function get(sql, ...p) { return db.prepare(sql).get(...p); }
+
+const out = {
+  tenant,
+  dbPath,
+  generatedAt: new Date().toISOString(),
+  sinceDays,
+  windowStartMs: windowStart,
+  tables: safe('tables', () => all("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name").map((r) => r.name), []),
+  warnings: [],
+};
+
+// ---- term_sessions ---------------------------------------------------------
+if (hasTable('term_sessions')) {
+  const c = cols('term_sessions');
+  const createdCol = c.has('created_at') ? 'created_at' : null;
+  const win = createdCol ? `WHERE ${createdCol} >= ${windowStart}` : '';
+  out.sessions = {
+    total: safe('sessions.total', () => get(`SELECT COUNT(*) n FROM term_sessions ${win}`)?.n ?? 0, 0),
+    byStatus: safe('sessions.byStatus', () => all(`SELECT status, COUNT(*) n FROM term_sessions ${win} GROUP BY status ORDER BY n DESC`), []),
+    byAgent: safe('sessions.byAgent', () => all(
+      `SELECT agent, COUNT(*) n,
+              SUM(CASE WHEN status='crashed' THEN 1 ELSE 0 END) crashed,
+              SUM(CASE WHEN status='stopped' THEN 1 ELSE 0 END) stopped
+       FROM term_sessions ${win} GROUP BY agent ORDER BY n DESC LIMIT 40`), []),
+  };
+  // Provenance buckets (member vs automation vs task vs chat).
+  if (c.has('spawned_by')) {
+    out.sessions.provenance = safe('sessions.provenance', () => {
+      const rows = all(`SELECT spawned_by FROM term_sessions ${win}`);
+      const b = { member: 0, automation: 0, task: 0, chat: 0, none: 0 };
+      for (const r of rows) {
+        const s = r.spawned_by;
+        if (!s) b.none++;
+        else if (s.startsWith('automation:')) b.automation++;
+        else if (s.startsWith('task:')) b.task++;
+        else if (s.startsWith('chat:')) b.chat++;
+        else b.member++;
+      }
+      return b;
+    }, null);
+  }
+  // Failed/stopped sessions — the friction roster for deep-dive.
+  const taskCol = c.has('task') ? 'task' : "''";
+  out.failedSessions = safe('failedSessions', () => all(
+    `SELECT id, agent, title, ${taskCol} task, status, ${createdCol || 0} created_at
+     FROM term_sessions ${win ? win + " AND" : "WHERE"} status IN ('crashed','stopped')
+     ORDER BY ${createdCol || 'rowid'} DESC LIMIT 40`).map((r) => ({ ...r, task: trunc(r.task, 300) })), []);
+  // Recent session tasks — clustering fodder for "recurring workflows".
+  out.recentTasks = safe('recentTasks', () => all(
+    `SELECT id, agent, title, ${taskCol} task, status, ${createdCol || 0} created_at
+     FROM term_sessions ${win} ORDER BY ${createdCol || 'rowid'} DESC LIMIT 200`)
+    .map((r) => ({ id: r.id, agent: r.agent, title: r.title, status: r.status, task: trunc(r.task, 240) })), []);
+}
+
+// ---- audit_events ----------------------------------------------------------
+if (hasTable('audit_events')) {
+  const c = cols('audit_events');
+  const tsCol = c.has('ts') ? 'ts' : null;
+  const win = tsCol ? `WHERE ${tsCol} >= ${windowStart}` : '';
+  out.audit = {
+    byType: safe('audit.byType', () => all(`SELECT type, COUNT(*) n FROM audit_events ${win} GROUP BY type ORDER BY n DESC LIMIT 80`), []),
+  };
+  // One raw `data` sample per type — lets the analyst see the real JSON shape
+  // without this script hardcoding field names that vary across versions.
+  out.audit.sampleByType = safe('audit.sampleByType', () => {
+    const types = (out.audit.byType || []).slice(0, 25).map((r) => r.type);
+    const m = {};
+    for (const t of types) {
+      const row = get(`SELECT data FROM audit_events WHERE type=? ${tsCol ? `AND ${tsCol}>=${windowStart}` : ''} ORDER BY ${c.has('id') ? 'id' : 'rowid'} DESC LIMIT 1`, t);
+      if (row) m[t] = trunc(row.data, 500);
+    }
+    return m;
+  }, {});
+  // Gate decisions grouped by capability + effect. `data.decision` is a nested
+  // object ({effect, level, riskClass, reason}); pull `.effect` for a clean
+  // allow/approve/deny split, with a null fallback if the shape differs.
+  out.audit.gateDecisions = safe('audit.gateDecisions', () => all(
+    `SELECT json_extract(data,'$.capability') capability,
+            COALESCE(json_extract(data,'$.decision.effect'), json_extract(data,'$.decision')) effect,
+            COUNT(*) n
+     FROM audit_events WHERE type='gate.decision' ${tsCol ? `AND ${tsCol}>=${windowStart}` : ''}
+     GROUP BY capability, effect ORDER BY n DESC LIMIT 80`), []);
+  // Errors + friction signal types.
+  out.audit.friction = safe('audit.friction', () => all(
+    `SELECT type, COUNT(*) n FROM audit_events
+     WHERE type IN ('episode.error','session.error','budget.exceeded','gate.killswitch','approval.resolved','question.asked')
+     ${tsCol ? `AND ${tsCol}>=${windowStart}` : ''} GROUP BY type ORDER BY n DESC`), []);
+}
+
+// ---- approvals (via messages, version-stable) ------------------------------
+if (hasTable('messages')) {
+  const c = cols('messages');
+  const createdCol = c.has('created_at') ? 'created_at' : null;
+  const win = createdCol ? `AND ${createdCol} >= ${windowStart}` : '';
+  out.approvals = safe('approvals', () => ({
+    byCapabilityStatus: c.has('capability') ? all(
+      `SELECT capability, status, COUNT(*) n FROM messages
+       WHERE type='approval' ${win} GROUP BY capability, status ORDER BY n DESC LIMIT 60`) : [],
+    total: get(`SELECT COUNT(*) n FROM messages WHERE type='approval' ${win}`)?.n ?? 0,
+  }), null);
+  // Questions agents asked humans (recurring asks = missing product context).
+  out.questions = safe('questions', () => ({
+    byStatus: all(`SELECT status, COUNT(*) n FROM messages WHERE type='question' ${win} GROUP BY status ORDER BY n DESC`),
+    sample: all(`SELECT agent, title, body, status FROM messages WHERE type='question' ${win} ORDER BY ${createdCol || 'rowid'} DESC LIMIT 40`)
+      .map((r) => ({ agent: r.agent, status: r.status, title: trunc(r.title, 160), body: trunc(r.body, 300) })),
+  }), null);
+  // Completion outcomes.
+  if (c.has('outcome')) {
+    out.outcomes = safe('outcomes', () => all(
+      `SELECT outcome, COUNT(*) n FROM messages WHERE type='completed' ${win} GROUP BY outcome ORDER BY n DESC`), []);
+  }
+}
+
+// ---- episodes + memory health (self-learning signal) -----------------------
+if (hasTable('memories')) {
+  const c = cols('memories');
+  const createdCol = c.has('created_at') ? 'created_at' : null;
+  const win = createdCol ? `WHERE ${createdCol} >= ${windowStart}` : '';
+  out.memoryHealth = safe('memoryHealth', () => {
+    const recallCol = c.has('recall_count') ? 'recall_count' : null;
+    return {
+      total: get('SELECT COUNT(*) n FROM memories')?.n ?? 0,
+      neverRecalled: recallCol ? (get(`SELECT COUNT(*) n FROM memories WHERE ${recallCol} IS NULL OR ${recallCol}=0`)?.n ?? null) : null,
+      avgRecall: recallCol ? (get(`SELECT AVG(${recallCol}) a FROM memories`)?.a ?? null) : null,
+    };
+  }, null);
+  // Top episodes by importance = highest-friction/effort runs. Content + metadata
+  // (salience, outcome, sessionId) are the qualitative core of the analysis.
+  const impCol = c.has('importance') ? 'importance' : null;
+  const metaCol = c.has('metadata') ? 'metadata' : null;
+  const agentCol = c.has('agent_id') ? 'agent_id' : (c.has('agent') ? 'agent' : "''");
+  out.topEpisodes = safe('topEpisodes', () => all(
+    `SELECT ${agentCol} agent, content, ${impCol || 0} importance, ${metaCol || "''"} metadata, ${createdCol || 0} created_at
+     FROM memories ${win ? win + " AND" : "WHERE"} tags LIKE '%"episode"%'
+     ORDER BY ${impCol || 'rowid'} DESC LIMIT 40`).map((r) => {
+      let meta = null; try { meta = r.metadata ? JSON.parse(r.metadata) : null; } catch {}
+      return {
+        agent: r.agent, importance: r.importance,
+        outcome: meta?.outcome ?? null, sessionId: meta?.sessionId ?? null,
+        salience: meta?.salience ?? null, content: trunc(r.content, 700),
+      };
+    }), []);
+  // Deliberate lessons agents recorded via report().
+  out.topLessons = safe('topLessons', () => all(
+    `SELECT ${agentCol} agent, content, ${createdCol || 0} created_at
+     FROM memories ${win ? win + " AND" : "WHERE"} tags LIKE '%"lesson"%'
+     ORDER BY ${createdCol || 'rowid'} DESC LIMIT 30`).map((r) => ({ agent: r.agent, content: trunc(r.content, 500) })), []);
+}
+
+db.close();
+process.stdout.write(JSON.stringify(out, null, 2) + '\n');
+warn(`collected: ${out.sessions?.total ?? 0} sessions, ${(out.audit?.byType || []).reduce((a, r) => a + r.n, 0)} audit events, ${(out.topEpisodes || []).length} episodes`);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.77.4] — 2026-07-10
+### Added
+- **`fleet-insights` maintainer skill** (`.claude/skills/fleet-insights/`). Mines agent sessions across
+  all three tenants (instapods / instawp / expresstech) read-only via a zero-dependency, schema-defensive
+  `node:sqlite` collector, ranks the friction into product insights, and ships the safe wins as a PR. The
+  Slack-egress fix below was the first change it produced.
+### Changed
+- **Slack egress gives agents an actionable error instead of a dead end.** When `slack_send`/`slack_reply`
+  failed (e.g. `missing_scope` or `not_in_channel` posting to a private channel), the agent got back the
+  raw Slack error code and no recourse — real fleet runs then stranded on repeated `ask`s to a human. Now
+  `explainSlackError` maps the common codes to a one-line remedy ("ask a human to `/invite` the bot", "add
+  the missing scope in Settings → Integrations and reinstall", …), `postMessage` surfaces the specific
+  `needed` scope, and `slack_reply` joins-and-retries once on `not_in_channel` for parity with `slack_send`.
+
 ## [0.77.3] — 2026-07-10
 ### Changed
 - **`npm run test:governance` refuses to run against a stale `dist/`.** The conformance suite exercises

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.77.3",
+  "version": "0.77.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.77.3",
+      "version": "0.77.4",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.77.3",
+  "version": "0.77.4",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -52,9 +52,43 @@ export async function postMessage(
     });
     const j: any = await res.json().catch(() => ({}));
     if (j?.ok) return { ok: true, ts: String(j.ts || '') };
-    return { error: String(j?.error || `chat.postMessage failed (${res.status})`) };
+    // Slack returns the specific missing scope in `needed` on a `missing_scope` error — keep it so the
+    // egress layer can tell the agent exactly which scope to have an admin add.
+    const code = String(j?.error || `chat.postMessage failed (${res.status})`);
+    const needed = j?.needed ? ` (needed: ${j.needed})` : '';
+    return { error: code + needed };
   } catch (e) {
     return { error: e instanceof Error ? e.message : 'chat.postMessage failed' };
+  }
+}
+
+/**
+ * Turn a raw Slack API error into a one-line, ACTIONABLE hint an unattended agent can act on itself —
+ * instead of stranding on a human. Derived from real fleet friction: a `compass` agent that produced a
+ * report but hit `missing_scope`/`not_in_channel` posting to a private channel had no recourse but to
+ * `ask` a human (repeatedly). The raw code is preserved (agents/audit still see it) and a remedy appended.
+ */
+export function explainSlackError(error: string, channelRef?: string): string {
+  const where = channelRef ? ` "${channelRef}"` : '';
+  const code = error.split(' ')[0]; // strip any appended "(needed: …)" for the match
+  switch (code) {
+    case 'not_in_channel':
+    case 'is_private':
+      return `${error} — the bot isn't a member of${where} and can't self-join it (private/restricted). ` +
+        `Ask a human to \`/invite\` the bot to that channel, or post to a public channel / DM the person instead.`;
+    case 'missing_scope':
+      return `${error} — the Slack app is missing a required OAuth scope. Ask an admin to add it in ` +
+        `Settings → Integrations and reinstall the app; then retry.`;
+    case 'channel_not_found':
+      return `${error} — no channel${where} is visible to the bot. Double-check the id/name, or the bot ` +
+        `may need to be invited to a private channel first.`;
+    case 'is_archived':
+      return `${error} — channel${where} is archived; pick a live channel.`;
+    case 'restricted_action':
+    case 'cant_post_message':
+      return `${error} — workspace policy blocks the bot from posting${where}. Escalate to a human.`;
+    default:
+      return error;
   }
 }
 

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -16,7 +16,7 @@
  */
 import { AgentOS } from '../kernel';
 import { Automations } from './automations';
-import { joinChannel, lookupBotUserId, lookupChannelByName, lookupUserByEmail, lookupUserEmail, openDmChannel, openSocketConnection, parseSlackEvent, postMessage } from '../connectors/slack';
+import { explainSlackError, joinChannel, lookupBotUserId, lookupChannelByName, lookupUserByEmail, lookupUserEmail, openDmChannel, openSocketConnection, parseSlackEvent, postMessage } from '../connectors/slack';
 
 const RECONNECT_MIN_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
@@ -227,10 +227,17 @@ export class SlackSocket {
     if (!row) return { ok: false, error: 'no Slack thread bound to this session' };
     const body = (text || '').trim();
     if (!body) return { ok: false, error: 'empty reply' };
-    const res = await postMessage(this.os.settings.slackBotToken(), row.channel, body, row.thread_ts || undefined);
+    const token = this.os.settings.slackBotToken();
+    let res = await postMessage(token, row.channel, body, row.thread_ts || undefined);
+    // Parity with sendToChannel: a public channel the bot isn't in returns `not_in_channel`; join once
+    // and retry (a private channel's join fails, then explainSlackError guides the agent to get invited).
+    if ('error' in res && res.error.startsWith('not_in_channel')) {
+      await joinChannel(token, row.channel);
+      res = await postMessage(token, row.channel, body, row.thread_ts || undefined);
+    }
     if ('error' in res) {
       this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'slack', type: 'slack.reply.failed', data: { channel: row.channel, error: res.error } });
-      return { ok: false, error: res.error };
+      return { ok: false, error: explainSlackError(res.error, row.channel) };
     }
     this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'slack', type: 'slack.reply', data: { channel: row.channel, ts: res.ts, chars: body.length } });
     return { ok: true };
@@ -268,7 +275,7 @@ export class SlackSocket {
 
   private sendFailed(sessionId: string, channel: string, error: string): { ok: false; error: string } {
     this.os.audit.append({ ts: Date.now(), runId: sessionId, tenant: this.os.tenant, principal: 'slack', type: 'slack.send.failed', data: { channel, error } });
-    return { ok: false, error };
+    return { ok: false, error: explainSlackError(error, channel) };
   }
 
   /**


### PR DESCRIPTION
## What

Two things, produced end-to-end by running a new analysis skill against real fleet usage:

1. **`fleet-insights` maintainer skill** (`.claude/skills/fleet-insights/`) — a read-only, cross-tenant session-analysis harness. `collect.mjs` is a zero-dependency, schema-defensive `node:sqlite` collector that pulls session roster, gate decisions, approvals, questions, outcomes, episodes and memory-health from any tenant's DB (the three tenants run different versions). `SKILL.md` is the collect → analyze → synthesize → implement-in-a-worktree → PR playbook.

2. **Actionable Slack egress errors** (`src/connectors/slack.ts`, `src/edge/slack-socket.ts`) — the first insight it shipped (see below).

## Why (evidence from the fleet)

Ran the skill across **instapods** (22 sessions), **instawp** (113), **expresstech** (6), 45-day window. The clearest **safe** win: a `compass` agent on instawp produced its Daily CS Report but couldn't deliver it — Slack returned `missing_scope`/`not_in_channel` posting to a **private** channel — and, given only the raw error code, it had no recourse but to `ask` a human. It did this **3× (duplicate pending cards)**. `slack_reply` also lacked the join-and-retry that `slack_send` already had.

### The fix
- `explainSlackError(code, channel)` maps `not_in_channel` / `missing_scope` / `channel_not_found` / `is_archived` / `restricted_action` to a one-line remedy the agent can act on (get the bot invited, add the scope + reinstall, pick a live channel…). Raw code preserved for audit.
- `postMessage` surfaces Slack's specific `needed` scope on `missing_scope`.
- `slack_reply` now joins-and-retries once on `not_in_channel`, parity with `slack_send`.

Zero governance/session-semantics risk — pure error-clarity + a retry already proven in the sibling path.

## Validation
- `npm run typecheck` clean · `npm run build` clean · `cd web && npm run build` clean
- `npm run test:governance` → **57/57 passed**

## Proposed, NOT implemented (need your call — auto-merging these would be speculative)

The bigger signals the analysis surfaced, deliberately left as proposals:

1. **Droplet crash rate.** instawp: **49/113 (43%) crashed**, all 0–1.6 days old (i.e. *after* the v0.72.1 restart-fix). 45/48 are non-resident (member/automation) runs whose pane died before `notify_ended` — the leading suspect is **OOM/resource pressure** from many concurrent heavy `claude` processes on the 2 GB box. These also write false `outcome:crashed` episodes that pollute the learning loop. → Investigate OOM (cgroup counters, a concurrency cap) before any code change.
2. **Unattended runs strand on blocking `ask`/approval.** 17 pending questions across all three tenants, dominated by cron/Slack/automation agents (`gsc-analyst` daily cron crashed 3×; `onboarding-assistant` asked the same first-run question 3×). No human watches an 11 AM cron, so the block never resolves and the run is wasted. → Needs a design decision (timeout/auto-resolve, or suppress re-fire while an automation has an unanswered question).
3. **Approval volume for routine ops.** `file.write → approve` 52 (instapods) + 43 (instawp); `shell.exec` approvals with **21 pending** on instawp. Likely the default policy routes too much to humans → pending pile-up. → A governance-tuning decision, not a blind change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)