### PR TITLE
Governance: apply host rules in the engine, not the editable policy (v0.81.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.81.1] — 2026-07-10
+### Fixed
+- **Host governance now applies on every tenant, not just fresh ones.** The `net.connect`/`ssh.exec`
+  gating rules lived only in `config/policy/default.policy.json`, so a tenant with a **persisted policy**
+  that predated them (i.e. any existing workspace) silently no-op'd — enabling "Govern host access" did
+  nothing, and an ungranted `ssh` was allowed. Caught while dogfooding on the live tenant. The host
+  verdict is now applied by the **engine** (`hostGovernanceDecision` in `host-match.ts`), combined
+  most-restrictive with the editable policy's verdict in `TerminalManager.gate` — so enabling the feature
+  works regardless of the tenant's policy document, while the policy still contributes the never-tier
+  (`ssh box 'rm -rf /'` is still denied outright). The host rules were removed from the default policy
+  JSON (they're redundant with the built-in). No behaviour change for a fresh tenant.
+
 ## [0.81.0] — 2026-07-10
 ### Added
 - **Per-agent trust & maturity stats — "which agent can the system trust to run with less oversight?"**

--- a/config/policy/default.policy.json
+++ b/config/policy/default.policy.json
@@ -1,6 +1,6 @@
 {
   "id": "default@v3",
-  "description": "What your agents may do on their own vs. what needs a human. The rule of thumb: LOCAL, reversible work runs freely (editing files, running shell, calling connectors); only OUTWARD-FACING or IRREVERSIBLE effects pause. never = refused outright regardless of who approves (irreversible: destructive ops, spend over $moneyCapUsd, bulk deletes over $bulkDeleteCount — both caps live in Settings → Governance; a host marked posture=never). ask = pauses for the named approver (external email, granting a new OAuth connection, reaching a host that isn't granted). Everything else allows. Host rules (net.connect/ssh.exec) only fire when host governance is enabled in Settings → Governance.",
+  "description": "What your agents may do on their own vs. what needs a human. The rule of thumb: LOCAL, reversible work runs freely (editing files, running shell, calling connectors); only OUTWARD-FACING or IRREVERSIBLE effects pause. never = refused outright regardless of who approves (irreversible: destructive ops, spend over $moneyCapUsd, bulk deletes over $bulkDeleteCount — both caps live in Settings → Governance). ask = pauses for the named approver (external email, granting a new OAuth connection). Everything else allows. NOTE: host governance (reaching SSH/internal/DB hosts) is applied by the ENGINE when enabled in Settings → Governance — it is not expressed as rules here, so it works on every tenant regardless of this document. See docs/host-connections-plan.md.",
   "default": { "action": "allow" },
   "rules": [
     { "match": { "capability": "*", "when": { "arg": "destructive", "op": "eq", "value": true } }, "action": "never" },
@@ -11,16 +11,6 @@
 
     { "match": { "capability": "secret.put" }, "action": "ask", "approver": "admin" },
 
-    { "match": { "capability": "connector.connect" }, "action": "ask", "approver": "owner" },
-
-    { "match": { "capability": "ssh.exec", "when": { "arg": "hostPosture", "op": "eq", "value": "never" } }, "action": "never" },
-    { "match": { "capability": "ssh.exec", "when": { "arg": "hostUnknown", "op": "eq", "value": true } }, "action": "ask", "approver": "owner" },
-    { "match": { "capability": "ssh.exec", "when": { "arg": "hostAllowed", "op": "eq", "value": false } }, "action": "ask", "approver": "owner" },
-    { "match": { "capability": "ssh.exec", "when": { "arg": "hostPosture", "op": "eq", "value": "ask" } }, "action": "ask", "approver": "owner" },
-
-    { "match": { "capability": "net.connect", "when": { "arg": "hostPosture", "op": "eq", "value": "never" } }, "action": "never" },
-    { "match": { "capability": "net.connect", "when": { "arg": "hostUnknown", "op": "eq", "value": true } }, "action": "ask", "approver": "admin" },
-    { "match": { "capability": "net.connect", "when": { "arg": "hostAllowed", "op": "eq", "value": false } }, "action": "ask", "approver": "admin" },
-    { "match": { "capability": "net.connect", "when": { "arg": "hostPosture", "op": "eq", "value": "ask" } }, "action": "ask", "approver": "admin" }
+    { "match": { "capability": "connector.connect" }, "action": "ask", "approver": "owner" }
   ]
 }

--- a/docs/host-connections-plan.md
+++ b/docs/host-connections-plan.md
@@ -4,8 +4,13 @@
 > table + Connections UI) shipped in v0.73.0. **Phase 2b** (the governance engine — egress parsing,
 > `net.connect`/`ssh.exec` reclassification, `netMode`, the master switch) shipped behind
 > **Settings → Governance → "Govern host access"** (off by default): `src/governance/host-match.ts`
