### PR TITLE
feat(media): image_generate — governed text-to-image (v0.117.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.120.0] — 2026-07-11
+### Added
+- **Image generation — agents can now draw.** Claude can't create images natively, so `image_generate`
+  is a new OS-owned MCP tool: an agent gives a prompt, the image(s) land in the **Artifacts** gallery
+  (folder `generated-images`, `kind:'image'`) + an owner-scoped inbox card, and the tool returns the
+  artifact ids. Fully governed — the run is policy-classified as `image.generate` with the estimated
+  `amountUsd`, so the default **money-cap** rule gates a runaway spend for free, and it's audited
+  `image.generated` with the **real** per-image cost when the backend reports it. The vendor sits behind
+  a swappable `ImageBackend` (`src/edge/image-gen.ts`): **OpenRouter** (default — one Bearer POST reaches
+  30+ models and returns `usage.cost` for exact metering) or **Atlas Cloud** (OpenAI-compatible; the
+  future video lane too). URL-or-base64 vendor output is normalised to bytes and snapshotted immediately
+  (vendor URLs can expire in minutes) via the new `ArtifactStore.ingest` (server-side bytes → gallery).
+  Backend keys + optional default model live in **Settings → Integrations** (`IMAGE_GEN=1` exposes the
+  tool when a key is set). Design + provider research in `docs/media-integrations-plan.md`.
+  (`src/edge/image-gen.ts`, `src/state/artifacts.ts`, `src/terminal.ts`, `src/server.ts`,
+  `src/governance/settings.ts`, `src/memory/memory-mcp.ts`, `web/src/App.tsx`)
+
 ## [0.119.0] — 2026-07-11
 ### Added
 - **The strategist numbers task titles.** It now prefixes each task it files with its step number in run

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -58,8 +58,9 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `slack_dm` | `POST /api/agent/slack/dm` | `SlackSocket.dmMember` | W | proactive DM by Slack user id or email; audited `slack.dm`; only when `SLACK_EGRESS=1` |
 | `discord_send` | `POST /api/agent/discord/send` | `DiscordSocket.sendToChannel` | W | proactive post to any channel by id; audited `discord.send`; only when `DISCORD_EGRESS=1` (Discord configured) |
 | `discord_dm` | `POST /api/agent/discord/dm` | `DiscordSocket.dmMember` | W | proactive DM by Discord user id; audited `discord.dm`; only when `DISCORD_EGRESS=1` |
