### PR TITLE
feat(sessions): take over a headless run — convert it to interactive (v0.91.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.91.0] — 2026-07-10
+### Added
+- **Take over a headless run — convert it to an interactive session you can watch and steer.** A
+  headless run (cron/webhook/chat/task automation) is `claude -p` — non-interactive and unattended.
+  From the console you can now promote one to a live, attachable interactive TUI: a **Take over
+  (go interactive)** control sits over the live-streaming terminal, a **Continue interactively** button
+  sits on a finished run's read-only transcript, and a **Take over** action appears on the run's row in
+  every Sessions list. It re-launches the same run interactively under its pinned `--session-id`
+  (`claude --resume`), so the conversation continues with full context; if the `-p` run is still
+  streaming it's stopped first (the in-flight turn ends and resume picks up from the last completed
+  turn). Reuses the existing resume/attach machinery — the relaunch writes the `session-<id>.env` the
+  headless lane skips, so the run becomes resumable/attachable like any interactive session. New route
+  `POST /api/sessions/:id/interactive` (same per-member gate as stop/resume) → `TerminalManager.goInteractive`;
+  audited `session.interactive`. Only claude-code runs with a pinned session id qualify.
+
 ## [0.90.0] — 2026-07-10
 ### Added
 - **Member avatars now show on the Tasks board too.** The profile pictures added in 0.88.0 are reused

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.90.0",
+      "version": "0.91.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.90.0",
+  "version": "0.91.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1489,6 +1489,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
     return sendJson(res, 200, { ok: tm.stopSession(id, me.email) });
   }
