### PR TITLE
feat(chat): deep-link Slack/Discord notifications back to the console (v0.98.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.100.0] — 2026-07-10
+### Added
+- **Slack/Discord notifications now carry a one-tap deep-link back to the console.** The out-of-band
+  DMs and thread mirrors used to end with a flat instruction ("Open the Agent OS console → Tasks"); they
+  now embed a clickable masked link straight to the relevant page — a task's permalink (`#/tasks/<id>`)
+  for task-assigned / blocked / done / overdue notices, and the Inbox (`#/inbox`) for approval and
+  question pings. Rendered per platform (Slack mrkdwn `<url|label>`, Discord markdown `[label](url)`)
+  because a single DM fans out to both. A tenant's public origin is resolved once from the new
+  `AGENT_OS_PUBLIC_URL` env / config `publicUrl` (a background DM has no request Host to derive from);
+  unset falls back to `baseDomain` subdomains or localhost. New `src/governance/chat-links.ts`
+  (`consolePage` + `chatLink`); `deliverDM` and the chat-mirror sink now take a per-platform text
+  builder; `TenantRegistry.consoleOrigin(slug)` pins the URL. **Deploy note:** set
+  `AGENT_OS_PUBLIC_URL` to the box's real external URL (e.g. the Tailscale name) or the links point at
+  localhost.
+
 ## [0.99.1] — 2026-07-10
 ### Fixed
 - **Memory-backend migration is now resume-safe and can't duplicate or lose rows.** The migrate loop

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.99.1",
+  "version": "0.100.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.99.1",
+      "version": "0.100.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.99.1",
+  "version": "0.100.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/chat-links.ts
+++ b/src/governance/chat-links.ts
@@ -1,0 +1,24 @@
+/**
+ * Deep-links for the out-of-band chat notifications (Slack/Discord DMs and thread mirrors).
+ *
+ * A background notification fires from the scheduler / gate with NO request Host to derive the console
+ * URL from, so the tenant's public origin is resolved once (`TenantRegistry.consoleOrigin`) and passed
+ * in here to build `<origin>/#/<page>[/<detail>]` hash-router links. `chatLink` then renders one as a
+ * clickable label in each platform's markup — Slack mrkdwn `<url|label>`, Discord markdown `[label](url)`
+ * — so "Open the console → Tasks" becomes a one-tap quick link back into the interface instead of a
+ * wall of instructions. The two platforms' masked-link syntaxes are incompatible, so a message destined
+ * for both is built per-platform (see `deliverDM`'s text builder).
+ */
+
+export type ChatPlatform = 'slack' | 'discord';
+
+/** Absolute deep-link into a tenant's console (hash router `<origin>/#/<page>[/<detail>]`). */
+export function consolePage(origin: string, page: string, detail?: string): string {
+  const base = origin.replace(/\/+$/, '');
+  return `${base}/#/${page}${detail ? '/' + encodeURIComponent(detail) : ''}`;
+}
+
+/** A clickable masked hyperlink in the given platform's markup. */
+export function chatLink(platform: ChatPlatform, url: string, label: string): string {
+  return platform === 'slack' ? `<${url}|${label}>` : `[${label}](${url})`;
+}

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -255,6 +255,9 @@ export interface RootConfig {
   tenant: string;
   /** Base domain for subdomain routing (e.g. `agent-os.example.com`); tenants live at `<slug>.<base>`. */
   baseDomain?: string;
+  /** The console's real external origin (`https://host[:port]`), used to build deep-links in background
+   *  chat DMs that have no request Host to derive from. `AGENT_OS_PUBLIC_URL` env overrides this. */
+  publicUrl?: string;
   /** User data home (env AGENT_OS_HOME overrides). Default: ./data. */
   home?: string;
   /** Bundled example agents that ship with the software. Default: config/agents. */

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -21,6 +21,7 @@ import { DiscordSocket } from './edge/discord-socket';
 import { Member, Task } from './types';
 import { TaskNotice } from './state/tasks';
 import { Audience, approvalAudience, resolveRecipients } from './governance/recipients';
+import { ChatPlatform, chatLink, consolePage } from './governance/chat-links';
 import { controlHome, resolvePaths, resolveTenantPaths } from './home';
 import { TenantRecord, TenantStore } from './state/control';
 
@@ -179,7 +180,10 @@ export class TenantRegistry {
     }
 
     const ttydPort = isDefault ? (Number(process.env.TTYD_PORT) || this.basePort + 1) : this.nextTtydPort++;
-    const tm = new TerminalManager(os, this.loopbackBase, paths.tmuxSocket);
+    // The tenant's public console origin — resolved once here (no request Host in a background DM) and
+    // closed over by every notifier so its deep-links point at the deployment's REAL external URL.
+    const consoleOrigin = this.consoleOrigin(rec.slug);
+    const tm = new TerminalManager(os, this.loopbackBase, paths.tmuxSocket, consoleOrigin);
     const autos = new Automations(os, tm);
     autos.start();
     const slack = new SlackSocket(os, autos);
@@ -188,20 +192,25 @@ export class TenantRegistry {
     void discord.start();
     // Chat approval notifications (M5): when a risky action lands an approval card, DM whoever can
     // approve it — via their linked Slack/Discord account (identity map). Best-effort, off the hot path.
-    tm.setApprovalNotifier((notice) => { void notifyApprovers(os, slack, discord, notice); });
+    tm.setApprovalNotifier((notice) => { void notifyApprovers(os, slack, discord, consoleOrigin, notice); });
     // Question notifications: when an agent asks the human a question, DM the person the run acts for so
     // a blocking `ask` doesn't sit unseen until it times out — the question-side twin of the above.
-    tm.setQuestionNotifier((notice) => { void notifyQuestionAsked(os, slack, discord, notice); });
+    tm.setQuestionNotifier((notice) => { void notifyQuestionAsked(os, slack, discord, consoleOrigin, notice); });
     // Chat loop: mirror completions/questions/approvals back to the Slack/Discord thread a chat-triggered
-    // run is bound to. Both replies no-op when the session has no bound thread (non-chat runs).
-    tm.setChatMirror((sessionId, text) => { void slack.reply(sessionId, text); void discord.reply(sessionId, text); });
+    // run is bound to. `text` is a per-platform builder so an embedded deep-link uses each platform's
+    // masked-link syntax. Both replies no-op when the session has no bound thread (non-chat runs).
+    tm.setChatMirror((sessionId, text) => {
+      const render = (p: ChatPlatform) => (typeof text === 'function' ? text(p) : text);
+      void slack.reply(sessionId, render('slack'));
+      void discord.reply(sessionId, render('discord'));
+    });
     // Deadline notifications: when a task passes its due date, DM its owner (the human it runs as) once,
     // so a missed deadline surfaces off the board. Owner-less → owner/admins. Mirrors the question path.
-    autos.setOverdueNotifier((task) => { void notifyTaskOverdue(os, slack, discord, task); });
+    autos.setOverdueNotifier((task) => { void notifyTaskOverdue(os, slack, discord, consoleOrigin, task); });
     // Task lifecycle → Inbox: a create/assign/status change lands an audience-addressed inbox card for
     // the right human (assignee/owner) — routed via resolveRecipients — and DMs them. Fires for EVERY
     // mutation path (console, agent MCP, dispatcher) because the sink lives on the store, not the routes.
-    os.tasks.setNotifier((notice) => { void notifyTaskEvent(os, tm, slack, discord, notice); });
+    os.tasks.setNotifier((notice) => { void notifyTaskEvent(os, tm, slack, discord, consoleOrigin, notice); });
     // Agent → teammate: when an agent uses the `notify` tool, the inbox card is written inline (addressed
     // to the target member); this sink DMs that member on their linked Slack/Discord too.
     tm.setMemberNotifier((notice) => { void notifyMember(os, slack, discord, notice); });
@@ -216,6 +225,22 @@ export class TenantRegistry {
     if (this.cfg.baseDomain) return `https://${slug}.${this.cfg.baseDomain}/accept?token=${token}`;
     return `http://${slug}.localhost:${this.basePort}/accept?token=${token}`;
   }
+
+  /**
+   * The public origin (`scheme://host[:port]`, no trailing slash) of a tenant's console — the base for
+   * deep-links in out-of-band chat DMs, which fire from a background scheduler/gate with no request Host
+   * to derive from. Priority: `AGENT_OS_PUBLIC_URL` env / config `publicUrl` (the deployment's REAL
+   * external URL, e.g. a Tailscale name) pins the seed tenant's origin; a `baseDomain` gives every other
+   * tenant its own subdomain; otherwise a localhost dev fallback (links open only on the box but stay
+   * clickable). Unlike `loginUrl`, this prefers the pinned URL for the default tenant so a deployed box
+   * whose real host is NOT localhost still emits reachable links.
+   */
+  consoleOrigin(slug: string): string {
+    const pinned = (process.env.AGENT_OS_PUBLIC_URL || this.cfg.publicUrl || '').trim().replace(/\/+$/, '');
+    if (this.isDefault(slug)) return pinned || (this.cfg.baseDomain ? `https://${this.cfg.baseDomain}` : `http://localhost:${this.basePort}`);
+    if (this.cfg.baseDomain) return `https://${slug}.${this.cfg.baseDomain}`;
+    return pinned || `http://${slug}.localhost:${this.basePort}`;
+  }
 }
 
 /**
@@ -225,14 +250,17 @@ export class TenantRegistry {
  * callers pass an already-resolved set (see {@link resolveRecipients}) so WHO and HOW-to-reach stay
  * separate concerns.
  */
-async function deliverDM(slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, os: AgentOS, recipients: Member[], text: string): Promise<number> {
+async function deliverDM(slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, os: AgentOS, recipients: Member[], text: string | ((platform: ChatPlatform) => string)): Promise<number> {
+  // `text` may be a per-platform builder so a message can carry a masked deep-link, whose syntax differs
+  // between Slack mrkdwn (`<url|label>`) and Discord markdown (`[label](url)`). A plain string is sent as-is.
+  const render = (platform: ChatPlatform) => (typeof text === 'function' ? text(platform) : text);
   let dms = 0;
   for (const m of recipients) {
     const ids = os.team.externalIdsFor(m.id);
     const slackId = ids.find((i) => i.provider === 'slack')?.externalId;
     const discordId = ids.find((i) => i.provider === 'discord')?.externalId;
-    if (slackId && (await slack.dmUser(slackId, text)).ok) dms++;
-    if (discordId && (await discord.dmUser(discordId, text)).ok) dms++;
+    if (slackId && (await slack.dmUser(slackId, render('slack'))).ok) dms++;
+    if (discordId && (await discord.dmUser(discordId, render('discord'))).ok) dms++;
   }
   return dms;
 }
@@ -258,7 +286,7 @@ export async function notifyLoginLink(os: AgentOS, slack: Pick<SlackSocket, 'dmU
  * (`canApprove(role, level)`); `deliverDM` reaches them via the identity map. Off the gate's hot path
  * (the caller fires-and-forgets). Audited once.
  */
-export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: ApprovalNotice): Promise<void> {
+export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: ApprovalNotice): Promise<void> {
   // Route to the SAME audience the inbox card uses (approvalAudience): the session owner alone when they
   // can clear this level (an admin self-approving their own run), else the full approver tier — so we
   // stop DMing every admin about every other admin's self-approvable session.
@@ -266,10 +294,11 @@ export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmU
   if (!approvers.length) return;
   // Plain text + backticks render fine in both Slack mrkdwn and Discord markdown (no */** ambiguity).
   const dot = notice.riskClass === 'red' ? '🔴' : '🟡';
-  const text =
+  const inbox = consolePage(consoleOrigin, 'inbox');
+  const text = (p: ChatPlatform) =>
     `${dot} ${notice.riskClass.toUpperCase()} approval needed — \`${notice.capability}\` (${notice.level}) requested by agent ${notice.agent}.` +
     (notice.reason ? `\nwhy: ${notice.reason}` : '') +
-    `\nOpen the Agent OS console → Inbox to approve or reject.`;
+    `\nOpen the ${chatLink(p, inbox, 'Agent OS Inbox')} to approve or reject.`;
   const dms = await deliverDM(slack, discord, os, approvers, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'approval.notified', data: { capability: notice.capability, level: notice.level, approvers: approvers.length, dms } });
 }
@@ -280,13 +309,14 @@ export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmU
  * else a member who spawned it); if the run has no human owner (a pure automation), falls back to the
  * `admins` audience so the question still reaches someone. Best-effort, off the ask hot path. Audited once.
  */
