### PR TITLE
feat(sessions): badge how each session was initiated + headed/headless mode (v0.99.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.101.0] — 2026-07-10
+### Added
+- **The sessions list now shows how each run was initiated — and whether it's headed or headless.**
+  Origin used to collapse to a single "Started by" label with a coarse icon (member avatar / Bot /
+  generic person), so a task-dispatched run and a chat-router run were visually identical, and
+  headed-vs-headless wasn't surfaced or even stored. Now:
+  - Every session carries a server-resolved **`sourceKind`** — the full taxonomy of ways a session
+    starts: `manual` (a console member), the automation family split by trigger
+    (`cron`/`webhook`/`slack`/`discord`/`composio`/`scheduled`), `task` (the Tasks dispatcher), `chat`
+    (the `/agent` router), and `system` (an internal principal, e.g. the consolidation gardener). The
+    automation sub-type is resolved by joining the triggering automation's `type` — the raw
+    `automation:<id>` provenance can't tell the client that alone.
+  - A distinct **origin badge** (per-kind icon + label) replaces the old generic glyph; a manual run
+    still shows the starting member's avatar.
+  - Run **mode** (`headless` vs `interactive`) is now **persisted** on the session row (previously a
+    launch-only argument) and shown as a compact colored pill in both grid and list views, with a new
+    **Mode** filter (Any / Interactive / Headless).
+
 ## [0.100.0] — 2026-07-10
 ### Added
 - **Slack/Discord notifications now carry a one-tap deep-link back to the console.** The out-of-band

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.100.0",
+      "version": "0.101.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.100.0",
+  "version": "0.101.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -532,6 +532,10 @@ function migrate(db: Db): void {
   // Last time a resident session saw a turn (spawn or a delivered follow-up) — the idle-reaper clock.
   // NULL for non-resident rows (never reaped on idle).
   addColumn(db, 'term_sessions', 'last_activity', 'INTEGER');
+  // Whether the run launched headless (`claude -p`, non-interactive → exits when done) vs an
+  // attachable interactive TUI. Persists what was previously a launch-only argument so the console can
+  // badge each session's mode. Older rows default 0 (interactive) — a cosmetic backfill only.
+  addColumn(db, 'term_sessions', 'headless', 'INTEGER NOT NULL DEFAULT 0');
 
   // Session status vocabulary widened: running|idle → running|done|stopped|crashed. Legacy terminal
   // rows collapsed every non-running end state into 'idle'; we can't retro-classify how they actually

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -109,6 +109,17 @@ lever to pull:
  */
 export type SessionStatus = 'running' | 'done' | 'stopped' | 'crashed';
 
+/**
+ * Every distinct way a session gets initiated, normalized for the console's origin badge. Resolved
+ * server-side by `sourceKind()` — the automation family (`cron`/`webhook`/`slack`/`discord`/`composio`/
+ * `scheduled`) is split by joining the triggering automation's `type`, which the raw `spawnedBy`
+ * (`automation:<id>`) can't tell the client. `manual` = a console member spawned it directly; `task` =
+ * the Tasks dispatcher; `chat` = the `/agent` chat router; `system` = an internal principal with no
+ * member (e.g. the consolidation gardener).
+ */
+export type SessionSourceKind =
+  | 'manual' | 'cron' | 'webhook' | 'slack' | 'discord' | 'composio' | 'scheduled' | 'task' | 'chat' | 'system';
+
 export interface Session {
   id: string;
   agent: string;
@@ -135,6 +146,15 @@ export interface Session {
   spawnedBy?: string;
   /** Human-readable provenance for the console (member name/email, or the automation's name). */
   spawnedByLabel?: string;
+  /** Normalized origin category — every distinct WAY a session gets initiated, resolved server-side
+   *  (the automation sub-types below need a join the raw `spawnedBy` can't give the client). Drives the
+   *  console's origin icon/badge. `manual` = a console member started it; the automation family splits by
+   *  trigger; `task`/`chat` = the dispatcher/chat-router; `system` = an internal principal (e.g. the
+   *  consolidation gardener). */
+  sourceKind?: SessionSourceKind;
+  /** True when the run launched headless (`claude -p`, non-interactive) rather than as an attachable
+   *  interactive TUI. The console badges the two differently. */
+  headless?: boolean;
   /** The member id this session ACTS AS (run_as) — distinct from `spawnedBy` provenance. A task- or
    *  chat-triggered run is spawned by `task:`/`automation:` but runs as (and is owned by) a member,
    *  so the console keys "my sessions" off this too. */
@@ -207,6 +227,7 @@ interface SessionRow {
   status: SessionStatus;
   spawned_by: string | null;
   run_as: string | null;
+  headless: number | null;
   created_at: number;
   updated_at: number;
   rating: string | null;
@@ -403,6 +424,7 @@ export class TerminalManager {
       alive: alive ? alive.has(r.tmux) : undefined,
       resumable: resumable.has(r.id),
       spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as),
+      sourceKind: this.sourceKind(r.spawned_by),
       runAsLabel: this.runAsLabel(r.run_as),
       ratedByLabel: this.runAsLabel(r.rated_by),
     }));
