### PR TITLE
fix(memory): catch a bad automem token at health time, not mid-migration (v0.91.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.91.1] — 2026-07-10
+### Fixed
+- **A bad automem token now fails loudly at Test/health time instead of mid-migration.** automem's
+  `/health` endpoint is unauthenticated, so a wrong/stale token still reported "healthy · N memories" —
+  the green backend badge, Settings → **Test connection**, and the drift banner all passed, and the bad
+  token only surfaced on the first authenticated write as an opaque `store failed after 0 migrated:
+  automem POST /memory → 401`. `AutomemMemoryProvider.health()` now follows the `/health` liveness probe
+  with a cheap authenticated `GET /recall?limit=1`: a 401 there is reported as `token rejected (401) —
+  check the token in Settings → Memory`, so a wrong token turns the badge red and blocks the confusing
+  migrate attempt. The migrate route's own 401 error also now appends that hint.
+
 ## [0.91.0] — 2026-07-10
 ### Added
 - **Take over a headless run — convert it to an interactive session you can watch and steer.** A

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.91.0",
+  "version": "0.91.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.91.0",
+      "version": "0.91.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.91.0",
+  "version": "0.91.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/automem-provider.ts
+++ b/src/memory/automem-provider.ts
@@ -190,12 +190,27 @@ export class AutomemMemoryProvider implements MemoryProvider {
   }
 
   async health(): Promise<{ ok: boolean; backend: string; detail?: string }> {
+    let count: number | undefined;
     try {
       const res = (await this.req('GET', '/health')) as { status?: string; memory_count?: number };
-      return { ok: res.status === 'healthy', backend: 'automem', detail: `${res.memory_count ?? '?'} memories @ ${this.endpoint}` };
+      if (res.status !== 'healthy') return { ok: false, backend: 'automem', detail: `unhealthy @ ${this.endpoint}` };
+      count = res.memory_count;
     } catch (e) {
       return { ok: false, backend: 'automem', detail: e instanceof Error ? e.message : String(e) };
     }
+    // `/health` is UNAUTHENTICATED on automem, so a wrong/stale token still reports "healthy" here — and only
+    // surfaces as a 401 on the first authenticated write (store / migrate). Validate the token with a cheap
+    // authenticated read so a bad token fails loudly at Test/health time (green badge, Settings → Test, the
+    // drift banner) instead of mid-migration as an opaque `store failed → 401`.
+    try {
+      await this.req('GET', '/recall', new URLSearchParams({ limit: '1' }));
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      // Only a 401 means the token is bad; any other read quirk (e.g. a query-less 400) shouldn't mask a live
+      // server that `/health` already confirmed up.
+      if (msg.includes('→ 401')) return { ok: false, backend: 'automem', detail: 'token rejected (401) — check the token in Settings → Memory' };
+    }
+    return { ok: true, backend: 'automem', detail: `${count ?? '?'} memories @ ${this.endpoint}` };
   }
 
   private async req(method: 'GET' | 'POST' | 'PATCH' | 'DELETE', pathName: string, params?: URLSearchParams, body?: unknown): Promise<unknown> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -2473,7 +2473,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         });
       } catch (e) {
         // Stop cleanly: this orphan stays put (not deleted). The client retries with the SAME `before` to resume.
-        return sendJson(res, 500, { error: `store failed after ${migrated} migrated: ${e instanceof Error ? e.message : String(e)}`, before, migrated, skipped, remaining: remainingBefore(before) });
+        const raw = e instanceof Error ? e.message : String(e);
+        // A 401 here is the backend rejecting our token (automem's /health is unauthenticated, so a bad token
+        // passes the Test/health check and only bites on this first write) — point the operator at the fix.
+        const hint = raw.includes('→ 401') ? ' — backend rejected the token; check the token in Settings → Memory' : '';
+        return sendJson(res, 500, { error: `store failed after ${migrated} migrated: ${raw}${hint}`, before, migrated, skipped, remaining: remainingBefore(before) });
       }
       del.run(os.tenant, r.id); migrated++;
     }


### PR DESCRIPTION
## Problem

Testing the SQLite→automem migration on the **instawp** tenant failed with:

```
⚠ store failed after 0 migrated: automem POST /memory → 401
```

The immediate cause is a token mismatch (the token in Settings → Memory ≠ the automem server's `AUTOMEM_API_TOKEN`). But the product should have caught that upfront: automem's `/health` endpoint is **unauthenticated**, so a wrong/stale token still reported `healthy · N memories`. The green backend badge, Settings → **Test connection**, and the drift banner all passed — the bad token only surfaced on the first *authenticated write* as an opaque 401 mid-migration.

## Fix

- `AutomemMemoryProvider.health()` now follows the `/health` liveness probe with a cheap **authenticated** `GET /recall?limit=1`. A 401 there is reported as `token rejected (401) — check the token in Settings → Memory`, turning the badge red and blocking the confusing migrate attempt. Non-401 read quirks (e.g. a query-less 400) don't mask a server `/health` already confirmed up.
- The migrate route's own 401 error gains the same actionable hint.

## Verification

- `npm run typecheck` clean; `npm run test:governance` → 68/68.
- In-process harness mocking automem responses:
  - bad token → `ok:false · token rejected (401) — check the token in Settings → Memory`
  - good token → `ok:true · 0 memories @ …`
  - server down → `ok:false · connect ECONNREFUSED`

🤖 Generated with [Claude Code](https://claude.com/claude-code)