### PR TITLE
Saving Slack/Discord tokens hot-reloads — stop looking like it needs a restart (v0.86.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.86.1] — 2026-07-10
+### Fixed
+- **Saving Slack/Discord tokens no longer looks like it needs a server restart.** The server already
+  re-dials the Socket-Mode / Gateway connection live when tokens change (`SlackSocket.restart()` /
+  `DiscordSocket.restart()` on the cached per-tenant runtime — no process restart), but the Integrations
+  panel polled connection status only **once**, 1.2 s after saving. A Slack/Discord handshake (auth check →
+  WebSocket → READY) routinely takes longer than that, so the panel showed "Disconnected" mid-reconnect and
+  people restarted the whole box to fix a non-problem. The panel now polls with backoff (up to ~12 s) until
+  the touched platform settles — connected, or intentionally cleared — so it reflects the live reconnect.
+  Web-only change (`web/src/App.tsx`).
+
 ## [0.86.0] — 2026-07-10
 ### Added
 - **`agent-os policy reconcile` — align agents' `policyContext` to the enforced ruleset.** The command

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.85.0",
+  "version": "0.86.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.85.0",
+      "version": "0.86.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.86.0",
+  "version": "0.86.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7172,6 +7172,30 @@ function IntegrationsSettings({ me }: { me: Member }) {
     api.slackStatus().then((s) => { if (s && !s.error) setSlackState(s) }).catch(() => {})
     api.discordStatus().then((s) => { if (s && !s.error) setDiscordState(s) }).catch(() => {})
   }
+  // After a token change the server re-dials the Socket-Mode / Gateway connection live (no restart) —
+  // but the handshake (auth check → WebSocket → READY) can take several seconds. A single poll would
+  // catch a mid-handshake "Disconnected" and make the panel look broken (and tempt a needless server
+  // restart). So poll with backoff until the touched platform(s) settle: connected, or intentionally
+  // cleared (unconfigured stays down = terminal).
+  const pollReconnect = (want: { slack: boolean; discord: boolean }) => {
+    let tries = 0
+    const settled = (s?: { configured: boolean; connected: boolean } | null) => !!s && (!s.configured || s.connected)
+    const tick = async () => {
+      tries++
+      let slackDone = !want.slack, discordDone = !want.discord
+      if (want.slack) {
+        const s = await api.slackStatus().catch(() => null)
+        if (s && !s.error) { setSlackState(s); slackDone = settled(s) }
+      }
+      if (want.discord) {
+        const d = await api.discordStatus().catch(() => null)
+        if (d && !d.error) { setDiscordState(d); discordDone = settled(d) }
+      }
+      if ((slackDone && discordDone) || tries >= 8) return
+      setTimeout(tick, 1500)
+    }
+    setTimeout(tick, 800)
+  }
   useEffect(() => {
     api.integrations().then((r) => {
       if (r.error) return setHint('⚠ ' + r.error)
@@ -7188,8 +7212,11 @@ function IntegrationsSettings({ me }: { me: Member }) {
     setKey(''); setWh(''); setAppTok(''); setBotTok(''); setDiscordTok('')
     apply(r)
     setHint(label); setTimeout(() => setHint(''), 1500)
-    // The Socket-Mode / Gateway connection re-dials on the server when tokens change — poll the new state.
-    if (body.slackAppToken !== undefined || body.slackBotToken !== undefined || body.discordBotToken !== undefined) setTimeout(loadStatus, 1200)
+    // The Socket-Mode / Gateway connection re-dials on the server when tokens change — poll until the
+    // reconnect settles so the panel reflects reality rather than a mid-handshake "Disconnected".
+    const wantSlack = body.slackAppToken !== undefined || body.slackBotToken !== undefined
+    const wantDiscord = body.discordBotToken !== undefined
+    if (wantSlack || wantDiscord) pollReconnect({ slack: wantSlack, discord: wantDiscord })
   }
 
   if (!isAdmin) return <div className="text-sm text-muted-foreground">Owner or admin access required.</div>


### PR DESCRIPTION
## Problem
Saving Slack/Discord tokens *appeared* to require restarting the whole `agent-os` process.

## Root cause (it's a UI feedback gap, not a server one)
The server already re-dials the connection live on token change — `SlackSocket.restart()` / `DiscordSocket.restart()` are wired into `PUT /api/settings/integrations` (`src/server.ts:2269,2280`) and operate on the **cached** per-tenant runtime (`src/tenant-registry.ts`), reading the freshly-saved tokens. No process restart is needed.

But the Integrations panel polled connection status exactly **once**, 1.2s after save (`web/src/App.tsx`). A Slack Socket-Mode / Discord Gateway handshake (auth check → WebSocket → READY) routinely takes longer than that, so the panel caught a mid-handshake **"Disconnected"** — which is what pushed people to restart the box to "fix" a non-problem.

## Fix
Replace the single poll with a bounded backoff poller (`pollReconnect`) that re-checks status until the touched platform(s) **settle** — `connected`, or intentionally **cleared** (unconfigured stays down = terminal) — up to ~12s. The panel now reflects the live reconnect.

Web-only change. `cd web && npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)