### PR TITLE
fix(updater): self-update no longer blocks itself on lockfile churn (v0.117.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.117.1] — 2026-07-11
+### Fixed
+- **Self-update no longer blocks itself on lockfile churn.** The in-console "Update & restart" button ran
+  `npm install`, which routinely rewrites `package-lock.json` (registry metadata / lockfile-format drift) —
+  leaving the tree dirty so the *next* update refused with "The box has uncommitted changes — commit or stash
+  them before updating". The updater now treats the regenerable lockfiles (`package-lock.json`,
+  `web/package-lock.json`) as non-blocking: it discards their churn (`git checkout --`) before the ff-pull and
+  excludes them from the dirty check (so the button isn't disabled either). Edits to any *other* tracked file
+  still block, as before.
+
 ## [0.117.0] — 2026-07-11
 ### Added
 - **Task dependencies — plans become enforced pipelines, not just ordered to-do lists.** A task can now

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.117.0",
+  "version": "0.117.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/updater.ts
+++ b/src/edge/updater.ts
@@ -20,6 +20,12 @@
  * incoming commit ever did collide with an untracked path, `git pull --ff-only` aborts cleanly and we
  * surface its error, so pre-blocking on untracked files would only produce false "can't update" states.
  *
+ * The lockfiles (`package-lock.json`, `web/package-lock.json`) are a further exception: the `npm install`
+ * steps below routinely rewrite them (registry metadata / lockfile-format drift), so a SUCCESSFUL update
+ * leaves the tree dirty and would block its own next run with "uncommitted changes". They're build-derived
+ * and never hand-edited on a deploy box, so we discard any lockfile churn (`git checkout --`) before the
+ * ff-pull and don't count it as dirty — only edits to OTHER tracked files disable the button.
+ *
  * The git repo is process-wide (shared by every tenant in a multi-tenant runtime), so the cache is a
  * module-level singleton rather than per-tenant.
  */
@@ -67,9 +73,24 @@ function git(args: string[], timeout = 30_000): { ok: boolean; out: string; err:
   return { ok: r.status === 0, out: (r.stdout || '').trim(), err: (r.stderr || '').trim() };
 }
 
-/** True only when TRACKED files are modified/staged — untracked files don't block an ff-only pull. */
+/** Build-derived, box-local files an `npm install` rewrites — never a meaningful edit on a deploy box. */
+const REGENERABLE = new Set(['package-lock.json', 'web/package-lock.json']);
+
+/** Paths of TRACKED files that differ from HEAD (staged or unstaged); untracked files excluded.
+ *  `diff --name-only HEAD` yields bare paths — no porcelain status columns to strip/mis-slice. */
+function dirtyTrackedFiles(): string[] {
+  return git(['diff', '--name-only', 'HEAD']).out.split('\n').map((l) => l.trim()).filter(Boolean);
+}
+
+/** True only when a NON-regenerable tracked file is modified/staged — the case an ff-only pull can't survive. */
 function hasTrackedChanges(): boolean {
-  return git(['status', '--porcelain', '--untracked-files=no']).out.length > 0;
+  return dirtyTrackedFiles().some((f) => !REGENERABLE.has(f));
+}
+
+/** Discard any lockfile churn left by a prior `npm install` so the tree is clean for an ff-only pull. */
+function restoreLockfiles(): void {
+  const dirty = dirtyTrackedFiles().filter((f) => REGENERABLE.has(f));
+  if (dirty.length) git(['checkout', '--', ...dirty]);
 }
 
 let cache: UpdateStatus | null = null;
@@ -147,6 +168,7 @@ export async function applyUpdate(tenant: string): Promise<ApplyResult> {
     return r.status === 0;
   };
 
+  restoreLockfiles(); // drop lockfile churn from a prior update so it doesn't read as a dirty tree
   if (hasTrackedChanges())
     return { ok: false, steps, restarting: false, error: 'tracked files have uncommitted changes — commit or stash them on the box first' };
 


### PR DESCRIPTION
## Problem
The in-console **Update & restart** button (`applyUpdate`) runs `npm install`, which routinely rewrites `package-lock.json` (registry metadata / lockfile-format drift). That leaves the working tree dirty, so the **next** update refuses with:

> The box has uncommitted changes — commit or stash them before updating (a fast-forward pull can't run otherwise).

i.e. a successful update poisons its own next run. This was hit live on both the instawp (jump-server) and expresstech droplets, where the tracked `package-lock.json` showed modified and blocked the ff-pull.

## Fix
Treat the regenerable lockfiles (`package-lock.json`, `web/package-lock.json`) as **non-blocking**:
- `applyUpdate` discards their churn (`git checkout --`) **before** the dirty check / ff-pull.
- The dirty probe (`hasTrackedChanges`) excludes them, so the UI button isn't disabled by lockfile churn either.
- Edits to **any other tracked file** still block, exactly as before (a real ff-pull conflict risk).

Also swapped the tracked-change probe from parsing `git status --porcelain` status columns (fragile `slice(3)`, mis-sliced some paths) to `git diff --name-only HEAD`, which returns bare paths.

## Test
- `npm run build` clean, `npm run typecheck` clean, `npm run test:governance` → 68/68.
- Verified against a real dirtied `package-lock.json`: `dirtyTrackedFiles` parses exact paths, `restoreLockfiles` removes only the lockfile, and a non-regenerable edit still reports blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)