### PR TITLE
feat(artifacts,kb): folders & sub-folders — nested tree for the gallery and the wiki (v0.103.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.103.0] — 2026-07-10
+### Added
+- **Folders & sub-folders in the Artifacts gallery and the Knowledge Base.** Both surfaces were flat
+  lists (the KB grouped by a single-level `section`; Artifacts had no grouping at all), which doesn't
+  scale as they fill. Now items organize into a browsable, nested folder tree — for humans in the
+  console and for agents via their MCP tools:
+  - **Model: implicit path-strings** (no folder tables, no folder CRUD). A folder exists because an
+    item lives in it, exactly like KB sections already worked. **KB** `section` now accepts a nested
+    path (`engineering/backend`) — the `kb/<section>/<slug>.md` disk mirror and `(tenant,section,slug)`
+    index nest unchanged, so there's **no KB migration**. **Artifacts** gain a `folder` column
+    (`addColumn(db,'artifacts','folder',…)`, default `''` = root); the on-disk `<id>/<filename>`
+    layout is untouched — folder is pure organizing metadata.
+  - **Agents:** `kb_write`/`kb_search`/`kb_read` take nested section paths; `publish` gains an optional
+    `folder` (e.g. `reports/2024`). Every segment is normalized to `[a-z0-9-]` and `..`/absolute paths
+    collapse away, so a section/folder can never escape its root.
+  - **Console:** a shared collapsible `FolderNav` tree (with per-folder counts) drives both the KB
+    sidebar and the Artifacts gallery — select a folder to filter to its subtree. The new-page form
+    takes a nested section (with a datalist of existing folders); artifacts can be filed/moved via a new
+    `PATCH /api/artifacts/:id` (same gate as delete; audited `artifact.moved`).
+  - **Back-compat:** existing single-level KB sections render as root-level folders; existing artifacts
+    (empty `folder`) show under "All".
+
 ## [0.102.0] — 2026-07-10
 ### Added
 - **Console navigation is now made of real links — right-click "open in new tab", ⌘/ctrl/middle-click,

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -15,7 +15,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `forget` | `POST /api/memory/forget` | `MemoryProvider.delete` | W | author-guarded; audited `memory.forgotten` |
 | `kb_search` | `GET /api/kb/search` | `KbStore.search` | R | |
 | `kb_read` | `GET /api/kb/read` | `KbStore.read` | R | |
-| `kb_write` | `POST /api/kb/write` | `KbStore.write` | W | versioned; author `agent:<id>` |
+| `kb_write` | `POST /api/kb/write` | `KbStore.write` | W | versioned; author `agent:<id>`; `section` may nest with `/` (`engineering/backend`) → folder tree |
 | `kb_history` | `GET /api/kb/history` | `KbStore.history` | R | newest-first revisions |
 | `kb_revert` | `POST /api/kb/revert` | `KbStore.revert` | W | itself a new revision; audited `kb.reverted` |
 | `ask` | `POST /api/ask` + poll | questions | W (blocking) | blocks ~1h polling for the human answer; DMs the run-as human out-of-band (`question.notified`) + mirrors to the chat thread so it isn't missed |
@@ -23,7 +23,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `report` | `POST /api/report` | messages | W | `outcome` enum |
 | `update` | `POST /api/update` | messages | W | non-blocking progress note (session-owner scoped) |
 | `notify` | `POST /api/notify` | messages + member DM | W | notify ONE named teammate (`to` = name/email); inbox card addressed to them + Slack/Discord DM; the escape hatch from session-owner scoping — see below |
-| `publish` | `POST /api/publish` | `ArtifactStore` | W | snapshots the file |
+| `publish` | `POST /api/publish` | `ArtifactStore` | W | snapshots the file; optional `folder` path (`reports/2024`) files it into a gallery folder |
 | `skill_propose` | `POST /api/skills/propose` | `SkillsStore.propose` + messages | W | drafts a `.aos-proposed` skill (never materialised) + posts a `skill.proposed` inbox card to owner/admins; audited `skill.proposed`. Human publishes via `POST /api/skills/:name/publish` (owner/admin) or dismisses via `DELETE /api/skills/:name` |
 | `artifacts_list` | `GET /api/agent/artifacts` | `ArtifactStore.list` | R | scoped to the agent's own deliverables |
 | `schedule` | `POST /api/agent/schedule` | `Automations.schedule` (`type:'once'`) | W | one-shot deferred self-run; same agent + run-as; bounded 1 min–30 days, ≤25 pending/agent |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.102.0",