+  // Take over a headless run: convert it to an attachable interactive session (relaunch `claude --resume`
+  // under the same id). Kills the in-flight `-p` turn if still streaming. Same per-member gate as stop.
+  const interactiveMatch = p.match(/^\/api\/sessions\/([\w-]+)\/interactive$/);
+  if (method === 'POST' && interactiveMatch) {
+    const id = interactiveMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
+    const r = tm.goInteractive(id, me.email);
+    return sendJson(res, r.ok ? 200 : 400, r);
+  }
   // Human verdict on a finished run — 👍/👎 (or null to clear). The ground-truth signal for the agent
   // maturity score. Same per-member gate as stop: you can rate any run you're allowed to see.
   const rateMatch = p.match(/^\/api\/sessions\/([\w-]+)\/rate$/);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -875,6 +875,50 @@ export class TerminalManager {
   }
 
   /**
+   * "Take over" a headless run: convert it into an attachable INTERACTIVE session so a human can watch and
+   * steer. A headless run is `claude -p` — non-interactive, and its pane dies on completion leaving no
+   * resurrect env. But it was pinned to `--session-id CLAUDE_SESSION_ID`, so its transcript persists on
+   * disk; we re-launch the interactive lane under the SAME id with `resume:true` (`claude --resume`), which
+   * writes the `session-<id>.env` the attach/resume path needs and picks up the conversation. If the `-p`
+   * run is still streaming we kill it first (the in-flight turn is lost — resume continues from the last
+   * COMPLETED turn; a `-p` process can't be promoted to a TUI in place). Idempotent-ish: converting an
+   * already-interactive live session is a no-op success (it's already headed). Returns an error string when
+   * the session can't be converted (unknown, not a claude-code run, or predates the pinned session id).
+   */
+  goInteractive(sessionId: string, by: string): { ok: boolean; error?: string } {
+    const row = this.db.prepare('SELECT agent, secret, claude_session_id, run_as, spawned_by, status, task FROM term_sessions WHERE id = ?')
+      .get<{ agent: string; secret: string | null; claude_session_id: string | null; run_as: string | null; spawned_by: string | null; status: string; task: string }>(sessionId);
+    if (!row) return { ok: false, error: 'unknown session' };
+    // Only the real claude-code runtime resumes; a mock/other runtime has no transcript to continue.
+    const manifest = this.os.agents.get(row.agent);
+    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can go interactive' };
+    // No pinned claude id → the run predates resumable session ids (or never started claude); nothing to resume.
+    if (!row.claude_session_id) return { ok: false, error: 'this run has no resumable transcript' };
+    // Already an attachable interactive session (has a persisted resurrect env) and live → nothing to do.
+    const alreadyInteractive = !!this.os.paths && fs.existsSync(path.join(this.os.paths.connectors, `session-${sessionId}.env`));
+    if (alreadyInteractive && this.isAlive(sessionId)) return { ok: true };
+    const actingMember = row.run_as ?? undefined;
+    const hasSlack = !!this.db.prepare('SELECT 1 FROM slack_threads WHERE session_id = ?').get(sessionId);
+    const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
+    // If the headless `-p` pane is still alive, kill it so the tmux name frees for the interactive relaunch
+    // (backend.kill is synchronous). The in-flight turn ends here; the resume picks up the last saved turn.
+    const wasAlive = this.isAlive(sessionId);
+    if (wasAlive) this.backend.kill(this.spaceFor(actingMember ?? row.spawned_by ?? undefined), `aos-${sessionId}`);
+    // A prior stop must not veto the deliberate re-open; clear any sentinel before we relaunch/attach.
+    this.allowResume(sessionId);
+    this.db.prepare("UPDATE term_sessions SET status = 'running', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
+    this.audit(sessionId, by, 'session.interactive', { agent: row.agent, wasAlive });
+    // Re-launch the interactive lane for the SAME row: headless:false → writes session-<id>.env; resume:true
+    // → `claude --resume CLAUDE_SESSION_ID`. This reuses the whole resume/attach machinery (no new env plumbing).
+    this.launchClaudeCode({
+      id: sessionId, agent: row.agent, task: row.task, secret: row.secret ?? randomBytes(24).toString('hex'),
+      actingMember, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord,
+      headless: false, resident: false, resume: true, claudeSessionId: row.claude_session_id,
+    });
+    return { ok: true };
+  }
+
+  /**
    * Idle reaper: kill resident (warm) chat sessions whose last turn was longer ago than the configured
    * timeout (Settings → Integrations; default 30 min). Frees the held claude process + MCP servers; the
    * thread's row stays (status → stopped) so a later reply revives it. `timeoutMin = 0` disables residence

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,6 +60,20 @@ const resumeAndOpen = (s: Session, onOpen: (tmux: string, title: string) => void
   void api.resumeSession(s.id).finally(() => onOpen(s.tmux, s.agent + ' · ' + s.id))
 }
 
+/** A headless run (automation/cron/chat/task) is `claude -p` — non-interactive, and it writes no resurrect
+ *  env, so it's never `resumable`. It CAN be "taken over": relaunched as an attachable interactive session
+ *  (`claude --resume` under the same pinned id) so a human can watch and steer. Offered while it's live
+ *  (streaming) or after it finished (continue the transcript). Interactive runs already have a live/Resume
+ *  path, so they never show this. Server re-checks it's a claude-code run with a resumable transcript. */
+const canGoInteractive = (s: Session): boolean =>
+  !s.resumable && (isLive(s) || s.status === 'done' || s.status === 'crashed')
+
+/** Take over a headless run: convert it to an interactive session server-side (kills the in-flight `-p`
+ *  turn if still streaming), THEN open/focus its terminal so the user lands in the live, attachable TUI. */
+const takeOverAndOpen = (s: Session, onOpen: (tmux: string, title: string) => void): void => {
+  void api.goInteractive(s.id).finally(() => onOpen(s.tmux, s.agent + ' · ' + s.id))
+}
+
 /** Coarse provenance category of a session, from its raw `spawnedBy` (`automation:`/`task:`/`chat:`
  *  prefixes, else a member started it directly). Drives the Source filter on the sessions list. */
 type SessionSource = 'member' | 'automation' | 'task' | 'chat'
@@ -1327,6 +1341,14 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
   const [wsUrl, setWsUrl] = useState('')
   const [err, setErr] = useState('')
   const [transcript, setTranscript] = useState<string | null>(null)
+  // "Take over" state: converting a headless run to interactive re-launches it server-side, but the
+  // `session` prop (and its `resumable`/`status`) only refreshes on the next poll. `overrideAttach`
+  // forces the attach path immediately; `nonce` re-runs the attach fetch and remounts <Xterm> so it
+  // reconnects to the freshly-spawned interactive pane. Reset when the viewed session changes.
+  const [overrideAttach, setOverrideAttach] = useState(false)
+  const [nonce, setNonce] = useState(0)
+  const [takingOver, setTakingOver] = useState(false)
+  useEffect(() => { setOverrideAttach(false); setNonce(0); setTakingOver(false) }, [session?.id])
   // Terminal font size — lifted here so it drives BOTH the <Xterm> (a live prop) and the stepper in the
   // ImageDropZone chrome. Persisted so the choice sticks across sessions.
   const [fontSize, setFontSize] = useState(() => {
@@ -1336,8 +1358,21 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
   useEffect(() => { localStorage.setItem('aos_terminal_font', String(fontSize)) }, [fontSize])
   // A finished headless run (and a crashed headless run) has no resurrectable pane — never resumable
   // and no longer live — so attaching would show a dead terminal. Show its captured transcript instead.
-  // Interactive ended sessions stay resumable and keep the normal attach/resume path untouched.
-  const ended = Boolean(session) && !isLive(session!) && !session!.resumable
+  // Interactive ended sessions stay resumable and keep the normal attach/resume path untouched. Once
+  // taken over (overrideAttach), force the live attach path even before the prop reflects the new state.
+  const ended = Boolean(session) && !isLive(session!) && !session!.resumable && !overrideAttach
+  // A headless run can be promoted to an attachable interactive session (see canGoInteractive). Offer it
+  // both while streaming (live) and after it ended (continue) — hidden once taken over.
+  const showTakeover = Boolean(session) && !overrideAttach && canGoInteractive(session!)
+  const takeOver = async () => {
+    if (!session?.id || takingOver) return
+    setTakingOver(true); setErr('')
+    const r = await api.goInteractive(session.id)
+    setTakingOver(false)
+    if (!r.ok) { setErr(r.error || 'could not go interactive'); return }
+    // Drop the read-only transcript (if any) and force a fresh attach to the new interactive pane.
+    setTranscript(null); setOverrideAttach(true); setNonce((n) => n + 1)
+  }
   useEffect(() => {
     let alive = true
     setWsUrl(''); setErr(''); setTranscript(null)
@@ -1358,11 +1393,18 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
       else setErr(r.error || 'could not open terminal')
     })
     return () => { alive = false }
-  }, [session?.id, tmux, ended])
+  }, [session?.id, tmux, ended, nonce])
   if (transcript != null) return (
     <div className="flex min-h-0 flex-1 flex-col bg-black">
-      <div className="shrink-0 border-b border-neutral-800 px-3 py-1.5 text-xs text-neutral-500">
-        Session ended · headless transcript (read-only)
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-neutral-800 px-3 py-1.5 text-xs text-neutral-500">
+        <span>Session ended · headless transcript (read-only)</span>
+        {showTakeover && (
+          <button onClick={takeOver} disabled={takingOver}
+            className="flex items-center gap-1 rounded border border-sky-800 px-2 py-0.5 text-sky-300 hover:bg-sky-950 disabled:opacity-50"
+            title="continue this run in an interactive session you can watch and steer (claude --resume)">
+            <Terminal className="h-3 w-3" /> {takingOver ? 'opening…' : 'Continue interactively'}
+          </button>
+        )}
       </div>
       <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-xs leading-relaxed text-neutral-300">{transcript || '(no output captured)'}</pre>
     </div>
@@ -1370,10 +1412,19 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
   if (err) return <div className="flex flex-1 items-center justify-center bg-black text-sm text-red-400">⚠ {err}</div>
   if (!wsUrl) return <div className="flex flex-1 items-center justify-center bg-black text-sm text-neutral-500">opening terminal…</div>
   return (
-    <ImageDropZone session={session} onActivity={onActivity && session?.id ? () => onActivity(session.id) : undefined}
-      fontSize={fontSize} setFontSize={setFontSize}>
-      <Xterm wsUrl={wsUrl} fontSize={fontSize} copyOnSelect />
-    </ImageDropZone>
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      {showTakeover && (
+        <button onClick={takeOver} disabled={takingOver}
+          className="absolute left-1/2 top-2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-full border border-sky-700 bg-neutral-900/90 px-3 py-1 text-xs text-sky-300 shadow hover:bg-sky-950 disabled:opacity-50"
+          title="take over — this headless run is unattended; convert it to an interactive session you can type into (ends the current turn, then resumes)">
+          <Terminal className="h-3.5 w-3.5" /> {takingOver ? 'taking over…' : 'Take over (go interactive)'}
+        </button>
+      )}
+      <ImageDropZone session={session} onActivity={onActivity && session?.id ? () => onActivity(session.id) : undefined}
+        fontSize={fontSize} setFontSize={setFontSize}>
+        <Xterm key={nonce} wsUrl={wsUrl} fontSize={fontSize} copyOnSelect />
+      </ImageDropZone>
+    </div>
   )
 }
 
