### PR TITLE
feat(inbox): scope session notifications to their owner + `notify` tool (v0.98.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.95.0] — 2026-07-10
+### Changed
+- **Inbox notifications are now scoped to a session's owner instead of flooding every owner/admin.**
+  An owner used to be DMed and inbox-carded about *every* member's and admin's session, and every
+  approval broadcast to *all* approvers (so admins pinged each other about runs they could self-approve).
+  Root cause: session cards were written with no audience, so visibility fell through to the
+  "owner/admin see everything" rule. Now:
+  - Every session card (`question`/`update`/`completed`/`notification`/`artifact`) is addressed to the
+    session's owner (`run_as`/spawner) via the `sessionOwner` audience.
+  - Approval cards **and** their Slack/Discord DMs share one `approvalAudience` rule — the session owner
+    alone when they can clear that level (an admin self-approving their own run), otherwise escalate to
+    the full approver tier (owners+admins for yellow, owners for red).
+  - The Inbox feed (`GET /api/messages`) defaults to a **`mine`** scope (only cards addressed to you);
+    owner/admin can flip to **All** (`?scope=all`) for the fleet-wide oversight view. A **My activity /
+    All** toggle appears on the Inbox for owner/admin. Visibility itself is unchanged — overseers can
+    still see everything, they're just no longer flooded by default.
+### Added
+- **`notify` agent tool** — an agent can deliberately loop in ONE named teammate (`notify({ to, message,
+  important? })`, `to` = name or email) when a run concerns someone other than its owner: an inbox card
+  addressed to that member plus a Slack/Discord DM. The escape hatch from owner-scoping; one recipient
+  only (no team-wide broadcast), allow+audit (`member.notified`). See `docs/agent-mcp-tools.md`.
+
 ## [0.94.1] — 2026-07-10
 ### Fixed
 - **Memory migration now pre-flights the backend instead of failing mid-loop.** The

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,10 +188,13 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 34 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 35 always-on tools
   + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). KB: `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`. Operator/inbox:
