### PR TITLE
Per-agent trust & maturity stats (v0.81.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.81.0] — 2026-07-10
+### Added
+- **Per-agent trust & maturity stats — "which agent can the system trust to run with less oversight?"**
+  A read-side roll-up (`src/state/agent-stats.ts`, `GET /api/agents/:id/stats` + fleet `GET /api/agents/stats`,
+  a Trust card on the agent page) over signals already flowing through the governed gateway — it invents
+  no new bookkeeping. Each run gets a **governed** outcome (a human denial or a crash can't be papered over
+  by an optimistic self-report): `failure` if the run crashed / hit a denial (reject, policy deny,
+  killswitch, budget stop) / self-reported failure / its dispatching task ended `blocked`; `success` if the
+  task ended `done` or the agent self-reported success on a clean, un-denied run; else `inconclusive`.
+  **Maturity ≠ success rate** — it answers "trust to run alone": `autonomy × (1 − denialRate) ×
+  volumeConfidence`, where autonomy = governed actions that ran without suspending for a human, denials
+  multiply the score down hard, and small samples are discounted (5 clean runs can't outrank 200). So an
+  agent with a 95% self-reported success rate that needs a human approval every run stays low-maturity by
+  design. Stats are visibility-scoped (a member sees only agents they may run).
+
 ## [0.80.0] — 2026-07-10
 ### Changed
 - **Unattended runs no longer strand on a blocking `ask`/approval (#138).** A headless run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.80.0",
+      "version": "0.81.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.80.0",
+  "version": "0.81.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,6 +31,7 @@ import { extractSkillsFromZip } from './governance/skill-zip';
 import { parseBundle } from './governance/bundle-import';
 import { AgentManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus } from './types';
 import { AgentConfigSnapshot } from './state/agent-revisions';
+import { computeAgentStats, computeAgentStat } from './state/agent-stats';
 
 /** Settings → Memory view: stored backend config with secrets redacted to `…Set` booleans. */
 interface EmbeddingsView { provider: 'openai' | 'ollama'; url: string; model: string; dimensions?: number; apiKeySet: boolean }
@@ -1122,6 +1123,25 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       // context). Surfaced read-only in Settings → System so operators can see what the fleet is told.
       operatingNotes: AGENT_OS_OPERATING_NOTES,
     });
+  }
+
+  // ── agent trust / maturity stats ───────────────────────────────────────────────
+  // "Which agent can the system trust to run with less oversight?" A read-side roll-up of signals
+  // already flowing through the gateway (autonomy, denials), the sessions/tasks tables, and the
+  // agents' own self-reports. See src/state/agent-stats.ts for the scoring rules.
+  if (method === 'GET' && p === '/api/agents/stats') {
+    // Members see stats only for agents they may run; owner/admin see the whole fleet. Passing the
+    // visible ids includes freshly-created, zero-run agents (confidence: 'none') instead of hiding them.
+    const visible = terminalAgents(os).filter((a) => os.team.canRun(me, a.id)).map((a) => a.id);
+    const allow = new Set(visible);
+    const stats = computeAgentStats(os.db, visible).filter((s) => allow.has(s.agentId));
+    return sendJson(res, 200, { stats });
+  }
+  const agentStatMatch = p.match(/^\/api\/agents\/([\w.-]+)\/stats$/);
+  if (method === 'GET' && agentStatMatch) {
+    const id = agentStatMatch[1];
+    if (!os.team.canRun(me, id)) return sendJson(res, 403, { error: 'forbidden' });
+    return sendJson(res, 200, { stats: computeAgentStat(os.db, id) });
   }
 
   // ── self-update ────────────────────────────────────────────────────────────────

