### PR TITLE
Scheduler concurrency cap AOS_MAX_CONCURRENT_SESSIONS (v0.82.0, #137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.83.0] — 2026-07-10
+### Added
+- **Scheduler concurrency cap `AOS_MAX_CONCURRENT_SESSIONS` (#137).** Defense-in-depth against the
+  OOM bursts that drove the instawp crash rate (49/113 sessions): when set, the automation scheduler
+  stops firing NEW cron / one-shot / task-dispatch spawns once that many sessions are already alive on
+  the box, and resumes as they finish. A deferred cron isn't stamped `lastFiredAt` (a `once` isn't
+  disabled), so it simply re-fires on the next tick — no queue. **Interactive and chat spawns are never
+  gated** (a human is waiting; a chat spawn has no natural retry) but they DO count toward the total, so
+  the scheduler backs off when a human is already loading the box. Fail-open if tmux liveness can't be
+  polled. Default **0 = unlimited** (opt-in; set per box to its RAM). Deferrals are audited as
+  `scheduler.deferred`. NB: the "false `crashed` episodes pollute the learning loop" worry from the
+  issue was unfounded — a spawn-death with zero work already skips the episode (`composeEpisode` returns
+  null); only a run OOM-killed mid-work records `crashed`, which needs a kill-cause breadcrumb to
+  distinguish infra-kill from a real crash (left as a follow-up).
+
 ## [0.82.0] — 2026-07-10
 ### Added
 - **Human 👍/👎 verdict on a finished run — the ground-truth signal for the maturity score.** A member who

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.82.0",
+      "version": "0.83.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.82.0",
+  "version": "0.83.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -231,6 +231,10 @@ export function buildTaskPrompt(t: { id: string; title: string; body: string }):
 export class Automations {
   private readonly db: Db;
   private timer?: NodeJS.Timeout;
+  // Whole-box concurrency cap: the scheduler stops firing NEW cron/task spawns once this many sessions
+  // are alive (defense-in-depth against an OOM-inducing burst — see #137). Interactive/chat spawns are
+  // never gated (a human is waiting; a chat spawn has no natural retry). 0 = unlimited (opt-in per box).
+  private readonly maxConcurrent = Number(process.env.AOS_MAX_CONCURRENT_SESSIONS) || 0;
 
   constructor(
     private readonly os: AgentOS,
@@ -664,13 +668,22 @@ export class Automations {
   /** One scheduler pass — public so tests (and a future "catch-up" boot pass) can drive it. */
   tick(now: Date): void {
     const minute = Math.floor(now.getTime() / 60_000);
+    // Whole-box concurrency cap (#137). When set, count sessions already alive and stop firing NEW
+    // scheduler spawns once we hit the ceiling — a deferred cron/one-shot isn't stamped `lastFiredAt`
+    // (and a `once` isn't disabled), so it simply RE-FIRES next tick. No queue needed. 0 = unlimited.
+    const cap = this.maxConcurrent;
+    let running = cap > 0 ? this.tm.aliveSessionCount() : 0;
+    let deferred = 0;
+    const overCap = (): boolean => cap > 0 && running >= cap;
     for (const a of this.list()) {
       if (!a.enabled) continue;
       // One-shot deferred tasks: fire once when due, then disable so they never re-fire.
       if (a.type === 'once') {
         if (!a.runAt || a.lastFiredAt || now.getTime() < a.runAt) continue;
+        if (overCap()) { deferred++; continue; } // over cap → leave enabled; retry next tick
         try {
           this.fire(a, { guard: false, runAs: a.runAs });
+          running++;
         } catch {
           // a one-shot that errors on spawn shouldn't loop forever — fall through and disable it
         }
@@ -686,9 +699,15 @@ export class Automations {
       }
       if (!cronMatches(spec, now)) continue;
       if (a.lastFiredAt && Math.floor(a.lastFiredAt / 60_000) === minute) continue; // already fired this minute
-      this.fire(a, { guard: true });
+      if (overCap()) { deferred++; continue; } // over cap → not stamped, so it re-fires next tick
+      const r = this.fire(a, { guard: true });
+      if (r.ok) running++;
     }
-    this.dispatchTasks();
+    // Tasks share the same budget — dispatch only up to the remaining headroom (Infinity when uncapped).
+    this.dispatchTasks(cap > 0 ? Math.max(0, cap - running) : Infinity);
+    if (deferred > 0) {
+      this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'scheduler', type: 'scheduler.deferred', data: { deferred, cap, running } });
+    }
     this.sweepOverdue(now);
   }
 
@@ -716,8 +735,9 @@ export class Automations {
    * per tick (don't stack a second on an agent already running a task session — the per-agent concurrency
    * cap). Guarded + attempt-ceilinged inside dispatchTask. Wrapped so a bad row never kills the scheduler.
    */
-  private dispatchTasks(): void {
+  private dispatchTasks(budget: number = Infinity): void {
     try {
+      if (budget <= 0) return; // whole-box concurrency cap already reached — dispatch nothing this tick
       // Agents already running a task session (their `task:<id>` spawn is still alive) — skip this tick.
       const busy = new Set<string>();
       for (const r of this.db
@@ -726,10 +746,11 @@ export class Automations {
         if (this.tm.isAlive(r.id)) busy.add(r.agent);
       }
       for (const t of this.os.tasks.dispatchable(this.os.tenant)) {
+        if (budget <= 0) break; // hit the concurrency cap mid-drain — the rest retry next tick
         const agentId = t.assignee!.slice('agent:'.length);
         if (busy.has(agentId)) continue;
         const r = this.dispatchTask(t.id, { guard: true });
-        if (r.ok) busy.add(agentId); // one per agent per tick
+        if (r.ok) { busy.add(agentId); budget--; } // one per agent per tick, and one off the cap budget
       }
     } catch {
       // never let the task sweep take down the automation scheduler

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -534,6 +534,22 @@ export class TerminalManager {
     return m ? m.name || m.email : undefined;
   }
 
+  /**
+   * How many sessions have a `running` row AND a live tmux pane right now — the whole-box concurrency
+   * measure for the scheduler cap (`AOS_MAX_CONCURRENT_SESSIONS`). Counts every provenance (interactive,
+   * chat, automation, task) since they all consume memory, so the scheduler backs off when a human is
+   * already loading the box. FAIL-OPEN: if liveness can't be polled (launcher backend / transient tmux
+   * failure) it returns 0 so a hiccup never freezes the scheduler into deferring everything.
+   */
+  aliveSessionCount(): number {
+    const alive = this.backend.aliveNames();
+    if (!alive) return 0;
+    const rows = this.db.prepare("SELECT tmux FROM term_sessions WHERE status = 'running'").all<{ tmux: string }>();
+    let n = 0;
+    for (const r of rows) if (alive.has(r.tmux)) n++;
+    return n;
+  }
+
   /** Is this session's tmux shell still alive? (The automations guard against pile-ups.) */
   isAlive(sessionId: string): boolean {
     const r = this.db.prepare('SELECT tmux, status FROM term_sessions WHERE id = ?').get<{ tmux: string; status: string }>(sessionId);


### PR DESCRIPTION
Part of #137.

## Why
The instawp crash rate (49/113 = 43%) was OOM on the pre-upgrade 8 GB box — many concurrent heavy `claude`+node+MCP processes (crons + task dispatches + smoke tests firing in the same minute). The RAM upgrade (8→16 GB) mitigated it; this is the **defense-in-depth** so a future fleet burst can't OOM even a bigger box. Trace confirmed no global concurrency limit exists — the current guards are only per-automation and per-agent-per-tick.

## What
`AOS_MAX_CONCURRENT_SESSIONS` (default **0 = unlimited / opt-in**). When set, `tick()` counts alive sessions and stops firing NEW cron / one-shot / task-dispatch spawns once at the cap; it resumes as sessions finish. A deferred cron isn't stamped `lastFiredAt` (a `once` isn't disabled), so it **re-fires next tick** — no queue needed (verified this is how the scheduler already retries).

- **Interactive & chat spawns are never gated** — a human is waiting, and a chat spawn has no natural retry — but they *count* toward the total, so the scheduler backs off under human load.
- **Fail-open**: if tmux liveness can't be polled, the count is 0 (a hiccup never freezes the scheduler).
- Deferrals audited as `scheduler.deferred {deferred, cap, running}`.

New helper `TerminalManager.aliveSessionCount()`; cap logic in `Automations.tick()` + `dispatchTasks(budget)`.

## Validation
- `npm run typecheck` / `npm run build` clean · `npm run test:governance` **57/57**
- **New behavioral test** (against compiled code, 5/5): cap=0 unchanged (5 fire, 0 deferred); cap=3 empty→fire 3 defer 2; cap=3 with 2 alive→fire 1 defer 4; cap=3 at/over cap→fire 0 defer 5 (never negative).

## Not in this PR (noted on #137)
- The "false `crashed` episodes pollute the learning loop" concern was **unfounded** — a zero-work spawn-death already skips the episode (`composeEpisode` → null). Only a run OOM-killed *mid-work* records `crashed`; distinguishing infra-kill from a real crash needs a kill-cause breadcrumb (follow-up).
- Launch-failure breadcrumb + operator-`tmux kill-server` draining to `stopped` (follow-ups).

Rollout plan: expresstech=2 (2 GB), instawp=8 (16 GB), instapods=10 (24 GB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)