### PR TITLE
feat(notifications): in-app session bell + toasts + per-member prefs (v0.111.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.115.0] — 2026-07-11
+### Added
+- **In-app session notifications — a Facebook-style bell + toasts.** The console now surfaces when one of
+  your sessions changes state: it's **waiting** on you (permission prompt / idle / `agent_needs_input`),
+  it **finished**, it **crashed**, or it needs an **approval / answer**. A new header bell shows an
+  unread count and a dropdown of recent notifications (click one to jump to the session or Inbox);
+  fresh events also **toast** in from the bottom-right with an optional chime. Per-member
+  **notification settings** (in the bell's gear) let each person choose which events ping them, toggle
+  toasts/sound, and opt into a **Slack/Discord DM** for complete/waiting events. Completions and crashes
+  now always leave a feed card — a run that exits without calling `report` gets a "Finished" fallback, and
+  a crashed session gets a "Crashed" card — so nothing finishes silently. Prefs persist per member in a new
+  `member_prefs` table (`GET`/`PUT /api/me/prefs`); the browser-tab 🔔 badge now reflects the full unread
+  count. (`src/types.ts`, `src/state/db.ts`, `src/governance/team.ts`, `src/terminal.ts`,
+  `src/tenant-registry.ts`, `src/server.ts`, `web/src/App.tsx`, `web/src/lib/api.ts`)
+
 ## [0.114.0] — 2026-07-11
 ### Added
 - **Goals — the strategy agent ("goal steward"): the outbound edge (goal → work).** Goals could be linked

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.114.0",
+      "version": "0.115.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.114.0",
+  "version": "0.115.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -9,7 +9,7 @@
  */
 import { randomBytes } from 'crypto';
 import { Db } from '../state/db';
-import { AgentAccess, Member, MemberIdentity, IdentityProvider, Role, ApprovalLevel, canApprove } from '../types';
+import { AgentAccess, Member, MemberIdentity, IdentityProvider, Role, ApprovalLevel, canApprove, NotificationPrefs, sanitizeNotificationPrefs } from '../types';
 
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // magic links valid for 7 days
 const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // login cookie valid for 30 days
@@ -54,6 +54,30 @@ export class TeamStore {
   }
   count(): number {
     return this.db.prepare('SELECT COUNT(*) AS n FROM members').get<{ n: number }>()!.n;
+  }
+
+  // ── per-member notification preferences ──────────────────────────────────────
+  /** This member's notification prefs, merged over the defaults (missing row → all defaults). */
+  notificationPrefs(memberId: string): NotificationPrefs {
+    const row = this.db.prepare('SELECT prefs FROM member_prefs WHERE member_id = ?').get<{ prefs: string }>(memberId);
+    if (!row) return sanitizeNotificationPrefs(undefined);
+    try {
+      return sanitizeNotificationPrefs(JSON.parse(row.prefs));
+    } catch {
+      return sanitizeNotificationPrefs(undefined);
+    }
+  }
+
+  /** Persist a member's notification prefs (sanitized over the defaults) and return the resolved set. */
+  setNotificationPrefs(memberId: string, prefs: unknown): NotificationPrefs {
+    const clean = sanitizeNotificationPrefs(prefs);
+    this.db
+      .prepare(
+        `INSERT INTO member_prefs (member_id, prefs, updated_at) VALUES (?, ?, ?)
+         ON CONFLICT(member_id) DO UPDATE SET prefs = excluded.prefs, updated_at = excluded.updated_at`,
+      )
+      .run(memberId, JSON.stringify(clean), Date.now());
+    return clean;
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -1725,6 +1725,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   // default `mine` narrows to cards addressed to the viewer so owner/admin aren't flooded.
   if (method === 'GET' && p === '/api/messages') return sendJson(res, 200, tm.listMessages(me, inboxScope(url, me)));
 
+  // This member's own notification preferences (which session events ping them, toasts/sound/DM). Per
+  // person, not workspace-wide — every role reads/writes their OWN, so it's not admin-gated.
+  if (method === 'GET' && p === '/api/me/prefs') return sendJson(res, 200, os.team.notificationPrefs(me.id));
+  if (method === 'PUT' && p === '/api/me/prefs') {
+    const b = await readBody(req);
+    return sendJson(res, 200, os.team.setNotificationPrefs(me.id, b));
+  }
+
   // Dismiss the whole Activity feed at once (soft hide). Leaves action-required items (pending
   // approvals/questions, waiting notifications) in place. Same per-viewer visibility as the feed.
   if (method === 'POST' && p === '/api/messages/dismiss-all') {

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -518,6 +518,16 @@ function migrate(db: Db): void {
       dismissed_at INTEGER,
       PRIMARY KEY (message_id, member_id)
     );
+
+    -- Per-member preferences (JSON blob). Today it holds notification prefs (which session events ping
+    -- me, whether toasts/sound/DM fire); a single row per member keyed by member id. Absent row = the
+    -- code defaults (see DEFAULT_NOTIFICATION_PREFS). Kept separate from the shared settings table
+    -- because these are per-person, not workspace-wide.
+    CREATE TABLE IF NOT EXISTS member_prefs (
+      member_id    TEXT PRIMARY KEY,
+      prefs        TEXT NOT NULL,
+      updated_at   INTEGER NOT NULL
+    );
   `);
 
   // Idempotent column additions for the inbox feed (older DBs won't have these).

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { AgentOS, loadAgentOS, readRootConfig, RootConfig } from './kernel';
 import { exampleCapabilities } from './capabilities/examples';
-import { TerminalManager, ApprovalNotice, QuestionNotice, MemberNotice } from './terminal';
+import { TerminalManager, ApprovalNotice, QuestionNotice, MemberNotice, SessionEventNotice } from './terminal';
 import { Automations } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
@@ -214,6 +214,10 @@ export class TenantRegistry {
     // Agent → teammate: when an agent uses the `notify` tool, the inbox card is written inline (addressed
     // to the target member); this sink DMs that member on their linked Slack/Discord too.
     tm.setMemberNotifier((notice) => { void notifyMember(os, slack, discord, notice); });
+    // Session lifecycle → chat: when one of a member's sessions starts waiting / finishes / crashes, DM
+    // the run's owner IF they opted into `dm` notifications (default off — the inbox bell already covers
+    // it). The complete/waiting/crashed twin of the always-on approval/question DMs above.
+    tm.setSessionEventNotifier((notice) => { void notifySessionEvent(os, slack, discord, consoleOrigin, notice); });
     const ttyd = launchTtyd(paths.tmuxSocket, ttydPort, paths.connectors);
     console.log(`  [tenant:${rec.slug}] home=${paths.home}  ttyd=:${ttydPort}`);
     return { record: rec, os, tm, autos, slack, discord, ttyd, ttydPort, firstLogin: firstLogin ?? undefined };
@@ -399,6 +403,24 @@ export async function notifyMember(os: AgentOS, slack: Pick<SlackSocket, 'dmUser
   const text = `${bell} Message from agent ${notice.agent}:\n${notice.message}\nOpen the Agent OS console → Inbox.`;
   const dms = await deliverDM(slack, discord, os, targets, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'member.notified', data: { to: notice.to, important: notice.important, dms } });
+}
+
+/**
+ * DM the owner of a session that just changed state (started waiting / finished / crashed), on their
+ * linked Slack/Discord — the lifecycle twin of {@link notifyMember}. Unlike approvals/questions this is
+ * OPT-IN: only fires when the run's owner set their `dm` notification preference, since the inbox bell
+ * already surfaces every one of these. Targets the `sessionOwner` audience only — a pure automation/task
+ * run with no human owner pings nobody (there's no one whose bell it belongs to). Best-effort, audited.
+ */
+export async function notifySessionEvent(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: SessionEventNotice): Promise<void> {
+  const targets = resolveRecipients(os, { kind: 'sessionOwner', id: notice.sessionId })
+    .filter((m) => os.team.notificationPrefs(m.id).dm);
+  if (!targets.length) return;
+  const icon = notice.kind === 'waiting' ? '🔔' : notice.kind === 'crashed' ? '💥' : '✅';
+  const url = consolePage(consoleOrigin, 'sessions');
+  const text = (p: ChatPlatform) => `${icon} ${notice.title}\n${notice.message}\nOpen it in the ${chatLink(p, url, 'Agent OS console')}.`;
+  const dms = await deliverDM(slack, discord, os, targets, text);
+  os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'session.event.notified', data: { kind: notice.kind, agent: notice.agent, targets: targets.length, dms } });
 }
 
 /** Launch a ttyd bound to one tenant's tmux socket on `ttydPort`. (Moved verbatim from server.ts.) */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -310,6 +310,20 @@ export interface MemberNotice {
   important: boolean;
 }
 
+/** What the session-event notifier sink receives when one of a member's own sessions changes state —
+ *  it started waiting on them, finished, or crashed. The registry DMs the run's owner (its `run_as`,
+ *  else the console member who spawned it) on Slack/Discord IF that member opted into `dm` notifications.
+ *  The inbox card is written inline regardless; this is only the out-of-band push, gated on preference so
+ *  it doesn't flood. Approvals/questions have their own (always-on) notifiers — this covers the newer
+ *  complete/waiting/crashed events the console added a bell for. */
+export interface SessionEventNotice {
+  sessionId: string;
+  agent: string;
+  kind: 'waiting' | 'completed' | 'crashed';
+  title: string;
+  message: string;
+}
+
 export class TerminalManager {
   /** Scripted demo runner — for `runtime: mock` agents. */
   private readonly runner = path.resolve(__dirname, '../terminal/agent-runner.sh');
@@ -346,6 +360,14 @@ export class TerminalManager {
    *  registry DMs the target member on their linked Slack/Discord (the inbox card is written inline). */
   private memberNotifier?: (notice: MemberNotice) => void;
   setMemberNotifier(fn: (notice: MemberNotice) => void): void { this.memberNotifier = fn; }
+  /** Optional sink notified when one of a member's sessions starts waiting / finishes / crashes, so the
+   *  registry can DM the run's owner out-of-band (gated on their `dm` preference). Set by the registry
+   *  once the chat sockets exist; absent = no push (the inbox card is always written regardless). */
+  private sessionEventNotifier?: (notice: SessionEventNotice) => void;
+  setSessionEventNotifier(fn: (notice: SessionEventNotice) => void): void { this.sessionEventNotifier = fn; }
+  private fireSessionEvent(sessionId: string, agent: string, kind: SessionEventNotice['kind'], title: string, message: string): void {
+    try { this.sessionEventNotifier?.({ sessionId, agent, kind, title, message }); } catch { /* advisory — never let a push wedge the caller */ }
+  }
 
   constructor(
     private readonly os: AgentOS,
@@ -423,6 +445,15 @@ export class TerminalManager {
           // A crashed agent can't answer or act — retire its open questions + approvals like a clean stop.
           this.cancelPendingQuestions(r.id, 'system');
           this.cancelPendingApprovals(r.id, 'system');
+          // Surface the crash to the owner: a 'completed' card (outcome 'crashed') is the only feed entry a
+          // crash produces, since it fires no clean end signal. Guarded on hasCompleted so a run that had
+          // already reported before its pane died isn't double-carded; the status flip makes it once-only.
+          if (!this.hasCompleted(r.id)) {
+            const title = `Crashed — ${r.agent}`;
+            const body = 'The session ended unexpectedly (the process died).';
+            this.addMessage({ type: 'completed', sessionId: r.id, agent: r.agent, title, body, status: 'open', outcome: 'crashed', audienceKind: 'sessionOwner', audienceId: r.id });
+            this.fireSessionEvent(r.id, r.agent, 'crashed', title, body);
+          }
         }
       }
     }
@@ -1900,11 +1931,16 @@ export class TerminalManager {
    *  kinds get a card — auth/elicitation noise is dropped. Best-effort, never blocks (the hook can't). */
   notify(sessionId: string, agent: string, kind: string, message: string): void {
     if (!this.hasSession(sessionId)) return;
-    if (kind !== 'permission_prompt' && kind !== 'idle_prompt') return;
+    // The human-actionable Notification kinds only: a permission prompt / idle wait in the TUI, or the
+    // newer `agent_needs_input` Claude Code emits when it's blocked on the human. Auth/elicitation noise
+    // and the per-turn `agent_completed` are dropped here (session completion is signalled by markEnded).
+    if (kind !== 'permission_prompt' && kind !== 'idle_prompt' && kind !== 'agent_needs_input') return;
     this.clearNotifications(sessionId);
     const fallback = kind === 'permission_prompt' ? 'Claude needs permission to continue.' : 'Claude is waiting for your input.';
-    this.addMessage({ type: 'notification', sessionId, agent, title: `Waiting — ${agent}`, body: (message || '').trim() || fallback, status: 'open', audienceKind: 'sessionOwner', audienceId: sessionId });
+    const body = (message || '').trim() || fallback;
+    this.addMessage({ type: 'notification', sessionId, agent, title: `Waiting — ${agent}`, body, status: 'open', audienceKind: 'sessionOwner', audienceId: sessionId });
     this.audit(sessionId, agent, 'session.notified', { kind, message });
+    this.fireSessionEvent(sessionId, agent, 'waiting', `Waiting — ${agent}`, body);
   }
 
   /** Drop any open 'waiting' notification for a session — once it reports/ends, the bell is stale. */
@@ -1920,6 +1956,7 @@ export class TerminalManager {
     if (this.hasCompleted(sessionId)) return;
     this.clearNotifications(sessionId);
     this.addMessage({ type: 'completed', sessionId, agent, title: `Completed — ${agent}`, body: summary || '(no summary)', status: 'open', outcome, audienceKind: 'sessionOwner', audienceId: sessionId });
+    this.fireSessionEvent(sessionId, agent, 'completed', `Completed — ${agent}`, summary || `Finished (${outcome}).`);
     // Close the chat loop: a chat-triggered run's completion goes back to the thread the human pinged
     // from, not just the console. No-op for non-chat runs. The agent's own `slack_reply`/`discord_reply`
     // still work for finer-grained replies; this guarantees the outcome lands even if it never called them.
@@ -2192,7 +2229,11 @@ export class TerminalManager {
   markEnded(sessionId: string): void {
     const s = this.db.prepare('SELECT agent, status FROM term_sessions WHERE id = ?').get<{ agent: string; status: string }>(sessionId);
     if (!s) return;
-    if (s.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'done', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
+    // A "natural end": the row was still live and the process returned on its own — as opposed to a human
+    // `stopSession` (already 'stopped') or a crash the sweep caught ('crashed'). Only a natural end earns
+    // the completion-fallback card below, so closing a session yourself doesn't ping you about it.
+    const naturalEnd = s.status === 'running';
+    if (naturalEnd) this.db.prepare("UPDATE term_sessions SET status = 'done', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.clearNotifications(sessionId);
     // claude exited on its own. The launcher normally holds the pane on a "press [r] to resume" prompt,
     // but if that pane dies (an idle/detached `read` bailing out), ttyd's silent auto-reconnect would
@@ -2204,8 +2245,16 @@ export class TerminalManager {
     // already landed by now if the agent left one, so writeEpisode prefers it; otherwise it summarises
     // the audit stream. Best-effort + idempotent; never blocks the end signal.
     this.writeEpisode(sessionId, s.agent);
-    // No "Ended" card — exit is lifecycle noise. The agent's own `report` is the meaningful completion
-    // signal; a run that exits without reporting simply leaves no feed entry.
+    // Completion fallback: a run that exits without leaving its own `report` card still tells its owner it
+    // finished — the "session complete" bell/toast the console shows. Posted AFTER writeEpisode so this
+    // synthetic card can't be mistaken for the agent's own summary when composing the episode, and gated
+    // on `hasCompleted` so it never doubles a real report. Owner-scoped like every session card.
+    if (naturalEnd && !this.hasCompleted(sessionId)) {
+      const title = `Finished — ${s.agent}`;
+      const body = 'The session ended.';
+      this.addMessage({ type: 'completed', sessionId, agent: s.agent, title, body, status: 'open', outcome: 'ended', audienceKind: 'sessionOwner', audienceId: sessionId });
+      this.fireSessionEvent(sessionId, s.agent, 'completed', title, body);
+    }
     this.audit(sessionId, s.agent, 'session.ended', {});
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,60 @@ export interface Member {
 }
 
 /**
+ * Per-member notification preferences — which session events raise an in-app notification for THIS
+ * person, and through which channels. The inbox card itself is always written (audience-scoped as
+ * before); these prefs only decide what pings the member: the console bell/toast counts (client-side
+ * filtering) and whether the same event also DMs them on Slack/Discord (server-side, read by the
+ * session-event notifier). Stored per member in `member_prefs`; every field defaults ON except the DM
+ * push and sound, which are opt-in to avoid noise. Approvals/questions already DM their approver/owner
+ * regardless — the `dm` toggle here governs the newer complete/waiting pushes.
+ */
+export interface NotificationPrefs {
+  /** Which event kinds count toward this member's bell + surface a toast. */
+  events: {
+    completed: boolean;
+    waiting: boolean;
+    crashed: boolean;
+    approval: boolean;
+    question: boolean;
+  };
+  /** Show a transient toast when a new notification arrives while the console is open. */
+  toasts: boolean;
+  /** Play a short chime alongside a new toast. */
+  sound: boolean;
+  /** Also DM this member on Slack/Discord when one of their sessions completes or starts waiting. */
+  dm: boolean;
+}
+
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
+  events: { completed: true, waiting: true, crashed: true, approval: true, question: true },
+  toasts: true,
+  sound: false,
+  dm: false,
+};
+
+/** Merge a partial (possibly untrusted JSON) prefs object over the defaults so a stored row that
+ *  predates a new field, or a bad payload, can never drop a setting. Unknown keys are ignored. */
+export function sanitizeNotificationPrefs(input: unknown): NotificationPrefs {
+  const p = (input && typeof input === 'object' ? input : {}) as Partial<NotificationPrefs>;
+  const e = (p.events && typeof p.events === 'object' ? p.events : {}) as Partial<NotificationPrefs['events']>;
+  const bool = (v: unknown, d: boolean) => (typeof v === 'boolean' ? v : d);
+  const d = DEFAULT_NOTIFICATION_PREFS;
+  return {
+    events: {
+      completed: bool(e.completed, d.events.completed),
+      waiting: bool(e.waiting, d.events.waiting),
+      crashed: bool(e.crashed, d.events.crashed),
+      approval: bool(e.approval, d.events.approval),
+      question: bool(e.question, d.events.question),
+    },
+    toasts: bool(p.toasts, d.toasts),
+    sound: bool(p.sound, d.sound),
+    dm: bool(p.dm, d.dm),
+  };
+}
+
+/**
  * The external accounts a member is known by on other platforms — the join key that lets a chat
  * trigger (Slack/Discord) run AS the right person. One external id maps to at most one member
  * (enforced by the table's `(provider, external_id)` primary key), so run-as is never ambiguous.

--- a/terminal/notify-hook.sh
+++ b/terminal/notify-hook.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Claude Code Notification hook — surfaces "Claude needs you" events into the Agent OS inbox as a
 # per-session bell. Fires when claude is blocked waiting on the human: a permission prompt in the TUI
-# (notification_type=permission_prompt) or idle waiting for input (idle_prompt). Dumb transport, like
+# (notification_type=permission_prompt), idle waiting for input (idle_prompt), or agent_needs_input.
+# Dumb transport, like
 # gate-hook.sh: read the event, ship {kind, message} to the server, which posts the inbox card and
 # filters out the noise kinds. The Notification hook CANNOT block, so this is best-effort / fail-open —
 # a transport failure must never wedge the session.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
-import { type Branding, type PublicBranding } from '@/lib/api'
+import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage } from '@/connectors'
 import { docPages } from '@/docs'
@@ -694,6 +694,18 @@ function Console({ me }: { me: Member }) {
   // re-binding them every render / going stale on the captured `messages`.
   const messagesRef = useRef<Msg[]>([])
   messagesRef.current = messages
+  // This member's notification preferences (which events ping me, toasts/sound/DM). Loaded once; the
+  // bell's settings panel writes through `saveNotificationPrefs`. Defaults keep the bell fully on until
+  // the real prefs land, so a slow load never silently mutes anyone.
+  const [prefs, setPrefs] = useState<NotificationPrefs>(DEFAULT_NOTIFICATION_PREFS)
+  useEffect(() => { api.notificationPrefs().then(setPrefs).catch(() => {}) }, [])
+  const savePrefs = async (p: NotificationPrefs) => { setPrefs(p); try { await api.saveNotificationPrefs(p) } catch { /* keep the optimistic value */ } }
+  // Transient toast pop-ins for freshly-arrived notifications (Facebook-chat style). `seenNotifyIds`
+  // seeds on the first poll so a page load doesn't flood with toasts for the existing backlog; only
+  // ids that appear AFTER that raise a toast.
+  const [toasts, setToasts] = useState<ToastItem[]>([])
+  const seenNotifyIds = useRef<Set<string> | null>(null)
+  const dismissToast = (key: string) => setToasts((t) => t.filter((x) => x.key !== key))
   const { route, detail, query: urlQuery, nav, setQuery: setUrlQuery } = useHashRoute()
   // The open terminal is a URL detail (`#/sessions/<tmux>`), not local state, so a refresh /
   // back-forward reopens the same session. Title is best-effort from the loaded list (falls back to
@@ -731,14 +743,28 @@ function Console({ me }: { me: Member }) {
     return () => clearInterval(t)
   }, [])
 
-  // Browser-tab badge: a 🔔 + count of sessions where Claude is waiting on you (one open
-  // notification per session), so the tab nags even when the console isn't focused. The tenant
-  // name leads the title so several instances are distinguishable across browser tabs.
+  // Browser-tab badge: a 🔔 + the bell's unread count (waiting + completions + crashes + approvals +
+  // questions, filtered by this member's prefs), so the tab nags even when the console isn't focused.
+  // The tenant name leads the title so several instances are distinguishable across browser tabs.
+  const notifyItems = useMemo(() => buildNotifyItems(messages, prefs), [messages, prefs])
+  const notifyUnread = notifyItems.filter((x) => x.unread).length
   useEffect(() => {
-    const n = messages.filter((m) => m.type === 'notification' && m.status === 'open').length
     const base = `${state?.tenantName || state?.tenant ? `${state.tenantName || state.tenant} · ` : ''}Agent OS`
-    document.title = n > 0 ? `🔔 (${n}) ${base}` : base
-  }, [messages, state?.tenantName, state?.tenant])
+    document.title = notifyUnread > 0 ? `🔔 (${notifyUnread}) ${base}` : base
+  }, [notifyUnread, state?.tenantName, state?.tenant])
+
+  // Toast pop-ins: watch the unread notification set and surface a toast for any item that's newly
+  // appeared since the last poll (seeded on first load so the backlog stays quiet). Respects the
+  // member's toast + sound prefs; each toast auto-dismisses itself (see ToastCard).
+  useEffect(() => {
+    const unread = notifyItems.filter((x) => x.unread)
+    if (seenNotifyIds.current === null) { seenNotifyIds.current = new Set(messages.map((m) => m.id)); return }
+    const fresh = unread.filter((x) => !seenNotifyIds.current!.has(x.m.id))
+    seenNotifyIds.current = new Set(messages.map((m) => m.id))
+    if (!fresh.length || !prefs.toasts) return
+    setToasts((t) => [...fresh.map((x) => ({ key: x.m.id, m: x.m, kind: x.kind })), ...t].slice(0, 4))
+    if (prefs.sound) chimeOnce()
+  }, [notifyItems, messages, prefs.toasts, prefs.sound])
 
   const refreshState = () => api.state().then(setState)
   // Team roster (with avatars) for attributing people across pages — the "run as" facet on a session
