### PR TITLE
Host credential injection (Phase 2c): SSH key → session ssh_config + PATH shim (v0.78.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.78.0] — 2026-07-10
+### Added
+- **Host credential injection (Phase 2c) — a granted SSH host's key is now delivered to the agent's
+  shell, so plain `ssh` just works.** When an agent session launches, each enabled SSH [Host
+  connection](./docs/host-connections-plan.md) bound to it that carries a `secret:KEY` credential has
+  its key resolved from the vault and materialised into a **session-scoped** `ssh_config` + an
+  `ssh`/`scp` PATH shim (`TerminalManager.injectHostCredentials`). The key is written `0600` under the
+  session's private dir and offered **only to its host** (`IdentitiesOnly` on the matched `Host`
+  pattern), so an agent can `ssh deploy@box.prod.internal` without ever handling the key — and the prod
+  key is never offered to other hosts. Cleaned up with the session; audited `host.secret.injected`.
+  Local-lane only for now (uid-isolation is a follow-up); CIDR-matcher hosts are skipped (an ssh_config
+  `Host` can't express a CIDR — governance still applies, the key just isn't auto-offered).
+
 ## [0.77.5] — 2026-07-10
 ### Fixed
 - **Editing an automation now scrolls the form into view.** The create/edit form renders at the top of the

--- a/docs/host-connections-plan.md
+++ b/docs/host-connections-plan.md
@@ -1,14 +1,17 @@
 # Host / Network Connections — Phase 2 of the access model (scoping plan)
 
-> **Status: 2a + 2b shipped (2026-07-10).** Decisions in §7 are resolved. **Phase 2a** (the `hosts`
+> **Status: 2a + 2b + 2c shipped (2026-07-10).** Decisions in §7 are resolved. **Phase 2a** (the `hosts`
 > table + Connections UI) shipped in v0.73.0. **Phase 2b** (the governance engine — egress parsing,
 > `net.connect`/`ssh.exec` reclassification, `netMode`, the master switch) shipped behind
-> **Settings → Governance → "Govern host access"** (off by default). Implementation:
-> `src/governance/host-match.ts` (parsing + matching), the `isShell` host block in
-> `src/governance/enricher.ts`, the reclassification in `TerminalManager.gate` (`src/terminal.ts`),
-> and the `net.connect`/`ssh.exec` rules in `config/policy/default.policy.json`. **Phase 2d** (kernel
-> egress enforcement under uid-isolation) remains future work. Builds on the north-star
-> [`access-model.md`](./access-model.md) and the decision layer [`governance-model.md`](./governance-model.md).
+> **Settings → Governance → "Govern host access"** (off by default): `src/governance/host-match.ts`
+> (parsing + matching), the `isShell` host block in `src/governance/enricher.ts`, the reclassification in
+> `TerminalManager.gate`, and the `net.connect`/`ssh.exec` rules in `config/policy/default.policy.json`.
+> **Phase 2c** (credential injection) shipped: `TerminalManager.injectHostCredentials` materialises a
+> granted SSH host's vault key into a session-scoped `ssh_config` + `ssh`/`scp` PATH shim (host-scoped
+> via `IdentitiesOnly`), so a plain `ssh` authenticates without the agent handling the key — local-lane
+> only (uid-isolation is a follow-up), CIDR matchers skipped. **Phase 2d** (kernel egress enforcement
+> under uid-isolation) remains future work. Builds on the north-star [`access-model.md`](./access-model.md)
+> and the decision layer [`governance-model.md`](./governance-model.md).
 
 ## 1. Goal
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.77.5",
+  "version": "0.78.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.77.5",
+      "version": "0.78.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.77.5",
+  "version": "0.78.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/hosts/hosts.ts
+++ b/src/hosts/hosts.ts
@@ -198,4 +198,17 @@ export class HostStore {
       .filter((h) => h.scope !== 'personal' || h.shared || (!!memberId && h.ownerMemberId === memberId))
       .map((h) => ({ match: h.match, protocol: h.protocol, posture: h.posture }));
   }
