### PR TITLE
feat(team): member profile pictures (avatars) (v0.88.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.88.0] — 2026-07-10
+### Added
+- **Team members can attach a profile picture.** Each member now has an avatar that renders in the
+  Team roster and the sidebar user badge, falling back to their initial when unset. You set your own
+  from the Team page (hover your avatar → click to pick an image; a small ✕ removes it); owners/admins
+  may set anyone's. The console down-scales + center-crops the picked image to a small square JPEG
+  before upload, so avatars stay tiny in the DB and on every `/api/team` load. Stored as a
+  self-contained `data:` URL in a new `members.avatar` column (no file store to serve from), so it
+  survives restarts and travels with the member row. New routes `POST`/`DELETE /api/team/:id/avatar`
+  (self-or-admin gated, audited `member.avatar`, base64-image + size validated). Types + store +
+  server + web (`src/types.ts`, `src/state/db.ts`, `src/governance/team.ts`, `src/server.ts`,
+  `web/src/lib/api.ts`, `web/src/App.tsx`).
+
 ## [0.87.0] — 2026-07-10
 ### Added
 - **Video artifacts play inline in the deliverables gallery.** The artifact library now previews

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.87.0",
+      "version": "0.88.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.87.0",
+  "version": "0.88.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -21,6 +21,7 @@ interface MemberRow {
   role: Role;
   status: 'invited' | 'active';
   created_at: number;
+  avatar: string | null;
 }
 
 interface IdentityRow {
@@ -101,6 +102,14 @@ export class TeamStore {
 
   setRole(id: string, role: Role): Member | undefined {
     this.db.prepare('UPDATE members SET role = ? WHERE id = ?').run(role, id);
+    return this.getMember(id);
+  }
+
+  /** Set (or, with null, clear) a member's profile picture. Returns the updated member, or undefined
+   *  if the id is unknown. The caller validates the data URL (see server.ts). */
+  setAvatar(id: string, avatar: string | null): Member | undefined {
+    if (!this.getMember(id)) return undefined;
+    this.db.prepare('UPDATE members SET avatar = ? WHERE id = ?').run(avatar, id);
     return this.getMember(id);
   }
 
@@ -303,7 +312,7 @@ export class TeamStore {
 }
 
 function toMember(r: MemberRow): Member {
-  return { id: r.id, email: r.email, name: r.name, role: r.role, status: r.status, createdAt: r.created_at };
+  return { id: r.id, email: r.email, name: r.name, role: r.role, status: r.status, createdAt: r.created_at, avatar: r.avatar ?? undefined };
 }
 
 function toIdentity(r: IdentityRow): MemberIdentity {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1251,6 +1251,25 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'identity.unlinked', data: { member: teamIdentDel[1], provider } });
     return sendJson(res, 200, { ok: true, identities: os.team.externalIdsFor(teamIdentDel[1]) });
   }