@@ -864,6 +890,24 @@ function Console({ me }: { me: Member }) {
     setSessions(await api.sessions())
     openTerminal(r.tmux, agentId + ' · ' + r.id)
     return null
+  }
+
+  // Click a bell item / toast → go to the thing it's about. A session-scoped kind (waiting/finished/
+  // crashed) opens that session's terminal (which clears its waiting bell); an approval/question opens
+  // the Inbox to act on it. Informational cards (completed/crashed) are marked read on open.
+  const openNotification = (m: Msg) => {
+    if (!m.read && m.type === 'completed') {
+      setMessages((ms) => ms.map((x) => (x.id === m.id ? { ...x, read: true } : x)))
+      void api.markRead(m.id)
+    }
+    const kind = notifyKindOf(m)
+    const sess = sessions.find((s) => s.id === m.sessionId)
+    if ((kind === 'waiting' || kind === 'completed' || kind === 'crashed') && sess) openTerminal(sess.tmux)
+    else nav('inbox')
+  }
+  const markAllNotificationsRead = async () => {
+    setMessages((ms) => ms.map((x) => ({ ...x, read: true })))
+    try { await api.markAllRead() } catch { /* optimistic */ }
   }
 
   const pendingApprovals = messages.filter(isActionRequired).length
@@ -1064,6 +1108,7 @@ function Console({ me }: { me: Member }) {
               </h1>
             </div>
           )}
