### PR TITLE
feat(kb,artifacts): agents discover the existing folder tree before filing (v0.105.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.105.0] — 2026-07-11
+### Added
+- **Agents can now discover the existing folder tree before filing into it.** #178 taught agents the
+  folder *syntax* (nested KB `section` paths, a `folder` on `publish`), but nothing let them see what
+  folders already existed — so an agent could file into `eng` when the tree already had
+  `engineering/backend`. Now the "look before you write" tools return the taxonomy:
+  - `kb_search` also returns the existing KB **sections** (`GET /api/kb/search` → `sections`, via
+    `KbStore.sections`) and lists them in the tool output — shown even when the query matches nothing.
+  - `artifacts_list` also returns the tenant-wide gallery **folders** (`GET /api/agent/artifacts` →
+    `folders`, via a new `ArtifactStore.folders()`) so a `publish` can reuse an existing folder; the
+    artifact list itself stays scoped to the agent's own outputs.
+  - `kb_write` / `publish` folder-arg descriptions now nudge reuse over invention; the stale flat
+    `kb_history` / `kb_revert` `section` examples were updated to show nesting.
+
 ## [0.104.0] — 2026-07-11
 ### Added
 - **Deep-link permalinks for Knowledge Base pages and Artifacts.** Opening a KB page or an artifact

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -13,7 +13,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `remember` | `POST /api/memory/remember` | `MemoryProvider.store` | W | `shared:true` may be downgraded in a curated workspace |
 | `revise` | `POST /api/memory/revise` | `MemoryProvider.update` | W | author-guarded; audited `memory.revised` |
 | `forget` | `POST /api/memory/forget` | `MemoryProvider.delete` | W | author-guarded; audited `memory.forgotten` |
-| `kb_search` | `GET /api/kb/search` | `KbStore.search` | R | |
+| `kb_search` | `GET /api/kb/search` | `KbStore.search` + `KbStore.sections` | R | also returns the existing section/folder tree so a new page files into the established structure (discovery) |
 | `kb_read` | `GET /api/kb/read` | `KbStore.read` | R | |
 | `kb_write` | `POST /api/kb/write` | `KbStore.write` | W | versioned; author `agent:<id>`; `section` may nest with `/` (`engineering/backend`) → folder tree |
 | `kb_history` | `GET /api/kb/history` | `KbStore.history` | R | newest-first revisions |
@@ -25,7 +25,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `notify` | `POST /api/notify` | messages + member DM | W | notify ONE named teammate (`to` = name/email); inbox card addressed to them + Slack/Discord DM; the escape hatch from session-owner scoping — see below |
 | `publish` | `POST /api/publish` | `ArtifactStore` | W | snapshots the file; optional `folder` path (`reports/2024`) files it into a gallery folder |
 | `skill_propose` | `POST /api/skills/propose` | `SkillsStore.propose` + messages | W | drafts a `.aos-proposed` skill (never materialised) + posts a `skill.proposed` inbox card to owner/admins; audited `skill.proposed`. Human publishes via `POST /api/skills/:name/publish` (owner/admin) or dismisses via `DELETE /api/skills/:name` |
-| `artifacts_list` | `GET /api/agent/artifacts` | `ArtifactStore.list` | R | scoped to the agent's own deliverables |
+| `artifacts_list` | `GET /api/agent/artifacts` | `ArtifactStore.list` + `ArtifactStore.folders` | R | list scoped to the agent's own deliverables; also returns the tenant-wide gallery folders so a `publish` files into the existing tree (discovery) |
 | `schedule` | `POST /api/agent/schedule` | `Automations.schedule` (`type:'once'`) | W | one-shot deferred self-run; same agent + run-as; bounded 1 min–30 days, ≤25 pending/agent |
 | `unschedule` | `POST /api/agent/schedule/cancel` | `Automations.cancelScheduled` | W | cancel a pending one, scoped to the agent |
 | `list_capabilities` | `GET /api/agent/policy` | policy preview | R | |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.104.0",