+| `image_generate` | `POST /api/agent/image/generate` | `TerminalManager.generateImage` → `ImageBackend` + `ArtifactStore.ingest` | W | text→image (Claude can't draw natively). Governed as capability `image.generate` with `amountUsd`=estimate (the money-cap `never` rule applies), then the vendor call (OpenRouter default / Atlas alt, `resolveImageBackend`); each image is `ingest`ed into the gallery (`kind:'image'`, folder `generated-images`) + an owner-scoped inbox card; audited `image.generated` with the REAL cost (OpenRouter `usage.cost`) else the estimate. Only when `IMAGE_GEN=1` (a backend key set in Settings → Integrations) |
 
-44 always-on tools + 6 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
+44 always-on tools + 7 conditional. Read-only tools carry `annotations.readOnlyHint`; `forget`
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 

--- a/docs/media-integrations-plan.md
+++ b/docs/media-integrations-plan.md
@@ -1,0 +1,197 @@
+# Media & Peer-Agent Integrations — Design Plan
+
+> **Status (2026-07-11): IMAGE v1 SHIPPED.** `image_generate` MCP tool → `/api/agent/image/generate`
+> loopback → `TerminalManager.generateImage` (governed via `gate('image.generate', {amountUsd})` → the
+> money-cap rule) → swappable `ImageBackend` (OpenRouter default / Atlas alt, `src/edge/image-gen.ts`) →
+> `ArtifactStore.ingest` (server-side bytes → gallery `kind:'image'`) → audited `image.generated` with
+> the real `usage.cost`. Keys live in Settings → Integrations (`imageGenConfigured` → `IMAGE_GEN=1`
+> exposes the tool). Video + Codex/Antigravity remain the roadmap below.
+>
+> **Original planning notes (kept as design of record):** This doc captures the full design space for
+> giving Claude sessions capabilities Claude can't do natively: **image generation**, **video
+> generation**, and **talking to peer coding agents** (Codex, Antigravity/Gemini). Image is the first
+> cut; the rest is roadmap. The through-line: in Agent OS the question is never "which vendor API" —
+> it's **where in the trust layer the capability lives**, because that decides whether it's governed,
+> budgeted, audited, and whether the output becomes a first-class artifact.
+
+## 0. The core framing
+
+Claude sessions cannot generate images or video. So we hand them a **tool**. But *how* we wire that tool
+determines everything about governance. Agent OS already has three placement patterns, each with a
+different trust posture. Every integration below is really a choice among these three.
+
+| Pattern | How it works | Governance you get | Best for |
+|---|---|---|---|
+| **1. OS-owned MCP tool** (loopback) | session-secret-gated MCP tool → `/api/*` route *before* the auth gate → routed through the 7-step **gateway** | Policy classify, **Budget debit**, Idempotency, structured **Audit**, artifact integration — all free | first-class capabilities |
+| **2. Composio / connector egress** | connector secret via the MCP bag; call the vendor Composio already wraps | connector-level, audit-only | vendors Composio already has |
+| **3. Shell + `shellSecrets`** | inject a vendor key as an env var; agent shells out to a CLI/curl | only the PreToolUse **gate-hook** — no budget, no artifact, no structured audit | fast escape hatch / prototypes |
+
+The existing memory/slack/publish tools are all **pattern 1** — that's the template we copy for media.
+
+## 1. Image & Video → Pattern 1 (MCP loopback), driven by three forces
+
+### a) Integrate an aggregator, not N vendors
+Back `image_generate` / `video_generate` with an **aggregator** and make `model` a **parameter**. One
+integration buys the whole model zoo; adding a model is adding a string, not a connector.
+
+**Aggregator candidates (ranked after the 2026-07-11 deep-research pass + Atlas Cloud fetch):**
+
+1. **OpenRouter — Unified Image API** ⭐ *research pick.* Launched **June 23, 2026** (weeks old). ONE
+   Bearer-authed `POST https://openrouter.ai/api/v1/images`, **30+ models** normalized behind a single
+   `model` param (Google, OpenAI, Black Forest Labs, Recraft, ByteDance, Sourceful, Microsoft, xAI).
+   Discovery routes `/api/v1/images/models` + `…/{id}/endpoints`. **Killer feature for us: every
+   response's `usage` object returns the exact USD `cost`** (plus per-endpoint pricing lines: billable
+   unit + USD), so the **budget plane debits the real number with NO static cost table**. That single
+   fact is why it wins requirement (c) outright. *Verified 3-0 in the research pass.*
+2. **Atlas Cloud** (`atlascloud.ai`) — unified inference, **300+ models**, **OpenAI-compatible REST** +
+   single key, **sync AND async**. Image (Seedream 5.0, GPT Image 2, Flux.2, Nano Banana 2/Pro, Qwen
+   Image, Ideogram, Imagen), **video** (Seedance, Kling v3, Veo 3.1, Hailuo…), plus 3D & audio.
+   Transparent per-unit pricing — images **$0.004–$0.15**, video **$0.018–$0.49/s**. Strongest *breadth*
+   play and the only candidate that **covers phase-2 video under the same key**. *(Not in the research
+   pass — added from a direct fetch; confirm the machine-readable cost field + sync image return shape.)*
+3. **fal.ai** — established, image-focused, `subscribe()` gives a sync-style blocking call that
+   auto-polls a queue. Per-image list pricing confirmed (Recraft V4.1 base **$0.035/image**, verified
+   3-0). *Caveat: this pass could NOT confirm fal's auth header, queue submit/poll contract, URL-vs-base64
+   response, webhook support, or any programmatic cost API — treat those as unknown, verify against live
+   docs before building on it.*
+4. **Replicate** — broadest catalog, but default **async predict-and-poll**, **compute-time** billing
+   (not flat per-image), and whether cost is machine-readable in the response was unconfirmed. Weakest fit
+   for a simple synchronous, cost-metered v1.
+
+**Direct providers (context, not the v1 path):** Black Forest Labs **FLUX** is async (submit →
+`request_id`+`polling_url`, poll to Ready/Failed, webhooks optional) and returns **short-lived
+`delivery.*.bfl.ai` URLs** (~10 min — snapshot promptly), *verified*. Google **Nano Banana Pro** (Gemini
+3 Pro Image) ~**$0.134/img** std / $0.24 4K; **Imagen 4** ~$0.02/$0.04/$0.06 Fast/Std/Ultra; OpenAI
+**gpt-image** token-billed (~$0.005/img for Mini) — *these per-image figures came from blog-grade
+sources and were NOT independently verified; check the vendor's own pricing page before relying on them.*
+**Midjourney = API-inaccessible** (Discord-only; no official REST/SDK) — excluded.
+
+- **Image models**: Flux (Black Forest Labs), Google Imagen / "Nano Banana", Ideogram, Recraft,
+  Stability, OpenAI gpt-image-1. (Midjourney has no official API.)
+- **Video models**: Google Veo, OpenAI Sora, Kling, Runway, Luma Dream Machine, Pika, Minimax/Hailuo.
+
+Keep the tool signature **vendor-agnostic** so the backend can be swapped later without touching the
+tool contract.
+
+### b) Output is binary → it MUST become an artifact
+The single most important integration point. Generated bytes land in the **`artifacts` store** and the
+tool returns an **artifact ref / URL**, never base64 in the transcript. This:
+- plugs media straight into `artifacts_list` / `publish` and the Inbox,
+- keeps sessions cheap (no giant blobs in context),
+- gives every generated asset an audited, addressable home.
+
+Without this, nothing else matters.
+
+### c) Video is async (minutes) → it needs a job model
+Never block a session for a multi-minute render. Two clean options, both have primitives already:
+- **Poll**: tool returns a `job_id`; the agent `task_wait`s, or a `schedule`d one-shot re-checks.
+- **Webhook callback** (preferred for video): vendor → `/hooks/<id>?key=` → an **automation** fires
+  when the render lands and DMs/inboxes the result. "Video-done" becomes a first-class event instead of
+  a blocked session.
+
+Image is fast enough (seconds) to return synchronously in the first cut.
+
+### Governance that falls out of Pattern 1
+- **Budget** debits the real dollar cost per generation (image cents, video dollars).
+- **Policy** can gate — e.g. "video over $X or > N seconds needs owner approval" — with the standard
+  approval card.
+- The whole thing lands in the **audit trail** (`image.generate` / `video.generate` events).
+
+This governance is the entire reason to prefer Pattern 1 over the shell escape hatch (Pattern 3).
+
+## 2. Codex / Antigravity → a DIFFERENT problem (peer *agents*, not single-shot APIs)
+
+These aren't "call an endpoint" — they're **agentic CLIs** with their own loops. Value: second opinion,
+different model strengths, parallel exploration. Four integration depths, increasing power & lift:
+
+1. **One-shot shell-out** (Pattern 3) — `codex exec "…"` from bash, key via `shellSecrets`. Quick "get a
+   second opinion," zero plumbing. Ungoverned beyond the gate-hook, no fleet visibility.
+2. **MCP bridge** (Pattern 1) — Codex ships an MCP server mode; expose an `ask_codex` / `ask_gemini` MCP
+   tool so a Claude session delegates a subtask and gets the answer inline. Governed like any loopback
+   tool. Good, cheap middle ground to prove the ergonomics.
+3. **First-class sibling agent (the big one)** — extend `TerminalManager` with a **non-claude launch
+   lane** so Codex/Antigravity become real fleet members: they take `task_dispatch` hand-offs, run under
+   the same gate hook, run-as identity, budget, and audit. Turns Agent OS into a **cross-model fleet**,
+   not just multi-vendor APIs. The A2A delegation path already exists (`task_create` → assigned agent →
+   governed session); the lift is teaching the launcher a **second binary** (today `claude-launch.sh` +
+   tuning + gate wiring are all claude-shaped).
+4. **Automation trigger target** — Codex/Antigravity as the spawn target of an automation, for
+   scheduled/triggered non-claude runs.
+
+**Tension to name honestly:** depth 3 is where the platform thesis pays off (a governed multi-model
+fleet), but it's a real launcher refactor — a roadmap item, not a first cut.
+
+## 3. Recommendation / build order
+
+1. **Image now** — `image_generate` MCP tool → **OpenRouter Unified Image API** backend → **artifact
+   out**, synchronous. Small, high-value, fully governed. Budget debits the **`usage.cost`** the response
+   hands back (no static price table). *(This is what we're building first — pending final backend
+   confirmation with Vikas; Atlas Cloud is the alternative if we want video under the same key from day 1.)*
+2. **Video next** — same tool family, but land the **webhook-callback + automation** job model so long
+   renders are events, not blocked sessions.
+3. **Codex/Antigravity** — start at **depth 2 (MCP bridge)** to prove "ask a peer model" cheaply, then
+   invest in **depth 3 (non-claude launch lane)** only when true cross-model dispatch is wanted.
+
+## 4. Image v1 — concrete design (building now)
+
+> **Backend decision (2026-07-11):** build v1 against a **swappable `ImageBackend` interface** with two
+> adapters — **OpenRouter** (default when `OPENROUTER_API_KEY` present; uses `usage.cost`) and **Atlas
+> Cloud** (OpenAI-compatible; static/again-response cost) — and plug in whichever key is provided first.
+> Selection = config/available-key, not a hardcoded vendor.
+
+**Tool** (`src/memory/memory-mcp.ts`, always-on, session-secret-gated loopback — copy the `slack_send`
+shape):
+
+```
+image_generate({
+  prompt: string,
+  model?: string,        // aggregator model id; sensible default (e.g. a Flux variant)
+  size?: string,         // e.g. "1024x1024"; vendor-mapped
+  n?: number,            // default 1
+})  → { artifacts: [{ id, url, model, ... }] }
+```
+
+**Route** (`src/server.ts` loopback, *before* the auth gate, mirrors other `/api/agent|api/*` MCP
+routes): `POST /api/images/generate` →
+1. resolve the aggregator key from the **vault** (not `shellSecrets` — server-side only),
+2. call the aggregator, poll/await the (fast) result,
+3. download bytes → **`artifacts` store** (reuse the existing artifact write path),
+4. **audit** `image.generate` (prompt, model, cost, artifact ids — no raw bytes),
+5. return artifact refs.
+
+**Governance wiring:**
+- Route through the **gateway** so **Budget** debits the per-image cost and **Policy** *can* classify it
+  (default: allow; leave a hook so an owner can later require approval for expensive models).
+- Audit event carries model + cost + artifact ids.
+
+**Open questions to settle during build:**
+- **Backend** — *leaning OpenRouter* (research pick: machine-readable `usage.cost`, 30+ models, one
+  Bearer POST). Atlas Cloud is the alternative if we want image+video under one key from day 1. Keep the
+  call site behind a small backend interface so we can add/swap.
+- **Key storage**: new vault key (`OPENROUTER_API_KEY`, or `ATLAS_*` / `FAL_KEY`) surfaced in
+  **Settings → Integrations**.
+- **Cost source** — *RESOLVED for OpenRouter*: read the response's `usage.cost` (exact USD per request)
+  and debit that; no static table. Nuance: it's **per-request** (aggregate when `n>1`) and documented
+  "when available" — validate it's populated for each model we enable, and fall back to a small default
+  if absent. For a non-usage backend (Atlas/fal) we'd need a static per-model table instead.
+- **Output shape** — confirm per model whether OpenRouter returns a **URL vs base64** (may vary across
+  the 30+ models); handle both in the ingest path (download URL → bytes, or decode base64 → bytes). URLs
+  from providers like FLUX expire in ~10 min, so **snapshot to the artifact immediately**, never store
+  the URL as the deliverable.
+- **Rate/concurrency limits** — unconfirmed for OpenRouter's Image API; find them before enabling
+  high-volume/automation use.
+- **Artifact write** — *RESOLVED*: `ArtifactStore.publish` only snapshots a file *from the agent's
+  working folder* (`allowRoot` + `containedPath`), but generated bytes originate **server-side**. Add a
+  sibling **`ArtifactStore.ingest(bytes, filename, {sessionId, agent, source, title, ...})`** that writes
+  the blob straight into a fresh `<home>/artifacts/<id>/<filename>` and inserts the row — same table/shape,
+  skips the working-folder copy. `mimeOf` already covers `.png/.jpg/.webp/.gif/.svg` and `.mp4/.webm/.mov`,
+  so the gallery previews generated media with **zero UI work**. Artifact `kind: 'image'`,
+  `source: 'image_generate'`.
+- **Default model + size** and how vendor-specific params (aspect ratio, steps, seed) are exposed
+  without leaking vendor shape into the tool contract.
+
+## 5. What this deliberately is NOT (v1 cuts)
+- No video yet (job model comes with it).
+- No Codex/Antigravity lanes yet.
+- No image editing / inpainting / img2img — text-to-image only first.
+- No per-model policy presets — one allow rule, budget-debited, refine later.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.119.0",
+  "version": "0.120.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.119.0",
+      "version": "0.120.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"
@@ -15,6 +15,9 @@
         "@types/node": "^20.11.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.4.0"
