### PR TITLE
feat(skills): agents request skills, humans install — skill_find + skill_request (v0.108.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.104.0] — 2026-07-11
+## [0.105.0] — 2026-07-11
+### Added
+- **Agents can ask a human to install a skill — and only ask.** An agent can now discover and request
+  skills from the workspace's integrated library on the fly, but it can never install one itself; a
+  human approves every install. Two new always-on MCP tools:
+  - **`skill_find`** (read-only) — lists what's installable: the agent's own library (each flagged
+    whether it's `active` for that agent) plus the bundled catalog of ready-made skills. The agent
+    calls this when a task looks like it has an established procedure it lacks.
+  - **`skill_request`** — asks an owner/admin to install a named catalog skill. It validates the name
+    against the catalog (a typo fails fast), dedupes an already-open request, and posts a
+    `skill.request` inbox card addressed to owner/admins. The agent is told it's requested and will be
+    available on its next session — it does NOT install anything.
+  - **Human review** on the Skills page (a new "Requested by agents" section) and in the Inbox: an
+    owner/admin **Installs** the skill into the Library (all agents, or scoped to just the requester via
+    a toggle) or **Dismisses** the request. Routes `GET /api/skills/requests`,
+    `POST /api/skills/requests/:id/approve`, `POST /api/skills/requests/:id/dismiss` (all owner/admin);
+    the loopback `GET /api/skills/discover` + `POST /api/skills/request` are session-secret-gated like
+    the other agent tools. Audited `skill.requested` (agent asked) and `skill.installed`
+    (`source: 'agent-request'`, human approved). Delivery is next-session; live same-session delivery
+    is a later phase.
 ### Added
 - **Deep-link permalinks for Knowledge Base pages and Artifacts.** Opening a KB page or an artifact
   was in-memory only — the URL stayed at `#/kb` / `#/artifacts`, so a page/deliverable couldn't be

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 37 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 39 always-on tools
   + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). KB: `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`. Operator/inbox:
   `ask`/`check_inbox`/`report`/`update`/`notify`/`publish`/`artifacts_list` (session cards are
@@ -196,7 +196,10 @@ Key modules:
   Inbox default `mine` view isn't flooded; `notify({to,message})` is the escape hatch to loop in ONE
   named teammate, and owner/admin flip to `?scope=all` for oversight). Skills: `skill_propose` (draft a
   reusable playbook — Lever 6 procedural memory; lands as a NOT-YET-PUBLISHED `.aos-proposed` skill +
-  a `skill.proposed` inbox card, gated behind an owner/admin publish). Scheduling: `schedule`/`unschedule`
+  a `skill.proposed` inbox card, gated behind an owner/admin publish), plus `skill_find` (discover the
+  installed library + bundled catalog) / `skill_request` (ASK an owner/admin to install a catalog skill —
+  never self-installs; posts a `skill.request` card, human installs via `POST /api/skills/requests/:id/approve`,
+  available next session). Scheduling: `schedule`/`unschedule`
   (one-shot deferred self-run via a `type:'once'` automation). Tasks (shared work queue):
   `task_create`/`task_list`/`task_get`/`task_claim`/`task_update`/`task_wait`/`task_dispatch`/`task_attach`
   (file/claim/drain durable work + attach a file from the agent's folder onto a task; an

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -25,6 +25,8 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `notify` | `POST /api/notify` | messages + member DM | W | notify ONE named teammate (`to` = name/email); inbox card addressed to them + Slack/Discord DM; the escape hatch from session-owner scoping — see below |
 | `publish` | `POST /api/publish` | `ArtifactStore` | W | snapshots the file; optional `folder` path (`reports/2024`) files it into a gallery folder |
 | `skill_propose` | `POST /api/skills/propose` | `SkillsStore.propose` + messages | W | drafts a `.aos-proposed` skill (never materialised) + posts a `skill.proposed` inbox card to owner/admins; audited `skill.proposed`. Human publishes via `POST /api/skills/:name/publish` (owner/admin) or dismisses via `DELETE /api/skills/:name` |
+| `skill_find` | `GET /api/skills/discover` | `TerminalManager.requestableSkills` | R | the caller's installed library (each flagged `active` for this agent) + the bundled catalog — what's installable to ask for |
+| `skill_request` | `POST /api/skills/request` | `TerminalManager.requestSkill` + messages | W | **asks** an owner/admin to install an existing catalog skill (never installs itself); validates the name against the catalog, dedupes an open request, posts a `skill.request` inbox card to owner/admins; audited `skill.requested`. Human installs via `POST /api/skills/requests/:id/approve` (owner/admin; optional `scope:'agent'`) or dismisses via `POST /api/skills/requests/:id/dismiss` |
 | `artifacts_list` | `GET /api/agent/artifacts` | `ArtifactStore.list` | R | scoped to the agent's own deliverables |
 | `schedule` | `POST /api/agent/schedule` | `Automations.schedule` (`type:'once'`) | W | one-shot deferred self-run; same agent + run-as; bounded 1 min–30 days, ≤25 pending/agent |
 | `unschedule` | `POST /api/agent/schedule/cancel` | `Automations.cancelScheduled` | W | cancel a pending one, scoped to the agent |
@@ -53,7 +55,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `discord_send` | `POST /api/agent/discord/send` | `DiscordSocket.sendToChannel` | W | proactive post to any channel by id; audited `discord.send`; only when `DISCORD_EGRESS=1` (Discord configured) |
 | `discord_dm` | `POST /api/agent/discord/dm` | `DiscordSocket.dmMember` | W | proactive DM by Discord user id; audited `discord.dm`; only when `DISCORD_EGRESS=1` |
 
-37 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+39 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.104.0",
+  "version": "0.105.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.104.0",
+      "version": "0.105.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.104.0",
+  "version": "0.105.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -422,6 +422,35 @@ const TOOLS = [
     },
   },
   {
+    name: 'skill_find',
+    description:
+      'Discover installable SKILLS — the reusable playbooks packaged for this workspace. Returns your ' +
+      "library (the skills you already have, each flagged whether it's active for you) plus the bundled " +
+      'catalog of ready-made skills you could ask to have installed. Call this when a task looks like it ' +
+      'has an established procedure you lack, BEFORE working it out from scratch — if a fitting catalog ' +
+      "skill exists, request it with `skill_request`. You cannot install skills yourself; a human does.",
+    annotations: { readOnlyHint: true },
+    inputSchema: { type: 'object', additionalProperties: false, properties: {} },
+  },
+  {
+    name: 'skill_request',
+    description:
+      'Ask a human to INSTALL an existing catalog skill for the workspace (find installable skills with ' +
+      '`skill_find`). You do NOT install it yourself — this raises a request card an owner/admin reviews; ' +
+      'once approved the skill is in the library and available to you on your next session. Use it when a ' +
+      "catalog skill would help with your work. Pass the skill's `name` and, optionally, a `rationale` " +
+      'saying why you need it (helps the reviewer decide quickly).',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        name: { type: 'string', description: 'The catalog skill id to install (from skill_find).' },
+        rationale: { type: 'string', description: 'Optional: why you need this skill / what task it unblocks.' },
+      },
+      required: ['name'],
+    },
+  },
+  {
     name: 'list_capabilities',
     description:
       'List the governed capabilities and how policy treats each one right now: allowed outright, ' +
@@ -964,6 +993,45 @@ async function skillPropose(args: Record<string, unknown>): Promise<string> {
   return d.ok
     ? `Proposed skill "${d.skill ?? name}" — it's a draft in the inbox for an owner/admin to review and publish. It won't be active until then.`
     : `Could not propose skill: ${d.error ?? 'unknown error'}`;
+}
+
+async function skillFind(_args: Record<string, unknown>): Promise<string> {
+  const u = new URL(AOS_URL + '/api/skills/discover');
+  u.searchParams.set('session', SESSION);
+  const res = await fetch(u, { headers: H() });
+  const d = (await res.json()) as {
+    installed?: Array<{ name: string; description: string; active: boolean }>;
+    catalog?: Array<{ name: string; description: string; installed: boolean }>;
+    error?: string;
+  };
+  if (d.error) return `Could not list skills: ${d.error}`;
+  const active = (d.installed ?? []).filter((s) => s.active);
+  const requestable = (d.catalog ?? []).filter((s) => !s.installed);
+  const lines: string[] = [];
+  lines.push(active.length ? `Active for you (${active.length}):` : 'No skills are active for you yet.');
+  for (const s of active) lines.push(`  • ${s.name} — ${s.description}`);
+  if (requestable.length) {
+    lines.push('', `Installable from the catalog — ask with skill_request({name}) (${requestable.length}):`);
+    for (const s of requestable) lines.push(`  • ${s.name} — ${s.description}`);
+  } else {
+    lines.push('', 'Nothing new in the catalog to request — everything is already installed.');
+  }
+  return lines.join('\n');
+}
+
+async function skillRequest(args: Record<string, unknown>): Promise<string> {
+  const name = String(args.name ?? '').trim();
+  if (!name) return 'skill_request needs the name of a catalog skill (see skill_find).';
+  const res = await fetch(AOS_URL + '/api/skills/request', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, agent: AGENT, name, rationale: args.rationale ? String(args.rationale) : undefined }),
+  });
+  const d = (await res.json()) as { ok?: boolean; status?: string; error?: string };
+  if (!d.ok) return `Could not request skill: ${d.error ?? 'unknown error'}`;
+  if (d.status === 'installed') return `"${name}" is already installed and available to you.`;
+  if (d.status === 'duplicate') return `A request for "${name}" is already awaiting review.`;
+  return `Requested "${name}" — an owner/admin will review and install it. It'll be available to you on your next session (not this one).`;
 }
 
 async function update(args: Record<string, unknown>): Promise<string> {
@@ -1629,6 +1697,8 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'notify' ? await notify(args)
         : name === 'publish' ? await publish(args)
         : name === 'skill_propose' ? await skillPropose(args)
+        : name === 'skill_find' ? await skillFind(args)
+        : name === 'skill_request' ? await skillRequest(args)
         : name === 'slack_reply' ? await slackReply(args)
         : name === 'discord_reply' ? await discordReply(args)
         : name === 'slack_send' ? await slackSend(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -737,6 +737,29 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const out = tm.proposeSkill(session, agent, { name, description, body, rationale: b.rationale ? String(b.rationale) : undefined });
     return sendJson(res, out.ok ? 200 : 400, out);
   }
+  // agent discovers what's installable (`skill_find`) — its own library (with an `active` flag) + the
+  // bundled catalog. Read-only; the counterpart to `skill_request`. Pre-auth loopback, session-secret gated.
+  if (method === 'GET' && p === '/api/skills/discover') {
+    const session = String(url.searchParams.get('session') || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    return sendJson(res, 200, tm.requestableSkills(agent));
+  }
+  // agent ASKS a human to install an existing catalog skill (`skill_request`) — it never installs
+  // itself. Posts an owner/admin 'skill.request' card; the install happens only when a human approves
+  // (POST /api/skills/requests/:id/approve). Pre-auth loopback, session-secret gated.
+  if (method === 'POST' && p === '/api/skills/request') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const name = String(b.name || '').trim();
+    if (!name) return sendJson(res, 400, { error: 'name is required' });
+    const out = tm.requestSkill(session, agent, { name, source: b.source ? String(b.source) : undefined, rationale: b.rationale ? String(b.rationale) : undefined });
+    return sendJson(res, out.ok ? 200 : 400, out);
+  }
   // native Slack egress: the agent posts its reply back to the thread that triggered the session.
   // Channel/thread come from the server-side binding (slack_threads) — the agent only sends text.
   if (method === 'POST' && p === '/api/agent/slack/reply') {
@@ -2600,6 +2623,43 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!ok) return sendJson(res, 404, { error: 'no such proposed skill' });
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.published', data: { skill: name } });
     return sendJson(res, 200, { ok: true, skill: os.skills.get(name) });
+  }
+  // List open agent skill-requests for the Skills page review section (owner/admin).
+  if (method === 'GET' && p === '/api/skills/requests') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { requests: tm.openSkillRequests() });
+  }
+  // Approve an agent's skill.request card (owner/admin): install the requested catalog skill into the
+  // library, optionally scope it to just the requesting agent, and mark the card resolved. The install
+  // is the human's act — the agent only ever asked. Audited `skill.installed` (source agent-request).
+  const skillReqApprove = p.match(/^\/api\/skills\/requests\/([\w.-]+)\/approve$/);
+  if (method === 'POST' && skillReqApprove) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (!os.skills.enabled) return sendJson(res, 400, { error: 'installing skills requires a data home' });
+    const card = tm.skillRequestCard(skillReqApprove[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such skill request' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this request was already resolved' });
+    const b = await readBody(req);
+    try {
+      const s = os.skills.get(card.skill) ?? os.skills.install(card.skill); // idempotent if already installed
+      if (b.scope === 'agent') os.skills.setAssignment(s.name, [card.agent]); // else stays all-agents
+      tm.setSkillRequestStatus(skillReqApprove[1], 'approved');
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.installed', data: { skill: s.name, source: 'agent-request', requestedBy: card.agent, scope: b.scope === 'agent' ? 'agent' : 'all' } });
+      return sendJson(res, 200, { ok: true, skill: s });
+    } catch (e) {
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  // Dismiss an agent's skill.request card (owner/admin) without installing — marks it resolved.
+  const skillReqReject = p.match(/^\/api\/skills\/requests\/([\w.-]+)\/dismiss$/);
+  if (method === 'POST' && skillReqReject) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const card = tm.skillRequestCard(skillReqReject[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such skill request' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this request was already resolved' });
+    tm.setSkillRequestStatus(skillReqReject[1], 'rejected');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.request.dismissed', data: { skill: card.skill, requestedBy: card.agent } });
+    return sendJson(res, 200, { ok: true });
   }
   // Duplicate an installed skill under a new name — a deep copy (markers stripped, assignments reset
   // to all-agents). Owner/admin only. MUST precede the generic /api/skills/:name route (the trailing

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -18,6 +18,7 @@ import { enrichArgs, autoClearsApproval } from './governance/enricher';
 import { hostGovernanceDecision, stricterDecision } from './governance/host-match';
 import { Audience, approvalAudience, resolveRecipients } from './governance/recipients';
 import { ChatPlatform, chatLink, consolePage } from './governance/chat-links';
