### PR TITLE
feat(agents): a session can stop itself — new `stop` MCP tool (v0.111.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.111.0] — 2026-07-11
+### Added
+- **A session can now stop itself.** New always-on MCP tool `stop` lets an agent end its OWN run when
+  the work is done or it's blocked with no point waiting (defer with `schedule` first if it should
+  resume later). It loops back to `POST /api/agent/stop`, which runs the same `TerminalManager.stopSession`
+  halt the console kill button performs — kills the tmux, cancels the session's pending questions/approvals,
+  blocks auto-resume, and records a `stopped` episode — but with `by` = the agent id and an optional
+  `reason` in the audit trail. The server acks first and halts ~150ms later so the tool's reply flushes
+  before the process is torn down (`src/memory/memory-mcp.ts`, `src/server.ts`, `src/terminal.ts`).
+
 ## [0.110.1] — 2026-07-11
 ### Fixed
 - **Session tabs no longer look "grabbed" on hover.** The drag-reorderable tabs used a `cursor-grab`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 43 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 44 always-on tools
   + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). KB: `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`. Operator/inbox:
   `ask`/`check_inbox`/`report`/`update`/`notify`/`publish`/`artifacts_list` (session cards are
@@ -202,7 +202,9 @@ Key modules:
   omitted ⇒ bundled catalog, `source:'owner/repo'` ⇒ a remote GitHub repo resolved at request time; posts a
   `skill.request` card, human installs via `POST /api/skills/requests/:id/approve` — catalog install or
   `fetchSkill`+`installFiles`, available next session). Scheduling: `schedule`/`unschedule`
-  (one-shot deferred self-run via a `type:'once'` automation). Tasks (shared work queue):
+  (one-shot deferred self-run via a `type:'once'` automation) + `stop` (the session ENDS ITSELF —
+  loopback to `/api/agent/stop` → the same `TerminalManager.stopSession` halt the console kill button
+  performs, `by` = the agent id). Tasks (shared work queue):
   `task_create`/`task_list`/`task_get`/`task_claim`/`task_update`/`task_wait`/`task_dispatch`/`task_attach`
   (file/claim/drain durable work + attach a file from the agent's folder onto a task; an
   agent-assigned `autoDispatch` task spawns a governed session — the A2A delegation path; per-task `mode`

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -30,6 +30,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `artifacts_list` | `GET /api/agent/artifacts` | `ArtifactStore.list` + `ArtifactStore.folders` | R | list scoped to the agent's own deliverables; also returns the tenant-wide gallery folders so a `publish` files into the existing tree (discovery) |
 | `schedule` | `POST /api/agent/schedule` | `Automations.schedule` (`type:'once'`) | W | one-shot deferred self-run; same agent + run-as; bounded 1 min–30 days, ≤25 pending/agent |
 | `unschedule` | `POST /api/agent/schedule/cancel` | `Automations.cancelScheduled` | W | cancel a pending one, scoped to the agent |
+| `stop` | `POST /api/agent/stop` | `TerminalManager.stopSession` (`by` = agent id) | W | the session ends ITSELF — same halt as the console kill (kills tmux, cancels its pending questions/approvals, blocks auto-resume, writes a `stopped` episode). Server acks then halts ~150ms later so the reply flushes first; audited `session.stopped` with the agent id + optional `reason` |
 | `list_capabilities` | `GET /api/agent/policy` | policy preview | R | |
 | `policy_check` | `POST /api/agent/policy/check` | policy preview | R | dry-run, no side effects |
 | `directory_lookup` | `GET /api/agent/directory` | `TeamStore` | R | people + their chat identities |
@@ -58,7 +59,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `discord_send` | `POST /api/agent/discord/send` | `DiscordSocket.sendToChannel` | W | proactive post to any channel by id; audited `discord.send`; only when `DISCORD_EGRESS=1` (Discord configured) |
 | `discord_dm` | `POST /api/agent/discord/dm` | `DiscordSocket.dmMember` | W | proactive DM by Discord user id; audited `discord.dm`; only when `DISCORD_EGRESS=1` |
 
-43 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+44 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.110.1",
+  "version": "0.111.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.110.1",
+      "version": "0.111.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.110.1",
+  "version": "0.111.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -571,6 +571,21 @@ const TOOLS = [
       required: ['id'],
     },
   },
+  {
+    name: 'stop',
+    description:
+      'End THIS session now — the clean way to finish. Call it when the work is done, or when you are ' +
+      'blocked and staying alive to wait is pointless (defer with `schedule` first if the work should ' +
+      'resume later). This halts your run immediately: it cannot be undone from inside the session, so ' +
+      'do any final `report`/`update` BEFORE calling it. A stopped session stays stopped (it will not ' +
+      'auto-resume); a human can re-open it later from the console. Any of your pending questions or ' +
+      'approvals are cancelled, since you will no longer be around to act on the answers.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: { reason: { type: 'string', description: 'Optional short note on why you are stopping — recorded in the audit trail.' } },
+    },
+  },
   // ── Tasks: the shared work queue (the durable unit of work, distinct from Memory + KB) ──
   {
     name: 'task_create',
@@ -1367,6 +1382,19 @@ async function unschedule(args: Record<string, unknown>): Promise<string> {
   return d.cancelled ? `Cancelled scheduled task ${id}.` : `Nothing to cancel for ${id} (already fired, or not yours).`;
 }
 
+async function stop(args: Record<string, unknown>): Promise<string> {
+  const reason = String(args.reason ?? '').trim();
+  const res = await fetch(AOS_URL + '/api/agent/stop', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, reason: reason || undefined }),
+  });
+  const d = (await res.json()) as { ok?: boolean; error?: string };
+  if (!d.ok) return `Could not stop: ${d.error ?? 'unknown error'}`;
+  // The server halts this session ~150ms after acking, so this line is the last thing the run does.
+  return 'Ending this session now.';
+}
+
 // ── Tasks: the shared work queue ──────────────────────────────────────────────
 interface TaskLite { id: string; title: string; status: string; priority: number; assignee?: string; labels?: string[]; body?: string }
 interface TaskEventLite { kind: string; body?: string; author: string; createdAt: number }
