### PR TITLE
Fail fast on Node < 22.5 + spec `policy reconcile` (v0.83.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.83.0] — 2026-07-10
+## [0.83.1] — 2026-07-10
+### Added
+- **Fail fast on an unsupported Node.** The OS depends on the built-in `node:sqlite` (`DatabaseSync`),
+  which only exists on Node ≥ 22.5 — but running under older Node (e.g. a box whose default `/usr/bin/node`
+  is v20 while the service uses nvm v22) crashed with a cryptic `ERR_UNKNOWN_BUILTIN_MODULE: No such
+  built-in module: node:sqlite` from deep inside a store module. A new side-effect `src/preflight.ts`,
+  imported first in `cli.ts` (before any `node:sqlite` import loads), now exits with one clear line:
+  *"agent-os requires Node >= 22.5.0 (found vX) … switch to Node 22.5+"*. Also added `engines.node
+  ">=22.5.0"` to `package.json` so `npm install` warns.
+
+### Docs
+- **Spec: `agent-os policy reconcile`** (`docs/policy-reconcile-plan.md`) — a governed command to align
+  every agent's `policyContext` to the enforced ruleset id (per-tenant or `--all`, dry-run by default,
+  audited + agent-revision snapshot), replacing the manual `sed` sweeps needed today when a tenant's
+  enforced id changes. Follow-up to the #136 mismatch warning; not yet implemented.
 ### Added
 - **Scheduler concurrency cap `AOS_MAX_CONCURRENT_SESSIONS` (#137).** Defense-in-depth against the
   OOM bursts that drove the instawp crash rate (49/113 sessions): when set, the automation scheduler

--- a/docs/policy-reconcile-plan.md
+++ b/docs/policy-reconcile-plan.md
@@ -1,0 +1,83 @@
+# Plan: `agent-os policy reconcile` — align agent `policyContext` to the enforced ruleset
+
+## Problem
+
+An agent manifest's `policyContext` names the ruleset the agent *expects* to be governed by, but the
+engine enforces exactly one loaded ruleset (`os.policy.id`) and `classify()` ignores the per-agent
+context (per-agent policy *selection* is not implemented). PR #136 made the drift **visible** — a
+`console.warn` at registration when an agent's `policyContext` diverges from `os.policy.id`. But the
+only way to *clear* that drift today is to hand-edit every agent manifest, per tenant, across every box.
+
+That hand-editing is the actual source of the operational pain we hit:
+- A tenant's enforced id changed (`default@v1` → `default@v2` → `default@v3-instapods` → `default@v3`)
+  and left N agents mismatched; each fix was a manual `sed` sweep over `agents/*/agent.json`.
+- Multi-tenant boxes multiply the work (each tenant home has its own agents and its own enforced id).
+- Ad-hoc sweeps are error-prone (e.g. `perl` interpolating an `@v3` id into nothing).
+
+There should be one governed command that reconciles the fleet to the enforced id.
+
+## Command
+
+```
+agent-os policy reconcile [--tenant <slug>|--all] [--dry-run] [--yes]
+```
+
+- Default (no `--tenant`): operate on the **apex/default tenant** (`AGENT_OS_TENANT` ?? config `tenant`),
+  matching how `agent-os tenant` resolves the default.
+- `--tenant <slug>`: reconcile one named tenant.
+- `--all`: reconcile every tenant in the control plane (`TenantStore.list()`).
+- `--dry-run`: print the diff (agent → old → new) and exit 0 without writing. **Default is dry-run**;
+  writing requires `--yes` (or an interactive confirm) — policy alignment is a fleet-wide edit.
+
+### Behaviour, per tenant
+
+1. Resolve the enforced id = the tenant's loaded ruleset id (home override
+   `<home>/policy/default.policy.json` if present, else the bundled `config/policy/default.policy.json`) —
+   read **live**, never hardcoded.
+2. For each `<home>/agents/*/agent.json`, if `policyContext` is present and `!== enforced`, rewrite it
+   to the enforced id (JSON round-trip via the manifest, not string substitution — avoids the `@`/regex
+   footguns and preserves formatting via the existing manifest writer).
+3. Leave manifests that already match, and manifests with no `policyContext`, untouched.
+4. Emit a summary: `N reconciled, M already-aligned, tenant <slug> @ <enforced-id>`.
+
+### Governance & safety
+
+- **This edits agent manifests, not the policy** — so it is NOT an approval-gated effect; it's the same
+  class as `agent-os invite`/`tenant` (a box-side admin action). It does, however, snapshot each changed
+  manifest through the existing **agent-revisions** backbone (`src/state/agent-revisions.ts`) so a bad
+  reconcile is one `agent_revert` away, and it appends an audit event per tenant:
+  `policy.reconciled { tenant, enforced, changed: [{agent, from}] }`.
+- **Never touches the policy document or its id.** Reconcile makes the agents match the policy, never the
+  reverse — consistent with the guidance that the enforced id is a fixed contract agents conform to.
+- **Live-server note:** manifests are read at agent registration, so a reconcile takes effect on the next
+  registration/rescan/restart. The command prints that reminder. (A future `--reload` could re-register in
+  place, but a restart is the reliable path today.)
+
+## Where it lives
+
+- CLI: a new `reconcile` sub-branch in `tenants()`-style dispatch, or a small `policy(rest)` handler in
+  `src/cli.ts` (mirrors `tenant <sub>`). Pure filesystem + `TenantStore`; no server required, so it runs
+  over SSH like `tenant remove`.
+- Shared core: extract `reconcileTenant(paths, enforcedId): { changed, aligned }` into
+  `src/governance/policy-reconcile.ts` (pure, unit-testable) so both the CLI and a future
+  `POST /api/admin/policy/reconcile` (superadmin, the live mirror) call the same logic — the same
+  CLI/API mirroring pattern as tenant provisioning.
+
+## Console mirror (later)
+
+The #136 warning could surface in the console **Policy** page as a banner: *"5 agents declare a
+policyContext that doesn't match the enforced `default@v3` — [Reconcile]"*, wired to the API above. This
+turns the passive warning into a one-click fix and is the natural home for the feature once the CLI exists.
+
+## Test
+
+`scripts/test-policy-reconcile.cjs`: build a temp home with a policy id `X` and agents at `X`, `Y`,
+and none; assert reconcile rewrites only the `Y` agent to `X`, leaves the others, reports `1 reconciled /
+1 aligned / 1 skipped`, and that `--dry-run` writes nothing. Run against `dist/` like the other governance
+tests.
+
+## Explicitly out of scope
+
+- Actually *honoring* `policyContext` (selecting among multiple registered rulesets at classify time) —
+  that's the larger "per-agent policy selection" feature PR #136 flagged as future work. Reconcile is the
+  cheap, correct stopgap: make the declared context true by conforming it to the one enforced ruleset.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.83.0",
+  "version": "0.83.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
+  "engines": {
+    "node": ">=22.5.0"
+  },
   "main": "dist/index.js",
   "bin": {
     "agent-os": "bin/agent-os"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@
  *   agent-os demo                  run the scripted governance demo in the terminal
  *   agent-os help                  show this help
  */
+import './preflight'; // MUST be first — fail fast on Node < 22.5 before any node:sqlite import loads.
 import * as path from 'path';
 import { bootstrap, startServer } from './server';
 import { init } from './init';

--- a/src/preflight.ts
+++ b/src/preflight.ts
@@ -1,0 +1,18 @@
+/**
+ * Fail fast on an unsupported Node BEFORE any `node:sqlite` import loads and throws the cryptic
+ * `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite` from deep inside a store module.
+ * The OS depends on the built-in `node:sqlite` (`DatabaseSync`), which is only available on Node >= 22.5.
+ * This module is imported FIRST in `cli.ts` (a bare side-effect import) so the check runs before the
+ * store modules — `state/db`, `state/control` — are required.
+ */
+const [major, minor] = process.versions.node.split('.').map(Number);
+const supported = major > 22 || (major === 22 && minor >= 5);
+
+if (!supported) {
+  process.stderr.write(
+    `agent-os requires Node >= 22.5.0 (found v${process.versions.node}).\n` +
+      `It depends on the built-in node:sqlite (DatabaseSync), which is unavailable on older Node.\n` +
+      `Switch to Node 22.5+ (e.g. \`nvm use 22\`) and retry.\n`,
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## (a) Hardening: fail fast on an unsupported Node

The OS depends on the built-in **`node:sqlite`** (`DatabaseSync`), which only exists on **Node ≥ 22.5**. Running under older Node crashed with a cryptic `ERR_UNKNOWN_BUILTIN_MODULE: No such built-in module: node:sqlite` from deep inside a store module. We hit this on the jump-server: the systemd service runs nvm Node v22, but the box's default `/usr/bin/node` is v20 — so any **non-login shell** (SSH `BatchMode`, cron, an agent's `Bash` running `dist/cli.js`) died with the unhelpful error.

- New side-effect module **`src/preflight.ts`**, imported **first** in `cli.ts` (before any `node:sqlite` import loads — verified in the compiled `cli.js`: `require("./preflight")` precedes `./server`/`./kernel`/`./state/control`). It exits `1` with one clear line:
  > agent-os requires Node >= 22.5.0 (found v20.16.0) … Switch to Node 22.5+ (e.g. `nvm use 22`) and retry.
- Added **`engines.node: ">=22.5.0"`** so `npm install` warns.

Verified: guard exits `1` on a simulated v20 and passes through on current Node; `test:governance` 57/57; `tsc` clean.

## (b) Spec: `agent-os policy reconcile`

`docs/policy-reconcile-plan.md` specs a governed command to align every agent's `policyContext` to the enforced ruleset id — the missing tool that forced the manual `sed` sweeps whenever a tenant's enforced id changed. Per-tenant or `--all`, **dry-run by default**, audited (`policy.reconciled`) with an agent-revision snapshot for rollback, never touches the policy doc itself. Includes a shared pure `reconcileTenant()` for a future `POST /api/admin/policy/reconcile` + console banner. Follow-up to the #136 mismatch warning; **spec only, not implemented**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)