-export async function notifyQuestionAsked(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: QuestionNotice): Promise<void> {
+export async function notifyQuestionAsked(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: QuestionNotice): Promise<void> {
   let targets = resolveRecipients(os, { kind: 'sessionOwner', id: notice.sessionId });
   if (!targets.length) targets = resolveRecipients(os, { kind: 'admins' });
   if (!targets.length) return;
-  const text =
+  const inbox = consolePage(consoleOrigin, 'inbox');
+  const text = (p: ChatPlatform) =>
     `❓ Agent ${notice.agent} is waiting on your answer:\n${notice.prompt}` +
-    `\nOpen the Agent OS console → Inbox to reply.`;
+    `\nOpen the ${chatLink(p, inbox, 'Agent OS Inbox')} to reply.`;
   const dms = await deliverDM(slack, discord, os, targets, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'question.notified', data: { agent: notice.agent, targets: targets.length, dms } });
 }
@@ -297,14 +327,15 @@ export async function notifyQuestionAsked(os: AgentOS, slack: Pick<SlackSocket, 
  * an owner-less (or deleted-owner) task falls back to the `admins` audience so the miss still reaches
  * someone. Best-effort, fired once per task from the scheduler sweep (the once-guard lives in the DB).
  */
-export async function notifyTaskOverdue(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, task: Task): Promise<void> {
+export async function notifyTaskOverdue(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, task: Task): Promise<void> {
   let targets = task.owner ? resolveRecipients(os, { kind: 'member', id: task.owner }) : [];
   if (!targets.length) targets = resolveRecipients(os, { kind: 'admins' });
   if (!targets.length) return;
   const due = task.dueAt ? new Date(task.dueAt).toISOString().slice(0, 10) : 'its deadline';
-  const text =
+  const url = consolePage(consoleOrigin, 'tasks', task.id);
+  const text = (p: ChatPlatform) =>
     `⏰ Task overdue — \`${task.title}\` (${task.id}) passed ${due} and is still ${task.status}.` +
-    `\nOpen the Agent OS console → Tasks to reprioritise, reassign, or extend it.`;
+    `\nOpen it in the ${chatLink(p, url, 'Agent OS console')} to reprioritise, reassign, or extend it.`;
   const dms = await deliverDM(slack, discord, os, targets, text);
   os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.overdue.notified', data: { id: task.id, targets: targets.length, dms } });
 }
@@ -340,7 +371,7 @@ function taskCard(n: TaskNotice): { audience: Audience; title: string; event: st
  * the awaited DM) so it's durable even if the process exits right after; the DM is best-effort. Skips
  * entirely when the change warrants no card or the only recipient is the actor who made it.
  */
-export async function notifyTaskEvent(os: AgentOS, tm: Pick<TerminalManager, 'postTaskCard'>, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, notice: TaskNotice): Promise<void> {
+export async function notifyTaskEvent(os: AgentOS, tm: Pick<TerminalManager, 'postTaskCard'>, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: TaskNotice): Promise<void> {
   const card = taskCard(notice);
   if (!card) return;
   // Resolve the receiver, then drop the actor themselves — nobody needs a card for their own action.
@@ -349,7 +380,9 @@ export async function notifyTaskEvent(os: AgentOS, tm: Pick<TerminalManager, 'po
   const t = notice.task;
   const agentLabel = t.assignee?.startsWith('agent:') ? t.assignee.slice('agent:'.length) : 'tasks';
   tm.postTaskCard({ taskId: t.id, agent: agentLabel, title: card.title, body: t.title, audience: card.audience, event: card.event });
-  const text = `📋 ${card.title} — \`${t.title}\` (${t.id}).\nOpen the Agent OS console → Tasks.`;
+  // Deep-link straight to the task's permalink (`#/tasks/<id>`), so the DM is one tap from the board.
+  const url = consolePage(consoleOrigin, 'tasks', t.id);
+  const text = (p: ChatPlatform) => `📋 ${card.title} — \`${t.title}\` (${t.id}).\nOpen it in the ${chatLink(p, url, 'Agent OS console')}.`;
   const dms = await deliverDM(slack, discord, os, recipients, text);
   os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.notified', data: { id: t.id, event: card.event, recipients: recipients.length, dms } });
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -17,6 +17,7 @@ import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, 
 import { enrichArgs, autoClearsApproval } from './governance/enricher';
 import { hostGovernanceDecision, stricterDecision } from './governance/host-match';
 import { Audience, approvalAudience, resolveRecipients } from './governance/recipients';
+import { ChatPlatform, chatLink, consolePage } from './governance/chat-links';
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
 import { LauncherSessionBackend, LocalSessionBackend, SessionBackend, SpawnErrorSink } from './edge/session-backend';
@@ -309,8 +310,8 @@ export class TerminalManager {
    *  Slack/Discord thread a chat-triggered session is bound to, so the human who pinged the agent in
    *  chat sees the outcome there instead of having to switch to the console. No-op for non-chat runs
    *  (the sink resolves no bound thread). Set by the registry once the chat sockets exist. */
-  private chatMirror?: (sessionId: string, text: string) => void;
-  setChatMirror(fn: (sessionId: string, text: string) => void): void { this.chatMirror = fn; }
+  private chatMirror?: (sessionId: string, text: string | ((platform: ChatPlatform) => string)) => void;
+  setChatMirror(fn: (sessionId: string, text: string | ((platform: ChatPlatform) => string)) => void): void { this.chatMirror = fn; }
   /** Optional sink notified when an agent uses the `notify` tool to ping a specific teammate — the
    *  registry DMs the target member on their linked Slack/Discord (the inbox card is written inline). */
   private memberNotifier?: (notice: MemberNotice) => void;
@@ -320,6 +321,9 @@ export class TerminalManager {
     private readonly os: AgentOS,
     private readonly baseUrl: string,
     private readonly tmuxSocket: string,
+    /** The console's public origin (`scheme://host`) — the base for deep-links mirrored into chat
+     *  threads. Optional so test/demo call sites can omit it; links fall back to a bare console path. */
+    private readonly publicOrigin = '',
   ) {
     this.db = os.db;
     const onError: SpawnErrorSink = (sessionId, agent, error) => this.audit(sessionId, agent, 'session.error', { error });
@@ -1397,7 +1401,8 @@ export class TerminalManager {
     // If the run was triggered from chat, surface the gate in that thread too (the approver DM reaches
     // the approver; this reaches everyone watching the thread). No-op for non-chat runs.
     const dot = decision.riskClass === 'red' ? '🔴' : '🟡';
-    try { this.chatMirror?.(sessionId, `${dot} ${agent} needs approval — \`${capability}\` (${decision.riskClass.toUpperCase()} · ${decision.level}).\n_why: ${decision.reason}_\nOpen the Agent OS console → Inbox to approve or reject.`); } catch { /* advisory */ }
+    const inboxLink = consolePage(this.publicOrigin, 'inbox');
+    try { this.chatMirror?.(sessionId, (p) => `${dot} ${agent} needs approval — \`${capability}\` (${decision.riskClass.toUpperCase()} · ${decision.level}).\n_why: ${decision.reason}_\nOpen the ${chatLink(p, inboxLink, 'Agent OS Inbox')} to approve or reject.`); } catch { /* advisory */ }
 
     // The message + gate status are derived from the approvals table at read time, so all this
     // waiter has to do is leave an audit trail. (It won't fire across a restart — that's fine.)
@@ -1639,7 +1644,7 @@ export class TerminalManager {
     // unseen in the console. And if the run was triggered from chat, mirror the question into that
     // thread. Both best-effort, off the hot path.
     try { this.questionNotifier?.({ sessionId, agent, prompt }); } catch { /* notifications are advisory */ }
-    try { this.chatMirror?.(sessionId, `❓ ${agent} needs your input:\n${prompt}\n\nAnswer in the Agent OS console → Inbox.`); } catch { /* advisory */ }
+    try { this.chatMirror?.(sessionId, (p) => `❓ ${agent} needs your input:\n${prompt}\n\nAnswer in the ${chatLink(p, consolePage(this.publicOrigin, 'inbox'), 'Agent OS Inbox')}.`); } catch { /* advisory */ }
     return { id };
   }
 
@@ -1734,7 +1739,8 @@ export class TerminalManager {
     // from, not just the console. No-op for non-chat runs. The agent's own `slack_reply`/`discord_reply`
     // still work for finer-grained replies; this guarantees the outcome lands even if it never called them.
     const mark = outcome === 'success' ? '✅' : outcome === 'failure' ? '❌' : '☑️';
-    try { this.chatMirror?.(sessionId, `${mark} ${agent} finished (${outcome}).\n${summary || '(no summary)'}`); } catch { /* advisory */ }
+    const inboxLink = consolePage(this.publicOrigin, 'inbox');
+    try { this.chatMirror?.(sessionId, (p) => `${mark} ${agent} finished (${outcome}).\n${summary || '(no summary)'}\n${chatLink(p, inboxLink, 'Open in Agent OS')}`); } catch { /* advisory */ }
     // Rename the session from the agent's own summary — an AI-written label that reflects what the run
     // actually did, replacing the provisional title (the task text / automation name set at spawn).
     // Claude Code's internal /resume summaries aren't available for governed sessions (headless `-p`


### PR DESCRIPTION
## What

Out-of-band Slack/Discord notifications now carry a **one-tap quick link** back into the console, instead of ending with a flat instruction like *"Open the Agent OS console → Tasks."*

| Notification | Links to |
|---|---|
| Task assigned / blocked / done (`notifyTaskEvent`) | the task permalink `#/tasks/<id>` |
| Task overdue (`notifyTaskOverdue`) | the task permalink `#/tasks/<id>` |
| Approval needed (`notifyApprovers` + thread mirror) | `#/inbox` |
| Agent question (`notifyQuestionAsked` + thread mirror) | `#/inbox` |
| Session completed (thread mirror) | `#/inbox` |

Links render per platform because one DM fans out to both — **Slack** mrkdwn `<url|label>`, **Discord** markdown `[label](url)`:

```
📋 New task assigned to you — `Phase 1+2: factor provisionIngress …` (c9f45095).
Open it in the [Agent OS console](https://…/#/tasks/c9f45095).
```

## How

- **`src/governance/chat-links.ts`** (new) — `consolePage(origin, page, detail)` builds `<origin>/#/<page>[/<detail>]`; `chatLink(platform, url, label)` renders the masked link per platform.
- **`deliverDM`** and the **chat-mirror sink** now accept a `string | ((platform) => string)` text builder, so a message can embed the right masked-link syntax for each destination.
- **`TenantRegistry.consoleOrigin(slug)`** resolves the tenant's real external origin once (a background DM has no request Host to derive from): `AGENT_OS_PUBLIC_URL` env → config `publicUrl` → `baseDomain` subdomain → localhost.
- The 4 DM notifiers + 3 `TerminalManager` thread-mirror lines now emit deep links.

## ⚠ Deploy note

Set **`AGENT_OS_PUBLIC_URL`** to the box's real external URL (e.g. the Tailscale name `https://vikass-mac-mini.taild4dd35.ts.net`) — otherwise links fall back to `http://localhost:3010` and only work on the box.

## Test

- `npm run typecheck`, `npm run build`, `npm run test:governance` → **68/68 ✓**
- Isolated in-process test drives `notifyTaskEvent` end-to-end with mock `dmUser`s and asserts both platforms receive the correctly-masked task deep-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)