### PR TITLE
feat(tasks): file attachments on tasks (v0.87.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.89.0] — 2026-07-10
+### Added
+- **File attachments on tasks.** A task can now carry files — screenshots, logs, PDFs, CSVs, generated
+  deliverables — alongside its description and activity timeline. Humans upload from the Tasks detail
+  drawer (a picker **or** drag-and-drop) with per-file download and delete; a working agent attaches a
+  file from its own working folder with the new **`task_attach`** MCP tool (path resolved strictly under
+  the agent folder, like `publish`, so it can't escape). Files snapshot immutably to disk under
+  `<home>/task-attachments/<taskId>/` (the same model as the Artifacts gallery, keyed to a task); the
+  DB gets a `task_attachments` table; each attach logs an `attach` event on the task timeline and audits
+  `task.attached`, and deleting a task cascades its attachment rows + files. New routes: agent loopback
+  `POST /api/tasks/attach` (+ attachments now returned by `task_get`), and member console
+  `POST/GET/DELETE /api/tasks/:id/attachments[...]`. `task_get`'s output lists attachments too.
+
 ## [0.88.0] — 2026-07-10
 ### Added
 - **Team members can attach a profile picture.** Each member now has an avatar that renders in the
@@ -32,6 +45,8 @@ new version heading in the same commit.
   `Accept-Ranges: bytes` and `Content-Length` on the full response, and returns `416` for an
   unsatisfiable range. Scrubbing/seeking depends on this, and Safari refuses to play a video served
   without range support at all. Server + web (`src/server.ts`, `web/src/App.tsx`).
+
+## [0.86.1] — 2026-07-10
 ### Fixed
 - **Saving Slack/Discord tokens no longer looks like it needs a server restart.** The server already
   re-dials the Socket-Mode / Gateway connection live when tokens change (`SlackSocket.restart()` /

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,14 +188,15 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 33 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 34 always-on tools
   + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). KB: `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`. Operator/inbox:
   `ask`/`check_inbox`/`report`/`update`/`publish`/`artifacts_list`. Skills: `skill_propose` (draft a
   reusable playbook — Lever 6 procedural memory; lands as a NOT-YET-PUBLISHED `.aos-proposed` skill +
   a `skill.proposed` inbox card, gated behind an owner/admin publish). Scheduling: `schedule`/`unschedule`
   (one-shot deferred self-run via a `type:'once'` automation). Tasks (shared work queue):
-  `task_create`/`task_list`/`task_get`/`task_claim`/`task_update` (file/claim/drain durable work; an
+  `task_create`/`task_list`/`task_get`/`task_claim`/`task_update`/`task_attach` (file/claim/drain durable
+  work + attach a file from the agent's folder onto a task; an
   agent-assigned `autoDispatch` task spawns a governed session — the A2A delegation path; per-task `mode`
   headless/interactive; owner = run-as passthrough so a hand-off keeps the accountable human). Secrets
   (shared credential handoff): `secret_put`/`secret_get`/`secret_list` — an agent stores a password/key

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -35,6 +35,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `task_get` | `GET /api/tasks/get` | `TaskStore.withEvents` | R | task + full activity timeline |
 | `task_claim` | `POST /api/tasks/claim` | `TaskStore.claim` | W | atomic take (→ doing); loses if already claimed |
 | `task_update` | `POST /api/tasks/update` | `TaskStore.update` | W | status/note/reassign/reprioritise/`due` (ISO date, or "" to clear); closes a dispatched loop |
+| `task_attach` | `POST /api/tasks/attach` | `TerminalManager.attachTaskFile` → `TaskStore.attachFromPath` | W | snapshots a file from the caller's OWN working folder onto a task (path resolved strictly under the agent folder, like `publish`); logs an `attach` event; audited `task.attached` |
 | `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
 | `agent_update` | `POST /api/agents/update` | `AgentOS.registerAgent` + `AgentRevisions.commit` | W | **self-only** (edits the caller's OWN manifest/CLAUDE.md — a body `id` must equal the session's agent); user-home agents only; snapshots a revision; audited `agent.config.updated` |
 | `agent_history` | `POST /api/agents/history` | `AgentRevisions.list` | R | the caller's own listing revisions (rev/author/summary/date), newest first |
@@ -49,7 +50,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `discord_send` | `POST /api/agent/discord/send` | `DiscordSocket.sendToChannel` | W | proactive post to any channel by id; audited `discord.send`; only when `DISCORD_EGRESS=1` (Discord configured) |
 | `discord_dm` | `POST /api/agent/discord/dm` | `DiscordSocket.dmMember` | W | proactive DM by Discord user id; audited `discord.dm`; only when `DISCORD_EGRESS=1` |
 
-33 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+34 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 

--- a/docs/tasks-plan.md
+++ b/docs/tasks-plan.md
@@ -486,6 +486,17 @@ session spawned and the pile-up guard blocks a second). **Isolate `AGENT_OS_HOME
 > dependencies**, projects/epics/swimlanes, a burndown, pool auto-assignment, agent-triggered dispatch,
 > the policy brake, and the recurring-task Automation.
 
+> **Update (2026-07-10, v0.89.0): file attachments shipped.** A task now carries files. `TaskStore` gained
+> the on-disk attachment dir (`<home>/task-attachments/<taskId>/`, snapshot model borrowed from
+> `ArtifactStore` — so the store is no longer strictly db-only, but task ROWS still are per §Decision 2)
+> plus `attachBytes`/`attachFromPath`/`attachments`/`readAttachment`/`removeAttachment` over a
+> `task_attachments` table. Humans upload from the drawer (picker + drag-and-drop, download + delete);
+> agents attach from their working folder via the `task_attach` MCP tool → `TerminalManager.attachTaskFile`
+> → `TaskStore.attachFromPath` (strict-contained path resolution). Each attach logs an `attach` timeline
+> event + audits `task.attached`; `task_get` and the console detail both list attachments; deleting a task
+> cascades its attachment rows + files. Routes: agent loopback `POST /api/tasks/attach`; member console
+> `POST/GET-raw/DELETE /api/tasks/:id/attachments`.
+
 - **Pool auto-assignment.** Route unassigned `auto_dispatch` tasks to a workspace **default worker agent**
   (or a small pool), so a human can drop tasks on the board with no assignee and the fleet picks them up.
   This is the agent-spawns-agent frontier Automations also parks — needs a concurrency budget + a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.88.0",
+      "version": "0.89.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.88.0",
+  "version": "0.89.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/home.ts
+++ b/src/home.ts
@@ -32,6 +32,8 @@ export interface Paths {
   skills: string;
   /** The deliverables gallery: snapshotted artifacts agents publish (`<id>/<filename>`). */
   artifacts: string;
+  /** Files attached to tasks (`<taskId>/<id>-<filename>`). */
+  taskAttachments: string;
   /** The company knowledge base: living wiki pages (`kb/<section>/<slug>.md`). */
   kb: string;
   /** Append-only audit event store for this instance. */
@@ -96,6 +98,7 @@ function pathsUnder(baseDir: string, cfg: HomeConfig, home: string): Paths {
     connectors: path.join(home, 'connectors'),
     skills: path.join(home, 'skills'),
     artifacts: path.join(home, 'artifacts'),
+    taskAttachments: path.join(home, 'task-attachments'),
     kb: path.join(home, 'kb'),
     audit: path.join(home, 'audit'),
     db: path.join(home, 'agent-os.db'),

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -128,7 +128,9 @@ export class AgentOS {
     this.artifacts = new ArtifactStore(this.db, opts.paths?.artifacts);
     this.kb = new KbStore(this.db, opts.paths?.kb);
     this.agentRevisions = new AgentRevisions(this.db);
-    this.tasks = new TaskStore(this.db); // db-only (structured state, no on-disk mirror — see tasks-plan.md §Decision 2)
+    // Task rows are db-only structured state (§Decision 2), but attachments are real files, so the
+    // store also gets the on-disk attachments dir (snapshot model, like artifacts).
+    this.tasks = new TaskStore(this.db, opts.paths?.taskAttachments);
     this.memory = createMemoryProvider(opts.memory ?? { backend: 'sqlite' }, this.db);
 
     const sinks: AuditSink[] = [this.memoryAudit, new SqliteAuditSink(this.db)];

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -599,6 +599,24 @@ const TOOLS = [
       required: ['id'],
     },
   },
+  {
+    name: 'task_attach',
+    description:
+      'Attach a file from YOUR working folder onto a task — a screenshot, log, report, generated artifact, ' +
+      'CSV, etc. — so whoever picks up the task (or the human reviewing it) can see your output. Give the ' +
+      'path relative to your working folder (or absolute within it). The file is snapshotted onto the task ' +
+      'and listed on its detail view alongside the activity timeline (see task_get). Use this to hand off ' +
+      'concrete deliverables with a task, rather than pasting large content into a note.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string', description: 'The task id to attach the file to.' },
+        path: { type: 'string', description: 'Path to the file in your working folder (e.g. "report.pdf" or "out/summary.csv").' },
+      },
+      required: ['id', 'path'],
+    },
+  },
   // ── Agents: author new agents (the agent-author's build tools) ──
   {
     name: 'agent_create',
@@ -1119,6 +1137,7 @@ async function unschedule(args: Record<string, unknown>): Promise<string> {
 // ── Tasks: the shared work queue ──────────────────────────────────────────────
 interface TaskLite { id: string; title: string; status: string; priority: number; assignee?: string; labels?: string[]; body?: string }
 interface TaskEventLite { kind: string; body?: string; author: string; createdAt: number }
+interface TaskAttachmentLite { id: string; filename: string; mime: string; bytes: number; uploadedBy: string }
 
 /** Parse an agent-supplied `due` (ISO date/datetime) → epoch ms. '' / null → null (clear). undefined → undefined (leave). */
 function parseDue(due: unknown): number | null | undefined {
@@ -1291,13 +1310,31 @@ async function taskGet(args: Record<string, unknown>): Promise<string> {
   u.searchParams.set('id', String(args.id ?? ''));
   const res = await fetch(u, { headers: H() });
   if (!res.ok) return 'Task not found.';
-  const d = (await res.json()) as { task?: TaskLite; events?: TaskEventLite[] };
+  const d = (await res.json()) as { task?: TaskLite; events?: TaskEventLite[]; attachments?: TaskAttachmentLite[] };
   if (!d.task) return 'Task not found.';
   const t = d.task;
   const timeline = (d.events ?? [])
     .map((e) => `  · ${e.kind}${e.body ? `: ${e.body}` : ''} — ${e.author}`)
     .join('\n');
-  return `${t.id} · [${t.status}] · P${t.priority}${t.assignee ? ` · ${t.assignee}` : ''}\n# ${t.title}\n${t.body ?? ''}\n\nActivity:\n${timeline || '  (none)'}`;
+  const files = (d.attachments ?? [])
+    .map((a) => `  · ${a.filename} (${a.mime}, ${a.bytes} bytes) — ${a.uploadedBy}`)
+    .join('\n');
+  const attachSection = d.attachments?.length ? `\n\nAttachments:\n${files}` : '';
+  return `${t.id} · [${t.status}] · P${t.priority}${t.assignee ? ` · ${t.assignee}` : ''}\n# ${t.title}\n${t.body ?? ''}\n\nActivity:\n${timeline || '  (none)'}${attachSection}`;
+}
+
+async function taskAttach(args: Record<string, unknown>): Promise<string> {
+  const id = String(args.id ?? '').trim();
+  const filePath = String(args.path ?? '').trim();
+  if (!id || !filePath) return 'Both id and path are required.';
+  const res = await fetch(AOS_URL + '/api/tasks/attach', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, id, path: filePath }),
+  });
+  const d = (await res.json()) as { ok?: boolean; filename?: string; error?: string };
+  if (!d.ok) return `Could not attach: ${d.error ?? 'unknown error'}`;
+  return `Attached ${d.filename} to task ${id}. It's now visible on the task (task_get "${id}").`;
 }
 
 async function taskClaim(args: Record<string, unknown>): Promise<string> {
@@ -1475,6 +1512,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'task_get' ? await taskGet(args)
         : name === 'task_claim' ? await taskClaim(args)
         : name === 'task_update' ? await taskUpdate(args)
+        : name === 'task_attach' ? await taskAttach(args)
         : name === 'agent_create' ? await agentCreate(args)
         : name === 'agent_update' ? await agentUpdate(args)
         : name === 'agent_history' ? await agentHistory()

--- a/src/server.ts
+++ b/src/server.ts
@@ -949,7 +949,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.sessionAgent(session)) return sendJson(res, 404, { error: 'unknown session' });
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     const found = os.tasks.withEvents(url.searchParams.get('id') || '');
-    return sendJson(res, found ? 200 : 404, found ?? { error: 'task not found' });
+    if (!found) return sendJson(res, 404, { error: 'task not found' });
+    return sendJson(res, 200, { ...found, attachments: os.tasks.attachments(found.task.id) });
   }
   if (method === 'POST' && p === '/api/tasks/claim') {
     const b = await readBody(req);
@@ -982,6 +983,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!task) return sendJson(res, 200, { ok: false, error: 'task not found' });
     os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: task.status === 'done' ? 'task.completed' : 'task.updated', data: { id: task.id, status: task.status } });
     return sendJson(res, 200, { ok: true, task });
