### PR TITLE
feat(tasks): synchronous hand-off — task_wait blocks on a delegated task, resumes with its result (v0.96.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.99.0] — 2026-07-10
+### Added
+- **Synchronous task hand-off — a delegating agent can now wait for the result.** `task_dispatch`
+  (v0.96.0) spawns a worker and returns immediately; this adds the *waiting* half. New `task_wait(id)`
+  MCP tool (or `task_create({ …, wait:true })` in one call) long-polls until the task reaches
+  `done`/`cancelled`/`blocked`, then returns the delegate's closing note — the agent-to-agent analog of
+  `ask`. The caller's session stays alive on the pending tool call and resumes on its own; no session
+  revival needed. Each poll of the new `POST /api/tasks/wait` route kicks a **guarded immediate dispatch**
+  when the task is stalled (not terminal, not `blocked`, agent-assigned, nothing live on it), so waiting
+  *drives* the work and auto-retries a crashed run — self-limited by the existing `dispatchTask` guard +
+  `TASK_MAX_ATTEMPTS` ceiling (a re-polled crash-loop parks `blocked`, it can't spin). Headless callers
+  park after `AOS_TASK_WAIT_S` (default 900s) with a "still running, check back" message; interactive
+  callers wait up to an hour. The result note is `TaskStore.latestNote` — the newest `comment` event,
+  ordered by insertion (`rowid`) so it's unambiguous even for same-millisecond events. 37 always-on MCP
+  tools now.
+- **An agent-filed `autoDispatch` hand-off now dispatches immediately** instead of waiting for the next
+  ≤20s scheduler tick — parity with the console `POST /api/tasks` route, which already dispatched on
+  create. So a delegated task begins the moment it's filed, and a `task_wait` caller makes progress at
+  once (`src/server.ts`, `src/memory/memory-mcp.ts`, `src/state/tasks.ts`, `docs/tasks-plan.md`,
+  `docs/agent-mcp-tools.md`).
+
 ## [0.98.0] — 2026-07-10
 ### Changed
 - **Inbox notifications are now scoped to a session's owner instead of flooding every owner/admin.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 36 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 37 always-on tools
   + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). KB: `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`. Operator/inbox:
   `ask`/`check_inbox`/`report`/`update`/`notify`/`publish`/`artifacts_list` (session cards are
@@ -198,12 +198,15 @@ Key modules:
   reusable playbook — Lever 6 procedural memory; lands as a NOT-YET-PUBLISHED `.aos-proposed` skill +
   a `skill.proposed` inbox card, gated behind an owner/admin publish). Scheduling: `schedule`/`unschedule`
   (one-shot deferred self-run via a `type:'once'` automation). Tasks (shared work queue):
