### PR TITLE
feat(automations): "Run now" asks headless vs interactive (v0.93.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.93.0] — 2026-07-10
+### Added
+- **"Run now" on an automation asks headless vs interactive.** Firing an automation once from the
+  console now pops a small chooser: **Interactive** (opens an attachable terminal you can watch and
+  steer, and drops you into it) or **Headless** (fire-and-forget `claude -p`, progress lands in the
+  Inbox). The pick is a per-run override — it does **not** change the automation's saved default mode.
+  The current default is labelled in the dialog. Server: `POST /api/automations/:id/run` accepts an
+  optional `{ mode }`, threaded through `Automations.fire` (new `opts.mode`, falling back to `a.mode`);
+  the `automation.fired` audit records the effective mode. Pairs with 0.91.0's headless "Take over".
+
 ## [0.92.0] — 2026-07-10
 ### Added
 - **Member avatars now show on sessions and the inbox too.** A session's **"run as"** facet (in the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.92.0",
+      "version": "0.93.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.92.0",
+  "version": "0.93.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -387,7 +387,7 @@ export class Automations {
    * Spawn the automation's session. `guard: true` skips when the previous spawn is still alive —
    * the no-pile-ups rule for cron/webhook; "Run now" from the console passes guard: false.
    */
-  fire(a: Automation, opts: { guard: boolean; extra?: string; runAs?: string; slack?: { channel: string; threadTs: string }; discord?: { channel: string; messageId: string } } = { guard: true }): FireResult {
+  fire(a: Automation, opts: { guard: boolean; extra?: string; runAs?: string; mode?: ExecMode; slack?: { channel: string; threadTs: string }; discord?: { channel: string; messageId: string } } = { guard: true }): FireResult {
     if (opts.guard && a.lastSessionId && this.tm.isAlive(a.lastSessionId)) {
       return { ok: false, reason: 'previous session still running' };
     }
@@ -396,7 +396,11 @@ export class Automations {
     // one, e.g. the Slack user who @-mentioned the bot) is passed separately so the session binds their
     // connectors/Composio + lands in their inbox, while the audit/label still show what fired it.
     const spawnedBy = `automation:${a.id}`;
-    const s = this.tm.createSession(a.agentId, a.name, task, spawnedBy, a.mode === 'headless', opts.slack, opts.discord, opts.runAs);
+    // A one-off "Run now" from the console may override the automation's saved mode — run it headless
+    // (fire-and-forget) or interactive (watch/steer it live). Scheduled/trigger firings pass no mode
+    // and keep the automation's own `a.mode`.
+    const mode: ExecMode = opts.mode ?? a.mode;
+    const s = this.tm.createSession(a.agentId, a.name, task, spawnedBy, mode === 'headless', opts.slack, opts.discord, opts.runAs);
     this.db.prepare('UPDATE automations SET last_fired_at = ?, last_session_id = ? WHERE id = ?').run(Date.now(), s.id, a.id);
     this.os.audit.append({
       ts: Date.now(),
@@ -404,7 +408,7 @@ export class Automations {
       tenant: this.os.tenant,
       principal: opts.runAs ? `member:${opts.runAs}` : `automation:${a.id}`,
       type: 'automation.fired',
-      data: { automation: a.id, name: a.name, agent: a.agentId, trigger: a.type, mode: a.mode, runAs: opts.runAs ?? null },
+      data: { automation: a.id, name: a.name, agent: a.agentId, trigger: a.type, mode, runAs: opts.runAs ?? null },
     });
     return { ok: true, sessionId: s.id, tmux: s.tmux };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1336,7 +1336,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const a = autos.get(autoRun[1]);
     if (!a) return sendJson(res, 404, { error: 'not found' });
     if (!os.team.canRun(me, a.agentId)) return sendJson(res, 403, { error: `you are not assigned to run "${a.agentId}"` });
-    const r = autos.fire(a, { guard: false }); // explicit human action — no pile-up guard
+    // Optional one-off mode override: the "Run now" dialog lets the human pick headless (fire-and-forget)
+    // or interactive (watch/steer live) for THIS run without changing the automation's saved default.
+    const b = await readBody(req);
+    const mode = b.mode === 'headless' ? 'headless' : b.mode === 'interactive' ? 'interactive' : undefined;
+    const r = autos.fire(a, { guard: false, mode }); // explicit human action — no pile-up guard
     return sendJson(res, 200, r);
   }
   const autoRuns = p.match(/^\/api\/automations\/([\w-]+)\/runs$/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4092,6 +4092,7 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
   const [busy, setBusy] = useState('')
   const [hint, setHint] = useState('')
   const [openRuns, setOpenRuns] = useState<string | null>(null) // automation id whose Runs list is expanded
+  const [runPrompt, setRunPrompt] = useState<Automation | null>(null) // "Run now" asks headless vs interactive first
   const [showForm, setShowForm] = useState(false) // the New-automation form is collapsed until requested
   const [editId, setEditId] = useState<string | null>(null) // when set, the form edits this automation instead of creating
   const formRef = useRef<HTMLDivElement>(null) // the create/edit form — scroll it into view when it opens (Edit sits below the fold)
@@ -4149,16 +4150,17 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
   const setItemMode = async (a: Automation, m: 'interactive' | 'headless') => { setBusy(a.id); await api.updateAutomation(a.id, { mode: m }); await load(); setBusy('') }
   const toggle = async (a: Automation) => { setBusy(a.id); await api.updateAutomation(a.id, { enabled: !a.enabled }); await load(); setBusy('') }
   const remove = async (a: Automation) => { setBusy(a.id); await api.deleteAutomation(a.id); await load(); setBusy('') }
-  const runNow = async (a: Automation) => {
-    setBusy(a.id); setHint('')
-    const r = await api.runAutomation(a.id)
+  // Fire a one-off run in the chosen mode (overriding the automation's saved default just for this run).
+  const runNow = async (a: Automation, mode: 'interactive' | 'headless') => {
+    setRunPrompt(null); setBusy(a.id); setHint('')
+    const r = await api.runAutomation(a.id, mode)
     setBusy('')
     if (!r.ok) return setHint('⚠ ' + (r.reason || r.error || 'failed'))
     await load()
     // A headless run exits into a dead terminal — don't drop the operator onto it. Send them to the
-    // sessions list where the new run shows up; only interactive runs open the attachable TUI.
+    // sessions list where the new run shows up; interactive runs open the attachable TUI to watch/steer.
     if (r.sessionId) {
-      if (a.mode === 'headless') nav('sessions')
+      if (mode === 'headless') nav('sessions')
       else onOpen('aos-' + r.sessionId, a.agentId + ' · ' + r.sessionId)
     }
   }
@@ -4174,6 +4176,34 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
 
   return (
     <div className="max-w-4xl space-y-6">
+      {/* "Run now" asks headless vs interactive for this one-off run, without touching the saved default. */}
+      <Dialog open={!!runPrompt} onOpenChange={(o) => { if (!o) setRunPrompt(null) }}>
+        <DialogContent className="max-w-md">
+          <DialogHeader><DialogTitle className="flex items-center gap-2"><Play className="h-4 w-4" /> Run “{runPrompt?.name}” now</DialogTitle></DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            How should this one-off run behave? This doesn’t change the automation’s saved default
+            {runPrompt ? <> (<span className="font-medium">{runPrompt.mode}</span>)</> : null}.
+          </p>
+          <div className="mt-1 grid gap-2">
+            <button disabled={busy === runPrompt?.id} onClick={() => runPrompt && runNow(runPrompt, 'interactive')}
+              className="rounded-lg border p-3 text-left transition-colors hover:bg-muted disabled:opacity-50">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Terminal className="h-4 w-4" /> Interactive — watch &amp; steer
+                {runPrompt?.mode === 'interactive' && <span className="text-[11px] font-normal text-muted-foreground">· current default</span>}
+              </div>
+              <div className="mt-0.5 text-xs text-muted-foreground">Opens an attachable terminal you can type into to take over. Stays open until closed.</div>
+            </button>
+            <button disabled={busy === runPrompt?.id} onClick={() => runPrompt && runNow(runPrompt, 'headless')}
+              className="rounded-lg border p-3 text-left transition-colors hover:bg-muted disabled:opacity-50">
+              <div className="flex items-center gap-2 text-sm font-medium">
+                <Zap className="h-4 w-4" /> Headless — fire and forget
+                {runPrompt?.mode === 'headless' && <span className="text-[11px] font-normal text-muted-foreground">· current default</span>}
+              </div>
+              <div className="mt-0.5 text-xs text-muted-foreground">Runs to completion unattended (<code>claude -p</code>) and exits; progress lands in the Inbox. You can still “Take over” a live headless run from Sessions.</div>
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
       <p className="text-sm text-muted-foreground">
         Automations run agents without you: on a <strong>cron schedule</strong>, when an external service hits a
         <strong> webhook</strong>, on a <strong>Composio event</strong>, or on a <strong>Slack</strong> / <strong>Discord
@@ -4320,7 +4350,7 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
                     <HistoryIcon className="mr-1 h-3.5 w-3.5" />Runs
                     <ChevronDown className={`ml-1 h-3.5 w-3.5 transition-transform ${openRuns === a.id ? 'rotate-180' : ''}`} />
                   </Button>
-                  <Button size="sm" variant="secondary" disabled={busy === a.id} onClick={() => runNow(a)} title="fire once now">
+                  <Button size="sm" variant="secondary" disabled={busy === a.id} onClick={() => setRunPrompt(a)} title="fire once now — pick headless or interactive">
                     <Play className="mr-1 h-3.5 w-3.5" />Run now
                   </Button>
                   {/* Manage controls only for automations this member may edit: owner (any) or the creator.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -829,7 +829,9 @@ export const api = {
   updateAutomation: (id: string, patch: Partial<Pick<Automation, 'name' | 'mode' | 'schedule' | 'filter' | 'task' | 'enabled'>>) =>
     call<Automation & { error?: string }>('PATCH', '/api/automations/' + id, patch),
   deleteAutomation: (id: string) => call<{ ok: boolean }>('DELETE', '/api/automations/' + id),
-  runAutomation: (id: string) => call<{ ok: boolean; sessionId?: string; reason?: string; error?: string }>('POST', `/api/automations/${id}/run`),
+  /** Fire an automation once now. `mode` overrides its saved default for this run only (headless =
+   *  fire-and-forget, interactive = watch/steer the live TUI); omit to keep the automation's own mode. */
+  runAutomation: (id: string, mode?: 'interactive' | 'headless') => call<{ ok: boolean; sessionId?: string; reason?: string; error?: string }>('POST', `/api/automations/${id}/run`, mode ? { mode } : {}),
   automationRuns: (id: string) => call<{ runs: Session[]; error?: string }>('GET', `/api/automations/${id}/runs`),
 
   memory: (agent: string, q = '', limit = 50, scope: 'all' | 'agent' | 'tenant' = 'all') =>


### PR DESCRIPTION
## What

**Run now** on an automation now asks how the one-off run should behave, instead of always using the automation's saved mode:

- **Interactive** — opens an attachable terminal you can watch and steer; you're dropped into it.
- **Headless** — fire-and-forget `claude -p`; progress lands in the Inbox.

The choice is a **per-run override** — it does not change the automation's saved default (the dialog labels which one is the current default). Pairs naturally with #161's headless **Take over**.

## Changes

- **Server** — `POST /api/automations/:id/run` accepts an optional `{ mode }` body; threaded through `Automations.fire` via new `opts.mode` (falls back to `a.mode` when absent, so scheduled/trigger firings are unchanged). The `automation.fired` audit records the effective mode.
- **Client** — `runAutomation(id, mode?)` sends the body; the **Run now** button opens a small chooser dialog; `runNow(a, mode)` fires and only opens the live TUI for interactive runs (headless routes to Sessions).

## Validation

- `npm run typecheck` ✓, `cd web && npm run build` ✓, `npm run build` ✓
- `npm run test:governance` → 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)