### PR TITLE
feat(web): sidebar Feedback shortcut → GitHub issues (v0.118.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.118.0] — 2026-07-11
+### Added
+- **Feedback shortcut in the sidebar.** The console's **Manage** group now has a **Feedback** link (under
+  Docs) that opens the project's GitHub issues tab (`vikasprogrammer/agent-os/issues`) in a new tab — a
+  one-click path to report a bug or request a feature.
+
 ## [0.117.1] — 2026-07-11
 ### Fixed
 - **Self-update no longer blocks itself on lockfile churn.** The in-console "Update & restart" button ran

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.117.0",
+      "version": "0.118.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.117.1",
+  "version": "0.118.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink } from 'lucide-react'
 import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -447,6 +447,10 @@ function TuningFields({ tuning, onChange, modelPlaceholder = 'inherit', inheritL
     </div>
   )
 }
+
+/** Where the sidebar "Feedback" shortcut points — the project's GitHub issues tab, for bug reports
+ *  and feature requests. Opens in a new tab. */
+const FEEDBACK_URL = 'https://github.com/vikasprogrammer/agent-os/issues'
 
 /** Minimal hash router — `#/<page>` with an optional detail segment (`#/sessions/<tmux>`) so a
  *  deep-linked view (an open terminal, later other pages' selections) survives a refresh and
@@ -1066,6 +1070,17 @@ function Console({ me }: { me: Member }) {
                 <NavItem icon={<Building2 className="h-4 w-4" />} label="Settings" active={route === 'settings'} href={navHref('settings')} onClick={() => nav('settings')} />
               )}
               <NavItem icon={<BookOpen className="h-4 w-4" />} label="Docs" active={route === 'docs'} href={navHref('docs')} onClick={() => nav('docs')} />
+              <a
+                href={FEEDBACK_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm text-foreground no-underline hover:bg-muted"
+                title="Report a bug or request a feature on GitHub"
+              >
+                <Bug className="h-4 w-4" />
+                <span className="flex-1 text-left">Feedback</span>
+                <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />
+              </a>
             </nav>
           )}
 


### PR DESCRIPTION
## What

Adds a **Feedback** shortcut to the console's **Manage** nav group (right under Docs) that opens the project's GitHub issues tab (`vikasprogrammer/agent-os/issues`) in a new tab — a one-click path for users to report a bug or request a feature.

- External link (new tab, `rel="noopener noreferrer"`) with a `Bug` icon and a small `ExternalLink` affordance so it's visually distinct from in-app nav.
- Target URL lives in one `FEEDBACK_URL` constant.
- Version bumped 0.117.1 → 0.118.0; CHANGELOG updated.

## Verification

`npm run build` (root + web) and `npm run test:governance` (68/68) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)