+      "version": "0.103.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.102.0",
+  "version": "0.103.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -232,7 +232,7 @@ const TOOLS = [
       additionalProperties: false,
       properties: {
         query: { type: 'string', description: 'What to look for (free text).' },
-        section: { type: 'string', description: 'Optional: restrict to one section, e.g. "engineering".' },
+        section: { type: 'string', description: 'Optional: restrict to one section/folder path, e.g. "engineering" or "engineering/backend".' },
         tags: { type: 'array', items: { type: 'string' }, description: 'Optional tag filters.' },
         limit: { type: 'number', minimum: 1, maximum: 50, default: 8, description: 'Max results (default 8).' },
       },
@@ -247,7 +247,7 @@ const TOOLS = [
       type: 'object',
       additionalProperties: false,
       properties: {
-        section: { type: 'string', description: 'The page\'s section, e.g. "engineering".' },
+        section: { type: 'string', description: 'The page\'s section (folder path), e.g. "engineering" or "engineering/backend".' },
         slug: { type: 'string', description: 'The page\'s slug, e.g. "deploy-runbook".' },
       },
       required: ['section', 'slug'],
@@ -264,7 +264,7 @@ const TOOLS = [
       type: 'object',
       additionalProperties: false,
       properties: {
-        section: { type: 'string', description: 'Section/folder, e.g. "engineering" (lowercased, url-safe).' },
+        section: { type: 'string', description: 'Section/folder path, e.g. "engineering" or "engineering/backend" (lowercased, url-safe; nest sub-folders with "/").' },
         slug: { type: 'string', description: 'Page slug, e.g. "deploy-runbook" (identifies the page; created if absent).' },
         title: { type: 'string', description: 'Human title (required when creating a new page).' },
         body: { type: 'string', description: 'The full page markdown. Link related pages with [[section/slug]].' },
@@ -393,6 +393,7 @@ const TOOLS = [
         path: { type: 'string', description: 'Path to the file in your working folder (relative, e.g. "report.pdf").' },
         title: { type: 'string', description: 'A short human-readable title for the deliverable.' },
         description: { type: 'string', description: 'Optional one-line description / context.' },
+        folder: { type: 'string', description: 'Optional folder path to file it under, e.g. "reports/2024" (nest sub-folders with "/"). Omit for the gallery root.' },
       },
       required: ['path', 'title'],
     },
@@ -1002,11 +1003,13 @@ async function publish(args: Record<string, unknown>): Promise<string> {
       path: filePath,
       title: String(args.title ?? ''),
       description: args.description ? String(args.description) : undefined,
+      folder: args.folder ? String(args.folder) : undefined,
     }),
   });
   const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
+  const where = args.folder ? ` under "${String(args.folder)}"` : '';
   return d.ok
-    ? `Published "${filePath}" to the Artifacts gallery (id ${d.id}). The operator has been notified.`
+    ? `Published "${filePath}" to the Artifacts gallery${where} (id ${d.id}). The operator has been notified.`
     : `Could not publish: ${d.error ?? 'unknown error'}`;
 }
 
@@ -1162,7 +1165,7 @@ async function checkInbox(args: Record<string, unknown>): Promise<string> {
     .join('\n');
 }
 
-interface ArtifactLite { title: string; description?: string; kind: string; filename: string; bytes: number; createdAt: number }
+interface ArtifactLite { title: string; description?: string; folder?: string; kind: string; filename: string; bytes: number; createdAt: number }
 
 async function artifactsList(args: Record<string, unknown>): Promise<string> {
   const u = new URL(AOS_URL + '/api/agent/artifacts');
@@ -1174,7 +1177,7 @@ async function artifactsList(args: Record<string, unknown>): Promise<string> {
   const arts = data.artifacts ?? [];
   if (!arts.length) return 'You have not published any deliverables yet.';
   return arts
-    .map((a) => `- ${a.title}${a.description ? ` — ${a.description}` : ''} (${a.kind}, ${a.filename})`)
+    .map((a) => `- ${a.title}${a.description ? ` — ${a.description}` : ''} (${a.kind}, ${a.filename}${a.folder ? `, in ${a.folder}/` : ''})`)
     .join('\n');
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -718,7 +718,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     const filePath = String(b.path || '').trim();
     if (!filePath) return sendJson(res, 400, { error: 'path is required' });
-    const out = tm.publishArtifact(session, { path: filePath, title: String(b.title || ''), description: b.description ? String(b.description) : undefined });
+    const out = tm.publishArtifact(session, { path: filePath, title: String(b.title || ''), description: b.description ? String(b.description) : undefined, folder: b.folder ? String(b.folder) : undefined });
     return sendJson(res, out.ok ? 200 : 400, out);
   }
   // agent proposes a new skill (Lever 6 — procedural memory). Drafts a NOT-YET-PUBLISHED skill in the
@@ -2946,6 +2946,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return;
   }
   const artMatch = p.match(/^\/api\/artifacts\/([\w-]+)$/);
