### PR TITLE
feat(policy): `agent-os policy reconcile` — align policyContext to the enforced ruleset (v0.84.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.86.0] — 2026-07-10
+### Added
+- **`agent-os policy reconcile` — align agents' `policyContext` to the enforced ruleset.** The command
+  that retires the manual `sed` sweeps needed whenever a tenant's enforced policy id changes (the drift the
+  #136 warning reports). Rewrites every `<home>/agents/*/agent.json` whose `policyContext` diverges from the
+  tenant's enforced id — `--tenant <slug>` or `--all` across the control plane, **dry-run by default**
+  (`--yes` to apply). It only ever touches agent manifests, never the policy document (agents conform to the
+  policy, not the reverse). Pure filesystem like `tenant remove` (no server, runs over SSH): the enforced id
+  is read straight from each tenant's resolved policy file exactly as the runtime resolves it (home override
+  else bundled), and the apex tenant maps to the un-nested home just like the registry. Rewrites are a JSON
+  round-trip that preserves other fields + the on-disk format (no regex/`@`-interpolation footguns). New pure
+  `reconcileTenant()` (`src/governance/policy-reconcile.ts`) is shared-ready for a future audited
+  `POST /api/admin/policy/reconcile` + console banner. Test: `npm run test:policy-reconcile` (11/11).
+
 ## [0.85.0] — 2026-07-10
 ### Fixed
 - **Enricher no longer flags a hyphenated flag/compound as `risky` shell (#139).** `RISKY_SHELL` matched

--- a/docs/policy-reconcile-plan.md
+++ b/docs/policy-reconcile-plan.md
@@ -1,4 +1,18 @@
-# Plan: `agent-os policy reconcile` — align agent `policyContext` to the enforced ruleset
+# `agent-os policy reconcile` — align agent `policyContext` to the enforced ruleset
+
+> **Status: implemented (v0.84.0).** The CLI + pure `reconcileTenant()` shipped. The console banner and the
+> audited `POST /api/admin/policy/reconcile` mirror remain future work (see "Console mirror"). Two
+> deviations from the original plan, both to keep the CLI a pure box-side tool like `tenant remove`:
+> - **No `agent-revisions` snapshot.** That store tracks the self-editable fields (model, CLAUDE.md, …),
+>   not `policyContext`, so it's the wrong rollback vehicle. Recovery is the git-tracked home + the printed
+>   diff; the audited record lives in the API mirror.
+> - **No `loadAgentOS` / no audit row in the CLI.** Loading a full runtime would run `seedBuiltinAgents`
+>   and *install* missing bundled agents (a mutation reconcile must not cause). So the CLI reads the enforced
+>   id straight from the resolved policy file (identical to the runtime) and does not open the tenant DB —
+>   matching `tenant remove`, which also doesn't audit. The `policy.reconciled` audit event belongs to the
+>   API mirror, which already holds an `os.audit`.
+
+
 
 ## Problem
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.85.0",
+  "version": "0.86.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -28,7 +28,8 @@
     "test:governance": "node scripts/governance-conformance.cjs",
     "test:enrich": "node scripts/test-enrich-patterns.cjs",
     "test:context": "node scripts/context-injection-test.cjs",
-    "test:policy-context": "node scripts/test-policy-context.cjs"
+    "test:policy-context": "node scripts/test-policy-context.cjs",
+    "test:policy-reconcile": "node scripts/test-policy-reconcile.cjs"
   },
   "keywords": [
     "agents",

--- a/scripts/test-policy-reconcile.cjs
+++ b/scripts/test-policy-reconcile.cjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Unit test for `reconcileTenant` — aligns agent manifests' `policyContext` to the enforced ruleset id.
+ * Builds a throwaway agents dir with a matching agent, a drifted agent, and a context-less agent, then
+ * asserts only the drifted one is rewritten (and only when NOT dry-run), formatting preserved.
+ * Run: node scripts/test-policy-reconcile.cjs
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const assert = require('assert');
+const { reconcileTenant } = require(path.join(__dirname, '..', 'dist/governance/policy-reconcile'));
+
+let pass = 0;
+const ok = (cond, label) => {
+  assert.ok(cond, `FAIL: ${label}`);
+  pass++;
+  console.log(`  ok  ${label}`);
+};
+
+// Build a scratch agents dir: <dir>/<id>/agent.json
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-reconcile-'));
+const agentsDir = path.join(root, 'agents');
+const write = (id, ctx) => {
+  fs.mkdirSync(path.join(agentsDir, id), { recursive: true });
+  const m = { id, version: '1.0.0', principal: `svc-${id}`, runtime: 'claude-code' };
+  if (ctx !== undefined) m.policyContext = ctx;
+  fs.writeFileSync(path.join(agentsDir, id, 'agent.json'), JSON.stringify(m, null, 2) + '\n');
+};
+write('aligned-one', 'tenant@v2');
+write('drifted-one', 'tenant@v1');
+write('no-context', undefined);
+// A stray non-agent dir (no agent.json) must be ignored, not crash.
+fs.mkdirSync(path.join(agentsDir, 'not-an-agent'), { recursive: true });
+
+const ENF = 'tenant@v2';
+
+// 1) Dry-run classifies correctly and writes NOTHING.
+const before = fs.readFileSync(path.join(agentsDir, 'drifted-one', 'agent.json'), 'utf8');
+const dry = reconcileTenant(agentsDir, ENF, { dryRun: true });
+ok(dry.enforced === ENF, 'reports enforced id');
+ok(dry.changed.length === 1 && dry.changed[0].agent === 'drifted-one' && dry.changed[0].from === 'tenant@v1', 'dry-run flags only the drifted agent (with from)');
+ok(dry.aligned.length === 1 && dry.aligned[0] === 'aligned-one', 'dry-run counts the already-aligned agent');
+ok(dry.skipped.length === 1 && dry.skipped[0] === 'no-context', 'dry-run skips the context-less agent');
+ok(fs.readFileSync(path.join(agentsDir, 'drifted-one', 'agent.json'), 'utf8') === before, 'dry-run writes nothing to disk');
+
+// 2) Apply rewrites only the drifted agent, preserving other fields + format, and is then idempotent.
+const applied = reconcileTenant(agentsDir, ENF, {});
+ok(applied.changed.length === 1, 'apply rewrites exactly one agent');
+const after = JSON.parse(fs.readFileSync(path.join(agentsDir, 'drifted-one', 'agent.json'), 'utf8'));
+ok(after.policyContext === ENF, 'drifted agent now declares the enforced id');
+ok(after.id === 'drifted-one' && after.principal === 'svc-drifted-one' && after.runtime === 'claude-code', 'other manifest fields preserved');
+ok(fs.readFileSync(path.join(agentsDir, 'drifted-one', 'agent.json'), 'utf8').endsWith('}\n'), 'on-disk format preserved (2-space + trailing newline)');
+const again = reconcileTenant(agentsDir, ENF, {});
+ok(again.changed.length === 0 && again.aligned.length === 2, 're-run is idempotent (nothing left to change)');
+
+// 3) A missing agents dir yields an empty result, not a throw.
+const empty = reconcileTenant(path.join(root, 'nope'), ENF, {});
+ok(empty.changed.length === 0 && empty.aligned.length === 0 && empty.skipped.length === 0, 'missing agents dir → empty result');
+
+fs.rmSync(root, { recursive: true, force: true });
+console.log(`\npolicy-reconcile: ${pass}/11 checks passed`);
+process.exit(0);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,12 +10,14 @@
  *   agent-os help                  show this help
  */
 import './preflight'; // MUST be first — fail fast on Node < 22.5 before any node:sqlite import loads.
+import * as fs from 'fs';
 import * as path from 'path';
 import { bootstrap, startServer } from './server';
 import { init } from './init';
 import { loadAgentOS, readRootConfig } from './kernel';
-import { controlHome, resolveTenantPaths } from './home';
+import { controlHome, resolvePaths, resolveTenantPaths } from './home';
 import { TenantStore } from './state/control';
+import { reconcileTenant } from './governance/policy-reconcile';
 import { Role } from './types';
 import { VERSION } from './version';
 
@@ -50,6 +52,9 @@ async function main(): Promise<void> {
     case 'tenant':
     case 'tenants':
       tenants(rest);
+      break;
+    case 'policy':
+      policy(rest);
       break;
     case 'demo':
       await import('./demo');
@@ -200,6 +205,77 @@ function tenants(rest: string[]): void {
   process.exitCode = 1;
 }
 
+/**
+ * Policy admin from the box. `reconcile` aligns every agent's `policyContext` to the enforced ruleset id
+ * (the drift the #136 warning reports) — per-tenant, or `--all` across the control plane. DRY-RUN by
+ * default; writing is opt-in with `--yes`. It only rewrites agent manifests, never the policy document —
+ * agents conform to the policy, never the reverse. Pure filesystem (like `tenant remove`, no server): the
+ * enforced id is read straight from each tenant's resolved policy file, exactly as the runtime resolves it.
+ */
+function policy(rest: string[]): void {
+  if (rest[0] !== 'reconcile') {
+    console.log('usage: agent-os policy reconcile [--tenant <slug> | --all] [--yes]');
+    process.exitCode = 1;
+    return;
+  }
+
+  const baseDir = path.resolve(__dirname, '..');
+  const configPath = 'config/agent-os.config.json';
+  const cfg = readRootConfig(configPath, baseDir);
+  const defaultTenant = process.env.AGENT_OS_TENANT || cfg.tenant;
+  const store = new TenantStore(path.join(controlHome(baseDir, cfg), 'control.db'));
+
+  const apply = rest.includes('--yes') || rest.includes('--apply');
+  const dryRun = !apply; // dry-run is the default; a write is opt-in
+  const flag = rest.find((a) => a.startsWith('--tenant='));
+  const ti = rest.indexOf('--tenant');
+  const named = flag ? flag.split('=')[1] : ti >= 0 ? rest[ti + 1] : undefined;
+
+  let slugs: string[];
+  if (rest.includes('--all')) {
+    slugs = store.list().map((t) => t.slug);
+    if (!slugs.includes(defaultTenant)) slugs.unshift(defaultTenant); // the apex may not be a control-plane row
+  } else {
+    slugs = [named || defaultTenant];
+  }
+
+  let totalChanged = 0;
+  for (const slug of slugs) {
+    const isDefault = slug === defaultTenant;
+    const paths = isDefault ? resolvePaths(baseDir, cfg) : resolveTenantPaths(baseDir, cfg, slug);
+    let enforced: unknown;
+    try {
+      enforced = (JSON.parse(fs.readFileSync(paths.policyFile, 'utf8')) as { id?: unknown }).id;
+    } catch {
+      console.log(`\n[${slug}] cannot read policy (${paths.policyFile}) — skipping`);
+      continue;
+    }
+    if (typeof enforced !== 'string' || !enforced) {
+      console.log(`\n[${slug}] policy has no string id — skipping`);
+      continue;
+    }
+
+    const result = reconcileTenant(paths.userAgents, enforced, { dryRun });
+    totalChanged += result.changed.length;
+    console.log(`\n[${slug}] enforced=${enforced}`);
+    if (!result.changed.length) {
+      console.log(`  nothing to do — ${result.aligned.length} aligned, ${result.skipped.length} without policyContext`);
+      continue;
+    }
+    const verb = dryRun ? 'would reconcile' : 'reconciled';
+    for (const c of result.changed) console.log(`  ${verb}: ${c.agent}  ${c.from} → ${enforced}`);
+    console.log(`  ${result.changed.length} ${verb}, ${result.aligned.length} already aligned`);
+  }
+
+  if (totalChanged) {
+    console.log(
+      dryRun
+        ? `\n${totalChanged} manifest(s) would change. Re-run with --yes to apply, then restart the tenant(s) so agents re-register.`
+        : `\nApplied to ${totalChanged} manifest(s). Restart the tenant(s) so agents re-register under the enforced id.`,
+    );
+  }
+}
+
 function usage(): void {
   console.log(`agent-os <command>
 
@@ -209,6 +285,7 @@ function usage(): void {
   login-link <email>    print a fresh login link for an existing member (recovery)
   members               list workspace members and their roles
   tenant <sub>          multi-tenant admin: list | create <slug> --owner <email> | remove <slug>
+  policy reconcile      align agents' policyContext to the enforced ruleset (--tenant <slug> | --all; --yes to apply)
   demo                  run the scripted governance demo in the terminal
   launcher [--socket=…] run the privileged per-member session launcher (root; Phase A)
   version               print the software version (from package.json)

--- a/src/governance/policy-reconcile.ts
+++ b/src/governance/policy-reconcile.ts
@@ -1,0 +1,80 @@
+/**
+ * Reconcile agent manifests' `policyContext` to the enforced ruleset id.
+ *
+ * An agent's `policyContext` names the ruleset it expects to be governed by, but the engine enforces a
+ * single loaded ruleset (`os.policy.id`) and ignores per-agent context (see {@link
+ * ./policy.policyContextMismatch}). When a tenant's enforced id changes, every agent that declared the
+ * old id drifts — the #136 warning surfaces it, and THIS reconciles it: rewrite the declared context to
+ * the enforced id so the fleet conforms to the one policy actually applied. It never touches the policy
+ * document — agents conform to the policy, never the reverse.
+ *
+ * Pure filesystem so a CLI can run it over SSH with no server. Rewrites are a JSON round-trip through the
+ * manifest (not string substitution — avoids `@`/regex footguns) and preserve every other field plus the
+ * app's `JSON.stringify(…, 2) + '\n'` on-disk format.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface ReconcileChange {
+  agent: string;
+  from: string;
+}
+
+export interface ReconcileResult {
+  enforced: string;
+  /** Agents rewritten to the enforced id (or that WOULD be, when `dryRun`). */
+  changed: ReconcileChange[];
+  /** Agents whose `policyContext` already equals the enforced id. */
+  aligned: string[];
+  /** Agents with no `policyContext` to reconcile (nothing to do). */
+  skipped: string[];
+}
+
+/**
+ * Align every `<agentsDir>/<id>/agent.json`'s `policyContext` to `enforcedId`. With `dryRun`, computes
+ * the diff without writing. A missing `agentsDir` yields an empty result (no agents installed yet).
+ */
+export function reconcileTenant(
+  agentsDir: string,
+  enforcedId: string,
+  opts: { dryRun?: boolean } = {},
+): ReconcileResult {
+  const changed: ReconcileChange[] = [];
+  const aligned: string[] = [];
+  const skipped: string[] = [];
+
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(agentsDir, { withFileTypes: true });
+  } catch {
+    return { enforced: enforcedId, changed, aligned, skipped };
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const file = path.join(agentsDir, entry.name, 'agent.json');
+    let manifest: Record<string, unknown>;
+    try {
+      manifest = JSON.parse(fs.readFileSync(file, 'utf8')) as Record<string, unknown>;
+    } catch {
+      continue; // no/invalid manifest — not an installed agent
+    }
+    const id = typeof manifest.id === 'string' ? manifest.id : entry.name;
+    const current = manifest.policyContext;
+    if (typeof current !== 'string' || current === '') {
+      skipped.push(id);
+      continue;
+    }
+    if (current === enforcedId) {
+      aligned.push(id);
+      continue;
+    }
+    changed.push({ agent: id, from: current });
+    if (!opts.dryRun) {
+      manifest.policyContext = enforcedId;
+      fs.writeFileSync(file, JSON.stringify(manifest, null, 2) + '\n');
+    }
+  }
+
+  return { enforced: enforcedId, changed, aligned, skipped };
+}


### PR DESCRIPTION
Implements the command spec'd in #152 (`docs/policy-reconcile-plan.md`) — the tool that retires the manual `sed` sweeps needed whenever a tenant's enforced policy id changes (the drift the #136 warning reports).

## What it does
```
agent-os policy reconcile [--tenant <slug> | --all] [--yes]
```
Rewrites every `<home>/agents/*/agent.json` whose `policyContext` diverges from the tenant's **enforced** id, to match it. **Dry-run by default**; `--yes` applies. `--all` sweeps every control-plane tenant. It only ever edits agent manifests — **never the policy document** (agents conform to the policy, not the reverse).

## Design (matches `tenant remove`'s precedent)
- **Pure filesystem, no server** — runs over SSH. Enforced id is read straight from each tenant's resolved policy file, exactly as the runtime resolves it (home override else bundled); the apex tenant maps to the un-nested home just like the registry (`isDefault ? resolvePaths : resolveTenantPaths`).
- Rewrites are a **JSON round-trip** that preserves other fields + the `JSON.stringify(…, 2) + '\n'` on-disk format — no regex/`@`-interpolation footguns (the perl bug that bit the manual sweeps).
- **Deliberately does NOT `loadAgentOS`** — that runs `seedBuiltinAgents` and would *install* missing bundled agents (e.g. add `sales`/`ops` to expresstech), a mutation reconcile must not cause. Consequently no DB audit row in the CLI (same as `tenant remove`); the audited `policy.reconciled` event belongs to the future `POST /api/admin/policy/reconcile` mirror.
- **Does NOT use `agent-revisions`** — that store tracks the self-edit fields (model, CLAUDE.md, …), not `policyContext`.

Pure `reconcileTenant()` (`src/governance/policy-reconcile.ts`) is extracted so the future API mirror + console banner reuse it.

## Verification
- `test:policy-reconcile` **11/11** (dry-run classification, apply, field/format preservation, idempotence, missing-dir).
- Drove the real CLI end-to-end against a scratch home: dry-run wrote nothing → `--yes` rewrote only the drifted agent, left the aligned one → re-run idempotent. Apex path resolution confirmed.
- `test:governance` 57/57, `test:policy-context` 8/8, `tsc` clean.

Follow-up (not here): the audited API mirror + a console "Reconcile" banner on the Policy page. Out of scope: actually *honoring* `policyContext` (per-agent selection) — the larger #136 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)