### PR TITLE
Lossless take-over: unattended runs are an attachable TUI, not `claude -p` (v0.110.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.113.0] — 2026-07-11
+### Changed
+- **Take-over is now lossless — unattended runs are an attachable TUI, not `claude -p`.** Automation/cron/
+  task runs launch as a real interactive claude in a detached tmux pane (`--dangerously-skip-permissions`;
+  the PreToolUse gate still governs every effect), so "take over" (`POST /api/sessions/:id/interactive` →
+  `TerminalManager.claimSession`) just marks the live run **claimed** and the console attaches to the
+  still-streaming pane — no kill, no `--resume`, no discarded turn (the old `goInteractive` killed the
+  in-flight `-p` turn and resumed from the last completed one, which read as the run "stopping"). A claimed
+  run is **sticky** (never auto-closed). See `docs/attachable-sessions-plan.md`.
+  - **Server-driven teardown.** A new **Stop hook** (`terminal/stop-hook.sh`) beacons `/api/turn-idle` when
+    claude finishes a turn; `markTurnIdle` closes an unattended run at turn-end — capturing its pane to the
+    transcript log, marking it `done`, and killing the pane so tmux drops and the automations pile-up guard
+    releases (parity with the old `-p` exit) — UNLESS it's claimed, a human is attached, or it's blocked on
+    a person. The idle sweep (`reapIdleResidents` → `reapIdleSessions`) gains a backstop for beaconless
+    stragglers (only ones that have seen a turn-end beacon, so a long first turn is never reaped mid-run).
+  - **New:** `term_sessions.claimed_by`/`claimed_at`; `SessionBackend.hasClient()` (attach detection) +
+    `capturePane()` (transcript snapshot, replacing the `-p` stdout tee); launch env `UNATTENDED=1`
+    (was `HEADLESS=1`), honored by the gate hook's bounded approval wait and the memory MCP's `ask`/
+    `task_wait` parking.
+
 ## [0.112.0] — 2026-07-11
 ### Added
 - **Same-session skill delivery (Phase 3).** When an owner/admin approves an agent's `skill_request`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,10 +173,16 @@ Key modules:
   thread-create failure → channel fallback). The `discord_reply` MCP tool is bound to `discord_threads`;
   `DISCORD_REPLY=1` exposes it. `discord.connected` records the READY guild count. Reconnect backoff + zombie
   detection mirror SlackSocket.
-  Per-automation **execution mode**: `headless` (default) runs `claude -p --dangerously-skip-permissions`
-  (the PreToolUse gate hook still runs + blocks risky Bash under that flag) and exits so the session goes
-  `idle` and the guard releases; `interactive` keeps the attachable TUI (a cron won't re-fire while it's
-  alive). `HEADLESS=1` selects the lane in `terminal/claude-launch.sh`.
+  Per-automation **execution mode**: `headless` (default) and `interactive` now run the SAME way — an
+  attachable interactive claude TUI (NOT `claude -p`) with `--dangerously-skip-permissions` (the PreToolUse
+  gate hook still runs + blocks risky Bash under that flag). The difference is teardown: an `headless`
+  (unattended) run is closed by the SERVER at turn-end — the Stop hook (`terminal/stop-hook.sh`) beacons
+  `/api/turn-idle` → `TerminalManager.markTurnIdle` kills the pane so tmux drops and the pile-up guard
+  releases (parity with the old `-p` exit) UNLESS a human has taken it over / is watching / it's blocked on
+  a person; `interactive` stays live until closed. `UNATTENDED=1` (was `HEADLESS=1`) selects the lane in
+  `terminal/claude-launch.sh`. **Take-over** is now lossless: `POST /api/sessions/:id/interactive` →
+  `claimSession` just marks the live run claimed (sticky, no kill/resume) and the console attaches to the
+  still-streaming pane. See `docs/attachable-sessions-plan.md`.
 - `src/memory/` — the **memory plane** (per-agent persistent recall). `index.ts` factory →
   `sqlite-provider.ts` (default; FTS5 bm25 keyword recall, **+ optional in-JS-cosine hybrid** when an
   embedder is set), `libsql-provider.ts` (native in-file vectors; opt-in `@libsql/client`),

--- a/docs/attachable-sessions-plan.md
+++ b/docs/attachable-sessions-plan.md
@@ -1,0 +1,126 @@
+# Attachable-unattended sessions — kill the `-p` lane
+
+**Status:** in progress (slice 1). **Owner:** platform.
+
+## Problem
+
+"Unattended" runs (automations / cron / tasks / chat) launch as `claude -p` (print mode) — a
+non-interactive process with **no attachable TTY**. So "take over" (`TerminalManager.goInteractive`)
+has to **kill the running process and relaunch `claude --resume`**. That discards the in-flight turn and
+drops the human onto an idle prompt — the run visibly "stops" the moment you take it over. You cannot
+promote a live `-p` process into a TUI in place.
+
+## The invariant we change
+
+**Every claude-code session is an interactive TUI in a detached tmux pane.** Runs differ only in
+*teardown policy* and *whether a human has claimed them* — never in process mode. "Take over" becomes a
+metadata flip plus a plain ttyd attach: nothing is killed, nothing is resumed, no turn is lost.
+
+The resident chat lane already proves this shape works unattended (interactive claude +
+`--dangerously-skip-permissions`, detached in tmux, the PreToolUse gate hook still governing every
+effect). We generalize it to all unattended runs.
+
+## Hard constraint from Claude Code
+
+The **Stop hook** fires once per turn but **cannot exit the process** — it can only beacon out (same as
+`notify-hook.sh`). So teardown cannot live inside claude: the Stop hook POSTs a "turn ended" beacon to a
+loopback route and the **server** decides whether to tear the pane down. The server is already the
+authority that kills panes (`stopSession`, `reapIdleResidents`).
+
+## Session model — three teardown policies, one process mode
+
+| Origin | Launch | Teardown policy |
+|---|---|---|
+| Member spawn (interactive) | interactive TUI (unchanged) | **sticky** — lives until Stop-idle / close / stop |
+| Chat (resident) | interactive TUI, warm (unchanged) | **idle-timeout** reap (unchanged) |
+| Automation / cron / task | interactive TUI, `--dangerously-skip-permissions`, detached | **immediate** — torn down at turn-end IF no client attached & no pending ask |
+| Any unattended run, **taken over** | no relaunch — just attach | flips to **sticky** (claimed) |
+
+The `immediate` policy reproduces exactly what `-p` gives today (the pane vanishes the instant the run
+completes → tmux drops → the pile-up guard `isAlive` releases), but because the pane is a real TUI the
+whole time it is alive, a human can attach mid-run with zero disruption.
+
+## Data model
+
+Reuse existing columns; add two nullable ones (non-destructive `ALTER TABLE`):
+
+- Keep `term_sessions.headless` (0/1) but re-read it as **"unattended, immediate-teardown"** — the launch
+  just stops using `-p`.
+- Add `claimed_by TEXT NULL`, `claimed_at INTEGER NULL` — set when a human takes over. Any session with
+  `claimed_by` set is **sticky** (never auto-reaped by the immediate/idle policies); also gives the
+  console a "taken over by X" badge and an audit trail.
+
+## Control flow
+
+1. **Spawn (automation/task)** — `createSession(..., headless=true)` keeps its call sites, but
+   `launchClaudeCode` routes `headless` runs into the interactive-unattended lane instead of `-p`. Launch
+   env: `UNATTENDED=1` (not `HEADLESS=1`).
+2. **Turn ends** — `terminal/stop-hook.sh` (modeled on `notify-hook.sh`) POSTs `/api/turn-idle {session}`
+   (session-secret gated). Server → `markTurnIdle(session)`:
+   ```
+   if unattended && !claimed && !hasClient(tmux) && noPendingQuestionOrApproval(session):
+       capturePane → session-<id>.log     # preserve the "what did it do" transcript view
+       markEnded(session)                  # clean status → 'done' + episode (parity with -p)
+       backend.kill(tmux)                  # pane dies → pile-up guard releases now
+   else:
+       no-op                               # human is watching, or blocked on an ask → keep alive
+   ```
+3. **Take over** — `goInteractive` is replaced by `claimSession(id, by)`:
+   ```
+   UPDATE term_sessions SET headless=0, claimed_by=?, claimed_at=? WHERE id=?
+   audit 'session.claimed'   # NO kill, NO relaunch — the live TUI keeps streaming
+   ```
+   `POST /api/sessions/:id/interactive` calls `claimSession`; the frontend then opens ttyd exactly as
+   before. The user lands in the live pane, mid-work, and can type.
+4. **Backstop reaper** — `reapIdleResidents` generalizes to `reapIdleSessions`: still reaps resident chats
+   on idle-timeout, and additionally reaps any `immediate` session that is idle with **no client
+   attached** (covers a missed Stop beacon, or a human who attached then detached without a further turn).
+   Same guards: skip if `claimed_by` set, skip if pending question/approval.
+
+## New primitive — attach detection
+
+`SessionBackend.hasClient(space, tmuxName): boolean | null`:
+- `LocalSessionBackend`: `tmux -S <sock> list-clients -t <name>` → count > 0.
+- `LauncherSessionBackend`: `null` (uid-private socket, unknowable) → server treats `null` as "fall back
+  to idle-timeout reaping," matching the launcher's existing liveness limitations.
+
+The takeover race (agent finishes the turn a split-second before the browser attaches) is closed
+structurally: `claimSession` sets `claimed_by` **before** ttyd opens, and both `markTurnIdle` and the
+reaper honor `claimed_by`, so a claimed session is never reaped regardless of attach timing.
+
+## `claude-launch.sh` changes
+
+- Delete the `HEADLESS` `-p` branch.
+- Unattended lane = the resident lane's shape (interactive `claude`, `--dangerously-skip-permissions`,
+  seeded with `$TASK`) minus warm-hold semantics. On `UNATTENDED=1`, take the interactive path but use
+  `--dangerously-skip-permissions` instead of `--permission-mode`.
+- Add `tmux pipe-pane -o` (or `capture-pane` on teardown) so the console transcript view keeps working
+  now that there is no `-p` stdout to tee.
+- Wire `terminal/stop-hook.sh` into `aos-settings.json` under `hooks.Stop`, beside the `Notification` hook.
+
+## Decisions (settled)
+
+1. **Takeover permission mode** — a claimed session keeps `--dangerously-skip-permissions`; the gate hook
+   still governs every effect (the real boundary). No native TUI prompts on takeover; accepted.
+2. **Teardown speed** — Stop-hook fast-path + reaper backstop (near-instant guard release, `-p` parity).
+3. **Resident chat** — left as-is (its idle-timeout policy is deliberately different); only the `-p`
+   automation lane is unified.
+
+## Files
+
+- `terminal/claude-launch.sh` — remove `-p` lane; unified interactive-unattended launch; Stop-hook
+  wiring; pane capture.
+- `terminal/stop-hook.sh` — **new**, turn-end beacon → `/api/turn-idle`.
+- `src/edge/session-backend.ts` — `hasClient()` on both backends.
+- `src/terminal.ts` — `launchClaudeCode` routing; `markTurnIdle`; `claimSession` (replaces
+  `goInteractive`); `reapIdleResidents` → `reapIdleSessions`; capture-pane on teardown.
+- `src/server.ts` — `POST /api/turn-idle`; repoint `/api/sessions/:id/interactive` → `claimSession`.
+- `src/state/db.ts` — `claimed_by` / `claimed_at` columns.
+- `web/src/App.tsx` — copy/tooltip updates; optional "taken over by X" badge.
+
+## Migration / compat
+
+- Old `-p` sessions in flight at deploy finish under the old in-memory code; new automations go
+  interactive after the server restart (server + launcher change → build + restart).
+- Resource cost unchanged: an unattended run holds claude + MCP servers only for the run's duration
+  (torn down at turn-end), the same window as `-p` — no warm-holding beyond the turn.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.112.0",
+  "version": "0.113.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.112.0",
+      "version": "0.113.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.112.0",
+  "version": "0.113.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/launcher.ts
+++ b/src/edge/launcher.ts
@@ -66,7 +66,7 @@ const AGENT_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;      // agent id = a folder nam
 /** env keys the app may set on a session (everything else is dropped). */
 export const ENV_ALLOWLIST = new Set([
   'AOS_URL', 'SESSION', 'AGENT', 'TASK_B64', 'AOS_SECRET', 'CLAUDE_SESSION_ID',
-  'HEADLESS', 'LOG_DIR', 'AGENT_DIR', 'HOOK', 'MCP_CONFIG', 'COMPANY_FILE', 'PATH',
+  'UNATTENDED', 'RESIDENT', 'RESUME', 'AGENT_DIR', 'HOOK', 'MCP_CONFIG', 'COMPANY_FILE', 'PATH',
 ]);
 const TTYD_PORT_MIN = 7700;
 const TTYD_PORT_MAX = 7999;
