### PR TITLE
feat(web): declutter Automations page — compact cards + kebab menu (v0.116.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.116.0] — 2026-07-11
+### Changed
+- **Automations page redesign — compact, scannable cards.** The old layout put a full-width six-control
+  toolbar (Runs · Run now · mode-select · Disable · Edit · trash) plus three badges on every card, which
+  read as clutter once more than a couple of automations existed. Each automation is now a tight row: the
+  trigger type is a **glyph** (schedule/webhook/Slack/Discord/Composio) instead of a badge, the agent ·
+  trigger-summary · run-mode collapse into one meta line, and the status line shows just **next-in** +
+  **last-fired**. The only always-visible action is **Run now**; everything secondary (Past runs,
+  Enable/Disable, switch run-mode, Edit, Delete) moves into a **kebab (⋯) menu**. Paused automations dim.
+  New reusable `web/src/components/ui/dropdown-menu.tsx` (Base UI `menu`). (`web/src/App.tsx`)
+
 ## [0.115.3] — 2026-07-11
 ### Changed
 - **Landing page reflects what's shipped.** The public `/landing` capability grid gains two cards for

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.115.3",
+  "version": "0.116.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.115.3",
+      "version": "0.116.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.115.3",
+  "version": "0.116.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent } from 'react'
 import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target } from 'lucide-react'
-import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, type LucideIcon } from 'lucide-react'
+import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -11,6 +11,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
 import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
@@ -5056,6 +5057,30 @@ const TRIGGER_ITEMS: Record<string, string> = {
   composio: 'Composio event',
 }
 
+/** The glyph that marks an automation's trigger family — a scannable stand-in for the old `type` badge. */
+function triggerIcon(type: Automation['type']): LucideIcon {
+  switch (type) {
+    case 'cron': return CalendarClock
+    case 'webhook': return Webhook
+    case 'slack': return Hash
+    case 'discord': return MessageSquare
+    case 'once': return Clock
+    default: return Zap
+  }
+}
+/** One-line, human trigger summary for the card's meta row (schedule phrasing, or event + filter scope). */
+function triggerSummary(a: Automation): string {
+  switch (a.type) {
+    case 'cron': return a.schedule ? cronToHuman(a.schedule) : 'Schedule'
+    case 'webhook': return 'Webhook'
+    case 'slack': return `Slack · ${a.filter || 'any message'}`
+    case 'discord': return `Discord · ${a.filter || 'any message'}`
+    case 'composio': return `Composio · ${a.filter || 'any event'}`
+    case 'once': return 'One-shot'
+    default: return a.type
+  }
+}
+
 function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; agents: AgentInfo[]; serverTz?: string; onOpen: (tmux: string, title: string) => void; nav: (r: Route, detail?: string) => void }) {
   const [items, setItems] = useState<Automation[] | null>(null)
   const [busy, setBusy] = useState('')
@@ -5278,80 +5303,95 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
         )}
         {active.length === 0 && !showForm && <div className="text-sm text-muted-foreground">No active automations{spent.length ? ' — only spent one-shot runs remain (below).' : isAdmin ? ' yet — click New automation to create one.' : '.'}</div>}
         <div className="space-y-2">
