### PR TITLE
feat(kb): surface agent read-count on the console KB page (v0.97.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.97.0] — 2026-07-10
+### Added
+- **KB page view now shows how often agents read it.** The page metadata line (under the title) now
+  reads `… · read N× by agents` (or `never read by agents`), with the last-read timestamp on hover —
+  surfacing the `readCount`/`lastReadAt` added in v0.95.0 so a human can spot dead pages at a glance
+  before the eventual auto-archive pass exists (`MemoryBrowse`/KB viewer in `web/src/App.tsx`,
+  `KbPage` in `web/src/lib/api.ts`). Console-only, no server change.
+
 ## [0.96.0] — 2026-07-10
 ### Added
 - **Agents can now dispatch tasks, not just create them.** New `task_dispatch` MCP tool (→

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.96.0",
+      "version": "0.97.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.96.0",
+  "version": "0.97.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4633,7 +4633,7 @@ function KnowledgeBasePage({ me }: { me: Member }) {
             <div className="flex items-start justify-between gap-2">
               <div>
                 <div className="text-lg font-semibold">{sel.title}</div>
-                <div className="text-[11px] text-muted-foreground"><code>{sel.section}/{sel.slug}</code> · rev {sel.rev} · updated {new Date(sel.updatedAt).toLocaleString()} by {sel.updatedBy}</div>
+                <div className="text-[11px] text-muted-foreground"><code>{sel.section}/{sel.slug}</code> · rev {sel.rev} · updated {new Date(sel.updatedAt).toLocaleString()} by {sel.updatedBy} · <span title={sel.lastReadAt ? `last read by an agent ${new Date(sel.lastReadAt).toLocaleString()}` : 'no agent has fetched this page yet'}>{sel.readCount ? `read ${sel.readCount}× by agents` : 'never read by agents'}</span></div>
                 {sel.tags.length > 0 && <div className="mt-1 flex flex-wrap gap-1">{sel.tags.map((t) => <Badge key={t} variant="outline" className="px-1.5 py-0 text-[10px] font-normal">{t}</Badge>)}</div>}
               </div>
               {!editing && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -201,6 +201,8 @@ export interface KbPage {
   createdAt: number
   updatedAt: number
   updatedBy: string
+  readCount: number
+  lastReadAt?: number
 }
 export interface Recommendation {
   id: string


### PR DESCRIPTION
## What
Surfaces the per-page agent read-count (tracked since v0.95.0) in the console KB page view.

The metadata line under a page's title now reads:

> `engineering/deploy-runbook · rev 3 · updated … by … · read 12× by agents`

…or **`never read by agents`** when the count is 0. Hover shows the last-read timestamp. This lets a human eyeball which pages are dead weight ahead of the eventual auto-archive pass.

- `KbPage` in `web/src/lib/api.ts` gains `readCount` / `lastReadAt` (already returned by the server).
- One line in the KB viewer (`web/src/App.tsx`). Console-only — no server/API change.

## Verification
- `cd web && npm run build` clean.
- Backing data was verified end-to-end in #168 (counter bumps on `kb_read`, timestamp stamped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)