### PR TITLE
fix(memory): pre-flight the backend before migrating, fail fast on a bad store (v0.94.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.94.0] — 2026-07-10
+## [0.94.1] — 2026-07-10
+### Fixed
+- **Memory migration now pre-flights the backend instead of failing mid-loop.** The
+  `POST /api/settings/memory/migrate` route batched straight into writes, so an unreachable or
+  auth-rejected external store surfaced only as a confusing `store failed after 0 migrated: … → 401`
+  after the first row. The first batch now runs `os.memory.health()` first and, if the backend isn't
+  ready, returns `503 backend not ready — <detail>. Fix it in Settings → Memory, then migrate.`
+  (paired with the v0.91.1 authenticated automem health probe, so a bad/truncated automem token is
+  reported as `token rejected (401)` before any migration starts). Only the first batch checks — once a
+  store lands the token is proven, so later batches skip the extra round-trip.
 ### Added
 - **Member avatars on a session's "started by" too.** The Sessions list (both the card grid and the
   list view) and the terminal-header facts now show the avatar of the member who started a session,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.94.0",
+      "version": "0.94.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.94.0",
+  "version": "0.94.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2450,8 +2450,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // store lands in the same millisecond. The client passes the server-assigned `before` back each batch.
     let before = Number(b.before) || 0;
     if (!before) {
-      // First batch — idempotency guard: if the backend already holds everything (no drift), no-op so a
-      // stray click can't duplicate. Otherwise fix the horizon at now. (Fresh switch → empty store → passes.)
+      // First batch — pre-flight the backend so a doomed migration fails FAST with an actionable message
+      // instead of looping into a partial `store failed after 0 migrated` (e.g. a token automem's public
+      // /health can't catch — the exact trap this guards). Only the first batch checks; once one store
+      // lands the token is proven, so later batches skip the extra round-trip.
+      const h = await os.memory.health();
+      if (!h.ok) return sendJson(res, 503, { error: `backend not ready — ${h.detail ?? 'health check failed'}. Fix it in Settings → Memory, then migrate.` });
+      // Idempotency guard: if the backend already holds everything (no drift), no-op so a stray click can't
+      // duplicate. Otherwise fix the horizon at now. (Fresh switch → empty store → passes.)
       const backendCount = os.memory.count ? await os.memory.count(os.tenant) : null;
       if (backendCount != null && backendCount >= localTotal()) {
         return sendJson(res, 200, { ok: true, done: true, migrated: 0, skipped: 0, remaining: 0, note: 'already consistent — nothing to migrate' });


### PR DESCRIPTION
## Context

Follow-up to #162, from verifying a real automem 401 on the instawp tenant. Root cause there was a **one-character-truncated token** saved into Settings → Memory (a human copy-paste miss — the save path's `.trim()` is correct and does not truncate non-whitespace). #162 already made automem's `health()` authenticated so a bad token turns the badge red. This closes the remaining gap in the **migrate** path.

## Problem

`POST /api/settings/memory/migrate` batched straight into writes. An unreachable or auth-rejected external store therefore surfaced only *after* the first row, as the opaque `store failed after 0 migrated: automem POST /memory → 401` — exactly the confusing failure originally reported.

## Fix

The **first** migrate batch now runs `os.memory.health()` before touching any rows. If the backend isn't ready it returns:

```
503  backend not ready — token rejected (401) — check the token in Settings → Memory. Fix it in Settings → Memory, then migrate.
```

Only the first batch checks (once a store lands, the token is proven), so mid-migration batches skip the extra round-trip.

## Verification

- `npm run typecheck` clean; `npm run test:governance` → 68/68.
- Decision-table harness: bad token → `503` with **0** store calls; healthy+drift → proceeds to batch; healthy+no-drift → `already consistent` no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)