@@ -316,13 +316,13 @@ export class LauncherDaemon {
 
   /**
    * Write per-session files (the `.mcp.json` + company markdown) INTO the member's home so the member
-   * uid can read them, and return the env additions (MCP_CONFIG/COMPANY_FILE/LOG_DIR) pointing at them.
+   * uid can read them, and return the env additions (MCP_CONFIG/COMPANY_FILE) pointing at them.
    * Written as root then chowned to the member uid, 0600. (The app can't write the member's 0700 home.)
    */
   private writeSessionFiles(member: string, uid: number, sessionId: string, files?: { mcp?: string; company?: string }): Record<string, string> {
     const dir = this.sessionsDir(member);
     this.prepareDir(dir, uid); // mkdir + chown uid + 0700
-    const extra: Record<string, string> = { LOG_DIR: dir }; // headless transcripts land here too (member-writable)
+    const extra: Record<string, string> = {};
     const put = (name: string, contents: string, envKey: string): void => {
       const f = path.join(dir, name);
       fs.writeFileSync(f, contents, { mode: 0o600 });
@@ -406,7 +406,7 @@ export class LauncherDaemon {
     const uid = ensured.uid;
 
     // Materialise the session's .mcp.json / company file into the member home (readable by the member
-    // uid) and point MCP_CONFIG/COMPANY_FILE/LOG_DIR at them — overriding any app-supplied values.
+    // uid) and point MCP_CONFIG/COMPANY_FILE at them — overriding any app-supplied values.
     const fileEnv = this.writeSessionFiles(member, uid, req.sessionId!, req.files);
     const env = { ...sanitizeEnv(req.env), ...fileEnv };
     // Per-member agent working copy: AGENT_DIR must be a dir the member uid owns + can write.

--- a/src/edge/session-backend.ts
+++ b/src/edge/session-backend.ts
@@ -40,6 +40,15 @@ export interface SessionBackend {
   injectText(space: string, tmuxName: string, text: string, submit: boolean): boolean;
   /** Live tmux session names, or null when liveness can't be polled (→ rely on end signals). */
   aliveNames(): Set<string> | null;
+  /** Is a browser terminal currently ATTACHED to `tmuxName` (tmux has ≥1 client on the session)?
+   *  Distinguishes "a human is watching this live pane" from "running but unobserved" — the signal the
+   *  turn-end/idle reapers use to leave a taken-over run alone. `null` when it can't be determined
+   *  (launcher backend: the member's tmux socket is uid-private) → callers fall back to timeout reaping. */
+  hasClient(space: string, tmuxName: string): boolean | null;
+  /** Snapshot the visible scrollback of `tmuxName` as text (tmux capture-pane, full history), for the
+   *  console's "what did this run do" transcript view once its pane is gone. `null` when unavailable
+   *  (no such session, or the socket can't be reached). Replaces the old `-p` stdout tee. */
+  capturePane(space: string, tmuxName: string): string | null;
   /**
    * Ensure a browser can attach to `tmuxName` and return the iframe URL. Local → the classic shared
    * `/terminal/?arg=…` (one ttyd). Launcher → bring up the member's own ttyd and return a
@@ -135,6 +144,21 @@ export class LocalSessionBackend implements SessionBackend {
     return new Set((r.stdout || '').split('\n').filter(Boolean));
   }
 
+  hasClient(_space: string, tmuxName: string): boolean | null {
+    // `list-clients -t <session>` prints one line per attached ttyd/xterm client; empty → nobody watching.
+    const r = spawnSync('tmux', ['-S', this.tmuxSocket, 'list-clients', '-t', tmuxName, '-F', '#{client_name}'], { encoding: 'utf8' });
+    if (r.error) return null;              // couldn't poll → unknown (don't reap on a hiccup)
+    if (r.status !== 0) return false;      // no such session / no server → nothing attached
+    return (r.stdout || '').split('\n').some(Boolean);
+  }
+
+  capturePane(_space: string, tmuxName: string): string | null {
+    // -p: print to stdout; -J: join wrapped lines; -S -: from the start of the scrollback history.
+    const r = spawnSync('tmux', ['-S', this.tmuxSocket, 'capture-pane', '-p', '-J', '-S', '-', '-t', tmuxName], { encoding: 'utf8' });
+    if (r.error || r.status !== 0) return null;
+    return r.stdout || '';
+  }
+
   async attachUrl(_space: string, tmuxName: string): Promise<string> {
     return TERMINAL_URL(null, tmuxName); // the single shared ttyd, fronted by nginx as today
   }
@@ -174,7 +198,7 @@ export class LauncherSessionBackend implements SessionBackend {
   spawn(space: string, spec: SpawnSpec): void {
     this.seen.add(space);
     // Fire-and-forget (like the local spawn) — surface only failures to the audit log. The launcher
-    // writes spec.files into the member home (member-readable) and sets MCP_CONFIG/COMPANY_FILE/LOG_DIR.
+    // writes spec.files into the member home (member-readable) and sets MCP_CONFIG/COMPANY_FILE.
     this.client
       .startSession(space, spec.sessionId, spec.tmuxName, spec.env, spec.argv, { files: spec.files, agent: spec.agent, agentSrc: spec.agentSrc })
       .then((r) => { if (!r.ok) this.onError(spec.sessionId, spec.agent, r.error ?? 'launcher start failed'); })
@@ -197,6 +221,14 @@ export class LauncherSessionBackend implements SessionBackend {
     // flip to idle via the explicit /api/ended + /api/report signals; precise launcher-side liveness
     // (a `list_sessions` verb) is a later refinement.
     return null;
+  }
+
+  hasClient(_space: string, _tmuxName: string): boolean | null {
+    return null; // uid-private socket — attachment can't be polled from the app (→ timeout-reap fallback).
+  }
+
+  capturePane(_space: string, _tmuxName: string): string | null {
+    return null; // uid-private socket — the app can't capture the pane (a launcher verb is a later refinement).
   }
 
   async attachUrl(space: string, tmuxName: string): Promise<string> {

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -20,9 +20,10 @@ const SECRET = process.env.AOS_SECRET || '';
 // Tenant id (multi-tenant): the server routes these loopback calls to THIS tenant's runtime via the
 // `x-aos-tenant` header (loopback has no Host subdomain). Empty → the server falls back to default.
 const TENANT = process.env.AOS_TENANT || '';
-// HEADLESS marks an unattended run (automation/cron/task, `claude -p`) — no human at the terminal and no
-// idle-reaper bound. A blocking `ask` therefore parks after a short window instead of hanging ~1h (#138).
-const HEADLESS = process.env.HEADLESS === '1';
+// UNATTENDED marks an automation/cron/task run — nobody at the terminal (it's an attachable TUI the
+// server tears down at turn-end). A blocking `ask` therefore parks after a short window instead of
+// hanging ~1h (#138). (Renamed from HEADLESS when unattended runs stopped being `claude -p`.)
+const UNATTENDED = process.env.UNATTENDED === '1';
 const UNATTENDED_ASK_WAIT_S = Number(process.env.AOS_UNATTENDED_ASK_WAIT_S) || 120;
 // How long a delegating agent blocks in `task_wait` for a handed-off task to reach a terminal state. A
 // delegated task can legitimately run many minutes, so this is far longer than the ask window — but still
@@ -946,11 +947,13 @@ async function ask(args: Record<string, unknown>): Promise<string> {
   const { id } = (await res.json()) as { id?: string };
   if (!id) return 'Could not post the question.';
   // Poll the inbox for the human's answer. An INTERACTIVE run waits ~1h (a human is at the terminal and
-  // may take a while). A HEADLESS run (automation/cron/task) has no human attached AND no idle-reaper
-  // bound, so an hour-long block just strands the session and holds its memory — the question is already
-  // in the operator's Inbox + DM'd the moment it was asked, so we only wait a short window in case an
-  // operator is live, then PARK (return stop-cleanly guidance rather than hang or guess).
-  const maxPolls = HEADLESS ? Math.max(1, Math.ceil(UNATTENDED_ASK_WAIT_S / 2)) : 1800;
+  // may take a while). An UNATTENDED run (automation/cron/task) has nobody attached, so an hour-long block
+  // just strands the session and holds its memory — the question is already in the operator's Inbox +
+  // DM'd the moment it was asked, so we only wait a short window in case an operator is live, then PARK
+  // (return stop-cleanly guidance rather than hang or guess). NOTE: a pending question also keeps the
+  // pane alive server-side (markTurnIdle won't reap a run blocked on a person), so parking here is what
+  // lets the pane finally close.
+  const maxPolls = UNATTENDED ? Math.max(1, Math.ceil(UNATTENDED_ASK_WAIT_S / 2)) : 1800;
   for (let i = 0; i < maxPolls; i++) {
     await sleep(2000);
     const r = await fetch(`${AOS_URL}/api/ask/${id}`);
@@ -958,8 +961,8 @@ async function ask(args: Record<string, unknown>): Promise<string> {
     if (d.status === 'answered') return d.answer || '(the operator gave no answer)';
     if (d.status === 'cancelled') return 'The operator dismissed this question without answering. Proceed using your best judgement, or ask again if you are still blocked.';
   }
-  if (HEADLESS) {
-    return 'No operator is available on this unattended run (automation/cron/headless), and none answered in ' +
+  if (UNATTENDED) {
+    return 'No operator is available on this unattended run (automation/cron/task), and none answered in ' +
       `the ${UNATTENDED_ASK_WAIT_S}s window. Your question is recorded in the operator's Inbox and they have been ` +
       'notified, so it is NOT lost. Do NOT proceed with any risky or irreversible action on a guess. Wrap up ' +
       'now: call `report` to summarise what you did and note that you are blocked on this question, then end the ' +
@@ -1447,9 +1450,9 @@ async function taskWait(args: Record<string, unknown>): Promise<string> {
   const id = String(args.id ?? '').trim();
   if (!id) return 'Which task? (id is required).';
   const requested = typeof args.timeoutSeconds === 'number' ? args.timeoutSeconds : undefined;
-  // Interactive callers can afford a long block (a human can steer); headless park sooner so a stuck child
-  // can't strand them. An explicit timeoutSeconds always wins. Clamped to [10s, 6h].
-  const ceilingS = HEADLESS ? TASK_WAIT_S : Math.max(TASK_WAIT_S, 3600);
+  // Interactive callers can afford a long block (a human can steer); unattended runs park sooner so a stuck
+  // child can't strand them. An explicit timeoutSeconds always wins. Clamped to [10s, 6h].
+  const ceilingS = UNATTENDED ? TASK_WAIT_S : Math.max(TASK_WAIT_S, 3600);
   const maxWaitS = Math.min(21600, Math.max(10, requested ?? ceilingS));
   const deadline = Date.now() + maxWaitS * 1000;
   let lastStatus = '';

--- a/src/server.ts
+++ b/src/server.ts
@@ -212,7 +212,7 @@ export function startServer(port = Number(process.env.PORT) || 3010): http.Serve
   // Idle GC (A5): reclaim idle members' uids/ttyds. No-op under the local backend, so always-on is safe.
   const reaper = setInterval(() => registry.forEach((rt) => {
     try { rt.tm.reapIdleSpaces(); } catch { /* never let the sweep crash */ }
-    try { rt.tm.reapIdleResidents(); } catch { /* warm-chat idle reaper — never let it crash the sweep */ }
+    try { rt.tm.reapIdleSessions(); } catch { /* idle reaper (warm chat + unattended backstop) — never crash the sweep */ }
   }), 60_000);
   reaper.unref?.();
   // Memory upkeep + self-learning: hourly check per tenant; each is a no-op unless that tenant opted in.
@@ -865,6 +865,17 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     tm.markEnded(session);
+    return sendJson(res, 200, { ok: true });
+  }
+  // Claude Code Stop hook (stop-hook.sh): claude finished a turn. For an UNATTENDED (automation/task)
+  // run this is the end-of-run signal — the server closes it now UNLESS a human has taken it over / is
+  // watching / it's blocked on a person (see markTurnIdle). Best-effort, session-secret gated.
+  if (method === 'POST' && p === '/api/turn-idle') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    tm.markTurnIdle(session);
     return sendJson(res, 200, { ok: true });
   }
   // Claude Code Notification hook (notify-hook.sh): the session is blocked waiting on the human
