### PR TITLE
Enricher: hyphenated flags aren't risky shell (v0.84.0, #139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.85.0] — 2026-07-10
+### Fixed
+- **Enricher no longer flags a hyphenated flag/compound as `risky` shell (#139).** `RISKY_SHELL` matched
+  its keywords (`delete`, `drop`, `deploy`, `prod`, …) anywhere in the command, so `gh pr merge
+  --delete-branch` tripped on `--delete-branch` and multi-line blocks tripped on `deploy-preview`-style
+  tokens — over-firing the `shell.exec risky → ask` gate on routine ops. The regex now excludes a
+  leading/trailing `-` (and word char) via lookarounds, so a flag name isn't treated as a destructive
+  verb, while real commands (`drop table`, `sudo systemctl restart`, `kubectl delete`) still match. The
+  conformance runner gained an optional `expectRisky` fact assertion (the default posture no longer GATES
+  `risky`, so this is invisible in the decision alone) with fixtures covering both the false positives and
+  the true positives.
+
 ## [0.84.0] — 2026-07-10
 ### Fixed
 - **Removing a built-in agent now sticks.** A built-in agent (`agent-author`, `engineer`, `support`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.84.0",
+      "version": "0.85.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.84.0",
+  "version": "0.85.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/governance-conformance.cjs
+++ b/scripts/governance-conformance.cjs
@@ -85,6 +85,12 @@ for (const c of fixture.decisions) {
   const got = tag(decision);
   if (got === c.expect) pass++;
   else failures.push(`decision  ✗ ${c.name}\n            expected ${c.expect}, got ${got}  (facts: destructive=${args.destructive} risky=${args.risky} amountUsd=${args.amountUsd} deleteCount=${args.deleteCount})`);
+  // Optional fact-level assertion: the default posture no longer GATES `risky`, so a change in what the
+  // enricher classifies as risky is invisible in the decision alone — assert the fact directly (#139).
+  if (typeof c.expectRisky === 'boolean') {
+    if (!!args.risky === c.expectRisky) pass++;
+    else failures.push(`risky     ✗ ${c.name}\n            expected risky=${c.expectRisky}, got ${!!args.risky}`);
+  }
 }
 
 for (const c of fixture.context) {
@@ -93,7 +99,8 @@ for (const c of fixture.context) {
   else failures.push(`context   ✗ ${c.name}\n            expected autoClear=${c.expectAutoClear}, got ${got}`);
 }
 
-const total = fixture.decisions.length + fixture.context.length;
+const riskyChecks = fixture.decisions.filter((c) => typeof c.expectRisky === 'boolean').length;
+const total = fixture.decisions.length + fixture.context.length + riskyChecks;
 if (failures.length) {
   console.error(`\nGOVERNANCE CONFORMANCE: ${pass}/${total} passed, ${failures.length} FAILED\n`);
   for (const f of failures) console.error('  ' + f);

--- a/src/governance/enricher.ts
+++ b/src/governance/enricher.ts
@@ -44,7 +44,11 @@ const DESTRUCTIVE: RegExp[] = [
 ];
 const DESTRUCTIVE_TOOL = /delete_site|drop_database|drop_table|drop_schema/i;
 const MUTATION_TOOL = /create|send|update|delete|remove|write|post|put|patch|merge|publish|upload|deploy|pay|refund|archive|invite|execute/i;
-const RISKY_SHELL = /\b(stripe|refund|deploy|prod|drop|delete|kubectl|systemctl|shutdown)\b/i;
+// Risky-shell keywords, but NOT when they're part of a hyphenated flag or compound token: the lookarounds
+// exclude a leading/trailing `-` so `gh pr merge --delete-branch`, `deploy-preview`, `--prod` don't trip
+// (a flag name isn't a destructive verb — #139), while `drop table`, `sudo systemctl restart`, `kubectl
+// delete` still match. `\w` in the lookarounds just mirrors the word-boundary these keywords already had.
+const RISKY_SHELL = /(?<![-\w])(stripe|refund|deploy|prod|drop|delete|kubectl|systemctl|shutdown)(?![-\w])/i;
 const AMOUNT_KEY = /amount.*usd|usd.*amount|amountusd|amount_usd/i;
 const PAYMENT_TOOL = /refund|payment|charge|payout|\bpay\b/i;
 const PAYMENT_AMOUNT_KEY = /^(amount|total|amount_cents|amountcents)$/i;

--- a/test/governance/conformance.json
+++ b/test/governance/conformance.json
@@ -26,7 +26,68 @@
           "command": "npm run deploy:prod"
         }
       },
-      "expect": "allow"
+      "expect": "allow",
+      "expectRisky": true
+    },
+    {
+      "name": "#139: gh pr merge --delete-branch is NOT risky (a flag, not a destructive verb)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "gh pr merge 15 --repo acme/docs --squash --delete-branch"
+        }
+      },
+      "expect": "allow",
+      "expectRisky": false
+    },
+    {
+      "name": "#139: deploy-preview compound is NOT risky (hyphenated token)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "gh workflow run deploy-preview.yml"
+        }
+      },
+      "expect": "allow",
+      "expectRisky": false
+    },
+    {
+      "name": "#139: gh run list is NOT risky (no destructive keyword)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "gh run list --repo acme/docs --limit 1"
+        }
+      },
+      "expect": "allow",
+      "expectRisky": false
+    },
+    {
+      "name": "#139: drop table is destructive → never (and still matches, space-bounded)",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "psql -c 'drop table users'"
+        }
+      },
+      "expect": "never",
+      "expectRisky": true
+    },
+    {
+      "name": "#139: sudo systemctl restart IS still risky",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "sudo systemctl restart nginx"
+        }
+      },
+      "expect": "allow",
+      "expectRisky": true
     },
     {
       "name": "rm -rf data is never",


### PR DESCRIPTION
Follow-up to #139 (the policy edits were applied live; this hardens the underlying heuristic).

## Problem
`RISKY_SHELL = /\b(stripe|refund|deploy|prod|drop|delete|kubectl|systemctl|shutdown)\b/i` tested the whole command, so `\bdelete\b` matched inside `gh pr merge --delete-branch` (a git branch-cleanup flag, not a destructive delete), and `deploy`/`prod` matched inside hyphenated tokens like `deploy-preview`. On the live instawp/expresstech tenants this over-fired the `shell.exec risky → ask` gate on the `docs-bot`'s routine `gh` work.

## Fix
Exclude a leading/trailing `-` (and word char) via lookarounds: `/(?<![-\w])(…)(?![-\w])/i`. A flag name is no longer treated as a destructive verb, while real commands (`drop table`, `sudo systemctl restart`, `kubectl delete`, `npm run deploy:prod`) still match.

## Testing
The default posture no longer *gates* `risky`, so this change is invisible in the decision alone. Added an optional **`expectRisky`** fact assertion to the conformance runner and fixtures covering both sides:
- NOT risky: `gh pr merge --delete-branch`, `gh workflow run deploy-preview.yml`, `gh run list …`
- still risky: `npm run deploy:prod`, `sudo systemctl restart nginx`; `drop table users` still `never` (destructive)

`npm run test:governance` → **68/68** (was 57; +5 #139 fixtures +6 pre-existing that now carry expectRisky… net new cases). typecheck + build clean.

## Note
No live behavior change on the tenants — after #139 none of them gate `risky` — so this is correctness/hygiene for the demo policy and any future re-enablement, plus regression cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)