-  `ask`/`check_inbox`/`report`/`update`/`publish`/`artifacts_list`. Skills: `skill_propose` (draft a
+  `ask`/`check_inbox`/`report`/`update`/`notify`/`publish`/`artifacts_list` (session cards are
+  **owner-scoped** — addressed to the run's `run_as`/spawner via the `sessionOwner` audience — so the
+  Inbox default `mine` view isn't flooded; `notify({to,message})` is the escape hatch to loop in ONE
+  named teammate, and owner/admin flip to `?scope=all` for oversight). Skills: `skill_propose` (draft a
   reusable playbook — Lever 6 procedural memory; lands as a NOT-YET-PUBLISHED `.aos-proposed` skill +
   a `skill.proposed` inbox card, gated behind an owner/admin publish). Scheduling: `schedule`/`unschedule`
   (one-shot deferred self-run via a `type:'once'` automation). Tasks (shared work queue):

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -21,7 +21,8 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `ask` | `POST /api/ask` + poll | questions | W (blocking) | blocks ~1h polling for the human answer; DMs the run-as human out-of-band (`question.notified`) + mirrors to the chat thread so it isn't missed |
 | `check_inbox` | `GET /api/inbox` | `TerminalManager.sessionInbox` | R | non-blocking pull of this session's feed |
 | `report` | `POST /api/report` | messages | W | `outcome` enum |
-| `update` | `POST /api/update` | messages | W | non-blocking progress note |
+| `update` | `POST /api/update` | messages | W | non-blocking progress note (session-owner scoped) |
+| `notify` | `POST /api/notify` | messages + member DM | W | notify ONE named teammate (`to` = name/email); inbox card addressed to them + Slack/Discord DM; the escape hatch from session-owner scoping — see below |
 | `publish` | `POST /api/publish` | `ArtifactStore` | W | snapshots the file |
 | `skill_propose` | `POST /api/skills/propose` | `SkillsStore.propose` + messages | W | drafts a `.aos-proposed` skill (never materialised) + posts a `skill.proposed` inbox card to owner/admins; audited `skill.proposed`. Human publishes via `POST /api/skills/:name/publish` (owner/admin) or dismisses via `DELETE /api/skills/:name` |
 | `artifacts_list` | `GET /api/agent/artifacts` | `ArtifactStore.list` | R | scoped to the agent's own deliverables |
@@ -50,9 +51,30 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `discord_send` | `POST /api/agent/discord/send` | `DiscordSocket.sendToChannel` | W | proactive post to any channel by id; audited `discord.send`; only when `DISCORD_EGRESS=1` (Discord configured) |
 | `discord_dm` | `POST /api/agent/discord/dm` | `DiscordSocket.dmMember` | W | proactive DM by Discord user id; audited `discord.dm`; only when `DISCORD_EGRESS=1` |
 
-34 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+35 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
+
+### `notify` — deliberately looping in one teammate (inbox scoping)
+
+Every session's inbox cards — an agent's `update`/`report`, its `ask` question, a `notification`
+("Claude is waiting"), a published `artifact`, and the approval card the gate raises — are **addressed
+to the session's owner** (its `run_as`, else the member who spawned it) via the `sessionOwner`
+audience, not left un-addressed. This is what stops an owner/admin from being flooded by *every*
+member's and admin's session activity: the default Inbox (`GET /api/messages`, scope `mine`) shows a
+viewer only the cards addressed to them, so a session is "allocated" to one human. Owner/admin can flip
+to `scope=all` for the oversight view (every session's cards); a plain member always sees only their
+own. Approval cards/DMs route through `approvalAudience` (`src/governance/recipients.ts`): the session
+owner alone when they hold approval authority for the level (an admin self-approving their own run),
+else they escalate to the full approver tier — so admins stop DMing each other about self-approvable
+sessions.
+
+`notify` is the **escape hatch**: when a run genuinely needs someone *other* than its owner to know,
+the agent calls `notify({ to, message, important? })` with a teammate's name or email. It writes an
+inbox card addressed to that one member (`member` audience → lands in their `mine` feed) and DMs them
+on their linked Slack/Discord (`TerminalManager.setMemberNotifier` → `notifyMember` in the registry).
+It is **one named recipient only** — there is deliberately no team-wide broadcast — and it's
+allow+audit (`member.notified`), no policy gate, same posture as `slack_send`.
 
 ### `secret_put` / `secret_get` — the shared credential handoff
 

--- a/docs/inbox-plan.md
+++ b/docs/inbox-plan.md
@@ -55,6 +55,15 @@ would be pinged (owner/admin always see all). This is how a **session-less** car
 a **Tasks** notification has no session, so it carries `audience = {member: assignee|owner}` and a
 `session_id = 'task:<id>'` sentinel. See §4.10.
 
+**Owner-scoped session cards + `mine`/`all` scope (v0.95.0 — §4.11).** Every session card
+(`question`/`completed`/`update`/`notification`/`artifact`) now carries `audience =
+{sessionOwner: <session>}`, and approval cards carry the `approvalAudience` (owner-if-approver, else
+`approvers`). Visibility (`canView*`) is unchanged — owner/admin *can* still see everything — but
+`listMessages(viewer, scope)` adds a **`mine`** default that narrows the feed to cards *addressed to*
+the viewer (role-neutral: `isAddressedTo`, no owner/admin blanket pass). Owner/admin request `scope=all`
+for the oversight view; a member's `mine` and `all` are identical. This fixes the flood where an
+owner/admin saw — and was DMed about — every other person's session. See §4.11.
+
 ---
 
 ## 2. Write paths
@@ -143,6 +152,19 @@ provenance. **Fixed in two steps:** (1) one `Audience` vocabulary + `resolveReci
 (v0.63.1). (2) Messages gained an explicit `audience` (the pull face of the same resolver), and
 `TaskStore` gained a notifier so create/assign/blocked/done events land an **audience-addressed** inbox
 card + DM for the right human — assignee or owner (v0.64.0). See §4 header for the audience mechanics.
+
+### 4.11 Owner/admin flooded by everyone's session cards — ✅ SHIPPED (v0.95.0)
+Because session cards were **un-addressed**, `canViewMessageRow` fell through to `canViewRow`, whose
+"owner/admin see everything" rule meant an owner was DMed + inbox-carded about *every* member's and
+admin's session — and every approval broadcast to *all* approvers, so admins pinged each other about
+self-approvable runs. **Fixed:** (1) every session card carries `audience = {sessionOwner}`; the two
+approval cards + `notifyApprovers` share `approvalAudience` (session owner if they can clear the level,
+else escalate) — card audience == DM audience. (2) `listMessages(viewer, scope)` defaults to **`mine`**
+(cards addressed to the viewer, via the role-neutral `isAddressedTo`); owner/admin opt into `scope=all`
+for oversight (`GET /api/messages?scope=all`, gated by `inboxScope`). (3) The **`notify`** MCP tool
+(`POST /api/notify` → `TerminalManager.notifyMember` + `setMemberNotifier`) is the escape hatch: an
+agent loops in ONE named teammate (inbox card addressed to them + DM) when a run concerns someone other
+than its owner. Console: an **My activity / All** toggle on the Inbox (owner/admin only).
 
 ### 4.9 Agent can't be *pushed* an answer — ⏳ LATER
 An agent only learns its question was answered by polling `ask` or remembering to `check_inbox`. No push,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.94.1",
+  "version": "0.95.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.94.1",
+      "version": "0.95.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.94.1",
+  "version": "0.95.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/recipients.ts
+++ b/src/governance/recipients.ts
@@ -55,3 +55,20 @@ export function resolveRecipients(os: AgentOS, audience: Audience): Member[] {
     }
   }
 }
+
+/**
+ * Who an approval card/DM should reach — the one rule shared by the inbox card's audience and the
+ * out-of-band approver DM, so a card is shown to exactly whom it's pushed to. Scoping principle: an
+ * approval is the session owner's OWN business when they hold approval authority for its level (an
+ * admin/owner running their own agent self-approves — nobody else needs pinging). Only when the owner
+ * can't clear it does it escalate to the full approver tier (`canApprove(role, level)` — owners for
+ * red, owners+admins for yellow). This is what stops every admin from being DMed about every other
+ * admin's self-approvable session — the flood the un-audienced broadcast used to cause.
+ */
+export function approvalAudience(os: AgentOS, sessionId: string, level: ApprovalLevel): Audience {
+  const owner = resolveRecipients(os, { kind: 'sessionOwner', id: sessionId })[0];
+  if (owner && owner.status === 'active' && canApprove(owner.role, level)) {
+    return { kind: 'sessionOwner', id: sessionId };
+  }
+  return { kind: 'approvers', level };
+}

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -354,6 +354,26 @@ const TOOLS = [
     },
   },
   {
+    name: 'notify',
+    description:
+      'Notify a SPECIFIC teammate — the person who should know about something on this run, when that is ' +
+      'someone OTHER than the operator you already report to. By default your progress/updates/questions ' +
+      'go only to the human who owns this session; use `notify` to deliberately loop in someone else: ' +
+      '"@alex the deploy you asked about is live", "flagging this to the on-call admin". Pass `to` (their ' +
+      'name or email) and a one-line `message`. They get an Inbox card + a DM. This does NOT block — keep ' +
+      'working. Use it purposefully for the RIGHT person, not to broadcast; there is no team-wide notify.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        to: { type: 'string', description: "The teammate to notify — their name or email (e.g. \"Alex Rivera\" or \"alex@acme.com\")." },
+        message: { type: 'string', description: 'One line: what you want them to know.' },
+        important: { type: 'boolean', description: 'Flag as urgent/high-priority. Default false.' },
+      },
+      required: ['to', 'message'],
+    },
+  },
+  {
     name: 'publish',
     description:
       'Publish a finished deliverable to the Artifacts gallery so the operator can view and download ' +
@@ -911,6 +931,20 @@ async function update(args: Record<string, unknown>): Promise<string> {
   });
   const d = (await res.json()) as { ok?: boolean; error?: string };
   return d.ok ? 'Progress posted to the inbox.' : `Could not post update: ${d.error ?? 'unknown error'}`;
+}
+
+async function notify(args: Record<string, unknown>): Promise<string> {
+  const to = String(args.to ?? '').trim();
+  const message = String(args.message ?? '').trim();
+  if (!to) return 'Who should I notify? (`to` is required — a teammate name or email.)';
+  if (!message) return 'Nothing to send (message is required).';
+  const res = await fetch(AOS_URL + '/api/notify', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, to, message, important: args.important === true }),
+  });
+  const d = (await res.json()) as { ok?: boolean; to?: string; error?: string };
+  return d.ok ? `Notified ${d.to ?? to} (inbox + DM).` : `Could not notify: ${d.error ?? 'unknown error'}`;
 }
 
 async function publish(args: Record<string, unknown>): Promise<string> {
@@ -1491,6 +1525,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'ask' ? await ask(args)
         : name === 'report' ? await report(args)
         : name === 'update' ? await update(args)
+        : name === 'notify' ? await notify(args)
         : name === 'publish' ? await publish(args)
         : name === 'skill_propose' ? await skillPropose(args)
         : name === 'slack_reply' ? await slackReply(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -693,6 +693,21 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     tm.progress(session, agent, message, b.important === true || b.important === 'true');
     return sendJson(res, 200, { ok: true });
   }
+  // agent deliberately notifies a specific teammate (the `notify` tool) — the escape hatch from the
+  // session-owner-scoped default: an inbox card addressed to that member + an out-of-band DM.
+  if (method === 'POST' && p === '/api/notify') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const to = String(b.to || '').trim();
+    const message = String(b.message || '').trim();
+    if (!to) return sendJson(res, 400, { error: 'to is required' });
+    if (!message) return sendJson(res, 400, { error: 'message is required' });
+    const out = tm.notifyMember(session, agent, to, message, b.important === true || b.important === 'true');
+    return sendJson(res, out.ok ? 200 : 400, out);
+  }
   // agent publishes a deliverable to the Artifacts gallery (→ snapshot + inbox card + audit). The
   // file path is resolved under the agent's own folder by the store; only that session may publish.
   if (method === 'POST' && p === '/api/publish') {
@@ -1535,17 +1550,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: tm.deleteSession(id, me.email) });
   }
 
-  if (method === 'GET' && p === '/api/messages') return sendJson(res, 200, tm.listMessages(me));
+  // Inbox feed. `scope=all` is the oversight view (owner/admin only — resolved server-side); the
+  // default `mine` narrows to cards addressed to the viewer so owner/admin aren't flooded.
+  if (method === 'GET' && p === '/api/messages') return sendJson(res, 200, tm.listMessages(me, inboxScope(url, me)));
 
   // Dismiss the whole Activity feed at once (soft hide). Leaves action-required items (pending
   // approvals/questions, waiting notifications) in place. Same per-viewer visibility as the feed.
   if (method === 'POST' && p === '/api/messages/dismiss-all') {
-    return sendJson(res, 200, { ok: true, dismissed: tm.dismissAllMessages(me) });
+    return sendJson(res, 200, { ok: true, dismissed: tm.dismissAllMessages(me, inboxScope(url, me)) });
   }
 
   // Mark every message the viewer can see as read (per-member) — clears the unread badge.
   if (method === 'POST' && p === '/api/messages/read-all') {
-    return sendJson(res, 200, { ok: true, read: tm.markAllRead(me) });
+    return sendJson(res, 200, { ok: true, read: tm.markAllRead(me, inboxScope(url, me)) });
   }
 
   // Mark one message read for this member (per-member state; the shared feed is unaffected for others).
@@ -3253,6 +3270,14 @@ function runView(r: Run) {
 /** Parse a stored JSON column, degrading to a `{ raw }` wrapper rather than throwing on bad data. */
 function safeJson(s: string): Record<string, unknown> {
   try { const v = JSON.parse(s); return v && typeof v === 'object' ? v : { value: v }; } catch { return { raw: s }; }
+}
+/** Resolve the requested inbox scope from `?scope=`. Only owner/admin may see the `all` oversight view;
+ *  a member is always pinned to `mine` (they can't see others' cards regardless, so this just keeps the
+ *  contract explicit). Default = `mine` — the un-flooded personal feed. */
+function inboxScope(url: URL, me: Member): 'mine' | 'all' {
+  const want = url.searchParams.get('scope');
+  if (want === 'all' && (me.role === 'owner' || me.role === 'admin')) return 'all';
+  return 'mine';
 }
 /** Parse a stored `tags` JSON column into a string[] (empty on null/garbage). */
 function parseTags(s: string | null): string[] {

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -14,13 +14,13 @@ import * as path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { AgentOS, loadAgentOS, readRootConfig, RootConfig } from './kernel';
 import { exampleCapabilities } from './capabilities/examples';
-import { TerminalManager, ApprovalNotice, QuestionNotice } from './terminal';
+import { TerminalManager, ApprovalNotice, QuestionNotice, MemberNotice } from './terminal';
 import { Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
 import { Member, Task } from './types';
 import { TaskNotice } from './state/tasks';
-import { Audience, resolveRecipients } from './governance/recipients';
+import { Audience, approvalAudience, resolveRecipients } from './governance/recipients';
 import { controlHome, resolvePaths, resolveTenantPaths } from './home';
 import { TenantRecord, TenantStore } from './state/control';
 
@@ -202,6 +202,9 @@ export class TenantRegistry {
     // the right human (assignee/owner) — routed via resolveRecipients — and DMs them. Fires for EVERY
     // mutation path (console, agent MCP, dispatcher) because the sink lives on the store, not the routes.
     os.tasks.setNotifier((notice) => { void notifyTaskEvent(os, tm, slack, discord, notice); });
+    // Agent → teammate: when an agent uses the `notify` tool, the inbox card is written inline (addressed
+    // to the target member); this sink DMs that member on their linked Slack/Discord too.
+    tm.setMemberNotifier((notice) => { void notifyMember(os, slack, discord, notice); });
     const ttyd = launchTtyd(paths.tmuxSocket, ttydPort, paths.connectors);
     console.log(`  [tenant:${rec.slug}] home=${paths.home}  ttyd=:${ttydPort}`);
     return { record: rec, os, tm, autos, slack, discord, ttyd, ttydPort, firstLogin: firstLogin ?? undefined };
@@ -256,7 +259,10 @@ export async function notifyLoginLink(os: AgentOS, slack: Pick<SlackSocket, 'dmU
  * (the caller fires-and-forgets). Audited once.
  */
 export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: ApprovalNotice): Promise<void> {
-  const approvers = resolveRecipients(os, { kind: 'approvers', level: notice.level });
+  // Route to the SAME audience the inbox card uses (approvalAudience): the session owner alone when they
+  // can clear this level (an admin self-approving their own run), else the full approver tier — so we
+  // stop DMing every admin about every other admin's self-approvable session.
+  const approvers = resolveRecipients(os, approvalAudience(os, notice.sessionId, notice.level));
   if (!approvers.length) return;
   // Plain text + backticks render fine in both Slack mrkdwn and Discord markdown (no */** ambiguity).
   const dot = notice.riskClass === 'red' ? '🔴' : '🟡';
@@ -346,6 +352,20 @@ export async function notifyTaskEvent(os: AgentOS, tm: Pick<TerminalManager, 'po
   const text = `📋 ${card.title} — \`${t.title}\` (${t.id}).\nOpen the Agent OS console → Tasks.`;
   const dms = await deliverDM(slack, discord, os, recipients, text);
   os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.notified', data: { id: t.id, event: card.event, recipients: recipients.length, dms } });
+}
+
+/**
+ * DM the one teammate an agent deliberately notified via the `notify` tool. The inbox card is already
+ * written (addressed to that member) by {@link TerminalManager.notifyMember}; this is the out-of-band
+ * push to their linked Slack/Discord. Single named recipient — never a broadcast. Best-effort, audited.
+ */
+export async function notifyMember(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: MemberNotice): Promise<void> {
+  const targets = resolveRecipients(os, { kind: 'member', id: notice.to });
+  if (!targets.length) return;
+  const bell = notice.important ? '❗' : '📨';
+  const text = `${bell} Message from agent ${notice.agent}:\n${notice.message}\nOpen the Agent OS console → Inbox.`;
+  const dms = await deliverDM(slack, discord, os, targets, text);
+  os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'member.notified', data: { to: notice.to, important: notice.important, dms } });
 }
 
 /** Launch a ttyd bound to one tenant's tmux socket on `ttydPort`. (Moved verbatim from server.ts.) */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -13,10 +13,10 @@ import * as path from 'path';
 import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