@@ -1666,14 +1677,15 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
     return sendJson(res, 200, { ok: tm.stopSession(id, me.email) });
   }
-  // Take over a headless run: convert it to an attachable interactive session (relaunch `claude --resume`
-  // under the same id). Kills the in-flight `-p` turn if still streaming. Same per-member gate as stop.
+  // Take over an unattended run: CLAIM its live TUI so the caller can attach and steer — no kill, no
+  // resume, nothing interrupted (the run is already an attachable interactive session). Marks it sticky so
+  // it isn't auto-closed at turn-end. The frontend opens ttyd right after. Same per-member gate as stop.
   const interactiveMatch = p.match(/^\/api\/sessions\/([\w-]+)\/interactive$/);
   if (method === 'POST' && interactiveMatch) {
     const id = interactiveMatch[1];
     if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
-    const r = tm.goInteractive(id, me.email);
+    const r = tm.claimSession(id, me.email);
     return sendJson(res, r.ok ? 200 : 400, r);
   }
   // Human verdict on a finished run — 👍/👎 (or null to clear). The ground-truth signal for the agent

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -622,6 +622,13 @@ function migrate(db: Db): void {
   addColumn(db, 'term_sessions', 'rated_by', 'TEXT');     // member id who gave the verdict
   addColumn(db, 'term_sessions', 'rated_at', 'INTEGER');  // when (epoch ms)
 
+  // Take-over: a human "claimed" an unattended run to watch/steer it live. Setting this makes the
+  // session STICKY — the turn-end (`markTurnIdle`) and idle backstop reapers never tear it down, so a
+  // claimed run keeps its live TUI instead of being auto-closed when it goes idle. NULL = unclaimed
+  // (the default; every existing row). See docs/attachable-sessions-plan.md.
+  addColumn(db, 'term_sessions', 'claimed_by', 'TEXT');    // member id who took it over (NULL = unclaimed)
+  addColumn(db, 'term_sessions', 'claimed_at', 'INTEGER'); // when (epoch ms)
+
   // Profile picture: a small square `data:image/…;base64,…` URL. NULL → the UI shows the member's
   // initial. Members set their own from the Team page; owners/admins may set anyone's.
   addColumn(db, 'members', 'avatar', 'TEXT');

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -155,9 +155,13 @@ export interface Session {
    *  trigger; `task`/`chat` = the dispatcher/chat-router; `system` = an internal principal (e.g. the
    *  consolidation gardener). */
   sourceKind?: SessionSourceKind;
-  /** True when the run launched headless (`claude -p`, non-interactive) rather than as an attachable
-   *  interactive TUI. The console badges the two differently. */
+  /** True when the run launched unattended (an automation/cron/task run). These now run as an attachable
+   *  interactive TUI (not `claude -p`) that a human can take over live; the console badges them as
+   *  unattended vs. a member's own interactive session. */
   headless?: boolean;
+  /** The member id who "took over" (claimed) this unattended run to watch/steer it — set makes the
+   *  session sticky (never auto-reaped at turn-end). Undefined = nobody has claimed it. */
+  claimedBy?: string;
   /** The member id this session ACTS AS (run_as) — distinct from `spawnedBy` provenance. A task- or
    *  chat-triggered run is spawned by `task:`/`automation:` but runs as (and is owned by) a member,
    *  so the console keys "my sessions" off this too. */
@@ -231,6 +235,8 @@ interface SessionRow {
   spawned_by: string | null;
   run_as: string | null;
   headless: number | null;
+  claimed_by: string | null;
+  claimed_at: number | null;
   created_at: number;
   updated_at: number;
   rating: string | null;
@@ -898,7 +904,12 @@ export class TerminalManager {
     const mcpJson = this.buildMcpConfigJson(o.id, o.agent, o.actingMember, o.secret, o.hasSlack, o.hasDiscord);
     const companyMd = this.buildCompanyMd(o.agent);
     this.materializeSkills(o.id, o.agent, manifest.dir);
-    if (o.headless) env.HEADLESS = '1';
+    // Unattended (automation/cron/task) runs are now an attachable interactive TUI, not `claude -p` — so a
+    // human can take one over mid-run by simply attaching (no kill, no resume). The launcher's UNATTENDED
+    // lane runs interactive + `--dangerously-skip-permissions` (the gate hook still governs every effect),
+    // and the run is torn down at turn-end by the server (Stop-hook → markTurnIdle) rather than by the
+    // process exiting. See docs/attachable-sessions-plan.md.
+    if (o.headless) env.UNATTENDED = '1';
     // Resident (warm) chat session: the launcher's RESIDENT lane keeps an interactive claude alive so
     // thread follow-ups are delivered by send-keys (see deliverToResident / reviveResident).
     if (o.resident) env.RESIDENT = '1';
@@ -933,7 +944,6 @@ export class TerminalManager {
       if (mcpFile) env.MCP_CONFIG = mcpFile;
       const companyFile = this.writeSessionFile(o.id, 'company.md', companyMd);
       if (companyFile) env.COMPANY_FILE = companyFile;
-      if (o.headless) env.LOG_DIR = this.os.paths?.connectors ?? '/tmp';
       if (!o.headless) this.writeEnvFile(o.id, env);
       this.backend.spawn(this.spaceFor(o.actingMember ?? o.spawnedBy), { sessionId: o.id, agent: o.agent, tmuxName: tmux, env, argv: ['bash', this.launcher] });
     }
@@ -988,61 +998,55 @@ export class TerminalManager {
   }
 
   /**
-   * "Take over" a headless run: convert it into an attachable INTERACTIVE session so a human can watch and
-   * steer. A headless run is `claude -p` — non-interactive, and its pane dies on completion leaving no
-   * resurrect env. But it was pinned to `--session-id CLAUDE_SESSION_ID`, so its transcript persists on
-   * disk; we re-launch the interactive lane under the SAME id with `resume:true` (`claude --resume`), which
-   * writes the `session-<id>.env` the attach/resume path needs and picks up the conversation. If the `-p`
-   * run is still streaming we kill it first (the in-flight turn is lost — resume continues from the last
-   * COMPLETED turn; a `-p` process can't be promoted to a TUI in place). Idempotent-ish: converting an
-   * already-interactive live session is a no-op success (it's already headed). Returns an error string when
-   * the session can't be converted (unknown, not a claude-code run, or predates the pinned session id).
+   * "Take over" an unattended run: CLAIM its live, attachable TUI so a human can watch and steer — with
+   * ZERO disruption. Unattended automation/task runs are now a real interactive claude in a detached tmux
+   * pane (not `claude -p`), so there is nothing to kill and nothing to resume: we just mark the row claimed
+   * and the caller attaches to the still-streaming pane. Claiming makes the session STICKY — the turn-end
+   * (`markTurnIdle`) and idle-backstop reapers leave a claimed run alone, so it keeps its TUI instead of
+   * being auto-closed when it next goes idle. Also flips `headless → 0` (it is now attended) and clears any
+   * stay-stopped sentinel so a re-open resurrects cleanly. Idempotent: claiming an already-claimed or an
+   * interactive session is a no-op success. Returns an error only for an unknown / non-claude-code run.
    */
-  goInteractive(sessionId: string, by: string): { ok: boolean; error?: string } {
-    const row = this.db.prepare('SELECT agent, secret, claude_session_id, run_as, spawned_by, status, task FROM term_sessions WHERE id = ?')
-      .get<{ agent: string; secret: string | null; claude_session_id: string | null; run_as: string | null; spawned_by: string | null; status: string; task: string }>(sessionId);
+  claimSession(sessionId: string, by: string): { ok: boolean; error?: string } {
+    const row = this.db.prepare('SELECT agent, claimed_by FROM term_sessions WHERE id = ?')
+      .get<{ agent: string; claimed_by: string | null }>(sessionId);
     if (!row) return { ok: false, error: 'unknown session' };
-    // Only the real claude-code runtime resumes; a mock/other runtime has no transcript to continue.
+    // Only the real claude-code runtime has an attachable governed TUI; a mock/other runtime has nothing to take over.
     const manifest = this.os.agents.get(row.agent);
-    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can go interactive' };
-    // No pinned claude id → the run predates resumable session ids (or never started claude); nothing to resume.
-    if (!row.claude_session_id) return { ok: false, error: 'this run has no resumable transcript' };
-    // Already an attachable interactive session (has a persisted resurrect env) and live → nothing to do.
-    const alreadyInteractive = !!this.os.paths && fs.existsSync(path.join(this.os.paths.connectors, `session-${sessionId}.env`));
-    if (alreadyInteractive && this.isAlive(sessionId)) return { ok: true };
-    const actingMember = row.run_as ?? undefined;
-    const hasSlack = !!this.db.prepare('SELECT 1 FROM slack_threads WHERE session_id = ?').get(sessionId);
-    const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
-    // If the headless `-p` pane is still alive, kill it so the tmux name frees for the interactive relaunch
-    // (backend.kill is synchronous). The in-flight turn ends here; the resume picks up the last saved turn.
-    const wasAlive = this.isAlive(sessionId);
-    if (wasAlive) this.backend.kill(this.spaceFor(actingMember ?? row.spawned_by ?? undefined), `aos-${sessionId}`);
-    // A prior stop must not veto the deliberate re-open; clear any sentinel before we relaunch/attach.
+    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be taken over' };
+    if (row.claimed_by) return { ok: true }; // already taken over — the pane is already sticky/attachable
+    // A prior stop must not veto the deliberate take-over; clear any sentinel so a re-open resurrects.
     this.allowResume(sessionId);
-    this.db.prepare("UPDATE term_sessions SET status = 'running', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
-    this.audit(sessionId, by, 'session.interactive', { agent: row.agent, wasAlive });
-    // Re-launch the interactive lane for the SAME row: headless:false → writes session-<id>.env; resume:true
-    // → `claude --resume CLAUDE_SESSION_ID`. This reuses the whole resume/attach machinery (no new env plumbing).
-    this.launchClaudeCode({
-      id: sessionId, agent: row.agent, task: row.task, secret: row.secret ?? randomBytes(24).toString('hex'),
-      actingMember, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord,
-      headless: false, resident: false, resume: true, claudeSessionId: row.claude_session_id,
-    });
+    this.db.prepare("UPDATE term_sessions SET headless = 0, claimed_by = ?, claimed_at = ?, updated_at = ? WHERE id = ?")
+      .run(by, Date.now(), Date.now(), sessionId);
+    // No kill, no relaunch — the live pane keeps streaming; the caller opens ttyd and attaches to it.
+    this.audit(sessionId, by, 'session.claimed', { agent: row.agent });
     return { ok: true };
   }
 
   /**
-   * Idle reaper: kill resident (warm) chat sessions whose last turn was longer ago than the configured
-   * timeout (Settings → Integrations; default 30 min). Frees the held claude process + MCP servers; the
-   * thread's row stays (status → stopped) so a later reply revives it. `timeoutMin = 0` disables residence
-   * → reap everything resident. Run from the process-wide 60s sweep in server.ts. Never throws.
+   * Idle reaper (run from the process-wide 60s sweep in server.ts). Two jobs, one pass; never throws:
+   *
+   *  1. RESIDENT (warm chat) sessions whose last turn is older than the configured timeout
+   *     (Settings → Integrations; default 30 min) → killed, row → `stopped`, revivable on a later reply.
+   *     `timeoutMin = 0` disables residence → reap all now.
+   *
+   *  2. UNATTENDED backstop — the safety net for the Stop-hook fast path (`markTurnIdle`). An
+   *     automation/task run is now an attachable interactive TUI, torn down at turn-end by the Stop
+   *     beacon; if that beacon never lands (transport failure), or a human attached then detached without
+   *     a further turn, the run would linger. So we also reap unattended (`headless=1`, non-resident,
+   *     UNCLAIMED) running rows that have SEEN at least one turn-end beacon (`last_activity` stamped, so we
+   *     never touch a mid-first-turn long run) and have been idle past the same timeout with NO client
+   *     attached and no pending human block.
    */
-  reapIdleResidents(): void {
+  reapIdleSessions(): void {
     const timeoutMin = this.os.settings.chatIdleTimeoutMinutes();
     const cutoff = timeoutMin > 0 ? Date.now() - timeoutMin * 60_000 : Date.now() + 1; // 0 → reap all now
-    const rows = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent FROM term_sessions WHERE resident = 1 AND status = 'running' AND COALESCE(last_activity, created_at) < ?")
+
+    // (1) resident warm-chat idle reap — unchanged behavior.
+    const residents = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent FROM term_sessions WHERE resident = 1 AND status = 'running' AND COALESCE(last_activity, created_at) < ?")
       .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string }>(cutoff);
-    for (const r of rows) {
+    for (const r of residents) {
       try {
         this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
         this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), r.id);
@@ -1055,6 +1059,72 @@ export class TerminalManager {
         this.audit(r.id, r.agent, 'chat.reaped', { idleMin: timeoutMin });
       } catch { /* one bad row must not stop the sweep */ }
     }
+
+    // (2) unattended turn-end backstop. `last_activity IS NOT NULL` = a turn-end beacon has fired, so this
+    // never reaps a run still working its first turn (that row's last_activity is NULL until markTurnIdle).
+    const stragglers = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent FROM term_sessions WHERE headless = 1 AND resident = 0 AND claimed_by IS NULL AND status = 'running' AND last_activity IS NOT NULL AND last_activity < ?")
+      .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string }>(cutoff);
+    for (const r of stragglers) {
+      try {
+        const space = this.spaceFor(r.run_as ?? r.spawned_by);
+        if (this.backend.hasClient(space, r.tmux) === true) continue; // a human is still watching — leave it
+        if (this.hasPendingHumanBlock(r.id)) continue;               // blocked on an answer/approval — keep alive
+        this.teardownUnattended(r.id, space, r.tmux, 'idle-backstop');
+      } catch { /* one bad row must not stop the sweep */ }
+    }
+  }
+
+  /**
+   * Stop-hook fast path (POST /api/turn-idle, fired by terminal/stop-hook.sh when claude finishes a turn).
+   * For an UNATTENDED run this is the normal end-of-run teardown: if no human has claimed or is watching it
+   * and it isn't blocked on a person, close it NOW — capture the transcript, mark it done, kill the pane so
+   * the automations pile-up guard releases immediately (parity with the old `claude -p` exit). Otherwise
+   * (claimed / attached / blocked) it stays a live TUI; we only stamp the turn-end time so the idle backstop
+   * has a clock. No-op for interactive/resident runs and for anything not running.
+   */
+  markTurnIdle(sessionId: string): void {
+    const r = this.db.prepare('SELECT tmux, status, headless, resident, claimed_by, run_as, spawned_by FROM term_sessions WHERE id = ?')
+      .get<{ tmux: string; status: string; headless: number; resident: number; claimed_by: string | null; run_as: string | null; spawned_by: string | null }>(sessionId);
+    if (!r || r.status !== 'running' || !r.headless || r.resident) return; // only unattended, still-running runs
+    // Record the turn-end time regardless of the decision below — it's the idle backstop's clock and the
+    // signal that this run has completed at least one turn (so the backstop won't reap a mid-turn run).
+    this.db.prepare('UPDATE term_sessions SET last_activity = ? WHERE id = ?').run(Date.now(), sessionId);
+    if (r.claimed_by) return;                       // taken over → sticky, the human owns its lifecycle
+    if (this.hasPendingHumanBlock(sessionId)) return; // waiting on an answer/approval → keep the pane alive
+    const space = this.spaceFor(r.run_as ?? r.spawned_by);
+    if (this.backend.hasClient(space, r.tmux) === true) return; // a human is watching live → don't close on them
+    this.teardownUnattended(sessionId, space, r.tmux, 'turn-end');
+  }
+
+  /** Close a finished unattended run: snapshot its pane for the console transcript view, mark it done
+   *  (blocks resurrection + writes the episode), then kill the pane so tmux drops and the pile-up guard
+   *  releases. Shared by the Stop-hook fast path and the idle backstop. */
+  private teardownUnattended(sessionId: string, space: string, tmux: string, reason: string): void {
+    this.captureTranscript(sessionId, space, tmux);
+    this.markEnded(sessionId);   // status → done (if still running), blockResume, writeEpisode
+    this.backend.kill(space, tmux);
+    this.audit(sessionId, 'system', 'session.reaped', { reason });
+  }
+
+  /** Is this session blocked on a human right now (a pending question OR a pending approval)? Used to
+   *  keep an unattended run's pane alive while it legitimately waits, instead of reaping mid-`ask`. */
+  private hasPendingHumanBlock(sessionId: string): boolean {
+    const q = this.db.prepare("SELECT 1 FROM questions WHERE run_id = ? AND status = 'pending' LIMIT 1").get(sessionId);
+    if (q) return true;
+    return this.os.approvals.pending(this.os.tenant).some((a) => a.runId === sessionId);
+  }
+
+  /** Snapshot a live pane's scrollback to `<connectors>/session-<id>.log` (0600) so the console's
+   *  transcript view survives the pane being killed — the replacement for the old headless `-p` tee.
+   *  Best-effort: no paths, an unreachable socket, or a launcher backend (capturePane → null) → skip. */
+  private captureTranscript(sessionId: string, space: string, tmux: string): void {
+    if (!this.os.paths) return;
+    try {
+      const text = this.backend.capturePane(space, tmux);
+      if (text == null) return;
+      fs.mkdirSync(this.os.paths.connectors, { recursive: true }); // the dir exists once a session wrote its .mcp.json, but don't depend on it
+      fs.writeFileSync(path.join(this.os.paths.connectors, `session-${sessionId}.log`), text, { mode: 0o600 });
+    } catch { /* transcript capture is a nicety — never block teardown */ }
   }
 
   /** `{ AOS_URL, SESSION, AGENT, TASK_B64, AOS_SECRET }` — the base env every runner/launcher inherits. */
@@ -2200,7 +2270,11 @@ export class TerminalManager {
   stopSession(sessionId: string, by: string, reason?: string): boolean {
     const r = this.db.prepare('SELECT agent, tmux, status, spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ agent: string; tmux: string; status: string; spawned_by: string | null; run_as: string | null }>(sessionId);
     if (!r) return false;
-    this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
+    const space = this.spaceFor(r.run_as ?? r.spawned_by);
+    // Snapshot the pane before we kill it, so the console transcript view still shows what the run did
+    // (an attachable unattended run has no `-p` tee to fall back on). Best-effort; never blocks the stop.
+    this.captureTranscript(sessionId, space, r.tmux);
+    this.backend.kill(space, r.tmux);
     if (r.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.clearNotifications(sessionId);
     // The agent that asked is now dead — no one can answer its open questions or act on its approvals.
@@ -2547,7 +2621,7 @@ function titleFromSummary(summary: string): string {
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -11,9 +11,10 @@
 #   TASK_B64   base64-encoded task text (becomes claude's opening prompt)
 #   AGENT_DIR  the agent's folder — claude opens here and writes its memory/scratch here
 #   HOOK       absolute path to gate-hook.sh (the PreToolUse gate)
-#   HEADLESS   "1" → run non-interactively (`claude -p`) and exit when done (automations);
-#              unset/empty → interactive attachable TUI that stays live (manual spawns)
-#   LOG_DIR    where to tee the headless run transcript (headless only)
+#   UNATTENDED "1" → an unattended automation/cron/task run: an INTERACTIVE, attachable TUI (so a human
+#              can take it over live) run with --dangerously-skip-permissions; the server tears it down
+#              at turn-end via the Stop hook (no `claude -p`). unset/empty → a member's own interactive
+#              session. (RESIDENT is the warm-chat variant; both share the unattended lane below.)
 set -u
 # RESUME path: ttyd's attach wrapper (attach.sh) re-launches us against a session whose tmux shell
 # was killed (stopped/ended). The new tmux session does NOT inherit the original launch env, so
@@ -49,6 +50,9 @@ cd "$AGENT_DIR" 2>/dev/null || { red "agent folder not found: $AGENT_DIR"; exec 
 # interactive sessions. Enumerating a partial list caused exactly that gap; the server name covers all.
 # The Notification hook lives beside the gate hook; derive its path so it's correct on every machine.
 NOTIFY_HOOK="$(dirname "$HOOK")/notify-hook.sh"
+# The Stop hook (fires when claude finishes a turn) lives beside them — it beacons /api/turn-idle so the
+# server can tear down an UNATTENDED run at turn-end (parity with the old `claude -p` exit).
+STOP_HOOK="$(dirname "$HOOK")/stop-hook.sh"
 # The Agent OS status line renderer (native claude statusLine) lives beside the hooks too.
 STATUSLINE="$(dirname "$HOOK")/statusline.js"
 # NO OS-level Bash sandbox. Governance is the gate hook (PreToolUse), which is now the SOLE
@@ -94,6 +98,9 @@ cat > .claude/aos-settings.json <<JSON
     ],
     "Notification": [
       { "hooks": [ { "type": "command", "command": "bash '$NOTIFY_HOOK'" } ] }
+    ],
+    "Stop": [
+      { "hooks": [ { "type": "command", "command": "bash '$STOP_HOOK'" } ] }
     ]
   },
   "statusLine": { "type": "command", "command": "node '$STATUSLINE'", "padding": 1, "refreshInterval": 5 }
@@ -199,52 +206,27 @@ RUNTIME_ARGS=()
 # expands to nothing when MCP_ARGS/SYS_ARGS are empty instead of tripping "unbound variable".
 COMMON_ARGS=(--settings .claude/aos-settings.json "${MCP_ARGS[@]+"${MCP_ARGS[@]}"}" "${SYS_ARGS[@]+"${SYS_ARGS[@]}"}" "${RUNTIME_ARGS[@]+"${RUNTIME_ARGS[@]}"}")
 
-if [ "${HEADLESS:-}" = "1" ]; then
-  # Headless lane (automations): run the task to completion non-interactively, then EXIT. The pane
-  # dies → tmux drops the session → Agent OS marks it idle and the pile-up guard releases, so the
-  # next cron/webhook firing isn't skipped. No TUI, so the interactive-scroll issues don't apply.
+if [ "${RESIDENT:-}" = "1" ] || [ "${UNATTENDED:-}" = "1" ]; then
+  # UNATTENDED lane — the single path for every run with no human at the keyboard: automation/cron/task
+  # runs (UNATTENDED=1) AND warm chat sessions (RESIDENT=1). An INTERACTIVE, ATTACHABLE claude (NOT
+  # `claude -p`), so a person can "take over" a live run by simply attaching — no kill, no resume, no lost
+  # turn. Unattended, so --dangerously-skip-permissions (there's no one to answer a native prompt) — the
+  # SAME PreToolUse gate hook still runs and still BLOCKS risky Bash for inbox approval under the flag, so
+  # Bash stays governed; the flag only removes prompts claude can't ask.
   #
-  # --dangerously-skip-permissions: there's no human to answer permission prompts here, and in -p
-  # mode an unapproved tool would otherwise ABORT the run. The SAME PreToolUse gate hook still runs
-  # and still BLOCKS risky Bash for inbox approval even under this flag — so Bash stays governed;
-  # the flag only removes the prompts claude can't ask non-interactively.
-  LOG="${LOG_DIR:-/tmp}/session-$SESSION.log"
-  # Create the transcript 0600 before writing — it can contain connector output / secrets, so it must
-  # not be world-readable (matches the 0600 .mcp.json the server writes). umask in a subshell so the
-  # restriction applies only to this file, not to anything claude writes during the run.
-  ( umask 077; : > "$LOG" ) 2>/dev/null || true
-  dim "headless run — transcript → $LOG. This pane closes when the task completes."
-  echo
-  # Pin the run to CLAUDE_SESSION_ID (`--session-id`) so a later chat-thread follow-up can `--resume`
-  # the SAME transcript and keep context. RESUME=1 (a thread follow-up) resumes it, seeding the new
-  # message as the next turn; if the resume fails (no persisted transcript) fall back to a fresh run so
-  # the user still gets an answer (context lost, but no dead end). No id set → mint-your-own as before.
-  if [ "${RESUME:-}" = "1" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
-    dim "resuming claude session $CLAUDE_SESSION_ID (thread follow-up) …"
-    claude -p "$TASK" --resume "$CLAUDE_SESSION_ID" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG" \
-      || claude -p "$TASK" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG"
-  elif [ -n "${CLAUDE_SESSION_ID:-}" ]; then
-    claude -p "$TASK" --session-id "$CLAUDE_SESSION_ID" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG"
-  else
-    claude -p "$TASK" --dangerously-skip-permissions "${COMMON_ARGS[@]}" 2>&1 | tee -a "$LOG"
-  fi
-  notify_ended
-  exit 0
-fi
-
-if [ "${RESIDENT:-}" = "1" ]; then
-  # RESIDENT (warm chat) lane: an INTERACTIVE claude that STAYS ALIVE after it answers, so a Slack/Discord
-  # thread follow-up is delivered by typing into this very pane (tmux send-keys) — fast, no cold reload of
-  # MCP servers / transcript. Unattended (no human to answer prompts), so --dangerously-skip-permissions —
-  # the SAME PreToolUse gate hook still runs and still BLOCKS risky Bash for inbox approval under the flag.
-  # Seeded with the first message ($TASK); RESUME=1 continues a prior transcript, still seeded with the new
-  # message. The OS keeps it warm and the idle reaper kills it after the configured timeout. On an abnormal
-  # exit (crash/quit) the pane just ends → the row goes done and the next follow-up revives it fresh (no
-  # ungoverned holding shell, matching the interactive lane's security stance).
+  # Teardown is SERVER-driven, not by the process exiting: when claude finishes a turn the Stop hook beacons
+  # /api/turn-idle and the server closes an unattended run (kills this pane → tmux drops → the automations
+  # pile-up guard releases, parity with the old `-p` exit) UNLESS a human has taken it over / is watching /
+  # it's blocked on a person. A RESIDENT (chat) run instead stays warm for send-keys follow-ups until the
+  # idle reaper. Seeded with $TASK; RESUME=1 continues a prior transcript (chat thread continuity).
   export CLAUDE_CODE_NO_FLICKER=1
   export CLAUDE_CODE_DISABLE_MOUSE_CLICKS=1
   RES_ARGS=(--dangerously-skip-permissions "${COMMON_ARGS[@]}")
-  dim "resident warm chat session — unattended (gate hook still governs); kept warm for fast follow-ups"
+  if [ "${RESIDENT:-}" = "1" ]; then
+    dim "resident warm chat session — unattended (gate hook still governs); kept warm for fast follow-ups"
+  else
+    dim "unattended run — attachable TUI (gate hook still governs); take it over anytime. Closes at turn-end."
+  fi
   echo
   if [ "${RESUME:-}" = "1" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
     notify_resumed
@@ -259,8 +241,8 @@ if [ "${RESIDENT:-}" = "1" ]; then
   exit 0
 fi
 
-# INTERACTIVE lane only (the headless/resident branches above already exited). Add the permission mode
-# here — NOT in COMMON_ARGS — so it never touches the headless `-p --dangerously-skip-permissions` run.
+# INTERACTIVE lane only (the unattended/resident branch above already exited). Add the permission mode
+# here — NOT in COMMON_ARGS — so it never touches the unattended `--dangerously-skip-permissions` run.
 # Defaults to `auto` if the env is unset (e.g. resuming a session launched before this knob existed).
 COMMON_ARGS+=(--permission-mode "${CLAUDE_PERMISSION_MODE:-auto}")
 dim "permission mode: ${CLAUDE_PERMISSION_MODE:-auto} (gate hook still governs every side effect)"

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -13,10 +13,11 @@
 # denial layered on top of ours). `"deny"` blocks the call. An approval that's still pending
 # blocks the hook synchronously (polling) until a human resolves it, then emits allow/deny —
 # so an interactive run is governed identically to one with NO `--dangerously-skip-permissions`
-# (there's no prompt to answer; the hook itself is the gate). A HEADLESS `-p` run (automation/cron)
-# has no human at the terminal and no idle-reaper bound, so it waits only a bounded window
+# (there's no prompt to answer; the hook itself is the gate). An UNATTENDED run (automation/cron/task)
+# has nobody at the terminal by default, so it waits only a bounded window
 # (AOS_UNATTENDED_APPROVAL_WAIT_S, default 180s) and then FAILS CLOSED (deny) — it never falls through
-# to allow; the approval stays pending in the inbox for a human to act on and re-run (#138).
+# to allow; the approval stays pending in the inbox for a human to act on and re-run (#138). (A human can
+# still "take over" the run and approve within the window — see docs/attachable-sessions-plan.md.)
 # Built-in Read/Glob/Grep and the OS-owned mcp__agentos__* tools aren't world side effects, so
 # the hook stays silent (bare exit 0) and defers to Claude's normal permission flow — that's
 # what keeps the crown-jewel `permissions.deny` Read rules in force for the built-in Read tool.
@@ -75,9 +76,9 @@ while :; do
 done
 
 echo "Agent OS: this action needs approval — see the inbox. Waiting…" >&2
-# Interactive runs wait indefinitely for a human. A HEADLESS run has nobody at the terminal, so bound the
-# wait and FAIL CLOSED (deny) — we only ever stop THIS blocked call, never fall through to allow, and the
-# approval row stays pending in the inbox for a human to resolve + re-run.
+# Interactive runs wait indefinitely for a human. An UNATTENDED run has nobody at the terminal, so bound
+# the wait and FAIL CLOSED (deny) — we only ever stop THIS blocked call, never fall through to allow, and
+# the approval row stays pending in the inbox for a human to resolve + re-run.
 APPROVAL_WAIT_S="${AOS_UNATTENDED_APPROVAL_WAIT_S:-180}"
 waited=0
 while :; do
@@ -86,7 +87,7 @@ while :; do
   [ "$st" = "allow" ] && emit allow "Agent OS: approved by human."
   [ "$st" = "deny" ]  && emit deny "Agent OS: rejected by human."
   # any other status (pending / empty / gate momentarily unreachable) → keep waiting, never proceed
-  if [ "${HEADLESS:-}" = "1" ]; then
+  if [ "${UNATTENDED:-}" = "1" ]; then
     waited=$((waited + 1))
     if [ "$waited" -ge "$APPROVAL_WAIT_S" ]; then
       emit deny "Agent OS: no operator approved this within ${APPROVAL_WAIT_S}s on an unattended run — blocked (fail-closed). The approval is still in the inbox; a human can approve and re-run. Wrap up: report what you did and end the run."

--- a/terminal/stop-hook.sh
+++ b/terminal/stop-hook.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Claude Code Stop hook — fires when claude finishes a turn. For an UNATTENDED run (automation/cron/task)
+# this is the end-of-run signal: beacon the server so it can tear the session down at turn-end (kill the
+# pane → tmux drops → the automations pile-up guard releases), the parity replacement for the old
+# `claude -p` process exit. The server (markTurnIdle) does nothing UNLESS the run is unattended and
+# nobody has taken it over / is watching / it's blocked on a person — so this beacon is harmless for a
+# member's own interactive session or a claimed take-over. Dumb transport, like notify-hook.sh: a Stop
+# hook must never wedge the turn, so this is best-effort / fail-open (always exit 0, never `decision:block`).
+#
+# Env: AOS_URL, SESSION, AOS_SECRET, AOS_TENANT  (exported when the claude session is launched)
+set -u
+cat >/dev/null 2>&1 || true   # drain the hook's JSON stdin; we key off SESSION, not the payload
+
+payload=$(SESSION="$SESSION" node -e 'console.log(JSON.stringify({session:process.env.SESSION}))' 2>/dev/null) || exit 0
+
+curl -s --max-time 10 -X POST "$AOS_URL/api/turn-idle" -H 'content-type: application/json' \
+  -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" -d "$payload" >/dev/null 2>&1 || true
+exit 0

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -60,16 +60,15 @@ const resumeAndOpen = (s: Session, onOpen: (tmux: string, title: string) => void
   void api.resumeSession(s.id).finally(() => onOpen(s.tmux, s.agent + ' · ' + s.id))
 }
 
-/** A headless run (automation/cron/chat/task) is `claude -p` — non-interactive, and it writes no resurrect
- *  env, so it's never `resumable`. It CAN be "taken over": relaunched as an attachable interactive session
- *  (`claude --resume` under the same pinned id) so a human can watch and steer. Offered while it's live
- *  (streaming) or after it finished (continue the transcript). Interactive runs already have a live/Resume
- *  path, so they never show this. Server re-checks it's a claude-code run with a resumable transcript. */
+/** An unattended run (automation/cron/chat/task) is now an ATTACHABLE interactive TUI (not `claude -p`),
+ *  so while it's LIVE you can "take over" — claim it and attach to the still-streaming pane with nothing
+ *  interrupted. Offered only while live: a finished run has no pane to attach to (you view its transcript
+ *  instead). Interactive runs already have a live/Resume path, so they never show this. */
 const canGoInteractive = (s: Session): boolean =>
-  !s.resumable && (isLive(s) || s.status === 'done' || s.status === 'crashed')
+  !s.resumable && !s.claimedBy && isLive(s)
 
-/** Take over a headless run: convert it to an interactive session server-side (kills the in-flight `-p`
- *  turn if still streaming), THEN open/focus its terminal so the user lands in the live, attachable TUI. */
+/** Take over an unattended run: CLAIM it server-side (no kill, no resume — nothing interrupted), THEN
+ *  open/focus its terminal so the user lands in the live, attachable TUI it was already running in. */
 const takeOverAndOpen = (s: Session, onOpen: (tmux: string, title: string) => void): void => {
   void api.goInteractive(s.id).finally(() => onOpen(s.tmux, s.agent + ' · ' + s.id))
 }
@@ -1452,10 +1451,10 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
   const [wsUrl, setWsUrl] = useState('')
   const [err, setErr] = useState('')
   const [transcript, setTranscript] = useState<string | null>(null)
-  // "Take over" state: converting a headless run to interactive re-launches it server-side, but the
-  // `session` prop (and its `resumable`/`status`) only refreshes on the next poll. `overrideAttach`
-  // forces the attach path immediately; `nonce` re-runs the attach fetch and remounts <Xterm> so it
-  // reconnects to the freshly-spawned interactive pane. Reset when the viewed session changes.
+  // "Take over" state: claiming an unattended run doesn't relaunch it (the pane is already a live TUI) —
+  // we just want to hide the overlay button and stay attached. `overrideAttach` hides the button
+  // immediately (the `session` prop's `claimedBy` only reflects on the next poll); `nonce` re-runs the
+  // attach fetch so <Xterm> is freshly connected to the live pane. Reset when the viewed session changes.
   const [overrideAttach, setOverrideAttach] = useState(false)
   const [nonce, setNonce] = useState(0)
   const [takingOver, setTakingOver] = useState(false)
@@ -1467,21 +1466,20 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
     return n >= TERM_FONT_MIN && n <= TERM_FONT_MAX ? n : 14
   })
   useEffect(() => { localStorage.setItem('aos_terminal_font', String(fontSize)) }, [fontSize])
-  // A finished headless run (and a crashed headless run) has no resurrectable pane — never resumable
-  // and no longer live — so attaching would show a dead terminal. Show its captured transcript instead.
-  // Interactive ended sessions stay resumable and keep the normal attach/resume path untouched. Once
-  // taken over (overrideAttach), force the live attach path even before the prop reflects the new state.
+  // A finished/crashed unattended run has no live pane — never resumable and no longer live — so attaching
+  // would show a dead terminal. Show its captured transcript instead. Interactive ended sessions stay
+  // resumable and keep the normal attach/resume path untouched.
   const ended = Boolean(session) && !isLive(session!) && !session!.resumable && !overrideAttach
-  // A headless run can be promoted to an attachable interactive session (see canGoInteractive). Offer it
-  // both while streaming (live) and after it ended (continue) — hidden once taken over.
+  // A LIVE unattended run can be taken over — attach to its streaming pane (see canGoInteractive). Hidden
+  // once claimed (overrideAttach flips it off immediately; the prop's claimedBy follows on the next poll).
   const showTakeover = Boolean(session) && !overrideAttach && canGoInteractive(session!)
   const takeOver = async () => {
     if (!session?.id || takingOver) return
     setTakingOver(true); setErr('')
     const r = await api.goInteractive(session.id)
     setTakingOver(false)
-    if (!r.ok) { setErr(r.error || 'could not go interactive'); return }
-    // Drop the read-only transcript (if any) and force a fresh attach to the new interactive pane.
+    if (!r.ok) { setErr(r.error || 'could not take over this run'); return }
+    // Claimed — the live pane keeps streaming; just hide the button and (re)attach to it cleanly.
     setTranscript(null); setOverrideAttach(true); setNonce((n) => n + 1)
   }
   useEffect(() => {
@@ -1508,14 +1506,7 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
   if (transcript != null) return (
     <div className="flex min-h-0 flex-1 flex-col bg-black">
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-neutral-800 px-3 py-1.5 text-xs text-neutral-500">
-        <span>Session ended · headless transcript (read-only)</span>
-        {showTakeover && (
-          <button onClick={takeOver} disabled={takingOver}
-            className="flex items-center gap-1 rounded border border-sky-800 px-2 py-0.5 text-sky-300 hover:bg-sky-950 disabled:opacity-50"
-            title="continue this run in an interactive session you can watch and steer (claude --resume)">
-            <Terminal className="h-3 w-3" /> {takingOver ? 'opening…' : 'Continue interactively'}
-          </button>
-        )}
+        <span>Session ended · transcript (read-only)</span>
       </div>
       <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-xs leading-relaxed text-neutral-300">{transcript || '(no output captured)'}</pre>
     </div>
@@ -1527,8 +1518,8 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
       {showTakeover && (
         <button onClick={takeOver} disabled={takingOver}
           className="absolute left-1/2 top-2 z-10 flex -translate-x-1/2 items-center gap-1 rounded-full border border-sky-700 bg-neutral-900/90 px-3 py-1 text-xs text-sky-300 shadow hover:bg-sky-950 disabled:opacity-50"
-          title="take over — this headless run is unattended; convert it to an interactive session you can type into (ends the current turn, then resumes)">
-          <Terminal className="h-3.5 w-3.5" /> {takingOver ? 'taking over…' : 'Take over (go interactive)'}
+          title="take over — attach to this live unattended run and steer it by typing; nothing is interrupted">
+          <Terminal className="h-3.5 w-3.5" /> {takingOver ? 'taking over…' : 'Take over'}
         </button>
       )}
       <ImageDropZone session={session} onActivity={onActivity && session?.id ? () => onActivity(session.id) : undefined}
@@ -1943,7 +1934,7 @@ function SessionsPage({
             </button>
           )}
           {canGoInteractive(s) && (
-            <button className="rounded p-0.5 text-sky-400 hover:bg-neutral-600 hover:text-sky-300" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — convert this headless run to an interactive session you can watch and steer">
+            <button className="rounded p-0.5 text-sky-400 hover:bg-neutral-600 hover:text-sky-300" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — attach to this live run and steer it; nothing is interrupted">
               <Terminal className="h-3 w-3" />
             </button>
           )}
@@ -2161,7 +2152,7 @@ function SessionsPage({
                   </Button>
                 )}
                 {canGoInteractive(s) && (
-                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — convert this headless run to an interactive session you can watch and steer">
+                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — attach to this live run and steer it; nothing is interrupted">
                     <Terminal className="h-3 w-3" /> Take over
                   </Button>
                 )}
@@ -2228,7 +2219,7 @@ function SessionsPage({
                   </Button>
                 )}
                 {canGoInteractive(s) && (
-                  <Button size="icon" variant="ghost" className="h-7 w-7 text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — convert this headless run to an interactive session you can watch and steer">
+                  <Button size="icon" variant="ghost" className="h-7 w-7 text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — attach to this live run and steer it; nothing is interrupted">
                     <Terminal className="h-3.5 w-3.5" />
                   </Button>
                 )}
@@ -4885,10 +4876,10 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
             <button disabled={busy === runPrompt?.id} onClick={() => runPrompt && runNow(runPrompt, 'headless')}
               className="rounded-lg border p-3 text-left transition-colors hover:bg-muted disabled:opacity-50">
               <div className="flex items-center gap-2 text-sm font-medium">
-                <Zap className="h-4 w-4" /> Headless — fire and forget
+                <Zap className="h-4 w-4" /> Unattended — fire and forget
                 {runPrompt?.mode === 'headless' && <span className="text-[11px] font-normal text-muted-foreground">· current default</span>}
               </div>
-              <div className="mt-0.5 text-xs text-muted-foreground">Runs to completion unattended (<code>claude -p</code>) and exits; progress lands in the Inbox. You can still “Take over” a live headless run from Sessions.</div>
+              <div className="mt-0.5 text-xs text-muted-foreground">Runs unattended in an attachable terminal; progress lands in the Inbox and it closes when the task completes. “Take over” a live run anytime from Sessions.</div>
             </button>
           </div>
         </DialogContent>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -128,9 +128,12 @@ export interface Session {
    *  `task` = the Tasks dispatcher; `chat` = the `/agent` chat router; `system` = an internal principal.
    *  Server-resolved (the automation sub-type needs a join the raw `spawnedBy` can't give). */
   sourceKind?: 'manual' | 'cron' | 'webhook' | 'slack' | 'discord' | 'composio' | 'scheduled' | 'task' | 'chat' | 'system'
-  /** True when the run launched headless (`claude -p`, non-interactive) rather than as an attachable
-   *  interactive TUI. The list badges the two differently. */
+  /** True when the run launched unattended (an automation/cron/task run). These now run as an attachable
+   *  interactive TUI a human can take over live; the list badges them as unattended vs. a member session. */
   headless?: boolean
+  /** The member id who "took over" (claimed) this unattended run — set means it's sticky (won't be
+   *  auto-closed at turn-end) and the Take-over affordance is hidden. Undefined = unclaimed. */
+  claimedBy?: string
   /** The member id this session runs AS (run_as). A task/chat-triggered run is spawnedBy `task:`/
    *  `automation:` but runs as a member — the sidebar keys "my sessions" off this too. */
   runAs?: string


### PR DESCRIPTION
## Problem

"Take over" on an unattended run (automation/cron/task) was disruptive: those runs were `claude -p` (print mode), a non-interactive process with **no attachable TTY**, so `goInteractive` had to **kill the running process and `claude --resume`**. That discarded the in-flight turn and dropped the human onto an idle prompt — the run visibly "stopped" the moment you took it over.

## Change

Every unattended run is now a real **interactive claude in a detached tmux pane** (`--dangerously-skip-permissions`; the PreToolUse gate hook still governs every effect — the resident-chat lane already proved this shape). Taking over is a **metadata flip + attach**: nothing is killed, nothing is resumed, no turn is lost.

- **`claimSession`** replaces `goInteractive` — marks the live run *claimed* (sticky, never auto-closed) and the console attaches to the still-streaming pane. `POST /api/sessions/:id/interactive` is unchanged for the client.
- **Server-driven teardown.** New **Stop hook** (`terminal/stop-hook.sh`) beacons `/api/turn-idle` when claude finishes a turn → `markTurnIdle` closes an unattended run at turn-end (capture pane → mark `done` → kill pane so tmux drops and the automations pile-up guard releases, parity with the old `-p` exit) **UNLESS** it's claimed, a human is attached, or it's blocked on a person.
- **Backstop.** `reapIdleResidents` → `reapIdleSessions` adds an idle sweep for beaconless stragglers — gated on having seen a turn-end beacon, so a long first turn is **never** reaped mid-run.
- **New primitives.** `SessionBackend.hasClient()` (attach detection) + `capturePane()` (transcript snapshot, replacing the `-p` stdout tee); `term_sessions.claimed_by`/`claimed_at`; launch env `UNATTENDED=1` (was `HEADLESS=1`), honored by the gate-hook's bounded approval wait and the memory MCP's `ask`/`task_wait` parking.

## Decisions (as speced)

1. A claimed run keeps `--dangerously-skip-permissions` (no native TUI prompts on take-over); the gate hook is the real boundary.
2. Stop-hook fast path + idle backstop (near-instant guard release, `-p` parity).
3. Resident chat lane left as-is; only the `-p` automation lane is unified.

## Verification

- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` → **68/68**.
- In-process harness (**15/15**) over `markTurnIdle` / `claimSession` / `reapIdleSessions`, covering the claimed / attached / pending-approval guards and the "never reap a mid-first-turn run" property.
- `bash -n` on the launcher + hooks; generated `aos-settings.json` (with the new `Stop` block) parses.

## Follow-ups (not in this PR)

- uid-isolation lane: `hasClient`/`capturePane` return `null` (uid-private socket) → teardown still works via the beacon, but no live-attach detection / transcript capture there (a launcher verb, like the existing `aliveNames` limitation).
- "Continue a *finished* unattended run" (old resume-from-transcript affordance) is dropped — a finished run has no live pane; could return as an explicit "re-run resumed" spawn.

See `docs/attachable-sessions-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)