@@ -1858,6 +1886,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'artifacts_list' ? await artifactsList(args)
         : name === 'schedule' ? await schedule(args)
         : name === 'unschedule' ? await unschedule(args)
+        : name === 'stop' ? await stop(args)
         : name === 'task_create' ? await taskCreate(args)
         : name === 'task_list' ? await taskList(args)
         : name === 'task_get' ? await taskGet(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -666,6 +666,21 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (cancelled) os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: agent, type: 'automation.cancelled', data: { id } });
     return sendJson(res, 200, { ok: true, cancelled });
   }
+  // agent ENDS ITS OWN session — the self-stop escape hatch (work is done / blocked with no point
+  // waiting). Same halt the console kill button performs (stopSession: kills tmux, cancels pending
+  // questions/approvals, blocks auto-resume, records a `stopped` episode), but `by` = the agent id.
+  if (method === 'POST' && p === '/api/agent/stop') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const reason = String(b.reason || '').trim() || undefined;
+    // Ack first, halt just after: stopSession kills the tmux that is running THIS caller, so deferring
+    // the kill a beat lets the 200 flush back to the agent before its process group is torn down.
+    setTimeout(() => { try { tm.stopSession(session, agent, reason); } catch { /* best effort — the session is going away regardless */ } }, 150);
+    return sendJson(res, 200, { ok: true });
+  }
 
   // ask-human: the agent posts a question (→ inbox) and polls until a human answers it.
   if (method === 'POST' && p === '/api/ask') {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2159,8 +2159,10 @@ export class TerminalManager {
    * Stop a running session: kill its tmux shell (terminate a runaway/hung agent) and flip the row
    * to `idle`. The row, its messages and on-disk files all stay — this is "halt", not "remove".
    * Emits no feed card (lifecycle noise); the audit log records the stop. No-op on unknown id.
+   * Called both by a human (console kill, `by` = member email) and by the agent itself ending its
+   * own run (`stop` MCP tool → /api/agent/stop, `by` = agent id, optional `reason`).
    */
-  stopSession(sessionId: string, by: string): boolean {
+  stopSession(sessionId: string, by: string, reason?: string): boolean {
     const r = this.db.prepare('SELECT agent, tmux, status, spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ agent: string; tmux: string; status: string; spawned_by: string | null; run_as: string | null }>(sessionId);
     if (!r) return false;
     this.backend.kill(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
@@ -2181,7 +2183,9 @@ export class TerminalManager {
     // session did nothing worth remembering.
     this.writeEpisode(sessionId, r.agent, 'stopped');
     // No "Stopped" card — a human halting a run is lifecycle noise; the audit log records who/when.
-    this.audit(sessionId, by, 'session.stopped', { tmux: r.tmux });
+    // `by` distinguishes a human halt (member email) from a self-stop (the agent id, via the `stop`
+    // MCP tool → /api/agent/stop); an agent-supplied `reason` rides along for the audit trail.
+    this.audit(sessionId, by, 'session.stopped', { tmux: r.tmux, ...(reason ? { reason } : {}) });
     return true;
   }
 


### PR DESCRIPTION
## What

Adds the ability for an agent session to **stop itself**. New always-on MCP tool `stop`:

- Use it to end the current run when the work is done, or when blocked with no point staying alive to wait (defer with `schedule` first if the work should resume later).
- Optional `reason` is recorded in the audit trail.

## How it's wired

- **`stop` tool** (`src/memory/memory-mcp.ts`) → session-secret-gated loopback `POST /api/agent/stop`.
- **Route** (`src/server.ts`) sits before the member-auth gate like the other agent loopback routes; validates the per-session secret, derives the agent from the session row, then calls `stopSession`. It **acks first and halts ~150ms later** so the 200 flushes back before the caller's process group is torn down.
- **`TerminalManager.stopSession`** (`src/terminal.ts`) gains an optional `reason` param (all existing callers unchanged). This is the *same halt the console kill button performs*: kills the tmux, cancels the session's pending questions/approvals, blocks auto-resume, writes a `stopped` episode. For a self-stop `by` = the agent id (vs a member email for a human halt), and `reason` rides along in the `session.stopped` audit event.

## Verification

- `npm run typecheck`, `npm run build`, `cd web && npm run build` — clean.
- `npm run test:governance` — 68/68 ✓.
- Ephemeral-server smoke: `POST /api/agent/stop {session:"nope"}` → **404 "unknown session"** (route present, before the member gate), vs a nonexistent route → **401** (the CLAUDE.md wiring check).

## Docs

- `docs/agent-mcp-tools.md` matrix row + count (43 → 44 always-on).
- `CLAUDE.md` tool list + count.
- `CHANGELOG.md` + version bump to 0.111.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)