-  `task_create`/`task_list`/`task_get`/`task_claim`/`task_update`/`task_attach`/`task_dispatch` (file/claim/drain
-  durable work + attach a file from the agent's folder onto a task; an
+  `task_create`/`task_list`/`task_get`/`task_claim`/`task_update`/`task_wait`/`task_dispatch`/`task_attach`
+  (file/claim/drain durable work + attach a file from the agent's folder onto a task; an
   agent-assigned `autoDispatch` task spawns a governed session — the A2A delegation path; per-task `mode`
-  headless/interactive; owner = run-as passthrough so a hand-off keeps the accountable human. `task_dispatch`
-  kicks an agent-assigned task into a session NOW instead of waiting on the tick — `guard:true` pile-up brake
-  + `TASK_MAX_ATTEMPTS` ceiling). Secrets
+  headless/interactive; owner = run-as passthrough so a hand-off keeps the accountable human). `task_dispatch`
+  kicks an agent-assigned task into a session NOW instead of waiting on the tick (`guard:true` pile-up brake +
+  `TASK_MAX_ATTEMPTS` ceiling); **`task_wait`** (or `task_create({ wait:true })`) makes the hand-off
+  SYNCHRONOUS — the caller BLOCKS until the delegate finishes and resumes with its result, each poll kicking
+  the same guarded dispatch so waiting drives the work (and retries a crashed run). An agent `task_create` now
+  also dispatches an `autoDispatch` hand-off immediately (parity with the console) instead of waiting for the tick. Secrets
   (shared credential handoff): `secret_put`/`secret_get`/`secret_list` — an agent stores a password/key
   tenant-wide under a KEY (approval-gated `secret.put`; value kept out of audit/approval-card/policy args,
   encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. Agents

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -36,6 +36,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `task_get` | `GET /api/tasks/get` | `TaskStore.withEvents` | R | task + full activity timeline |
 | `task_claim` | `POST /api/tasks/claim` | `TaskStore.claim` | W | atomic take (→ doing); loses if already claimed |
 | `task_update` | `POST /api/tasks/update` | `TaskStore.update` | W | status/note/reassign/reprioritise/`due` (ISO date, or "" to clear); closes a dispatched loop |
+| `task_wait` | `POST /api/tasks/wait` | `Automations.dispatchTask` + `TaskStore.get`/`latestNote` | W | **synchronous handoff**: long-polls until a task hits done/cancelled/blocked, then returns its closing note. Kicks a guarded immediate dispatch each poll if the task is stalled (not terminal, not `blocked`, agent-assigned, nothing live on it) so waiting DRIVES the work + auto-retries a crashed run (bounded by `TASK_MAX_ATTEMPTS`). Caller session stays alive on the pending call and resumes on completion (same shape as `ask`). Headless parks after `AOS_TASK_WAIT_S` (default 900s), interactive waits longer |
 | `task_attach` | `POST /api/tasks/attach` | `TerminalManager.attachTaskFile` → `TaskStore.attachFromPath` | W | snapshots a file from the caller's OWN working folder onto a task (path resolved strictly under the agent folder, like `publish`); logs an `attach` event; audited `task.attached` |
 | `task_dispatch` | `POST /api/tasks/dispatch` | `Automations.dispatchTask` | W | spawns a governed session NOW for an agent-assigned task (async hand-off, distinct from `task_claim`); `guard:true` (no pile-up) + `TASK_MAX_ATTEMPTS` ceiling; run-as = task owner; audited `task.dispatched` (`by:agent:<id>`) |
 | `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
@@ -52,7 +53,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `discord_send` | `POST /api/agent/discord/send` | `DiscordSocket.sendToChannel` | W | proactive post to any channel by id; audited `discord.send`; only when `DISCORD_EGRESS=1` (Discord configured) |
 | `discord_dm` | `POST /api/agent/discord/dm` | `DiscordSocket.dmMember` | W | proactive DM by Discord user id; audited `discord.dm`; only when `DISCORD_EGRESS=1` |
 
-36 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+37 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 

--- a/docs/tasks-plan.md
+++ b/docs/tasks-plan.md
@@ -509,6 +509,21 @@ session spawned and the pile-up guard blocks a second). **Isolate `AGENT_OS_HOME
   pile-up guard (never two live sessions per task) + the `TASK_MAX_ATTEMPTS` ceiling (parks a failing task
   `blocked`); the spawned session runs-as the task owner and every effect still passes the gateway. Still
   open: per-run **budget attribution** + **recursion-depth** limiting on this spawn path.
+
+> **Update (2026-07-10, v0.98.0): synchronous hand-off shipped (`task_wait`).** `task_dispatch` (above)
+> spawns a worker and returns; this adds the *waiting* half, so delegation can now BLOCK on the result: a
+> caller hands a task to another agent and waits until it finishes, then resumes with the delegate's closing
+> note — the A2A analog of `ask`. `task_wait(id)` (or `task_create({ wait:true })` in one call) long-polls
+> `POST /api/tasks/wait`; each poll kicks a **guarded immediate dispatch** when the task is stalled (not
+> terminal, not `blocked`, agent-assigned, nothing live on it), so waiting DRIVES the work and auto-retries a
+> crashed run — self-limited by the same `dispatchTask` guard + `TASK_MAX_ATTEMPTS` ceiling, so a re-polled
+> crash-loop parks `blocked` rather than spinning. The caller's session stays alive on the pending tool call
+> and resumes on its own; no session revival needed. The closing note is `TaskStore.latestNote` (newest
+> `comment` event, ordered by insertion so it's unambiguous within a millisecond). Headless callers park after
+> `AOS_TASK_WAIT_S` (default 900s) with a "still running, check back" message; interactive wait longer. Also:
+> an agent `task_create` now dispatches an `autoDispatch` hand-off **immediately** (parity with the console
+> route) instead of leaving it for the ≤20s scheduler tick. Still gated below: the hard policy brake, plus
+> per-run budget attribution + recursion-depth limiting on the spawn path.
 - **Optional policy brake on dispatch.** Run `Policy.classify('task.dispatch', {task})` in the dispatcher:
   green auto-spawns, yellow (a `budget`/`protected` label, or an estimated cost) suspends for approval, red
   needs owner — turning "start work" into a gated capability without touching the store. Designed for, off

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.98.0",
+      "version": "0.99.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.98.0",
+  "version": "0.99.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -24,6 +24,11 @@ const TENANT = process.env.AOS_TENANT || '';
 // idle-reaper bound. A blocking `ask` therefore parks after a short window instead of hanging ~1h (#138).
 const HEADLESS = process.env.HEADLESS === '1';
 const UNATTENDED_ASK_WAIT_S = Number(process.env.AOS_UNATTENDED_ASK_WAIT_S) || 120;
+// How long a delegating agent blocks in `task_wait` for a handed-off task to reach a terminal state. A
+// delegated task can legitimately run many minutes, so this is far longer than the ask window — but still
+// bounded, so a stuck child can't strand the caller forever (on timeout the tool returns "still running,
+// check back", not a hang). Interactive callers wait longer (a human can steer); headless park at this.
+const TASK_WAIT_S = Number(process.env.AOS_TASK_WAIT_S) || 900;
 /** Headers for a loopback agent call: the session bearer + tenant route, plus any extras (e.g. JSON). */
 function H(extra: Record<string, string> = {}): Record<string, string> {
   return { 'x-aos-secret': SECRET, ...(TENANT ? { 'x-aos-tenant': TENANT } : {}), ...extra };
@@ -534,7 +539,9 @@ const TOOLS = [
       'close, with a lifecycle (todo → doing → blocked → done). This is how you DELEGATE or HAND OFF: assign ' +
       'it to another agent by name to have them pick it up (e.g. a support agent files a coding task for ' +
       '`assignee:"agent:engineer"`). Set `autoDispatch:true` to have an agent-assigned task spawn a session ' +
-      'automatically. Distinct from `remember` (your private note) and `kb_write` (shared reference knowledge): ' +
+      'automatically. To hand off and WAIT for the result before you continue, set `wait:true` (or call ' +
+      '`task_wait` after filing) — one synchronous call that blocks until the delegate finishes and returns ' +
+      'its outcome. Distinct from `remember` (your private note) and `kb_write` (shared reference knowledge): ' +
       'a Task is WORK someone must do. Use sub-tasks (`parentId`) to break big work down. Give time-sensitive ' +
       'work a `due` date (ISO) — the owner is DMed once if it slips past the deadline.',
     inputSchema: {
@@ -550,6 +557,8 @@ const TOOLS = [
         autoDispatch: { type: 'boolean', description: 'If true and assigned to an agent, the board auto-spawns a session to work it. Default false.' },
         mode: { type: 'string', enum: ['headless', 'interactive'], description: 'How a dispatched session runs: "headless" (default — works to completion then exits) or "interactive" (an attachable TUI a human drives).' },
         due: { type: 'string', description: 'Optional soft deadline as an ISO date, e.g. "2026-07-15" or "2026-07-15T17:00:00Z".' },
+        wait: { type: 'boolean', description: 'If true, block until this task finishes and return its result (synchronous delegation). Implies autoDispatch. Only meaningful when assigned to an agent. Default false: file it and return immediately.' },
+        timeoutSeconds: { type: 'number', minimum: 10, maximum: 21600, description: 'When wait is true, max seconds to block before returning "still running" (default ~15 min headless / 1h interactive).' },
       },
       required: ['title'],
     },
@@ -615,6 +624,25 @@ const TOOLS = [
         priority: { type: 'number', minimum: 0, maximum: 3, description: '0 urgent … 3 low.' },
         labels: { type: 'array', items: { type: 'string' }, description: 'Replace the label set.' },
         due: { type: 'string', description: 'Set a soft deadline as an ISO date (e.g. "2026-07-15"), or "" / null to clear it.' },
+      },
+      required: ['id'],
+    },
+  },
+  {
+    name: 'task_wait',
+    description:
+      'Hand off and WAIT: block until a task reaches a terminal state (done / cancelled / blocked), then return ' +
+      'its outcome and closing note. Use this right after delegating with task_create({ assignee:"agent:<id>", ' +
+      'autoDispatch:true }) — or task_create({ …, wait:true }) to do both in one call — when you need the ' +
+      'delegate\'s result before you can continue. The task is dispatched immediately if it hasn\'t started, and ' +
+      'a crashed run is retried automatically. Your session stays put and resumes the moment the task finishes. ' +
+      'If it times out it keeps running in the background — call task_wait or task_get again to keep watching.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string', description: 'The task id to wait for.' },
+        timeoutSeconds: { type: 'number', minimum: 10, maximum: 21600, description: 'Max seconds to block before returning "still running" (default ~15 min headless / 1h interactive).' },
       },
       required: ['id'],
     },
