### PR TITLE
Human 👍/👎 verdict on a run + fleet maturity badges (v0.82.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.82.0] — 2026-07-10
+### Added
+- **Human 👍/👎 verdict on a finished run — the ground-truth signal for the maturity score.** A member who
+  oversaw a run can rate it from the Sessions list (grid + list views); the verdict becomes the
+  **highest-confidence outcome layer** in `src/state/agent-stats.ts`, sitting above the agent's own
+  self-report and even a task result (`up` → success, `down` → failure; clicking the active thumb clears
+  it). So a run the agent optimistically self-reported `success` flips to a failure the moment a human
+  thumbs it down. `POST /api/sessions/:id/rate` (`{rating: 'up'|'down'|null}`, gated by the same
+  can-view-session rule as stop), persisted on `term_sessions` (`rating`/`rated_by`/`rated_at`), audited
+  `session.rated`. `AgentStats` gains a `rated: {up, down}` tally, shown on the agent Trust card.
+- **Maturity surfaced across the fleet.** Beyond the per-agent Trust card, each agent chip on the Agents
+  page (grid + split rail) now carries a compact **maturity badge** (score + confidence, coloured by band,
+  hidden until an agent has run) — trust-at-a-glance across the whole fleet, fed by `GET /api/agents/stats`.
+
 ## [0.81.1] — 2026-07-10
 ### Fixed
 - **Host governance now applies on every tenant, not just fresh ones.** The `net.connect`/`ssh.exec`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.81.1",
+  "version": "0.82.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.81.1",
+      "version": "0.82.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.81.1",
+  "version": "0.82.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1455,6 +1455,18 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
     return sendJson(res, 200, { ok: tm.stopSession(id, me.email) });
   }
+  // Human verdict on a finished run — 👍/👎 (or null to clear). The ground-truth signal for the agent
+  // maturity score. Same per-member gate as stop: you can rate any run you're allowed to see.
+  const rateMatch = p.match(/^\/api\/sessions\/([\w-]+)\/rate$/);
+  if (method === 'POST' && rateMatch) {
+    const id = rateMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
+    const b = await readBody(req);
+    const rating = b.rating;
+    if (rating !== 'up' && rating !== 'down' && rating !== null) return sendJson(res, 400, { error: "rating must be 'up', 'down', or null" });
+    return sendJson(res, 200, tm.rateSession(id, me, rating));
+  }
   // Deliberately resume a stopped session: lift the stop-block so the ttyd attach wrapper resurrects it
   // (`claude --resume`) on the next reconnect. The actual relaunch happens in attach.sh when the terminal
   // (re)connects; this just clears the "stay stopped" sentinel. Same per-member gate as stop.

--- a/src/state/agent-stats.ts
+++ b/src/state/agent-stats.ts
@@ -4,14 +4,17 @@
  * signals already flowing through the governed gateway (audit_events), the sessions table, the
  * inbox self-reports (messages), the approvals plane, and the tasks board.
  *
- * A run's outcome is scored by the GOVERNED rule (a human denial or a crash can't be papered over
- * by an optimistic self-report):
+ * A run's outcome is scored best-available-source-wins, so an optimistic self-report can't paper over
+ * a human's judgement or a crash:
  *
- *   failure       if the run crashed, hit a denial (human reject / policy deny / killswitch /
- *                 budget stop), self-reported failure, OR its dispatching task ended `blocked`
- *   success       if its dispatching task ended `done`, OR the agent self-reported success on a
- *                 clean, un-denied run
- *   inconclusive  otherwise (still running, or ended with no verdict either way)
+ *   1. HUMAN VERDICT (ground truth) — a 👍/👎 a person gave the finished run trumps everything:
+ *      rating 'up' → success, 'down' → failure. This is the only true signal; when present, use it.
+ *   2. Otherwise the GOVERNED rule:
+ *        failure       run crashed, hit a denial (human reject / policy deny / killswitch / budget
+ *                      stop), self-reported failure, OR its dispatching task ended `blocked`
+ *        success       its dispatching task ended `done`, OR the agent self-reported success on a
+ *                      clean, un-denied run
+ *        inconclusive  otherwise (still running, or ended with no verdict either way)
  *
  * Maturity is NOT the success rate — it answers a different question ("trust to run alone"):
  *
@@ -45,6 +48,8 @@ export interface AgentStats {
     budgetStops: number;   // budget.exceeded
   };
   tasks: { done: number; blocked: number; cancelled: number };