-> (parsing + matching), the `isShell` host block in `src/governance/enricher.ts`, the reclassification in
-> `TerminalManager.gate`, and the `net.connect`/`ssh.exec` rules in `config/policy/default.policy.json`.
+> (parsing + matching + the built-in `hostGovernanceDecision`), the `isShell` host block in
+> `src/governance/enricher.ts`, and the reclassification + decision in `TerminalManager.gate`. **The host
+> verdict is applied by the ENGINE, not the editable policy** — combined most-restrictive with the
+> policy's own verdict — so enabling the feature works on any tenant even if its persisted policy predates
+> the rules (dogfooding on 2026-07-10 caught the opposite: rules that lived only in `default.policy.json`
+> silently no-op'd on an existing tenant). The policy still contributes the never-tier (`ssh box 'rm -rf /'`
+> is still denied).
 > **Phase 2c** (credential injection) shipped: `TerminalManager.injectHostCredentials` materialises a
 > granted SSH host's vault key into a session-scoped `ssh_config` + `ssh`/`scp` PATH shim (host-scoped
 > via `IdentitiesOnly`), so a plain `ssh` authenticates without the agent handling the key — local-lane

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.81.0",
+      "version": "0.81.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.81.0",
+  "version": "0.81.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/governance-conformance.cjs
+++ b/scripts/governance-conformance.cjs
@@ -48,6 +48,7 @@ if (newestSrc > newestDist) {
 
 const { enrichArgs, autoClearsApproval } = require(path.join(ROOT, 'dist/governance/enricher'));
 const { JsonPolicyEngine } = require(path.join(ROOT, 'dist/governance/policy'));
+const { hostGovernanceDecision, stricterDecision } = require(path.join(ROOT, 'dist/governance/host-match'));
 
 const fixture = JSON.parse(fs.readFileSync(path.join(ROOT, 'test/governance/conformance.json'), 'utf8'));
 const policyDoc = JSON.parse(fs.readFileSync(path.join(ROOT, 'config/policy/default.policy.json'), 'utf8'));
@@ -76,7 +77,12 @@ for (const c of fixture.decisions) {
     const govern = netMode === 'allowlist' ? true : (args.hostUnknown === true || args.hostInternal === true || args.hostListed === true);
     if (govern) capability = args.netProtocol === 'ssh' ? 'ssh.exec' : 'net.connect';
   }
-  const got = tag(engine.classify({ capabilityId: capability, args, reasoning: '' }, ctx));
+  let decision = engine.classify({ capabilityId: capability, args, reasoning: '' }, ctx);
+  // Mirror tm.gate: host governance is applied by the engine (not the JSON), combined most-restrictive.
+  if (c.hostGrants && (capability === 'net.connect' || capability === 'ssh.exec')) {
+    decision = stricterDecision(decision, hostGovernanceDecision(capability, args));
+  }
+  const got = tag(decision);
   if (got === c.expect) pass++;
   else failures.push(`decision  ✗ ${c.name}\n            expected ${c.expect}, got ${got}  (facts: destructive=${args.destructive} risky=${args.risky} amountUsd=${args.amountUsd} deleteCount=${args.deleteCount})`);
 }

