### PR TITLE
feat(goals): strategy agent — the outbound edge (goal → work) (v0.114.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.114.0] — 2026-07-11
+### Added
+- **Goals — the strategy agent ("goal steward"): the outbound edge (goal → work).** Goals could be linked
+  to and measured (Slices 1–2), but nothing turned a goal *into* work — you had to hand-file and hand-link
+  every task. Now a goal can plan itself. See `docs/goals-plan.md`.
+  - **"Plan this goal"** on the Goal page (owner/admin) spawns a governed, headless **`strategist`** agent
+    (`src/edge/strategist.ts`, provisioned on first use like the consolidation gardener; `POST
+    /api/goals/:id/plan`, audited `goal.planned`). It reads the goal + its current progress + already-linked
+    tasks, works out the GAP to the target, and **files** the tasks needed to close it — linked to the goal,
+    assigned to the right specialists (`list_agents`). **File-only**: it produces a reviewable plan that
+    lands in the goal's linked-tasks section; a human dispatches. It proposes sub-goals (`goal_propose`) but
+    never activates them, and is idempotent on re-run (fills gaps, doesn't duplicate).
+  - **`goalId` inheritance** — a sub-task (`task_create({ parentId })`) now inherits its parent's goal when
+    it doesn't name one, so an umbrella + its sub-tasks all roll up to the same goal automatically.
+  - **Leaf-progress** — `GoalStore.progress()` now counts only *leaf* linked tasks (a task with sub-tasks is
+    a grouping), so an umbrella no longer inflates or lags the progress bar.
+  - Deliberately **decoupled from Dreaming**: today's self-learning pass is a deterministic tally aggregator
+    with no goal awareness, so it can't act as a "this goal is stalled → plan it" sensor. The strategist is
+    human-triggered and stands alone; a deterministic goal-stall auto-trigger is a separate later phase.
+
 ## [0.113.0] — 2026-07-11
 ### Changed
 - **Take-over is now lossless — unattended runs are an attachable TUI, not `claude -p`.** Automation/cron/

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -34,7 +34,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `list_capabilities` | `GET /api/agent/policy` | policy preview | R | |
 | `policy_check` | `POST /api/agent/policy/check` | policy preview | R | dry-run, no side effects |
 | `directory_lookup` | `GET /api/agent/directory` | `TeamStore` | R | people + their chat identities |
-| `task_create` | `POST /api/tasks/create` | `TaskStore.create` | W | files a unit of work; author `agent:<id>`; owner = run-as (delegation passthrough); `mode` headless/interactive for the dispatched run; optional `due` (ISO date) soft deadline; optional `goalId` (link to a strategic goal) + single-line `criteria` (drives a headless dispatch under a `/goal` convergence condition — Slice 2) |
+| `task_create` | `POST /api/tasks/create` | `TaskStore.create` | W | files a unit of work; author `agent:<id>`; owner = run-as (delegation passthrough); `mode` headless/interactive for the dispatched run; optional `due` (ISO date) soft deadline; optional `goalId` (link to a strategic goal; a sub-task inherits its parent's `goalId` when omitted) + single-line `criteria` (drives a headless dispatch under a `/goal` convergence condition — Slice 2) |
 | `task_list` | `GET /api/tasks/list` | `TaskStore.list` | R | `assignee:"me"` → self; board query/FTS |
 | `task_get` | `GET /api/tasks/get` | `TaskStore.withEvents` | R | task + full activity timeline |
 | `task_claim` | `POST /api/tasks/claim` | `TaskStore.claim` | W | atomic take (→ doing); loses if already claimed |

--- a/docs/goals-plan.md
+++ b/docs/goals-plan.md
@@ -197,6 +197,40 @@ session is alive; convergence there stays manual).
 
 ---
 
+## Slice 3 — the strategy agent (the outbound edge)  ✅ Phase 1 shipped (v0.114.0)
+
+Slices 1–2 gave goals an **inbound** edge only: work links *up* to a goal and progress flows up. Nothing
+flowed *down* — you had to hand-file and hand-link every task, which is why goals felt like a place work
+reports to rather than something you *use*. Slice 3 adds the **outbound** edge: a goal can plan itself.
+
+**The insight:** this is a *role*, not plumbing — a **strategy agent** ("goal steward") whose job is
+goal → work. And it's mostly an agent definition, not engine code: it reuses `goal_get`, `list_agents`,
+`task_create`, and the consolidation gardener's "provision a governed headless agent + spawn it" mold.
+
+**Phase 1 (shipped):**
+- **`Strategist`** (`src/edge/strategist.ts`) — provisions a headless `strategist` agent on first use and
+  spawns it against a goal. Triggered by **"Plan this goal"** on the Goal page → `POST /api/goals/:id/plan`
+  (owner/admin; audited `goal.planned`), run-as the human who clicked.
+- Its contract (CLAUDE.md): read the goal + progress + already-linked tasks → identify the GAP → **file**
+  the tasks to close it, linked to the goal, assigned to specialists. **File-only** (a human dispatches);
+  proposes sub-goals via `goal_propose` but never activates them; idempotent on re-run.
+- Two supporting rules so its plans measure cleanly: **`goalId` inheritance** (a sub-task inherits its
+  parent's goal) and **leaf-progress** (`GoalStore.progress()` counts only leaf linked tasks, so an
+  umbrella grouping doesn't inflate the bar).
+
+**Decoupled from Dreaming — deliberately.** An assessment of the self-learning subsystem found Dreaming is
+a *deterministic tally aggregator, dormant by default, with zero goal awareness* — it cannot act as an
+intelligent "this goal is stalled → plan it" sensor. So the strategist is **human-triggered and stands
+alone**. The only reusable asset borrowed from that subsystem is the spawn-a-governed-agent scaffolding.
+
+**Phase 2 (deferred):** a **deterministic goal-stall auto-trigger** — on the scheduler tick, an active
+goal that is overdue / flat-progress / idle spawns the strategist (guarded, reusing the `dispatchTask`
+mold). Net-new and cheap (the Goals plane already computes `progress()` + `dueAt`); explicitly NOT a
+dependency on Dreaming's stub intelligence.
+
+**Phase 3 (later, separate concern):** if/when Dreaming gains real LLM reasoning, fold stall-judgment into
+it — a Dreaming upgrade tracked against its 🟡 Partial grade, not a blocker for goals.
+
 ## Out of scope (both slices)
 
 - **Agent-authored strategy with real authority.** Humans own goals + acceptance criteria; agents `goal_list`/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.113.0",
+      "version": "0.114.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.113.0",
+  "version": "0.114.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/strategist.ts
+++ b/src/edge/strategist.ts
@@ -1,0 +1,141 @@
+/**
+ * The **goal strategist** — the outbound edge of the Goals plane (goal → work).
+ *
+ * Where a goal is a passive, human-owned objective that work links UP to, the strategist is the actor
+ * that turns a goal DOWN into a concrete, reviewable plan of tasks. Triggered from the Goal page ("Plan
+ * this goal"), it spawns a governed headless claude-code agent that reads the goal + its current progress,
+ * figures out the gap to the target, and files the tasks needed to close it (linked to the goal, assigned
+ * to specialists) — then STOPS for a human to review and dispatch. File-only by design: it shapes work,
+ * it never runs it.
+ *
+ * Deliberately NOT wired to Dreaming: Dreaming today is a deterministic tally aggregator with no goal
+ * awareness, so it can't act as an intelligent "this goal is stalled → plan it" sensor. The strategist
+ * stands alone, human-triggered. (A deterministic goal-stall auto-trigger is a separate later phase.)
+ *
+ * Reuses the consolidation gardener's proven mold: provision a governed agent on first use, spawn it
+ * headless, audit the kickoff — no in-process LLM client, all governance/audit for free.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AgentOS } from '../kernel';
+import type { TerminalManager } from '../terminal';
+import type { AgentManifest, Goal, Task } from '../types';
+
+export const STRATEGIST_ID = 'strategist';
+const AGENT_ID = STRATEGIST_ID;
+
+export interface PlanResult {
+  spawned: boolean;
+  reason?: string;
+  sessionId?: string;
+}
+
+export class Strategist {
+  constructor(private readonly os: AgentOS, private readonly tm: TerminalManager) {}
+
+  /**
+   * Spawn the strategist to turn one goal into a reviewable task plan. `by` = provenance principal (the
+   * human who triggered it); `runAs` = the identity the session acts as (same human, so its filed tasks
+   * and any specialist it later delegates to ladder back to an accountable person). File-only — the run
+   * files tasks but never dispatches; a human reviews the plan under the goal and dispatches.
+   */
+  async plan(goalId: string, by: string, runAs?: string): Promise<PlanResult> {
+    const goal = this.os.goals.get(goalId);
+    if (!goal) return { spawned: false, reason: 'goal not found' };
+    if (goal.status !== 'active' && goal.status !== 'draft') {
+      return { spawned: false, reason: `goal is ${goal.status} — only an active or draft goal can be planned` };
+    }
+    this.ensureAgent();
+    const existing = this.os.tasks.tasksForGoal(goalId);
+    const task = this.buildTask(goal, existing);
+    const session = this.tm.createSession(AGENT_ID, `Plan goal — ${goal.title}`, task, `goal:${goalId}`, true /* headless */, undefined, undefined, runAs);
+    this.os.audit.append({
+      ts: Date.now(), runId: session.id, tenant: this.os.tenant, principal: by,
+      type: 'goal.planned', data: { goalId, title: goal.title, sessionId: session.id, existingTasks: existing.length },
+    });
+    return { spawned: true, sessionId: session.id };
+  }
+
+  /** The opening prompt: the goal, its current progress, and the tasks already linked (so a re-run only
+   *  fills gaps). The full method lives in the agent's CLAUDE.md. */
+  private buildTask(goal: Goal, existing: Task[]): string {
+    const prog = this.os.goals.progress(goal.id);
+    const existingList = existing.length
+      ? existing.map((t) => `  - [${t.status}] ${t.id} — ${t.title}${t.assignee ? ` (→ ${t.assignee})` : ''}`).join('\n')
+      : '  (none yet)';
+    const lines: string[] = [
+      'You are planning the work for the GOAL below. Turn it into a concrete set of tasks that will move it',
+      'to its target, then stop for a human to review and dispatch.',
+      '',
+      `GOAL ${goal.id}: ${goal.title}`,
+    ];
+    if (goal.target) lines.push(`Target: ${goal.target}`);
+    if (goal.body) lines.push('', goal.body);
+    lines.push(
+      '',
+      `Current progress: ${prog.percent}% (${prog.done}/${prog.total} linked tasks done).`,
+      'Tasks already linked to this goal:',
+      existingList,
+      '',
+      `Now follow your CLAUDE.md method: goal_get "${goal.id}" for the full picture, identify the GAP to the`,
+      `target, and file the tasks needed to close it with task_create({ goalId: "${goal.id}", ... }),`,
+      'assigning each to the right specialist (list_agents). Do NOT duplicate a task already linked above,',
+      'and do NOT set autoDispatch — leave the plan for a human to review and dispatch. Finish with report.',
+    );
+    return lines.join('\n');
+  }
+
+  /** Provision the strategist agent into the data home on first use (folder + manifest + CLAUDE.md), then
+   *  register it live so createSession resolves a real claude-code runtime. Idempotent. Mirrors the
+   *  consolidation gardener's ensureAgent. */
+  private ensureAgent(): void {
+    if (this.os.agents.get(AGENT_ID)?.dir) return;
+    const base = this.os.paths?.userAgents ?? path.join(process.cwd(), 'data', 'agents');
+    const dir = path.join(base, AGENT_ID);
+    fs.mkdirSync(dir, { recursive: true });
+    const manifestPath = path.join(dir, 'agent.json');
+    if (!fs.existsSync(manifestPath)) fs.writeFileSync(manifestPath, JSON.stringify(MANIFEST, null, 2));
+    if (!fs.existsSync(path.join(dir, 'CLAUDE.md'))) fs.writeFileSync(path.join(dir, 'CLAUDE.md'), CLAUDE_MD);
+    this.os.registerAgent({ ...MANIFEST, dir });
+  }
+}
+
+const MANIFEST: AgentManifest = {
+  id: AGENT_ID,
+  version: '1.0.0',
+  description: 'Goal strategist — turns a company goal into a reviewable plan of tasks for the fleet.',
+  category: 'System',
+  principal: 'svc-strategist',
+  policyContext: 'default@v3',
+  runtime: 'claude-code',
+  model: 'claude-opus-4-8',
+  budget: { usdCap: 1, tokenCap: 300_000, wallClockMs: 900_000 },
+};
+
+const CLAUDE_MD = `# Goal strategist
+
+You are Agent OS's **goal strategist**. You are handed one company GOAL and your job is to turn it into a
+concrete, reviewable PLAN of work — the tasks needed to move it to its target — then stop for a human to
+review and dispatch. You are the bridge from a strategic objective to actual work on the board.
+
+## Method
+1. **Understand the goal.** \`goal_get\` the goal you were given: its target, its current progress, and the
+   tasks ALREADY linked to it. Work out what is done, what is in flight, and — most importantly — what is
+   still MISSING or BLOCKED to reach the target. Plan the GAP, not the whole world.
+2. **Know your fleet.** \`list_agents\` to see which specialists you can hand work to. Assign each task to
+   the agent best suited to it rather than leaving it unassigned (an unassigned task just sits there).
+3. **File the gap as tasks.** For each concrete piece of work, \`task_create({ title, body, goalId:
+   "<this goal>", assignee: "agent:<specialist>" })\`, each well-scoped with enough detail to act on. Use
+   \`parentId\` to nest genuine sub-tasks under a larger one — a sub-task inherits the goal automatically.
+   - **Do NOT set autoDispatch.** You produce a PLAN; a human reviews it under the goal and dispatches.
+   - **Do NOT duplicate** a task already linked to the goal — you may be re-run as the goal evolves, so
+     only fill the gaps; skip work that already exists.
+   - Give a task a single-line \`criteria\` when it has a clear, checkable "done" condition — a later
+     headless dispatch will then converge under that condition.
+4. **Propose strategy, don't set it.** If the goal genuinely needs sub-objectives, \`goal_propose\` them for
+   a human to activate — never create or activate goals yourself. Tasks are yours to file; strategy is the
+   human's to own.
+5. **Finish with \`report\`** — outcome + a one-line summary of the plan you filed (e.g. "filed 6 tasks
+   across engineer + designer to close the gap on 'Grow signups'"). Note anything you could not plan.
+
+You act on the company's behalf. You never dispatch or run the work — you shape it and hand it back.`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
 import { DreamingEngine } from './edge/dreaming';
 import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
+import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
 import { CATALOG, redact } from './connectors/connectors';
@@ -2031,6 +2032,17 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   // steering-wheel concern). Auto-apply + audited; the append-only goal_events log is the safety net.
   const goalId = p.match(/^\/api\/goals\/([\w-]+)$/);
   const goalComment = p.match(/^\/api\/goals\/([\w-]+)\/comment$/);
+  const goalPlan = p.match(/^\/api\/goals\/([\w-]+)\/plan$/);
+  // "Plan this goal" — spawn the strategist (a governed headless agent) to turn the goal into a reviewable
+  // task plan linked to it. File-only: it files tasks, a human dispatches. Owner/admin, like goal edits.
+  if (goalPlan && method === 'POST') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const goal = os.goals.get(goalPlan[1]);
+    if (!goal) return sendJson(res, 404, { error: 'goal not found' });
+    const r = await new Strategist(os, tm).plan(goal.id, me.email, me.id);
+    if (r.spawned) os.audit.append({ ts: Date.now(), runId: r.sessionId ?? '-', tenant: os.tenant, principal: me.email, type: 'goal.plan.requested', data: { goalId: goal.id } });
+    return sendJson(res, r.spawned ? 200 : 409, r.spawned ? { ok: true, sessionId: r.sessionId } : { ok: false, error: r.reason });
+  }
   if (method === 'GET' && p === '/api/goals') {
     const goals = os.goals.list({ tenant: os.tenant, status: (url.searchParams.get('status') as GoalStatus) || undefined, query: url.searchParams.get('q') || undefined, limit: 500 });
     // Derived progress per goal (from its linked tasks) for the page's progress bars — keyed by id.

--- a/src/state/goals.ts
+++ b/src/state/goals.ts
@@ -199,8 +199,11 @@ export class GoalStore {
    */
   progress(goalId: string): GoalProgress {
     const byStatus = { todo: 0, doing: 0, blocked: 0, done: 0, cancelled: 0 } as Record<TaskStatus, number>;
+    // Count LEAF linked tasks only — a task that has sub-tasks is a grouping/umbrella (its children carry
+    // the real work), so counting both it and its children would double-count and lag the bar.
     for (const r of this.db
-      .prepare('SELECT status, COUNT(*) AS n FROM tasks WHERE goal_id = ? GROUP BY status')
+      .prepare(`SELECT status, COUNT(*) AS n FROM tasks t WHERE t.goal_id = ?
+                 AND NOT EXISTS (SELECT 1 FROM tasks c WHERE c.parent_id = t.id) GROUP BY status`)
       .all<{ status: TaskStatus; n: number }>(goalId)) {
       if (r.status in byStatus) byStatus[r.status] = r.n;
     }

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -81,6 +81,13 @@ export class TaskStore {
     const labels = input.labels ?? [];
     const priority = clampPriority(input.priority);
     const mode = input.mode === 'interactive' ? 'interactive' : 'headless';
+    // A sub-task inherits its parent's goal when it doesn't name one — so a strategist's umbrella + its
+    // sub-tasks all roll up to the same goal without the agent stamping goalId on every child.
+    let goalId = input.goalId ?? null;
+    if (!goalId && input.parentId) {
+      const parent = this.db.prepare('SELECT goal_id FROM tasks WHERE id = ?').get<{ goal_id: string | null }>(input.parentId);
+      goalId = parent?.goal_id ?? null;
+    }
     this.db
       .prepare(`INSERT INTO tasks
         (id, tenant, title, body, status, priority, labels, assignee, owner, parent_id, mode, auto_dispatch,
@@ -89,11 +96,11 @@ export class TaskStore {
       .run(
         id, input.tenant, input.title.trim() || 'Untitled task', input.body ?? '', priority,
         JSON.stringify(labels), input.assignee ?? null, input.owner ?? null, input.parentId ?? null,
-        mode, input.autoDispatch ? 1 : 0, input.goalId ?? null, oneLine(input.criteria),
+        mode, input.autoDispatch ? 1 : 0, goalId, oneLine(input.criteria),
         input.dueAt ?? null, input.createdBy, now, now, input.createdBy,
       );
-    if (input.goalId && this.db.prepare('SELECT 1 FROM goals WHERE id = ?').get(input.goalId)) {
-      this.addEvent(id, 'link', `goal:${input.goalId}`, input.createdBy);
+    if (goalId && this.db.prepare('SELECT 1 FROM goals WHERE id = ?').get(goalId)) {
+      this.addEvent(id, 'link', `goal:${goalId}`, input.createdBy);
     }
     this.addEvent(id, 'status', '→todo', input.createdBy);
     if (input.parentId && this.get(input.parentId)) this.addEvent(input.parentId, 'link', `task:${id}`, input.createdBy);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3792,6 +3792,7 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
   const [eTitle, setETitle] = useState('')
   const [eBody, setEBody] = useState('')
   const [confirmDel, setConfirmDel] = useState(false)
+  const [planNote, setPlanNote] = useState('') // inline confirmation for "Plan this goal"
 
   const isAdmin = me.role === 'owner' || me.role === 'admin'
   const nameOf = (id?: string) => principalLabel(id, members)
@@ -3819,7 +3820,7 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
     if (editing) return // don't overwrite an in-progress edit on a background refresh
     api.goal(selId).then((r) => { if (r.goal) setDetail({ goal: r.goal, events: r.events ?? [], tasks: r.tasks ?? [], progress: r.progress }) })
   }, [selId, goals, editing])
-  useEffect(() => { setEditing(false); setConfirmDel(false) }, [selId]) // fresh drawer per selection
+  useEffect(() => { setEditing(false); setConfirmDel(false); setPlanNote('') }, [selId]) // fresh drawer per selection
 
   const visible = goals ?? []
 
@@ -3833,6 +3834,16 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
   }
   const patch = async (id: string, b: Parameters<typeof api.patchGoal>[1]) => { setBusy(true); await api.patchGoal(id, b); await load(); await refreshDetail(id); setBusy(false) }
   const remove = async (id: string) => { setBusy(true); await api.deleteGoal(id); closeGoal(); setConfirmDel(false); await load(); setBusy(false) }
+  // Kick off the strategist agent to draft a plan of tasks under this goal. Files a reviewable
+  // plan (no dispatch) — refresh the detail shortly after so newly-filed tasks show up.
+  const plan = async (id: string) => {
+    setPlanNote(''); setHint(''); setBusy(true)
+    const r = await api.planGoal(id)
+    setBusy(false)
+    if (!r.ok) return setHint('⚠ ' + (r.error || 'Could not start the strategist.'))
+    setPlanNote('Strategist is drafting a plan — tasks will appear under this goal shortly.')
+    setTimeout(() => refreshDetail(id), 6000)
+  }
   const startEdit = () => { if (!detail) return; setETitle(detail.goal.title); setEBody(detail.goal.body); setEditing(true) }
   const saveEdit = async () => {
     if (!detail) return
@@ -4001,8 +4012,16 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
                 <div>
                   <div className="mb-2 flex items-center justify-between gap-2">
                     <span className="text-[11px] font-medium uppercase tracking-wider text-muted-foreground">Linked tasks{detail.tasks.length ? ` · ${detail.tasks.length}` : ''}</span>
-                    {detail.progress && detail.progress.total > 0 && <span className="text-[11px] text-muted-foreground">{detail.progress.percent}% · {detail.progress.done}/{detail.progress.total} done</span>}
+                    <div className="flex items-center gap-2">
+                      {detail.progress && detail.progress.total > 0 && <span className="text-[11px] text-muted-foreground">{detail.progress.percent}% · {detail.progress.done}/{detail.progress.total} done</span>}
+                      {isAdmin && (detail.goal.status === 'active' || detail.goal.status === 'draft') && (
+                        <Button size="sm" variant="outline" className="h-7" disabled={busy} onClick={() => plan(detail.goal.id)}>
+                          <Wand2 className="mr-1 h-3.5 w-3.5" />Plan this goal
+                        </Button>
+                      )}
+                    </div>
                   </div>
+                  {planNote && <div className="mb-2 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-2.5 py-1.5 text-xs text-emerald-700 dark:text-emerald-400">{planNote}</div>}
                   {detail.progress && detail.progress.total > 0 && <GoalProgressBar p={detail.progress} className="mb-2" />}
                   <div className="max-h-56 space-y-1.5 overflow-y-auto pr-1">
                     {detail.tasks.length === 0 && <div className="text-xs text-muted-foreground">No tasks linked yet — set this goal on a task to ground work under it.</div>}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -949,6 +949,7 @@ export const api = {
   patchGoal: (id: string, b: { title?: string; body?: string; status?: GoalStatus; target?: string | null; owner?: string | null; parentId?: string | null; labels?: string[]; dueAt?: number | null; note?: string }) => call<{ ok: boolean; goal?: Goal; error?: string }>('PATCH', `/api/goals/${id}`, b),
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
+  planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
   dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),


### PR DESCRIPTION
## Goals — the strategy agent ("goal steward")

Slices 1–2 gave goals an **inbound** edge (work links up, progress flows up). Nothing flowed *down* — you hand-filed and hand-linked every task. This adds the **outbound** edge: a goal can plan itself. Design + the Dreaming-decoupling rationale in `docs/goals-plan.md` §"Slice 3".

### What's in
- **"Plan this goal"** (Goal page, owner/admin) → `POST /api/goals/:id/plan` spawns a governed, headless **`strategist`** agent (`src/edge/strategist.ts`, provisioned on first use exactly like the consolidation gardener; audited `goal.planned`). It reads the goal + current progress + already-linked tasks, works out the **gap** to the target, and **files** the tasks to close it — linked to the goal, assigned to specialists (`list_agents`).
- **File-only** by design: it produces a reviewable plan in the goal's linked-tasks section; a human dispatches. It **proposes** sub-goals (`goal_propose`) but never activates them, and is **idempotent** on re-run (fills gaps, no duplicates).
- **`goalId` inheritance** — a sub-task inherits its parent's goal when it doesn't name one (umbrella rollup).
- **Leaf-progress** — `GoalStore.progress()` counts only *leaf* linked tasks, so an umbrella grouping doesn't inflate/lag the bar.
- **"Plan this goal" button** on the Goal detail (web).

### Decoupled from Dreaming — deliberately
An assessment of the self-learning subsystem found Dreaming is a **deterministic tally aggregator, dormant by default, with zero goal awareness** — it can't act as a "this goal is stalled → plan it" sensor. So the strategist is **human-triggered and stands alone**; the only thing reused from that subsystem is the spawn-a-governed-agent scaffolding. A deterministic goal-stall **auto-trigger** is a deferred **Phase 2** (not a Dreaming dependency).

### Verification
- `npm run typecheck` clean · backend + web builds clean (incl. post-merge with main)
- `npm run test:governance` → **68/68**
- In-memory smoke test of the two rules: `goalId` inheritance (explicit wins over inherited) + leaf-progress (umbrella excluded → 50%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)