@@ -583,6 +605,30 @@ export class TerminalManager {
     if (spawnedBy.startsWith('task:')) return `Task · ${spawnedBy.slice('task:'.length)}${asSuffix}`;
     const m = this.os.team.getMember(spawnedBy);
     return m ? m.name || m.email : spawnedBy;
+  }
+
+  /** Normalize a session's raw provenance to a {@link SessionSourceKind} — the every-way-a-session-starts
+   *  taxonomy the console badges. The automation family is split by joining the triggering automation's
+   *  `type` (`once` → `scheduled`), which the bare `automation:<id>` can't tell the client; a `spawnedBy`
+   *  that resolves to no known member is an internal `system` principal. */
+  private sourceKind(spawnedBy: string | null): SessionSourceKind {
+    if (!spawnedBy) return 'system';
+    if (spawnedBy.startsWith('task:')) return 'task';
+    if (spawnedBy.startsWith('chat:')) return 'chat';
+    if (spawnedBy.startsWith('automation:')) {
+      const auto = this.db.prepare('SELECT type FROM automations WHERE id = ?').get<{ type: string }>(spawnedBy.slice('automation:'.length));
+      switch (auto?.type) {
+        case 'cron': return 'cron';
+        case 'webhook': return 'webhook';
+        case 'slack': return 'slack';
+        case 'discord': return 'discord';
+        case 'composio': return 'composio';
+        case 'once': return 'scheduled';
+        default: return 'cron'; // deleted/unknown automation → treat as a generic scheduled trigger
+      }
+    }
+    // A bare principal: a console member spawned it manually, or an internal system principal.
+    return this.os.team.getMember(spawnedBy) ? 'manual' : 'system';
   }
 
   /** The run-as member's display name (name → email), for the sessions-list Owner filter. Undefined
@@ -795,8 +841,8 @@ export class TerminalManager {
     const secret = randomBytes(24).toString('hex');
     const session: Session = { id, agent, title, task, tmux, status: 'running', createdAt: Date.now(), updatedAt: Date.now() };
     this.db
-      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, resident, last_activity, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
-      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, claudeSessionId, resident ? 1 : 0, resident ? session.createdAt : null, session.createdAt, session.createdAt);
+      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, resident, last_activity, headless, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(session.id, agent, title, task, tmux, 'running', spawnedBy ?? null, actingMember ?? null, secret, claudeSessionId, resident ? 1 : 0, resident ? session.createdAt : null, headless ? 1 : 0, session.createdAt, session.createdAt);
     // No spawn card — the Inbox is a feed of agent-authored signals (progress / questions / approvals /
     // completions / artifacts), not a session lifecycle log. A run that never speaks stays off the feed
     // and lives only on the Sessions page.
@@ -2336,7 +2382,7 @@ function titleFromSummary(summary: string): string {
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent } from 'react'
 import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown } from 'lucide-react'
-import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, type LucideIcon } from 'lucide-react'
+import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -99,6 +99,31 @@ const SESSION_STATUS_LABELS: Record<SessionStatusFilter, string> =
 const SESSION_SOURCE_LABELS: Record<'all' | SessionSource, string> =
   { all: 'All sources', member: 'Member', automation: 'Automation', task: 'Task', chat: 'Chat' }
 
+/** The mode axis of the sessions list: interactive (attachable TUI) vs headless (`claude -p`, exits when
+ *  done). Independent of who/what started it — an automation can be either, a manual spawn is always
+ *  interactive. */
+type SessionModeFilter = 'all' | 'interactive' | 'headless'
+const SESSION_MODE_LABELS: Record<SessionModeFilter, string> =
+  { all: 'Any mode', interactive: 'Interactive', headless: 'Headless' }
+
+/** Presentation for each normalized {@link Session.sourceKind} — the icon + short chip label the
+ *  sessions list badges every distinct way a session gets initiated. The server resolves the kind
+ *  (splitting the automation family by trigger); the client only maps it to a glyph. Falls back to
+ *  `system` for an unknown/missing kind. */
+const ORIGIN_META: Record<NonNullable<Session['sourceKind']>, { icon: LucideIcon; label: string }> = {
+  manual: { icon: User, label: 'Manual' },
+  cron: { icon: Clock, label: 'Cron' },
+  webhook: { icon: Webhook, label: 'Webhook' },
+  slack: { icon: MessageSquare, label: 'Slack' },
+  discord: { icon: Hash, label: 'Discord' },
+  composio: { icon: Plug, label: 'Composio' },
+  scheduled: { icon: CalendarClock, label: 'Scheduled' },
+  task: { icon: ListChecks, label: 'Task' },
+  chat: { icon: Send, label: 'Chat' },
+  system: { icon: Cpu, label: 'System' },
+}
+const originMeta = (kind?: Session['sourceKind']) => ORIGIN_META[kind ?? 'system'] ?? ORIGIN_META.system
+
 /** Sortable columns of the sessions list. `updated` is the default (most recently active first); it's
  *  the omitted value in the URL, so a clean `#/sessions` shows the freshest sessions on top. */
 type SessionSortKey = 'created' | 'title' | 'agent' | 'id' | 'startedBy' | 'status' | 'updated'