-          {active.map((a) => (
-            <Card key={a.id}>
-              <CardContent className="flex flex-wrap items-center justify-between gap-3 p-4">
-                <div className="min-w-0">
+          {active.map((a) => {
+            const TrigIcon = triggerIcon(a.type)
+            const canManage = isAdmin && a.canManage !== false
+            return (
+            <Card key={a.id} className={a.enabled ? '' : 'opacity-60'}>
+              <CardContent className="flex items-start gap-3 p-3.5">
+                {/* Trigger glyph — the type badge, promoted to a scannable icon. */}
+                <div className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg ${a.enabled ? 'bg-amber-500/10 text-amber-600' : 'bg-muted text-muted-foreground/50'}`} title={TRIGGER_ITEMS[a.type] ?? a.type}>
+                  <TrigIcon className="h-4 w-4" />
+                </div>
+                {/* Body */}
+                <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
-                    <Zap className={`h-4 w-4 shrink-0 ${a.enabled ? 'text-amber-500' : 'text-muted-foreground/40'}`} />
                     <span className="truncate text-sm font-medium">{a.name}</span>
-                    <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{a.type}</Badge>
-                    <Badge variant="outline" className="px-1.5 py-0 text-[10px]">{a.mode === 'headless' ? 'headless' : 'interactive'}</Badge>
-                    {!a.enabled && <Badge variant="outline" className="px-1.5 py-0 text-[10px]">disabled</Badge>}
+                    {!a.enabled && <Badge variant="outline" className="shrink-0 px-1.5 py-0 text-[10px] font-normal text-muted-foreground">paused</Badge>}
                   </div>
-                  <div className="mt-0.5 text-xs text-muted-foreground">
-                    {a.agentId}
-                    {a.type === 'cron' && a.schedule && <span className="ml-2" title={a.schedule}>{cronToHuman(a.schedule)}</span>}
-                    {(a.type === 'composio' || a.type === 'slack' || a.type === 'discord') && <span className="ml-2 font-mono">{a.filter || 'any event'}</span>}
+                  <div className="mt-0.5 flex min-w-0 flex-wrap items-center gap-x-1.5 text-xs text-muted-foreground">
+                    <AgentIcon icon={agents.find((ag) => ag.id === a.agentId)?.icon} className="h-3 w-3 shrink-0" />
+                    <span className="truncate font-medium text-foreground/75">{a.agentId}</span>
+                    <span className="text-muted-foreground/40">·</span>
+                    <span className="truncate" title={a.type === 'cron' ? a.schedule ?? undefined : undefined}>{triggerSummary(a)}</span>
+                    <span className="text-muted-foreground/40">·</span>
+                    <span>{a.mode}</span>
                   </div>
-                  <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5 text-[11px] text-muted-foreground">
+                  <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-muted-foreground">
                     {a.nextRunAt ? (
                       <span className="inline-flex items-center gap-1 text-emerald-600" title={serverTz ? `${fmtInServerTz(a.nextRunAt, serverTz)} (${serverTz})` : new Date(a.nextRunAt).toLocaleString()}>
-                        <Clock className="h-3 w-3" />next in {timeUntil(a.nextRunAt)} · {fmtInServerTz(a.nextRunAt, serverTz)}{serverTz ? ` (${serverTz})` : ''}
+                        <Clock className="h-3 w-3" />next in {timeUntil(a.nextRunAt)}
                       </span>
                     ) : a.type === 'cron' && !a.enabled ? (
                       <span className="text-amber-600">paused — won't fire while disabled</span>
                     ) : a.type !== 'cron' ? (
-                      <span>fires on {a.type === 'webhook' ? 'webhook' : `${a.type} message`} — no schedule</span>
+                      <span className="inline-flex items-center gap-1"><Zap className="h-3 w-3" />on demand</span>
                     ) : null}
+                    {(a.nextRunAt || a.type !== 'cron') && <span className="text-muted-foreground/40">·</span>}
                     <span title={a.lastFiredAt ? new Date(a.lastFiredAt).toLocaleString() : undefined}>
                       {a.lastFiredAt ? `last fired ${timeAgo(a.lastFiredAt)} ago` : 'never fired'}
                     </span>
                   </div>
                   {a.type === 'cron' && a.mode === 'interactive' && (
-                    <div className="mt-1 text-[11px] text-amber-600">Interactive sessions stay open until closed — this cron won't re-fire while its last run is still running.</div>
+                    <div className="mt-1 flex items-start gap-1 text-[11px] text-amber-600"><AlertTriangle className="mt-px h-3 w-3 shrink-0" />Interactive runs stay open — this cron won't re-fire while its last run is live.</div>
                   )}
-                  <div className="mt-1 truncate text-xs text-muted-foreground">{a.task}</div>
-                  {a.hookUrl && <div className="mt-2 w-full max-w-xl"><CopyLink link={a.hookUrl} /></div>}
+                  <div className="mt-1 truncate text-xs text-muted-foreground/80">{a.task}</div>
+                  {a.hookUrl && <div className="mt-2 max-w-xl"><CopyLink link={a.hookUrl} /></div>}
                 </div>
-                <div className="flex shrink-0 items-center gap-2">
-                  <Button size="sm" variant="ghost" onClick={() => setOpenRuns((cur) => (cur === a.id ? null : a.id))} title="show past runs of this automation">
-                    <HistoryIcon className="mr-1 h-3.5 w-3.5" />Runs
-                    <ChevronDown className={`ml-1 h-3.5 w-3.5 transition-transform ${openRuns === a.id ? 'rotate-180' : ''}`} />
-                  </Button>
+                {/* Actions — primary Run now, everything else tucked behind the kebab. */}
+                <div className="flex shrink-0 items-center gap-1">
                   <Button size="sm" variant="secondary" disabled={busy === a.id} onClick={() => setRunPrompt(a)} title="fire once now — pick headless or interactive">
                     <Play className="mr-1 h-3.5 w-3.5" />Run now
                   </Button>
-                  {/* Manage controls only for automations this member may edit: owner (any) or the creator.
-                      `canManage !== false` keeps them for older payloads without the flag; the server enforces. */}
-                  {isAdmin && a.canManage !== false && (
-                    <>
-                      <Select value={a.mode} onValueChange={(v) => v && v !== a.mode && setItemMode(a, v as 'interactive' | 'headless')}>
-                        <SelectTrigger className="h-8 w-32"><SelectValue /></SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="headless">headless</SelectItem>
-                          <SelectItem value="interactive">interactive</SelectItem>
-                        </SelectContent>
-                      </Select>
-                      <Button size="sm" variant="outline" disabled={busy === a.id} onClick={() => toggle(a)}>
-                        {a.enabled ? 'Disable' : 'Enable'}
-                      </Button>
-                      <Button size="sm" variant="outline" disabled={busy === a.id} onClick={() => startEdit(a)} title="edit name, schedule, task…">
-                        <Pencil className="mr-1 h-3.5 w-3.5" />Edit
-                      </Button>
-                      <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" disabled={busy === a.id} onClick={() => remove(a)} title="remove">
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </>
-                  )}
-                  {isAdmin && a.canManage === false && (
-                    <span className="text-[11px] text-muted-foreground" title="Only the creator or the owner can change this automation">created by another member</span>
-                  )}
+                  <DropdownMenu>
+                    <DropdownMenuTrigger
+                      render={<Button size="icon" variant="ghost" className="h-8 w-8" disabled={busy === a.id} title="more actions"><MoreHorizontal className="h-4 w-4" /></Button>}
+                    />
+                    <DropdownMenuContent>
+                      <DropdownMenuItem onClick={() => setOpenRuns((cur) => (cur === a.id ? null : a.id))}>
+                        <HistoryIcon className="h-4 w-4" />{openRuns === a.id ? 'Hide past runs' : 'Past runs'}
+                      </DropdownMenuItem>
+                      {/* Manage items only for automations this member may edit: owner (any) or the creator.
+                          The server enforces; `canManage !== false` keeps them for older payloads. */}
+                      {canManage && (
+                        <>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem onClick={() => toggle(a)}>
+                            {a.enabled ? <><PowerOff className="h-4 w-4" />Disable</> : <><Power className="h-4 w-4" />Enable</>}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => setItemMode(a, a.mode === 'headless' ? 'interactive' : 'headless')}>
+                            <SlidersHorizontal className="h-4 w-4" />Switch to {a.mode === 'headless' ? 'interactive' : 'headless'}
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => startEdit(a)}>
+                            <Pencil className="h-4 w-4" />Edit…
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem variant="destructive" onClick={() => remove(a)}>
+                            <Trash2 className="h-4 w-4" />Delete
+                          </DropdownMenuItem>
+                        </>
+                      )}
+                      {isAdmin && a.canManage === false && (
+                        <DropdownMenuItem disabled><User className="h-4 w-4" />Created by another member</DropdownMenuItem>
+                      )}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
               </CardContent>
               {openRuns === a.id && <AutomationRuns id={a.id} onOpen={onOpen} />}
             </Card>
-          ))}
+            )
+          })}
         </div>
         {hint && <div className="mt-2 font-mono text-xs text-destructive">{hint}</div>}
       </section>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,98 @@
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+
+const DropdownMenu = MenuPrimitive.Root
+const DropdownMenuTrigger = MenuPrimitive.Trigger
+const DropdownMenuGroup = MenuPrimitive.Group
+
+function DropdownMenuContent({
+  className,
+  children,
+  side = "bottom",
+  sideOffset = 4,
+  align = "end",
+  alignOffset = 0,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        className="isolate z-50"
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn(
+            "relative isolate z-50 min-w-40 origin-(--transform-origin) overflow-hidden rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        >
+          {children}
+        </MenuPrimitive.Popup>
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & { variant?: "default" | "destructive" }) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-variant={variant}
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-md px-2 py-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuLabel({
+  className,
+  ...props
+}: MenuPrimitive.GroupLabel.Props) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      className={cn("px-2 py-1 text-[11px] uppercase tracking-wider text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuGroup,
+  DropdownMenuSeparator,
+}


### PR DESCRIPTION
## What

The Automations page looked cluttered: every automation card carried a full-width **six-control toolbar** (Runs · Run now · mode `<Select>` · Disable · Edit · trash) plus **three badges** (type · mode · disabled), and stacked metadata across several lines. Past a couple of automations it was a wall of controls.

## Redesign

Each automation is now a **compact, scannable row**:
- Trigger type is a **glyph** (schedule / webhook / Slack / Discord / Composio) in a tinted square — replaces the `type` badge.
- `agent · trigger-summary · run-mode` collapse into **one meta line** (with the agent's icon and a human schedule phrase).
- Status line shows just **next-in** (emerald) + **last-fired**.
- The only always-visible action is **Run now**. Everything secondary — Past runs, Enable/Disable, Switch run-mode, Edit, Delete — moves into a **kebab (⋯) menu**.
- Paused automations **dim**; the `paused` state is a single subtle badge.

New reusable `web/src/components/ui/dropdown-menu.tsx` wrapping Base UI's `menu` (matches the existing `select.tsx` portal/styling conventions). No API or behavior changes — the same handlers, relocated.

## Verification

- `npm run build` (tsc) + `cd web && npm run build` clean.
- `npm run test:governance` → 68/68.
- Booted an isolated instance, seeded automations across all trigger types + a paused one, and screenshotted the page and the open kebab menu in a headless browser to confirm the layout and menu render.

### Before
Full-width toolbar + 3 badges per card — cluttered.

### After
Glyph + one meta line + one status line + `Run now` + `⋯`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)