+      },
+      "engines": {
+        "node": ">=22.5.0"
       },
       "optionalDependencies": {
         "@libsql/client": "^0.14.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.119.0",
+  "version": "0.120.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/image-gen.ts
+++ b/src/edge/image-gen.ts
@@ -1,0 +1,171 @@
+/**
+ * Image generation — the backend behind the OS-owned `image_generate` MCP tool.
+ *
+ * Claude can't draw natively, so this is a first-class capability: an agent asks for an image, the
+ * bytes are snapshotted into the Artifacts gallery, and the run is governed (policy-classified on the
+ * estimated cost, audited with the real cost). This module is ONLY the vendor call — it takes a prompt,
+ * returns image bytes + the real USD cost when the vendor reports it. Governance/artifact wiring lives
+ * in `TerminalManager.generateImage`.
+ *
+ * The vendor is behind a small `ImageBackend` interface with two adapters, picked by whichever key is
+ * configured (Settings → Integrations):
+ *  - **OpenRouter** (default) — one Bearer POST reaches 30+ models via a normalized `model` param, and
+ *    every response's `usage.cost` is the exact USD we debit. No static price table.
+ *  - **Atlas Cloud** — OpenAI-compatible images endpoint; also covers video later under one key. Cost
+ *    isn't guaranteed in the response, so we fall back to the per-image estimate for metering.
+ *
+ * Both normalize the two return shapes (a URL to download, or inline base64) into raw bytes, since the
+ * gallery stores bytes and vendor URLs (e.g. FLUX's) can expire within minutes.
+ */
+
+/** A conservative default per-image cost, used ONLY for the pre-generation policy gate (the money-cap
+ *  rule) when the backend can't be asked ahead of time. The AUDIT records the real cost when known. */
+export const DEFAULT_IMAGE_COST_USD = 0.05;
+
+export interface GeneratedImage {
+  bytes: Buffer;
+  ext: string; // 'png' | 'jpg' | 'webp' — drives the artifact filename + mime
+}
+
+export interface ImageGenResult {
+  images: GeneratedImage[];
+  model: string; // the model actually used (as reported/requested)
+  costUsd?: number; // real USD cost when the vendor reports it (OpenRouter usage.cost); else undefined
+}
+
+export interface ImageGenRequest {
+  prompt: string;
+  model?: string;
+  size?: string; // e.g. '1024x1024'; passed through, vendor clamps
+  n: number;
+}
+
+export interface ImageBackend {
+  readonly name: 'openrouter' | 'atlas';
+  readonly defaultModel: string;
+  generate(req: ImageGenRequest): Promise<ImageGenResult>;
+}
+
+/** What the factory needs from Settings — passed in (not the whole store) to keep this testable. */
+export interface ImageBackendConfig {
+  openRouterKey?: string;
+  atlasKey?: string;
+  atlasBaseUrl?: string; // override; default below
+  defaultModel?: string; // workspace override for the default model
+}
+
+/** Pick a backend from configured keys. OpenRouter wins when both are set (verified cost telemetry). */
+export function resolveImageBackend(cfg: ImageBackendConfig): ImageBackend | undefined {
+  if (cfg.openRouterKey && cfg.openRouterKey.trim()) {
+    return new OpenRouterBackend(cfg.openRouterKey.trim(), cfg.defaultModel);
+  }
+  if (cfg.atlasKey && cfg.atlasKey.trim()) {
+    return new AtlasBackend(cfg.atlasKey.trim(), cfg.atlasBaseUrl, cfg.defaultModel);
+  }
+  return undefined;
+}
+
+// ── shared helpers ──────────────────────────────────────────────────────────
+
+const EXT_BY_MIME: Record<string, string> = {
+  'image/png': 'png',
+  'image/jpeg': 'jpg',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+};
+
+/** Turn one vendor image entry (a URL or inline base64) into raw bytes + a file extension. */
+async function toBytes(entry: { url?: string; b64_json?: string; b64?: string }): Promise<GeneratedImage> {
+  const b64 = entry.b64_json ?? entry.b64;
+  if (b64) {
+    const comma = b64.indexOf(','); // tolerate a data: URI prefix
+    const raw = comma >= 0 && b64.slice(0, comma).includes('base64') ? b64.slice(comma + 1) : b64;
+    return { bytes: Buffer.from(raw, 'base64'), ext: 'png' };
+  }
+  if (entry.url) {
+    const res = await fetch(entry.url);
+    if (!res.ok) throw new Error(`fetching generated image failed (${res.status})`);
+    const ct = (res.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+    const buf = Buffer.from(await res.arrayBuffer());
+    const ext = EXT_BY_MIME[ct] || extFromUrl(entry.url) || 'png';
+    return { bytes: buf, ext };
+  }
+  throw new Error('vendor returned an image with neither a url nor base64 data');
+}
+
+function extFromUrl(url: string): string | undefined {
+  const m = /\.(png|jpe?g|webp|gif)(?:\?|#|$)/i.exec(url);
+  if (!m) return undefined;
+  const e = m[1].toLowerCase();
+  return e === 'jpeg' ? 'jpg' : e;
+}
+
+// ── OpenRouter ──────────────────────────────────────────────────────────────
+
+interface OpenRouterResponse {
+  data?: { url?: string; b64_json?: string }[];
+  images?: { url?: string; b64_json?: string }[];
+  usage?: { cost?: number };
+  error?: { message?: string } | string;
+}
+
+class OpenRouterBackend implements ImageBackend {
+  readonly name = 'openrouter' as const;
+  readonly defaultModel: string;
+  constructor(private readonly key: string, defaultModel?: string) {
+    this.defaultModel = defaultModel?.trim() || 'google/gemini-3.1-flash-image-preview';
+  }
+
+  async generate(req: ImageGenRequest): Promise<ImageGenResult> {
+    const model = req.model?.trim() || this.defaultModel;
+    const body: Record<string, unknown> = { model, prompt: req.prompt, n: req.n };
+    if (req.size) body.size = req.size;
+    const res = await fetch('https://openrouter.ai/api/v1/images', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${this.key}`, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const d = (await res.json().catch(() => ({}))) as OpenRouterResponse;
+    if (!res.ok) throw new Error(errMsg(d, res.status));
+    const entries = d.data ?? d.images ?? [];
+    if (!entries.length) throw new Error('OpenRouter returned no images');
+    const images = await Promise.all(entries.map(toBytes));
+    return { images, model, costUsd: typeof d.usage?.cost === 'number' ? d.usage.cost : undefined };
+  }
+}
+
+// ── Atlas Cloud (OpenAI-compatible images endpoint) ──────────────────────────
+
+class AtlasBackend implements ImageBackend {
+  readonly name = 'atlas' as const;
+  readonly defaultModel: string;
+  private readonly base: string;
+  constructor(private readonly key: string, baseUrl?: string, defaultModel?: string) {
+    this.base = (baseUrl?.trim() || 'https://api.atlascloud.ai/v1').replace(/\/+$/, '');
+    this.defaultModel = defaultModel?.trim() || 'flux.2';
+  }
+
+  async generate(req: ImageGenRequest): Promise<ImageGenResult> {
+    const model = req.model?.trim() || this.defaultModel;
+    const body: Record<string, unknown> = { model, prompt: req.prompt, n: req.n };
+    if (req.size) body.size = req.size;
+    const res = await fetch(`${this.base}/images/generations`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${this.key}`, 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const d = (await res.json().catch(() => ({}))) as OpenRouterResponse;
+    if (!res.ok) throw new Error(errMsg(d, res.status));
+    const entries = d.data ?? d.images ?? [];
+    if (!entries.length) throw new Error('Atlas returned no images');
+    const images = await Promise.all(entries.map(toBytes));
+    // Atlas doesn't reliably report cost in-band; caller falls back to the per-image estimate.
+    return { images, model, costUsd: typeof d.usage?.cost === 'number' ? d.usage.cost : undefined };
+  }
+}
+
+function errMsg(d: OpenRouterResponse, status: number): string {
+  const e = d.error;
+  const msg = typeof e === 'string' ? e : e?.message;
+  return msg ? `image backend error (${status}): ${msg}` : `image backend error (${status})`;
+}

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -18,6 +18,9 @@ const COMPOSIO_WEBHOOK_KEY = 'composio_webhook_secret';
 const SLACK_APP_TOKEN_KEY = 'slack_app_token'; // xapp-… (Socket Mode, connections:write)
 const SLACK_BOT_TOKEN_KEY = 'slack_bot_token'; // xoxb-… (chat.postMessage, users.info)
 const DISCORD_BOT_TOKEN_KEY = 'discord_bot_token'; // Bot … (Gateway connect + post messages)
+const IMAGE_OPENROUTER_KEY = 'image_openrouter_key'; // OpenRouter Unified Image API key (default backend)
+const IMAGE_ATLAS_KEY = 'image_atlas_key'; // Atlas Cloud key (alt backend; covers video later)
+const IMAGE_MODEL_KEY = 'image_default_model'; // workspace default image model id (backend-specific); '' = adapter default
 const MEMORY_KEY = 'memory_config'; // the live memory backend (JSON MemoryConfig; overrides the file default)
 const MEMORY_SWITCH_KEY = 'memory_backend_switched_at'; // ts the active external backend became active — the stable orphan horizon for migration
 const RUNTIME_DEFAULTS_KEY = 'runtime_defaults'; // workspace-wide model/effort/permission fallback (JSON RuntimeTuning)
@@ -182,6 +185,57 @@ export class SettingsStore {
   }
   setDiscordBotToken(token: string, by?: string): void {
     this.set(DISCORD_BOT_TOKEN_KEY, token.trim(), by);
+  }
+
+  // ── image generation ─────────────────────────────────────────────────────────────
+  // Keys for the `image_generate` capability's backend. OpenRouter (default) reports the real per-
+  // request cost in-band; Atlas is the alternative (and the future video lane). Either key present
+  // ⇒ the tool is offered to sessions. Backend selection lives in resolveImageBackend (edge/image-gen).
+
+  /** OpenRouter Unified Image API key, or '' when unset. */
+  openRouterKey(): string {
+    return this.getRow(IMAGE_OPENROUTER_KEY)?.value?.trim() ?? '';
+  }
+  /** Atlas Cloud key, or '' when unset. */
+  atlasKey(): string {
+    return this.getRow(IMAGE_ATLAS_KEY)?.value?.trim() ?? '';
+  }
+  /** Workspace default image model id (backend-specific), or '' to use the adapter's own default. */
+  imageDefaultModel(): string {
+    return this.getRow(IMAGE_MODEL_KEY)?.value?.trim() ?? '';
+  }
+  /** At least one backend key present → the tool is exposed. */
+  imageGenConfigured(): boolean {
+    return !!this.openRouterKey() || !!this.atlasKey();
+  }
+  /** Which backend a run would use (OpenRouter wins when both set) — for the console + status. */
+  imageGenBackend(): 'openrouter' | 'atlas' | null {
+    if (this.openRouterKey()) return 'openrouter';
+    if (this.atlasKey()) return 'atlas';
+    return null;
+  }
+  /** Whether each image key is set (never returns the secret) + the default model + last editor. */
+  imageGenMeta(): { openRouter: boolean; atlas: boolean; backend: 'openrouter' | 'atlas' | null; defaultModel: string; updatedAt?: number; updatedBy?: string } {
+    const or = this.getRow(IMAGE_OPENROUTER_KEY);
+    const at = this.getRow(IMAGE_ATLAS_KEY);
+    const newest = [or, at].filter(Boolean).sort((a, b) => (b!.updated_at ?? 0) - (a!.updated_at ?? 0))[0];
+    return {
+      openRouter: !!or?.value,
+      atlas: !!at?.value,
+      backend: this.imageGenBackend(),
+      defaultModel: this.imageDefaultModel(),
+      updatedAt: newest?.updated_at ?? undefined,
+      updatedBy: newest?.updated_by ?? undefined,
+    };
+  }
+  setOpenRouterKey(key: string, by?: string): void {
+    this.set(IMAGE_OPENROUTER_KEY, key.trim(), by);
+  }
+  setAtlasKey(key: string, by?: string): void {
+    this.set(IMAGE_ATLAS_KEY, key.trim(), by);
+  }
+  setImageDefaultModel(model: string, by?: string): void {
+    this.set(IMAGE_MODEL_KEY, model.trim(), by);
   }
 
   // ── memory backend ───────────────────────────────────────────────────────────────

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -83,6 +83,8 @@ const DISCORD_REPLY_TOOL = {
 // are NOT thread-bound: the agent names a channel or person, so it can message anyone / anywhere.
 const SLACK_EGRESS = process.env.SLACK_EGRESS === '1';
 const DISCORD_EGRESS = process.env.DISCORD_EGRESS === '1';
+// IMAGE_GEN: '1' when a workspace image backend (OpenRouter/Atlas) is configured — exposes image_generate.
+const IMAGE_GEN = process.env.IMAGE_GEN === '1';
 
 const SLACK_SEND_TOOL = {
   name: 'slack_send',
@@ -143,6 +145,25 @@ const DISCORD_DM_TOOL = {
       text: { type: 'string', description: 'The message to send (Discord markdown supported).' },
     },
     required: ['to', 'text'],
+  },
+};
+
+const IMAGE_GENERATE_TOOL = {
+  name: 'image_generate',
+  description:
+    'Generate image(s) from a text prompt. Use this whenever you need to CREATE an image — you cannot ' +
+    'draw natively. Each image is saved to the Artifacts gallery (and an inbox card) and the tool ' +
+    'returns the artifact id(s); reference those rather than expecting the raw bytes. The generation is ' +
+    'governed (cost-metered + audited).',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      prompt: { type: 'string', description: 'What to draw — be specific about subject, style, composition, colours.' },
+      model: { type: 'string', description: 'Optional model id (backend-specific). Omit to use the workspace default.' },
+      size: { type: 'string', description: 'Optional dimensions, e.g. "1024x1024". Omit for the model default.' },
+      n: { type: 'number', description: 'How many images to generate (1–4, default 1).' },
+    },
+    required: ['prompt'],
   },
 };
 
@@ -995,6 +1016,25 @@ async function discordReply(args: Record<string, unknown>): Promise<string> {
   });
   const d = (await res.json()) as { ok?: boolean; error?: string };
   return d.ok ? 'Posted to Discord.' : `Could not post to Discord: ${d.error ?? 'unknown error'}`;
+}
+
+async function imageGenerate(args: Record<string, unknown>): Promise<string> {
+  const prompt = String(args.prompt ?? '').trim();
+  if (!prompt) return 'A prompt is required.';
+  const body: Record<string, unknown> = { session: SESSION, prompt };
+  if (typeof args.model === 'string' && args.model.trim()) body.model = args.model.trim();
+  if (typeof args.size === 'string' && args.size.trim()) body.size = args.size.trim();
+  if (args.n !== undefined) body.n = Number(args.n);
+  const res = await fetch(AOS_URL + '/api/agent/image/generate', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify(body),
+  });
+  const d = (await res.json()) as { ok?: boolean; error?: string; artifacts?: { id: string; filename: string }[]; model?: string; costUsd?: number };
+  if (!d.ok) return `Could not generate image: ${d.error ?? 'unknown error'}`;
+  const list = (d.artifacts ?? []).map((a) => `${a.id} (${a.filename})`).join(', ');
+  const cost = typeof d.costUsd === 'number' ? ` · ~$${d.costUsd.toFixed(3)}` : '';
+  return `Generated ${d.artifacts?.length ?? 0} image(s) with ${d.model ?? 'the default model'}${cost}. Saved to the Artifacts gallery: ${list}.`;
 }
 
 async function slackSend(args: Record<string, unknown>): Promise<string> {
@@ -1858,6 +1898,7 @@ async function handle(req: JsonRpc): Promise<void> {
       ...(DISCORD_REPLY ? [DISCORD_REPLY_TOOL] : []),
       ...(SLACK_EGRESS ? [SLACK_SEND_TOOL, SLACK_DM_TOOL] : []),
       ...(DISCORD_EGRESS ? [DISCORD_SEND_TOOL, DISCORD_DM_TOOL] : []),
+      ...(IMAGE_GEN ? [IMAGE_GENERATE_TOOL] : []),
     ] } });
     return;
   }
