### PR TITLE
feat(goals): numbered plans, deps in goal modal, delete detaches tasks (v0.119.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.118.0] — 2026-07-11
+### Added
+- **The strategist numbers task titles.** It now prefixes each task it files with its step number in run
+  order ("1. …", "2. …"), so a plan's sequence is visible at a glance on the board (instruction lives in
+  its per-run prompt, so the already-provisioned agent picks it up).
+- **Dependencies are visible in the Goal detail modal.** The goal's "Linked tasks" list now shows a
+  **"⏳ waiting on N"** chip on any task with unfinished blockers (matching the Tasks board), and the linked
+  tasks read in **creation/pipeline order** — `TaskStore.tasksForGoal` now attaches `dependsOn` and orders
+  by `created_at` (it previously did neither, so the modal couldn't show gating).
+### Changed
+- **Deleting a goal detaches its tasks instead of orphaning them.** `GoalStore.remove` now clears
+  `goal_id` on every linked task (with a timeline note) rather than leaving a dangling reference — a task
+  is real work, so it survives on the board, unlinked. (Child goals already detached this way.)
+
 ## [0.117.0] — 2026-07-11
 ### Added
 - **Task dependencies — plans become enforced pipelines, not just ordered to-do lists.** A task can now

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.117.0",
+      "version": "0.118.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.117.0",
+  "version": "0.118.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/strategist.ts
+++ b/src/edge/strategist.ts
@@ -83,6 +83,8 @@ export class Strategist {
       'File tasks in ORDER: when a step can only start after an earlier one finishes, capture the earlier',
       "task's id from its result and pass it as the later task's dependsOn — a dependent won't dispatch until",
       'its blockers are done, so this turns your plan into an enforced pipeline (not just a to-do list).',
+      'NUMBER the titles: prefix each task title with its step number in run order — "1. ", "2. ", … — so',
+      'the sequence is visible at a glance on the board (a parallel/independent track can share a number).',
       'Do NOT set autoDispatch — leave the plan for a human to review and dispatch. Finish with report.',
     );
     return lines.join('\n');
@@ -138,6 +140,8 @@ review and dispatch. You are the bridge from a strategic objective to actual wor
    - **Set \`dependsOn\` to encode ORDER.** When a step can't start until an earlier one finishes, file the
      earlier task first, capture its id, and pass it in the later task's \`dependsOn\`. A dependent won't
      dispatch until every blocker is done — that makes your plan an enforced pipeline, not a flat list.
+   - **Number the titles.** Prefix each task title with its step number in execution order ("1. …",
+     "2. …", …) so the sequence is obvious on the board — matching the \`dependsOn\` order.
 4. **Propose strategy, don't set it.** If the goal genuinely needs sub-objectives, \`goal_propose\` them for
    a human to activate — never create or activate goals yourself. Tasks are yours to file; strategy is the
    human's to own.

--- a/src/state/goals.ts
+++ b/src/state/goals.ts
@@ -173,12 +173,23 @@ export class GoalStore {
     return goal;
   }
 
-  /** Hard delete + cascade the activity log. (Detaches children by clearing their parent_id.) */
+  /**
+   * Hard delete + cascade the activity log. Detaches (never deletes) related work: child GOALS lose their
+   * parent_id, and linked TASKS lose their goal_id — a task is real work that may still be valid, so
+   * deleting its goal unlinks it (leaving it on the board) rather than destroying it. Each detached task
+   * gets a timeline note so the unlink is traceable.
+   */
   remove(id: string): boolean {
     const res = this.db.prepare('DELETE FROM goals WHERE id = ?').run(id);
     if (res.changes === 0) return false;
     this.db.prepare('DELETE FROM goal_events WHERE goal_id = ?').run(id);
     this.db.prepare('UPDATE goals SET parent_id = NULL WHERE parent_id = ?').run(id);
+    for (const t of this.db.prepare('SELECT id FROM tasks WHERE goal_id = ?').all<{ id: string }>(id)) {
+      this.db
+        .prepare('INSERT INTO task_events (id, task_id, kind, body, author, session_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
+        .run(randomUUID().slice(0, 8), t.id, 'link', 'goal deleted — detached', 'system', null, Date.now());
+    }
+    this.db.prepare('UPDATE tasks SET goal_id = NULL WHERE goal_id = ?').run(id);
     return true;
   }
 

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -315,10 +315,14 @@ export class TaskStore {
 
   /** All tasks linked to a goal (newest-updated first) — feeds the goal's derived progress + detail view. */
   tasksForGoal(goalId: string): Task[] {
-    return this.db
-      .prepare('SELECT * FROM tasks WHERE goal_id = ? ORDER BY updated_at DESC')
-      .all<TaskRow>(goalId)
-      .map(toTask);
+    // Creation order = the order the strategist filed the plan (its pipeline order), so a numbered plan
+    // reads top-to-bottom. attachDeps so the goal detail can show each task's blockers / "waiting" state.
+    return this.attachDeps(
+      this.db
+        .prepare('SELECT * FROM tasks WHERE goal_id = ? ORDER BY created_at ASC')
+        .all<TaskRow>(goalId)
+        .map(toTask),
+    );
   }
 
   // ── Dependencies ─────────────────────────────────────────────────────────────────────────────────

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4296,7 +4296,11 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
                   {detail.progress && detail.progress.total > 0 && <GoalProgressBar p={detail.progress} className="mb-2" />}
                   <div className="max-h-56 space-y-1.5 overflow-y-auto pr-1">
                     {detail.tasks.length === 0 && <div className="text-xs text-muted-foreground">No tasks linked yet — set this goal on a task to ground work under it.</div>}
-                    {detail.tasks.map((t) => (
+                    {detail.tasks.map((t) => {
+                      // Dependency gating — resolve each blocker from this goal's own tasks (no extra fetch).
+                      // A dep is *unmet* only if its blocker is present here AND not yet done/cancelled.
+                      const unmet = (t.dependsOn ?? []).filter((id) => { const b = detail.tasks.find((x) => x.id === id); return b && b.status !== 'done' && b.status !== 'cancelled' }).length
+                      return (
                       <a
                         key={t.id}
                         href={navHref('tasks', t.id)}
@@ -4305,8 +4309,10 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
                       >
                         <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] capitalize ${taskStatusTone(t.status)}`}>{t.status}</span>
                         <span className={`min-w-0 flex-1 truncate text-foreground ${t.status === 'cancelled' ? 'line-through opacity-60' : ''}`}>{t.title}</span>