+  "version": "0.105.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.104.0",
+      "version": "0.105.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.104.0",
+  "version": "0.105.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -264,7 +264,7 @@ const TOOLS = [
       type: 'object',
       additionalProperties: false,
       properties: {
-        section: { type: 'string', description: 'Section/folder path, e.g. "engineering" or "engineering/backend" (lowercased, url-safe; nest sub-folders with "/").' },
+        section: { type: 'string', description: 'Section/folder path, e.g. "engineering" or "engineering/backend" (lowercased, url-safe; nest sub-folders with "/"). Reuse an existing folder (kb_search lists them) rather than inventing a new one.' },
         slug: { type: 'string', description: 'Page slug, e.g. "deploy-runbook" (identifies the page; created if absent).' },
         title: { type: 'string', description: 'Human title (required when creating a new page).' },
         body: { type: 'string', description: 'The full page markdown. Link related pages with [[section/slug]].' },
@@ -285,7 +285,7 @@ const TOOLS = [
       type: 'object',
       additionalProperties: false,
       properties: {
-        section: { type: 'string', description: 'The page\'s section, e.g. "engineering".' },
+        section: { type: 'string', description: 'The page\'s section (folder path), e.g. "engineering" or "engineering/backend".' },
         slug: { type: 'string', description: 'The page\'s slug, e.g. "deploy-runbook".' },
       },
       required: ['section', 'slug'],
@@ -301,7 +301,7 @@ const TOOLS = [
       type: 'object',
       additionalProperties: false,
       properties: {
-        section: { type: 'string', description: 'The page\'s section.' },
+        section: { type: 'string', description: 'The page\'s section (folder path), e.g. "engineering" or "engineering/backend".' },
         slug: { type: 'string', description: 'The page\'s slug.' },
         rev: { type: 'number', minimum: 1, description: 'The revision number to restore (from kb_history).' },
       },
@@ -393,7 +393,7 @@ const TOOLS = [
         path: { type: 'string', description: 'Path to the file in your working folder (relative, e.g. "report.pdf").' },
         title: { type: 'string', description: 'A short human-readable title for the deliverable.' },
         description: { type: 'string', description: 'Optional one-line description / context.' },
-        folder: { type: 'string', description: 'Optional folder path to file it under, e.g. "reports/2024" (nest sub-folders with "/"). Omit for the gallery root.' },
+        folder: { type: 'string', description: 'Optional folder path to file it under, e.g. "reports/2024" (nest sub-folders with "/"). Reuse an existing gallery folder (artifacts_list shows them) rather than inventing a new one. Omit for the gallery root.' },
       },
       required: ['path', 'title'],
     },
@@ -1080,12 +1080,15 @@ async function kbSearch(args: Record<string, unknown>): Promise<string> {
   if (Array.isArray(args.tags) && args.tags.length) u.searchParams.set('tags', args.tags.map(String).join(','));
   u.searchParams.set('limit', String(typeof args.limit === 'number' ? args.limit : 8));
   const res = await fetch(u, { headers: H() });
-  const data = (await res.json()) as { pages?: KbPageLite[] };
+  const data = (await res.json()) as { pages?: KbPageLite[]; sections?: string[] };
   const pages = data.pages ?? [];
-  if (!pages.length) return 'No knowledge-base pages found.';
+  // Always surface the existing folder tree so a new page lands in the established structure rather
+  // than an inconsistent new folder (e.g. reuse `engineering/backend`, don't invent `eng`).
+  const folders = data.sections?.length ? `\n\nExisting folders (reuse one when filing a new page): ${data.sections.join(', ')}` : '';
+  if (!pages.length) return `No knowledge-base pages found.${folders}`;
   return pages
     .map((p) => `- ${p.section}/${p.slug} — ${p.title}${p.tags?.length ? ` [${p.tags.join(', ')}]` : ''}`)
-    .join('\n') + '\n(Use kb_read with a section + slug to open a page.)';
+    .join('\n') + '\n(Use kb_read with a section + slug to open a page.)' + folders;
 }
 
 async function kbRead(args: Record<string, unknown>): Promise<string> {
@@ -1172,13 +1175,16 @@ async function artifactsList(args: Record<string, unknown>): Promise<string> {
   u.searchParams.set('session', SESSION);
   u.searchParams.set('limit', String(typeof args.limit === 'number' ? args.limit : 20));
   const res = await fetch(u, { headers: H() });
-  const data = (await res.json()) as { artifacts?: ArtifactLite[]; enabled?: boolean };
+  const data = (await res.json()) as { artifacts?: ArtifactLite[]; folders?: string[]; enabled?: boolean };
   if (data.enabled === false) return 'The Artifacts gallery is disabled in this workspace.';
   const arts = data.artifacts ?? [];
-  if (!arts.length) return 'You have not published any deliverables yet.';
+  // The gallery's existing folders (all agents) so a `publish` files into the established tree rather
+  // than inventing a new folder. Shown even when you personally have nothing published yet.
+  const folders = data.folders?.length ? `\n\nGallery folders (pass one as \`folder\` to publish): ${data.folders.join(', ')}` : '';
+  if (!arts.length) return `You have not published any deliverables yet.${folders}`;
   return arts
     .map((a) => `- ${a.title}${a.description ? ` — ${a.description}` : ''} (${a.kind}, ${a.filename}${a.folder ? `, in ${a.folder}/` : ''})`)
-    .join('\n');
+    .join('\n') + folders;
 }
 
 async function schedule(args: Record<string, unknown>): Promise<string> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -616,7 +616,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     const limit = Math.min(Math.max(Number(url.searchParams.get('limit')) || 20, 1), 50);
     const artifacts = os.artifacts.list().filter((a) => a.agent === agent).slice(0, limit);
-    return sendJson(res, 200, { artifacts, enabled: os.artifacts.enabled });
+    // `folders` is the tenant-wide folder taxonomy (all agents) so a publisher can file into the
+    // existing tree instead of inventing a new folder; the artifact LIST stays own-scoped.
+    return sendJson(res, 200, { artifacts, folders: os.artifacts.folders(), enabled: os.artifacts.enabled });
   }
   // agent schedules a ONE-SHOT deferred run of itself (a follow-up / "check back later"). Stored as a
   // `once` automation that runs the same agent under the same run-as identity, bounded by the SCHEDULE_*
@@ -840,7 +842,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       section: url.searchParams.get('section') || undefined,
       tags: tags.length ? tags : undefined, limit: Number(url.searchParams.get('limit')) || 12,
     });