@@ -1210,7 +1238,8 @@ async function taskCreate(args: Record<string, unknown>): Promise<string> {
       priority: typeof args.priority === 'number' ? args.priority : undefined,
       labels: Array.isArray(args.labels) ? args.labels.map(String) : undefined,
       parentId: args.parentId !== undefined ? String(args.parentId) : undefined,
-      autoDispatch: args.autoDispatch === true,
+      // `wait` implies autoDispatch — you can't block on work that never starts.
+      autoDispatch: args.autoDispatch === true || args.wait === true,
       mode: args.mode === 'interactive' ? 'interactive' : undefined,
       dueAt: parseDue(args.due),
     }),
@@ -1218,7 +1247,47 @@ async function taskCreate(args: Record<string, unknown>): Promise<string> {
   const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
   if (!d.ok) return `Could not create the task: ${d.error ?? 'unknown error'}`;
   const who = args.assignee ? ` (assigned to ${String(args.assignee)})` : ' (open — anyone can claim it)';
+  // wait:true → delegate synchronously: file it, then block until the delegate closes the loop.
+  if (args.wait === true) {
+    const outcome = await taskWait({ id: d.id, timeoutSeconds: args.timeoutSeconds });
+    return `Filed task ${d.id}: "${title}"${who}.\n${outcome}`;
+  }
   return `Filed task ${d.id}: "${title}"${who}. Track it with task_get "${d.id}".`;
+}
+
+// Block until a handed-off task reaches a terminal state, driving its dispatch/retry via /api/tasks/wait.
+// The caller's session stays alive on this pending tool call and resumes with the result — same shape as
+// `ask`, but waiting on another agent's task rather than a human's answer.
+async function taskWait(args: Record<string, unknown>): Promise<string> {
+  const id = String(args.id ?? '').trim();
+  if (!id) return 'Which task? (id is required).';
+  const requested = typeof args.timeoutSeconds === 'number' ? args.timeoutSeconds : undefined;
+  // Interactive callers can afford a long block (a human can steer); headless park sooner so a stuck child
+  // can't strand them. An explicit timeoutSeconds always wins. Clamped to [10s, 6h].
+  const ceilingS = HEADLESS ? TASK_WAIT_S : Math.max(TASK_WAIT_S, 3600);
+  const maxWaitS = Math.min(21600, Math.max(10, requested ?? ceilingS));
+  const deadline = Date.now() + maxWaitS * 1000;
+  let lastStatus = '';
+  while (Date.now() < deadline) {
+    const res = await fetch(AOS_URL + '/api/tasks/wait', {
+      method: 'POST',
+      headers: H({ 'content-type': 'application/json' }),
+      body: JSON.stringify({ session: SESSION, id }),
+    });
+    const d = (await res.json()) as { ok?: boolean; error?: string; status?: string; terminal?: boolean; note?: string | null };
+    if (!d.ok) return `Could not wait on task ${id}: ${d.error ?? 'unknown error'}`;
+    lastStatus = d.status ?? lastStatus;
+    // done/cancelled are terminal; blocked won't finish on its own, so stop waiting and surface it too.
+    if (d.terminal || d.status === 'blocked') {
+      const note = d.note ? ` — ${d.note}` : '';
+      if (d.status === 'done') return `Task ${id} completed${note}. You can continue.`;
+      if (d.status === 'cancelled') return `Task ${id} was cancelled${note}.`;
+      return `Task ${id} is blocked and needs attention${note}. It won't finish on its own — read task_get "${id}" and decide how to proceed.`;
+    }
+    await sleep(3000);
+  }
+  const where = lastStatus ? ` (currently "${lastStatus}")` : '';
+  return `Task ${id} hasn't finished within ${maxWaitS}s${where}. It's still running in the background — call task_wait or task_get "${id}" again to keep watching, or move on and check back later.`;
 }
 
 // ── Agents: author new agents ─────────────────────────────────────────────────