@@ -1716,6 +1767,11 @@ function SessionsPage({
               <Play className="h-3 w-3" />
             </button>
           )}
+          {canGoInteractive(s) && (
+            <button className="rounded p-0.5 text-sky-400 hover:bg-neutral-600 hover:text-sky-300" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — convert this headless run to an interactive session you can watch and steer">
+              <Terminal className="h-3 w-3" />
+            </button>
+          )}
           {isLive(s) && (
             <button className="rounded p-0.5 text-amber-400 hover:bg-neutral-600 hover:text-amber-300" onClick={() => onStop(s.id)} title="stop — kill this session's shell">
               <Square className="h-3 w-3" />
@@ -1908,6 +1964,11 @@ function SessionsPage({
                     <Play className="h-3 w-3" /> Resume
                   </Button>
                 )}
+                {canGoInteractive(s) && (
+                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — convert this headless run to an interactive session you can watch and steer">
+                    <Terminal className="h-3 w-3" /> Take over
+                  </Button>
+                )}
                 {isLive(s) && (
                   <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-amber-600" onClick={() => onStop(s.id)} title="kill this session's shell">
                     <X className="h-3 w-3" /> Stop
@@ -1966,6 +2027,11 @@ function SessionsPage({
                 {canResume(s) && (
                   <Button size="icon" variant="ghost" className="h-7 w-7 text-emerald-600" onClick={() => resumeAndOpen(s, onOpen)} title="resume — reopen and continue this session (claude --resume)">
                     <Play className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+                {canGoInteractive(s) && (
+                  <Button size="icon" variant="ghost" className="h-7 w-7 text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — convert this headless run to an interactive session you can watch and steer">
+                    <Terminal className="h-3.5 w-3.5" />
                   </Button>
                 )}
                 {isLive(s) && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -781,6 +781,9 @@ export const api = {
   rateSession: (id: string, rating: 'up' | 'down' | null) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/rate`, { rating }),
   /** Lift the stop-block so a stopped session resurrects (claude --resume) on the next terminal open. */
   resumeSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/resume`),
+  /** Take over a headless run: convert it to an attachable interactive session (claude --resume). Kills
+   *  the in-flight `-p` turn if still streaming; then open the terminal to watch/steer. */
+  goInteractive: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/interactive`),
   deleteSession: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/sessions/' + id),
   attach: (id: string) => call<{ url?: string; error?: string }>('GET', `/api/sessions/${id}/attach`),
   sessionTranscript: (id: string) => call<{ text?: string; error?: string }>('GET', `/api/sessions/${id}/transcript`),


### PR DESCRIPTION
## What

Adds the ability to **take over a headless run** — convert an unattended `claude -p` session (cron/webhook/chat/task automation) into a live, attachable **interactive** TUI you can watch and steer.

Requested: *"Ability to convert headless session into headed mode as I am watching on the terminal."*

## Surfaces (web console)

- **Take over (go interactive)** — a pill over the live-streaming terminal of a running headless run.
- **Continue interactively** — a button on a finished run's read-only transcript header.
- **Take over** — a row action on the run in all three Sessions list layouts (tab strip, cards, table).

## How it works

`goInteractive(id)` re-launches the same run through the **interactive** lane under its pinned `--session-id` (`claude --resume`), so the conversation continues with full context. The headless lane already runs `claude -p … --session-id "$CLAUDE_SESSION_ID"`, so the transcript persists on disk and resumes cleanly (the Slack thread-follow-up path already relies on this).

- If the `-p` run is still streaming, its pane is killed first — the in-flight turn ends and the resume picks up from the last **completed** turn (a `-p` process can't be promoted to a TUI in place).
- The one thing the headless lane skips is writing `session-<id>.env`; the interactive relaunch (`headless:false`) writes it, so the run becomes resumable/attachable like any interactive session — no new env/attach plumbing. Mirrors the proven `reviveResident` path.

## API / audit

- New route `POST /api/sessions/:id/interactive` (same per-member gate as stop/resume) → `TerminalManager.goInteractive`.
- Audited `session.interactive`.
- Guards: only claude-code runs with a pinned session id qualify (`unknown session` / `only claude-code sessions can go interactive` / `this run has no resumable transcript`).

## Validation

- `npm run typecheck` ✓, `cd web && npm run build` ✓, `npm run build` ✓
- `npm run test:governance` → 68/68 ✓
- In-process smoke test of the three guard paths (unknown / mock-runtime / no-pinned-id) returns the expected errors. Happy path reuses the existing claude-code relaunch machinery (real `claude` CLI not exercisable in-harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)