--- a/src/state/agent-stats.ts
+++ b/src/state/agent-stats.ts
@@ -1,0 +1,213 @@
+/**
+ * Per-agent trust / maturity stats — the "which agent can the system trust to run with less
+ * oversight" view. This is a READ-SIDE aggregator: it invents no new bookkeeping, it rolls up
+ * signals already flowing through the governed gateway (audit_events), the sessions table, the
+ * inbox self-reports (messages), the approvals plane, and the tasks board.
+ *
+ * A run's outcome is scored by the GOVERNED rule (a human denial or a crash can't be papered over
+ * by an optimistic self-report):
+ *
+ *   failure       if the run crashed, hit a denial (human reject / policy deny / killswitch /
+ *                 budget stop), self-reported failure, OR its dispatching task ended `blocked`
+ *   success       if its dispatching task ended `done`, OR the agent self-reported success on a
+ *                 clean, un-denied run
+ *   inconclusive  otherwise (still running, or ended with no verdict either way)
+ *
+ * Maturity is NOT the success rate — it answers a different question ("trust to run alone"):
+ *
+ *   maturity = autonomy × (1 − denialRate) × volumeConfidence
+ *
+ *   autonomy         = (governed actions − human-gated actions) / governed actions
+ *                      (how often the agent acted without suspending for a human approval)
+ *   denialRate       = runs with a denial / total runs   (a human/policy saying "no" — the sharpest
+ *                      "not ready" signal, so it multiplies down hard)
+ *   volumeConfidence = runs / (runs + K)                 (5 clean runs must not outrank 200)
+ */
+import { Db } from './db';
+
+/** Smoothing constant for volume confidence: at K runs, confidence is 0.5. */
+const CONFIDENCE_K = 8;
+
+export interface AgentStats {
+  agentId: string;
+  runs: { total: number; running: number; done: number; stopped: number; crashed: number };
+  /** Governed per-run verdict (see the module header). `inconclusive` = running or no verdict. */
+  outcomes: { success: number; failure: number; inconclusive: number };
+  /** Governed-action tallies from the audit stream. */
+  actions: {
+    governed: number;      // gate.attempt — every governed action the agent tried
+    humanGated: number;    // approval.requested — actions that suspended for a human
+    autoApproved: number;  // approval.auto_approved — needed a level but an auto-approver cleared it
+    denied: number;        // policy hard-deny (gate.decision effect=deny)
+    rejected: number;      // approval.resolved with approved=false (a human said no)
+    killswitch: number;    // gate.killswitch
+    errors: number;        // session.error
+    budgetStops: number;   // budget.exceeded
+  };
+  tasks: { done: number; blocked: number; cancelled: number };
+  /** Distinct runs that hit any denial (reject / policy deny / killswitch / budget stop). */
+  deniedRuns: number;
+  /** question.asked — times the agent blocked on a human decision. */
+  questions: number;
+  firstRunAt: number | null;
+  lastRunAt: number | null;
+  // ── derived ──────────────────────────────────────────────────────────────────
+  autonomy: number;          // 0..1
+  denialRate: number;        // 0..1
+  successRate: number | null; // success / (success + failure); null when nothing decided
+  volumeConfidence: number;  // 0..1
+  maturity: number;          // 0..1 — the headline trust score
+  confidence: 'none' | 'low' | 'medium' | 'high';
+}
+
+interface SessionRow { id: string; agent: string; status: string; spawned_by: string | null; created_at: number; updated_at: number | null; }
+
+function blank(agentId: string): AgentStats {
+  return {
+    agentId,
+    runs: { total: 0, running: 0, done: 0, stopped: 0, crashed: 0 },
+    outcomes: { success: 0, failure: 0, inconclusive: 0 },
+    actions: { governed: 0, humanGated: 0, autoApproved: 0, denied: 0, rejected: 0, killswitch: 0, errors: 0, budgetStops: 0 },
+    tasks: { done: 0, blocked: 0, cancelled: 0 },
+    deniedRuns: 0,
+    questions: 0,
+    firstRunAt: null,
+    lastRunAt: null,
+    autonomy: 1,
+    denialRate: 0,
+    successRate: null,
+    volumeConfidence: 0,
+    maturity: 0,
+    confidence: 'none',
+  };
+}
+
+const clamp01 = (n: number) => (n < 0 ? 0 : n > 1 ? 1 : n);
+
+/**
+ * Compute per-agent maturity stats over the whole workspace history.
+ * @param agentIds when provided, agents with zero runs are still included (blank rows), so the
+ *   console can show a freshly-created agent at `confidence: 'none'` rather than omitting it.
+ */
+export function computeAgentStats(db: Db, agentIds?: string[]): AgentStats[] {
+  const by = new Map<string, AgentStats>();
+  const get = (agent: string): AgentStats => {
+    let s = by.get(agent);
+    if (!s) { s = blank(agent); by.set(agent, s); }
+    return s;
+  };
+  for (const id of agentIds ?? []) get(id);
+
+  // ── 1. sessions → runs, status counts, activity window; and the run_id → agent join map ──
+  const sessions = db.prepare(
+    'SELECT id, agent, status, spawned_by, created_at, COALESCE(updated_at, created_at) AS updated_at FROM term_sessions'
+  ).all() as unknown as SessionRow[];
+  const agentOf = new Map<string, string>();      // session id → agent
+  const spawnedByOf = new Map<string, string | null>();
+  const statusOf = new Map<string, string>();
+  for (const r of sessions) {
+    agentOf.set(r.id, r.agent);
+    spawnedByOf.set(r.id, r.spawned_by);
+    statusOf.set(r.id, r.status);
+    const s = get(r.agent);
+    s.runs.total++;
+    if (r.status === 'running') s.runs.running++;
+    else if (r.status === 'stopped') s.runs.stopped++;
+    else if (r.status === 'crashed') s.runs.crashed++;
+    else s.runs.done++;
+    if (s.firstRunAt === null || r.created_at < s.firstRunAt) s.firstRunAt = r.created_at;
+    const last = r.updated_at ?? r.created_at;
+    if (s.lastRunAt === null || last > s.lastRunAt) s.lastRunAt = last;
+  }
+
+  // ── 2. self-reported outcomes (the agent grading its own homework) — latest 'completed' per run ──
+  const selfOutcome = new Map<string, string>();
+  const completed = db.prepare(
+    "SELECT session_id, outcome FROM messages WHERE type = 'completed' AND outcome IS NOT NULL ORDER BY created_at ASC"
+  ).all() as unknown as Array<{ session_id: string; outcome: string }>;
+  for (const c of completed) selfOutcome.set(c.session_id, c.outcome); // ASC → last write wins
+
+  // ── 3. task outcomes (ground truth for dispatched work) ──
+  const taskStatus = new Map<string, string>();
+  const tasks = db.prepare('SELECT id, status, assignee FROM tasks').all() as unknown as Array<{ id: string; status: string; assignee: string | null }>;
+  for (const t of tasks) {
+    taskStatus.set(t.id, t.status);
+    if (t.assignee && t.assignee.startsWith('agent:')) {
+      const s = get(t.assignee.slice('agent:'.length));
+      if (t.status === 'done') s.tasks.done++;
+      else if (t.status === 'blocked') s.tasks.blocked++;
+      else if (t.status === 'cancelled') s.tasks.cancelled++;
+    }
+  }
+
+  // ── 4. governed-action tallies from the audit stream, joined to the agent via run_id ──
+  const deniedRunSet = new Set<string>();
+  const audit = db.prepare(
+    `SELECT run_id, type, data FROM audit_events WHERE type IN
+      ('gate.attempt','approval.requested','approval.resolved','approval.auto_approved',
+       'gate.decision','gate.killswitch','session.error','budget.exceeded','question.asked')`
+  ).all() as unknown as Array<{ run_id: string; type: string; data: string }>;
+  for (const ev of audit) {
+    const agent = agentOf.get(ev.run_id);
+    if (!agent) continue; // an audit row whose session we can't resolve (e.g. '-' housekeeping) — skip
+    const s = get(agent);
+    let d: Record<string, unknown> = {};
+    try { d = JSON.parse(ev.data) as Record<string, unknown>; } catch { /* keep {} */ }
+    switch (ev.type) {
+      case 'gate.attempt': s.actions.governed++; break;
+      case 'approval.requested': s.actions.humanGated++; break;
+      case 'approval.auto_approved': s.actions.autoApproved++; break;
+      case 'approval.resolved':
+        if (d.approved === false) { s.actions.rejected++; deniedRunSet.add(ev.run_id); }
+        break;
+      case 'gate.decision': {
+        const eff = (d.decision as { effect?: string } | undefined)?.effect;
+        if (eff === 'deny') { s.actions.denied++; deniedRunSet.add(ev.run_id); }
+        break;
+      }
+      case 'gate.killswitch': s.actions.killswitch++; deniedRunSet.add(ev.run_id); break;
+      case 'session.error': s.actions.errors++; break;
+      case 'budget.exceeded': s.actions.budgetStops++; deniedRunSet.add(ev.run_id); break;
+      case 'question.asked': s.questions++; break;
+    }
+  }
+
+  // ── 5. governed per-run outcome + derived scores ──
+  for (const r of sessions) {
+    const s = get(r.agent);
+    const denied = deniedRunSet.has(r.id);
+    const crashed = r.status === 'crashed';
+    const self = selfOutcome.get(r.id);
+    const sb = spawnedByOf.get(r.id) ?? null;
+    const taskStat = sb && sb.startsWith('task:') ? taskStatus.get(sb.slice('task:'.length)) : undefined;
+    if (crashed || denied || self === 'failure' || taskStat === 'blocked') s.outcomes.failure++;
+    else if (taskStat === 'done' || (self === 'success' && !denied && r.status === 'done')) s.outcomes.success++;
+    else s.outcomes.inconclusive++;
+  }
+
+  for (const s of by.values()) {
+    s.deniedRuns = 0; // recount from the set per agent
+  }
+  for (const runId of deniedRunSet) {
+    const agent = agentOf.get(runId);
+    if (agent) get(agent).deniedRuns++;
+  }
+
+  for (const s of by.values()) {
+    const runs = s.runs.total;
+    s.autonomy = s.actions.governed > 0 ? clamp01((s.actions.governed - s.actions.humanGated) / s.actions.governed) : 1;
+    s.denialRate = runs > 0 ? clamp01(s.deniedRuns / runs) : 0;
+    s.volumeConfidence = runs > 0 ? runs / (runs + CONFIDENCE_K) : 0;
+    const decided = s.outcomes.success + s.outcomes.failure;
+    s.successRate = decided > 0 ? s.outcomes.success / decided : null;
+    s.maturity = clamp01(s.autonomy * (1 - s.denialRate) * s.volumeConfidence);
+    s.confidence = runs === 0 ? 'none' : runs < 10 ? 'low' : runs < 40 ? 'medium' : 'high';
+  }
+
+  return [...by.values()].sort((a, b) => b.maturity - a.maturity || b.runs.total - a.runs.total);
+}
+
+/** Convenience: stats for one agent (blank row when it has no history). */
+export function computeAgentStat(db: Db, agentId: string): AgentStats {
+  return computeAgentStats(db, [agentId]).find((s) => s.agentId === agentId) ?? blank(agentId);
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
 import { type Branding, type PublicBranding } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage } from '@/connectors'