@@ -1576,6 +1645,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'task_get' ? await taskGet(args)
         : name === 'task_claim' ? await taskClaim(args)
         : name === 'task_update' ? await taskUpdate(args)
+        : name === 'task_wait' ? await taskWait(args)
         : name === 'task_attach' ? await taskAttach(args)
         : name === 'task_dispatch' ? await taskDispatch(args)
         : name === 'agent_create' ? await agentCreate(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -939,6 +939,10 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         createdBy: `agent:${agent}`,
       });
       os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: 'task.created', data: { id: task.id, title: task.title, assignee: task.assignee ?? null } });
+      // Immediate dispatch (parity with the console route above): an agent-assigned auto-dispatch hand-off
+      // starts NOW rather than waiting for the next ~20s scheduler tick, so a delegated task begins the
+      // moment it's filed — and a waiting caller (task_wait / wait:true) makes progress at once.
+      if (task.autoDispatch && (task.assignee || '').startsWith('agent:')) autos.dispatchTask(task.id, { guard: true, by: `agent:${agent}` });
       return sendJson(res, 200, { ok: true, id: task.id });
     } catch (e) {
       return sendJson(res, 200, { ok: false, error: e instanceof Error ? e.message : String(e) });
@@ -999,6 +1003,28 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!task) return sendJson(res, 200, { ok: false, error: 'task not found' });
     os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: task.status === 'done' ? 'task.completed' : 'task.updated', data: { id: task.id, status: task.status } });
     return sendJson(res, 200, { ok: true, task });
