### PR TITLE
fix(skills): same-session delivery reaches console interactive sessions (v0.115.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.115.1] — 2026-07-11
+## [0.115.2] — 2026-07-11
+### Fixed
+- **Same-session skill delivery now reaches console-spawned interactive sessions.** Phase 3's
+  `TerminalManager.refreshAgentSkills` filtered on `resident = 1`, but a console-spawned interactive TUI
+  is `headless = 0, resident = 0` (the `resident` flag marks chat-continuity sessions, not console runs) —
+  so approving a skill for an agent with a live interactive session returned `reloaded: 0` and delivered
+  nothing until the next launch. Filter is now `headless = 0` (any live claude REPL we can inject into),
+  which covers both console TUIs and resident chat sessions. Found by dogfooding the request→approve flow
+  with a real `engineer` agent on the live instance.
 ### Added
 - **"Go to session" link after planning a goal.** When "Plan this goal" spawns the strategist, the
   confirmation banner now shows a **Go to session →** link (using the returned `sessionId`) so you can jump

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.115.1",
+      "version": "0.115.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.115.1",
+  "version": "0.115.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1465,12 +1465,15 @@ export class TerminalManager {
 
   /**
    * Phase 3 same-session skill delivery. After a skill is installed for `agent` (an approved
-   * `skill_request`), push it into that agent's LIVE interactive (resident) sessions instead of waiting
-   * for their next launch: re-materialise the library into the agent's watched `.claude/skills` (so the
-   * new skill lands as a folder claude's file-watcher picks up), then inject `/reload-skills` to force a
-   * re-scan + re-surface skill descriptions. Best-effort and non-disruptive to correctness:
-   *  - only resident+running+alive sessions (a headless `claude -p` run has no REPL to inject into and
-   *    exits anyway — it gets the skill on its next run, which is the existing behavior);
+   * `skill_request`), push it into that agent's LIVE interactive sessions instead of waiting for their
+   * next launch: re-materialise the library into the agent's watched `.claude/skills` (so the new skill
+   * lands as a folder claude's file-watcher picks up), then inject `/reload-skills` to force a re-scan +
+   * re-surface skill descriptions. Best-effort and non-disruptive to correctness:
+   *  - only INTERACTIVE (`headless = 0`) running+alive sessions — those have a live claude REPL we can
+   *    send-keys into. This covers both a console-spawned TUI (`resident = 0`) and a chat-continuity
+   *    resident session; a headless `claude -p` run has no REPL and exits anyway, so it gets the skill on
+   *    its next run (the existing behavior). (Filtering on `resident` here was the bug dogfooding caught:
+   *    a console interactive session is `headless = 0, resident = 0`, so it was skipped.)
    *  - the `/reload-skills` inject is gated on `claude` ≥ 2.1.152 — on an older binary we still
    *    re-materialise (the watcher exposes the skill as `/name` next turn), we just skip the forced rescan.
    * Returns how many live sessions were refreshed.
@@ -1479,7 +1482,7 @@ export class TerminalManager {
     const manifest = this.os.agents.get(agent);
     if (!manifest || manifest.runtime !== 'claude-code' || !manifest.dir) return { reloaded: 0 };
     const rows = this.db
-      .prepare(`SELECT id, tmux, run_as, spawned_by FROM term_sessions WHERE agent = ? AND status = 'running' AND resident = 1`)
+      .prepare(`SELECT id, tmux, run_as, spawned_by FROM term_sessions WHERE agent = ? AND status = 'running' AND headless = 0`)
       .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null }>(agent)
       .filter((r) => this.isAlive(r.id));
     if (!rows.length) return { reloaded: 0 };


### PR DESCRIPTION
Phase 3 (`refreshAgentSkills`) filtered `term_sessions` on `resident = 1`, but a console-spawned interactive TUI is `headless = 0, resident = 0` — the `resident` flag marks chat-continuity sessions, not console runs. So approving a skill for an agent with a live interactive session returned `reloaded: 0` and delivered nothing until next launch. Filter is now `headless = 0` (any live claude REPL we can `send-keys` into), covering both console TUIs and resident chat sessions.

**Found by dogfooding** the request→approve flow with a real `engineer` agent on the live instapods instance: it called `skill_find` (incl. the skills.sh community search — 64 hits) + `skill_request` for `design-review`; approving returned `reloaded: 0`. Manually materialising + injecting `/reload-skills` into the live session confirmed the mechanism works and `/design-review` became invocable — isolating the filter as the sole bug.

**Verified:** P3 8/8 (fake session now `resident=0, headless=0` — the exact bug shape), P1 16/16, P2 9/9, governance 68/68, core+web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)