+  }
+  // agent attaches a file from its own working folder onto a task (→ snapshot + `attach` event + audit).
+  // The path is resolved strictly under the agent folder by the store; only that session may attach.
+  if (method === 'POST' && p === '/api/tasks/attach') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const id = String(b.id || '').trim();
+    const filePath = String(b.path || '').trim();
+    if (!id || !filePath) return sendJson(res, 200, { ok: false, error: 'id and path are required' });
+    const out = tm.attachTaskFile(session, id, filePath);
+    return sendJson(res, 200, out.ok ? { ok: true, id: out.id, filename: out.filename } : { ok: false, error: out.error });
   }
 
   // ── Agents (agent loopback) ──────────────────────────────────────────────────
@@ -1690,13 +1705,50 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   const taskId = p.match(/^\/api\/tasks\/([\w-]+)$/);
   const taskComment = p.match(/^\/api\/tasks\/([\w-]+)\/comment$/);
   const taskDispatch = p.match(/^\/api\/tasks\/([\w-]+)\/dispatch$/);
+  const taskAttachments = p.match(/^\/api\/tasks\/([\w-]+)\/attachments$/);
+  const taskAttachmentRaw = p.match(/^\/api\/tasks\/[\w-]+\/attachments\/([\w-]+)\/raw$/);
+  const taskAttachment = p.match(/^\/api\/tasks\/[\w-]+\/attachments\/([\w-]+)$/);
   if (method === 'GET' && p === '/api/tasks') {
     const tasks = os.tasks.list({ tenant: os.tenant, status: (url.searchParams.get('status') as TaskStatus) || undefined, query: url.searchParams.get('q') || undefined, limit: 500 });
     return sendJson(res, 200, { tasks, counts: os.tasks.counts(os.tenant), agents: terminalAgents(os).map((a) => a.id) });
   }
   if (taskId && method === 'GET') {
     const found = os.tasks.withEvents(taskId[1]);
-    return sendJson(res, found ? 200 : 404, found ?? { error: 'task not found' });
+    if (!found) return sendJson(res, 404, { error: 'task not found' });
+    return sendJson(res, 200, { ...found, attachments: os.tasks.attachments(found.task.id) });
+  }
+  // Upload a file onto a task (raw bytes in the body; original name in ?name=). Any member, like a task edit.
+  if (taskAttachments && method === 'POST') {
+    if (!os.tasks.get(taskAttachments[1])) return sendJson(res, 404, { error: 'task not found' });
+    const name = url.searchParams.get('name') || '';
+    if (!name.trim()) return sendJson(res, 400, { error: 'a file name (?name=) is required' });
+    const buf = await readRawBuffer(req);
+    if (buf.length === 0) return sendJson(res, 400, { error: 'empty upload' });
+    const out = os.tasks.attachBytes({ taskId: taskAttachments[1], filename: name, bytes: buf, uploadedBy: me.id });
+    if (!out.ok) return sendJson(res, 400, { error: out.error });
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'task.attached', data: { taskId: taskAttachments[1], id: out.attachment.id, filename: out.attachment.filename, bytes: out.attachment.bytes } });
+    return sendJson(res, 200, { ok: true, attachment: out.attachment });
+  }
+  // Stream an attachment's bytes (inline; browser previews images/pdf, downloads the rest). Any member.
+  if (taskAttachmentRaw && method === 'GET') {
+    const resolved = os.tasks.readAttachment(taskAttachmentRaw[1]);
+    if (!resolved) return sendJson(res, 404, { error: 'attachment not found' });
+    const st = fs.statSync(resolved.absPath);
+    const stream = fs.createReadStream(resolved.absPath);
+    stream.on('error', () => { if (!res.headersSent) sendJson(res, 500, { error: 'read failed' }); else res.end(); });
+    res.writeHead(200, {
+      'content-type': resolved.mime,
+      'content-length': String(st.size),
+      'content-disposition': `inline; filename="${resolved.filename.replace(/"/g, '')}"`,
+    });
+    stream.pipe(res);
+    return;
+  }
+  // Remove an attachment. Any member (like a task edit); the removal is logged on the task timeline.
+  if (taskAttachment && method === 'DELETE') {
+    const ok = os.tasks.removeAttachment(taskAttachment[1], me.id);
+    if (ok) os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'task.attachment.removed', data: { id: taskAttachment[1] } });
+    return sendJson(res, ok ? 200 : 404, { ok });
   }
   if (method === 'POST' && p === '/api/tasks') {
     const b = await readBody(req);

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -426,6 +426,22 @@ function migrate(db: Db): void {
       INSERT INTO tasks_fts(rowid, title, body, labels) VALUES (new.rowid, new.title, new.body, new.labels);
     END;
 
+    -- Files attached to a task (humans upload from the console; agents snapshot from their working
+    -- folder via task_attach). Each row is a file copied into <home>/task-attachments/<task_id>/<id>-
+    -- <filename> — same on-disk snapshot model as artifacts, keyed to the task instead of a session.
+    CREATE TABLE IF NOT EXISTS task_attachments (
+      id          TEXT PRIMARY KEY,
+      task_id     TEXT NOT NULL,
+      tenant      TEXT NOT NULL,
+      filename    TEXT NOT NULL,           -- original basename (display + download name)
+      rel_path    TEXT NOT NULL,           -- path under <home>/task-attachments/ (<task_id>/<id>-<filename>)
+      mime        TEXT NOT NULL,
+      bytes       INTEGER NOT NULL,
+      uploaded_by TEXT NOT NULL,           -- member id | 'agent:<id>'
+      created_at  INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_task_attachments ON task_attachments(task_id, created_at);
+
     -- Which agents a library skill is scoped to (the skill artifact itself stays on disk under
     -- home/skills/name). Same join-table shape as assignments (members->agents). A skill with
     -- NO rows here is materialised into EVERY claude-code agent (the default & today's behavior);

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -17,8 +17,10 @@
  * the KB pattern — see docs/tasks-plan.md §Decision 2.)
  */
 import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
 import { Db } from './db';
-import { Task, TaskCreateInput, TaskEvent, TaskQuery, TaskStatus, TaskUpdateInput } from '../types';
+import { Task, TaskAttachment, TaskCreateInput, TaskEvent, TaskQuery, TaskStatus, TaskUpdateInput } from '../types';
 
 interface TaskRow {
   id: string; tenant: string; title: string; body: string; status: string; priority: number;
@@ -31,6 +33,12 @@ interface EventRow {
   id: string; task_id: string; kind: string; body: string | null; author: string;
   session_id: string | null; created_at: number;
 }
+interface AttachmentRow {
+  id: string; task_id: string; tenant: string; filename: string; rel_path: string;
+  mime: string; bytes: number; uploaded_by: string; created_at: number;
+}
+
+export type AttachResult = { ok: true; attachment: TaskAttachment } | { ok: false; error: string };
 
 const TERMINAL: ReadonlySet<TaskStatus> = new Set<TaskStatus>(['done', 'cancelled']);
 const STATUSES: readonly TaskStatus[] = ['todo', 'doing', 'blocked', 'done', 'cancelled'];
@@ -52,7 +60,12 @@ export interface TaskNotice {
 }
 
 export class TaskStore {
-  constructor(private readonly db: Db) {}
+  /** `dir` = `<home>/task-attachments/`, where attached files snapshot to. Undefined (demo/tests on
+   *  `:memory:`) disables attachments. Task ROWS are still db-only (§Decision 2); only files hit disk. */
+  constructor(private readonly db: Db, private readonly dir?: string) {}
+
+  /** Are file attachments available? (Needs a data home; off for demo/tests on `:memory:`.) */
+  get attachmentsEnabled(): boolean { return !!this.dir; }
 
   private notifier?: (n: TaskNotice) => void;
   /** Register the sink fired on task create / (re)assignment / status change. Best-effort, post-construction
@@ -211,11 +224,13 @@ export class TaskStore {
     this.addEvent(id, 'dispatch', `dispatched session ${sessionId}`, 'system', sessionId);
   }
 
-  /** Hard delete + cascade the activity log (owner/admin at the route layer). */
+  /** Hard delete + cascade the activity log, attachment rows, and the on-disk attachment dir. */
   remove(id: string): boolean {
     const res = this.db.prepare('DELETE FROM tasks WHERE id = ?').run(id);
     if (res.changes === 0) return false;
     this.db.prepare('DELETE FROM task_events WHERE task_id = ?').run(id);
+    this.db.prepare('DELETE FROM task_attachments WHERE task_id = ?').run(id);
+    if (this.dir) fs.rmSync(path.join(this.dir, id), { recursive: true, force: true });
     return true;
   }
 
@@ -261,6 +276,89 @@ export class TaskStore {
       .map(toTask);
   }
 
+  // ── Attachments ────────────────────────────────────────────────────────────────────────────────
+  // Files attached to a task, snapshotted onto disk under <home>/task-attachments/<taskId>/<id>-<name>
+  // (the same immutable-copy model as ArtifactStore). Both humans (console upload → raw bytes) and
+  // agents (task_attach → a path in their working folder) land here through attachBytes / attachFromPath.
+
+  /** Attach a file from raw bytes (the console upload path). Logs an `attach` event on the task. */
+  attachBytes(input: { taskId: string; filename: string; bytes: Buffer; uploadedBy: string }): AttachResult {
+    if (!this.dir) return { ok: false, error: 'no data home configured (attachments disabled)' };
+    if (!this.get(input.taskId)) return { ok: false, error: 'task not found' };
+    const filename = sanitizeName(input.filename);
+    if (!filename) return { ok: false, error: 'invalid file name' };
+    return this.writeAttachment(input.taskId, filename, input.bytes, input.uploadedBy);
+  }
+
+  /**
+   * Attach a file the agent names in its working folder (the `task_attach` MCP path). `allowRoot` is the
+   * agent's folder; `srcPath` is resolved STRICTLY under it (lexically + after symlink resolution), so an
+   * agent can't attach `/etc/passwd` or escape via a symlink. Mirrors ArtifactStore.publish.
+   */
+  attachFromPath(input: { taskId: string; allowRoot: string; srcPath: string; uploadedBy: string }): AttachResult {
+    if (!this.dir) return { ok: false, error: 'no data home configured (attachments disabled)' };
+    if (!this.get(input.taskId)) return { ok: false, error: 'task not found' };
+    const src = containedPath(input.allowRoot, input.srcPath);
+    if (!src) return { ok: false, error: 'path escapes the agent folder or does not exist' };
+    let st: fs.Stats;
+    try { st = fs.statSync(src); } catch { return { ok: false, error: 'not found' }; }
+    if (!st.isFile()) return { ok: false, error: 'not a file' };
+    return this.writeAttachment(input.taskId, path.basename(src), fs.readFileSync(src), input.uploadedBy);
+  }
+
+  /** Shared writer: copy bytes to disk, insert the row, log the `attach` event. */
+  private writeAttachment(taskId: string, filename: string, bytes: Buffer, uploadedBy: string): AttachResult {
+    const id = randomUUID().slice(0, 8);
+    const rel = path.join(taskId, `${id}-${filename}`);
+    const dest = path.join(this.dir!, rel);
+    try {
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.writeFileSync(dest, bytes);
+    } catch (e) {
+      return { ok: false, error: `write failed: ${(e as Error).message}` };
+    }
+    const now = Date.now();
+    this.db
+      .prepare(`INSERT INTO task_attachments (id, task_id, tenant, filename, rel_path, mime, bytes, uploaded_by, created_at)
+                 VALUES (?, ?, (SELECT tenant FROM tasks WHERE id = ?), ?, ?, ?, ?, ?, ?)`)
+      .run(id, taskId, taskId, filename, rel, mimeOf(filename), bytes.length, uploadedBy, now);
+    this.addEvent(taskId, 'attach', filename, uploadedBy);
+    return { ok: true, attachment: toAttachment(this.db.prepare('SELECT * FROM task_attachments WHERE id = ?').get<AttachmentRow>(id)!) };
+  }
+
+  /** All attachments on a task, oldest first (upload order). */
+  attachments(taskId: string): TaskAttachment[] {
+    return this.db
+      .prepare('SELECT * FROM task_attachments WHERE task_id = ? ORDER BY created_at ASC, id ASC')
+      .all<AttachmentRow>(taskId)
+      .map(toAttachment);
+  }
+
+  getAttachment(id: string): TaskAttachment | undefined {
+    const r = this.db.prepare('SELECT * FROM task_attachments WHERE id = ?').get<AttachmentRow>(id);
+    return r ? toAttachment(r) : undefined;
+  }
+
+  /** Resolve an attachment's bytes for streaming/download. null if missing or the dir is disabled. */
+  readAttachment(id: string): { absPath: string; mime: string; filename: string } | null {
+    if (!this.dir) return null;
+    const a = this.getAttachment(id);
+    if (!a) return null;
+    const abs = path.join(this.dir, a.relPath);
+    try { if (!fs.statSync(abs).isFile()) return null; } catch { return null; }
+    return { absPath: abs, mime: a.mime, filename: a.filename };
+  }
+
+  /** Remove one attachment: its row, its on-disk file, and a `comment` event noting the removal. */
+  removeAttachment(id: string, by: string): boolean {
+    const a = this.getAttachment(id);
+    if (!a) return false;
+    this.db.prepare('DELETE FROM task_attachments WHERE id = ?').run(id);
+    if (this.dir) fs.rmSync(path.join(this.dir, a.relPath), { force: true });
+    this.addEvent(a.taskId, 'comment', `removed attachment ${a.filename}`, by);
+    return true;
+  }
+
   /** Append one row to the append-only activity log. */
   private addEvent(taskId: string, kind: TaskEvent['kind'], body: string, author: string, sessionId?: string): void {
     this.db
@@ -298,4 +396,45 @@ function toEvent(r: EventRow): TaskEvent {
     id: r.id, taskId: r.task_id, kind: r.kind as TaskEvent['kind'], body: r.body ?? undefined,
     author: r.author, sessionId: r.session_id ?? undefined, createdAt: r.created_at,
   };
+}
+
+function toAttachment(r: AttachmentRow): TaskAttachment {
+  return {
+    id: r.id, taskId: r.task_id, tenant: r.tenant, filename: r.filename, relPath: r.rel_path,
+    mime: r.mime, bytes: r.bytes, uploadedBy: r.uploaded_by, createdAt: r.created_at,
+  };
+}
+
+/** Collapse an uploaded name to a single safe basename (no path separators, no `.`/`..`). */
+function sanitizeName(name: string): string {
+  const base = path.basename(String(name ?? '').trim().replace(/[/\\]+/g, '/'));
+  return base === '.' || base === '..' ? '' : base;
+}
+
+/** Resolve `rel` under `root`, rejecting escapes lexically AND after symlink resolution. The target
+ *  must already exist (you attach a real file). Mirrors ArtifactStore.containedPath. */
+function containedPath(root: string, rel: string): string | null {
+  let realRoot: string;
+  try { realRoot = fs.realpathSync(root); } catch { realRoot = path.resolve(root); }
+  const within = (p: string) => p === realRoot || p.startsWith(realRoot + path.sep);
+  const target = path.resolve(realRoot, rel.replace(/^[/\\]+/, ''));
+  if (!within(target) || !fs.existsSync(target)) return null;
+  let real: string;
+  try { real = fs.realpathSync(target); } catch { return null; }
+  return within(real) ? real : null;
+}
+
+/** Content-type by extension — self-contained (no server dependency). Mirrors ArtifactStore.mimeOf. */
+function mimeOf(file: string): string {
+  const e = path.extname(file).toLowerCase();
+  const map: Record<string, string> = {
+    '.md': 'text/markdown; charset=utf-8', '.markdown': 'text/markdown; charset=utf-8',
+    '.txt': 'text/plain; charset=utf-8', '.log': 'text/plain; charset=utf-8',
+    '.csv': 'text/csv; charset=utf-8', '.json': 'application/json',
+    '.html': 'text/html; charset=utf-8', '.htm': 'text/html; charset=utf-8',
+    '.pdf': 'application/pdf', '.png': 'image/png', '.jpg': 'image/jpeg', '.jpeg': 'image/jpeg',
+    '.gif': 'image/gif', '.webp': 'image/webp', '.svg': 'image/svg+xml',
+    '.zip': 'application/zip',
+  };
+  return map[e] || 'application/octet-stream';
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1710,6 +1710,22 @@ export class TerminalManager {
   }
 
   /**
+   * Agent attaches a file from its OWN working folder onto a task (the `task_attach` MCP path). The
+   * store resolves the path strictly under the agent folder + snapshots it into the task's attachment
+   * dir. Uploader = `agent:<id>`; auto-apply + audited, exactly like publishArtifact / task edits.
+   */
+  attachTaskFile(sessionId: string, taskId: string, srcPath: string): { ok: boolean; id?: string; filename?: string; error?: string } {
+    const agent = this.sessionAgent(sessionId);
+    if (!agent) return { ok: false, error: 'unknown session' };
+    const manifest = this.os.agents.get(agent);
+    if (!manifest?.dir) return { ok: false, error: 'agent has no working folder' };
+    const r = this.os.tasks.attachFromPath({ taskId, allowRoot: manifest.dir, srcPath, uploadedBy: `agent:${agent}` });
+    if (!r.ok) return { ok: false, error: r.error };
+    this.audit(sessionId, agent, 'task.attached', { taskId, id: r.attachment.id, filename: r.attachment.filename, bytes: r.attachment.bytes, mime: r.attachment.mime });
+    return { ok: true, id: r.attachment.id, filename: r.attachment.filename };
+  }
+
+  /**
    * Console operator pasted/dropped a file (typically an image) onto a LIVE session. Save it under the
    * agent's OWN working folder (`.inbox/`) — reachable by the agent's Read tool via a relative path —
    * and type its relative path into the running claude (no auto-submit) so the operator can add a

--- a/src/types.ts
+++ b/src/types.ts
@@ -606,10 +606,23 @@ export interface Task {
 export interface TaskEvent {
   id: string;
   taskId: string;
-  kind: 'comment' | 'status' | 'claim' | 'dispatch' | 'assign' | 'link';
+  kind: 'comment' | 'status' | 'claim' | 'dispatch' | 'assign' | 'link' | 'attach';
   body?: string;
   author: string; // member id | 'agent:<id>' | 'automation:<id>' | 'system'
   sessionId?: string;
+  createdAt: number;
+}
+
+/** A file attached to a task — a durable on-disk snapshot (mirrors {@link Artifact}, keyed to a task). */
+export interface TaskAttachment {
+  id: string;
+  taskId: string;
+  tenant: string;
+  filename: string; // original basename (display + download name)
+  relPath: string; // under <home>/task-attachments/ (<taskId>/<id>-<filename>)
+  mime: string;
+  bytes: number;
+  uploadedBy: string; // member id | 'agent:<id>'
   createdAt: number;
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
 import { type Branding, type PublicBranding } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage } from '@/connectors'
@@ -3406,7 +3406,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
   const selId = taskId || null
   const openTask = (id: string) => nav('tasks', id)
   const closeTask = () => { setEditing(false); nav('tasks') }
-  const [detail, setDetail] = useState<{ task: Task; events: TaskEvent[] } | null>(null)
+  const [detail, setDetail] = useState<{ task: Task; events: TaskEvent[]; attachments: TaskAttachment[] } | null>(null)
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   // view + filters
@@ -3462,7 +3462,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
   useEffect(() => {
     if (!selId) { setDetail(null); return }
     if (editing) return // don't overwrite an in-progress edit on a background refresh
-    api.task(selId).then((r) => { if (r.task) setDetail({ task: r.task, events: r.events ?? [] }) })
+    api.task(selId).then((r) => { if (r.task) setDetail({ task: r.task, events: r.events ?? [], attachments: r.attachments ?? [] }) })
   }, [selId, tasks, editing])
   useEffect(() => { setEditing(false); setConfirmDel(false) }, [selId]) // fresh drawer per selection
 
@@ -3512,8 +3512,10 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
     await api.patchTask(detail.task.id, { title: eTitle, body: eBody })
     setEditing(false); setBusy(false)
     await load()
-    const r = await api.task(detail.task.id); if (r.task) setDetail({ task: r.task, events: r.events ?? [] })
+    const r = await api.task(detail.task.id); if (r.task) setDetail({ task: r.task, events: r.events ?? [], attachments: r.attachments ?? [] })
   }
+  // Re-pull the open task's detail (events + attachments) after a mutation that doesn't move columns.
+  const refreshDetail = async (id: string) => { const r = await api.task(id); if (r.task) setDetail({ task: r.task, events: r.events ?? [], attachments: r.attachments ?? [] }) }
 
   if (!tasks) return <div className="text-sm text-muted-foreground">Loading…</div>
 
@@ -3783,7 +3785,15 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
                 )}
                 {hint && <div className="font-mono text-xs text-destructive">{hint}</div>}
 
-                <CommentBox onSubmit={async (text) => { await api.commentTask(detail.task.id, text); await api.task(detail.task.id).then((r) => r.task && setDetail({ task: r.task, events: r.events ?? [] })) }} />
+                <CommentBox onSubmit={async (text) => { await api.commentTask(detail.task.id, text); await refreshDetail(detail.task.id) }} />
+
+                <TaskAttachments
+                  taskId={detail.task.id}
+                  attachments={detail.attachments}
+                  nameOf={nameOf}
+                  onChange={() => refreshDetail(detail.task.id)}
+                />
+
 
                 <div>
                   <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Activity</div>
@@ -3828,6 +3838,67 @@ function CommentBox({ onSubmit }: { onSubmit: (text: string) => Promise<void> })
     <div className="flex items-end gap-2">
       <Textarea value={text} onChange={(e) => setText(e.target.value)} rows={1} placeholder="Add a comment…" className="min-h-8 text-xs" />
       <Button size="sm" disabled={!text.trim() || busy} onClick={async () => { setBusy(true); await onSubmit(text); setText(''); setBusy(false) }}><Send className="h-3.5 w-3.5" /></Button>
+    </div>
+  )
+}
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`
+}
+
+/** Attachments section of the task drawer: upload (button/drop), list with download, delete. */
+function TaskAttachments({ taskId, attachments, nameOf, onChange }: {
+  taskId: string; attachments: TaskAttachment[]; nameOf: (id?: string) => string; onChange: () => Promise<void> | void
+}) {
+  const [busy, setBusy] = useState(false)
+  const [hint, setHint] = useState('')
+  const [drag, setDrag] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const upload = async (files: FileList | null) => {
+    if (!files || files.length === 0) return
+    setBusy(true); setHint('')
+    for (const f of Array.from(files)) {
+      const r = await api.uploadTaskAttachment(taskId, f)
+      if (!r.ok) { setHint('⚠ ' + (r.error || `could not upload ${f.name}`)); break }
+    }
+    if (inputRef.current) inputRef.current.value = ''
+    await onChange()
+    setBusy(false)
+  }
+  const del = async (attId: string) => { setBusy(true); await api.deleteTaskAttachment(taskId, attId); await onChange(); setBusy(false) }
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Attachments{attachments.length ? ` · ${attachments.length}` : ''}</div>
+        <Button size="sm" variant="outline" className="h-7" disabled={busy} onClick={() => inputRef.current?.click()}>
+          <Upload className="mr-1 h-3.5 w-3.5" />Upload
+        </Button>
+        <input ref={inputRef} type="file" multiple className="hidden" onChange={(e) => upload(e.target.files)} />
+      </div>
+      <div
+        onDragOver={(e) => { e.preventDefault(); setDrag(true) }}
+        onDragLeave={() => setDrag(false)}
+        onDrop={(e) => { e.preventDefault(); setDrag(false); upload(e.dataTransfer.files) }}
+        className={`space-y-1 rounded-md border border-dashed p-2 ${drag ? 'border-primary bg-primary/10' : 'border-border'}`}
+      >
+        {attachments.length === 0 && <div className="py-1 text-center text-xs text-muted-foreground">Drop files here or use Upload.</div>}
+        {attachments.map((a) => (
+          <div key={a.id} className="flex items-center gap-2 rounded-md border bg-muted/20 p-2">
+            <FileIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              <a href={api.taskAttachmentUrl(taskId, a.id)} target="_blank" rel="noreferrer" className="block truncate text-xs font-medium text-foreground hover:underline" title={a.filename}>{a.filename}</a>
+              <div className="text-[10px] text-muted-foreground">{fmtBytes(a.bytes)} · {nameOf(a.uploadedBy)}</div>
+            </div>
+            <a href={api.taskAttachmentUrl(taskId, a.id)} download={a.filename} className="text-muted-foreground hover:text-foreground" title="Download"><Download className="h-3.5 w-3.5" /></a>
+            <button disabled={busy} onClick={() => del(a.id)} className="text-muted-foreground hover:text-destructive" title="Remove"><Trash2 className="h-3.5 w-3.5" /></button>
+          </div>
+        ))}
+      </div>
+      {hint && <div className="mt-1 font-mono text-xs text-destructive">{hint}</div>}
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -285,10 +285,21 @@ export interface Task {
 export interface TaskEvent {
   id: string
   taskId: string
-  kind: 'comment' | 'status' | 'claim' | 'dispatch' | 'assign' | 'link'
+  kind: 'comment' | 'status' | 'claim' | 'dispatch' | 'assign' | 'link' | 'attach'
   body?: string
   author: string
   sessionId?: string
+  createdAt: number
+}
+export interface TaskAttachment {
+  id: string
+  taskId: string
+  tenant: string
+  filename: string
+  relPath: string
+  mime: string
+  bytes: number
+  uploadedBy: string
   createdAt: number
 }
 export interface AddTaskReq {
@@ -844,12 +855,20 @@ export const api = {
   kbDelete: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/kb/page/${id}`),
 
   tasks: (q = '', status = '') => call<{ tasks: Task[]; counts: Record<TaskStatus, number>; agents: string[] }>('GET', `/api/tasks?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
-  task: (id: string) => call<{ task?: Task; events?: TaskEvent[]; error?: string }>('GET', `/api/tasks/${id}`),
+  task: (id: string) => call<{ task?: Task; events?: TaskEvent[]; attachments?: TaskAttachment[]; error?: string }>('GET', `/api/tasks/${id}`),
   addTask: (b: AddTaskReq) => call<{ ok: boolean; task?: Task; error?: string }>('POST', '/api/tasks', b),
   patchTask: (id: string, b: { title?: string; body?: string; status?: TaskStatus; assignee?: string | null; priority?: number; labels?: string[]; mode?: 'headless' | 'interactive'; dueAt?: number | null; note?: string }) => call<{ ok: boolean; task?: Task; error?: string }>('PATCH', `/api/tasks/${id}`, b),
   commentTask: (id: string, body: string) => call<{ ok: boolean; task?: Task; error?: string }>('POST', `/api/tasks/${id}/comment`, { body }),
   dispatchTask: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/tasks/${id}/dispatch`),
   deleteTask: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/tasks/${id}`),
+  /** Upload a file onto a task (raw bytes). */
+  uploadTaskAttachment: async (id: string, file: File): Promise<{ ok: boolean; attachment?: TaskAttachment; error?: string }> => {
+    const r = await fetch(`/api/tasks/${id}/attachments?name=${encodeURIComponent(file.name)}`, { method: 'POST', credentials: 'same-origin', body: file })
+    return r.json()
+  },
+  deleteTaskAttachment: (taskId: string, attId: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/tasks/${taskId}/attachments/${attId}`),
+  /** Direct URL to an attachment's bytes (inline; for download/preview links). */
+  taskAttachmentUrl: (taskId: string, attId: string) => `/api/tasks/${taskId}/attachments/${attId}/raw`,
   dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),