+  }
+  // A delegating agent long-polls this until a handed-off task finishes (the `task_wait` tool). Each poll,
+  // if the task is stalled — not terminal, not deliberately `blocked`, assigned to an agent, and nothing
+  // live is on it — kick a guarded immediate dispatch so WAITING drives the work forward and auto-retries a
+  // crashed run. dispatchTask is guarded (no double-spawn while alive) + attempt-ceilinged (parks `blocked`
+  // after TASK_MAX_ATTEMPTS), so re-polling a crash-looping child self-limits. Returns a compact snapshot;
+  // no new trust surface — the dispatched session is still fully gated. Auto-apply + audited via dispatchTask.
+  if (method === 'POST' && p === '/api/tasks/wait') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const t = os.tasks.get(String(b.id || ''));
+    if (!t) return sendJson(res, 200, { ok: false, error: 'task not found' });
+    const terminal = t.status === 'done' || t.status === 'cancelled';
+    if (!terminal && t.status !== 'blocked' && (t.assignee || '').startsWith('agent:') && !(t.lastSessionId && tm.isAlive(t.lastSessionId))) {
+      autos.dispatchTask(t.id, { guard: true, by: `wait:${agent}` });
+    }
+    // The delegate's closing "what I did" — the newest comment (task_update writes the done note as one).
+    const note = os.tasks.latestNote(t.id) ?? null;
+    return sendJson(res, 200, { ok: true, status: t.status, terminal, note, assignee: t.assignee ?? null });
   }
   // agent attaches a file from its own working folder onto a task (→ snapshot + `attach` event + audit).
   // The path is resolved strictly under the agent folder by the store; only that session may attach.

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -114,6 +114,18 @@ export class TaskStore {
   }
 
   /**
+   * The newest free-text comment on a task — the closing "what I did" note a delegate leaves when it calls
+   * task_update({ status:"done", note }). Ordered by insertion (created_at, then the monotonic rowid) so it
+   * is unambiguous even when several events land in the same millisecond. Feeds the `task_wait` result.
+   */
+  latestNote(id: string): string | undefined {
+    const r = this.db
+      .prepare("SELECT body FROM task_events WHERE task_id = ? AND kind = 'comment' AND body IS NOT NULL AND body != '' ORDER BY created_at DESC, rowid DESC LIMIT 1")
+      .get<{ body: string }>(id);
+    return r?.body ?? undefined;
+  }
+
+  /**
    * Board query. FTS (bm25) when `query` is set, else ordered by status, then priority, then most-recently
    * updated. status/assignee/label filter in SQL/JS. Mirrors KbStore.search.
    */


