### PR TITLE
Durable removal of built-in agents (v0.84.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.84.0] — 2026-07-10
+### Fixed
+- **Removing a built-in agent now sticks.** A built-in agent (`agent-author`, `engineer`, `support`,
+  `marketer`, `researcher`) is seeded from the catalog into the data home on boot, so it lives under the
+  home and always showed a delete button — but deleting its folder wasn't durable: the next server boot
+  re-seeded it and the agent came back. Deleting a built-in now records a tombstone
+  (`settings.suppressed_builtins`); `seedBuiltinAgents` skips any tombstoned id, so the removal survives a
+  restart. Re-installing the agent from the agent library (`POST /api/agents/catalog/:id/install`) clears
+  the tombstone, so it seeds normally again. The console's delete confirmation now tells you a built-in can
+  be re-added later, and `agent.deleted` audit rows carry a `builtin` flag.
+
 ## [0.83.1] — 2026-07-10
 ### Added
 - **Fail fast on an unsupported Node.** The OS depends on the built-in `node:sqlite` (`DatabaseSync`),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.83.0",
+  "version": "0.84.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.83.0",
+      "version": "0.84.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.83.1",
+  "version": "0.84.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/agent-catalog.ts
+++ b/src/edge/agent-catalog.ts
@@ -109,7 +109,11 @@ export function installAgentFromCatalog(catalogDir: string | undefined, userAgen
 export function seedBuiltinAgents(os: AgentOS): void {
   if (!os.paths) return; // demo/tests run in-memory with no agents home to write into
   const catalogDir = os.paths.bundledAgents;
+  // A built-in an admin deleted is tombstoned so its removal is durable — don't restore it. Re-installing
+  // it from the agent library clears the tombstone (POST /api/agents/catalog/:id/install).
+  const suppressed = new Set(os.settings.suppressedBuiltins());
   for (const id of BUILTIN_SEED_IDS) {
+    if (suppressed.has(id)) continue;
     const dest = path.join(os.paths.userAgents, id);
     if (fs.existsSync(dest)) {
       // Already on disk — loadAgentsFrom(userAgents) has registered it; nothing to seed.

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -47,6 +47,7 @@ const EMAIL_ORG_DOMAINS_KEY = 'email_org_domains'; // internal email domains (JS
 const CHAT_ROUTER_KEY = 'chat_router_enabled'; // generic Slack/Discord `/agent` router fallback ('off' disables)
 const CHAT_IDLE_MIN_KEY = 'chat_idle_timeout_min'; // resident (warm) chat session idle-kill, minutes
 const KILL_SWITCH_KEY = 'kill_switch'; // workspace-wide emergency stop (JSON KillSwitchState)
+const SUPPRESSED_BUILTINS_KEY = 'suppressed_builtins'; // built-in agent ids an admin deleted (JSON string[]); boot won't re-seed them
 
 /** The workspace emergency stop. When engaged, the gate denies EVERY action, fleet-wide, until cleared. */
 export interface KillSwitchState {
@@ -501,6 +502,38 @@ export class SettingsStore {
   setKillSwitch(engaged: boolean, reason: string | undefined, by?: string): KillSwitchState {
     this.set(KILL_SWITCH_KEY, JSON.stringify({ engaged: !!engaged, reason: reason?.trim() || undefined }), by);
     return this.killSwitch();
+  }
+
+  // ── suppressed built-in agents (durable removal tombstone) ───────────────────────
+  // A built-in agent is seeded from the catalog into the data home on boot, so deleting its folder
+  // isn't durable — the next boot restores it. When an admin deletes one we record its id here as a
+  // tombstone; `seedBuiltinAgents` skips any id on this list, so the removal sticks. Re-installing the
+  // agent from the library clears the tombstone.
+
+  /** The built-in agent ids an admin has deleted (so boot won't re-seed them). */
+  suppressedBuiltins(): string[] {
+    const raw = this.getRow(SUPPRESSED_BUILTINS_KEY)?.value;
+    if (!raw) return [];
+    try {
+      const v = JSON.parse(raw) as unknown;
+      return Array.isArray(v) ? [...new Set(v.map(String).filter(Boolean))] : [];
+    } catch {
+      return [];
+    }
+  }
+
+  /** Tombstone a built-in id so boot won't re-seed it. Idempotent. */
+  suppressBuiltin(id: string, by?: string): string[] {
+    const next = [...new Set([...this.suppressedBuiltins(), id])];
+    this.set(SUPPRESSED_BUILTINS_KEY, JSON.stringify(next), by);
+    return next;
+  }
+
+  /** Clear a built-in's tombstone (e.g. on re-install), so boot seeds it again. Idempotent. */
+  unsuppressBuiltin(id: string, by?: string): string[] {
+    const next = this.suppressedBuiltins().filter((x) => x !== id);
+    this.set(SUPPRESSED_BUILTINS_KEY, JSON.stringify(next), by);
+    return next;
   }
 
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1965,6 +1965,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     try {
       const manifest = installAgentFromCatalog(os.paths.bundledAgents, os.paths.userAgents, agentInstall[1]);
       os.registerAgent(manifest);
+      // Installing a built-in clears any deletion tombstone, so it seeds normally again on future boots.
+      os.settings.unsuppressBuiltin(manifest.id, me.email);
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.installed', data: { agent: manifest.id, source: 'catalog', dir: manifest.dir } });
       return sendJson(res, 200, { ok: true, id: manifest.id });
     } catch (e) {
@@ -2003,9 +2005,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, id: newId });
   }
 
-  // ── delete a user-created agent: deregister + remove its folder — owner/admin only ──
-  //    Only agents that live UNDER the data home can be deleted; the bundled examples that
-  //    ship with the software are read-only (they'd reappear on restart anyway).
+  // ── delete an agent: deregister + remove its folder — owner/admin only ──
+  //    Any agent that lives UNDER the data home can be deleted. A seeded built-in lives there too, so
+  //    it's deletable — but deleting its folder alone wouldn't stick (boot re-seeds it), so we also
+  //    tombstone its id in settings (suppressedBuiltins) to make the removal durable. Re-installing it
+  //    from the agent library clears that tombstone. An agent whose folder is OUTSIDE the home (a
+  //    bundled example registered straight from the catalog) stays read-only.
   const agentDel = p.match(/^\/api\/agents\/([\w.-]+)$/);
   if (method === 'DELETE' && agentDel) {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
@@ -2029,7 +2034,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     let memoriesForgotten = 0;
     try { memoriesForgotten = (await os.memory.forgetAgent?.(os.tenant, id)) ?? 0; } catch { /* best-effort */ }
     fs.rmSync(dir, { recursive: true, force: true });
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.deleted', data: { agent: id, dir, memoriesForgotten } });
+    // Deleting a built-in's folder isn't durable on its own (boot re-seeds it) — tombstone the id so the
+    // removal survives a restart. A user-created agent isn't seeded, so it needs no tombstone.
+    const builtin = BUILTIN_SEED_IDS.includes(id);
+    if (builtin) os.settings.suppressBuiltin(id, me.email);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.deleted', data: { agent: id, dir, memoriesForgotten, builtin } });
     return sendJson(res, 200, { ok: true, memoriesForgotten });
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -584,8 +584,11 @@ function Console({ me }: { me: Member }) {
   }, [messages, state?.tenantName, state?.tenant])
 
   const refreshState = () => api.state().then(setState)
-  const deleteAgent = async (id: string) => {
-    if (!confirm(`Delete agent "${id}"? Its folder (agent.json + CLAUDE.md) is permanently removed. Its memory and audit history are kept.`)) return
+  const deleteAgent = async (id: string, builtIn?: boolean) => {
+    const note = builtIn
+      ? ` This is a built-in agent — you can re-add it later from the agent library.`
+      : ''
+    if (!confirm(`Delete agent "${id}"? Its folder (agent.json + CLAUDE.md) is permanently removed. Its memory and audit history are kept.${note}`)) return
     const r = await api.deleteAgent(id)
     if (r.error) { alert(r.error); return }
     await refreshState()
@@ -941,7 +944,7 @@ function AgentsPage({
   run: (agentId: string, task: string) => Promise<string | null>
   onEdit: (id: string) => void
   onNew: () => void
-  onDelete: (id: string) => void
+  onDelete: (id: string, builtIn?: boolean) => void
   onDuplicate: (id: string) => void
   onRescan: () => Promise<void>
   onImport: (file: File) => Promise<void>
@@ -1067,7 +1070,7 @@ function AgentsPage({
             </Button>
           )}
           {canEdit && agent.deletable && (
-            <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0 text-destructive" onClick={() => onDelete(agent.id)} title="delete agent (removes its folder)">
+            <Button size="icon" variant="ghost" className="h-8 w-8 shrink-0 text-destructive" onClick={() => onDelete(agent.id, agent.builtIn)} title="delete agent (removes its folder)">
               <Trash2 className="h-4 w-4" />
             </Button>
           )}


### PR DESCRIPTION
## What

You could always click delete on a built-in agent (`agent-author`, `engineer`, `support`, `marketer`, `researcher`) — it lives under the data home like any other agent, so the trash button showed and the folder was removed. But the removal **didn't stick**: `seedBuiltinAgents` re-copied it from the catalog on the next boot and the agent came back.

This makes removing a built-in **durable** via a tombstone.

## How

- **`SettingsStore`** — new `suppressed_builtins` setting + `suppressedBuiltins()` / `suppressBuiltin()` / `unsuppressBuiltin()`.
- **`seedBuiltinAgents`** — skips any tombstoned id, so a deleted built-in is not restored on boot.
- **`DELETE /api/agents/:id`** — when the deleted id is a built-in seed id, records the tombstone; `agent.deleted` audit rows now carry a `builtin` flag.
- **`POST /api/agents/catalog/:id/install`** — clears the tombstone, so re-installing from the agent library brings the built-in back durably.
- **Console** — delete confirmation notes that a built-in can be re-added from the library.

A user-created agent isn't seeded, so it needs no tombstone — its behavior is unchanged.

## Testing

- `npm run typecheck` + `cd web && npm run build` — clean.
- `npm run test:governance` — 57/57.
- Isolated in-process test (scratch `AGENT_OS_HOME`): seed fleet → delete `engineer` → re-boot (not restored; `support` intact; folder not recreated) → clear tombstone → re-boot (restored). All assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)