### PR TITLE
feat(tasks): show member avatars on the Tasks board (v0.90.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.90.0] — 2026-07-10
+### Added
+- **Member avatars now show on the Tasks board too.** The profile pictures added in 0.88.0 are reused
+  wherever a task names a person: the assignee badge on Kanban cards and list rows, and both "Assign to"
+  dropdowns show the member's avatar (falling back to their initial when unset). Agents keep their own
+  manifest icon and system/automation/unknown assignees keep the person glyph — the swap only applies to
+  ids that resolve to a real member. Done via the existing `assigneeIcon` helper + the shared
+  `MemberAvatar`, so no new data plumbing (`web/src/App.tsx`). Other people-naming surfaces
+  (Sessions "started by"/"run as", Inbox attributions, Audit principal) still show label strings only —
+  those receive a name from the server, not a member object, so they'd need API changes to gain avatars.
+
 ## [0.89.0] — 2026-07-10
 ### Added
 - **File attachments on tasks.** A task can now carry files — screenshots, logs, PDFs, CSVs, generated

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.89.0",
+      "version": "0.90.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.89.0",
+  "version": "0.90.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3438,11 +3438,15 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
   const isAdmin = me.role === 'owner' || me.role === 'admin'
   const chatAgents = agents.filter((a) => a.runtime === 'claude-code')
   const nameOf = (id?: string) => principalLabel(id, members)
-  // Assignee glyph: an AGENT shows its OWN icon (from the manifest), a human shows the person glyph.
-  const assigneeIcon = (id: string | undefined, cls: string) =>
-    id?.startsWith('agent:')
-      ? <AgentIcon icon={agents.find((a) => a.id === id.slice('agent:'.length))?.icon} className={cls} />
-      : <User className={cls} />
+  // Assignee glyph: an AGENT shows its OWN icon (from the manifest); a member shows their avatar (or
+  // their initial when they haven't uploaded one); anyone/anything else (system, automation, unknown
+  // id) falls back to the person glyph.
+  const assigneeIcon = (id: string | undefined, cls: string) => {
+    if (id?.startsWith('agent:')) return <AgentIcon icon={agents.find((a) => a.id === id.slice('agent:'.length))?.icon} className={cls} />
+    const mem = id ? members.find((m) => m.id === id) : undefined
+    if (mem) return <MemberAvatar member={mem} className={`${cls} text-[8px]`} />
+    return <User className={cls} />
+  }
   // An assignee shown as a chip: its icon + friendly name. Used on cards, list rows, and select items.
   const assigneeChip = (id?: string, cls = 'h-3 w-3') => <span className="inline-flex items-center gap-1">{assigneeIcon(id, cls)}{nameOf(id)}</span>
 
@@ -3606,7 +3610,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
                   <SelectContent>
                     <SelectItem value="none">Unassigned</SelectItem>
                     {chatAgents.map((a) => <SelectItem key={a.id} value={`agent:${a.id}`}><span className="flex items-center gap-1.5"><AgentIcon icon={a.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />{a.id}</span></SelectItem>)}
-                    {members.map((m) => <SelectItem key={m.id} value={m.id}><span className="flex items-center gap-1.5"><User className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />{m.name || m.email}</span></SelectItem>)}
+                    {members.map((m) => <SelectItem key={m.id} value={m.id}><span className="flex items-center gap-1.5"><MemberAvatar member={m} className="h-4 w-4 text-[8px]" />{m.name || m.email}</span></SelectItem>)}
                   </SelectContent>
                 </Select>
               </Field>
@@ -3753,7 +3757,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
                       <SelectContent>
                         <SelectItem value="none">Unassigned</SelectItem>
                         {chatAgents.map((a) => <SelectItem key={a.id} value={`agent:${a.id}`}><span className="flex items-center gap-1.5"><AgentIcon icon={a.icon} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />{a.id}</span></SelectItem>)}
-                        {members.map((m) => <SelectItem key={m.id} value={m.id}><span className="flex items-center gap-1.5"><User className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />{m.name || m.email}</span></SelectItem>)}
+                        {members.map((m) => <SelectItem key={m.id} value={m.id}><span className="flex items-center gap-1.5"><MemberAvatar member={m} className="h-4 w-4 text-[8px]" />{m.name || m.email}</span></SelectItem>)}
                       </SelectContent>
                     </Select>
                   </Field>


### PR DESCRIPTION
## What

Extends the member profile pictures from #158 to the **Tasks page** — the one other surface that already has full member objects in hand (it loads the team list for its assignee dropdowns).

Avatars now appear on:
- **Kanban card + list-row assignee badges**
- **Both "Assign to" dropdowns** (create form + detail drawer)

Falls back to the member's **initial** when they haven't uploaded a picture. **Agents** keep their manifest icon and **system/automation/unknown** assignees keep the person glyph — the avatar swap only applies to ids that resolve to a real member.

## How

Single-point change in the existing `assigneeIcon` helper plus swapping the two dropdowns' inline `<User>` for the shared `MemberAvatar`. No new data plumbing — `TasksPage` already fetches the full member list.

## Why not everywhere

Other people-naming surfaces — Sessions "started by"/"run as", Inbox "resolved by"/"answered by", Audit `principal`, KB/agent-revision authors — receive a **label string** from the server, not a member object, so there's nothing to draw an avatar from without API changes. Called out in the changelog; happy to do a follow-up that enriches those responses if wanted.

## Verification

`cd web && npm run build` clean. Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)