### PR TITLE
fix(memory): resume-safe backend migration anchored to the switch time (v0.99.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.99.1] — 2026-07-10
+### Fixed
+- **Memory-backend migration is now resume-safe and can't duplicate or lose rows.** The migrate loop
+  used a per-run `Date.now()` horizon threaded through the browser, so leaving the tab halted it
+  mid-run, and re-clicking to finish couldn't tell an un-migrated orphan from an already-mirrored row —
+  it could re-migrate rows as duplicates, or (via a count-based `backendCount >= localCount` guard)
+  falsely report "already consistent" while real orphans remained. Migration now anchors to a **stable
+  backend-switch timestamp** (`memory_backend_switched_at`, stamped only on a real backend *type* change,
+  not a token/ranking re-save): orphans = local rows written before the switch, so each is migrated
+  exactly once (re-mirrored with a fresh `created_at` that leaves the orphan set) and post-switch rows
+  are never touched. Leaving the tab and clicking **Migrate** again cleanly resumes where it stopped.
+  The drift banner/count and the "already consistent" guard are now orphan-based too, and the banner
+  explains that migration is resume-safe. (Follow-up to the automem 401 work — #162/#167.)
+
 ## [0.99.0] — 2026-07-10
 ### Added
 - **Synchronous task hand-off — a delegating agent can now wait for the result.** `task_dispatch`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.99.0",
+      "version": "0.99.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.99.0",
+  "version": "0.99.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -19,6 +19,7 @@ const SLACK_APP_TOKEN_KEY = 'slack_app_token'; // xapp-… (Socket Mode, connect
 const SLACK_BOT_TOKEN_KEY = 'slack_bot_token'; // xoxb-… (chat.postMessage, users.info)
 const DISCORD_BOT_TOKEN_KEY = 'discord_bot_token'; // Bot … (Gateway connect + post messages)
 const MEMORY_KEY = 'memory_config'; // the live memory backend (JSON MemoryConfig; overrides the file default)
+const MEMORY_SWITCH_KEY = 'memory_backend_switched_at'; // ts the active external backend became active — the stable orphan horizon for migration
 const RUNTIME_DEFAULTS_KEY = 'runtime_defaults'; // workspace-wide model/effort/permission fallback (JSON RuntimeTuning)
 const DREAMING_KEY = 'dreaming_every_hours'; // self-learning cadence in hours; 0/unset = off
 const DREAMING_STATE_KEY = 'dreaming_state'; // compounding self-learning state (cumulative totals/topics/recent)
@@ -208,6 +209,19 @@ export class SettingsStore {
 
   setMemoryConfig(cfg: MemoryConfig, by?: string): void {
     this.set(MEMORY_KEY, JSON.stringify(cfg), by);
+  }
+
+  /** The timestamp the active external backend became active (set only on a real backend TYPE switch — not
+   *  a token/ranking re-save). The stable horizon for identifying "orphan" local rows the migration must
+   *  copy up: rows written BEFORE this are from the previous backend and aren't in the current one.
+   *  `undefined` → no switch on record (treat the ledger as already consistent). */
+  memorySwitchedAt(): number | undefined {
+    const n = Number(this.getRow(MEMORY_SWITCH_KEY)?.value);
+    return Number.isFinite(n) && n > 0 ? n : undefined;
+  }
+
+  stampMemorySwitch(ts: number, by?: string): void {
+    this.set(MEMORY_SWITCH_KEY, String(ts), by);
   }
 
   // ── runtime defaults ───────────────────────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -2449,7 +2449,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const localCount = Number(os.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ?').get<{ n: number }>(os.tenant)?.n ?? 0);
     const external = (os.settings.memoryConfig()?.backend ?? 'sqlite') !== 'sqlite';
     const backendCount = external && os.memory.count ? await os.memory.count(os.tenant) : null;
-    const drift = external && backendCount != null && localCount > backendCount ? localCount - backendCount : 0;
+    // Drift = local rows written BEFORE the current backend became active (the true orphans not in it),
+    // anchored to the stable switch horizon rather than a count heuristic. No horizon on record (never
+    // switched, or switched pre-feature) → 0, so we never flag/duplicate an already-consistent ledger.
+    const horizon = external ? memoryOrphanHorizon(os) : null;
+    const drift = horizon != null ? countOrphans(os, horizon) : 0;
     return sendJson(res, 200, { ...memoryView(os), health: await os.memory.health(), localCount, backendCount, drift });
   }
   // Probe a (local) Ollama for the embeddings UI: is it reachable, which models are pulled, and —
@@ -2478,8 +2482,17 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     } catch (e) {
       return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
     }
