### PR TITLE
Hosts: fix Add-a-host posture help copy (v0.79.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.79.3] — 2026-07-10
+### Fixed
+- **Add-a-host dialog: corrected the posture help copy.** It read "Takes effect once host governance
+  *ships*" — but host governance has shipped (v0.77.0); it now reads "once host governance is *enabled*
+  (Settings → Governance)". Caught in the browser QA pass.
+
 ## [0.79.2] — 2026-07-10
 ### Changed
 - **Sessions list now defaults to "My sessions" for owner/admin.** The scope toggle added in 0.79.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.79.2",
+  "version": "0.79.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.79.2",
+      "version": "0.79.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.79.2",
+  "version": "0.79.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -753,7 +753,7 @@ function AddHostDialog({ me, host, scope, onClose, onSaved }: {
 
           <Field label="Protocol"><Segmented value={protocol} onChange={setProtocol} options={HOST_PROTOCOLS} /></Field>
 
-          <Field label="Default posture" help="allow = reach freely · ask = pause for approval · never = always refuse. Takes effect once host governance ships.">
+          <Field label="Default posture" help="allow = reach freely · ask = pause for approval · never = always refuse. Takes effect once host governance is enabled (Settings → Governance).">
             <Segmented value={posture} onChange={setPosture} options={HOST_POSTURES} />
           </Field>
 


### PR DESCRIPTION
One-line copy fix caught in the browser QA pass: the Add-a-host dialog's *Default posture* help said "Takes effect once host governance **ships**" — but host governance shipped in v0.77.0. Now reads "once host governance is **enabled** (Settings → Governance)".

Web-only, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)