+  // Move an artifact into a folder ('' = root). Same gate as delete: owner/admin, or the member whose
+  // session produced it. Auto-apply + audited (`artifact.moved`) — folders are organizing metadata.
+  if (method === 'PATCH' && artMatch) {
+    const a = os.artifacts.get(artMatch[1]);
+    if (!a) return sendJson(res, 404, { error: 'not found' });
+    if (!isAdmin(me) && a.source !== me.id) return sendJson(res, 403, { error: 'forbidden' });
+    const b = await readBody(req);
+    const folder = String(b.folder ?? '');
+    os.artifacts.move(a.id, folder);
+    const moved = os.artifacts.get(a.id);
+    os.audit.append({ ts: Date.now(), runId: a.sessionId, tenant: os.tenant, principal: me.email, type: 'artifact.moved', data: { id: a.id, from: a.folder, to: moved?.folder ?? '' } });
+    return sendJson(res, 200, { ok: true, artifact: moved });
+  }
   if (method === 'DELETE' && artMatch) {
     const a = os.artifacts.get(artMatch[1]);
     if (!a) return sendJson(res, 404, { error: 'not found' });

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -24,6 +24,7 @@ export interface Artifact {
   kind: string;
   title: string;
   description?: string;
+  folder: string; // '/'-separated folder path ('' = root); organizes the gallery into a browsable tree
   filename: string;
   relPath: string;
   mime: string;
@@ -39,6 +40,7 @@ interface ArtifactRow {
   kind: string;
   title: string;
   description: string | null;
+  folder: string | null;
   filename: string;
   rel_path: string;
   mime: string;
@@ -67,6 +69,7 @@ export class ArtifactStore {
     source?: string;
     title: string;
     description?: string;
+    folder?: string;
     allowRoot: string;
     srcPath: string;
     kind?: string;
@@ -96,6 +99,7 @@ export class ArtifactStore {
       kind: input.kind ?? 'file',
       title: input.title,
       description: input.description ?? null,
+      folder: normFolder(input.folder),
       filename,
       rel_path: path.join(id, filename),
       mime: mimeOf(filename),
@@ -104,12 +108,12 @@ export class ArtifactStore {
     };
     this.db
       .prepare(
-        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, filename, rel_path, mime, bytes, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         row.id, row.session_id, row.agent, row.source, row.kind, row.title, row.description,
-        row.filename, row.rel_path, row.mime, row.bytes, row.created_at,
+        row.folder, row.filename, row.rel_path, row.mime, row.bytes, row.created_at,
       );
     return { ok: true, artifact: toArtifact(row) };
   }
@@ -148,6 +152,12 @@ export class ArtifactStore {
     return { absPath: abs, mime: mimeOf(abs), filename: path.basename(abs) };
   }
 
+  /** Move an artifact into a folder (metadata only — the on-disk id-dir never moves). '' = root. */
+  move(id: string, folder: string): boolean {
+    const info = this.db.prepare('UPDATE artifacts SET folder = ? WHERE id = ?').run(normFolder(folder), id);
+    return info.changes > 0;
+  }
+
   /** Remove an artifact: its row and its on-disk id-dir. */
   remove(id: string): boolean {
     const a = this.get(id);
@@ -167,12 +177,26 @@ function toArtifact(r: ArtifactRow): Artifact {
     kind: r.kind,
     title: r.title,
     description: r.description ?? undefined,
+    folder: r.folder ?? '',
     filename: r.filename,
     relPath: r.rel_path,
     mime: r.mime,
     bytes: r.bytes,
     createdAt: r.created_at,
   };
+}
+
+/**
+ * Normalize a folder into a '/'-separated path of url-safe segments ('' = root). Each segment is
+ * lowercased to [a-z0-9-] and empties are dropped, so `..`/absolute paths collapse away — a folder
+ * is pure organizing metadata and can never point at the filesystem. Mirrors KB's `normPath`.
+ */
+function normFolder(s?: string): string {
+  return String(s || '')
+    .split('/')
+    .map((seg) => seg.toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 64))
+    .filter(Boolean)
+    .join('/');
 }
 
 /** Resolve `rel` under `root`, rejecting escapes lexically AND after symlink resolution. The

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -582,6 +582,11 @@ function migrate(db: Db): void {
     INSERT INTO kb_fts(kb_fts, rowid, title, tags, body) VALUES('delete', old.rowid, old.title, old.tags, old.body);
     INSERT INTO kb_fts(rowid, title, tags, body) VALUES (new.rowid, new.title, new.tags, new.body);
   END`);
+
+  // Artifacts folders: a '/'-separated folder path ('' = root) that groups the gallery into a
+  // browsable tree. Pure organizing metadata — the on-disk <id>/<filename> layout is unchanged.
+  // Existing artifacts default to '' (root).
+  addColumn(db, 'artifacts', 'folder', "TEXT NOT NULL DEFAULT ''");
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/state/kb.ts
+++ b/src/state/kb.ts
@@ -42,9 +42,9 @@ export class KbStore {
    * page row + FTS (via triggers), and mirrors the body to disk when a home is configured.
    */
   write(input: KbWriteInput): KbPage {
-    const section = normSeg(input.section);
+    const section = normPath(input.section);
     const slug = normSeg(input.slug);
-    if (!section || !slug) throw new Error('section and slug must be url-safe (letters, digits, hyphens)');
+    if (!section || !slug) throw new Error('section and slug must be url-safe (letters, digits, hyphens; section may nest with "/")');
 
     const now = Date.now();
     const existing = this.db
@@ -95,7 +95,7 @@ export class KbStore {
         .all<PageRow>(q.tenant, fetchN);
     }
     let pages = rows.map(toPage);
-    if (q.section) pages = pages.filter((p) => p.section === normSeg(q.section!));
+    if (q.section) pages = pages.filter((p) => p.section === normPath(q.section!));
     if (q.tags?.length) { const want = new Set(q.tags); pages = pages.filter((p) => p.tags.some((t) => want.has(t))); }
     return pages.slice(0, limit);
   }
@@ -103,7 +103,7 @@ export class KbStore {
   read(tenant: string, section: string, slug: string): KbPage | null {
     const r = this.db
       .prepare('SELECT * FROM kb_pages WHERE tenant = ? AND section = ? AND slug = ?')
-      .get<PageRow>(tenant, normSeg(section), normSeg(slug));
+      .get<PageRow>(tenant, normPath(section), normSeg(slug));
     return r ? toPage(r) : null;
   }
 
@@ -126,7 +126,7 @@ export class KbStore {
   /** All pages for a tenant (newest-updated first), optionally one section. */
   list(tenant: string, section?: string): KbPage[] {
     const rows = section
-      ? this.db.prepare('SELECT * FROM kb_pages WHERE tenant = ? AND section = ? ORDER BY updated_at DESC').all<PageRow>(tenant, normSeg(section))
+      ? this.db.prepare('SELECT * FROM kb_pages WHERE tenant = ? AND section = ? ORDER BY updated_at DESC').all<PageRow>(tenant, normPath(section))
       : this.db.prepare('SELECT * FROM kb_pages WHERE tenant = ? ORDER BY updated_at DESC').all<PageRow>(tenant);
     return rows.map(toPage);
   }
@@ -175,13 +175,22 @@ export class KbStore {
     if (!this.dir) return null;
     const root = path.resolve(this.dir);
     const abs = path.resolve(root, section, `${slug}.md`);
-    return abs === root || abs.startsWith(root + path.sep) ? abs : null; // section/slug are normSeg'd, so always true — defense in depth
+    return abs === root || abs.startsWith(root + path.sep) ? abs : null; // section is normPath'd (per-segment [a-z0-9-]), so always true — defense in depth
   }
 }
 
 /** Lowercase to a single url-safe path segment ([a-z0-9-]); '' if nothing usable. */
 function normSeg(s: string): string {
   return String(s || '').toLowerCase().trim().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 64);
+}
+
+/**
+ * Normalize a section into a nested folder PATH: '/'-joined url-safe segments ('' if nothing usable).
+ * Each segment is normSeg'd, so `..`/absolute paths collapse to empty and are dropped — a section can
+ * never escape the KB root. A plain single-level section (`engineering`) round-trips unchanged.
+ */
+function normPath(s: string): string {
+  return String(s || '').split('/').map(normSeg).filter(Boolean).join('/');
 }
 
 /** Word tokens ORed as quoted FTS5 terms (quoting neutralises operator chars). '' → caller uses recency. */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1882,7 +1882,7 @@ export class TerminalManager {
    * it with full provenance (the session's spawned_by → `source`), posts an 'artifact' inbox card,
    * and audits it. The file path is resolved STRICTLY under the agent's own folder by the store.
    */
-  publishArtifact(sessionId: string, input: { path: string; title?: string; description?: string }): { ok: boolean; id?: string; error?: string } {
+  publishArtifact(sessionId: string, input: { path: string; title?: string; description?: string; folder?: string }): { ok: boolean; id?: string; error?: string } {
     const agent = this.sessionAgent(sessionId);
     if (!agent) return { ok: false, error: 'unknown session' };
     const manifest = this.os.agents.get(agent);
@@ -1893,7 +1893,7 @@ export class TerminalManager {
     const source = srow?.run_as ?? srow?.spawned_by ?? undefined;
     const title = (input.title || '').trim() || path.basename(input.path);
     const r = this.os.artifacts.publish({
-      sessionId, agent, source, title, description: input.description,
+      sessionId, agent, source, title, description: input.description, folder: input.folder,
       allowRoot: manifest.dir, srcPath: input.path,
     });
     if (!r.ok) return { ok: false, error: r.error };
@@ -1904,7 +1904,7 @@ export class TerminalManager {
       source, args: { artifactId: a.id, filename: a.filename, mime: a.mime, kind: a.kind },
       audienceKind: 'sessionOwner', audienceId: sessionId,
     });
-    this.audit(sessionId, agent, 'artifact.published', { id: a.id, filename: a.filename, bytes: a.bytes, mime: a.mime, title: a.title });
+    this.audit(sessionId, agent, 'artifact.published', { id: a.id, filename: a.filename, bytes: a.bytes, mime: a.mime, title: a.title, folder: a.folder });
     return { ok: true, id: a.id };
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2908,6 +2908,65 @@ const mdComponents = {
   img: (p: any) => <img className="my-2 max-w-full rounded" {...p} />,
 }
 
+/**
+ * A collapsible folder tree built from a flat list of '/'-separated path strings. Folders are implicit
+ * — one exists because an item lives in it (same model as KB sections). Selecting a folder calls
+ * `onSelect(path)`; '' selects the root ("All"). Presentational: the parent owns the selection + does
+ * the actual filtering. Shared by the Artifacts gallery and the Knowledge Base. Renders nothing when
+ * nothing is filed into a folder yet (a flat, folderless store shows no tree).
+ */
+function FolderNav({ paths, selected, onSelect, rootLabel = 'All' }: {
+  paths: string[]
+  selected: string
+  onSelect: (path: string) => void
+  rootLabel?: string
+}) {
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set())
+  // Every prefix of every path is a folder node.
+  const nodes = new Set<string>()
+  for (const p of paths) {
+    if (!p) continue
+    const segs = p.split('/')
+    for (let i = 1; i <= segs.length; i++) nodes.add(segs.slice(0, i).join('/'))
+  }
+  const within = (base: string) => paths.filter((p) => p === base || p.startsWith(base + '/')).length
+  const childrenOf = (parent: string) =>
+    [...nodes].filter((n) => (parent === '' ? !n.includes('/') : n.startsWith(parent + '/') && !n.slice(parent.length + 1).includes('/'))).sort()
+  const toggle = (n: string) => setCollapsed((c) => { const s = new Set(c); s.has(n) ? s.delete(n) : s.add(n); return s })
+
+  const roots = childrenOf('')
+  if (roots.length === 0) return null
+
+  const Row = ({ node, depth }: { node: string; depth: number }) => {
+    const kids = childrenOf(node)
+    const open = !collapsed.has(node)
+    const active = selected === node
+    return (
+      <div>
+        <div className={`flex items-center gap-1 rounded pr-1 text-xs ${active ? 'bg-primary/10 text-foreground' : 'text-muted-foreground hover:bg-muted/50'}`} style={{ paddingLeft: depth * 12 }}>
+          {kids.length > 0
+            ? <button onClick={() => toggle(node)} className="flex h-5 w-4 shrink-0 items-center justify-center" title={open ? 'collapse' : 'expand'}><ChevronRight className={`h-3 w-3 transition-transform ${open ? 'rotate-90' : ''}`} /></button>
+            : <span className="w-4 shrink-0" />}
+          <button onClick={() => onSelect(node)} className="flex min-w-0 flex-1 items-center gap-1 py-1 text-left" title={node}>
+            <Folder className="h-3 w-3 shrink-0" /><span className="truncate">{node.split('/').pop()}</span>
+            <span className="ml-auto shrink-0 text-[10px] opacity-60">{within(node)}</span>
+          </button>
+        </div>
+        {open && kids.map((k) => <Row key={k} node={k} depth={depth + 1} />)}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-0.5 rounded-lg border p-1.5">
+      <button onClick={() => onSelect('')} className={`flex w-full items-center gap-1 rounded px-1 py-1 text-left text-xs ${selected === '' ? 'bg-primary/10 text-foreground' : 'text-muted-foreground hover:bg-muted/50'}`}>
+        <FolderTree className="h-3 w-3 shrink-0" /><span>{rootLabel}</span><span className="ml-auto text-[10px] opacity-60">{paths.length}</span>
+      </button>
+      {roots.map((r) => <Row key={r} node={r} depth={0} />)}
+    </div>
+  )
+}
+
 function ArtifactIcon({ a, className }: { a: Artifact; className?: string }) {
   if (isPdfMime(a.mime)) return <FileText className={className ?? 'h-4 w-4 text-red-500'} />
   if (isImageMime(a.mime)) return <ImageIcon className={className ?? 'h-4 w-4 text-sky-500'} />
@@ -2951,6 +3010,7 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
   const [enabled, setEnabled] = useState(true)
   const [sel, setSel] = useState<string | undefined>(initialId)
   const [agentFilter, setAgentFilter] = useState('')
+  const [folder, setFolder] = useState('')
   const [hint, setHint] = useState('')
 
   const load = () => api.artifacts().then((r) => { setArtifacts(r.artifacts ?? []); setEnabled(r.enabled !== false) })
@@ -2958,7 +3018,8 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
   useEffect(() => { if (initialId) setSel(initialId) }, [initialId])
 
   const agents = Array.from(new Set(artifacts.map((a) => a.agent))).sort()
-  const shown = agentFilter ? artifacts.filter((a) => a.agent === agentFilter) : artifacts
+  const inFolder = (f: string) => folder === '' || f === folder || f.startsWith(folder + '/')
+  const shown = artifacts.filter((a) => (!agentFilter || a.agent === agentFilter) && inFolder(a.folder || ''))
   const selected = artifacts.find((a) => a.id === sel)
 
   const remove = async (id: string) => {
@@ -2966,6 +3027,14 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
     const r = await api.deleteArtifact(id)
     if (r.error) { setHint('⚠ ' + r.error); return }
     if (sel === id) setSel(undefined)
+    load()
+  }
+
+  const move = async (a: Artifact) => {
+    const to = window.prompt('Move to folder (e.g. reports/2024; nest with "/", blank = root):', a.folder || '')
+    if (to === null) return
+    const r = await api.moveArtifact(a.id, to.trim())
+    if (r.error || !r.ok) { setHint('⚠ ' + (r.error ?? 'move failed')); return }
     load()
   }
 
@@ -2990,7 +3059,9 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
       <div className="grid gap-3 lg:grid-cols-[minmax(260px,340px)_1fr]">
         {/* gallery list */}
         <div className="space-y-2">
-          {shown.length === 0 && <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">No artifacts yet. When an agent calls its <span className="font-mono">publish</span> tool, the deliverable shows up here.</div>}
+          <FolderNav paths={artifacts.map((a) => a.folder || '')} selected={folder} onSelect={setFolder} rootLabel="All artifacts" />
+          {folder && <div className="flex items-center gap-1 px-0.5 text-[11px] text-muted-foreground"><Folder className="h-3 w-3" /><span className="font-mono">{folder}/</span><button className="ml-auto underline hover:text-foreground" onClick={() => setFolder('')}>clear</button></div>}
+          {shown.length === 0 && <div className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground">{folder ? <>No artifacts in <span className="font-mono">{folder}/</span>.</> : <>No artifacts yet. When an agent calls its <span className="font-mono">publish</span> tool, the deliverable shows up here.</>}</div>}
           {shown.map((a) => {
             const active = a.id === sel
             return (
@@ -3030,6 +3101,7 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
                     <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
                       <Badge variant="secondary" className="px-1.5 py-0 text-[10px] font-normal">{selected.agent}</Badge>
                       <span className="font-mono">{selected.filename}</span>
+                      {selected.folder && <span className="inline-flex items-center gap-0.5"><Folder className="h-3 w-3" /><span className="font-mono">{selected.folder}/</span></span>}
                       <span>· {fmtSize(selected.bytes)}</span>
                       <span>· session <span className="font-mono">{selected.sessionId}</span></span>
                     </div>
@@ -3037,7 +3109,10 @@ function ArtifactsPage({ me, initialId }: { me: Member; initialId?: string }) {
                   <div className="flex shrink-0 gap-2">
                     <a href={api.artifactRawUrl(selected.id)} download={selected.filename}><Button size="sm" variant="secondary"><Download className="mr-1 h-4 w-4" />Download</Button></a>
                     {(me.role === 'owner' || me.role === 'admin' || selected.source === me.id) && (
-                      <Button size="sm" variant="ghost" className="text-destructive" onClick={() => remove(selected.id)}><Trash2 className="h-4 w-4" /></Button>
+                      <>
+                        <Button size="sm" variant="ghost" onClick={() => move(selected)} title="Move to a folder"><FolderPlus className="h-4 w-4" /></Button>
+                        <Button size="sm" variant="ghost" className="text-destructive" onClick={() => remove(selected.id)}><Trash2 className="h-4 w-4" /></Button>
+                      </>
                     )}
                   </div>
                 </div>
@@ -4672,6 +4747,7 @@ function KnowledgeBasePage({ me }: { me: Member }) {
   const isAdmin = me.role === 'owner' || me.role === 'admin'
   const [pages, setPages] = useState<KbPage[] | null>(null)
   const [sections, setSections] = useState<string[]>([])
+  const [folder, setFolder] = useState('')
   const [query, setQuery] = useState('')
   const [sel, setSel] = useState<KbPage | null>(null)
   const [history, setHistory] = useState<KbRevision[]>([])
@@ -4718,13 +4794,14 @@ function KnowledgeBasePage({ me }: { me: Member }) {
           <Input value={query} onChange={(e) => setQuery(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && load()} placeholder="search the wiki…" className="h-8 text-xs" />
           <Button size="sm" variant="outline" className="h-8 shrink-0 px-2" onClick={() => load()}>Go</Button>
         </div>
-        <Button size="sm" className="w-full" onClick={() => { setCreating(true); setSel(null); setEditing(false) }}><Plus className="mr-1 h-3.5 w-3.5" />New page</Button>
+        <Button size="sm" className="w-full" onClick={() => { setCreating(true); setSel(null); setEditing(false); setNSection(folder ? folder + '/' : '') }}><Plus className="mr-1 h-3.5 w-3.5" />New page</Button>
+        <FolderNav paths={(pages ?? []).map((p) => p.section)} selected={folder} onSelect={setFolder} rootLabel="All pages" />
         <div className="space-y-3">
           {pages === null && <div className="text-xs text-muted-foreground">Loading…</div>}
           {pages !== null && pages.length === 0 && <div className="text-xs text-muted-foreground">No pages yet. Agents and you write them; the self-learning pass also keeps an <code className="text-[10px]">operations/fleet-learnings</code> page.</div>}
-          {sections.map((s) => (
+          {sections.filter((s) => folder === '' || s === folder || s.startsWith(folder + '/')).map((s) => (
             <div key={s}>
-              <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">{s}</div>
+              <div className="mb-1 truncate text-[10px] uppercase tracking-wider text-muted-foreground" title={s}>{s}</div>
               <div className="space-y-0.5">
                 {(pages ?? []).filter((p) => p.section === s).map((p) => (
                   <button key={p.id} onClick={() => open(p.id)} className={`block w-full truncate rounded px-2 py-1 text-left text-xs ${sel?.id === p.id ? 'bg-primary/10 text-foreground' : 'text-muted-foreground hover:bg-muted/50'}`} title={`${p.section}/${p.slug}`}>{p.title}</button>
@@ -4743,7 +4820,7 @@ function KnowledgeBasePage({ me }: { me: Member }) {
           <Card><CardContent className="space-y-3 p-4">
             <div className="text-sm font-medium">New page</div>
             <div className="grid gap-3 sm:grid-cols-3">
-              <Field label="Section" help="folder, e.g. engineering"><Input value={nSection} onChange={(e) => setNSection(e.target.value)} placeholder="engineering" className="font-mono text-xs" /></Field>
+              <Field label="Section" help="folder path — nest with / e.g. engineering/backend"><Input list="kb-sections" value={nSection} onChange={(e) => setNSection(e.target.value)} placeholder="engineering/backend" className="font-mono text-xs" /><datalist id="kb-sections">{sections.map((s) => <option key={s} value={s} />)}</datalist></Field>
               <Field label="Slug" help="url id, e.g. deploy-runbook"><Input value={nSlug} onChange={(e) => setNSlug(e.target.value)} placeholder="deploy-runbook" className="font-mono text-xs" /></Field>
               <Field label="Title"><Input value={nTitle} onChange={(e) => setNTitle(e.target.value)} placeholder="Deploy Runbook" /></Field>
             </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -189,6 +189,7 @@ export interface Artifact {
   kind: string
   title: string
   description?: string
+  folder: string
   filename: string
   relPath: string
   mime: string
@@ -1009,6 +1010,7 @@ export const api = {
 
   artifacts: () => call<{ artifacts: Artifact[]; enabled: boolean }>('GET', '/api/artifacts'),
   deleteArtifact: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/artifacts/' + id),
+  moveArtifact: (id: string, folder: string) => call<{ ok: boolean; artifact?: Artifact; error?: string }>('PATCH', '/api/artifacts/' + id, { folder }),
   /** Direct URL to an artifact's bytes (for <img>/<iframe>/download). `file` selects a sibling (sites). */
   artifactRawUrl: (id: string, file?: string) => `/api/artifacts/${id}/raw${file ? `?file=${encodeURIComponent(file)}` : ''}`,
 


### PR DESCRIPTION
## What

Adds **folder / sub-folder** (nested) organization to both the **Artifacts gallery** and the **Knowledge Base**. Both were flat lists — the KB grouped by a single-level `section`, Artifacts had no grouping at all — which doesn't scale as they fill. Now items live in a browsable, nested folder tree, for humans in the console and for agents via their MCP tools.

## Model — implicit path-strings (no folder tables)

A folder exists because an item lives in it, exactly how KB sections already worked. This keeps the change minimal, backward-compatible, and consistent across both surfaces.

- **KB:** `section` now accepts a nested path (`engineering/backend`). New `normPath()` normalizes per-segment; the `kb/<section>/<slug>.md` disk mirror and `(tenant,section,slug)` index nest unchanged → **no KB migration**.
- **Artifacts:** new `folder` column (`addColumn(db,'artifacts','folder',…)`, default `''` = root). The on-disk `<id>/<filename>` layout is untouched — folder is pure organizing metadata.
- **Safety:** every segment is normalized to `[a-z0-9-]`; `..`/absolute paths collapse to empty and are dropped, so a section/folder can never escape its root (verified in the smoke test).

## Agents (MCP)

- `kb_write` / `kb_search` / `kb_read` take nested section paths (descriptions updated).
- `publish` gains an optional `folder` (e.g. `reports/2024`). *(tool-schema change → live sessions must relaunch to see the new param; existing sessions keep working — it's optional.)*
- `artifacts_list` surfaces the folder.

## Console

- Shared collapsible **`FolderNav`** tree (per-folder counts) drives both the KB sidebar and the Artifacts gallery — select a folder to filter to its subtree.
- KB new-page form takes a nested section (datalist of existing folders); "New page" pre-fills the selected folder.
- Artifacts can be filed/moved via a new **`PATCH /api/artifacts/:id`** (same gate as delete; audited `artifact.moved`).

## Back-compat

Existing single-level KB sections render as root-level folders; existing artifacts (empty `folder`) show under "All".

## Verification

- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → **68/68** ✓
- Isolated round-trip (ephemeral `AGENT_OS_HOME`): KB `Engineering/Back End` → normalizes to `engineering/back-end`, nests on disk, `read()` round-trips, `sections()` returns nested paths; artifact `publish({folder:'Reports/2024/Q3'})` → stored `reports/2024/q3`, `move()` to root and back works. Path traversal (`../../etc`, `../evil`) collapses to safe leaf segments — no escape.

## Rollout

Backend/store/API + DB migration → build **+ restart the server**; `cd web && npm run build` for the console; relaunch live sessions for the `publish` schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)