+    const prevBackend = os.settings.memoryConfig()?.backend ?? 'sqlite';
     os.settings.setMemoryConfig(cfg, me.email);
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'memory.backend.changed', data: { backend: cfg.backend } });
+    // A real backend TYPE switch resets the orphan horizon (existing local rows are from the OLD store, so
+    // they're the ones to migrate up). A same-backend re-save (token/endpoint/ranking edit) must NOT move it,
+    // or already-migrated rows would look like orphans again and re-migrate as duplicates.
+    if (cfg.backend !== prevBackend) {
+      os.settings.stampMemorySwitch(Date.now(), me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'memory.backend.changed', data: { backend: cfg.backend, from: prevBackend } });
+    } else {
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'memory.config.updated', data: { backend: cfg.backend } });
+    }
     return sendJson(res, 200, { ok: true, ...memoryView(os), health: await os.memory.health() });
   }
   // Run a maintenance pass now (prune + consolidate), using the saved policy. Owner/admin.
@@ -2503,33 +2516,28 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const b = await readBody(req);
     const skipEpisodes = b.skipEpisodes === true;
     const limit = Math.max(1, Math.min(Number(b.limit) || 50, 500)); // rows migrated per batch (progress-friendly)
-    const localTotal = () => Number(os.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ?').get<{ n: number }>(os.tenant)?.n ?? 0);
-    const remainingBefore = (t: number) => Number(os.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ? AND created_at < ?').get<{ n: number }>(os.tenant, t)?.n ?? 0);
-    // `before` fixes the migration horizon: rows STRICTLY before it are the ORPHANS to move; rows the
-    // mirror writes DURING migration (created_at >= `before`, since the backend stamps Date.now() ≥ our
-    // capture) are excluded — so a batch never re-migrates what an earlier batch just mirrored, even if a
-    // store lands in the same millisecond. The client passes the server-assigned `before` back each batch.
-    let before = Number(b.before) || 0;
-    if (!before) {
-      // First batch — pre-flight the backend so a doomed migration fails FAST with an actionable message
-      // instead of looping into a partial `store failed after 0 migrated` (e.g. a token automem's public
-      // /health can't catch — the exact trap this guards). Only the first batch checks; once one store
-      // lands the token is proven, so later batches skip the extra round-trip.
-      const h = await os.memory.health();
-      if (!h.ok) return sendJson(res, 503, { error: `backend not ready — ${h.detail ?? 'health check failed'}. Fix it in Settings → Memory, then migrate.` });
-      // Idempotency guard: if the backend already holds everything (no drift), no-op so a stray click can't
-      // duplicate. Otherwise fix the horizon at now. (Fresh switch → empty store → passes.)
-      const backendCount = os.memory.count ? await os.memory.count(os.tenant) : null;
-      if (backendCount != null && backendCount >= localTotal()) {
-        return sendJson(res, 200, { ok: true, done: true, migrated: 0, skipped: 0, remaining: 0, note: 'already consistent — nothing to migrate' });
-      }
-      before = Date.now();
+    // The migration horizon is the STABLE backend-switch timestamp, not a per-run `Date.now()`. Orphans =
+    // local rows written before the switch (from the old store, absent from the current one). This makes the
+    // loop resume-safe across a closed tab / stray double-click: each migrated orphan is deleted and
+    // re-mirrored with created_at = now (≥ horizon, so it leaves the orphan set), and rows agents write
+    // post-switch are ≥ horizon too — so a fresh call can never re-migrate an already-moved row (no
+    // duplicates) nor falsely report "done" while true orphans remain.
+    const horizon = memoryOrphanHorizon(os);
+    if (horizon == null) {
+      return sendJson(res, 200, { ok: true, done: true, migrated: 0, skipped: 0, remaining: 0, note: 'no backend-switch on record — nothing to migrate' });
     }
-    // One batch of the oldest remaining orphans. We delete each as we go (migrated → re-mirrored under a
-    // new id with created_at > before; skipped episode → simply dropped), so it won't resurface next batch.
+    if (countOrphans(os, horizon) === 0) {
+      return sendJson(res, 200, { ok: true, done: true, migrated: 0, skipped: 0, remaining: 0, note: 'already consistent — nothing to migrate' });
+    }
+    // Pre-flight the backend so a doomed batch fails FAST with an actionable message instead of a partial
+    // `store failed after 0 migrated` (catches a token automem's public /health can't — see AutomemProvider).
+    const h = await os.memory.health();
+    if (!h.ok) return sendJson(res, 503, { error: `backend not ready — ${h.detail ?? 'health check failed'}. Fix it in Settings → Memory, then migrate.` });
+    // One batch of the oldest orphans. Delete each as we go (migrated → re-mirrored with a new id/created_at;
+    // skipped episode → simply dropped), so it won't resurface next batch.
     const rows = os.db
       .prepare('SELECT id, agent_id, content, tags, type, importance, metadata, scope FROM memories WHERE tenant = ? AND created_at < ? ORDER BY created_at, id LIMIT ?')
-      .all<{ id: string; agent_id: string; content: string; tags: string | null; type: string | null; importance: number | null; metadata: string | null; scope: string }>(os.tenant, before, limit);
+      .all<{ id: string; agent_id: string; content: string; tags: string | null; type: string | null; importance: number | null; metadata: string | null; scope: string }>(os.tenant, horizon, limit);
     const del = os.db.prepare('DELETE FROM memories WHERE tenant = ? AND id = ?');
     let migrated = 0, skipped = 0;
     for (const r of rows) {
@@ -2543,19 +2551,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
           scope: r.scope === 'tenant' ? 'tenant' : 'agent',
         });
       } catch (e) {
-        // Stop cleanly: this orphan stays put (not deleted). The client retries with the SAME `before` to resume.
+        // Stop cleanly: this orphan stays put (not deleted). A retry (same horizon) resumes from here.
         const raw = e instanceof Error ? e.message : String(e);
         // A 401 here is the backend rejecting our token (automem's /health is unauthenticated, so a bad token
         // passes the Test/health check and only bites on this first write) — point the operator at the fix.
         const hint = raw.includes('→ 401') ? ' — backend rejected the token; check the token in Settings → Memory' : '';
-        return sendJson(res, 500, { error: `store failed after ${migrated} migrated: ${raw}${hint}`, before, migrated, skipped, remaining: remainingBefore(before) });
+        return sendJson(res, 500, { error: `store failed after ${migrated} migrated: ${raw}${hint}`, migrated, skipped, remaining: countOrphans(os, horizon) });
       }
       del.run(os.tenant, r.id); migrated++;
     }
