### PR TITLE
feat(web): public marketing landing page at /landing (v0.106.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.106.0] — 2026-07-11
+### Added
+- **A public marketing landing page at `/landing`.** A standalone, self-contained static HTML page
+  (no auth, no React, no external requests) that introduces Agent OS as an operating system for a
+  fleet of autonomous agents — the fleet, memory, shared knowledge/tasks, chat, governance, and
+  self-improvement — with governance as one capability rather than the whole pitch. "Soft Ambient"
+  visual identity: warm plush neutrals, rounded display type, soft cards, a faint dawn glow, a live
+  fleet roster, and full light/dark theming. Served straight off disk from `public/landing.html`
+  (`src/server.ts` → `LANDING_HTML`, a public route above the member-auth gate) so it can be iterated
+  on without a web build. First cut — copy and design to be refined.
+
 ## [0.105.0] — 2026-07-11
 ### Added
 - **Agents can now discover the existing folder tree before filing into it.** #178 taught agents the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.105.0",
+  "version": "0.106.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.105.0",
+      "version": "0.106.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.105.0",
+  "version": "0.106.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/public/landing.html
+++ b/public/landing.html
@@ -1,0 +1,770 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Agent OS — an operating system for your AI workforce</title>
+<meta name="description" content="Agent OS is where you run a fleet of autonomous agents that remember what they learn, share one knowledge base and task queue, answer in Slack and Discord as the teammate who asked, and get better on their own — with every real action under your policy, budget, and audit trail." />
+<meta name="color-scheme" content="light dark" />
+<style>
+  :root {
+    --ground:#FAF7F4;
+    --surface:#FFFFFF;
+    --ink:#221F1C;
+    --ink-soft:#655E57;
+    --ink-faint:#9C948B;
+    --line:#EDE7E0;
+    --accent:#8A4F73;
+    --accent-soft:#B77FA3;
+    --glow-a:rgba(216,150,120,0.22);
+    --glow-b:rgba(138,79,115,0.16);
+    --warn:#C9922F;
+
+    --shadow-sm: 0 1px 2px rgba(34,31,28,0.04), 0 2px 8px rgba(34,31,28,0.05);
+    --shadow-md: 0 4px 12px rgba(34,31,28,0.05), 0 18px 40px rgba(34,31,28,0.07);
+    --shadow-lg: 0 8px 24px rgba(34,31,28,0.06), 0 30px 70px rgba(34,31,28,0.10);
+    --accent-tint: rgba(138,79,115,0.10);
+
+    --display: ui-rounded, "SF Pro Rounded", "Hiragino Maru Gothic ProN", system-ui, -apple-system, sans-serif;
+    --body: ui-sans-serif, -apple-system, "Segoe UI", system-ui, sans-serif;
+    --mono: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --ground:#17131A;
+      --surface:#201A24;
+      --ink:#F1ECEF;
+      --ink-soft:#B4A9B2;
+      --ink-faint:#7A6F79;
+      --line:#2C2431;
+      --accent:#C98FB6;
+      --accent-soft:#E0B6D3;
+      --glow-a:rgba(201,143,182,0.20);
+      --glow-b:rgba(230,150,110,0.14);
+      --warn:#E0B45C;
+
+      --shadow-sm: 0 1px 2px rgba(0,0,0,0.25), 0 2px 10px rgba(0,0,0,0.30);
+      --shadow-md: 0 4px 14px rgba(0,0,0,0.30), 0 18px 44px rgba(0,0,0,0.40);
+      --shadow-lg: 0 8px 26px rgba(0,0,0,0.35), 0 34px 80px rgba(0,0,0,0.50);
+      --accent-tint: rgba(201,143,182,0.14);
+    }
+  }
+
+  :root[data-theme="dark"] {
+    --ground:#17131A;
+    --surface:#201A24;
+    --ink:#F1ECEF;
+    --ink-soft:#B4A9B2;
+    --ink-faint:#7A6F79;
+    --line:#2C2431;
+    --accent:#C98FB6;
+    --accent-soft:#E0B6D3;
+    --glow-a:rgba(201,143,182,0.20);
+    --glow-b:rgba(230,150,110,0.14);
+    --warn:#E0B45C;
+    --shadow-sm: 0 1px 2px rgba(0,0,0,0.25), 0 2px 10px rgba(0,0,0,0.30);
+    --shadow-md: 0 4px 14px rgba(0,0,0,0.30), 0 18px 44px rgba(0,0,0,0.40);
+    --shadow-lg: 0 8px 26px rgba(0,0,0,0.35), 0 34px 80px rgba(0,0,0,0.50);
+    --accent-tint: rgba(201,143,182,0.14);
+  }
+
+  :root[data-theme="light"] {
+    --ground:#FAF7F4;
+    --surface:#FFFFFF;
+    --ink:#221F1C;
+    --ink-soft:#655E57;
+    --ink-faint:#9C948B;
+    --line:#EDE7E0;
+    --accent:#8A4F73;
+    --accent-soft:#B77FA3;
+    --glow-a:rgba(216,150,120,0.22);
+    --glow-b:rgba(138,79,115,0.16);
+    --warn:#C9922F;
+    --shadow-sm: 0 1px 2px rgba(34,31,28,0.04), 0 2px 8px rgba(34,31,28,0.05);
+    --shadow-md: 0 4px 12px rgba(34,31,28,0.05), 0 18px 40px rgba(34,31,28,0.07);
+    --shadow-lg: 0 8px 24px rgba(34,31,28,0.06), 0 30px 70px rgba(34,31,28,0.10);
+    --accent-tint: rgba(138,79,115,0.10);
+  }
+
+  * { box-sizing: border-box; }
+
+  html, body { margin: 0; padding: 0; background: var(--ground); }
+
+  #top {
+    background: var(--ground);
+    color: var(--ink);
+    font-family: var(--body);
+    line-height: 1.6;
+    font-size: 17px;
+    letter-spacing: -0.005em;
+    overflow-x: hidden;
+    position: relative;
+    min-height: 100vh;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding-left: clamp(1.25rem, 5vw, 4.5rem);
+    padding-right: clamp(1.25rem, 5vw, 4.5rem);
+  }
+
+  a { color: inherit; }
+
+  :focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+    border-radius: 6px;
+  }
+
+  .eyebrow {
+    font-family: var(--mono);
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.72rem;
+    color: var(--accent);
+    font-weight: 500;
+  }
+
+  h1, h2, h3 {
+    font-family: var(--display);
+    line-height: 1.08;
+    letter-spacing: -0.02em;
+    font-weight: 600;
+    margin: 0;
+  }
+
+  .accent { color: var(--accent); }
+
+  /* ---------- NAV ---------- */
+  .nav {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    backdrop-filter: saturate(1.2) blur(14px);
+    -webkit-backdrop-filter: saturate(1.2) blur(14px);
+    background: color-mix(in srgb, var(--ground) 78%, transparent);
+    border-bottom: 1px solid transparent;
+    transition: border-color .3s ease;
+  }
+  .nav.stuck { border-bottom: 1px solid var(--line); }
+  .nav-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding-top: 1.05rem;
+    padding-bottom: 1.05rem;
+    gap: 1rem;
+  }
+  .wordmark {
+    font-family: var(--display);
+    font-weight: 600;
+    font-size: 1.25rem;
+    letter-spacing: -0.02em;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.1em;
+  }
+  .wordmark .dot {
+    width: 0.42em; height: 0.42em;
+    border-radius: 50%;
+    background: var(--accent);
+    display: inline-block;
+    margin-right: 0.35em;
+  }
+  .nav-links {
+    display: flex;
+    align-items: center;
+    gap: clamp(0.4rem, 2vw, 1.6rem);
+  }
+  .nav-links a {
+    text-decoration: none;
+    color: var(--ink-soft);
+    font-size: 0.95rem;
+    padding: 0.4rem 0.2rem;
+    transition: color .2s ease;
+  }
+  .nav-links a:hover { color: var(--ink); }
+  .nav-desk { display: inline; }
+
+  .theme-btn {
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.1em;
+    text-transform: lowercase;
+    color: var(--ink-soft);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    padding: 0.42rem 0.85rem;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    box-shadow: var(--shadow-sm);
+    transition: color .2s ease, border-color .2s ease, transform .2s ease;
+  }
+  .theme-btn:hover { color: var(--ink); border-color: var(--accent-soft); }
+  .theme-btn:active { transform: scale(0.97); }
+  .theme-btn .glyph { font-size: 0.85rem; line-height: 1; }
+
+  @media (max-width: 620px) {
+    .nav-desk { display: none; }
+  }
+
+  /* ---------- AMBIENT GLOW ---------- */
+  .ambient {
+    position: absolute;
+    inset: -10% -10% auto -10%;
+    height: 900px;
+    pointer-events: none;
+    z-index: 0;
+    filter: blur(10px);
+    background:
+      radial-gradient(46% 42% at 28% 20%, var(--glow-a) 0%, transparent 62%),
+      radial-gradient(50% 48% at 74% 34%, var(--glow-b) 0%, transparent 66%),
+      radial-gradient(38% 38% at 52% 8%, var(--glow-a) 0%, transparent 60%);
+    animation: drift 26s ease-in-out infinite alternate;
+    will-change: transform;
+  }
+  @keyframes drift {
+    0%   { transform: translate3d(-1.5%, -1%, 0) scale(1); }
+    50%  { transform: translate3d(2%, 1.5%, 0) scale(1.06); }
+    100% { transform: translate3d(-1%, 2%, 0) scale(1.02); }
+  }
+
+  /* ---------- HERO ---------- */
+  .hero {
+    position: relative;
+    z-index: 1;
+    padding-top: clamp(3.5rem, 8vw, 6.5rem);
+    padding-bottom: clamp(2.5rem, 6vw, 4rem);
+  }
+  .hero-copy { max-width: 760px; }
+  .hero h1 {
+    font-size: clamp(2.4rem, 6.2vw, 4.15rem);
+    margin: 1.15rem 0 0;
+  }
+  .lede {
+    color: var(--ink-soft);
+    font-size: clamp(1.05rem, 2vw, 1.24rem);
+    line-height: 1.55;
+    margin: 1.5rem 0 0;
+    max-width: 680px;
+  }
+  .cta-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 1rem;
+    margin-top: 2.2rem;
+  }
+
+  .copy-btn {
+    font-family: var(--mono);
+    font-size: 0.92rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.85rem;
+    background: var(--accent);
+    color: #fff;
+    border: none;
+    border-radius: 999px;
+    padding: 0.85rem 1.1rem 0.85rem 1.4rem;
+    cursor: pointer;
+    box-shadow: var(--shadow-md);
+    transition: transform .2s ease, box-shadow .2s ease, filter .2s ease;
+  }
+  :root[data-theme="dark"] .copy-btn { color: #17131A; }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) .copy-btn { color: #17131A; }
+  }
+  .copy-btn:hover { transform: translateY(-1px); box-shadow: var(--shadow-lg); filter: brightness(1.04); }
+  .copy-btn:active { transform: translateY(0); }
+  .copy-btn .cmd::before { content: "$ "; opacity: 0.6; }
+  .copy-btn .copylbl {
+    font-size: 0.7rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    background: rgba(255,255,255,0.22);
+    padding: 0.28rem 0.6rem;
+    border-radius: 999px;
+    min-width: 62px;
+    text-align: center;
+  }
+  :root[data-theme="dark"] .copy-btn .copylbl { background: rgba(23,19,26,0.18); }
+
+  .ghost-link {
+    font-size: 0.98rem;
+    text-decoration: none;
+    color: var(--ink-soft);
+    border: 1px solid var(--line);
+    background: var(--surface);
+    border-radius: 999px;
+    padding: 0.8rem 1.25rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    box-shadow: var(--shadow-sm);
+    transition: color .2s ease, border-color .2s ease, transform .2s ease;
+  }
+  .ghost-link:hover { color: var(--ink); border-color: var(--accent-soft); transform: translateY(-1px); }
+  .ghost-link .arr { transition: transform .2s ease; }
+  .ghost-link:hover .arr { transform: translateX(3px); }
+
+  /* ---------- FLEET CARD ---------- */
+  .card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 22px;
+    box-shadow: var(--shadow-md);
+  }
+
+  .fleet {
+    position: relative;
+    z-index: 1;
+    margin-top: clamp(2.5rem, 5vw, 3.5rem);
+    padding: clamp(1.4rem, 3vw, 2rem);
+    max-width: 720px;
+  }
+  .fleet-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-bottom: 1.15rem;
+    margin-bottom: 0.4rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .fleet-head h3 { font-size: 1.2rem; }
+  .fleet-count {
+    font-family: var(--mono);
+    font-size: 0.76rem;
+    color: var(--ink-faint);
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+  }
+  .fleet-rows { display: flex; flex-direction: column; }
+  .frow {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.85rem 0.35rem;
+    border-bottom: 1px solid var(--line);
+  }
+  .frow:last-child { border-bottom: none; }
+  .fname {
+    font-family: var(--mono);
+    font-size: 0.9rem;
+    color: var(--ink);
+    flex: 0 0 auto;
+    min-width: 148px;
+  }
+  .frole { color: var(--ink-soft); font-size: 0.92rem; flex: 1 1 auto; }
+  .pill {
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.04em;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.34rem 0.75rem;
+    border-radius: 999px;
+    white-space: nowrap;
+    flex: 0 0 auto;
+    border: 1px solid transparent;
+  }
+  .pill .dot { width: 7px; height: 7px; border-radius: 50%; flex: 0 0 auto; }
+  .pill-running { color: var(--accent); background: var(--accent-tint); border-color: color-mix(in srgb, var(--accent) 26%, transparent); }
+  .pill-running .dot { background: var(--accent); animation: pulse 2.2s ease-in-out infinite; }
+  .pill-warn { color: var(--warn); background: color-mix(in srgb, var(--warn) 14%, transparent); border-color: color-mix(in srgb, var(--warn) 30%, transparent); }
+  .pill-warn .dot { background: var(--warn); }
+  .pill-idle { color: var(--ink-faint); background: color-mix(in srgb, var(--ink-faint) 12%, transparent); }
+  .pill-idle .dot { background: var(--ink-faint); }
+  @keyframes pulse {
+    0%,100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent); opacity: 1; }
+    50% { box-shadow: 0 0 0 5px transparent; opacity: 0.55; }
+  }
+
+  @media (max-width: 540px) {
+    .frow { flex-wrap: wrap; gap: 0.5rem 0.9rem; }
+    .fname { min-width: 0; }
+    .frole { flex-basis: 100%; order: 3; }
+  }
+
+  /* ---------- SECTIONS ---------- */
+  section { position: relative; z-index: 1; }
+  .caps { padding-top: clamp(4rem, 9vw, 7rem); padding-bottom: clamp(2rem, 5vw, 3rem); }
+  .sec-head { max-width: 720px; margin-bottom: clamp(2rem, 4vw, 3rem); }
+  .sec-head h2 { font-size: clamp(1.9rem, 4.2vw, 2.9rem); margin-top: 1rem; }
+  .sec-lede { color: var(--ink-soft); font-size: 1.08rem; margin-top: 1.1rem; }
+
+  .cap-grid {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: clamp(1rem, 2vw, 1.5rem);
+  }
+  @media (max-width: 760px) { .cap-grid { grid-template-columns: 1fr; } }
+
+  .cap-card {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 20px;
+    padding: clamp(1.5rem, 3vw, 2rem);
+    box-shadow: var(--shadow-sm);
+    transition: transform .3s ease, box-shadow .3s ease, border-color .3s ease;
+  }
+  .cap-card:hover { transform: translateY(-3px); box-shadow: var(--shadow-md); border-color: color-mix(in srgb, var(--accent-soft) 40%, var(--line)); }
+  .cap-tag {
+    font-family: var(--mono);
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.68rem;
+    color: var(--accent);
+    font-weight: 500;
+  }
+  .cap-card h3 { font-size: 1.28rem; margin-top: 0.85rem; }
+  .cap-card p { color: var(--ink-soft); margin: 0.75rem 0 0; font-size: 0.99rem; line-height: 1.58; }
+  .cap-inline {
+    color: var(--accent);
+    text-decoration: none;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+  }
+  .cap-inline:hover { text-decoration: underline; }
+  .chip {
+    font-family: var(--mono);
+    font-size: 0.74rem;
+    line-height: 1.5;
+    background: var(--ground);
+    border: 1px solid var(--line);
+    border-radius: 12px;
+    padding: 0.6rem 0.8rem;
+    margin-top: 1.1rem;
+    color: var(--ink-soft);
+    display: block;
+    overflow-x: auto;
+    white-space: nowrap;
+  }
+  .chip .warn { color: var(--warn); }
+
+  /* ---------- CLOSING ---------- */
+  .closing-wrap { padding-top: clamp(4rem, 9vw, 7rem); padding-bottom: clamp(3rem, 7vw, 5rem); }
+  .closing {
+    position: relative;
+    text-align: center;
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 28px;
+    padding: clamp(2.5rem, 6vw, 4.5rem) clamp(1.5rem, 5vw, 3.5rem);
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+  }
+  .closing::before {
+    content: "";
+    position: absolute;
+    inset: -40% 10% auto 10%;
+    height: 380px;
+    z-index: 0;
+    filter: blur(8px);
+    pointer-events: none;
+    background:
+      radial-gradient(50% 60% at 30% 30%, var(--glow-a) 0%, transparent 64%),
+      radial-gradient(48% 58% at 72% 34%, var(--glow-b) 0%, transparent 66%);
+  }
+  .closing > * { position: relative; z-index: 1; }
+  .closing h2 { font-size: clamp(1.9rem, 4.5vw, 3rem); }
+  .closing p { color: var(--ink-soft); max-width: 620px; margin: 1.2rem auto 0; font-size: 1.06rem; }
+  .closing .cta-row { justify-content: center; margin-top: 2.3rem; }
+  .top-link { font-size: 0.98rem; text-decoration: none; color: var(--ink-soft); display: inline-flex; align-items: center; gap: 0.35rem; }
+  .top-link:hover { color: var(--ink); }
+
+  /* ---------- FOOTER ---------- */
+  footer {
+    position: relative;
+    z-index: 1;
+    border-top: 1px solid var(--line);
+    padding-top: 2rem;
+    padding-bottom: 3rem;
+  }
+  .foot-inner {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.8rem 1.5rem;
+    font-family: var(--mono);
+    font-size: 0.75rem;
+    color: var(--ink-faint);
+    letter-spacing: 0.02em;
+  }
+  .foot-inner a { color: var(--ink-faint); text-decoration: none; }
+  .foot-inner a:hover { color: var(--ink-soft); }
+
+  /* ---------- FADE-UP ---------- */
+  .fade { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s cubic-bezier(.2,.7,.2,1); }
+  .fade.in { opacity: 1; transform: none; }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ambient { animation: none; }
+    .pill-running .dot { animation: none; }
+    .fade { opacity: 1; transform: none; transition: none; }
+    .copy-btn, .cap-card, .ghost-link { transition: none; }
+  }
+</style>
+</head>
+<body>
+<div id="top">
+  <div class="ambient" aria-hidden="true"></div>
+
+  <nav class="nav" id="nav">
+    <div class="wrap nav-inner">
+      <a class="wordmark" href="#top" aria-label="Agent OS home"><span class="dot"></span>Agent<span class="accent">&nbsp;OS</span></a>
+      <div class="nav-links">
+        <a class="nav-desk" href="#top">What it is</a>
+        <a class="nav-desk" href="#caps">Capabilities</a>
+        <a class="nav-desk" href="#start">Get started</a>
+        <button class="theme-btn" id="themeBtn" type="button" aria-label="Toggle color theme">
+          <span class="glyph" id="themeGlyph" aria-hidden="true">&#9789;</span>theme
+        </button>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="wrap">
+      <div class="hero-copy">
+        <p class="eyebrow">An operating system for autonomous agents</p>
+        <h1>Give your company a workforce of AI agents — and keep <span class="accent">the keys</span>.</h1>
+        <p class="lede">Agent OS is where you run a fleet of autonomous agents that remember what they learn, share one knowledge base and task queue, answer in Slack and Discord as the teammate who asked, and get better on their own — with every real action still under your policy, your budget, and your audit trail.</p>
+        <div class="cta-row">
+          <button class="copy-btn" id="copyHero" type="button" aria-label="Copy command: npm run demo">
+            <span class="cmd">npm run demo</span>
+            <span class="copylbl" id="copyHeroLbl">copy</span>
+          </button>
+          <a class="ghost-link" href="#caps">See what they do <span class="arr">&rarr;</span></a>
+        </div>
+      </div>
+
+      <div class="card fleet fade" id="fleetCard">
+        <div class="fleet-head">
+          <h3>Your fleet</h3>
+          <span class="fleet-count" id="fleetCount">5 agents &middot; 3 running</span>
+        </div>
+        <div class="fleet-rows">
+          <div class="frow">
+            <span class="fname">support-triage</span>
+            <span class="frole">Front-line support</span>
+            <span class="pill pill-running"><span class="dot"></span>running</span>
+          </div>
+          <div class="frow">
+            <span class="fname">ops-oncall</span>
+            <span class="frole">Infra &amp; incidents</span>
+            <span class="pill pill-running"><span class="dot"></span>running</span>
+          </div>
+          <div class="frow">
+            <span class="fname">collections</span>
+            <span class="frole">Billing &amp; dunning</span>
+            <span class="pill pill-warn"><span class="dot"></span>needs a human</span>
+          </div>
+          <div class="frow">
+            <span class="fname">growth-research</span>
+            <span class="frole">Market &amp; SEO</span>
+            <span class="pill pill-idle" id="growthPill"><span class="dot"></span><span id="growthState">idle</span></span>
+          </div>
+          <div class="frow">
+            <span class="fname">consolidator</span>
+            <span class="frole">Fleet memory</span>
+            <span class="pill pill-running"><span class="dot"></span>running</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <section class="caps" id="caps">
+    <div class="wrap">
+      <div class="sec-head fade">
+        <p class="eyebrow">What Agent OS gives you</p>
+        <h2>Not a chatbot. A place to actually run agents.</h2>
+        <p class="sec-lede">Six things a team needs before autonomous agents can do real work — and one of them, not the whole story, is the gate that keeps them in bounds.</p>
+      </div>
+
+      <div class="cap-grid">
+        <div class="cap-card fade">
+          <span class="cap-tag">Fleet</span>
+          <h3>Stand up agents, watch or walk away</h3>
+          <p>Spin up agents for support, ops, coding, research — headed when you want to look over their shoulder, headless when you don't. Each runs in its own session you can drop into live from the browser.</p>
+        </div>
+
+        <div class="cap-card fade">
+          <span class="cap-tag">Memory</span>
+          <h3>They remember, and they compound</h3>
+          <p>Every agent keeps a persistent memory instead of starting cold each time. A recurring reflection pass turns what the fleet did — the wins and the friction — into lessons the whole team inherits.</p>
+        </div>
+
+        <div class="cap-card fade">
+          <span class="cap-tag">Knowledge</span>
+          <h3>One shared brain to draw from</h3>
+          <p>A living knowledge base and a shared task queue that people and agents write to together. Hand off a task; an agent picks it up, does the work, and closes the loop — all on one board.</p>
+        </div>
+
+        <div class="cap-card fade">
+          <span class="cap-tag">Chat</span>
+          <h3>Reachable where you already talk</h3>
+          <p>@mention an agent in Slack or Discord and it runs as you, in the thread, with your permissions — no public URL, no new app to learn. Follow-ups stay in the same conversation with full context.</p>
+        </div>
+
+        <div class="cap-card fade">
+          <span class="cap-tag">Governance</span>
+          <h3>Every real action stays in bounds</h3>
+          <p>A send, a charge, a deploy — each one passes through a single gate: your policy classifies it, a human approves what's risky, budget debits, identity signs it, and audit records it. Autonomy you can put in production.</p>
+          <p style="margin-top:0.9rem;"><a class="cap-inline" href="#start">How the gate works &rarr;</a></p>
+          <code class="chip">ssh.exec host=prod-db-1 <span class="warn">&rarr; held for owner approval</span></code>
+        </div>
+
+        <div class="cap-card fade">
+          <span class="cap-tag">Evolution</span>
+          <h3>They build and improve themselves</h3>
+          <p>Agents draft new reusable skills, refine their own instructions, and delegate work to each other — every change reversible, every change on the record. The fleet you run next month is sharper than today's.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="closing-wrap" id="start">
+    <div class="wrap">
+      <div class="closing fade">
+        <h2>Your agents. Your rules. In production.</h2>
+        <p>Run the scripted demo to watch a governed fleet work end to end — the memory, the tasks, the chat, and the gate — with the full audit trail printed as it goes.</p>
+        <div class="cta-row">
+          <button class="copy-btn" id="copyEnd" type="button" aria-label="Copy command: npm run demo">
+            <span class="cmd">npm run demo</span>
+            <span class="copylbl" id="copyEndLbl">copy</span>
+          </button>
+          <a class="top-link" href="#top">Back to top <span aria-hidden="true">&uarr;</span></a>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="wrap foot-inner">
+      <span>Agent OS — the operating system for your AI workforce</span>
+      <span><a href="#caps">Capabilities</a> &middot; <a href="#start">Get started</a></span>
+    </div>
+  </footer>
+</div>
+
+<script>
+  (function () {
+    var root = document.documentElement;
+    var reduce = window.matchMedia && window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    /* ---- theme toggle ---- */
+    var btn = document.getElementById("themeBtn");
+    var glyph = document.getElementById("themeGlyph");
+    function currentDark() {
+      var attr = root.getAttribute("data-theme");
+      if (attr === "dark") return true;
+      if (attr === "light") return false;
+      return window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+    }
+    function paintGlyph() {
+      glyph.innerHTML = currentDark() ? "&#9728;" : "&#9789;"; /* sun when dark (offers light), moon when light */
+    }
+    paintGlyph();
+    btn.addEventListener("click", function () {
+      var next = currentDark() ? "light" : "dark";
+      root.setAttribute("data-theme", next);
+      paintGlyph();
+    });
+
+    /* ---- copy buttons ---- */
+    function wireCopy(btnId, lblId) {
+      var b = document.getElementById(btnId);
+      var l = document.getElementById(lblId);
+      if (!b || !l) return;
+      b.addEventListener("click", function () {
+        var text = "npm run demo";
+        var done = function () {
+          l.textContent = "copied";
+          setTimeout(function () { l.textContent = "copy"; }, 1400);
+        };
+        try {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(text).then(done, function () { fallback(); });
+            return;
+          }
+        } catch (e) { /* fall through */ }
+        fallback();
+        function fallback() {
+          try {
+            var ta = document.createElement("textarea");
+            ta.value = text;
+            ta.setAttribute("readonly", "");
+            ta.style.position = "absolute";
+            ta.style.left = "-9999px";
+            document.body.appendChild(ta);
+            ta.select();
+            document.execCommand("copy");
+            document.body.removeChild(ta);
+          } catch (e) { /* no-op */ }
+          done();
+        }
+      });
+    }
+    wireCopy("copyHero", "copyHeroLbl");
+    wireCopy("copyEnd", "copyEndLbl");
+
+    /* ---- nav border on scroll ---- */
+    var nav = document.getElementById("nav");
+    function onScroll() {
+      if (window.scrollY > 8) nav.classList.add("stuck");
+      else nav.classList.remove("stuck");
+    }
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+
+    /* ---- fade up on scroll ---- */
+    var fades = document.querySelectorAll(".fade");
+    if (reduce || !("IntersectionObserver" in window)) {
+      fades.forEach(function (el) { el.classList.add("in"); });
+    } else {
+      var io = new IntersectionObserver(function (entries) {
+        entries.forEach(function (en) {
+          if (en.isIntersecting) { en.target.classList.add("in"); io.unobserve(en.target); }
+        });
+      }, { threshold: 0.14, rootMargin: "0px 0px -6% 0px" });
+      fades.forEach(function (el) { io.observe(el); });
+    }
+
+    /* ---- gently flip growth-research idle <-> running ---- */
+    if (!reduce) {
+      var pill = document.getElementById("growthPill");
+      var state = document.getElementById("growthState");
+      var count = document.getElementById("fleetCount");
+      var live = false;
+      setInterval(function () {
+        live = !live;
+        if (live) {
+          pill.classList.remove("pill-idle");
+          pill.classList.add("pill-running");
+          state.textContent = "running";
+          count.innerHTML = "5 agents &middot; 4 running";
+        } else {
+          pill.classList.remove("pill-running");
+          pill.classList.add("pill-idle");
+          state.textContent = "idle";
+          count.innerHTML = "5 agents &middot; 3 running";
+        }
+      }, 4200);
+    }
+  })();
+</script>
+</body>
+</html>

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,7 @@ interface MemorySettingsView {
 }
 
 const CONSOLE_HTML = path.resolve(__dirname, '../public/console.html');
