### PR TITLE
feat(kb): count agent reads per page for future auto-archive (v0.95.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.95.0] — 2026-07-10
+### Added
+- **KB pages now count how often agents read them.** Every `kb_read` fetch by an agent bumps a
+  per-page `read_count` and stamps `last_read_at` (new `kb_pages` columns, added additively for
+  existing tenants). It's a cheap targeted `UPDATE` — the FTS reindex trigger is re-scoped to
+  `UPDATE OF title, tags, body`, so a fetch never re-tokenizes the body. This is the signal a future
+  auto-archive pass will use to retire never/rarely-read pages. Surfaced on `KbPage` as
+  `readCount`/`lastReadAt`; only the agent fetch route (`GET /api/kb/read`) counts — console reads,
+  history and revert don't (`src/state/kb.ts` `recordRead`, `src/server.ts`, `src/state/db.ts`).
+
 ## [0.94.1] — 2026-07-10
 ### Fixed
 - **Memory migration now pre-flights the backend instead of failing mid-loop.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.94.1",
+  "version": "0.95.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.94.1",
+      "version": "0.95.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.94.1",
+  "version": "0.95.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -832,6 +832,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.sessionAgent(session)) return sendJson(res, 404, { error: 'unknown session' });
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     const page = os.kb.read(os.tenant, url.searchParams.get('section') || '', url.searchParams.get('slug') || '');
+    if (page) os.kb.recordRead(page.id); // an agent opened it — bump the fetch counter (auto-archive signal)
     return sendJson(res, page ? 200 : 404, page ? { page } : { error: 'page not found' });
   }
   if (method === 'POST' && p === '/api/kb/write') {

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -311,7 +311,9 @@ function migrate(db: Db): void {
       rev        INTEGER NOT NULL,         -- current revision number (starts at 1)
       created_at INTEGER NOT NULL,
       updated_at INTEGER NOT NULL,
-      updated_by TEXT NOT NULL             -- member id | agent:<id> | automation:<id>
+      updated_by TEXT NOT NULL,            -- member id | agent:<id> | automation:<id>
+      read_count INTEGER NOT NULL DEFAULT 0, -- times an agent has fetched the page (auto-archive signal)
+      last_read_at INTEGER                 -- when an agent last fetched it (epoch ms); NULL = never
     );
     CREATE UNIQUE INDEX IF NOT EXISTS idx_kb_slug ON kb_pages(tenant, section, slug);
 
@@ -364,7 +366,8 @@ function migrate(db: Db): void {
     CREATE TRIGGER IF NOT EXISTS kb_ad AFTER DELETE ON kb_pages BEGIN
       INSERT INTO kb_fts(kb_fts, rowid, title, tags, body) VALUES('delete', old.rowid, old.title, old.tags, old.body);
     END;
-    CREATE TRIGGER IF NOT EXISTS kb_au AFTER UPDATE ON kb_pages BEGIN
+    -- Scoped to content columns: a read_count/last_read_at bump on fetch must NOT re-tokenize the page.
+    CREATE TRIGGER IF NOT EXISTS kb_au AFTER UPDATE OF title, tags, body ON kb_pages BEGIN
       INSERT INTO kb_fts(kb_fts, rowid, title, tags, body) VALUES('delete', old.rowid, old.title, old.tags, old.body);
       INSERT INTO kb_fts(rowid, title, tags, body) VALUES (new.rowid, new.title, new.tags, new.body);
     END;
@@ -562,6 +565,19 @@ function migrate(db: Db): void {
   // Profile picture: a small square `data:image/…;base64,…` URL. NULL → the UI shows the member's
   // initial. Members set their own from the Team page; owners/admins may set anyone's.
   addColumn(db, 'members', 'avatar', 'TEXT');
+
+  // KB fetch counter: every time an agent opens a page (kb_read) we bump these. A never/rarely-read
+  // page is a candidate for auto-archive later. Older pages default to 0 / never-read.
+  addColumn(db, 'kb_pages', 'read_count', 'INTEGER NOT NULL DEFAULT 0');
+  addColumn(db, 'kb_pages', 'last_read_at', 'INTEGER');
+  // The bump is an UPDATE; re-scope the FTS reindex trigger to content columns only so a fetch doesn't
+  // re-tokenize the body. `CREATE TRIGGER IF NOT EXISTS` above leaves an existing DB's old un-scoped
+  // trigger in place, so drop + recreate it here.
+  db.exec('DROP TRIGGER IF EXISTS kb_au');
+  db.exec(`CREATE TRIGGER kb_au AFTER UPDATE OF title, tags, body ON kb_pages BEGIN
+    INSERT INTO kb_fts(kb_fts, rowid, title, tags, body) VALUES('delete', old.rowid, old.title, old.tags, old.body);
+    INSERT INTO kb_fts(rowid, title, tags, body) VALUES (new.rowid, new.title, new.tags, new.body);
+  END`);
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/state/kb.ts
+++ b/src/state/kb.ts
@@ -20,6 +20,7 @@ import { KbPage, KbRevision, KbSearchQuery, KbWriteInput } from '../types';
 interface PageRow {
   id: string; tenant: string; section: string; slug: string; title: string; tags: string;
   body: string; rel_path: string; rev: number; created_at: number; updated_at: number; updated_by: string;
+  read_count: number; last_read_at: number | null;
   rank?: number;
 }
 interface RevRow {
@@ -106,6 +107,17 @@ export class KbStore {
     return r ? toPage(r) : null;
   }
 
+  /**
+   * Record that an agent fetched a page: bump `read_count` and stamp `last_read_at`. Cheap targeted
+   * UPDATE (the FTS trigger is scoped to content columns, so this never re-tokenizes the body). A page
+   * with a low/stale count is a future auto-archive candidate. Best-effort — never fails a read.
+   */
+  recordRead(id: string, at: number = Date.now()): void {
+    try {
+      this.db.prepare('UPDATE kb_pages SET read_count = read_count + 1, last_read_at = ? WHERE id = ?').run(at, id);
+    } catch { /* counting is telemetry — a failure must not break the fetch */ }
+  }
+
   get(id: string): KbPage | undefined {
     const r = this.db.prepare('SELECT * FROM kb_pages WHERE id = ?').get<PageRow>(id);
     return r ? toPage(r) : undefined;
@@ -185,6 +197,7 @@ function toPage(r: PageRow): KbPage {
     id: r.id, tenant: r.tenant, section: r.section, slug: r.slug, title: r.title,
     tags: JSON.parse(r.tags) as string[], body: r.body, relPath: r.rel_path, rev: r.rev,
     createdAt: r.created_at, updatedAt: r.updated_at, updatedBy: r.updated_by,
+    readCount: r.read_count ?? 0, lastReadAt: r.last_read_at ?? undefined,
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -538,6 +538,8 @@ export interface KbPage {
   createdAt: number;
   updatedAt: number;
   updatedBy: string; // member id | agent:<id> | automation:<id>
+  readCount: number; // times an agent has fetched this page (feeds future auto-archive of dead pages)
+  lastReadAt?: number; // when an agent last fetched it (epoch ms); undefined = never fetched
 }
 
 /** A prior version of a page — the rollback + audit backbone (append-only). */


### PR DESCRIPTION
## What
Track how often each KB page is fetched by an agent, so a later pass can auto-archive dead pages.

- **New `kb_pages` columns** `read_count` (default 0) + `last_read_at` — added additively so existing tenants migrate cleanly.
- **Counting happens only on the agent fetch route** (`GET /api/kb/read`, the `kb_read` MCP tool) via a new best-effort `KbStore.recordRead(id)`. Console reads, `kb_history` and `kb_revert` do **not** count.
- **FTS stays cheap:** the read bump is a targeted `UPDATE`, and the `kb_au` FTS reindex trigger is re-scoped to `AFTER UPDATE OF title, tags, body`, so a fetch never re-tokenizes the page body. Content edits still reindex correctly (verified).
- Surfaced on `KbPage` as `readCount` / `lastReadAt`.

## Verification
- `npm run typecheck`, `npm run build` clean.
- `npm run test:governance` → 68/68.
- In-process test on an in-memory `KbStore`: `read_count` bumps 0→3 with `last_read_at` stamped; FTS search works after reads; a content edit preserves the counter, bumps rev, and reindexes FTS (`gadget` found, old `widget` gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)