### PR TITLE
fix(web): stopping the open session hops to the next one (v0.112.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.113.1] — 2026-07-11
+### Fixed
+- **Stopping the open session no longer strands you on a dead terminal.** When you stop the session
+  you're currently viewing in the terminal view, the console now hops to the next open (live) session,
+  or falls back to the all-sessions list when none remain — mirroring the existing "close tab"
+  behaviour. Stopping a session from the list or a background tab leaves your current view untouched.
+
 ## [0.113.0] — 2026-07-11
 ### Changed
 - **Take-over is now lossless — unattended runs are an attachable TUI, not `claude -p`.** Automation/cron/
@@ -27,7 +34,6 @@ new version heading in the same commit.
     `capturePane()` (transcript snapshot, replacing the `-p` stdout tee); launch env `UNATTENDED=1`
     (was `HEADLESS=1`), honored by the gate hook's bounded approval wait and the memory MCP's `ask`/
     `task_wait` parking.
-
 ## [0.112.0] — 2026-07-11
 ### Added
 - **Same-session skill delivery (Phase 3).** When an owner/admin approves an agent's `skill_request`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.113.0",
+  "version": "0.113.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.113.0",
+      "version": "0.113.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.113.0",
+  "version": "0.113.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -818,8 +818,17 @@ function Console({ me }: { me: Member }) {
   // Deep-link from an inbox 'artifact' card into the gallery, pre-opening that artifact's preview.
   const openArtifact = (id: string) => nav('artifacts', id)
   const stopSession = async (id: string) => {
+    const stopped = sessions.find((s) => s.id === id)
     await api.stopSession(id)
-    setSessions(await api.sessions())
+    const fresh = await api.sessions()
+    setSessions(fresh)
+    // If you stopped the session you're currently viewing, don't sit on a dead terminal:
+    // hop to the next open session, or fall back to the all-sessions list when none remain.
+    if (stopped && selected?.tmux === stopped.tmux) {
+      const next = fresh.find((s) => isLive(s) && s.tmux !== stopped.tmux && !hiddenTabs.has(s.tmux))
+      if (next) nav('sessions', next.tmux)
+      else nav('sessions')
+    }
   }
   // Human verdict on a finished run — feeds the agent maturity score. Clicking the active thumb clears it.
   const rateSession = async (id: string, rating: 'up' | 'down' | null) => {


### PR DESCRIPTION
## What

When you **stop the session you're currently viewing** in the terminal view, the console now automatically:
- hops to the **next open (live) session**, or
- falls back to the **all-sessions list** when none remain.

This mirrors the existing "close tab" navigation. Stopping a session from the list view or a background tab leaves your current view untouched.

## Why

Previously, stopping the open session left you sitting on a dead terminal (transcript/resume view), forcing a manual click back to the list or another session.

## Change

`stopSession` in `web/src/App.tsx` now captures the stopped session's `tmux`, and — only when it's the one you're viewing (`selected?.tmux`) — navigates to the next non-hidden live session or the sessions list, using the freshly-refreshed list.

Web-console-only (`web/src`) — no server restart needed; the Node server serves `web/dist` off disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)