@@ -1890,6 +1931,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'slack_dm' ? await slackDm(args)
         : name === 'discord_send' ? await discordSend(args)
         : name === 'discord_dm' ? await discordDm(args)
+        : name === 'image_generate' ? await imageGenerate(args)
         : name === 'list_capabilities' ? await listCapabilities()
         : name === 'policy_check' ? await policyCheck(args)
         : name === 'directory_lookup' ? await directoryLookup(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -829,6 +829,22 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const out = await slack.sendToChannel(session, String(b.channel || ''), String(b.text || ''));
     return sendJson(res, out.ok ? 200 : 400, out.ok ? { ok: true } : { ok: false, error: out.error });
   }
+  // OS-owned image generation (`image_generate` MCP tool): govern → vendor call → snapshot each image
+  // into the Artifacts gallery. Pre-auth loopback, session-secret gated like the other agent tools;
+  // TerminalManager.generateImage owns the gate/backend/artifact/audit path.
+  if (method === 'POST' && p === '/api/agent/image/generate') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const out = await tm.generateImage(session, {
+      prompt: String(b.prompt || ''),
+      model: b.model ? String(b.model) : undefined,
+      size: b.size ? String(b.size) : undefined,
+      n: b.n !== undefined ? Number(b.n) : undefined,
+    });
+    return sendJson(res, out.ok ? 200 : 400, out);
+  }
   // native Slack egress (proactive): DM a person by Slack user id or email. Audited as `slack.dm`.
   if (method === 'POST' && p === '/api/agent/slack/dm') {
     const b = await readBody(req);
@@ -2650,6 +2666,10 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       }
     }
     if (discordTouched && discord) void discord.restart();