-    return sendJson(res, 200, { pages });
+    // `sections` is the full folder tree (all existing section paths) so an agent can file a new page
+    // into the existing structure instead of inventing an inconsistent folder name.
+    return sendJson(res, 200, { pages, sections: os.kb.sections(os.tenant) });
   }
   if (method === 'GET' && p === '/api/kb/read') {
     const session = url.searchParams.get('session') || '';

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -126,6 +126,15 @@ export class ArtifactStore {
       .map(toArtifact);
   }
 
+  /** Distinct non-empty folder paths in use (for agent discovery — file into the existing tree
+   *  rather than inventing a new folder). Tenant-wide; the paths are organizing labels, not contents. */
+  folders(): string[] {
+    return this.db
+      .prepare("SELECT DISTINCT folder FROM artifacts WHERE folder <> '' ORDER BY folder")
+      .all<{ folder: string }>()
+      .map((r) => r.folder);
+  }
+
   get(id: string): Artifact | undefined {
     const r = this.db.prepare('SELECT * FROM artifacts WHERE id = ?').get<ArtifactRow>(id);
     return r ? toArtifact(r) : undefined;


### PR DESCRIPTION
## What

Follow-up to #178. That PR taught agents the folder **syntax** (nested KB `section` paths, a `folder` on `publish`), but nothing let them see **what folders already exist** — so an agent could file a page into `eng` when the tree already had `engineering/backend`, fragmenting the structure. This adds folder-structure **discovery** to the "look before you write" tools.

## Changes

- **`kb_search`** now also returns the existing KB **sections** (`GET /api/kb/search` → `sections`, via `KbStore.sections`) and lists them in the tool output — shown even when the query matches nothing, so an agent always sees where to file.
- **`artifacts_list`** now also returns the tenant-wide gallery **folders** (`GET /api/agent/artifacts` → `folders`, via a new `ArtifactStore.folders()`), so a `publish` can reuse an existing folder. The artifact **list** itself stays scoped to the agent's own outputs — only the folder taxonomy (labels, not contents) is tenant-wide.
- **Descriptions:** `kb_write` / `publish` folder args now nudge *reuse over invention*; the stale flat `kb_history` / `kb_revert` `section` examples were updated to show nesting.

## Scope / rollout

Backend (store + 2 route handlers) + MCP tool code. Server restart to pick up the routes; **session relaunch** for agents to see the new tool output/descriptions (existing sessions keep working — purely additive). No DB migration.

## Verification

- `npm run typecheck` ✓ · `npm run build` ✓ · `npm run test:governance` → **68/68** ✓
- Isolated store test (ephemeral `AGENT_OS_HOME`): `KbStore.sections` → `["engineering/backend","engineering/frontend","operations"]`; `ArtifactStore.folders()` → `["designs","reports/2024"]` (a root-only artifact correctly excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)