+  // Profile picture: a member sets their OWN avatar; owners/admins may set anyone's. The value is a
+  // self-contained data-URL image (the console resizes to a small square before upload), so there's no
+  // file store to serve from. Placed above the single-segment member routes so the /avatar suffix wins.
+  const teamAvatar = p.match(/^\/api\/team\/([\w-]+)\/avatar$/);
+  if ((method === 'POST' || method === 'DELETE') && teamAvatar) {
+    const targetId = teamAvatar[1];
+    if (targetId !== me.id && !isAdmin(me)) return sendJson(res, 403, { error: 'you can only change your own avatar' });
+    if (!os.team.getMember(targetId)) return sendJson(res, 404, { error: 'not found' });
+    let avatar: string | null = null;
+    if (method === 'POST') {
+      const b = await readBody(req);
+      const err = validateAvatar(b.avatar);
+      if (err) return sendJson(res, 400, { error: err });
+      avatar = String(b.avatar);
+    }
+    const updated = os.team.setAvatar(targetId, avatar);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'member.avatar', data: { member: targetId, set: !!avatar } });
+    return sendJson(res, 200, { ok: true, member: updated });
+  }
   const teamMember = p.match(/^\/api\/team\/([\w-]+)$/);
   if (method === 'DELETE' && teamMember) {
     if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
@@ -3507,6 +3526,15 @@ function isAdmin(m: Member): boolean {
 }
 function roleOf(v: unknown): Role | undefined {
   return v === 'owner' || v === 'admin' || v === 'member' ? v : undefined;
+}
+/** Validate a profile-picture upload: a base64 data-URL of a common image type, size-capped. Returns
+ *  an error string, or null when acceptable. ~1.5 MB of base64 ≈ ~1.1 MB of image — the console
+ *  resizes to a small square first, so this only guards against a hand-crafted oversized request. */
+function validateAvatar(v: unknown): string | null {
+  if (typeof v !== 'string' || !v) return 'avatar is required';
+  if (!/^data:image\/(png|jpe?g|gif|webp);base64,[A-Za-z0-9+/=]+$/.test(v)) return 'avatar must be a base64 image data URL';
+  if (v.length > 1_500_000) return 'image too large (max ~1MB)';
+  return null;
 }
 /** Build an absolute magic-link, honouring an nginx X-Forwarded-Proto in front of us. */
 function linkFor(req: http.IncomingMessage, token: string): string {

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -542,6 +542,10 @@ function migrate(db: Db): void {
   addColumn(db, 'term_sessions', 'rating', 'TEXT');       // 'up' | 'down' | NULL (unrated)
   addColumn(db, 'term_sessions', 'rated_by', 'TEXT');     // member id who gave the verdict
   addColumn(db, 'term_sessions', 'rated_at', 'INTEGER');  // when (epoch ms)
+
+  // Profile picture: a small square `data:image/…;base64,…` URL. NULL → the UI shows the member's
+  // initial. Members set their own from the Team page; owners/admins may set anyone's.
+  addColumn(db, 'members', 'avatar', 'TEXT');
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,9 @@ export interface Member {
   /** `invited` until they accept a magic link; then `active`. */
   status: 'invited' | 'active';
   createdAt: number;
+  /** Profile picture as a self-contained `data:image/…;base64,…` URL (small, square). Absent → the
+   *  UI falls back to the member's initial. Members set their own; owners/admins may set anyone's. */
+  avatar?: string;
 }
 
 /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -148,6 +148,72 @@ function RoleBadge({ role }: { role: Role }) {
   return <Badge variant={variant} className="px-1.5 py-0 text-[10px] font-normal">{ROLE_LABEL[role]}</Badge>
 }
 
+/** A member's profile picture — their uploaded avatar, or their initial in a muted circle. `className`
+ *  carries the size (e.g. `h-8 w-8 text-xs`). */
+function MemberAvatar({ member, className }: { member: Pick<Member, 'name' | 'avatar'>; className?: string }) {
+  const cls = `shrink-0 rounded-full bg-muted ${className ?? ''}`
+  return member.avatar
+    ? <img src={member.avatar} alt="" className={`${cls} object-cover`} />
+    : <span className={`grid place-items-center font-semibold uppercase text-foreground/70 ${cls}`}>{member.name.slice(0, 1)}</span>
+}
+
+/** Down-scale + center-crop a picked image into a small square JPEG data-URL, so avatars stay tiny in
+ *  the DB and on every /api/team load. */
+async function fileToAvatarDataUrl(file: File, size = 128): Promise<string> {
+  const url = URL.createObjectURL(file)
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const i = new Image()
+      i.onload = () => resolve(i)
+      i.onerror = () => reject(new Error('could not read image'))
+      i.src = url
+    })
+    const canvas = document.createElement('canvas')
+    canvas.width = size; canvas.height = size
+    const ctx = canvas.getContext('2d')!
+    const scale = Math.max(size / img.width, size / img.height) // cover-fit the square
+    const w = img.width * scale, h = img.height * scale
+    ctx.drawImage(img, (size - w) / 2, (size - h) / 2, w, h)
+    return canvas.toDataURL('image/jpeg', 0.85)
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+/** The member avatar plus (when `canEdit`) a click-to-upload overlay and a remove control. */
+function EditableAvatar({ member, canEdit, sizeClass, onChanged }: { member: Member; canEdit: boolean; sizeClass: string; onChanged: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  if (!canEdit) return <MemberAvatar member={member} className={sizeClass} />
+  const pick = async (file?: File | null) => {
+    if (!file) return
+    setBusy(true); setErr('')
+    try {
+      const r = await api.setAvatar(member.id, await fileToAvatarDataUrl(file))
+      if ('error' in r && r.error) setErr(r.error); else onChanged()
+    } catch { setErr('could not read that image') } finally { setBusy(false) }
+  }
+  const clear = async () => { setBusy(true); setErr(''); try { await api.clearAvatar(member.id); onChanged() } finally { setBusy(false) } }
+  return (
+    <div className="group relative" title={err || 'Change photo'}>
+      <button type="button" className="block rounded-full disabled:cursor-default" onClick={() => inputRef.current?.click()} disabled={busy}>
+        <MemberAvatar member={member} className={`${sizeClass} ${busy ? 'opacity-50' : ''} cursor-pointer`} />
+        <span className="pointer-events-none absolute inset-0 grid place-items-center rounded-full bg-black/40 opacity-0 transition group-hover:opacity-100">
+          <Camera className="h-3.5 w-3.5 text-white" />
+        </span>
+      </button>
+      {member.avatar && (
+        <button type="button" title="Remove photo" onClick={clear} disabled={busy}
+          className="absolute -right-1 -top-1 grid h-4 w-4 place-items-center rounded-full border border-background bg-muted text-foreground/70 hover:text-destructive">
+          <X className="h-2.5 w-2.5" />
+        </button>
+      )}
+      <input ref={inputRef} type="file" accept="image/*" className="hidden" onChange={(e) => { pick(e.target.files?.[0]); e.target.value = '' }} />
+    </div>
+  )
+}
+
 /** Prefill the spawn box with the agent's first starter prompt, if it defines any. Otherwise the box
  *  starts empty and shows its "Describe the task…" placeholder — no generic filler. */
 const exampleTask = (a?: AgentInfo): string => a?.examplePrompts?.[0] ?? ''
@@ -853,7 +919,7 @@ function Console({ me }: { me: Member }) {
           <Separator className="my-3" />
           <div className="flex items-center justify-between">
             <button className="flex min-w-0 items-center gap-2 text-left hover:underline" onClick={() => nav('team')} title="manage team">
-              <span className="grid h-7 w-7 shrink-0 place-items-center rounded-full bg-muted text-xs font-medium uppercase">{me.name.slice(0, 1)}</span>
+              <MemberAvatar member={state?.me ?? me} className="h-7 w-7 text-xs" />
               <span className="min-w-0">
                 <span className="flex items-center gap-1.5 text-sm font-medium leading-tight">
                   <span className="truncate">{me.name}</span>
@@ -898,7 +964,7 @@ function Console({ me }: { me: Member }) {
           {route === 'sessions' && <SessionsPage me={me} sessions={sessions} waiting={waiting} selected={selected} hiddenTabs={hiddenTabs} onOpen={openTerminal} onCloseTab={closeTab} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onRate={rateSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} />}
           {route === 'connectors' && <ConnectionsPage me={me} tab={detail} onTab={(t) => nav('connectors', t)} />}
-          {route === 'team' && <TeamPage me={me} />}
+          {route === 'team' && <TeamPage me={me} onProfileChange={refreshState} />}
           {route === 'automations' && <AutomationsPage me={me} agents={state?.agents ?? []} serverTz={state?.serverTz} onOpen={openTerminal} nav={nav} />}
           {route === 'tasks' && <TasksPage me={me} agents={state?.agents ?? []} taskId={detail} onOpen={openTerminal} nav={nav} />}
           {route === 'memory' && <MemoryPage agents={state?.agents ?? []} me={me} />}
@@ -3077,7 +3143,7 @@ function IdentityEditor({ member, identities, onChange }: { member: Member; iden
   )
 }
 
-function TeamPage({ me }: { me: Member }) {
+function TeamPage({ me, onProfileChange }: { me: Member; onProfileChange: () => void }) {
   const [data, setData] = useState<TeamResp | null>(null)
   const [links, setLinks] = useState<Record<string, string>>({})
   const [email, setEmail] = useState('')
@@ -3158,7 +3224,7 @@ function TeamPage({ me }: { me: Member }) {
             <Card key={m.id}>
               <CardContent className="flex flex-wrap items-center justify-between gap-3 p-3">
                 <div className="flex min-w-0 items-center gap-2.5">
-                  <span className="grid h-8 w-8 shrink-0 place-items-center rounded-full bg-muted text-xs font-semibold uppercase text-foreground/70">{m.name.slice(0, 1)}</span>
+                  <EditableAvatar member={m} canEdit={m.id === me.id || isAdmin} sizeClass="h-8 w-8 text-xs" onChanged={() => { load(); if (m.id === me.id) onProfileChange() }} />
                   <div className="min-w-0">
                     <div className="flex items-center gap-1.5 text-sm font-medium">
                       <span className="truncate">{m.name}</span>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -6,6 +6,8 @@ export interface Member {
   role: Role
   status: 'invited' | 'active'
   createdAt: number
+  /** Profile picture as a `data:image/…;base64,…` URL; absent → show the member's initial. */
+  avatar?: string
 }
 export type IdentityProvider = 'slack' | 'discord' | 'email' | 'github'
 export const IDENTITY_PROVIDERS: IdentityProvider[] = ['slack', 'discord', 'email', 'github']
@@ -801,6 +803,9 @@ export const api = {
   setRole: (id: string, role: Role) => call<Member | { error: string }>('POST', `/api/team/${id}/role`, { role }),
   removeMember: (id: string) => call<{ ok: boolean; reason?: string }>('DELETE', '/api/team/' + id),
   loginLink: (id: string) => call<{ link: string; error?: string }>('POST', `/api/team/${id}/login-link`),
+  /** Set (POST a data-URL) or clear (DELETE) a member's profile picture. */
+  setAvatar: (id: string, avatar: string) => call<{ ok: boolean; member?: Member; error?: string }>('POST', `/api/team/${id}/avatar`, { avatar }),
+  clearAvatar: (id: string) => call<{ ok: boolean; member?: Member; error?: string }>('DELETE', `/api/team/${id}/avatar`),
   setAssignment: (agentId: string, access: AgentAccess) => call<{ ok: boolean; assignment: AgentAccess }>('PUT', '/api/team/assignments/' + agentId, access),
   setIdentity: (id: string, provider: IdentityProvider, externalId: string) => call<{ ok: boolean; identities: MemberIdentity[]; error?: string }>('POST', `/api/team/${id}/identities`, { provider, externalId }),
   clearIdentity: (id: string, provider: IdentityProvider) => call<{ ok: boolean; identities: MemberIdentity[]; error?: string }>('DELETE', `/api/team/${id}/identities/${provider}`),


### PR DESCRIPTION
## What

Team members can now attach a **profile picture**. It renders in the Team roster and the sidebar user badge, falling back to the member's initial when unset.

- **Set your own** from the Team page — hover your avatar, click to pick an image; a small ✕ removes it. Owners/admins may set anyone's.
- The console **down-scales + center-crops** the picked image to a small square JPEG before upload (`fileToAvatarDataUrl`), so avatars stay tiny in the DB and on every `/api/team` load.
- Stored as a self-contained `data:` URL in a **new `members.avatar` column** — no file store to serve from, survives restarts, travels with the member row.

## How it's wired

| Layer | Change |
|---|---|
| Type | `Member.avatar?: string` (`src/types.ts`) → flows to `/api/state` + `/api/auth/me` for free |
| DB | `addColumn(members, avatar, TEXT)` migration (`src/state/db.ts`) |
| Store | `TeamStore.setAvatar()`, `MemberRow`/`toMember` carry it (`src/governance/team.ts`) |
| API | `POST`/`DELETE /api/team/:id/avatar` — self-or-admin gated, audited `member.avatar`, base64-image + ~1MB size validated (`src/server.ts`) |
| Web | `MemberAvatar` + `EditableAvatar` components, api client `setAvatar`/`clearAvatar`; sidebar reads `state.me` so it refreshes live (`web/src/App.tsx`, `web/src/lib/api.ts`) |

## Verification

- `npm run typecheck`, backend `npm run build`, `cd web && npm run build` — all clean.
- `npm run test:governance` — 68/68 ✓.
- End-to-end in-process smoke test against an isolated home: owner accepts magic link → `POST avatar` stores exactly what was sent → invalid data URL rejected `400` → `DELETE` clears → no-cookie call `401`. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)