### PR TITLE
Unattended runs park instead of stranding on blocking ask/approval (v0.80.0, #138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,21 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.79.3] — 2026-07-10
-### Fixed
-- **Add-a-host dialog: corrected the posture help copy.** It read "Takes effect once host governance
-  *ships*" — but host governance has shipped (v0.77.0); it now reads "once host governance is *enabled*
-  (Settings → Governance)". Caught in the browser QA pass.
-
-## [0.79.2] — 2026-07-10
+## [0.80.0] — 2026-07-10
 ### Changed
-- **Sessions list now defaults to "My sessions" for owner/admin.** The scope toggle added in 0.79.0
-  now starts on **My sessions** for fleet-wide viewers (owner/admin) so their default view is the
-  sessions they're accountable for rather than every session in the workspace; **All** is one click
-  away. Members are unaffected (their list is already only their own, and the default stays All so an
-  automation-fired run they're entitled to is never hidden). The choice is role-relative: only a
-  deviation from the per-viewer default is written to the URL, so a deliberate All/My pick still
-  survives a refresh, and the default view no longer shows a spurious "Clear filters" affordance.
+- **Unattended runs no longer strand on a blocking `ask`/approval (#138).** A headless run
+  (automation/cron/task, `claude -p`) has no human at the terminal and — unlike a resident chat —
+  no idle-reaper bound, so a blocking `ask` used to hang the session for ~1h and a gated approval
+  hung it indefinitely, wasting the run and holding its memory (a contributor to the OOM crash rate
+  in #137). Now, for headless runs only:
+  - **`ask`** waits a short bounded window (`AOS_UNATTENDED_ASK_WAIT_S`, default 120s) in case an
+    operator is live, then **parks**: the question is already in the operator's Inbox + DM'd, so it
+    returns guidance to stop cleanly (report + end) rather than hang or guess on a risky call.
+  - **Gated approvals** in the PreToolUse gate hook wait a bounded window
+    (`AOS_UNATTENDED_APPROVAL_WAIT_S`, default 180s) then **fail closed** (deny) — never allow. The
+    approval stays pending in the inbox for a human to resolve and re-run.
+  Interactive sessions are unchanged (they keep the full ~1h / indefinite wait — a human is present).
 
 ## [0.79.1] — 2026-07-10
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.79.3",
+  "version": "0.80.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.79.3",
+      "version": "0.80.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.79.3",
+  "version": "0.80.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -20,6 +20,10 @@ const SECRET = process.env.AOS_SECRET || '';
 // Tenant id (multi-tenant): the server routes these loopback calls to THIS tenant's runtime via the
 // `x-aos-tenant` header (loopback has no Host subdomain). Empty → the server falls back to default.
 const TENANT = process.env.AOS_TENANT || '';
+// HEADLESS marks an unattended run (automation/cron/task, `claude -p`) — no human at the terminal and no
+// idle-reaper bound. A blocking `ask` therefore parks after a short window instead of hanging ~1h (#138).
+const HEADLESS = process.env.HEADLESS === '1';
+const UNATTENDED_ASK_WAIT_S = Number(process.env.AOS_UNATTENDED_ASK_WAIT_S) || 120;
 /** Headers for a loopback agent call: the session bearer + tenant route, plus any extras (e.g. JSON). */
 function H(extra: Record<string, string> = {}): Record<string, string> {
   return { 'x-aos-secret': SECRET, ...(TENANT ? { 'x-aos-tenant': TENANT } : {}), ...extra };
@@ -750,13 +754,25 @@ async function ask(args: Record<string, unknown>): Promise<string> {
   });
   const { id } = (await res.json()) as { id?: string };
   if (!id) return 'Could not post the question.';
-  // Poll the inbox for the human's answer (up to ~1h), same model as the gate hook.
-  for (let i = 0; i < 1800; i++) {
+  // Poll the inbox for the human's answer. An INTERACTIVE run waits ~1h (a human is at the terminal and
+  // may take a while). A HEADLESS run (automation/cron/task) has no human attached AND no idle-reaper
+  // bound, so an hour-long block just strands the session and holds its memory — the question is already
+  // in the operator's Inbox + DM'd the moment it was asked, so we only wait a short window in case an
+  // operator is live, then PARK (return stop-cleanly guidance rather than hang or guess).
+  const maxPolls = HEADLESS ? Math.max(1, Math.ceil(UNATTENDED_ASK_WAIT_S / 2)) : 1800;
+  for (let i = 0; i < maxPolls; i++) {
     await sleep(2000);
     const r = await fetch(`${AOS_URL}/api/ask/${id}`);
     const d = (await r.json()) as { status?: string; answer?: string };
     if (d.status === 'answered') return d.answer || '(the operator gave no answer)';
     if (d.status === 'cancelled') return 'The operator dismissed this question without answering. Proceed using your best judgement, or ask again if you are still blocked.';
+  }
+  if (HEADLESS) {
+    return 'No operator is available on this unattended run (automation/cron/headless), and none answered in ' +
+      `the ${UNATTENDED_ASK_WAIT_S}s window. Your question is recorded in the operator's Inbox and they have been ` +
+      'notified, so it is NOT lost. Do NOT proceed with any risky or irreversible action on a guess. Wrap up ' +
+      'now: call `report` to summarise what you did and note that you are blocked on this question, then end the ' +
+      'run. The operator will follow up (e.g. by answering and re-running you).';
   }
   return 'No answer yet (timed out waiting on the operator). Proceed using your best judgement or ask again.';
 }

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -12,8 +12,11 @@
 # own permission engine (the `auto`-mode classifier never runs, so there's no second, hidden
 # denial layered on top of ours). `"deny"` blocks the call. An approval that's still pending
 # blocks the hook synchronously (polling) until a human resolves it, then emits allow/deny —
-# so a headless `-p` run is governed identically to an interactive one with NO
-# `--dangerously-skip-permissions` (there's no prompt to answer; the hook itself is the gate).
+# so an interactive run is governed identically to one with NO `--dangerously-skip-permissions`
+# (there's no prompt to answer; the hook itself is the gate). A HEADLESS `-p` run (automation/cron)
+# has no human at the terminal and no idle-reaper bound, so it waits only a bounded window
+# (AOS_UNATTENDED_APPROVAL_WAIT_S, default 180s) and then FAILS CLOSED (deny) — it never falls through
+# to allow; the approval stays pending in the inbox for a human to act on and re-run (#138).
 # Built-in Read/Glob/Grep and the OS-owned mcp__agentos__* tools aren't world side effects, so
 # the hook stays silent (bare exit 0) and defers to Claude's normal permission flow — that's
 # what keeps the crown-jewel `permissions.deny` Read rules in force for the built-in Read tool.
@@ -72,10 +75,21 @@ while :; do
 done
 
 echo "Agent OS: this action needs approval — see the inbox. Waiting…" >&2
+# Interactive runs wait indefinitely for a human. A HEADLESS run has nobody at the terminal, so bound the
+# wait and FAIL CLOSED (deny) — we only ever stop THIS blocked call, never fall through to allow, and the
+# approval row stays pending in the inbox for a human to resolve + re-run.
+APPROVAL_WAIT_S="${AOS_UNATTENDED_APPROVAL_WAIT_S:-180}"
+waited=0
 while :; do
   sleep 1
   st=$(curl -s --max-time 10 "$AOS_URL/api/gate/$gid" -H "x-aos-tenant: ${AOS_TENANT:-}" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.status||"")})')
   [ "$st" = "allow" ] && emit allow "Agent OS: approved by human."
   [ "$st" = "deny" ]  && emit deny "Agent OS: rejected by human."
   # any other status (pending / empty / gate momentarily unreachable) → keep waiting, never proceed
+  if [ "${HEADLESS:-}" = "1" ]; then
+    waited=$((waited + 1))
+    if [ "$waited" -ge "$APPROVAL_WAIT_S" ]; then
+      emit deny "Agent OS: no operator approved this within ${APPROVAL_WAIT_S}s on an unattended run — blocked (fail-closed). The approval is still in the inbox; a human can approve and re-run. Wrap up: report what you did and end the run."
+    fi
+  fi
 done


### PR DESCRIPTION
Closes #138.

## Problem
Traced from real fleet friction (`fleet-insights`). A blocking `ask` polls for **~1 hour** (1800 × 2s) and a gated approval in the PreToolUse gate hook waits **indefinitely** — with **no awareness of whether a human is attached**. On a headless run (automation/cron/task, `claude -p`) nobody is watching and there's no idle-reaper bound, so the session hangs, wastes the run, and holds its memory — a contributor to the instawp OOM crash rate (#137). Evidence: 17 pending questions across the three tenants, dominated by cron/Slack/automation agents (`gsc-analyst` daily cron, `onboarding-assistant` asking the same first-run question 3×, `compass` 3×).

## Fix — "park & stop cleanly" (owner-chosen semantic)
Headless runs only; interactive is unchanged (a human is present, keep the full wait):

- **`ask`** (`src/memory/memory-mcp.ts`): waits a bounded window (`AOS_UNATTENDED_ASK_WAIT_S`, default 120s) in case an operator is live, then **parks** — the question was already posted to the Inbox + DM'd the moment it was asked, so it returns guidance to stop cleanly (call `report`, note the blocker, end the run) rather than hang ~1h or guess on a risky call (e.g. a pod migration).
- **Gated approvals** (`terminal/gate-hook.sh`): the approval wait loop bounds itself (`AOS_UNATTENDED_APPROVAL_WAIT_S`, default 180s) then **fails closed** (`emit deny`) — it never falls through to allow. The approval row stays pending in the inbox for a human to resolve and re-run.

Signal is `HEADLESS=1` (already exported at launch). Scoped to headless deliberately: resident chats are already capped by the 30-min idle reaper; only headless is truly unbounded. The in-process `gateway.ts` `await settle` is left untouched so the governance conformance suite stays valid.

## Validation
- `npm run typecheck` clean · `bash -n terminal/gate-hook.sh` clean · `npm run build` clean
- `npm run test:governance` → **57/57 passed** (unchanged — the fix is in the MCP tool + bash hook, not the compiled gate)

## Follow-ups (noted on #138, not in this PR)
- The in-process `gateway.ts` approval `await settle` has the same unbounded wait for any direct (non-hook) gated path — bound it symmetrically for unattended runs.
- Optional: pile-up guard could also skip re-firing an automation whose prior run is parked on an unanswered question (largely moot now that parked runs end fast and their questions get cancelled on end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)