### PR TITLE
fix(sessions): scope the terminal tab strip to the viewer's own runs (v0.101.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.101.1] — 2026-07-10
+### Fixed
+- **The terminal tab strip no longer auto-pops tabs for other people's sessions.** An owner/admin
+  can see the whole fleet via `/api/sessions`, and the live-tab strip was built from that unfiltered
+  list — so every time any teammate (admin or member) spawned a session, a new terminal tab appeared
+  for the viewer. The strip now shows only the viewer's own runs (`spawnedBy`/`runAs` === me), matching
+  every other session surface (sidebar switcher, "My sessions" grid filter). The currently-open session
+  stays force-visible, so explicitly opening someone else's run (e.g. an admin taking over) still works.
+
 ## [0.101.0] — 2026-07-10
 ### Added
 - **The sessions list now shows how each run was initiated — and whether it's headed or headless.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.101.0",
+  "version": "0.101.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.101.0",
+      "version": "0.101.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.101.0",
+  "version": "0.101.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1867,10 +1867,15 @@ function SessionsPage({
     // A tab the user "closed" (hidden set) is dropped from the strip without stopping the session —
     // except the one currently open, which always stays visible so it can't orphan the iframe.
     const visible = (s: Session) => !hiddenTabs.has(s.tmux) || s.tmux === selected.tmux
-    const liveTabs = sessions.filter((s) => isLive(s) && visible(s))
+    // Only the viewer's own runs auto-populate the strip — otherwise an owner/admin (who can see the
+    // whole fleet via /api/sessions) gets a new tab popped in every time anyone else spawns a session.
+    // The currently-open session stays force-visible so explicitly opening someone else's run (e.g. an
+    // admin taking over) still shows its tab and can't orphan the iframe.
+    const mine = (s: Session) => s.spawnedBy === me.id || s.runAs === me.id || s.tmux === selected.tmux
+    const liveTabs = sessions.filter((s) => isLive(s) && visible(s) && mine(s))
     const endedTabs = sessions.filter((s) => !isLive(s))
     const selectedEnded = endedTabs.find((s) => s.tmux === selected.tmux)
-    const collapsibleEnded = endedTabs.filter((s) => s.tmux !== selected.tmux && visible(s))
+    const collapsibleEnded = endedTabs.filter((s) => s.tmux !== selected.tmux && visible(s) && mine(s))
     return (
       <div className="flex h-full flex-col">
         <div className="flex items-center gap-2 border-b bg-neutral-900 px-2 py-1.5 text-xs text-neutral-300">


### PR DESCRIPTION
## Problem
Terminals appeared to "auto-open" for other users. Root cause: the terminal **tab strip** (`SessionsPage` in `web/src/App.tsx`) built its live tabs from the raw `/api/sessions` list. For an **owner/admin**, that list is the entire fleet (`canViewSpawn` returns `true` for owner/admin), and it's polled every ~1.5s — so every time a teammate (admin or member) spawned a session, a new terminal tab popped into the viewer's strip.

The tab strip was the one live-session surface never brought in line with the run-as/owner scoping arc — the sidebar switcher (`App.tsx:838`) and the "My sessions" grid filter (`App.tsx:1787`) already scope by `spawnedBy`/`runAs === me`.

## Fix
Filter `liveTabs` (and `collapsibleEnded`) by the same ownership predicate. The currently-open session stays **force-visible** (`s.tmux === selected.tmux`), so an admin explicitly opening someone else's run still shows its tab and can't orphan the iframe.

## Verification
- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)