-import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, resolveRuntimeTuning, riskClassForLevel } from './types';
+import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval } from './governance/enricher';
 import { hostGovernanceDecision, stricterDecision } from './governance/host-match';
-import { Audience, resolveRecipients } from './governance/recipients';
+import { Audience, approvalAudience, resolveRecipients } from './governance/recipients';
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
 import { LauncherSessionBackend, LocalSessionBackend, SessionBackend, SpawnErrorSink } from './edge/session-backend';
@@ -268,6 +268,17 @@ export interface QuestionNotice {
   prompt: string;
 }
 
+/** What the member-notifier sink receives when an agent deliberately notifies a specific teammate via
+ *  the `notify` tool — the explicit "this task needs someone else to know" escape hatch from the
+ *  session-owner-scoped default. `to` is the resolved member id; the registry DMs them out-of-band. */
+export interface MemberNotice {
+  sessionId: string;
+  agent: string;
+  to: string;
+  message: string;
+  important: boolean;
+}
+
 export class TerminalManager {
   /** Scripted demo runner — for `runtime: mock` agents. */
   private readonly runner = path.resolve(__dirname, '../terminal/agent-runner.sh');
@@ -300,6 +311,10 @@ export class TerminalManager {
    *  (the sink resolves no bound thread). Set by the registry once the chat sockets exist. */
   private chatMirror?: (sessionId: string, text: string) => void;
   setChatMirror(fn: (sessionId: string, text: string) => void): void { this.chatMirror = fn; }
+  /** Optional sink notified when an agent uses the `notify` tool to ping a specific teammate — the
+   *  registry DMs the target member on their linked Slack/Discord (the inbox card is written inline). */
+  private memberNotifier?: (notice: MemberNotice) => void;
+  setMemberNotifier(fn: (notice: MemberNotice) => void): void { this.memberNotifier = fn; }
 
   constructor(
     private readonly os: AgentOS,
@@ -455,10 +470,50 @@ export class TerminalManager {
     return this.canViewMsg(r.audience_kind ?? null, r.audience_id ?? null, r.session_spawned_by ?? null, r.session_run_as ?? null, viewer);
   }
 
+  /**
+   * Role-NEUTRAL session ownership: is `viewer` the human this session acts for — its `run_as`, or the
+   * member who spawned it directly (a prefixed `automation:`/`task:`/`chat:` provenance has no human
+   * owner here)? Unlike {@link canViewRow} this does NOT grant owner/admin, so the default inbox scope
+   * can tell "a session I own" apart from "a session I can merely oversee".
+   */
+  private ownsSession(spawnedBy: string | null, runAs: string | null, viewer: Member): boolean {
+    if (runAs && runAs === viewer.id) return true;
+    if (spawnedBy && !spawnedBy.includes(':') && spawnedBy === viewer.id) return true;
+    return false;
+  }
+
+  /**
+   * Is a message ADDRESSED to `viewer` (vs merely visible via an oversight role)? This is the `mine`
+   * inbox scope — the fix for owner/admin being flooded by every session's cards. An explicit audience
+   * routes by REAL membership: a named `member`/`sessionOwner` by id, an `approvers`/`admins` card to
+   * anyone who genuinely holds that authority (they ARE an intended recipient — e.g. a member's session
+   * that escalated an approval legitimately belongs in every approver's queue). A card with no audience
+   * (legacy session card) is owned by its session's human. Owner/admin get NO blanket pass here.
+   */
+  private isAddressedTo(r: MessageRow, viewer: Member): boolean {
+    // A session's own human always sees their session's cards in `mine`, whatever the card's routing
+    // audience — e.g. an approval that escalated to the `approvers` tier still belongs in the member
+    // owner's feed for awareness. (Task cards have no session row → this is a no-op for them.)
+    if (this.ownsSession(r.session_spawned_by ?? null, r.session_run_as ?? null, viewer)) return true;
+    const kind = r.audience_kind ?? null;
+    if (kind === 'member') return r.audience_id === viewer.id;
+    if (kind === 'approvers') {
+      const a = audienceFromColumns('approvers', r.audience_id ?? null);
+      return a?.kind === 'approvers' && canApprove(viewer.role, a.level);
+    }
+    if (kind === 'admins') return viewer.role === 'owner' || viewer.role === 'admin';
+    // sessionOwner audience (audience_id === session id) and legacy un-audienced cards resolve to the
+    // session owner too — already covered by the ownsSession check above; nothing else addresses them.
+    return false;
+  }
+
   /** Field-level twin of {@link canViewMessageRow} for the read/dismiss/answer guards, which fetch just
-   *  the visibility columns: explicit audience wins, else the session provenance rule. */
+   *  the visibility columns. A card is visible to its explicit audience OR to the human of the session
+   *  it belongs to — so a member whose session escalates an approval to the `approvers` tier still sees
+   *  their OWN session's card (awareness), on top of the approvers who must act. A session-less card (a
+   *  Task, session cols null) is governed purely by the audience + the owner/admin oversight rule. */
   private canViewMsg(audienceKind: string | null, audienceId: string | null, spawnedBy: string | null, runAs: string | null, viewer: Member): boolean {
-    if (audienceKind) return this.canViewAudience(audienceKind, audienceId, viewer);
+    if (audienceKind && this.canViewAudience(audienceKind, audienceId, viewer)) return true;
     return this.canViewRow(spawnedBy, runAs, viewer);
   }
 
@@ -579,7 +634,7 @@ export class TerminalManager {
     if (!row) return undefined;
     return { sessionId: row.id, agent: row.agent, runAs: row.runAs ?? undefined, claudeSessionId: row.claudeSessionId ?? undefined };
   }
-  listMessages(viewer?: Member): FeedMessage[] {
+  listMessages(viewer?: Member, scope: 'mine' | 'all' = 'mine'): FeedMessage[] {
     // Approval messages take their live status from the approvals table, so the inbox stays
     // correct even after a restart (when the in-memory resolution waiter is gone). We also pull each
     // message's session `spawned_by` so the inbox can be scoped per member (owner/admin see all).
@@ -602,7 +657,11 @@ export class TerminalManager {
          ORDER BY m.created_at DESC`,
       )
       .all<MessageRow>(viewerId);
-    const visible = viewer ? rows.filter((r) => this.canViewMessageRow(r, viewer)) : rows;
+    let visible = viewer ? rows.filter((r) => this.canViewMessageRow(r, viewer)) : rows;
+    // `mine` (the default) narrows the visible set to what's ADDRESSED to the viewer, so owner/admin
+    // aren't flooded by every session's cards; `all` is the explicit oversight view (owner/admin only —
+    // a member's `all` and `mine` are identical since they only ever see their own).
+    if (viewer && scope === 'mine') visible = visible.filter((r) => this.isAddressedTo(r, viewer));
     return visible.map(toMessage);
   }
 
@@ -618,10 +677,11 @@ export class TerminalManager {
     return true;
   }
 
-  /** Mark every message the viewer can currently see as read (per-member). Returns how many were touched. */
-  markAllRead(viewer: Member): number {
+  /** Mark every message the viewer can currently see as read (per-member), within the given inbox
+   *  scope (so "mark all read" on the default `mine` view doesn't touch other people's cards). */
+  markAllRead(viewer: Member, scope: 'mine' | 'all' = 'mine'): number {
     let n = 0;
-    for (const m of this.listMessages(viewer)) {
+    for (const m of this.listMessages(viewer, scope)) {
       if (m.read) continue;
       this.upsertState(m.id, viewer.id, 'read_at');
       n++;
@@ -689,11 +749,11 @@ export class TerminalManager {
    * `dismissMessage`'s rules: only rows the viewer may see, and never an item still waiting on the
    * human (pending approval/question) — those are left in place. Returns how many were hidden.
    */
-  dismissAllMessages(viewer: Member): number {
+  dismissAllMessages(viewer: Member, scope: 'mine' | 'all' = 'mine'): number {
     // Reuse the feed (already visibility-scoped + per-member-dismiss filtered) and hide each dismissible
     // row for THIS viewer. Waiting items (pending approval/question, open notifications) stay put.
     let n = 0;
-    for (const m of this.listMessages(viewer)) {
+    for (const m of this.listMessages(viewer, scope)) {
       const stillWaiting =
         (m.type === 'approval' && (m.status ?? 'pending') === 'pending') ||
         (m.type === 'question' && (m.status ?? 'pending') === 'pending') ||
@@ -1234,7 +1294,7 @@ export class TerminalManager {
   say(sessionId: string, body: string): void {
     const s = this.db.prepare('SELECT agent FROM term_sessions WHERE id = ?').get<{ agent: string }>(sessionId);
     if (!s) return;
-    this.addMessage({ type: 'update', sessionId, agent: s.agent, title: `Task Update (${s.agent})`, body, status: 'open' });
+    this.addMessage({ type: 'update', sessionId, agent: s.agent, title: `Task Update (${s.agent})`, body, status: 'open', audienceKind: 'sessionOwner', audienceId: sessionId });
   }
 
   /** The gate. Same policy brain as the console — allow flows, ask → inbox approval (auto-cleared for
@@ -1314,6 +1374,9 @@ export class TerminalManager {
       attempt,
       reason: decision.reason,
     });
+    // Address the card to whoever will be pinged: the session owner if they can clear this level,
+    // else the approver tier. Card audience == DM audience, so it shows in exactly their "mine" inbox.
+    const aud = approvalAudience(this.os, sessionId, decision.level);
     this.addMessage({
       type: 'approval',
       sessionId,
@@ -1325,6 +1388,8 @@ export class TerminalManager {
       capability,
       args,
       level: decision.level,
+      audienceKind: aud.kind,
+      audienceId: audienceIdOf(aud),
     });
     this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability });
     // Out-of-band ping (Slack/Discord DM to whoever can approve) — best-effort, never blocks the gate.
@@ -1381,6 +1446,7 @@ export class TerminalManager {
           attempt,
           reason: decision.reason,
         });
+        const aud = approvalAudience(this.os, sessionId, decision.level);
         this.addMessage({
           type: 'approval',
           sessionId,
@@ -1392,6 +1458,8 @@ export class TerminalManager {
           capability: 'secret.put',
           args: { key },
           level: decision.level,
+          audienceKind: aud.kind,
+          audienceId: audienceIdOf(aud),
         });
         this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability: 'secret.put' });
         try { this.approvalNotifier?.({ sessionId, agent, capability: 'secret.put', level: decision.level, riskClass: decision.riskClass, reason: decision.reason }); } catch { /* advisory */ }
@@ -1551,14 +1619,10 @@ export class TerminalManager {
    * tenant-registry wiring (the `os.tasks` notifier) can call it.
    */
   postTaskCard(input: { taskId: string; agent: string; title: string; body: string; audience: Audience; event: string }): void {
-    const audienceId = input.audience.kind === 'member' ? input.audience.id
-      : input.audience.kind === 'sessionOwner' ? input.audience.id
-      : input.audience.kind === 'approvers' ? input.audience.level
-      : undefined;
     this.addMessage({
       type: 'task', sessionId: `task:${input.taskId}`, agent: input.agent, title: input.title,
       body: input.body, status: 'open', args: { taskId: input.taskId, event: input.event },
-      audienceKind: input.audience.kind, audienceId,
+      audienceKind: input.audience.kind, audienceId: audienceIdOf(input.audience),
     });
   }
 
@@ -1569,7 +1633,7 @@ export class TerminalManager {
     this.db
       .prepare('INSERT INTO questions (id, run_id, tenant, agent, prompt, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
       .run(id, sessionId, this.os.tenant, agent, prompt, 'pending', Date.now());
-    this.addMessage({ type: 'question', sessionId, agent, title: `Question — ${agent}`, body: prompt, status: 'pending', questionId: id });
+    this.addMessage({ type: 'question', sessionId, agent, title: `Question — ${agent}`, body: prompt, status: 'pending', questionId: id, audienceKind: 'sessionOwner', audienceId: sessionId });
     this.audit(sessionId, agent, 'question.asked', { questionId: id, prompt });
     // Out-of-band ping (like approvals): DM the person the run acts for so a blocking `ask` doesn't sit
     // unseen in the console. And if the run was triggered from chat, mirror the question into that
@@ -1649,7 +1713,7 @@ export class TerminalManager {
     if (kind !== 'permission_prompt' && kind !== 'idle_prompt') return;
     this.clearNotifications(sessionId);
     const fallback = kind === 'permission_prompt' ? 'Claude needs permission to continue.' : 'Claude is waiting for your input.';
-    this.addMessage({ type: 'notification', sessionId, agent, title: `Waiting — ${agent}`, body: (message || '').trim() || fallback, status: 'open' });
+    this.addMessage({ type: 'notification', sessionId, agent, title: `Waiting — ${agent}`, body: (message || '').trim() || fallback, status: 'open', audienceKind: 'sessionOwner', audienceId: sessionId });
     this.audit(sessionId, agent, 'session.notified', { kind, message });
   }
 
@@ -1665,7 +1729,7 @@ export class TerminalManager {
   report(sessionId: string, agent: string, outcome: string, summary: string, lessons?: string): void {
     if (this.hasCompleted(sessionId)) return;
     this.clearNotifications(sessionId);
-    this.addMessage({ type: 'completed', sessionId, agent, title: `Completed — ${agent}`, body: summary || '(no summary)', status: 'open', outcome });
+    this.addMessage({ type: 'completed', sessionId, agent, title: `Completed — ${agent}`, body: summary || '(no summary)', status: 'open', outcome, audienceKind: 'sessionOwner', audienceId: sessionId });
     // Close the chat loop: a chat-triggered run's completion goes back to the thread the human pinged
     // from, not just the console. No-op for non-chat runs. The agent's own `slack_reply`/`discord_reply`
     // still work for finer-grained replies; this guarantees the outcome lands even if it never called them.
@@ -1704,6 +1768,9 @@ export class TerminalManager {
         body: (input.description || s.description || `A new skill "${s.name}" is ready for review.`).trim(),
         status: 'open',
         args: { skill: s.name, ...(input.rationale ? { rationale: input.rationale } : {}) },
+        // Publishing a skill is an owner/admin act — address the review card to the admin tier so it
+        // lands in exactly their inbox (not the running agent's session owner).
+        audienceKind: 'admins',
       });
       this.audit(sessionId, agent, 'skill.proposed', { name: s.name, description: s.description, rationale: input.rationale });
       return { ok: true, skill: s.name };
@@ -1719,8 +1786,43 @@ export class TerminalManager {
   progress(sessionId: string, agent: string, message: string, important = false): void {
     const body = (message || '').trim();
     if (!body) return;
-    this.addMessage({ type: 'update', sessionId, agent, title: `Update — ${agent}`, body, status: 'open', args: important ? { important: true } : undefined });
+    this.addMessage({ type: 'update', sessionId, agent, title: `Update — ${agent}`, body, status: 'open', args: important ? { important: true } : undefined, audienceKind: 'sessionOwner', audienceId: sessionId });
     this.audit(sessionId, agent, 'session.progress', { important, message: body });
+  }
+
+  /**
+   * Agent deliberately notifies a specific teammate (the `notify` MCP tool) — the "this task needs
+   * someone else to know" escape hatch from the session-owner-scoped default. Resolves `to` (a member
+   * id, email, or display name), posts an inbox card ADDRESSED to that member (so it lands in their
+   * `mine` feed regardless of who owns the session), fires the out-of-band DM sink, and audits it.
+   * Never routes to the whole team — one named recipient, deliberately chosen by the agent.
+   */
+  notifyMember(sessionId: string, agent: string, to: string, message: string, important = false): { ok: boolean; to?: string; error?: string } {
+    const body = (message || '').trim();
+    if (!body) return { ok: false, error: 'message is required' };
+    const target = this.resolveMember(to);
+    if (!target) return { ok: false, error: `no teammate matches "${to}"` };
+    this.addMessage({
+      type: 'update', sessionId, agent, title: `Note from ${agent}`, body, status: 'open',
+      args: important ? { important: true } : undefined,
+      audienceKind: 'member', audienceId: target.id,
+    });
+    this.audit(sessionId, agent, 'member.notified', { to: target.id, important, message: body });
+    try { this.memberNotifier?.({ sessionId, agent, to: target.id, message: body, important }); } catch { /* advisory */ }
+    return { ok: true, to: target.email };
+  }
+
+  /** Resolve a person the agent named — by member id, email (case-insensitive), or display name — to a
+   *  member. Used by {@link notifyMember}; returns undefined when nothing matches unambiguously. */
+  private resolveMember(who: string): Member | undefined {
+    const q = (who || '').trim();
+    if (!q) return undefined;
+    const byId = this.os.team.getMember(q);
+    if (byId) return byId;
+    const lower = q.toLowerCase();
+    const members = this.os.team.listMembers().filter((m) => m.status === 'active');
+    return members.find((m) => m.email.toLowerCase() === lower)
+        ?? members.find((m) => (m.name ?? '').toLowerCase() === lower);
   }
 
   /**
@@ -1748,6 +1850,7 @@ export class TerminalManager {
     this.addMessage({
       type: 'artifact', sessionId, agent, title: `Artifact — ${agent}`, body: a.title, status: 'open',
       source, args: { artifactId: a.id, filename: a.filename, mime: a.mime, kind: a.kind },
+      audienceKind: 'sessionOwner', audienceId: sessionId,
     });
     this.audit(sessionId, agent, 'artifact.published', { id: a.id, filename: a.filename, bytes: a.bytes, mime: a.mime, title: a.title });
     return { ok: true, id: a.id };
@@ -2275,6 +2378,17 @@ function audienceFromColumns(kind: string, id: string | null): Audience | null {
     case 'admins': return { kind: 'admins' };
     case 'approvers': return id === 'head' || id === 'owner' ? { kind: 'approvers', level: id } : null;
     default: return null;
+  }
+}
+
+/** The `audience_id` column value for an {@link Audience} (its member id / session id / level; null for
+ *  the role-set `admins`) — the inverse of {@link audienceFromColumns}, shared by every card writer. */
+function audienceIdOf(a: Audience): string | undefined {
+  switch (a.kind) {
+    case 'member': return a.id;
+    case 'sessionOwner': return a.id;
+    case 'approvers': return a.level;
+    case 'admins': return undefined;
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2171,7 +2171,7 @@ function MsgHeading({ m, children }: { m: Msg; children?: ReactNode }) {
   )
 }
 
-function InboxPage({ messages, me, members, onOpen, onOpenArtifact, onOpenTask }: { messages: Msg[]; me: Member; members: Member[]; onOpen: (tmux: string, title: string) => void; onOpenArtifact: (id: string) => void; onOpenTask: (id: string) => void }) {
+function InboxPage({ messages: propMessages, me, members, onOpen, onOpenArtifact, onOpenTask }: { messages: Msg[]; me: Member; members: Member[]; onOpen: (tmux: string, title: string) => void; onOpenArtifact: (id: string) => void; onOpenTask: (id: string) => void }) {
   // Read state is now PER-MEMBER + server-backed (m.read): it syncs across this member's devices/tabs
   // and one admin marking read no longer touches another's badge. `readIds` optimistically bridges the
   // gap until the next poll reflects the server truth.
@@ -2179,6 +2179,21 @@ function InboxPage({ messages, me, members, onOpen, onOpenArtifact, onOpenTask }
   // Optimistically hide dismissed items; roll back on error. The server filters them from the next
   // poll anyway (per-member now), so the set just bridges the gap until then.
   const [dismissed, setDismissed] = useState<Set<string>>(() => new Set())
+  // Inbox scope. Default `mine` — only cards addressed to you (fed by the App-level poll, so the tab
+  // badge stays personal). Owner/admin can flip to `all` to oversee every session's cards; that view is
+  // fetched + polled LOCALLY here so switching to it doesn't spike the global badge.
+  const isOverseer = me.role === 'owner' || me.role === 'admin'
+  const [scope, setScope] = useState<'mine' | 'all'>('mine')
+  const [allMsgs, setAllMsgs] = useState<Msg[] | null>(null)
+  useEffect(() => {
+    if (scope !== 'all') { setAllMsgs(null); return }
+    let live = true
+    const pull = async () => { const m = await api.messages('all'); if (live) setAllMsgs(m) }
+    void pull()
+    const t = setInterval(pull, 2000)
+    return () => { live = false; clearInterval(t) }
+  }, [scope])
+  const messages = scope === 'all' ? (allMsgs ?? propMessages) : propMessages
   const dismiss = async (id: string) => {
     setDismissed((s) => new Set(s).add(id))
     const r = await api.dismissMessage(id)
@@ -2204,7 +2219,7 @@ function InboxPage({ messages, me, members, onOpen, onOpenArtifact, onOpenTask }
     const ids = activity.map((m) => m.id)
     if (ids.length === 0) return
     setDismissed((s) => { const n = new Set(s); ids.forEach((id) => n.add(id)); return n })
-    const r = await api.dismissAllMessages()
+    const r = await api.dismissAllMessages(scope)
     if (r.error) { setDismissed((s) => { const n = new Set(s); ids.forEach((id) => n.delete(id)); return n }); alert(r.error) }
   }
   const isUnread = (m: Msg): boolean => !m.read && !readIds.has(m.id)
@@ -2213,15 +2228,29 @@ function InboxPage({ messages, me, members, onOpen, onOpenArtifact, onOpenTask }
     const ids = activity.filter(isUnread).map((m) => m.id)
     if (ids.length === 0) return
     setReadIds((s) => { const n = new Set(s); ids.forEach((id) => n.add(id)); return n })
-    const r = await api.markAllRead()
+    const r = await api.markAllRead(scope)
     if (r.error) { setReadIds((s) => { const n = new Set(s); ids.forEach((id) => n.delete(id)); return n }); alert(r.error) }
   }
 
+  // The My/All scope toggle — owner/admin only (a member's feed is already just their own).
+  const scopeToggle = isOverseer ? (
+    <div className="inline-flex overflow-hidden rounded-md border text-[11px]">
+      <button onClick={() => setScope('mine')} className={`px-2.5 py-1 ${scope === 'mine' ? 'bg-muted font-medium' : 'text-muted-foreground hover:text-foreground'}`} title="only cards addressed to you">My activity</button>
+      <button onClick={() => setScope('all')} className={`border-l px-2.5 py-1 ${scope === 'all' ? 'bg-muted font-medium' : 'text-muted-foreground hover:text-foreground'}`} title="every session's cards across the workspace">All</button>
+    </div>
+  ) : null
+
   if (messages.length === 0)
-    return <div className="mx-auto max-w-xl pt-10 text-center text-sm text-muted-foreground">No messages yet. Spawn an agent to start.</div>
+    return (
+      <div className="mx-auto max-w-2xl">
+        {scopeToggle && <div className="mb-4 flex justify-end">{scopeToggle}</div>}
+        <div className="pt-10 text-center text-sm text-muted-foreground">{scope === 'all' ? 'No activity across the workspace yet.' : 'No messages addressed to you yet.'}</div>
+      </div>
+    )
 
   return (
     <div className="mx-auto max-w-2xl space-y-7">
+      {scopeToggle && <div className="flex justify-end">{scopeToggle}</div>}
       <section>
         <div className="mb-2 flex items-center justify-between">
           <span className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -775,7 +775,9 @@ export const api = {
   /** Owner-only: plain restart, no pull/rebuild. The process bounces ~1.5s after the response. */
   restart: () => call<RestartResult>('POST', '/api/restart'),
   sessions: () => call<Session[]>('GET', '/api/sessions'),
-  messages: () => call<Msg[]>('GET', '/api/messages'),
+  /** Inbox feed. `scope='all'` is the owner/admin oversight view (every session's cards); the default
+   *  `mine` is the personal feed — only cards addressed to you, so overseers aren't flooded. */
+  messages: (scope: 'mine' | 'all' = 'mine') => call<Msg[]>('GET', `/api/messages${scope === 'all' ? '?scope=all' : ''}`),
   run: (agent: string, task: string) => call<{ id: string; tmux: string; error?: string }>('POST', '/api/sessions', { agent, task }),
   stopSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/stop`),
   rateSession: (id: string, rating: 'up' | 'down' | null) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/rate`, { rating }),
@@ -800,9 +802,9 @@ export const api = {
   /** Dismiss a pending question without answering (cancels it; unblocks a still-live agent's `ask`). */
   cancelQuestion: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/questions/${id}/cancel`),
   dismissMessage: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/dismiss`),
-  dismissAllMessages: () => call<{ ok: boolean; dismissed?: number; error?: string }>('POST', '/api/messages/dismiss-all'),
+  dismissAllMessages: (scope: 'mine' | 'all' = 'mine') => call<{ ok: boolean; dismissed?: number; error?: string }>('POST', `/api/messages/dismiss-all${scope === 'all' ? '?scope=all' : ''}`),
   markRead: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/read`),
-  markAllRead: () => call<{ ok: boolean; read?: number; error?: string }>('POST', '/api/messages/read-all'),
+  markAllRead: (scope: 'mine' | 'all' = 'mine') => call<{ ok: boolean; read?: number; error?: string }>('POST', `/api/messages/read-all${scope === 'all' ? '?scope=all' : ''}`),
 
   team: () => call<TeamResp>('GET', '/api/team'),
   audit: (f: { session?: string; type?: string; principal?: string; limit?: number } = {}) => {


### PR DESCRIPTION
## Problem
As an owner you were notified — via Inbox cards **and** Slack/Discord DMs — about *every* member's and admin's terminal session. Admins were also pinged about each other's runs, including ones they could self-approve. A session wasn't "owned" by anyone for notification purposes.

**Root cause:** session-lifecycle cards (`question`/`update`/`completed`/`notification`/`artifact`) and approval cards were written with **no audience**, so inbox visibility fell through to the "owner/admin see everything" rule, and `notifyApprovers` DMed *all* approvers.

## Fix
- **Owner-addressed cards.** Every session card now carries `audience = {sessionOwner}` (the run's `run_as`/spawner). Approval cards **and** their DMs share one `approvalAudience` rule (`src/governance/recipients.ts`): the session owner alone when they can clear that level (an admin self-approving their own run), else escalate to the approver tier — so *card audience == DM audience*.
- **`mine` / `all` inbox scope.** `listMessages(viewer, scope)` defaults to `mine` — cards addressed to you (role-neutral `isAddressedTo`; a session's own human always sees their own session's cards regardless of routing audience). Owner/admin flip to **All** (`?scope=all`, gated by `inboxScope`) for the fleet oversight view. A **My activity / All** toggle appears on the Inbox (owner/admin only). Visibility itself is unchanged — overseers can still see everything, just not flooded by default.
- **New `notify` agent tool.** `notify({ to, message, important? })` loops in ONE named teammate (inbox card addressed to them + Slack/Discord DM) — the escape hatch for "this run concerns someone other than its owner". One recipient only, allow+audit (`member.notified`). Route `POST /api/notify` → `TerminalManager.notifyMember` + `setMemberNotifier`.

## Verification
- Isolated in-process harness — 24 assertions across inbox scoping, approval-audience routing (self-approve vs escalate, yellow vs red), the `notify` path, and the escalated-approval **owner-awareness** regression (a member must still see their own session's escalated approval; approvers must too).
- `npm run typecheck`, `npm run build`, `cd web && npm run build`, `npm run test:governance` → **68/68**.

## Docs
`CHANGELOG.md` (v0.95.0), `CLAUDE.md`, `docs/inbox-plan.md` (§4.11), `docs/agent-mcp-tools.md` (`notify` row + governance note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)