### PR TITLE
feat(artifacts): play video deliverables inline in the gallery (v0.87.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.86.1] — 2026-07-10
+## [0.87.0] — 2026-07-10
+### Added
+- **Video artifacts play inline in the deliverables gallery.** The artifact library now previews
+  `video/*` deliverables (`.mp4`/`.m4v`/`.webm`/`.mov`/`.ogv`) in a real `<video>` player instead of
+  falling through to a bare download link, with a first-frame thumbnail (Film icon) in the gallery list.
+  The store learned those extensions (`mimeOf` in `src/state/artifacts.ts`), and — the part that makes
+  playback actually work — the raw route (`GET /api/artifacts/:id/raw`) now honours HTTP **byte-range
+  requests**: it answers `Range:` with `206 Partial Content` + `Content-Range`, advertises
+  `Accept-Ranges: bytes` and `Content-Length` on the full response, and returns `416` for an
+  unsatisfiable range. Scrubbing/seeking depends on this, and Safari refuses to play a video served
+  without range support at all. Server + web (`src/server.ts`, `web/src/App.tsx`).
 ### Fixed
 - **Saving Slack/Discord tokens no longer looks like it needs a server restart.** The server already
   re-dials the Socket-Mode / Gateway connection live when tokens change (`SlackSocket.restart()` /

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.86.1",
+  "version": "0.87.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.86.1",
+      "version": "0.87.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.86.1",
+  "version": "0.87.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2740,9 +2740,44 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.canViewSpawn(a.source ?? null, me)) return sendJson(res, 403, { error: 'forbidden' });
     const resolved = os.artifacts.readPath(a.id, url.searchParams.get('file') || undefined);
     if (!resolved) return sendJson(res, 404, { error: 'file not found' });
+    let total: number;
+    try { total = fs.statSync(resolved.absPath).size; } catch { return sendJson(res, 404, { error: 'file not found' }); }
+    const disposition = `inline; filename="${resolved.filename.replace(/"/g, '')}"`;
+    // Honour byte-range requests — <video>/<audio> scrubbing (and Safari playback at all) depends on
+    // 206 Partial Content responses, and it keeps large downloads resumable.
+    const range = req.headers['range'];
+    const m = typeof range === 'string' ? range.match(/^bytes=(\d*)-(\d*)$/) : null;
+    if (m && (m[1] || m[2]) && total > 0) {
+      let start = m[1] ? parseInt(m[1], 10) : NaN;
+      let end = m[2] ? parseInt(m[2], 10) : NaN;
+      if (Number.isNaN(start)) { start = total - end; end = total - 1; }   // suffix range: bytes=-N
+      else if (Number.isNaN(end)) end = total - 1;                          // open range:   bytes=N-
+      if (start > end || start < 0 || start >= total) {
+        res.writeHead(416, { 'content-range': `bytes */${total}` });
+        res.end();
+        return;
+      }
+      end = Math.min(end, total - 1);
+      const stream = fs.createReadStream(resolved.absPath, { start, end });
+      stream.on('error', () => { if (!res.headersSent) sendJson(res, 500, { error: 'read failed' }); else res.end(); });
+      res.writeHead(206, {
+        'content-type': resolved.mime,
+        'content-disposition': disposition,
+        'content-range': `bytes ${start}-${end}/${total}`,
+        'accept-ranges': 'bytes',
+        'content-length': end - start + 1,
+      });
+      stream.pipe(res);
+      return;
+    }
     const stream = fs.createReadStream(resolved.absPath);
     stream.on('error', () => { if (!res.headersSent) sendJson(res, 500, { error: 'read failed' }); else res.end(); });
-    res.writeHead(200, { 'content-type': resolved.mime, 'content-disposition': `inline; filename="${resolved.filename.replace(/"/g, '')}"` });
+    res.writeHead(200, {
+      'content-type': resolved.mime,
+      'content-disposition': disposition,
+      'accept-ranges': 'bytes',
+      'content-length': total,
+    });
     stream.pipe(res);
     return;
   }

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -198,7 +198,7 @@ function containedPath(root: string, rel: string): string | null {
 }
 
 /** Content-type by extension — self-contained so the store has no server dependency. Covers the
- *  deliverable formats (Markdown/PDF/images/text) the gallery previews; default = octet-stream. */
+ *  deliverable formats (Markdown/PDF/images/video/text) the gallery previews; default = octet-stream. */
 function mimeOf(file: string): string {
   const e = path.extname(file).toLowerCase();
   const map: Record<string, string> = {
@@ -216,6 +216,11 @@ function mimeOf(file: string): string {
     '.gif': 'image/gif',
     '.webp': 'image/webp',
     '.svg': 'image/svg+xml',
+    '.mp4': 'video/mp4',
+    '.m4v': 'video/mp4',
+    '.webm': 'video/webm',
+    '.mov': 'video/quicktime',
+    '.ogv': 'video/ogg',
   };
   return map[e] || 'application/octet-stream';
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown } from 'lucide-react'
 import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -2594,6 +2594,7 @@ function FilesPage({ initialDir }: { initialDir?: string }) {
 
 // ── Artifacts (the deliverables gallery) ────────────────────────────────────────
 const isImageMime = (m: string) => m.startsWith('image/')
+const isVideoMime = (m: string) => m.startsWith('video/')
 const isPdfMime = (m: string) => m === 'application/pdf'
 const isMarkdownArt = (a: Artifact) => a.mime.startsWith('text/markdown') || /\.(md|markdown)$/i.test(a.filename)
 const isTextMime = (m: string) => m.startsWith('text/') || m === 'application/json'
@@ -2622,12 +2623,13 @@ const mdComponents = {
 function ArtifactIcon({ a, className }: { a: Artifact; className?: string }) {
   if (isPdfMime(a.mime)) return <FileText className={className ?? 'h-4 w-4 text-red-500'} />
   if (isImageMime(a.mime)) return <ImageIcon className={className ?? 'h-4 w-4 text-sky-500'} />
+  if (isVideoMime(a.mime)) return <Film className={className ?? 'h-4 w-4 text-orange-500'} />
   if (isMarkdownArt(a)) return <FileText className={className ?? 'h-4 w-4 text-violet-500'} />
   return <FileIcon className={className ?? 'h-4 w-4 text-muted-foreground'} />
 }
 
-/** Renders an artifact's contents by type: image inline, PDF in an iframe, Markdown rendered,
- *  text/JSON in a pre, anything else a download prompt. */
+/** Renders an artifact's contents by type: image inline, video in a player, PDF in an iframe,
+ *  Markdown rendered, text/JSON in a pre, anything else a download prompt. */
 function ArtifactBody({ a }: { a: Artifact }) {
   const raw = api.artifactRawUrl(a.id)
   const [text, setText] = useState<string | null>(null)
@@ -2640,6 +2642,7 @@ function ArtifactBody({ a }: { a: Artifact }) {
   }, [a.id])
 
   if (isImageMime(a.mime)) return <img src={raw} alt={a.title} className="max-h-[70vh] max-w-full rounded-lg border" />
+  if (isVideoMime(a.mime)) return <video src={raw} controls className="max-h-[72vh] w-full rounded-lg border bg-black" />
   if (isPdfMime(a.mime)) return <iframe src={raw} title={a.title} className="h-[72vh] w-full rounded-lg border" />
   if (wantsText) {
     if (text === null) return <div className="text-sm text-muted-foreground">Loading…</div>
@@ -2707,6 +2710,11 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
                 <div className="flex items-start gap-2.5 p-2.5">
                   {isImageMime(a.mime)
                     ? <img src={api.artifactRawUrl(a.id)} alt="" className="h-10 w-10 shrink-0 rounded border object-cover" />
+                    : isVideoMime(a.mime)
+                    ? <span className="relative flex h-10 w-10 shrink-0 items-center justify-center overflow-hidden rounded border bg-black">
+                        <video src={`${api.artifactRawUrl(a.id)}#t=0.1`} preload="metadata" muted className="h-full w-full object-cover" />
+                        <Play className="absolute h-3.5 w-3.5 fill-white/90 text-white/90" />
+                      </span>
                     : <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded bg-muted"><ArtifactIcon a={a} className="h-4 w-4 text-muted-foreground" /></span>}
                   <div className="min-w-0 flex-1">
                     <div className="truncate text-sm font-medium">{a.title}</div>


### PR DESCRIPTION
## What

The artifact library (deliverables gallery) now **previews video artifacts inline** instead of dropping them to a bare download link.

- **Store** — `mimeOf()` learns the video extensions `.mp4`/`.m4v`/`.webm`/`.mov`/`.ogv` so they persist the right `video/*` mime (`src/state/artifacts.ts`).
- **Server** — `GET /api/artifacts/:id/raw` now honours **HTTP byte-range requests**: a `Range:` header gets `206 Partial Content` + `Content-Range`; the full response advertises `Accept-Ranges: bytes` + `Content-Length`; an unsatisfiable range returns `416`. This is not optional polish — video **scrubbing/seeking** depends on it, and **Safari refuses to play** a video served without range support at all (`src/server.ts`).
- **Web** — `isVideoMime` detection drives a real `<video controls>` preview in the artifact body, a `Film` type icon, and a first-frame video thumbnail in the gallery list (`web/src/App.tsx`).

## Testing

- `npm run typecheck` — clean
- `cd web && npm run build` — clean
- `npm run test:governance` — 68/68 ✓
- Range serving branch exercised in isolation across full / open / suffix / clamped / unsatisfiable / empty-range cases — all correct status + `Content-Range` + byte counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)