@@ -123,17 +148,19 @@ const compareSessions = (a: Session, b: Session, key: SessionSortKey): number =>
 
 /** The sessions-list view state (filters + sort), held in the URL hash query so it survives a
  *  refresh / deep-link. */
-interface SessionFilters { q: string; status: SessionStatusFilter; agent: string; source: 'all' | SessionSource; owner: string; mine: boolean; sortKey: SessionSortKey; sortDir: SortDir }
+interface SessionFilters { q: string; status: SessionStatusFilter; agent: string; source: 'all' | SessionSource; mode: SessionModeFilter; owner: string; mine: boolean; sortKey: SessionSortKey; sortDir: SortDir }
 const parseSessionFilters = (qs: string): SessionFilters => {
   const p = new URLSearchParams(qs)
   const status = p.get('status') ?? ''
   const source = p.get('source') ?? ''
+  const mode = p.get('mode') ?? ''
   const sort = p.get('sort') ?? ''
   return {
     q: p.get('q') ?? '',
     status: (status in SESSION_STATUS_LABELS ? status : 'all') as SessionStatusFilter,
     agent: p.get('agent') ?? 'all',
     source: (source in SESSION_SOURCE_LABELS ? source : 'all') as 'all' | SessionSource,
+    mode: (mode in SESSION_MODE_LABELS ? mode : 'all') as SessionModeFilter,
     owner: p.get('owner') ?? 'all',
     mine: p.get('mine') === '1',
     sortKey: (SESSION_SORT_KEYS.includes(sort as SessionSortKey) ? sort : DEFAULT_SORT_KEY) as SessionSortKey,
@@ -147,6 +174,7 @@ const sessionFiltersToParams = (f: SessionFilters): Record<string, string> => {
   if (f.status !== 'all') p.status = f.status
   if (f.agent !== 'all') p.agent = f.agent
   if (f.source !== 'all') p.source = f.source
+  if (f.mode !== 'all') p.mode = f.mode
   if (f.owner !== 'all') p.owner = f.owner
   // `mine` is serialized by the caller, not here: its default is role-dependent (ON for owner/admin,
   // OFF for members), so only a deviation from that per-viewer default is written to the URL.
@@ -1311,16 +1339,36 @@ function AgentsPage({
 
 // ── Sessions ───────────────────────────────────────────────────────────────────
 /** Who started a session — a person icon + name for members, a bot icon for automations. */
-function StartedBy({ label, spawnedBy, members = [], className = '' }: { label?: string; spawnedBy?: string; members?: Member[]; className?: string }) {
+/** The origin of a session — how it was initiated — as a distinct per-kind icon + its human label.
+ *  The icon comes from the server-resolved {@link Session.sourceKind} (so cron vs slack vs task vs chat
+ *  are all visually distinct, not collapsed to a generic glyph); a manual run still shows the starting
+ *  member's avatar. The text is `spawnedByLabel` (e.g. "Cron · Nightly digest · as Alice"). */
+function OriginBadge({ s, members = [], className = '' }: { s: Session; members?: Member[]; className?: string }) {
+  const label = s.spawnedByLabel
   if (!label) return <span className={`flex items-center gap-1 text-xs text-muted-foreground/60 ${className}`}>—</span>
-  const isAuto = label.startsWith('Automation')
-  // A member-started session shows that member's avatar; an automation shows the Bot glyph
-  // (memberOfPrincipal returns undefined for automation:/task:/chat: ids); anything else, the person.
-  const mem = memberOfPrincipal(spawnedBy, members)
+  const meta = originMeta(s.sourceKind)
+  const Icon = meta.icon
+  // A manually-started run shows the member's avatar; every other kind shows its category glyph.
+  const mem = s.sourceKind === 'manual' ? memberOfPrincipal(s.spawnedBy, members) : undefined
   return (
-    <span className={`flex items-center gap-1 text-xs text-muted-foreground ${className}`} title={`started by ${label}`}>
-      {mem ? <MemberAvatar member={mem} className="h-3 w-3 text-[7px]" /> : isAuto ? <Bot className="h-3 w-3 shrink-0" /> : <User className="h-3 w-3 shrink-0" />}
+    <span className={`flex items-center gap-1 text-xs text-muted-foreground ${className}`} title={`${meta.label} · ${label}`}>
+      {mem ? <MemberAvatar member={mem} className="h-3 w-3 text-[7px]" /> : <Icon className="h-3 w-3 shrink-0" />}
       <span className="truncate">{label}</span>
+    </span>
+  )
+}
+
+/** The run mode of a session — headless (`claude -p`, ran to completion and exited) vs interactive (an
+ *  attachable TUI a human can watch and steer). A compact colored pill, shown alongside the origin so
+ *  the list makes both axes — who started it AND how it runs — legible at a glance. */
+function ModeBadge({ headless, className = '' }: { headless?: boolean; className?: string }) {
+  return headless ? (
+    <span title="headless — ran `claude -p` non-interactively and exited when done" className={`inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-amber-50 text-amber-700 ring-1 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20 ${className}`}>
+      <Zap className="h-2.5 w-2.5 shrink-0" /> Headless
+    </span>
+  ) : (
+    <span title="interactive — an attachable TUI you can watch and steer" className={`inline-flex shrink-0 items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium bg-sky-50 text-sky-700 ring-1 ring-sky-200 dark:bg-sky-500/10 dark:text-sky-400 dark:ring-sky-500/20 ${className}`}>
+      <Terminal className="h-2.5 w-2.5 shrink-0" /> Interactive
     </span>
   )
 }
@@ -1676,6 +1724,7 @@ function SessionsPage({
   const [statusFilter, setStatusFilter] = useState<SessionStatusFilter>(seed.status)
   const [agentFilter, setAgentFilter] = useState(seed.agent)
   const [sourceFilter, setSourceFilter] = useState<'all' | SessionSource>(seed.source)
+  const [modeFilter, setModeFilter] = useState<SessionModeFilter>(seed.mode) // interactive | headless | all
   const [ownerFilter, setOwnerFilter] = useState(seed.owner) // run-as member id, or 'all'
   // "My sessions" toggle. It narrows to the sessions the viewer is accountable for (spawned directly
   // OR runs as them) — same rule as the sidebar switcher's `mySessions`. It DEFAULTS ON for owner/admin
@@ -1689,12 +1738,12 @@ function SessionsPage({
   const [sortKey, setSortKey] = useState<SessionSortKey>(seed.sortKey)
   const [sortDir, setSortDir] = useState<SortDir>(seed.sortDir)
   useEffect(() => {
-    const params = sessionFiltersToParams({ q: query, status: statusFilter, agent: agentFilter, source: sourceFilter, owner: ownerFilter, mine, sortKey, sortDir })
+    const params = sessionFiltersToParams({ q: query, status: statusFilter, agent: agentFilter, source: sourceFilter, mode: modeFilter, owner: ownerFilter, mine, sortKey, sortDir })
     if (mine !== isFleetViewer) params.mine = mine ? '1' : '0' // only persist a deviation from the per-viewer default
     onFiltersChange(params)
     // onFiltersChange is a stable replaceState wrapper; depending on the filter/sort values only is intentional.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [query, statusFilter, agentFilter, sourceFilter, ownerFilter, mine, sortKey, sortDir])
+  }, [query, statusFilter, agentFilter, sourceFilter, modeFilter, ownerFilter, mine, sortKey, sortDir])
   // Clicking a column header sorts by it; clicking the active column flips direction. A fresh column
   // starts ascending, except `created` (time) which reads best newest-first.
   const toggleSort = (key: SessionSortKey) => {
@@ -1725,19 +1774,20 @@ function SessionsPage({
   const ownerLabel = (id: string) => (id === 'all' ? 'All owners' : ownerOptions.find((o) => o.id === id)?.label ?? id)
   // `mine` counts as "active" only when it deviates from the per-viewer default (My for owner/admin,
   // All for members), so the default view doesn't spuriously show the Clear-filters affordance.
-  const filtersActive = query.trim() !== '' || statusFilter !== 'all' || agentFilter !== 'all' || sourceFilter !== 'all' || ownerFilter !== 'all' || mine !== isFleetViewer
-  const clearFilters = () => { setQuery(''); setStatusFilter('all'); setAgentFilter('all'); setSourceFilter('all'); setOwnerFilter('all'); setMine(isFleetViewer) }
+  const filtersActive = query.trim() !== '' || statusFilter !== 'all' || agentFilter !== 'all' || sourceFilter !== 'all' || modeFilter !== 'all' || ownerFilter !== 'all' || mine !== isFleetViewer
+  const clearFilters = () => { setQuery(''); setStatusFilter('all'); setAgentFilter('all'); setSourceFilter('all'); setModeFilter('all'); setOwnerFilter('all'); setMine(isFleetViewer) }
   const filtered = useMemo(() => {
     const needle = query.trim().toLowerCase()
     return sessions.filter((s) =>
       matchesStatus(s, statusFilter) &&
       (agentFilter === 'all' || s.agent === agentFilter) &&
       (sourceFilter === 'all' || sessionSource(s) === sourceFilter) &&
+      (modeFilter === 'all' || (modeFilter === 'headless' ? !!s.headless : !s.headless)) &&
       (ownerFilter === 'all' || s.runAs === ownerFilter) &&
       (!mine || s.spawnedBy === me.id || s.runAs === me.id) &&
       (needle === '' || `${s.title} ${s.agent} ${s.id} ${s.task} ${s.spawnedByLabel ?? ''} ${s.runAsLabel ?? ''}`.toLowerCase().includes(needle)),
     )
-  }, [sessions, query, statusFilter, agentFilter, sourceFilter, ownerFilter, mine, me.id])
+  }, [sessions, query, statusFilter, agentFilter, sourceFilter, modeFilter, ownerFilter, mine, me.id])
   // Sorted view (both grid + list render this). A stable tiebreak on createdAt keeps equal keys in a
   // deterministic order rather than letting the sort shuffle them.
   const shown = useMemo(() => {
@@ -1932,6 +1982,14 @@ function SessionsPage({
             ))}
           </SelectContent>
         </Select>
+        <Select value={modeFilter} onValueChange={(v) => setModeFilter((v ?? 'all') as SessionModeFilter)}>
+          <SelectTrigger className="h-8 w-[130px] text-xs"><SelectValue>{(v) => SESSION_MODE_LABELS[(v ?? 'all') as SessionModeFilter]}</SelectValue></SelectTrigger>
+          <SelectContent>
+            {(Object.keys(SESSION_MODE_LABELS) as SessionModeFilter[]).map((v) => (
+              <SelectItem key={v} value={v}>{SESSION_MODE_LABELS[v]}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
         {/* Owner (run-as) filter — only when more than one distinct owner exists (a single-owner
             workspace has nothing to narrow). */}
         {ownerOptions.length > 1 && (
@@ -1972,9 +2030,12 @@ function SessionsPage({
                   <span className="truncate text-sm font-medium">{s.title}</span>
                   {waiting.has(s.id) && <WaitingBell className="h-3.5 w-3.5" />}
                 </div>
-                <div className="mt-1 truncate text-xs text-muted-foreground">{s.agent} · {statusLabel(s)} · <span className="font-mono">{s.id}</span></div>
+                <div className="mt-1 flex items-center gap-1.5 truncate text-xs text-muted-foreground">
+                  <span className="truncate">{s.agent} · {statusLabel(s)} · <span className="font-mono">{s.id}</span></span>
+                  <ModeBadge headless={s.headless} />
+                </div>
                 <div className="mt-1 flex items-center justify-between gap-2">
-                  <StartedBy label={s.spawnedByLabel} spawnedBy={s.spawnedBy} members={members} />
+                  <OriginBadge s={s} members={members} />
                   <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
                 </div>
               </button>
@@ -2021,6 +2082,7 @@ function SessionsPage({
               {sortHead('agent', 'Agent', 'hidden w-32 shrink-0 sm:flex')}
               {sortHead('id', 'ID', 'hidden w-20 shrink-0 md:flex')}
               {sortHead('startedBy', 'Started by', 'w-40 shrink-0')}
+              <span className="w-24 shrink-0">Mode</span>
               {sortHead('updated', 'Updated', 'w-20 shrink-0')}
               {sortHead('status', 'Status', 'w-16 shrink-0')}
             </div>
@@ -2041,7 +2103,8 @@ function SessionsPage({
                 {waiting.has(s.id) && <WaitingBell className="h-3.5 w-3.5" />}
                 <span className="hidden w-32 shrink-0 truncate text-xs text-muted-foreground sm:block">{s.agent}</span>
                 <span className="hidden w-20 shrink-0 truncate font-mono text-xs text-muted-foreground md:block" title={s.id}>{s.id}</span>
-                <StartedBy label={s.spawnedByLabel} spawnedBy={s.spawnedBy} members={members} className="w-40 shrink-0" />
+                <OriginBadge s={s} members={members} className="w-40 shrink-0" />
+                <span className="flex w-24 shrink-0 items-center"><ModeBadge headless={s.headless} /></span>
                 <span className="w-20 shrink-0 text-xs tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
                 <span className="w-16 shrink-0 text-xs text-muted-foreground">{statusLabel(s)}</span>
               </button>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -123,6 +123,14 @@ export interface Session {
   resumable?: boolean
   spawnedBy?: string
   spawnedByLabel?: string
+  /** Normalized origin category — how this session was initiated. `manual` = a console member; the
+   *  automation family splits by trigger (`cron`/`webhook`/`slack`/`discord`/`composio`/`scheduled`);
+   *  `task` = the Tasks dispatcher; `chat` = the `/agent` chat router; `system` = an internal principal.
+   *  Server-resolved (the automation sub-type needs a join the raw `spawnedBy` can't give). */
+  sourceKind?: 'manual' | 'cron' | 'webhook' | 'slack' | 'discord' | 'composio' | 'scheduled' | 'task' | 'chat' | 'system'
+  /** True when the run launched headless (`claude -p`, non-interactive) rather than as an attachable
+   *  interactive TUI. The list badges the two differently. */
+  headless?: boolean
   /** The member id this session runs AS (run_as). A task/chat-triggered run is spawnedBy `task:`/
    *  `automation:` but runs as a member — the sidebar keys "my sessions" off this too. */
   runAs?: string


### PR DESCRIPTION
## What

The sessions list surfaced origin as a single **"Started by"** label with a coarse icon (member avatar / Bot / generic person). A **task**-dispatched run and a **chat**-router run were visually identical (both fell through to the generic person icon), and **headed vs headless** wasn't shown — or even stored.

This makes both axes — *how a session was initiated* and *how it runs* — legible at a glance.

## Changes

**Backend**
- New server-resolved **`sourceKind`** on every session covering the full taxonomy of ways a run starts: `manual` (a console member), the automation family split by trigger (`cron` / `webhook` / `slack` / `discord` / `composio` / `scheduled`), `task` (the Tasks dispatcher), `chat` (the `/agent` router), and `system` (an internal principal, e.g. the consolidation gardener). The automation sub-type is resolved by joining the triggering automation's `type` — the raw `automation:<id>` provenance can't tell the client that alone.
- **Persist `headless`** on `term_sessions` (new column; it was previously a launch-only argument, never stored) and expose it as `Session.headless`. Older rows default to interactive — a cosmetic backfill only.

**Console (`web`)**
- A distinct **origin badge** (per-kind icon + label) replaces the old generic glyph; a manual run still shows the starting member's avatar.
- A compact colored **Headless / Interactive** mode pill in both the grid cards and the list (new **Mode** column).
- A new **Mode** filter (Any / Interactive / Headless), persisted in the URL like the other filters.

## Verification
- `npm run typecheck`, `npm run build`, `cd web && npm run build` — all clean.
- `npm run test:governance` — 68/68 pass.
- Isolated in-process test driving `listSessions()` over 8 rows (one per provenance shape + an automation join): every `sourceKind` and `headless` value serializes correctly (manual/slack/cron/scheduled/task/chat/system).

🤖 Generated with [Claude Code](https://claude.com/claude-code)