+                        {unmet > 0 && <span className="inline-flex shrink-0 items-center gap-0.5 rounded bg-amber-500/15 px-1 text-[10px] text-amber-600" title="Waiting on unfinished blocker tasks">⏳ waiting on {unmet}</span>}
                       </a>
-                    ))}
+                      )
+                    })}
                   </div>
                 </div>
 


### PR DESCRIPTION
A goals-polish batch from live dogfooding feedback.

- **Strategist numbers task titles** — it prefixes each task it files with its step number in run order ("1. …", "2. …"), so a plan's sequence is visible at a glance. Instruction lives in the per-run prompt, so the already-provisioned strategist picks it up.
- **Dependencies visible in the Goal detail modal** — `TaskStore.tasksForGoal` now attaches `dependsOn` and orders linked tasks by `created_at` (pipeline order); it previously did neither, so the goal modal couldn't show gating. The Linked-tasks list now shows a **"⏳ waiting on N"** chip on tasks with unfinished blockers (matching the Tasks board).
- **Deleting a goal detaches its tasks** instead of orphaning them — `GoalStore.remove` clears `goal_id` on each linked task (with a timeline note) rather than leaving a dangling reference. A task is real work, so it survives on the board, unlinked. (Child goals already detached this way.)

### Verification
- typecheck + backend + web builds clean (incl. post-merge with main); `npm run test:governance` → **68/68**
- Smoke-tested the goal-delete detach (task survives, `goalId` cleared, timeline note logged, goal gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)