### PR TITLE
fix(skills): publishing a proposed skill delivers same-session too (v0.116.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.116.0] — 2026-07-11
+## [0.116.1] — 2026-07-11
+### Fixed
+- **Publishing a proposed skill now delivers same-session too.** Same-session delivery (materialise +
+  `/reload-skills` into a live interactive run) was wired only into the `skill_request` **approve** path,
+  so publishing a `skill_propose` draft — the human-gated procedural-skills flow — only reached agents on
+  their next launch, an inconsistency an audit surfaced. `POST /api/skills/:name/publish` now calls
+  `TerminalManager.refreshAgentSkills` for the **proposing agent** (captured before publish drops the
+  `.aos-proposed` marker) and returns `reloaded`. Bounded to the proposer — console catalog/remote installs
+  stay next-launch by design (they install for the whole fleet, so a broadcast reload would be disruptive).
 ### Changed
 - **Automations page redesign — compact, scannable cards.** The old layout put a full-width six-control
   toolbar (Runs · Run now · mode-select · Disable · Edit · trash) plus three badges on every card, which

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.116.0",
+      "version": "0.116.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.116.0",
+  "version": "0.116.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2818,10 +2818,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'POST' && /^\/api\/skills\/([\w.-]+)\/publish$/.test(p)) {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const name = p.match(/^\/api\/skills\/([\w.-]+)\/publish$/)![1];
+    // Capture the proposing agent BEFORE publish drops the `.aos-proposed` marker (which clears `proposal`).
+    const proposer = os.skills.get(name)?.proposal?.agent;
     const ok = os.skills.publish(name);
     if (!ok) return sendJson(res, 404, { error: 'no such proposed skill' });
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.published', data: { skill: name } });
-    return sendJson(res, 200, { ok: true, skill: os.skills.get(name) });
+    // Same-session delivery (mirrors the skill_request approve path): if the proposing agent has a live
+    // interactive session, materialise the now-published skill into it + `/reload-skills` instead of
+    // waiting for next launch. Bounded to the proposer — a broadcast to the whole fleet would be disruptive.
+    const reloaded = proposer ? tm.refreshAgentSkills(proposer).reloaded : 0;
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.published', data: { skill: name, reloaded } });
+    return sendJson(res, 200, { ok: true, skill: os.skills.get(name), reloaded });
   }
   // List open agent skill-requests for the Skills page review section (owner/admin).
   if (method === 'GET' && p === '/api/skills/requests') {


### PR DESCRIPTION
Follow-up from the skills-work audit. Same-session delivery (materialise + `/reload-skills` into a live interactive run) was wired **only** into the `skill_request` *approve* path, so publishing a `skill_propose` draft (the human-gated procedural-skills flow) only reached agents on next launch — an inconsistency.

`POST /api/skills/:name/publish` now calls `TerminalManager.refreshAgentSkills` for the **proposing agent** (captured before publish drops the `.aos-proposed` marker) and returns `reloaded`. Bounded to the proposer; console catalog/remote installs stay next-launch by design (they install fleet-wide, so a broadcast reload would be disruptive).

**Verified:** publish 9/9 (propose → live interactive session → publish → `reloaded 1` → skill invocable), P3 8/8, P1 16/16, P2 9/9, governance 68/68, core+web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)