+const LANDING_HTML = path.resolve(__dirname, '../public/landing.html');
 const WEB_DIST = path.resolve(__dirname, '../web/dist');
 
 /** The agents Agent OS ships with, code-provisioned into every home on boot (the department
@@ -271,6 +272,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendFile(res, fs.existsSync(idx) ? idx : CONSOLE_HTML, 'text/html; charset=utf-8');
   }
   if (method === 'GET' && p === '/health') return sendJson(res, 200, { ok: true, tenant: os.tenant, name: os.tenantName, version: VERSION });
+  // Public marketing landing page — a standalone static HTML doc (no auth, no React). Served straight
+  // off disk from public/landing.html so it can be iterated on without a web build. Distinct from the
+  // console SPA at '/', which stays the app.
+  if (method === 'GET' && p === '/landing') {
+    if (fs.existsSync(LANDING_HTML)) return sendFile(res, LANDING_HTML, 'text/html; charset=utf-8');
+    return end(res, 404);
+  }
   // static assets from the built React app (web/dist)
   if (method === 'GET' && (p.startsWith('/assets/') || /\.(js|css|svg|png|ico|woff2?|json|map)$/.test(p))) {
     const file = path.join(WEB_DIST, p.replace(/^\/+/, ''));


### PR DESCRIPTION
## What

Adds a public marketing landing page served at **`/landing`** — a standalone, self-contained static HTML document (no auth, no React, no external requests).

It positions Agent OS as **an operating system for a fleet of autonomous agents** — the fleet, memory, shared knowledge/tasks, chat, governance, and self-improvement — with **governance as one capability among six**, rather than the whole pitch.

**Visual identity — "Soft Ambient":** warm plush neutrals, rounded display type, soft rounded cards, a faint drifting dawn glow, a live fleet roster (with a status pill that gently flips), and full light/dark theming with a toggle. System fonts only (CSP-safe), reduced-motion honored, keyboard focus states, no horizontal scroll.

## How

- `public/landing.html` — the full standalone page (converted from the design mockup to a real doc with `<!doctype>`, viewport/description meta, zeroed body margin).
- `src/server.ts` — a `LANDING_HTML` const + a public `GET /landing` route placed **above the member-auth gate**, served straight off disk with `sendFile`. No web build needed — iterate by editing the HTML.

## Verification

- `npm run build` ✓ · `npm run test:governance` → **68/68** ✓
- In-process end-to-end (ephemeral port, isolated scratch home): `/landing` returns **200 text/html** with doctype, the hero headline, the fleet roster, all six capability tags, and **no external asset refs**; a protected `/api/*` still **401s without a cookie** (gate intact).

## Notes

First cut — this is the persistent base we'll refine (copy, real fleet data, additional sections) going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)