### PR TITLE
v0.77.5: automation edit form scrolls into view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.77.5] — 2026-07-10
+### Fixed
+- **Editing an automation now scrolls the form into view.** The create/edit form renders at the top of the
+  Automations section, but the Edit buttons sit on cards further down — clicking Edit while scrolled down
+  opened the populated form above the viewport, so it looked like "nothing happens." The form now scrolls
+  itself into view when it opens or when switching which automation is being edited.
+
 ## [0.77.4] — 2026-07-10
 ### Added
 - **`fleet-insights` maintainer skill** (`.claude/skills/fleet-insights/`). Mines agent sessions across

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.77.4",
+  "version": "0.77.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.77.4",
+      "version": "0.77.5",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.77.4",
+  "version": "0.77.5",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3767,6 +3767,7 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
   const [openRuns, setOpenRuns] = useState<string | null>(null) // automation id whose Runs list is expanded
   const [showForm, setShowForm] = useState(false) // the New-automation form is collapsed until requested
   const [editId, setEditId] = useState<string | null>(null) // when set, the form edits this automation instead of creating
+  const formRef = useRef<HTMLDivElement>(null) // the create/edit form — scroll it into view when it opens (Edit sits below the fold)
   const [showSpent, setShowSpent] = useState(false) // reveal the collapsed "spent one-shots" section
   // create / edit form
   const [name, setName] = useState('')
@@ -3782,6 +3783,9 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
   const load = () => api.automations().then((r) => setItems(r.automations ?? []))
   useEffect(() => { load() }, [])
   useEffect(() => { if (!agentId && agents[0]) setAgentId(agents[0].id) }, [agents, agentId])
+  // The form mounts at the top of the section, but Edit buttons live on cards further down — scroll the
+  // form into view when it opens (or when switching which automation is being edited) so it isn't missed.
+  useEffect(() => { if (showForm) formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' }) }, [showForm, editId])
 
   const resetForm = () => { setName(''); setTask(''); setFilter(''); setType('cron'); setMode('headless'); setSchedule('*/30 * * * *'); setScheduleCustom(false); setEditId(null) }
   const startCreate = () => { resetForm(); setShowForm(true); setHint('') }
@@ -3860,7 +3864,7 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
           )}
         </div>
         {isAdmin && showForm && (
-          <Card className="mb-3 border-primary/30">
+          <Card ref={formRef} className="mb-3 border-primary/30">
             <CardContent className="space-y-3 p-4">
               <div className="text-[11px] uppercase tracking-wider text-muted-foreground">{editId ? 'Edit automation' : 'New automation'}</div>
               <div className="grid grid-cols-2 gap-3">


### PR DESCRIPTION
## Problem
On the Automations page, clicking **Edit** on a card below the fold appeared to do nothing. The Edit button was actually working — it opened the create/edit form and populated it — but the form renders at the *top* of the section, above the viewport, so the user never saw it.

## Fix
Add a `formRef` on the form Card and an effect that scrolls it into view (`block: 'center'`) whenever the form opens or the edited automation changes.

## Testing
- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 57/57 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)