+import { SkillSummary, CatalogSkill } from './governance/skills';
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
 import { LauncherSessionBackend, LocalSessionBackend, SessionBackend, SpawnErrorSink } from './edge/session-backend';
@@ -177,7 +178,7 @@ export interface Session {
 
 export interface FeedMessage {
   id: string;
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed';
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'skill.request';
   sessionId: string;
   agent: string;
   title: string;
@@ -1829,6 +1830,77 @@ export class TerminalManager {
     } catch (e) {
       return { ok: false, error: e instanceof Error ? e.message : String(e) };
     }
+  }
+
+  /**
+   * The skills an agent could ask to have installed — what `skill_find` returns. `installed` is the
+   * tenant's library (each flagged whether it's active for THIS agent, i.e. materialised at launch);
+   * `catalog` is the bundled software catalog with an `installed` flag already. Phase 1 covers the
+   * catalog + library; remote sources (skills.sh / GitHub) come later. */
+  requestableSkills(agent: string): { installed: (SkillSummary & { active: boolean })[]; catalog: CatalogSkill[] } {
+    const installed = this.os.skills.list()
+      .filter((s) => !s.proposed)
+      .map((s) => ({ ...s, active: s.agents.length === 0 || s.agents.includes(agent) }));
+    return { installed, catalog: this.os.skills.catalog() };
+  }
+
+  /**
+   * Agent asks a human to INSTALL an existing skill from the catalog (it never installs itself — the
+   * `skill_request` tool). Validates the name against the catalog so a typo fails fast, short-circuits
+   * when it's already in the library or already requested, else posts an owner/admin-addressed
+   * 'skill.request' card and audits `skill.requested`. The human approves via POST
+   * /api/skills/requests/:id/approve, which does the actual install. */
+  requestSkill(sessionId: string, agent: string, input: { name: string; source?: string; rationale?: string }): { ok: boolean; status?: 'requested' | 'installed' | 'duplicate'; error?: string } {
+    const name = (input.name || '').trim().toLowerCase();
+    if (!name) return { ok: false, error: 'a skill name is required' };
+    if (this.os.skills.get(name)) return { ok: true, status: 'installed' }; // already in the library
+    const cat = this.os.skills.catalog().find((c) => c.name === name);
+    if (!cat) return { ok: false, error: `"${name}" is not in the skill catalog — call skill_find to see what's installable` };
+    // Dedupe against an already-open request for the same skill (any session).
+    const open = this.db
+      .prepare(`SELECT args FROM messages WHERE type = 'skill.request' AND status = 'open'`)
+      .all<{ args: string | null }>()
+      .some((r) => { try { return JSON.parse(r.args || '{}').skill === name; } catch { return false; } });
+    if (open) return { ok: true, status: 'duplicate' };
+    this.addMessage({
+      type: 'skill.request', sessionId, agent,
+      title: `Skill requested — ${name}`,
+      body: (input.rationale?.trim() || cat.description || `${agent} wants the "${name}" skill installed.`).trim(),
+      status: 'open',
+      args: { skill: name, source: input.source || 'catalog', ...(input.rationale ? { rationale: input.rationale } : {}) },
+      // Installing a skill is an owner/admin act — address the review card to the admin tier.
+      audienceKind: 'admins',
+    });
+    this.audit(sessionId, agent, 'skill.requested', { name, source: input.source || 'catalog', rationale: input.rationale });
+    return { ok: true, status: 'requested' };
+  }
+
+  /** Read a 'skill.request' card's payload (for the approve/dismiss routes). undefined if not one. */
+  skillRequestCard(id: string): { skill: string; source: string; agent: string; status: string } | undefined {
+    const row = this.db
+      .prepare(`SELECT agent, args, status FROM messages WHERE id = ? AND type = 'skill.request'`)
+      .get<{ agent: string; args: string | null; status: string }>(id);
+    if (!row) return undefined;
+    let a: Record<string, unknown> = {};
+    try { a = row.args ? JSON.parse(row.args) : {}; } catch { /* tolerate a corrupt payload */ }
+    return { skill: String(a.skill ?? ''), source: String(a.source ?? 'catalog'), agent: row.agent, status: row.status };
+  }
+
+  /** Mark a 'skill.request' card resolved once a human approved (installed) or dismissed it. */
+  setSkillRequestStatus(id: string, status: 'approved' | 'rejected'): void {
+    this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'skill.request'`).run(status, id);
+  }
+
+  /** Open (unresolved) skill.request cards — the Skills page's agent-request review section. */
+  openSkillRequests(): { id: string; skill: string; source: string; agent: string; rationale?: string; createdAt: number }[] {
+    return this.db
+      .prepare(`SELECT id, agent, args, created_at FROM messages WHERE type = 'skill.request' AND status = 'open' ORDER BY created_at DESC`)
+      .all<{ id: string; agent: string; args: string | null; created_at: number }>()
+      .map((r) => {
+        let a: Record<string, unknown> = {};
+        try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate corrupt payload */ }
+        return { id: r.id, skill: String(a.skill ?? ''), source: String(a.source ?? 'catalog'), agent: r.agent, rationale: a.rationale ? String(a.rationale) : undefined, createdAt: r.created_at };
+      });
   }
 
   /** Agent posts a mid-task progress update to the Inbox feed. Unlike the (now removed) spawn/stop/exit

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,7 +11,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
 import { type Branding, type PublicBranding } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage } from '@/connectors'
@@ -2549,6 +2549,11 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onDismi
     Icon = Sparkles; iconCls = 'text-violet-600'; highlight = true
     verb = 'proposed a skill'; detail = m.body
     badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">review in Skills</Badge>
+  } else if (m.type === 'skill.request') {
+    Icon = Sparkles; iconCls = 'text-violet-600'; highlight = m.status === 'open'
+    const resolved = m.status === 'approved' ? 'installed' : m.status === 'rejected' ? 'dismissed' : ''
+    verb = 'requested a skill'; detail = m.body
+    badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">{resolved || 'review in Skills'}</Badge>
   } else if (m.type === 'update') {
     Icon = Activity; iconCls = 'text-muted-foreground'
     detail = m.body
@@ -5663,9 +5668,11 @@ function SkillsPage() {
   const [uploading, setUploading] = useState(false)
   const [uploadMsg, setUploadMsg] = useState('')
   const fileInput = useRef<HTMLInputElement>(null)
+  const [requests, setRequests] = useState<SkillRequest[]>([])
+  const loadRequests = () => api.skillRequests().then((r) => setRequests(r.requests ?? [])).catch(() => setRequests([]))
   const load = () => api.skills().then(setResp).catch(() => setResp({ enabled: false, skills: [] }))
   useEffect(() => {
-    load()
+    load(); loadRequests()
     api.state().then((s) => setAgents(s.agents.filter((a) => a.runtime === 'claude-code').map((a) => a.id))).catch(() => {})
   }, [])
 
@@ -5710,6 +5717,21 @@ function SkillsPage() {
         <div className="rounded-md border border-dashed p-3 text-sm text-muted-foreground">
           Skills need a data home — none is configured for this instance.
         </div>
+      )}
+
+      {requests.length > 0 && (
+        <section className="space-y-2 rounded-lg border border-sky-200 bg-sky-50/40 p-3">
+          <div className="flex items-center gap-2 text-[11px] uppercase tracking-wider text-sky-700">
+            <Sparkles className="h-3.5 w-3.5" />Requested by agents · {requests.length}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            An agent asked (via <span className="font-mono">skill_request</span>) to have a catalog skill installed — it <span className="font-medium text-foreground">cannot install one itself</span>.
+            Install adds the skill to the Library (available on the agent's next session); or dismiss the request.
+          </p>
+          <div className="space-y-2">
+            {requests.map((r) => <AgentSkillRequestCard key={r.id} r={r} onChanged={() => { loadRequests(); load() }} />)}
+          </div>
+        </section>
       )}
 
       {proposed.length > 0 && (
@@ -6141,6 +6163,55 @@ function NewSkillForm({ onCancel, onCreated }: { onCancel: () => void; onCreated
 /** A skill an agent drafted via `skill_propose`, awaiting a human's review. Review opens the draft in an
  *  editable box (edits save to the same SKILL.md); Publish drops the `.aos-proposed` marker so it goes
  *  live on each agent's next session; Dismiss deletes the draft. Owner/admin only (the page is gated). */
+/** A single agent skill-request awaiting review (via `skill_request`) — the human installs the named
+ *  catalog skill into the Library (all agents, or scoped to just the requester) or dismisses it. */
+function AgentSkillRequestCard({ r, onChanged }: { r: SkillRequest; onChanged: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const [hint, setHint] = useState('')
+  const [scoped, setScoped] = useState(false)
+  const install = async () => {
+    setBusy(true); setHint('')
+    const res = await api.approveSkillRequest(r.id, scoped ? 'agent' : 'all')
+    setBusy(false)
+    if (!res.ok || res.error) return setHint('⚠ ' + (res.error || 'failed'))
+    onChanged()
+  }
+  const dismiss = async () => {
+    setBusy(true); setHint('')
+    const res = await api.dismissSkillRequest(r.id)
+    setBusy(false)
+    if (!res.ok || res.error) return setHint('⚠ ' + (res.error || 'failed'))
+    onChanged()
+  }
+  return (
+    <Card className="border-sky-200">
+      <CardContent className="p-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="font-mono text-sm font-medium">{r.skill}</span>
+              <Badge variant="outline" className="border-sky-300 px-1.5 py-0 text-[10px] font-normal text-sky-700">requested</Badge>
+            </div>
+            <div className="mt-1 text-[11px] text-muted-foreground">
+              by <span className="font-mono">{r.agent}</span>{r.createdAt ? ` · ${timeAgo(r.createdAt)}` : ''}
+              {r.rationale ? <> · <span className="italic">“{r.rationale}”</span></> : null}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <label className="flex items-center gap-1 text-[11px] text-muted-foreground" title="scope this skill to only the requesting agent (default: all agents)">
+              <input type="checkbox" checked={scoped} disabled={busy} onChange={(e) => setScoped(e.target.checked)} />
+              {r.agent} only
+            </label>
+            <Button size="sm" disabled={busy} onClick={install}><Check className="mr-1 h-3.5 w-3.5" />Install</Button>
+            <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" title="dismiss" disabled={busy} onClick={dismiss}><Trash2 className="h-3.5 w-3.5" /></Button>
+          </div>
+        </div>
+        {hint && <div className="mt-2 text-xs text-destructive">{hint}</div>}
+      </CardContent>
+    </Card>
+  )
+}
+
 function ProposedSkillCard({ s, onChanged }: { s: SkillSummary; onChanged: () => void }) {
   const [reviewing, setReviewing] = useState(false)
   const [content, setContent] = useState('')

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -328,7 +328,7 @@ export interface AddTaskReq {
 
 export interface Msg {
   id: string
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed'
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'skill.request'
   sessionId: string
   agent: string
   title: string
@@ -620,6 +620,10 @@ export interface RemoteCatalogResp {
 /** A skills.sh directory hit — a skill in some repo, with its install count and source owner/repo. */
 export interface SkillshHit { skillId: string; name: string; installs: number; source: string; installed?: boolean }
 export interface SkillshResp { query: string; hits: SkillshHit[]; error?: string }
+
+/** An agent's pending request to have a catalog skill installed (via `skill_request`). */
+export interface SkillRequest { id: string; skill: string; source: string; agent: string; rationale?: string; createdAt: number }
+export interface SkillRequestsResp { requests: SkillRequest[]; error?: string }
 
 export interface CompanySettings {
   companyMd: string
@@ -954,6 +958,11 @@ export const api = {
     call<{ ok: boolean; skill?: SkillDetail; error?: string }>('POST', '/api/skills/' + encodeURIComponent(name) + '/publish'),
   setSkillAgents: (name: string, agents: string[]) =>
     call<{ ok: boolean; skill?: SkillDetail; error?: string }>('PUT', '/api/skills/' + encodeURIComponent(name) + '/agents', { agents }),
+  skillRequests: () => call<SkillRequestsResp>('GET', '/api/skills/requests'),
+  approveSkillRequest: (id: string, scope?: 'agent' | 'all') =>
+    call<{ ok: boolean; skill?: SkillDetail; error?: string }>('POST', '/api/skills/requests/' + encodeURIComponent(id) + '/approve', scope ? { scope } : {}),
+  dismissSkillRequest: (id: string) =>
+    call<{ ok: boolean; error?: string }>('POST', '/api/skills/requests/' + encodeURIComponent(id) + '/dismiss'),
   skillCatalog: () => call<CatalogResp>('GET', '/api/skills/catalog'),
   installSkill: (name: string) =>
     call<{ ok: boolean; skill?: SkillDetail; error?: string }>('POST', '/api/skills/catalog/' + encodeURIComponent(name) + '/install'),


### PR DESCRIPTION
## Phase 1 — agent-requested skill installation (ask-a-human, never self-install)

Agents can now discover the workspace's integrated skill library on the fly and **ask** a human to install a skill — but can never install one themselves. Mirrors the proven `skill_propose` inbox-card pattern.

### Agent MCP tools (always-on)
- **`skill_find`** (read-only) — lists the agent's installed library (each flagged `active` for it) + the bundled catalog of installable skills.
- **`skill_request`** — asks an owner/admin to install a named catalog skill. Validates the name against the catalog, dedupes an open request, posts a `skill.request` inbox card. Never installs.

### Human review
- Skills page "Requested by agents" section + Inbox card: **Install** (all agents, or scope to the requester) / **Dismiss**.
- Routes: `GET /api/skills/requests`, `POST /api/skills/requests/:id/approve` (optional `scope:'agent'`), `.../dismiss` (owner/admin). Loopback `GET /api/skills/discover` + `POST /api/skills/request` session-secret-gated like the other agent tools.
- Audit: `skill.requested` (agent) and `skill.installed` `source:'agent-request'` (human). Delivery is next-session.

### Verification
- `npm run typecheck` ✓ · `web` build ✓ · governance **68/68** ✓
- **End-to-end over the real HTTP server: 16/16** — discovery, secret gate, unknown-skill rejection, request, dedup, owner listing, unauth block (401), approve→install, library reflects it, card resolved, re-approve→409.

Deferred: Phase 2 (remote skills.sh/GitHub sources), Phase 3 (same-session delivery).

🤖 Generated with [Claude Code](https://claude.com/claude-code)