+          <NotificationsBell items={notifyItems} unread={notifyUnread} prefs={prefs} onOpen={openNotification} onMarkAllRead={markAllNotificationsRead} onSavePrefs={savePrefs} />
         </div>
 
         <div className={`min-h-0 flex-1 ${fullBleed ? '' : 'overflow-y-auto p-6'}`}>
@@ -1087,6 +1132,211 @@ function Console({ me }: { me: Member }) {
           {route === 'agent' && editAgent && <AgentPage agentId={editAgent} agents={state?.agents ?? []} onSaved={refreshState} />}
         </div>
       </main>
+      <ToastHost toasts={toasts} onOpen={openNotification} onDismiss={dismissToast} />
+    </div>
+  )
+}
+
+// ── Notifications (bell + toasts) ────────────────────────────────────────────────
+/** The five session events the console notifies on. `waiting`/`approval`/`question` are action-required
+ *  (they stay "unread" until resolved); `completed`/`crashed` are informational and clear once read. */
+export type NotifyKind = 'completed' | 'waiting' | 'crashed' | 'approval' | 'question'
+export interface NotifyItem { m: Msg; kind: NotifyKind; unread: boolean }
+interface ToastItem { key: string; m: Msg; kind: NotifyKind }
+
+/** Which notification a feed message represents (or null if it isn't a notify-worthy one). Mirrors the
+ *  server-side card types: an open 'notification' is a waiting session; a 'completed' card is a finish
+ *  unless its outcome is 'crashed'. Only unresolved approvals/questions notify. */
+function notifyKindOf(m: Msg): NotifyKind | null {
+  if (m.type === 'approval' && m.status === 'pending') return 'approval'
+  if (m.type === 'question' && m.status === 'pending') return 'question'
+  if (m.type === 'notification' && m.status === 'open') return 'waiting'
+  if (m.type === 'completed') return m.outcome === 'crashed' ? 'crashed' : 'completed'
+  return null
+}
+/** Action-required kinds count as unread until resolved; a completed/crashed card clears once read. */
+function isUnreadNotify(m: Msg, kind: NotifyKind): boolean {
+  return kind === 'completed' || kind === 'crashed' ? !m.read : true
+}
+/** The member's enabled notifications, newest first — the bell list + tab-badge + toast source. */
+function buildNotifyItems(messages: Msg[], prefs: NotificationPrefs): NotifyItem[] {
+  const out: NotifyItem[] = []
+  for (const m of messages) {
+    const kind = notifyKindOf(m)
+    if (!kind || !prefs.events[kind]) continue
+    out.push({ m, kind, unread: isUnreadNotify(m, kind) })
+  }
+  return out.sort((a, b) => b.m.createdAt - a.m.createdAt)
+}
+
+const NOTIFY_META: Record<NotifyKind, { label: string; icon: LucideIcon; tone: string }> = {
+  waiting: { label: 'Waiting on you', icon: Bell, tone: 'text-indigo-500' },
+  completed: { label: 'Finished', icon: CheckCircle2, tone: 'text-emerald-500' },
+  crashed: { label: 'Crashed', icon: AlertTriangle, tone: 'text-red-500' },
+  approval: { label: 'Needs approval', icon: Shield, tone: 'text-amber-500' },
+  question: { label: 'Question for you', icon: HelpCircle, tone: 'text-sky-500' },
+}
+
+/** Compact relative age: now · 12s · 5m · 3h · 2d · 4w. */
+function notifyAgo(ts: number): string {
+  const s = Math.max(0, Math.floor((Date.now() - ts) / 1000))
+  if (s < 5) return 'now'
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60); if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60); if (h < 24) return `${h}h`
+  const d = Math.floor(h / 24); if (d < 7) return `${d}d`
+  return `${Math.floor(d / 7)}w`
+}
+
+/** A short, self-contained chime for a new toast (WebAudio — no asset). Best-effort; silent if the
+ *  browser blocks audio before a user gesture. */
+function chimeOnce(): void {
+  try {
+    const AC = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+    if (!AC) return
+    const ctx = new AC()
+    const o = ctx.createOscillator(); const g = ctx.createGain()
+    o.connect(g); g.connect(ctx.destination)
+    o.type = 'sine'; o.frequency.value = 880
+    g.gain.setValueAtTime(0.0001, ctx.currentTime)
+    g.gain.exponentialRampToValueAtTime(0.12, ctx.currentTime + 0.02)
+    g.gain.exponentialRampToValueAtTime(0.0001, ctx.currentTime + 0.32)
+    o.start(); o.stop(ctx.currentTime + 0.34)
+    o.onended = () => { try { void ctx.close() } catch { /* already closed */ } }
+  } catch { /* audio unavailable */ }
+}
+
+/** One toast card — pops in bottom-right, auto-dismisses after 6s, click to open the session. */
+function ToastCard({ toast, onOpen, onDismiss }: { toast: ToastItem; onOpen: (m: Msg) => void; onDismiss: (key: string) => void }) {
+  useEffect(() => { const t = setTimeout(() => onDismiss(toast.key), 6000); return () => clearTimeout(t) }, [toast.key])
+  const meta = NOTIFY_META[toast.kind]
+  const Icon = meta.icon
+  return (
+    <div
+      className="pointer-events-auto flex w-80 items-start gap-3 rounded-lg border bg-background p-3 shadow-lg animate-in slide-in-from-bottom-2 fade-in"
+      role="status"
+    >
+      <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${meta.tone}`} />
+      <button className="min-w-0 flex-1 text-left" onClick={() => { onOpen(toast.m); onDismiss(toast.key) }}>
+        <p className="truncate text-sm font-medium">{toast.m.sessionTitle || toast.m.title}</p>
+        <p className="truncate text-xs text-muted-foreground">{meta.label} · {toast.m.agent}</p>
+      </button>
+      <button className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted" title="dismiss" onClick={() => onDismiss(toast.key)}>
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  )
+}
+
+/** The fixed toast stack (bottom-right). Rendered once at the app root. */
+function ToastHost({ toasts, onOpen, onDismiss }: { toasts: ToastItem[]; onOpen: (m: Msg) => void; onDismiss: (key: string) => void }) {
+  if (!toasts.length) return null
+  return (
+    <div className="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-2">
+      {toasts.map((t) => <ToastCard key={t.key} toast={t} onOpen={onOpen} onDismiss={onDismiss} />)}
+    </div>
+  )
+}
+
+/** The header notification bell: a count badge + a dropdown of recent notifications, plus a per-member
+ *  settings panel. Reuses the already-polled `messages` (via `items`), so it adds no new request cost. */
+function NotificationsBell({ items, unread, prefs, onOpen, onMarkAllRead, onSavePrefs }: {
+  items: NotifyItem[]
+  unread: number
+  prefs: NotificationPrefs
+  onOpen: (m: Msg) => void
+  onMarkAllRead: () => void
+  onSavePrefs: (p: NotificationPrefs) => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [showPrefs, setShowPrefs] = useState(false)
+  const recent = items.slice(0, 12)
+  const toggleEvent = (k: NotifyKind) => onSavePrefs({ ...prefs, events: { ...prefs.events, [k]: !prefs.events[k] } })
+  return (
+    <div className="relative">
+      <button
+        className="relative rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground"
+        title="Notifications"
+        onClick={() => { setOpen((o) => !o); setShowPrefs(false) }}
+      >
+        <Bell className="h-5 w-5" />
+        {unread > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-red-500 px-1 text-[10px] font-semibold leading-none text-white">
+            {unread > 99 ? '99+' : unread}
+          </span>
+        )}
+      </button>
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div className="absolute right-0 z-50 mt-2 w-96 max-w-[calc(100vw-2rem)] overflow-hidden rounded-lg border bg-background shadow-xl">
+            <div className="flex items-center justify-between border-b px-3 py-2">
+              <span className="text-sm font-semibold">Notifications</span>
+              <div className="flex items-center gap-1">
+                {unread > 0 && (
+                  <button className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-muted hover:text-foreground" onClick={onMarkAllRead}>
+                    Mark all read
+                  </button>
+                )}
+                <button className={`rounded p-1 hover:bg-muted ${showPrefs ? 'text-foreground' : 'text-muted-foreground'}`} title="Notification settings" onClick={() => setShowPrefs((s) => !s)}>
+                  <Cog className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            </div>
+            {showPrefs ? (
+              <div className="space-y-2 p-3 text-sm">
+                <p className="text-xs font-medium text-muted-foreground">Notify me about</p>
+                {(Object.keys(NOTIFY_META) as NotifyKind[]).map((k) => (
+                  <label key={k} className="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" checked={prefs.events[k]} onChange={() => toggleEvent(k)} />
+                    <span>{NOTIFY_META[k].label}</span>
+                  </label>
+                ))}
+                <div className="my-1 border-t" />
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input type="checkbox" checked={prefs.toasts} onChange={() => onSavePrefs({ ...prefs, toasts: !prefs.toasts })} />
+                  <span>Show pop-in toasts</span>
+                </label>
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input type="checkbox" checked={prefs.sound} onChange={() => onSavePrefs({ ...prefs, sound: !prefs.sound })} />
+                  <span>Play a sound</span>
+                </label>
+                <label className="flex cursor-pointer items-center gap-2">
+                  <input type="checkbox" checked={prefs.dm} onChange={() => onSavePrefs({ ...prefs, dm: !prefs.dm })} />
+                  <span>Also DM me on Slack/Discord</span>
+                </label>
+              </div>
+            ) : recent.length === 0 ? (
+              <div className="px-3 py-8 text-center text-sm text-muted-foreground">You're all caught up.</div>
+            ) : (
+              <ul className="max-h-96 overflow-y-auto">
+                {recent.map(({ m, kind, unread: un }) => {
+                  const meta = NOTIFY_META[kind]
+                  const Icon = meta.icon
+                  return (
+                    <li key={m.id}>
+                      <button
+                        className={`flex w-full items-start gap-3 border-b px-3 py-2 text-left last:border-b-0 hover:bg-muted ${un ? 'bg-muted/40' : ''}`}
+                        onClick={() => { onOpen(m); setOpen(false) }}
+                      >
+                        <Icon className={`mt-0.5 h-4 w-4 shrink-0 ${meta.tone}`} />
+                        <span className="min-w-0 flex-1">
+                          <span className="flex items-center justify-between gap-2">
+                            <span className="truncate text-sm font-medium">{m.sessionTitle || m.title}</span>
+                            <span className="shrink-0 text-[11px] text-muted-foreground">{notifyAgo(m.createdAt)}</span>
+                          </span>
+                          <span className="block truncate text-xs text-muted-foreground">{meta.label} · {m.agent}</span>
+                        </span>
+                        {un && <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-indigo-500" />}
+                      </button>
+                    </li>
+                  )
+                })}
+              </ul>
+            )}
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -407,6 +407,22 @@ export interface Msg {
   createdAt: number
 }
 
+/** Per-member notification preferences (mirrors src/types.ts NotificationPrefs). Which session events
+ *  ping ME in the console bell + toast, and whether they also chime / DM me on Slack/Discord. */
+export interface NotificationPrefs {
+  events: { completed: boolean; waiting: boolean; crashed: boolean; approval: boolean; question: boolean }
+  toasts: boolean
+  sound: boolean
+  dm: boolean
+}
+
+export const DEFAULT_NOTIFICATION_PREFS: NotificationPrefs = {
+  events: { completed: true, waiting: true, crashed: true, approval: true, question: true },
+  toasts: true,
+  sound: false,
+  dm: false,
+}
+
 export type ExecMode = 'interactive' | 'headless'
 export interface Automation {
   id: string
@@ -871,6 +887,9 @@ export const api = {
   dismissAllMessages: (scope: 'mine' | 'all' = 'mine') => call<{ ok: boolean; dismissed?: number; error?: string }>('POST', `/api/messages/dismiss-all${scope === 'all' ? '?scope=all' : ''}`),
   markRead: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/messages/${id}/read`),
   markAllRead: (scope: 'mine' | 'all' = 'mine') => call<{ ok: boolean; read?: number; error?: string }>('POST', `/api/messages/read-all${scope === 'all' ? '?scope=all' : ''}`),
+  /** This member's own notification preferences (bell/toast/sound/DM + which event kinds). */
+  notificationPrefs: () => call<NotificationPrefs>('GET', '/api/me/prefs'),
+  saveNotificationPrefs: (prefs: NotificationPrefs) => call<NotificationPrefs>('PUT', '/api/me/prefs', prefs),
 
   team: () => call<TeamResp>('GET', '/api/team'),
   audit: (f: { session?: string; type?: string; principal?: string; limit?: number } = {}) => {


### PR DESCRIPTION
## What

In-app notifications for session state changes — a Facebook-chat-style **bell + toasts** in the web console, plus per-member notification settings. Closes the gap where a session finishing, crashing, or waiting on you was easy to miss.

Researched Claude Code's hooks first: the **`Notification`** hook (`notification_type` ∈ `idle_prompt`/`permission_prompt`/`agent_needs_input`/`agent_completed`) plus the existing `markEnded`/crash-sweep signals give us everything needed — no new hook wiring, the `notify-hook.sh` → `/api/notify` path already existed.

## Triggers
- **Waiting** — permission prompt / idle / `agent_needs_input` (widened `notify()`).
- **Complete** — `report()`, **plus a "Finished" fallback** in `markEnded()` so runs that exit without reporting no longer vanish silently.
- **Crashed** — the liveness sweep now posts a "Crashed" card.
- **Approvals & questions** — folded into the same bell (already existed as cards).

## Surfaces
- **Header bell**: unread count + dropdown of recent notifications (click → jump to the session or Inbox), a **Mark all read**, and a **settings gear**.
- **Toasts**: bottom-right pop-ins for freshly-arrived items (seeded on first load so no backlog flood), with an optional WebAudio chime.
- **Browser-tab 🔔 badge**: now reflects the full unread count (was waiting-only).
- **Slack/Discord DM**: reuses the existing `deliverDM`/identity-map plumbing via a new `SessionEventNotice` sink — **opt-in** per member (`dm` pref), since the bell already covers it. Approvals/questions keep their always-on DMs.

## Per-member settings
New `member_prefs` table + `TeamStore.notificationPrefs/setNotificationPrefs`, exposed at `GET`/`PUT /api/me/prefs` (per-person, **not** admin-gated — Settings is company-scoped so prefs live in the bell's gear instead). Choose which events ping you, toggle toasts/sound, opt into DMs. Sanitized over defaults so a partial/old row never drops a field.

## Verification
- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` → **68/68**.
- Isolated in-process smoke (scratch `AGENT_OS_HOME`): prefs round-trip + junk-drop, `agent_needs_input` → waiting card + notifier, `markEnded` → "Finished" fallback (outcome `ended`) + status `done` + notifier, waiting card cleared on end, noise kinds (`authentication`) post nothing.

## Files
`src/types.ts`, `src/state/db.ts`, `src/governance/team.ts`, `src/terminal.ts`, `src/tenant-registry.ts`, `src/server.ts`, `terminal/notify-hook.sh`, `web/src/App.tsx`, `web/src/lib/api.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)