### PR TITLE
fix(web): drop grab cursor on session tabs so hover doesn't read as grabbed (v0.110.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.110.1] — 2026-07-11
+### Fixed
+- **Session tabs no longer look "grabbed" on hover.** The drag-reorderable tabs used a `cursor-grab`
+  (open-hand) cursor on hover, which over the tab's black padding read as if a drag had already started.
+  Dropped it — hovering shows the normal cursor, and the grabbing cursor only appears while you're
+  actually pressing/dragging a tab. Drag-to-reorder itself is unchanged (`web/src/App.tsx`).
+
 ## [0.110.0] — 2026-07-11
 ### Added
 - **Agent skill-requests reach beyond the bundled catalog — the whole skills.sh / GitHub universe

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.110.0",
+      "version": "0.110.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.110.0",
+  "version": "0.110.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1916,7 +1916,8 @@ function SessionsPage({
   if (selected) {
     // `draggable` is set only for the live tabs — they're the reorderable set. Dragging a tab reflows
     // the strip as the pointer crosses each sibling (onDragEnter); the inner link is un-draggable so the
-    // browser's native link-drag doesn't hijack the gesture.
+    // browser's native link-drag doesn't hijack the gesture. No `cursor-grab` on hover (it read as
+    // "already grabbing" over the tab's padding) — the grabbing cursor only shows while pressed/dragging.
     const renderTab = (s: Session, draggable = false) => (
       <div
         key={s.id}
@@ -1927,7 +1928,7 @@ function SessionsPage({
         onDragEnd={draggable ? () => setDragTmux(null) : undefined}
         className={`group/tab flex shrink-0 items-center gap-1.5 rounded px-2 py-1 ${
           selected.tmux === s.tmux ? 'bg-neutral-700 text-white' : 'hover:bg-neutral-800'
-        } ${draggable ? 'cursor-grab active:cursor-grabbing' : ''} ${dragTmux === s.tmux ? 'opacity-50' : ''}`}
+        } ${draggable ? 'active:cursor-grabbing' : ''} ${dragTmux === s.tmux ? 'opacity-50' : ''}`}
       >
         <a draggable={false} href={navHref('sessions', s.tmux)} onClick={onNavClick(() => onOpen(s.tmux, s.agent + ' · ' + s.id))} title={s.spawnedByLabel ? `started by ${s.spawnedByLabel}` : undefined} className="flex items-center gap-1.5 text-inherit no-underline">
           <span className={`h-1.5 w-1.5 rounded-full ${statusDot(s)}`} />


### PR DESCRIPTION
## What
Fixes a UX confusion reported on the drag-reorderable session tabs: hovering the tab's black padding area showed the `cursor-grab` (open-hand) cursor, which read as if a drag had *already started* just from hovering.

## Change
- Removed `cursor-grab` (the hover affordance) from the tab className; kept `active:cursor-grabbing` so the grabbing cursor only appears while the tab is pressed/dragged (`web/src/App.tsx`).
- Hovering now shows the normal cursor. Drag-to-reorder itself (native HTML5 DnD, click-and-drag) is unchanged.

Web-only — no server restart (`cd web && npm run build`, reload the browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)