@@ -4887,6 +4887,80 @@ function AgentTuningCard({ agentId, onSaved }: { agentId: string; onSaved?: () =
   )
 }
 
+/** Trust & maturity — "can the system let this agent run with less oversight?" A read-only roll-up of
+ *  the agent's real history: how autonomously it ran (vs. needing a human to approve), how often a human
+ *  or policy said no, and its governed run outcomes. Maturity ≠ success rate — it weights autonomy,
+ *  penalises denials, and discounts small samples so a handful of runs can't fake a track record. */
+function AgentTrustCard({ agentId }: { agentId: string }) {
+  const [s, setS] = useState<AgentStats | null>(null)
+  const [err, setErr] = useState('')
+  useEffect(() => {
+    setS(null); setErr('')
+    api.agentStats(agentId).then((r) => setS(r.stats)).catch((e) => setErr(String(e?.message || e)))
+  }, [agentId])
+
+  if (err) return null // agent the caller can't see (403) — just hide the card
+  const pct = (n: number) => Math.round(n * 100)
+  // Maturity colour keys off confidence too: an unproven agent shows neutral, not alarming red.
+  const tone = !s || s.confidence === 'none' ? 'muted' : s.maturity >= 0.66 ? 'good' : s.maturity >= 0.33 ? 'warn' : 'low'
+  const barColor = tone === 'good' ? 'bg-emerald-500' : tone === 'warn' ? 'bg-amber-500' : tone === 'low' ? 'bg-rose-500' : 'bg-muted-foreground/40'
+  const confLabel: Record<AgentStats['confidence'], string> = { none: 'no runs yet', low: 'low confidence', medium: 'building trust', high: 'well-established' }
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-2 text-sm font-medium"><Shield className="h-4 w-4 text-muted-foreground" /> Trust &amp; maturity</div>
+          {s && <Badge variant="outline" className="px-1.5 py-0 text-[10px] font-normal text-muted-foreground">{confLabel[s.confidence]}</Badge>}
+        </div>
+        {!s ? (
+          <div className="text-sm text-muted-foreground">Loading…</div>
+        ) : s.runs.total === 0 ? (
+          <div className="text-sm text-muted-foreground">No runs yet — trust is earned as this agent works. Metrics appear once it has run.</div>
+        ) : (
+          <>
+            {/* Headline maturity score + bar */}
+            <div className="space-y-1.5">
+              <div className="flex items-baseline justify-between">
+                <span className="text-2xl font-semibold tabular-nums">{pct(s.maturity)}<span className="text-sm text-muted-foreground">/100</span></span>
+                <span className="text-xs text-muted-foreground">maturity — autonomy, minus overrides, weighted by track record</span>
+              </div>
+              <div className="h-1.5 w-full overflow-hidden rounded-full bg-muted">
+                <div className={`h-full rounded-full ${barColor}`} style={{ width: `${Math.max(2, pct(s.maturity))}%` }} />
+              </div>
+            </div>
+            {/* Key metrics grid */}
+            <div className="grid grid-cols-2 gap-x-6 gap-y-2 pt-1 sm:grid-cols-4">
+              <Stat label="Runs" value={String(s.runs.total)} hint={`${s.runs.crashed} crashed`} />
+              <Stat label="Autonomy" value={`${pct(s.autonomy)}%`} hint={`${s.actions.humanGated} needed a human`} />
+              <Stat label="Overrides" value={String(s.deniedRuns)} hint={`${s.actions.rejected} rejected · ${s.actions.killswitch} killswitch`} tone={s.deniedRuns > 0 ? 'warn' : undefined} />
+              <Stat label="Outcomes" value={s.successRate === null ? '—' : `${pct(s.successRate)}%`} hint={`${s.outcomes.success}✓ ${s.outcomes.failure}✗ ${s.outcomes.inconclusive}·`} />
+            </div>
+            {(s.tasks.done + s.tasks.blocked + s.tasks.cancelled) > 0 && (
+              <div className="text-xs text-muted-foreground">Assigned tasks: {s.tasks.done} done · {s.tasks.blocked} blocked · {s.tasks.cancelled} cancelled</div>
+            )}
+            <p className="text-[11px] leading-relaxed text-muted-foreground">
+              A high outcome rate alone doesn't earn trust — an agent that needs a human to approve every action stays low-maturity
+              by design. Denials (a human or policy saying “no”) and small samples both pull the score down.
+            </p>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+/** One compact labelled metric for the trust card. */
+function Stat({ label, value, hint, tone }: { label: string; value: string; hint?: string; tone?: 'warn' }) {
+  return (
+    <div className="space-y-0.5">
+      <div className="text-[10px] uppercase tracking-wide text-muted-foreground">{label}</div>
+      <div className={`text-lg font-semibold tabular-nums ${tone === 'warn' ? 'text-amber-600 dark:text-amber-500' : ''}`}>{value}</div>
+      {hint && <div className="text-[10px] text-muted-foreground">{hint}</div>}
+    </div>
+  )
+}
+
 function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: AgentInfo[]; onSaved?: () => void }) {
   const [content, setContent] = useState('')
   const [saved, setSaved] = useState('')
@@ -4935,6 +5009,7 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
         system prompt: its role, conventions, and how it should use its tools (including when to
         <span className="font-mono text-xs"> recall</span>/<span className="font-mono text-xs">remember</span>). Applied on the agent's next session.
       </p>
+      <AgentTrustCard agentId={agentId} />
       {info?.runtime === 'claude-code' && <AgentTuningCard key={revBump} agentId={agentId} onSaved={onSaved} />}
       <Card>
         <CardContent className="space-y-3 p-4">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -233,6 +233,25 @@ export interface AgentRevision {
   createdAt: number
 }
 
+/** Per-agent trust / maturity stats (mirror of src/state/agent-stats.ts AgentStats). */
+export interface AgentStats {
+  agentId: string
+  runs: { total: number; running: number; done: number; stopped: number; crashed: number }
+  outcomes: { success: number; failure: number; inconclusive: number }
+  actions: { governed: number; humanGated: number; autoApproved: number; denied: number; rejected: number; killswitch: number; errors: number; budgetStops: number }
+  tasks: { done: number; blocked: number; cancelled: number }
+  deniedRuns: number
+  questions: number
+  firstRunAt: number | null
+  lastRunAt: number | null
+  autonomy: number
+  denialRate: number
+  successRate: number | null
+  volumeConfidence: number
+  maturity: number
+  confidence: 'none' | 'low' | 'medium' | 'high'
+}
+
 export type TaskStatus = 'todo' | 'doing' | 'blocked' | 'done' | 'cancelled'
 export interface Task {
   id: string
@@ -833,6 +852,8 @@ export const api = {
   agentCatalog: () => call<AgentCatalogResp>('GET', '/api/agents/catalog'),
   installAgentFromCatalog: (id: string) => call<{ ok: boolean; id?: string; error?: string }>('POST', `/api/agents/catalog/${encodeURIComponent(id)}/install`),
   rescanAgents: () => call<{ ok: boolean; added: string[]; updated: string[]; removed: string[]; errors: { folder: string; error: string }[]; error?: string }>('POST', '/api/agents/rescan'),
+  agentStats: (id: string) => call<{ stats: AgentStats }>('GET', `/api/agents/${encodeURIComponent(id)}/stats`),
+  agentStatsAll: () => call<{ stats: AgentStats[] }>('GET', '/api/agents/stats'),
   agentClaude: (id: string) => call<{ agent: string; runtime: string; exists: boolean; content: string; error?: string }>('GET', `/api/agents/${encodeURIComponent(id)}/claude`),
   saveAgentClaude: (id: string, content: string) => call<{ ok: boolean; error?: string }>('PUT', `/api/agents/${encodeURIComponent(id)}/claude`, { content }),
   agentConfig: (id: string) => call<{ agent: string; error?: string; description?: string; examplePrompts?: string[]; shellSecrets?: string[]; netMode?: 'open' | 'allowlist'; category?: string; icon?: string } & RuntimeTuning>('GET', `/api/agents/${encodeURIComponent(id)}/config`),


### PR DESCRIPTION
## What & why

> "shall we add agent's stats (runs, success, fails) and calc maturity — over time I wanna know which agent the system can trust more."

This adds a per-agent **trust / maturity** view that answers *"which agent can the system trust to run with less oversight?"* It's a **read-side roll-up** over signals already flowing through the governed gateway — it invents no new bookkeeping.

## How a run's success/failure is defined — the *governed* rule

There's no ground-truth "success" label for an autonomous run, so a single boolean would just be a guess. Instead each run gets a layered outcome, best-available-source wins, where a human denial or a crash can't be papered over by an optimistic self-report:

- **failure** — the run crashed, hit a denial (human reject / policy deny / killswitch / budget stop), self-reported failure, OR its dispatching task ended `blocked`
- **success** — its task ended `done`, OR the agent self-reported success on a clean, un-denied run
- **inconclusive** — otherwise (still running / no verdict)

## Maturity ≠ success rate

Success rate says "did runs go well." The trust question is different — *"run alone?"* — so:

```
maturity = autonomy × (1 − denialRate) × volumeConfidence
```

- **autonomy** = governed actions that ran without suspending for a human approval
- **denialRate** multiplies the score down hard (a human/policy "no" is the sharpest "not ready" signal)
- **volumeConfidence** = `runs / (runs + 8)` — 5 clean runs can't outrank 200

So an agent with a 95% self-reported success rate that needs a human approval **every** run stays low-maturity by design.

## Changes

- `src/state/agent-stats.ts` — the aggregator (`term_sessions` + `messages` self-reports + `approvals` + `audit_events` + `tasks`, grouped by agent).
- `GET /api/agents/:id/stats` + fleet `GET /api/agents/stats` — visibility-scoped (a member sees only agents they may run; zero-run agents included at `confidence: 'none'`).
- Web console: a **Trust & maturity** card on the agent page (headline score + autonomy / overrides / outcomes / tasks breakdown).

## Testing

- `npm run typecheck`, `npm run build`, `cd web && npm run build` — all clean.
- `npm run test:governance` — **57/57**.
- Aggregator smoke test (scratch DB): a high-success-but-always-gated agent correctly scores **0 maturity** while a clean autonomous agent tops the ranking.
- End-to-end route test (in-process authenticated server, isolated `AGENT_OS_HOME`): unauth → 401 (route reachable), authed single + fleet → 200 with real stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)