### PR TITLE
fix(web): edge-fade the session tab strip instead of a native scrollbar (v0.108.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.108.1] — 2026-07-11
+### Changed
+- **Session tab strip no longer shows an ugly native horizontal scrollbar.** When more session tabs are
+  open than fit the switcher bar, the chunky OS scrollbar is hidden (`.no-scrollbar`) and replaced with
+  a soft 24px edge fade that appears only on the side(s) with off-screen tabs — a subtle "there's more"
+  hint that matches the slim dark toolbar. The strip still scrolls via trackpad/shift-wheel; the "N
+  ended" toggle stays pinned right as before (`web/src/App.tsx`, `edgeFadeMask`).
+
 ## [0.108.0] — 2026-07-11
 ### Added
 - **Agents can ask a human to install a skill — and only ask.** An agent can now discover and request

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.108.0",
+  "version": "0.108.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.108.0",
+      "version": "0.108.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.108.0",
+  "version": "0.108.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1719,6 +1719,15 @@ function RunRating({ session, onRate }: { session: Session; onRate: (id: string,
   )
 }
 
+// Fades the session tab strip's edges to hint off-screen tabs (paired with `.no-scrollbar`). Each edge
+// dissolves over 24px only when there's more to scroll that way; a fully-visible strip stays crisp.
+function edgeFadeMask(fade: { left: boolean; right: boolean }): string | undefined {
+  if (!fade.left && !fade.right) return undefined
+  const l = fade.left ? '24px' : '0px'
+  const r = fade.right ? '24px' : '0px'
+  return `linear-gradient(to right, transparent 0, black ${l}, black calc(100% - ${r}), transparent 100%)`
+}
+
 function SessionsPage({
   me, members, sessions, waiting, selected, hiddenTabs, onOpen, onCloseTab, onActivity, onSpawn, onStop, onDelete, onRate, onBulkStop, onBulkDelete, urlQuery, onFiltersChange,
 }: {
@@ -1749,6 +1758,25 @@ function SessionsPage({
   // Terminal switcher bar: live tabs stay pinned; ended (stopped/done/crashed) ones collapse behind a
   // toggle so the bar doesn't accrete every past run. The open session always shows even if it ended.
   const [showEnded, setShowEnded] = useState(false)
+
+  // Tab strip overflow hint: instead of a chunky native scrollbar (`.no-scrollbar` hides it), we fade
+  // whichever edge has more tabs off-screen. `fade` mirrors the scroll position; recomputed on scroll,
+  // on resize, and after every render (tab count changes) — guarded to skip when the strip isn't mounted.
+  const stripRef = useRef<HTMLDivElement>(null)
+  const [fade, setFade] = useState({ left: false, right: false })
+  const syncFade = () => {
+    const el = stripRef.current
+    if (!el) return
+    const left = el.scrollLeft > 1
+    const right = el.scrollLeft + el.clientWidth < el.scrollWidth - 1
+    setFade((p) => (p.left === left && p.right === right ? p : { left, right }))
+  }
+  useEffect(() => { syncFade() })
+  useEffect(() => {
+    const onResize = () => syncFade()
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [])
 
   // The session whose agent-os primitive activity is open in the modal timeline (null = closed).
   const [inspect, setInspect] = useState<Session | null>(null)
@@ -1918,7 +1946,12 @@ function SessionsPage({
         <div className="flex items-center gap-2 border-b bg-neutral-900 px-2 py-1.5 text-xs text-neutral-300">
           <TerminalSquare className="h-4 w-4 shrink-0" />
           {/* Only the tabs scroll; the "ended" toggle stays pinned right so it's always reachable. */}
-          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-x-auto">
+          <div
+            ref={stripRef}
+            onScroll={syncFade}
+            className="no-scrollbar flex min-w-0 flex-1 items-center gap-2 overflow-x-auto"
+            style={{ maskImage: edgeFadeMask(fade), WebkitMaskImage: edgeFadeMask(fade) }}
+          >
             {liveTabs.map(renderTab)}
             {selectedEnded && renderTab(selectedEnded)}
             {showEnded && collapsibleEnded.map(renderTab)}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -132,3 +132,13 @@
     @apply font-sans;
     }
 }
+
+/* Scrollable strips (e.g. the session tab bar) that hint overflow with an edge
+   fade instead of a chunky native scrollbar. */
+.no-scrollbar {
+  scrollbar-width: none;          /* Firefox */
+  -ms-overflow-style: none;       /* old Edge */
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;                  /* Chrome/Safari */
+}


### PR DESCRIPTION
## What
The session switcher bar (`web/src/App.tsx`) rendered its open-tab strip with `overflow-x-auto`. Once more tabs were open than fit, the browser's chunky native horizontal scrollbar appeared under the slim 1.5-row dark toolbar and looked out of place.

## Change
- Hide the native scrollbar with a new `.no-scrollbar` utility (`web/src/index.css`).
- Replace it with a soft **24px edge fade** (`edgeFadeMask` + a CSS `mask-image`) that appears only on the side(s) that actually have off-screen tabs — a subtle "there's more this way" hint, background-independent.
- `fade` state mirrors scroll position; recomputed on scroll, on window resize, and after each render (tab count changes).
- Behavior unchanged otherwise: the strip still scrolls via trackpad/shift-wheel, and the "N ended" toggle stays pinned right.

Web-only — no server restart needed (`cd web && npm run build`, reload the browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)