+    // Image generation backend keys (OpenRouter default / Atlas alt) + optional default model.
+    if (typeof b.openRouterKey === 'string') os.settings.setOpenRouterKey(b.openRouterKey, me.email);
+    if (typeof b.atlasKey === 'string') os.settings.setAtlasKey(b.atlasKey, me.email);
+    if (typeof b.imageDefaultModel === 'string') os.settings.setImageDefaultModel(b.imageDefaultModel, me.email);
     // Generic `/agent` chat router toggle (Slack + Discord fallback when no automation matches).
     if (typeof b.chatRouter === 'boolean') os.settings.setChatRouterEnabled(b.chatRouter, me.email);
     // Warm (resident) Slack thread session idle-kill, minutes (0 = disable residence → cold replies).
@@ -3798,6 +3818,7 @@ function integrationsView(os: AgentOS): {
   webhook: { set: boolean };
   slack: { appToken: boolean; botToken: boolean; configured: boolean };
   discord: { botToken: boolean; configured: boolean };
+  image: { openRouter: boolean; atlas: boolean; backend: 'openrouter' | 'atlas' | null; defaultModel: string; configured: boolean };
   chatRouter: boolean;
   chatIdleTimeoutMin: number;
   updatedAt?: number;
@@ -3806,11 +3827,13 @@ function integrationsView(os: AgentOS): {
   const meta = os.settings.composioMeta();
   const slack = os.settings.slackMeta();
   const discord = os.settings.discordMeta();
+  const image = os.settings.imageGenMeta();
   return {
     composio: { set: meta.set, hint: redactSecret(os.settings.composioApiKey()) },
     webhook: { set: os.settings.composioWebhookSet() },
     slack: { appToken: slack.appToken, botToken: slack.botToken, configured: os.settings.slackConfigured() },
     discord: { botToken: discord.botToken, configured: os.settings.discordConfigured() },
+    image: { openRouter: image.openRouter, atlas: image.atlas, backend: image.backend, defaultModel: image.defaultModel, configured: os.settings.imageGenConfigured() },
     chatRouter: os.settings.chatRouterEnabled(),
     chatIdleTimeoutMin: os.settings.chatIdleTimeoutMinutes(),
     updatedAt: meta.updatedAt,

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -118,6 +118,57 @@ export class ArtifactStore {
     return { ok: true, artifact: toArtifact(row) };
   }
 
+  /**
+   * Ingest bytes that originate SERVER-SIDE (not from an agent's working folder) straight into the
+   * gallery — the path a generated image/video takes. Same table + id-dir shape as `publish`, but the
+   * source is a Buffer we already hold, so there's no `allowRoot`/containment check (nothing the agent
+   * named is being read from disk). The caller owns provenance (sessionId/agent/source) + title.
+   */
+  ingest(input: {
+    sessionId: string;
+    agent: string;
+    source?: string;
+    title: string;
+    description?: string;
+    folder?: string;
+    filename: string;
+    bytes: Buffer;
+    kind?: string;
+  }): PublishResult {
+    if (!this.dir) return { ok: false, error: 'no data home configured (artifacts disabled)' };
+    const filename = path.basename(input.filename) || 'image.png';
+    const id = randomUUID().slice(0, 8);
+    const destDir = path.join(this.dir, id);
+    fs.mkdirSync(destDir, { recursive: true });
+    fs.writeFileSync(path.join(destDir, filename), input.bytes);
+
+    const row: ArtifactRow = {
+      id,
+      session_id: input.sessionId,
+      agent: input.agent,
+      source: input.source ?? null,
+      kind: input.kind ?? 'file',
+      title: input.title,
+      description: input.description ?? null,
+      folder: normFolder(input.folder),
+      filename,
+      rel_path: path.join(id, filename),
+      mime: mimeOf(filename),
+      bytes: input.bytes.length,
+      created_at: Date.now(),
+    };
+    this.db
+      .prepare(
+        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        row.id, row.session_id, row.agent, row.source, row.kind, row.title, row.description,
+        row.folder, row.filename, row.rel_path, row.mime, row.bytes, row.created_at,
+      );
+    return { ok: true, artifact: toArtifact(row) };
+  }
+
   /** All artifacts, newest first. The server filters by viewer (inbox visibility rule). */
   list(): Artifact[] {
     return this.db

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -21,6 +21,7 @@ import { ChatPlatform, chatLink, consolePage } from './governance/chat-links';
 import { SkillSummary, CatalogSkill } from './governance/skills';
 import { browseRepo, RemoteCatalog } from './governance/skill-registry';
 import { claudeSupportsReloadSkills } from './edge/claude-cli';
+import { DEFAULT_IMAGE_COST_USD, resolveImageBackend } from './edge/image-gen';
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
 import { LauncherSessionBackend, LocalSessionBackend, SessionBackend, SpawnErrorSink } from './edge/session-backend';
@@ -1416,6 +1417,8 @@ export class TerminalManager {
         ...(discordReply ? { DISCORD_REPLY: '1' } : {}),
         ...(this.os.settings.slackConfigured() ? { SLACK_EGRESS: '1' } : {}),
         ...(this.os.settings.discordConfigured() ? { DISCORD_EGRESS: '1' } : {}),
+        // IMAGE_GEN: '1' exposes `image_generate` when a backend key (OpenRouter/Atlas) is configured.
+        ...(this.os.settings.imageGenConfigured() ? { IMAGE_GEN: '1' } : {}),
       },
     };
     return JSON.stringify(config, null, 2);
@@ -2177,6 +2180,74 @@ export class TerminalManager {
     });
     this.audit(sessionId, agent, 'artifact.published', { id: a.id, filename: a.filename, bytes: a.bytes, mime: a.mime, title: a.title, folder: a.folder });
     return { ok: true, id: a.id };
+  }
+
+  /**
+   * Generate image(s) from a prompt (the `image_generate` MCP path) and snapshot each into the
+   * Artifacts gallery. Claude can't draw natively, so this is a first-class governed capability:
+   *  1. the run is policy-classified as `image.generate` with `amountUsd` = the pre-estimate, so the
+   *     default money-cap `never` rule gates a runaway spend for free (and an owner can add a rule);
+   *  2. the vendor call (OpenRouter default, else Atlas) returns bytes we `ingest` server-side —
+   *     vendor URLs can expire in minutes, so we never store the URL as the deliverable;
+   *  3. each image lands as an `image` artifact + an owner-scoped inbox card, and the run is audited
+   *     with the REAL cost when the backend reports it (OpenRouter `usage.cost`), else the estimate.
+   */
+  async generateImage(sessionId: string, input: { prompt: string; model?: string; size?: string; n?: number }): Promise<{ ok: boolean; artifacts?: { id: string; filename: string; mime: string }[]; model?: string; costUsd?: number; error?: string }> {
+    const agent = this.sessionAgent(sessionId);
+    if (!agent) return { ok: false, error: 'unknown session' };
+    if (!this.os.artifacts.enabled) return { ok: false, error: 'artifacts store is disabled (no data home)' };
+    const prompt = (input.prompt || '').trim();
+    if (!prompt) return { ok: false, error: 'a prompt is required' };
+    const n = Math.max(1, Math.min(4, Math.floor(input.n ?? 1)));
+
+    const backend = resolveImageBackend({
+      openRouterKey: this.os.settings.openRouterKey(),
+      atlasKey: this.os.settings.atlasKey(),
+      defaultModel: this.os.settings.imageDefaultModel() || undefined,
+    });
+    if (!backend) return { ok: false, error: 'image generation is not configured — set an OpenRouter or Atlas key in Settings → Integrations' };
+
+    // Govern BEFORE spending: classify with the estimated dollar cost so the money-cap rule applies.
+    const estimateUsd = +(n * DEFAULT_IMAGE_COST_USD).toFixed(4);
+    const model = input.model?.trim() || backend.defaultModel;
+    const gate = this.gate(sessionId, agent, 'image.generate', { prompt, model, n, amountUsd: estimateUsd }, `generate ${n} image(s) with ${model}`);
+    if (gate.decision === 'deny') return { ok: false, error: 'blocked by policy' };
+    if (gate.decision === 'pending') return { ok: false, error: 'this generation needs human approval — an approval request was filed; retry once it is approved' };
+
+    let result;
+    try {
+      result = await backend.generate({ prompt, model: input.model, size: input.size, n });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.audit(sessionId, agent, 'image.failed', { model, n, error: msg });
+      return { ok: false, error: msg };
+    }
+
+    const srow = this.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(sessionId);
+    const source = srow?.run_as ?? srow?.spawned_by ?? undefined;
+    const shortPrompt = prompt.length > 60 ? prompt.slice(0, 57) + '…' : prompt;
+    const stamp = Date.now();
+    const out: { id: string; filename: string; mime: string }[] = [];
+    result.images.forEach((img, i) => {
+      const filename = `image-${stamp}${result.images.length > 1 ? `-${i + 1}` : ''}.${img.ext}`;
+      const r = this.os.artifacts.ingest({
+        sessionId, agent, source, title: shortPrompt, description: prompt,
+        folder: 'generated-images', filename, bytes: img.bytes, kind: 'image',
+      });
+      if (!r.ok) return;
+      const a = r.artifact;
+      out.push({ id: a.id, filename: a.filename, mime: a.mime });
+      this.addMessage({
+        type: 'artifact', sessionId, agent, title: `Image — ${agent}`, body: a.title, status: 'open',
+        source, args: { artifactId: a.id, filename: a.filename, mime: a.mime, kind: a.kind },
+        audienceKind: 'sessionOwner', audienceId: sessionId,
+      });
+    });
+    if (!out.length) return { ok: false, error: 'generation succeeded but no image could be stored' };
+
+    const costUsd = result.costUsd ?? estimateUsd;
+    this.audit(sessionId, agent, 'image.generated', { model: result.model, backend: backend.name, count: out.length, costUsd, costSource: result.costUsd != null ? 'actual' : 'estimate', artifactIds: out.map((o) => o.id), prompt: shortPrompt });
+    return { ok: true, artifacts: out, model: result.model, costUsd };
   }
 
   /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8665,6 +8665,10 @@ function IntegrationsSettings({ me }: { me: Member }) {
   const [slackState, setSlackState] = useState<SlackStatus | null>(null)
   const [discord, setDiscord] = useState<IntegrationsResp['discord']>({ botToken: false, configured: false })
   const [discordState, setDiscordState] = useState<DiscordStatus | null>(null)
+  const [image, setImage] = useState<IntegrationsResp['image']>({ openRouter: false, atlas: false, backend: null, defaultModel: '', configured: false })
+  const [orKey, setOrKey] = useState('')
+  const [atKey, setAtKey] = useState('')
+  const [imgModel, setImgModel] = useState('')
   const [chatRouter, setChatRouter] = useState(true)
   const [chatIdle, setChatIdle] = useState(30)
   const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
@@ -8680,11 +8684,14 @@ function IntegrationsSettings({ me }: { me: Member }) {
   // Defensive defaults so an older backend (one that predates a field) never white-screens the page.
   const SLACK_DEFAULT = { appToken: false, botToken: false, configured: false }
   const DISCORD_DEFAULT = { botToken: false, configured: false }
+  const IMAGE_DEFAULT = { openRouter: false, atlas: false, backend: null, defaultModel: '', configured: false } as const
   const apply = (r: IntegrationsResp) => {
     if (r.composio) setComposio(r.composio)
     if (r.webhook) setWebhook(r.webhook)
     setSlack(r.slack ?? SLACK_DEFAULT)
     setDiscord(r.discord ?? DISCORD_DEFAULT)
+    setImage(r.image ?? IMAGE_DEFAULT)
+    if (r.image) setImgModel(r.image.defaultModel || '')
     if (typeof r.chatRouter === 'boolean') setChatRouter(r.chatRouter)
     if (typeof r.chatIdleTimeoutMin === 'number') setChatIdle(r.chatIdleTimeoutMin)
     setMeta({ updatedAt: r.updatedAt, updatedBy: r.updatedBy })
@@ -8725,12 +8732,12 @@ function IntegrationsSettings({ me }: { me: Member }) {
     loadStatus()
   }, [])
 
-  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }, label: string) => {
+  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }, label: string) => {
     setBusy(true); setHint('')
     const r = await api.saveIntegrations(body)
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
-    setKey(''); setWh(''); setAppTok(''); setBotTok(''); setDiscordTok('')
+    setKey(''); setWh(''); setAppTok(''); setBotTok(''); setDiscordTok(''); setOrKey(''); setAtKey('')
     apply(r)
     setHint(label); setTimeout(() => setHint(''), 1500)
     // The Socket-Mode / Gateway connection re-dials on the server when tokens change — poll until the
@@ -8968,6 +8975,68 @@ function IntegrationsSettings({ me }: { me: Member }) {
               </div>
             )
           })()}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-medium">