### PR DESCRIPTION
## What

Adds **file attachments to tasks** — a task can now carry files (screenshots, logs, PDFs, CSVs, generated deliverables) alongside its description and activity timeline. Both humans (console) and working agents (MCP) can attach.

## How it works

- **Storage.** New `task_attachments` table + immutable on-disk snapshots under `<home>/task-attachments/<taskId>/<id>-<name>` — the same snapshot model as the Artifacts gallery, keyed to a task instead of a session. `TaskStore` gains `attachBytes` / `attachFromPath` / `attachments` / `readAttachment` / `removeAttachment`; deleting a task cascades its attachment rows + files. Task *rows* stay db-only (§Decision 2); only files hit disk.
- **Humans.** The Tasks detail drawer gets an **Attachments** section: upload via picker **or** drag-and-drop, per-file download, and delete. Member routes `POST/GET-raw/DELETE /api/tasks/:id/attachments[...]`.
- **Agents.** New **`task_attach`** MCP tool snapshots a file from the agent's own working folder (path resolved strictly under the agent dir, exactly like `publish`, so it can't escape). Loopback route `POST /api/tasks/attach` → `TerminalManager.attachTaskFile` → `TaskStore.attachFromPath`. `task_get` now also lists attachments.
- Each attach logs an `attach` timeline event + audits `task.attached`; removals log a comment event + audit `task.attachment.removed`.

## Verification

Driven end-to-end on an ephemeral instance (`createHttpServer` + `fetch`):
- Authenticated member lifecycle: **upload → task_get (attachment + `attach` event present) → raw download (correct content-type + bytes) → delete → back to 0**.
- Empty upload rejected (400); route registration confirmed (`/api/tasks/attach` → 404 for unknown session, not the 401 stale-server symptom; member routes → 401 unauthenticated).
- Store-level: name sanitisation (path traversal collapsed to basename), missing-task rejection, task-delete cascade.
- `npm run typecheck`, `cd web && npm run build`, `npm run demo`, and **68/68 governance conformance** all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)