--- a/src/governance/host-match.ts
+++ b/src/governance/host-match.ts
@@ -12,6 +12,8 @@
  *
  * This is best-effort policy-layer governance, not a firewall (see the plan's §2 "honest constraint").
  */
+import type { Decision, ApprovalLevel } from '../types';
+import { riskClassForLevel } from '../types';
 
 /** The host-row protocol vocabulary (matches src/hosts/hosts.ts HostProtocol). Finer wire protocols
  *  (mysql/redis/mongo/nc) collapse to 'any' — matching is primarily by host, protocol only narrows. */
@@ -229,4 +231,38 @@ export function computeHostFacts(command: string, grants: HostGrant[]): HostFact
   if (match) { facts.hostListed = true; facts.hostAllowed = true; facts.hostPosture = match.posture; }
   else { facts.hostListed = false; facts.hostAllowed = false; }
   return facts;
+}
+
+// ── the built-in host-governance decision (engine-level, Phase 2b) ────────────────────
+
+/**
+ * The host-governance verdict, computed IN CODE from the enriched facts — applied by the gate whenever
+ * host governance is enabled, independent of the editable policy document. This is the fix for the
+ * propagation gap: a tenant whose persisted policy predates the host rules still gets governed, because
+ * the rules live here, not in the JSON the tenant may never have adopted. The editable policy still
+ * contributes the never-tier (destructive / over-cap spend / bulk delete) via its `*` rules; the gate
+ * combines the two with `stricterDecision` (the more restrictive wins), so `ssh box 'rm -rf /'` is still
+ * denied. Per-host `posture` is the owner's knob; the approval LEVEL is fixed by capability
+ * (ssh.exec → owner, net.connect → admin/head). Only meaningful for the reclassified host capabilities.
+ */
+export function hostGovernanceDecision(capability: string, facts: Record<string, unknown>): Decision {
+  const level: ApprovalLevel = capability === 'ssh.exec' ? 'owner' : 'head';
+  const rc = riskClassForLevel(level);
+  if (facts.hostPosture === 'never') return { effect: 'deny', riskClass: 'deny', reason: `${capability}: host posture is never` };
+  if (facts.hostUnknown === true) return { effect: 'approve', level, riskClass: rc, reason: `${capability}: host could not be identified` };
+  if (facts.hostAllowed === false) return { effect: 'approve', level, riskClass: rc, reason: `${capability}: host is not a granted connection` };
+  if (facts.hostPosture === 'ask') return { effect: 'approve', level, riskClass: rc, reason: `${capability}: host posture is ask` };
+  return { effect: 'allow', riskClass: 'green', reason: `${capability}: granted host` };
+}
+
+/** Restrictiveness rank of a decision: deny (3) > approve@owner (2) > approve@head (1) > allow (0). */
+export function decisionRank(d: Decision): number {
+  if (d.effect === 'deny') return 3;
+  if (d.effect === 'approve') return d.level === 'owner' ? 2 : 1;
+  return 0;
+}
+
+/** The more restrictive of two decisions (a tie keeps `a` — the editable-policy verdict). */
+export function stricterDecision(a: Decision, b: Decision): Decision {
+  return decisionRank(b) > decisionRank(a) ? b : a;
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,6 +15,7 @@ import { Db } from './state/db';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
 import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval } from './governance/enricher';
+import { hostGovernanceDecision, stricterDecision } from './governance/host-match';
 import { Audience, resolveRecipients } from './governance/recipients';
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
@@ -1212,7 +1213,14 @@ export class TerminalManager {
       }
     }
     const attempt: ActionAttempt = { capabilityId: capability, args, reasoning };
-    const decision: Decision = this.os.policy.classify(attempt, this.ctx(sessionId, agent));
+    let decision: Decision = this.os.policy.classify(attempt, this.ctx(sessionId, agent));
+    // Host governance is applied by the ENGINE (not the editable policy), so enabling it works on any
+    // tenant even if its persisted policy predates the host rules. Combine with the policy verdict, most
+    // restrictive wins — so the never-tier (`ssh box 'rm -rf /'`) still denies, while an ungranted reach
+    // still pauses even when the tenant's policy has no host rule. Only for reclassified host caps.
+    if (hostGrants && (capability === 'net.connect' || capability === 'ssh.exec')) {
+      decision = stricterDecision(decision, hostGovernanceDecision(capability, args));
+    }
     this.audit(sessionId, agent, 'gate.attempt', { capability, args, reasoning });
     this.audit(sessionId, agent, 'gate.decision', { capability, decision });
 


### PR DESCRIPTION
**Bug caught while dogfooding host governance on the live tenant.** Enabling "Govern host access" did nothing — an ungranted `ssh` was allowed. Root cause: the `net.connect`/`ssh.exec` gating rules lived only in `config/policy/default.policy.json`, so a tenant with a **persisted policy** that predated them (i.e. *any* existing workspace) never had them. New default-policy rules don't propagate to existing tenants.

## Fix — host rules are now engine-level
- `hostGovernanceDecision(capability, facts)` in `host-match.ts` computes the verdict in code: posture `never` → deny; `hostUnknown` / `hostAllowed:false` / posture `ask` → approve (ssh.exec → owner, net.connect → admin); granted → allow.
- `TerminalManager.gate` combines it **most-restrictive** (`stricterDecision`) with the editable policy's verdict — so the never-tier (`ssh box 'rm -rf /'`) still denies outright, while host gating no longer depends on the tenant's policy doc.
- Removed the now-redundant host rules from `default.policy.json`.

Result: enabling the feature works on **every** tenant regardless of its policy document. No behaviour change for a fresh tenant.

## Verification
- **15 checks**: unit (decision matrix + `stricterDecision` combine) + **e2e `tm.gate` on a tenant whose policy has NO host rules** → ungranted `ssh` still pends, granted allows, `never` denies, destructive-ssh denies.
- Governance conformance **57/57** (now exercised via the engine path). `tsc` clean.

Follow-up to the Phase 2 arc (`docs/host-connections-plan.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)