+              Image generation
+              {image.configured
+                ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px] text-emerald-600">on · {image.backend === 'openrouter' ? 'OpenRouter' : 'Atlas Cloud'}</Badge>
+                : <Badge variant="outline" className="px-1.5 py-0 text-[10px]">not configured</Badge>}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Gives every agent an <code className="text-[11px]">image_generate</code> tool (Claude can't draw natively).
+              Generated images land in the <strong>Artifacts</strong> gallery and the run is cost-metered + audited. Set
+              <strong> one</strong> backend key — <strong>OpenRouter</strong> (recommended: reports the exact per-image cost) or
+              <strong> Atlas Cloud</strong> (broadest catalog; also covers video later). If both are set, OpenRouter is used.
+            </p>
+          </div>
+
+          <Field label="OpenRouter API key" help="openrouter.ai → Keys. One Bearer key reaches 30+ image models; usage.cost is debited per request.">
+            <Input
+              type="password"
+              value={orKey}
+              onChange={(e) => setOrKey(e.target.value)}
+              placeholder={image.openRouter ? '•••• (saved) — type a new key to replace' : 'sk-or-…'}
+              className="font-mono text-xs"
+            />
+            {image.openRouter && (
+              <button type="button" className="mt-1 text-[11px] text-muted-foreground hover:text-destructive disabled:opacity-50" onClick={() => save({ openRouterKey: '' }, 'removed')} disabled={busy}>Remove key</button>
+            )}
+          </Field>
+
+          <Field label="Atlas Cloud API key" help="atlascloud.ai → API keys. OpenAI-compatible; covers image + video under one key.">
+            <Input
+              type="password"
+              value={atKey}
+              onChange={(e) => setAtKey(e.target.value)}
+              placeholder={image.atlas ? '•••• (saved) — type a new key to replace' : 'atlas key'}
+              className="font-mono text-xs"
+            />
+            {image.atlas && (
+              <button type="button" className="mt-1 text-[11px] text-muted-foreground hover:text-destructive disabled:opacity-50" onClick={() => save({ atlasKey: '' }, 'removed')} disabled={busy}>Remove key</button>
+            )}
+          </Field>
+
+          <Field label="Default model" help="Optional — a backend-specific model id used when an agent doesn't name one. Blank = the backend's built-in default.">
+            <Input
+              value={imgModel}
+              onChange={(e) => setImgModel(e.target.value)}
+              onBlur={() => { if (imgModel.trim() !== (image.defaultModel || '')) save({ imageDefaultModel: imgModel.trim() }, 'default model saved') }}
+              placeholder="e.g. google/gemini-3.1-flash-image-preview (OpenRouter) or flux.2 (Atlas)"
+              className="font-mono text-xs"
+            />
+          </Field>
+
+          <div className="flex items-center gap-3">
+            <Button
+              onClick={() => save({ ...(orKey.trim() ? { openRouterKey: orKey.trim() } : {}), ...(atKey.trim() ? { atlasKey: atKey.trim() } : {}) }, 'saved')}
+              disabled={busy || (!orKey.trim() && !atKey.trim())}
+            >Save</Button>
+          </div>
         </CardContent>
       </Card>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -737,6 +737,8 @@ export interface IntegrationsResp {
   slack: { appToken: boolean; botToken: boolean; configured: boolean }
   /** Native Discord (Gateway) — whether the bot token is set; never the token. */
   discord: { botToken: boolean; configured: boolean }
+  /** Image generation backend — which keys are set (never the keys), the active backend, default model. */
+  image: { openRouter: boolean; atlas: boolean; backend: 'openrouter' | 'atlas' | null; defaultModel: string; configured: boolean }
   /** Generic `/agent` chat router: when on, an unmatched Slack/Discord message reaches any agent by name. */
   chatRouter: boolean
   /** Warm (resident) Slack thread session idle-kill, minutes. 0 = residence off (every reply cold-starts). */
@@ -1021,7 +1023,7 @@ export const api = {
   disconnectApp: (body: { id: string; scope: 'company' | 'personal' }) =>
     call<{ ok?: boolean; error?: string }>('POST', '/api/connections/disconnect', body),
   integrations: () => call<IntegrationsResp>('GET', '/api/settings/integrations'),
-  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
+  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
   slackStatus: () => call<SlackStatus>('GET', '/api/settings/slack/status'),
   discordStatus: () => call<DiscordStatus>('GET', '/api/settings/discord/status'),
 


### PR DESCRIPTION
## What

Gives every agent an **`image_generate`** MCP tool — Claude can't create images natively. Prompt in → image(s) land in the **Artifacts** gallery (`kind:'image'`, folder `generated-images`) + an owner-scoped inbox card → the tool returns the artifact ids.

First slice of the broader media/peer-agent integration arc (video + Codex/Antigravity are the documented roadmap in `docs/media-integrations-plan.md`).

## How it's wired (the OS-owned MCP tool pattern)

`image_generate` (memory-mcp) → `POST /api/agent/image/generate` (pre-auth loopback, session-secret gated) → `TerminalManager.generateImage`:

1. **Govern before spending** — classify capability `image.generate` with `amountUsd` = the per-image estimate, so the default **money-cap `never` rule gates a runaway spend for free** (deny/approval respected). An owner can add a policy rule to tighten it.
2. **Swappable backend** (`src/edge/image-gen.ts`, `resolveImageBackend`) — **OpenRouter** (default; one Bearer POST → 30+ models, and `usage.cost` gives the exact per-request USD so metering needs no static price table) or **Atlas Cloud** (OpenAI-compatible; also the future video lane). Picked by whichever key is set; OpenRouter wins if both.
3. **Artifact out** — URL-or-base64 vendor output is normalised to bytes and snapshotted **immediately** (vendor URLs can expire in minutes) via the new **`ArtifactStore.ingest`** (server-side bytes → gallery, mirrors `publish` minus the working-folder copy). The gallery already previews `image/*`, so zero UI work there.
4. **Audit** `image.generated` with the **real** cost when the backend reports it, else the estimate.

Keys + optional default model live in **Settings → Integrations** (new Image card); `imageGenConfigured()` → `IMAGE_GEN=1` exposes the tool per session.

## Backend choice

Informed by a deep-research pass (see the plan doc): OpenRouter's Unified Image API (launched 2026-06-23) is the standout for us because `usage.cost` is machine-readable — the budget/metering plane debits the real number. Atlas Cloud is the breadth/video alternative. Built behind an interface so either (or a future adapter) drops in.

## Test

- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → 68/68 ✓
- Backend factory sanity-checked (selection order, default-model override, no-key → undefined).
- ⚠️ End-to-end generation not exercised here — it needs a real OpenRouter/Atlas key. Set one in Settings → Integrations to verify the live path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)