+
+  /**
+   * Enabled, credential-bearing SSH hosts bound to `memberId` — the input to Phase 2c key injection.
+   * Same binding as grantsFor, narrowed to hosts that (a) carry a credential and (b) speak ssh (or any).
+   * Returns the RAW credential (a `secret:KEY` ref, resolved by the caller against the vault). Same
+   * ownership binding as grantsFor.
+   */
+  sshCredsFor(memberId?: string): { id: string; name: string; match: string; credential: string }[] {
+    return this.list()
+      .filter((h) => h.enabled && h.credential && (h.protocol === 'ssh' || h.protocol === 'any'))
+      .filter((h) => h.scope !== 'personal' || h.shared || (!!memberId && h.ownerMemberId === memberId))
+      .map((h) => ({ id: h.id, name: h.name, match: h.match, credential: h.credential }));
+  }
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -779,6 +779,9 @@ export class TerminalManager {
     if (o.resume) env.RESUME = '1';
     // The agent's opt-in shell secrets (vault keys → shell env vars, e.g. GH_TOKEN for `gh`).
     this.injectShellSecrets(env, o.agent, manifest, o.id);
+    // Phase 2c: granted Host connections' SSH keys → a session ssh_config + ssh/scp PATH shim, so the
+    // agent's plain `ssh` authenticates to a host without ever handling the key. (Local-lane only.)
+    this.injectHostCredentials(env, o.agent, o.actingMember, o.id);
     if (this.uidIsolation) {
       // Flag on: the launcher writes the files INTO the member's home and sets MCP_CONFIG/COMPANY_FILE itself.
       this.backend.spawn(this.spaceFor(o.actingMember ?? o.spawnedBy), { sessionId: o.id, agent: o.agent, tmuxName: tmux, env, argv: ['bash', this.launcher], files: { mcp: mcpJson || undefined, company: companyMd || undefined }, agentSrc: manifest.dir });
@@ -1857,7 +1860,8 @@ export class TerminalManager {
     const prefix = `session-${sessionId}.`;
     try {
       for (const f of fs.readdirSync(dir)) {
-        if (f.startsWith(prefix)) fs.rmSync(path.join(dir, f), { force: true });
+        // `recursive` also clears the Phase 2c `session-<id>.d/` dir (keys + ssh_config + shim).
+        if (f.startsWith(prefix)) fs.rmSync(path.join(dir, f), { recursive: true, force: true });
       }
     } catch {
       /* dir may not exist yet — nothing to clean */
@@ -1930,6 +1934,69 @@ export class TerminalManager {
       env[key] = value;
       this.audit(sessionId, agent, 'shell.secret.injected', { key, principal: agent });
     }
+  }
+
+  /** Find the real `ssh`/`scp` on the PARENT PATH (which never includes a session shim dir), so the
+   *  injected wrapper can exec the genuine binary. Falls back to the conventional /usr/bin path. */
+  private resolveBin(name: string): string {
+    for (const d of (process.env.PATH ?? '').split(path.delimiter)) {
+      if (!d) continue;
+      const p = path.join(d, name);
+      try { fs.accessSync(p, fs.constants.X_OK); return p; } catch { /* keep looking */ }
+    }
+    return `/usr/bin/${name}`;
+  }
+
+  /**
+   * Phase 2c — deliver a granted Host connection's SSH-key credential to the session so a plain
+   * `ssh`/`scp` authenticates transparently, WITHOUT the agent handling the key. For each enabled
+   * SSH host bound to this run that carries a `secret:` credential, we resolve the key from the vault
+   * and write, under a session-private `session-<id>.d/` dir: the key (0600), an `ssh_config` mapping
+   * each Host pattern → its key (`IdentitiesOnly`, so the prod key is only ever OFFERED to prod hosts),
+   * and an `ssh`/`scp` shim on PATH that injects `-F <ssh_config>`. Host-scoped by construction.
+   *
+   * Local-lane only for now: under uid-isolation the files must land in the member's home via the
+   * launcher (a follow-up). A CIDR matcher can't be an ssh_config Host pattern, so those are skipped
+   * (the key still governs via the gate; it just isn't auto-offered). Audited per key.
+   */
+  private injectHostCredentials(env: Record<string, string>, agent: string, actingMember: string | undefined, sessionId: string): void {
+    if (!this.os.paths || this.uidIsolation) return;
+    const hosts = this.os.hosts.sshCredsFor(actingMember);
+    if (!hosts.length) return;
+    const dir = path.join(this.os.paths.connectors, `session-${sessionId}.d`);
+    const keysDir = path.join(dir, 'keys');
+    const binDir = path.join(dir, 'bin');
+    fs.mkdirSync(keysDir, { recursive: true });
+    const cfg: string[] = [`# Agent OS host connections — session ${sessionId}`, ''];
+    let injected = 0;
+    for (const h of hosts) {
+      const m = h.match.trim();
+      if (m.includes('/')) { this.audit(sessionId, agent, 'host.cred.skipped', { host: h.id, reason: 'cidr-matcher', match: m }); continue; }
+      const ref = parseSecretRef(h.credential);
+      const principal = ref?.principal ?? actingMember ?? '*';
+      const key = ref ? this.os.secrets.getSync(this.os.tenant, principal, ref.key) : h.credential;
+      if (!key) { this.audit(sessionId, agent, 'host.secret.unresolved', { host: h.id, key: ref?.key ?? '(raw)', principal }); continue; }
+      const keyPath = path.join(keysDir, `${h.id}.key`);
+      fs.writeFileSync(keyPath, key.endsWith('\n') ? key : `${key}\n`, { mode: 0o600 });
+      const hostPat = m.replace(/:\d+$/, '');
+      const portM = m.match(/:(\d+)$/);
+      cfg.push(`Host ${hostPat}`, `  IdentityFile ${keyPath}`, `  IdentitiesOnly yes`);
+      if (portM) cfg.push(`  Port ${portM[1]}`);
+      cfg.push('');
+      injected++;
+      this.audit(sessionId, agent, 'host.secret.injected', { host: h.id, match: hostPat, principal });
+    }
+    if (!injected) { fs.rmSync(dir, { recursive: true, force: true }); return; }
+    const cfgPath = path.join(dir, 'ssh_config');
+    fs.writeFileSync(cfgPath, cfg.join('\n'), { mode: 0o600 });
+    fs.mkdirSync(binDir, { recursive: true });
+    for (const name of ['ssh', 'scp'] as const) {
+      const shim = path.join(binDir, name);
+      fs.writeFileSync(shim, `#!/bin/sh\nexec ${this.resolveBin(name)} -F "${cfgPath}" "$@"\n`, { mode: 0o755 });
+    }
+    // Prepend the shim dir so `ssh`/`scp` resolve to it (the launcher then prepends ~/.local/bin ahead,
+    // which won't shadow ssh in practice). Off-lane leaves env.PATH unset → seed from the parent PATH.
+    env.PATH = `${binDir}${path.delimiter}${env.PATH ?? process.env.PATH ?? ''}`;
   }
 
   /** The JSON policy engine ignores ctx; provide a minimal stand-in to satisfy the type. */

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -740,8 +740,9 @@ function AddHostDialog({ me, host, scope, onClose, onSaved }: {
         <div className="space-y-3">
           <p className="text-xs text-muted-foreground">
             A <b>host</b> is a reachable destination — an SSH box, an internal service, a database — your agents may talk to.
-            <span className="text-foreground"> Not yet enforced:</span> this registers the destination and its credential; the
-            gate begins governing reaches to it in a later update.
+            When <b>host governance</b> is on (<a href="#/settings/governance" className="underline hover:text-foreground">Settings → Governance</a>),
+            reaches here are gated by policy; an SSH credential below is injected into the agent's shell at launch, so a plain
+            <span className="font-mono"> ssh</span> authenticates without the agent handling the key.
           </p>
 
           <Field label="Name"><Input value={name} onChange={(e) => setName(e.target.value)} placeholder="Prod database" /></Field>
@@ -756,7 +757,7 @@ function AddHostDialog({ me, host, scope, onClose, onSaved }: {
             <Segmented value={posture} onChange={setPosture} options={HOST_POSTURES} />
           </Field>
 
-          <Field label="Credential" help="Optional. A Secrets-vault reference (secret:KEY) to an SSH key or password, injected at launch. Leave blank for none.">
+          <Field label="Credential" help="Optional. A Secrets-vault reference (secret:KEY) to an SSH private key. For an SSH host it's materialised into a session-scoped ssh_config at launch (offered only to this host); blank for none. Non-SSH creds aren't injected yet.">
             <Input value={credential} onChange={(e) => setCredential(e.target.value)} placeholder={editing && host?.credential ? `${host.credential} (saved) — type to replace` : 'secret:SSH_KEY'} className="font-mono text-xs" />
           </Field>
 


### PR DESCRIPTION
**Phase 2c** — makes Host connections' credentials actually work. A granted SSH host's vault key is delivered to the agent's shell so a plain `ssh`/`scp` authenticates transparently, **without the agent ever handling the key**.

## Mechanism (per-session ssh config + PATH shim)
At launch (`TerminalManager.injectHostCredentials`, right after `injectShellSecrets`), for each enabled `ssh`/`any` Host bound to the run-as member that carries a `secret:KEY` credential:
- resolve the key from the vault (same principal precedence as connectors);
- write it `0600` under a session-private `session-<id>.d/keys/`;
- write an `ssh_config` mapping each `Host` pattern → its key with **`IdentitiesOnly yes`** — so the **prod key is only ever *offered* to prod hosts**, never leaked to others;
- drop an `ssh`/`scp` shim on `PATH` that injects `-F <ssh_config>` (execs the real binary found on the parent PATH).

Host-scoped by construction; audited `host.secret.injected` / `host.secret.unresolved`. Cleaned up with the session (`removeSessionFiles` now recursive).

## Scope / limits (honest)
- **Local-lane only** — under uid-isolation the files must land in the member's home via the launcher; that's a follow-up (guarded, no-ops for now).
- **CIDR matchers skipped** — an `ssh_config` `Host` can't express a CIDR, so those hosts still *govern* (2b) but don't get an auto-offered key.
- Non-SSH creds (e.g. `PGPASSWORD`) aren't injected yet.

## Verification
- **18 end-to-end checks**: `sshCredsFor` filtering (ssh/any + credential; excludes postgres/credential-less), key `0600` + content, `ssh_config` `Host`/`IdentityFile`/`IdentitiesOnly`/`Port`, CIDR + unresolved-secret skips, shim executable + execs real ssh with `-F`, `PATH` prepend, recursive cleanup.
- `tsc` + `vite` clean; governance conformance **57/57** (2c doesn't touch the decision path).
- Add-a-host dialog copy updated (governance + injection are now real, not "later").

🤖 Generated with [Claude Code](https://claude.com/claude-code)