### PR TITLE
v0.79.2: default Sessions scope to "My sessions" for owner/admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.79.2] — 2026-07-10
+### Changed
+- **Sessions list now defaults to "My sessions" for owner/admin.** The scope toggle added in 0.79.0
+  now starts on **My sessions** for fleet-wide viewers (owner/admin) so their default view is the
+  sessions they're accountable for rather than every session in the workspace; **All** is one click
+  away. Members are unaffected (their list is already only their own, and the default stays All so an
+  automation-fired run they're entitled to is never hidden). The choice is role-relative: only a
+  deviation from the per-viewer default is written to the URL, so a deliberate All/My pick still
+  survives a refresh, and the default view no longer shows a spurious "Clear filters" affordance.
+
 ## [0.79.1] — 2026-07-10
 ### Fixed
 - **Warn on `policyContext` mismatch at agent registration.** An agent manifest's `policyContext` was

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.79.0",
+  "version": "0.79.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.79.0",
+      "version": "0.79.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.79.1",
+  "version": "0.79.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -134,7 +134,8 @@ const sessionFiltersToParams = (f: SessionFilters): Record<string, string> => {
   if (f.agent !== 'all') p.agent = f.agent
   if (f.source !== 'all') p.source = f.source
   if (f.owner !== 'all') p.owner = f.owner
-  if (f.mine) p.mine = '1'
+  // `mine` is serialized by the caller, not here: its default is role-dependent (ON for owner/admin,
+  // OFF for members), so only a deviation from that per-viewer default is written to the URL.
   if (f.sortKey !== DEFAULT_SORT_KEY) p.sort = f.sortKey
   if (f.sortDir !== 'desc') p.dir = f.sortDir
   return p
@@ -1481,14 +1482,21 @@ function SessionsPage({
   const [agentFilter, setAgentFilter] = useState(seed.agent)
   const [sourceFilter, setSourceFilter] = useState<'all' | SessionSource>(seed.source)
   const [ownerFilter, setOwnerFilter] = useState(seed.owner) // run-as member id, or 'all'
-  // "My sessions" toggle: owner/admin see the whole fleet by default; flipping this narrows to the
-  // sessions the viewer is accountable for (spawned directly OR runs as them) — same rule as the
-  // sidebar switcher's `mySessions`. For a member the two views coincide (they only see their own).
-  const [mine, setMine] = useState(seed.mine)
+  // "My sessions" toggle. It narrows to the sessions the viewer is accountable for (spawned directly
+  // OR runs as them) — same rule as the sidebar switcher's `mySessions`. It DEFAULTS ON for owner/admin
+  // (whose visibility is fleet-wide, so their unfiltered list is every session in the workspace) and
+  // OFF for a member (whose list is already only their own — narrowing it further could hide an
+  // automation-fired run they're entitled to, and the toggle is hidden for them anyway). An explicit
+  // `?mine=` in the URL wins over the default, so a deliberate choice survives a refresh / deep-link.
+  const isFleetViewer = me.role === 'owner' || me.role === 'admin'
+  const seedMineParam = useRef(new URLSearchParams(urlQuery).get('mine')).current
+  const [mine, setMine] = useState(seedMineParam === null ? isFleetViewer : seedMineParam === '1')
   const [sortKey, setSortKey] = useState<SessionSortKey>(seed.sortKey)
   const [sortDir, setSortDir] = useState<SortDir>(seed.sortDir)
   useEffect(() => {
-    onFiltersChange(sessionFiltersToParams({ q: query, status: statusFilter, agent: agentFilter, source: sourceFilter, owner: ownerFilter, mine, sortKey, sortDir }))
+    const params = sessionFiltersToParams({ q: query, status: statusFilter, agent: agentFilter, source: sourceFilter, owner: ownerFilter, mine, sortKey, sortDir })
+    if (mine !== isFleetViewer) params.mine = mine ? '1' : '0' // only persist a deviation from the per-viewer default
+    onFiltersChange(params)
     // onFiltersChange is a stable replaceState wrapper; depending on the filter/sort values only is intentional.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, statusFilter, agentFilter, sourceFilter, ownerFilter, mine, sortKey, sortDir])
@@ -1520,8 +1528,10 @@ function SessionsPage({
     return [...m].map(([id, label]) => ({ id, label })).sort((a, b) => a.label.localeCompare(b.label))
   }, [sessions])
   const ownerLabel = (id: string) => (id === 'all' ? 'All owners' : ownerOptions.find((o) => o.id === id)?.label ?? id)
-  const filtersActive = query.trim() !== '' || statusFilter !== 'all' || agentFilter !== 'all' || sourceFilter !== 'all' || ownerFilter !== 'all' || mine
-  const clearFilters = () => { setQuery(''); setStatusFilter('all'); setAgentFilter('all'); setSourceFilter('all'); setOwnerFilter('all'); setMine(false) }
+  // `mine` counts as "active" only when it deviates from the per-viewer default (My for owner/admin,
+  // All for members), so the default view doesn't spuriously show the Clear-filters affordance.
+  const filtersActive = query.trim() !== '' || statusFilter !== 'all' || agentFilter !== 'all' || sourceFilter !== 'all' || ownerFilter !== 'all' || mine !== isFleetViewer
+  const clearFilters = () => { setQuery(''); setStatusFilter('all'); setAgentFilter('all'); setSourceFilter('all'); setOwnerFilter('all'); setMine(isFleetViewer) }
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase()
     return sessions.filter((s) =>


### PR DESCRIPTION
Follow-up to #142. The Sessions scope toggle now **defaults to My sessions** for owner/admin.

## Why
Owner/admin have fleet-wide visibility, so their unfiltered list is every session in the workspace. Defaulting the toggle to **My sessions** makes their landing view the sessions they're accountable for; **All** is one click away.

## How
- The default is **role-relative**: ON for owner/admin (fleet viewers), OFF for members. A member's list is already only their own, and narrowing it further could hide an automation-fired run they're entitled to — plus the toggle is hidden for them — so their default stays All.
- Only a **deviation** from the per-viewer default is written to the URL (`?mine=0`/`?mine=1`), so an explicit All/My choice still round-trips across a refresh / deep-link, and the default view carries a clean URL.
- `filtersActive` / `clearFilters` are now measured against the per-viewer default, so the default view shows no spurious "Clear filters" affordance and Clear resets to the default rather than forcing All.

## Test
- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 57/57 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)