+  /** Human 👍/👎 verdicts on this agent's runs — the ground-truth outcome signal. */
+  rated: { up: number; down: number };
   /** Distinct runs that hit any denial (reject / policy deny / killswitch / budget stop). */
   deniedRuns: number;
   /** question.asked — times the agent blocked on a human decision. */
@@ -60,7 +65,7 @@ export interface AgentStats {
   confidence: 'none' | 'low' | 'medium' | 'high';
 }
 
-interface SessionRow { id: string; agent: string; status: string; spawned_by: string | null; created_at: number; updated_at: number | null; }
+interface SessionRow { id: string; agent: string; status: string; spawned_by: string | null; created_at: number; updated_at: number | null; rating: string | null; }
 
 function blank(agentId: string): AgentStats {
   return {
@@ -69,6 +74,7 @@ function blank(agentId: string): AgentStats {
     outcomes: { success: 0, failure: 0, inconclusive: 0 },
     actions: { governed: 0, humanGated: 0, autoApproved: 0, denied: 0, rejected: 0, killswitch: 0, errors: 0, budgetStops: 0 },
     tasks: { done: 0, blocked: 0, cancelled: 0 },
+    rated: { up: 0, down: 0 },
     deniedRuns: 0,
     questions: 0,
     firstRunAt: null,
@@ -100,7 +106,7 @@ export function computeAgentStats(db: Db, agentIds?: string[]): AgentStats[] {
 
   // ── 1. sessions → runs, status counts, activity window; and the run_id → agent join map ──
   const sessions = db.prepare(
-    'SELECT id, agent, status, spawned_by, created_at, COALESCE(updated_at, created_at) AS updated_at FROM term_sessions'
+    'SELECT id, agent, status, spawned_by, rating, created_at, COALESCE(updated_at, created_at) AS updated_at FROM term_sessions'
   ).all() as unknown as SessionRow[];
   const agentOf = new Map<string, string>();      // session id → agent
   const spawnedByOf = new Map<string, string | null>();
@@ -111,6 +117,8 @@ export function computeAgentStats(db: Db, agentIds?: string[]): AgentStats[] {
     statusOf.set(r.id, r.status);
     const s = get(r.agent);
     s.runs.total++;
+    if (r.rating === 'up') s.rated.up++;
+    else if (r.rating === 'down') s.rated.down++;
     if (r.status === 'running') s.runs.running++;
     else if (r.status === 'stopped') s.runs.stopped++;
     else if (r.status === 'crashed') s.runs.crashed++;
@@ -180,7 +188,11 @@ export function computeAgentStats(db: Db, agentIds?: string[]): AgentStats[] {
     const self = selfOutcome.get(r.id);
     const sb = spawnedByOf.get(r.id) ?? null;
     const taskStat = sb && sb.startsWith('task:') ? taskStatus.get(sb.slice('task:'.length)) : undefined;
-    if (crashed || denied || self === 'failure' || taskStat === 'blocked') s.outcomes.failure++;
+    // 1. A human's explicit verdict is ground truth — it trumps the governed heuristics below.
+    if (r.rating === 'up') s.outcomes.success++;
+    else if (r.rating === 'down') s.outcomes.failure++;
+    // 2. Otherwise fall back to the governed rule.
+    else if (crashed || denied || self === 'failure' || taskStat === 'blocked') s.outcomes.failure++;
     else if (taskStat === 'done' || (self === 'success' && !denied && r.status === 'done')) s.outcomes.success++;
     else s.outcomes.inconclusive++;
   }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -534,6 +534,14 @@ function migrate(db: Db): void {
   // How a dispatched task session runs (headless work-to-completion vs. an attachable interactive TUI).
   // Older `tasks` rows (created before this column) default to today's behavior: headless.
   addColumn(db, 'tasks', 'mode', "TEXT NOT NULL DEFAULT 'headless'");
+
+  // Human verdict on a finished run — the ground-truth signal for the agent maturity score (a person
+  // who oversaw the run says it did / didn't do what they wanted). One verdict per session, latest wins.
+  // Feeds src/state/agent-stats.ts as the HIGHEST-confidence outcome layer, above the agent's own
+  // self-report and even a task result.
+  addColumn(db, 'term_sessions', 'rating', 'TEXT');       // 'up' | 'down' | NULL (unrated)
+  addColumn(db, 'term_sessions', 'rated_by', 'TEXT');     // member id who gave the verdict
+  addColumn(db, 'term_sessions', 'rated_at', 'INTEGER');  // when (epoch ms)
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -145,6 +145,13 @@ export interface Session {
   /** Last time the session's status changed (report/end/stop/resume/crash); = createdAt until the
    *  first transition. Lets the sessions list sort by recent activity, not just creation. */
   updatedAt: number;
+  /** Human verdict on the finished run — a person who oversaw it saying it did ('up') / didn't ('down')
+   *  do what they wanted. The ground-truth signal for the agent maturity score. Undefined = unrated. */
+  rating?: 'up' | 'down';
+  /** The member id / display name who gave the verdict (for the byline). */
+  ratedBy?: string;
+  ratedByLabel?: string;
+  ratedAt?: number;
 }
 
 export interface FeedMessage {
@@ -201,6 +208,9 @@ interface SessionRow {
   run_as: string | null;
   created_at: number;
   updated_at: number;
+  rating: string | null;
+  rated_by: string | null;
+  rated_at: number | null;
 }
 interface MessageRow {
   id: string;
@@ -375,6 +385,7 @@ export class TerminalManager {
       resumable: resumable.has(r.id),
       spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as),
       runAsLabel: this.runAsLabel(r.run_as),
+      ratedByLabel: this.runAsLabel(r.rated_by),
     }));
   }
 
@@ -1817,6 +1828,23 @@ export class TerminalManager {
     return true;
   }
 
+  /**
+   * A human verdict on a finished run — 'up' (did what I wanted) / 'down' (didn't) / null (clear it).
+   * The ground-truth signal that feeds the agent maturity score above self-report + task result. One
+   * verdict per session (latest wins); the caller must be allowed to see the session (checked upstream).
+   */
+  rateSession(sessionId: string, by: Member, rating: 'up' | 'down' | null): { ok: boolean; error?: string } {
+    const r = this.db.prepare('SELECT id, agent FROM term_sessions WHERE id = ?').get<{ id: string; agent: string }>(sessionId);
+    if (!r) return { ok: false, error: 'unknown session' };
+    if (rating === null) {
+      this.db.prepare('UPDATE term_sessions SET rating = NULL, rated_by = NULL, rated_at = NULL WHERE id = ?').run(sessionId);
+    } else {
+      this.db.prepare('UPDATE term_sessions SET rating = ?, rated_by = ?, rated_at = ? WHERE id = ?').run(rating, by.id, Date.now(), sessionId);
+    }
+    this.audit(sessionId, by.email, 'session.rated', { rating, agent: r.agent });
+    return { ok: true };
+  }
+
   /** Path of a session's "do not auto-resurrect" sentinel (see stopSession / attach.sh). */
   private stopMarkerPath(sessionId: string): string | null {
     return this.os.paths ? path.join(this.os.paths.connectors, `session-${sessionId}.stopped`) : null;
@@ -2123,7 +2151,7 @@ function titleFromSummary(summary: string): string {
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown } from 'lucide-react'
 import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -182,6 +182,20 @@ function RuntimeBadge({ runtime }: { runtime: AgentInfo['runtime'] }) {
     <Badge variant={claude ? 'default' : 'secondary'} className="px-1.5 py-0 text-[10px] font-normal">
       {claude ? 'claude' : 'mock'}
     </Badge>
+  )
+}
+
+/** Compact fleet-wide trust signal on an agent chip — the maturity score (0–100), coloured by band.
+ *  Renders nothing until the agent has run (confidence 'none'), so an unproven agent isn't badged. */
+function MaturityBadge({ s, className = '' }: { s?: AgentStats; className?: string }) {
+  if (!s || s.confidence === 'none' || s.runs.total === 0) return null
+  const m = Math.round(s.maturity * 100)
+  const tone = s.maturity >= 0.66 ? 'text-emerald-600 border-emerald-500/40 dark:text-emerald-500' : s.maturity >= 0.33 ? 'text-amber-600 border-amber-500/40 dark:text-amber-500' : 'text-rose-600 border-rose-500/40 dark:text-rose-500'
+  return (
+    <span className={`inline-flex shrink-0 items-center gap-0.5 rounded border px-1 py-0 text-[10px] font-medium tabular-nums ${tone} ${className}`}
+      title={`maturity ${m}/100 · ${s.runs.total} run${s.runs.total === 1 ? '' : 's'} · ${Math.round(s.autonomy * 100)}% autonomous · ${s.confidence} confidence — trust to run with less oversight`}>
+      <Shield className="h-2.5 w-2.5" /> {m}
+    </span>
   )
 }
 
@@ -643,6 +657,11 @@ function Console({ me }: { me: Member }) {
     await api.stopSession(id)
     setSessions(await api.sessions())
   }
+  // Human verdict on a finished run — feeds the agent maturity score. Clicking the active thumb clears it.
+  const rateSession = async (id: string, rating: 'up' | 'down' | null) => {
+    await api.rateSession(id, rating)
+    setSessions(await api.sessions())
+  }
   const deleteSession = async (id: string, tmux: string) => {
     if (!confirm('Delete this session? Its inbox messages and transcript files are removed; the audit log is kept.')) return
     await api.deleteSession(id)
@@ -873,7 +892,7 @@ function Console({ me }: { me: Member }) {
         <div className={`min-h-0 flex-1 ${fullBleed ? '' : 'overflow-y-auto p-6'}`}>
           {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onDuplicate={duplicateAgent} onRescan={rescanAgents} onImport={importAgent} onRefresh={refreshState} />}
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); nav('agents', id) }} />}
-          {route === 'sessions' && <SessionsPage me={me} sessions={sessions} waiting={waiting} selected={selected} hiddenTabs={hiddenTabs} onOpen={openTerminal} onCloseTab={closeTab} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
+          {route === 'sessions' && <SessionsPage me={me} sessions={sessions} waiting={waiting} selected={selected} hiddenTabs={hiddenTabs} onOpen={openTerminal} onCloseTab={closeTab} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onRate={rateSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} />}
           {route === 'connectors' && <ConnectionsPage me={me} tab={detail} onTab={(t) => nav('connectors', t)} />}
           {route === 'team' && <TeamPage me={me} />}
@@ -947,6 +966,13 @@ function AgentsPage({
   const [view, setView] = useState<AgentsView>(() => (localStorage.getItem(AGENTS_VIEW_KEY) === 'grid' ? 'grid' : 'split'))
   const setViewPersist = (v: AgentsView) => { setView(v); localStorage.setItem(AGENTS_VIEW_KEY, v) }
   const [query, setQuery] = useState('')
+  // Fleet-wide maturity, keyed by agent id — the trust-at-a-glance signal on each agent chip.
+  const [maturity, setMaturity] = useState<Record<string, AgentStats>>({})
+  useEffect(() => {
+    let ok = true
+    api.agentStatsAll().then((r) => { if (ok) setMaturity(Object.fromEntries(r.stats.map((s) => [s.agentId, s]))) }).catch(() => {})
+    return () => { ok = false }
+  }, [])
 
   // The chosen agent is driven by the URL (`#/agents/<id>`) so a refresh keeps it. When the URL names
   // no agent (a bare `#/agents`), fall back to the last one you used (remembered across visits) then
@@ -1132,6 +1158,7 @@ function AgentsPage({
                       <span className="flex flex-wrap items-center gap-1">
                         <RuntimeBadge runtime={a.runtime} />
                         {a.builtIn && <BuiltInBadge />}
+                        <MaturityBadge s={maturity[a.id]} />
                       </span>
                       {a.description && <span className="line-clamp-2 text-[11px] text-muted-foreground">{a.description}</span>}
                     </button>
@@ -1158,7 +1185,10 @@ function AgentsPage({
                     <button key={a.id} type="button" onClick={() => pick(a.id)} title={a.description} className={'flex w-full items-center gap-1.5 rounded-md px-2 py-1.5 text-left text-sm transition ' + (active ? 'bg-muted font-medium text-foreground' : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground')}>
                       <AgentIcon icon={a.icon} className="h-3.5 w-3.5 shrink-0" />
                       <span className="truncate">{a.id}</span>
-                      {a.builtIn && <span className="ml-auto shrink-0"><BuiltInBadge /></span>}
+                      <span className="ml-auto flex shrink-0 items-center gap-1">
+                        <MaturityBadge s={maturity[a.id]} />
+                        {a.builtIn && <BuiltInBadge />}
+                      </span>
                     </button>
                   )
                 })}
@@ -1441,8 +1471,26 @@ function ImageDropZone({ session, children, onActivity, fontSize, setFontSize }:
   )
 }
 
+/** 👍/👎 verdict on a finished run — the ground-truth signal that feeds the agent's maturity score.
+ *  Clicking the already-active thumb clears the verdict. */
+function RunRating({ session, onRate }: { session: Session; onRate: (id: string, r: 'up' | 'down' | null) => void }) {
+  const r = session.rating
+  const set = (v: 'up' | 'down') => onRate(session.id, r === v ? null : v)
+  const rated = r ? `rated ${r === 'up' ? '👍' : '👎'}${session.ratedByLabel ? ' by ' + session.ratedByLabel : ''} — feeds agent maturity` : 'rate this run — feeds the agent maturity score'
+  return (
+    <span className="inline-flex items-center gap-0.5" title={rated}>
+      <button onClick={(e) => { e.stopPropagation(); set('up') }} className={`rounded p-0.5 hover:bg-muted ${r === 'up' ? 'text-emerald-600 dark:text-emerald-500' : 'text-muted-foreground'}`} title="thumbs up — this run did what I wanted" aria-label="rate up">
+        <ThumbsUp className="h-3 w-3" />
+      </button>
+      <button onClick={(e) => { e.stopPropagation(); set('down') }} className={`rounded p-0.5 hover:bg-muted ${r === 'down' ? 'text-rose-600 dark:text-rose-500' : 'text-muted-foreground'}`} title="thumbs down — this run didn't do what I wanted" aria-label="rate down">
+        <ThumbsDown className="h-3 w-3" />
+      </button>
+    </span>
+  )
+}
+
 function SessionsPage({
-  me, sessions, waiting, selected, hiddenTabs, onOpen, onCloseTab, onActivity, onSpawn, onStop, onDelete, onBulkStop, onBulkDelete, urlQuery, onFiltersChange,
+  me, sessions, waiting, selected, hiddenTabs, onOpen, onCloseTab, onActivity, onSpawn, onStop, onDelete, onRate, onBulkStop, onBulkDelete, urlQuery, onFiltersChange,
 }: {
   me: Member
   sessions: Session[]
@@ -1457,6 +1505,7 @@ function SessionsPage({
   onSpawn: () => void
   onStop: (id: string) => void
   onDelete: (id: string, tmux: string) => void
+  onRate: (id: string, rating: 'up' | 'down' | null) => void
   onBulkStop: (ids: string[]) => void
   onBulkDelete: (ids: string[]) => void
   /** Current hash-query string — the persisted filter state, read once to seed the filters. */
@@ -1778,6 +1827,12 @@ function SessionsPage({
                   <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
                 </div>
               </button>
+              {/* Human verdict — only for finished runs; stays visible once rated, faint-until-hover otherwise. */}
+              {!isLive(s) && (
+                <div className={`mt-1.5 transition-opacity ${s.rating ? '' : 'opacity-40 group-hover:opacity-100'}`}>
+                  <RunRating session={s} onRate={onRate} />
+                </div>
+              )}
               <div className="mt-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                 {canResume(s) && (
                   <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-emerald-600" onClick={() => resumeAndOpen(s, onOpen)} title="reopen and continue this session (claude --resume)">
@@ -1834,6 +1889,10 @@ function SessionsPage({
                 <span className="w-20 shrink-0 text-xs tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
                 <span className="w-16 shrink-0 text-xs text-muted-foreground">{statusLabel(s)}</span>
               </button>
+              {/* Human verdict — finished runs only; stays visible once rated, faint-until-hover otherwise. */}
+              <div className={`shrink-0 transition-opacity ${!isLive(s) ? (s.rating ? '' : 'opacity-40 group-hover:opacity-100') : 'invisible'}`}>
+                {!isLive(s) && <RunRating session={s} onRate={onRate} />}
+              </div>
               <div className="flex w-32 shrink-0 items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                 {canResume(s) && (
                   <Button size="icon" variant="ghost" className="h-7 w-7 text-emerald-600" onClick={() => resumeAndOpen(s, onOpen)} title="resume — reopen and continue this session (claude --resume)">
@@ -4936,12 +4995,18 @@ function AgentTrustCard({ agentId }: { agentId: string }) {
               <Stat label="Overrides" value={String(s.deniedRuns)} hint={`${s.actions.rejected} rejected · ${s.actions.killswitch} killswitch`} tone={s.deniedRuns > 0 ? 'warn' : undefined} />
               <Stat label="Outcomes" value={s.successRate === null ? '—' : `${pct(s.successRate)}%`} hint={`${s.outcomes.success}✓ ${s.outcomes.failure}✗ ${s.outcomes.inconclusive}·`} />
             </div>
-            {(s.tasks.done + s.tasks.blocked + s.tasks.cancelled) > 0 && (
-              <div className="text-xs text-muted-foreground">Assigned tasks: {s.tasks.done} done · {s.tasks.blocked} blocked · {s.tasks.cancelled} cancelled</div>
-            )}
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+              {(s.rated.up + s.rated.down) > 0 && (
+                <span>Human verdicts: <span className="text-emerald-600 dark:text-emerald-500">{s.rated.up}👍</span> · <span className="text-rose-600 dark:text-rose-500">{s.rated.down}👎</span></span>
+              )}
+              {(s.tasks.done + s.tasks.blocked + s.tasks.cancelled) > 0 && (
+                <span>Assigned tasks: {s.tasks.done} done · {s.tasks.blocked} blocked · {s.tasks.cancelled} cancelled</span>
+              )}
+            </div>
             <p className="text-[11px] leading-relaxed text-muted-foreground">
               A high outcome rate alone doesn't earn trust — an agent that needs a human to approve every action stays low-maturity
-              by design. Denials (a human or policy saying “no”) and small samples both pull the score down.
+              by design. Denials (a human or policy saying “no”) and small samples both pull the score down. Rate a finished run
+              👍/👎 from the Sessions list to feed the score a ground-truth verdict.
             </p>
           </>
         )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -131,6 +131,11 @@ export interface Session {
   /** Last time the session's status changed (report/end/stop/resume/crash); = createdAt until the
    *  first transition. Sortable "Updated" column on the sessions list. */
   updatedAt: number
+  /** Human verdict on the finished run — 👍 ('up') / 👎 ('down'); feeds the agent maturity score. */
+  rating?: 'up' | 'down'
+  ratedBy?: string
+  ratedByLabel?: string
+  ratedAt?: number
 }
 export interface AuditEvent {
   id: number
@@ -240,6 +245,7 @@ export interface AgentStats {
   outcomes: { success: number; failure: number; inconclusive: number }
   actions: { governed: number; humanGated: number; autoApproved: number; denied: number; rejected: number; killswitch: number; errors: number; budgetStops: number }
   tasks: { done: number; blocked: number; cancelled: number }
+  rated: { up: number; down: number }
   deniedRuns: number
   questions: number
   firstRunAt: number | null
@@ -759,6 +765,7 @@ export const api = {
   messages: () => call<Msg[]>('GET', '/api/messages'),
   run: (agent: string, task: string) => call<{ id: string; tmux: string; error?: string }>('POST', '/api/sessions', { agent, task }),
   stopSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/stop`),
+  rateSession: (id: string, rating: 'up' | 'down' | null) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/rate`, { rating }),
   /** Lift the stop-block so a stopped session resurrects (claude --resume) on the next terminal open. */
   resumeSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/resume`),
   deleteSession: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/sessions/' + id),


### PR DESCRIPTION
## What & why

Follow-up to the maturity feature (#147). Adds the one true signal that was missing: an explicit **human verdict** on a finished run, plus surfaces maturity across the fleet.

## Human 👍/👎 — the ground-truth outcome layer

A member who oversaw a run rates it 👍/👎 from the **Sessions list** (grid + list views). That verdict becomes the **highest-confidence outcome layer** in `agent-stats.ts`, sitting *above* the agent's own self-report and even a task result:

- `up` → success, `down` → failure — trumps the governed heuristics
- clicking the active thumb clears the verdict (back to the derived outcome)

So a run the agent optimistically self-reported `success` **flips to a failure** the moment a human thumbs it down. Verified end-to-end.

- `POST /api/sessions/:id/rate` — `{rating: 'up'|'down'|null}`, gated by the same can-view-session rule as stop.
- Persisted on `term_sessions` (`rating`/`rated_by`/`rated_at`); audited `session.rated`.
- `AgentStats` gains `rated: {up, down}`, shown on the agent Trust card.

## Maturity surfaced across the fleet

Answering *"where all are we surfacing this?"* — beyond the per-agent Trust card, every agent chip on the **Agents page** (grid + split rail) now carries a compact **maturity badge** (score + confidence, coloured by band, hidden until an agent has run), fed by `GET /api/agents/stats`. Trust-at-a-glance across the whole fleet.

## Testing

- `npm run typecheck`, `npm run build`, `cd web && npm run build` — clean.
- `npm run test:governance` — **57/57**.
- E2E (in-process authed server, isolated home): bad payload → 400; 👎 → 200 and the aggregator flips a self-reported `success` to `failure` with `rated.down=1`; clearing reverts. All PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)