-    const remaining = remainingBefore(before);
+    const remaining = countOrphans(os, horizon);
     const done = remaining === 0;
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'memory.migrated', data: { backend: os.settings.memoryConfig()?.backend, migrated, skipped, remaining, done } });
-    return sendJson(res, 200, { ok: true, done, before, migrated, skipped, remaining });
+    return sendJson(res, 200, { ok: true, done, migrated, skipped, remaining });
   }
   if (method === 'POST' && p === '/api/settings/memory/clear') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
@@ -3538,6 +3546,21 @@ function parseEmbeddings(eb: any, ep?: EmbeddingsConfig): EmbeddingsConfig | und
  * (`…Set`), plus who last changed it. Reflects the saved DB config; when none is saved yet, returns
  * a `sqlite` skeleton (the file default may differ, but the form edits the DB layer).
  */
+/**
+ * The stable migration horizon: the timestamp the active external backend became active. Local `memories`
+ * rows OLDER than this were written under the previous backend and aren't in the current one — the orphans
+ * the migrate button copies up. Anchoring to the switch (not a per-run `Date.now()`) is what makes the
+ * migration resume-safe. `null` → no switch on record → treat the ledger as already consistent.
+ */
+function memoryOrphanHorizon(os: AgentOS): number | null {
+  return os.settings.memorySwitchedAt() ?? null;
+}
+
+/** Count local rows written before `horizon` for this tenant — the un-migrated orphans. */
+function countOrphans(os: AgentOS, horizon: number): number {
+  return Number(os.db.prepare('SELECT count(*) AS n FROM memories WHERE tenant = ? AND created_at < ?').get<{ n: number }>(os.tenant, horizon)?.n ?? 0);
+}
+
 function memoryView(os: AgentOS): MemorySettingsView {
   const cfg = os.settings.memoryConfig() ?? { backend: 'sqlite' as const };
   const view: MemorySettingsView = { backend: cfg.backend, ...os.settings.memoryMeta() };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7088,14 +7088,17 @@ function MemorySettings({ me }: { me: Member }) {
   const refreshView = () => api.memorySettings().then((v) => { if (!v.error) apply(v) }).catch(() => {})
   // Batched migrate: loop the endpoint (each call moves ≤ a batch) passing back the server's `before`
   // horizon until it reports `done`, showing progress. Safe to resume — a failed batch leaves rows put.
+  // Batched migrate. Each call moves one batch of orphans (rows written before the backend switch) and
+  // reports how many are left; the server anchors the orphan set to the switch time, so this loop is
+  // resume-safe — if you leave the tab mid-migration, just re-open and click again and it picks up exactly
+  // where it stopped (no duplicates, no false "done"). No client-side horizon to thread anymore.
   const doMigrate = async () => {
     setReconBusy(true); setReconMsg('Migrating…')
-    let before: number | undefined
     let migrated = 0, skipped = 0
     for (let guard = 0; guard < 10000; guard++) {
-      const r = await api.migrateMemory({ skipEpisodes: reconSkipEp, before })
+      const r = await api.migrateMemory({ skipEpisodes: reconSkipEp })
       if (r.error) { setReconBusy(false); return setReconMsg('⚠ ' + r.error) }
-      migrated += r.migrated ?? 0; skipped += r.skipped ?? 0; before = r.before
+      migrated += r.migrated ?? 0; skipped += r.skipped ?? 0
       if (r.done) break
       setReconMsg(`Migrating… ${migrated} moved${skipped ? ` / ${skipped} skipped` : ''}, ${r.remaining ?? 0} left`)
     }
@@ -7227,7 +7230,7 @@ function MemorySettings({ me }: { me: Member }) {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => !reconBusy && setReconcileOpen(false)}>
           <div className="w-full max-w-lg space-y-3 rounded-lg border bg-background p-4 shadow-lg" onClick={(e) => e.stopPropagation()}>
             <div className="text-sm font-medium">Switched to {view?.backend} — reconcile the {view?.localCount ?? 0} existing {(view?.localCount ?? 0) === 1 ? 'memory' : 'memories'}?</div>
-            <p className="text-xs text-muted-foreground">Agents now recall from {view?.backend}, which has {view?.backendCount ?? 0}. Your {view?.drift ?? 0} local {(view?.drift ?? 0) === 1 ? 'memory' : 'memories'} aren't in it yet. <strong>Migrate</strong> copies them into {view?.backend}; <strong>Start fresh</strong> clears the local ledger; <strong>Later</strong> leaves them (the drift banner stays until you reconcile).</p>
+            <p className="text-xs text-muted-foreground">Agents now recall from {view?.backend}, which has {view?.backendCount ?? 0}. Your {view?.drift ?? 0} pre-switch {(view?.drift ?? 0) === 1 ? 'memory' : 'memories'} aren't in it yet. <strong>Migrate</strong> copies them into {view?.backend} (resume-safe — you can leave and continue later); <strong>Start fresh</strong> clears the local ledger; <strong>Later</strong> leaves them (the drift banner stays until you reconcile).</p>
             <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground"><input type="checkbox" checked={reconSkipEp} onChange={(e) => setReconSkipEp(e.target.checked)} />durable only — skip raw session episodes</label>
             <div className="flex flex-wrap items-center gap-2">
               <Button size="sm" onClick={doMigrate} disabled={reconBusy}><Upload className="mr-1 h-3.5 w-3.5" />Migrate to {view?.backend}</Button>
@@ -7256,8 +7259,8 @@ function MemorySettings({ me }: { me: Member }) {
           <div className="flex items-start gap-2">
             <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
             <div>
-              <div className="font-medium text-amber-700">{view!.drift} {view!.drift === 1 ? 'memory is' : 'memories are'} in this workspace's local ledger but not in the active {view?.backend} store.</div>
-              <div className="mt-0.5 text-muted-foreground">Agents recall from {view?.backend} ({view?.backendCount ?? 0} there), so they can't see these {view?.localCount ?? 0} local rows. Migrate them into {view?.backend}, or clear the ledger so the count matches what's recallable.</div>
+              <div className="font-medium text-amber-700">{view!.drift} {view!.drift === 1 ? 'memory was' : 'memories were'} written before you switched to {view?.backend} and {view!.drift === 1 ? 'isn\'t' : 'aren\'t'} in it yet.</div>
+              <div className="mt-0.5 text-muted-foreground">Agents recall from {view?.backend} ({view?.backendCount ?? 0} there), so they can't see these {view?.drift ?? 0} older rows. Migrate copies them up, or clear the ledger to drop them. Migration is resume-safe — you can leave this tab and click Migrate again later to continue where it stopped.</div>
             </div>
           </div>
           <div className="flex flex-wrap items-center gap-2 pl-6">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -852,7 +852,7 @@ export const api = {
   ollamaStatus: (url: string) => call<OllamaStatus>('GET', '/api/settings/memory/ollama?url=' + encodeURIComponent(url)),
   maintainMemory: () => call<{ ok: boolean; pruned?: number; merged?: number; error?: string }>('POST', '/api/settings/memory/maintain'),
   // Batched: call with { skipEpisodes } first, then loop passing back the server-assigned `before` until `done`.
-  migrateMemory: (opts: { skipEpisodes: boolean; before?: number; limit?: number }) => call<{ ok: boolean; done?: boolean; before?: number; migrated?: number; skipped?: number; remaining?: number; note?: string; error?: string }>('POST', '/api/settings/memory/migrate', opts),
+  migrateMemory: (opts: { skipEpisodes: boolean; limit?: number }) => call<{ ok: boolean; done?: boolean; migrated?: number; skipped?: number; remaining?: number; note?: string; error?: string }>('POST', '/api/settings/memory/migrate', opts),
   clearMemoryLedger: () => call<{ ok: boolean; cleared?: number; error?: string }>('POST', '/api/settings/memory/clear'),
 
   kb: (q = '', section = '') => call<{ pages: KbPage[]; sections: string[]; enabled: boolean }>('GET', `/api/kb?q=${encodeURIComponent(q)}&section=${encodeURIComponent(section)}`),


### PR DESCRIPTION
## Context

From a real ops session migrating instawp's local ledger into automem. After the automem 401 was fixed (#162/#167), the migration itself proved fragile: it's a **client-side loop** that halts if you leave the tab, and resuming it was unreliable.

## Two real defects

1. **Tab-close halts it, no safe resume.** `doMigrate` loops in the browser, threading a per-run `before = Date.now()` horizon. Close/navigate away → the loop dies mid-migration.
2. **Resume couldn't distinguish orphans from already-mirrored rows.** A fresh re-click set a *new* `before = now`, re-scanning everything — so it could **re-migrate already-moved rows as duplicates**, or (via the count-based `backendCount >= localCount` guard) **falsely report "already consistent"** while true orphans remained. This is why "migrate the rest" misbehaved and clearing the ledger became the only way out.

## Fix — anchor to the backend-switch time

Migration now uses a **stable horizon**: the timestamp the current external backend became active (`settings.memory_backend_switched_at`), stamped **only on a real backend TYPE change** (not a token/ranking re-save, which must not move it).

- **Orphans** = local rows with `created_at < switchedAt` (written under the previous store, absent from the current one).
- Each orphan migrates **exactly once**: it's re-mirrored with a fresh `created_at = now` (≥ horizon), so it leaves the orphan set; the original is deleted.
- Rows agents write **after** the switch are ≥ horizon → never migrated → no duplicates.
- A fresh call can't falsely report "done" (guard is orphan-count == 0) nor re-migrate (orphan set shrinks monotonically). **Leaving the tab and clicking Migrate again cleanly resumes.**
- Drift banner/count is orphan-based too; copy explains resume-safety. `memory.backend.changed` now fires only on a real switch (config re-saves audit as `memory.config.updated`).

No horizon on record (never switched, or switched before this shipped) → drift 0 / "nothing to migrate" — so it never flags or duplicates an already-consistent ledger (our live tenants stay quiet).

## Verification

- `npm run typecheck` clean; `cd web && npm run build` clean; `npm run test:governance` → 68/68.
- **End-to-end** against the real `MirroredMemoryProvider` + libsql store path: 3 durable orphans migrated **exactly once**, 2 episodes dropped, 2 post-switch rows untouched, orphans → 0, and a resume re-run is a **no-op** (asserted one row per durable content, zero for episodes — no duplicates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)