### PR DESCRIPTION
## What & why

Task delegation today is **fire-and-forget**: an agent calls `task_create({ assignee:"agent:x", autoDispatch:true })` and has no way to block on the outcome — it dispatches on the next ~20s scheduler tick and the caller moves on. This wires up **synchronous hand-off**: a caller can delegate a task to another agent and automatically **wait for it to finish, then resume with the result** — the agent-to-agent analog of `ask` (which blocks until a human answers).

## How it works

- **`task_wait(id)`** MCP tool (and **`task_create({ …, wait:true })`** sugar to create+dispatch+wait in one call). It long-polls the new **`POST /api/tasks/wait`** loopback route every 3s until the task reaches `done` / `cancelled` / `blocked`, then returns the delegate's closing note.
- The caller's session **stays alive on the pending tool call** and resumes on its own when the tool returns — no session revival machinery needed (same shape as `ask`).
- Each poll **kicks a guarded immediate dispatch** when the task is stalled (not terminal, not deliberately `blocked`, agent-assigned, nothing live on it). So *waiting drives the work* and **auto-retries a crashed run** — self-limited by the existing `dispatchTask` guard (no double-spawn while alive) + `TASK_MAX_ATTEMPTS` ceiling (a re-polled crash-loop parks `blocked` rather than spinning).
- **Parity fix:** an agent `task_create` now dispatches an `autoDispatch` hand-off **immediately** (the console `POST /api/tasks` route already did) instead of leaving it for the tick — so a delegated task begins the moment it's filed.
- `TaskStore.latestNote(id)` returns the newest `comment` event **ordered by insertion (`rowid`)** so the result note is unambiguous even when several events land in the same millisecond (a real bug the tests caught).

Headless callers park after `AOS_TASK_WAIT_S` (default 900s) with a "still running, check back" message; interactive callers wait up to an hour. No new trust surface — the dispatched session is still fully gated.

## Files

`src/memory/memory-mcp.ts` (tool + handler), `src/server.ts` (route + parity dispatch), `src/state/tasks.ts` (`latestNote`), `docs/agent-mcp-tools.md`, `docs/tasks-plan.md`, `CLAUDE.md`, `CHANGELOG.md`.

## Verification

- `npm run typecheck`, `npm run build`, `cd web && npm run build` — all pass.
- `npm run test:governance` — **68/68**.
- Isolated in-process tests (scratch `AGENT_OS_HOME`, ephemeral port): note-extraction returns the closing note (`latestNote`, terminal detection); routing smoke confirms `/api/tasks/wait` is a pre-auth loopback route (**404** unknown-session, not 401), matching the `/api/tasks/create` control.

> Note: agent-facing tool **schema** changes need `npm run build` + a session relaunch to take effect; the new server route needs a server restart. See CLAUDE.md → "What a change needs to take effect".

🤖 Generated with [Claude Code](https://claude.com/claude-code)