### PR TITLE
feat(goals): Phase 2 — the goal auto-planner (v0.121.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.121.0] — 2026-07-13
+### Added
+- **Goals Phase 2 — the goal auto-planner ("set the goal, the fleet keeps it moving").** When opted in, the
+  scheduler now notices a **stuck** active goal and runs the strategist to draft a plan on its own — no more
+  clicking "Plan this goal" for every goal. See `docs/goals-plan.md` §Slice 3 / Phase 2.
+  - **Detects** an active goal with **no open work** (no non-terminal linked task — never planned, or all its
+    tasks finished but it isn't achieved) that has sat idle past a grace window (so a goal you're still
+    editing isn't grabbed) — `GoalStore.stuck()`.
+  - **Acts** via `Automations.sweepStuckGoals()` on the scheduler tick: runs the strategist **file-only**
+    (drafts tasks for review; never auto-dispatches), **as the goal's owner** (human passthrough). Bounded by
+    a per-tick cap (`GOAL_AUTOPLAN_MAX_PER_TICK`), a per-goal cooldown (`GOAL_REPLAN_COOLDOWN_MS`, keyed on
+    the last `goal.planned` audit), and the whole-box concurrency cap — so it can't spam or burst sessions.
+    Audited `goal.autoplanned`.
+  - **Opt-in**: an **"Auto-plan stuck goals"** toggle on the Goals page (owner/admin), **default OFF**
+    (`settings.autoPlanGoals`) since it spawns agent sessions. Decoupled from Dreaming — a plain deterministic
+    check on the goal's own data, not AI "sensing". Activity-based stall (open-but-stale tasks) is a
+    documented future knob.
+
 ## [0.120.0] — 2026-07-11
 ### Added
 - **Image generation — agents can now draw.** Claude can't create images natively, so `image_generate`

--- a/docs/goals-plan.md
+++ b/docs/goals-plan.md
@@ -227,10 +227,13 @@ a *deterministic tally aggregator, dormant by default, with zero goal awareness*
 intelligent "this goal is stalled → plan it" sensor. So the strategist is **human-triggered and stands
 alone**. The only reusable asset borrowed from that subsystem is the spawn-a-governed-agent scaffolding.
 
-**Phase 2 (deferred):** a **deterministic goal-stall auto-trigger** — on the scheduler tick, an active
-goal that is overdue / flat-progress / idle spawns the strategist (guarded, reusing the `dispatchTask`
-mold). Net-new and cheap (the Goals plane already computes `progress()` + `dueAt`); explicitly NOT a
-dependency on Dreaming's stub intelligence.
+**Phase 2 (shipped, v0.121.0):** the **goal auto-planner**. On the scheduler tick, `Automations.sweepStuckGoals`
+finds active goals with **no open work** that have sat idle past a grace window (`GoalStore.stuck`) and runs
+the strategist to draft a plan — **file-only** (never dispatches), as the goal's owner, bounded by a per-tick
+cap + per-goal cooldown + the whole-box concurrency cap. **Opt-in** via the "Auto-plan stuck goals" toggle
+(Settings-backed `autoPlanGoals`, default OFF — it spawns sessions). A plain deterministic check on the goal's
+own data — NOT wired to Dreaming. Activity-based stall (open-but-stale tasks) is a documented future knob;
+this v1 triggers only on "no open work" (never-planned, or all tasks finished but goal not achieved).
 
 **Phase 3 (later, separate concern):** if/when Dreaming gains real LLM reasoning, fold stall-judgment into
 it — a Dreaming upgrade tracked against its 🟡 Partial grade, not a blocker for goals.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.120.0",
+  "version": "0.121.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.120.0",
+      "version": "0.121.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.120.0",
+  "version": "0.121.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -11,6 +11,7 @@
 import { randomBytes, randomUUID } from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
+import { Strategist } from './strategist';
 import { AgentOS } from '../kernel';
 import { Db } from '../state/db';
 import { TerminalManager } from '../terminal';
@@ -215,6 +216,13 @@ export const SCHEDULE_MAX_PENDING = 25;           // per agent: pending (enabled
 // A task that fails to complete N times stops being auto-dispatched and is parked `blocked` for a human,
 // so a broken task can't spin the scheduler forever (the Tasks analog of the automation pile-up guard).
 export const TASK_MAX_ATTEMPTS = 3;
+
+// Goal auto-planner (Phase 2) bounds. A "stuck" active goal (no open work) is auto-planned by the
+// strategist — but only after it's sat idle past the grace window (so a just-created goal you're still
+// editing isn't grabbed), no more than a few per tick, and not again within the cooldown.
+const GOAL_AUTOPLAN_GRACE_MS = Number(process.env.AOS_GOAL_AUTOPLAN_GRACE_MS) || 5 * 60_000; // 5 min
+const GOAL_REPLAN_COOLDOWN_MS = Number(process.env.AOS_GOAL_REPLAN_COOLDOWN_MS) || 6 * 3_600_000; // 6 h
+const GOAL_AUTOPLAN_MAX_PER_TICK = Number(process.env.AOS_GOAL_AUTOPLAN_MAX_PER_TICK) || 2;
 
 /**
  * The prompt a dispatched session runs: the task, plus the tools to close its own loop. Mirrors how the
@@ -738,6 +746,41 @@ export class Automations {
       this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'scheduler', type: 'scheduler.deferred', data: { deferred, cap, running } });
     }
     this.sweepOverdue(now);
+    this.sweepStuckGoals(now);
+  }
+
+  /**
+   * Phase 2 — the goal auto-planner. When opted in (Settings), find active goals with no open work that
+   * have sat idle past the grace window and run the strategist to draft/refresh a plan (file-only — it
+   * never dispatches). Bounded by a per-tick cap, a per-goal cooldown (the last `goal.planned` audit),
+   * and the whole-box concurrency cap, so it can't spam or burst sessions. Wrapped so a bad row never
+   * kills the scheduler; a no-op unless the toggle is on. Decoupled from Dreaming — a plain data check.
+   */
+  private sweepStuckGoals(now: Date): void {
+    if (!this.os.settings.autoPlanGoals()) return;
+    try {
+      const cap = this.maxConcurrent;
+      let spawned = 0;
+      for (const g of this.os.goals.stuck(this.os.tenant, GOAL_AUTOPLAN_GRACE_MS, now.getTime())) {
+        if (spawned >= GOAL_AUTOPLAN_MAX_PER_TICK) break;
+        if (cap > 0 && this.tm.aliveSessionCount() >= cap) break; // respect the whole-box concurrency cap
+        const last = this.db
+          .prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'goal.planned' AND data LIKE ?")
+          .get<{ t: number | null }>(`%"goalId":"${g.id}"%`);
+        if (last?.t && now.getTime() - last.t < GOAL_REPLAN_COOLDOWN_MS) continue; // recently planned — cool down
+        spawned++; // count optimistically to bound the per-tick burst
+        void new Strategist(this.os, this.tm)
+          .plan(g.id, 'automation:goal-planner', g.owner)
+          .then((r) => {
+            if (r.spawned) {
+              this.os.audit.append({ ts: Date.now(), runId: r.sessionId ?? '-', tenant: this.os.tenant, principal: 'automation:goal-planner', type: 'goal.autoplanned', data: { goalId: g.id, title: g.title } });
+            }
+          })
+          .catch(() => { /* a failed auto-plan must never take down the scheduler */ });
+      }
+    } catch {
+      // never let the goal sweep take down the automation scheduler
+    }
   }
 
   /**

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -26,6 +26,7 @@ const MEMORY_SWITCH_KEY = 'memory_backend_switched_at'; // ts the active externa
 const RUNTIME_DEFAULTS_KEY = 'runtime_defaults'; // workspace-wide model/effort/permission fallback (JSON RuntimeTuning)
 const DREAMING_KEY = 'dreaming_every_hours'; // self-learning cadence in hours; 0/unset = off
 const GOALS_INJECT_KEY = 'goals_inject'; // whether active goals ride in every agent's prompt (default on)
+const GOALS_AUTOPLAN_KEY = 'goals_autoplan'; // whether the scheduler auto-plans stuck goals (default OFF — opt-in)
 const DREAMING_STATE_KEY = 'dreaming_state'; // compounding self-learning state (cumulative totals/topics/recent)
 const LEARNED_GUIDANCE_KEY = 'learned_guidance'; // distilled imperatives injected into every agent's prompt
 const LEARNED_APPLY_KEY = 'learned_guidance_apply'; // 'off' to stop injecting (default on once guidance exists)
@@ -383,6 +384,14 @@ export class SettingsStore {
   }
   setInjectGoals(on: boolean, by?: string): void {
     this.set(GOALS_INJECT_KEY, on ? 'on' : 'off', by);
+  }
+  /** Whether the scheduler auto-plans "stuck" active goals via the strategist. Default OFF (opt-in —
+   *  it spawns governed agent sessions, which cost money). */
+  autoPlanGoals(): boolean {
+    return this.getRow(GOALS_AUTOPLAN_KEY)?.value === 'on';
+  }
+  setAutoPlanGoals(on: boolean, by?: string): void {
+    this.set(GOALS_AUTOPLAN_KEY, on ? 'on' : 'off', by);
   }
 
   /** Open config recommendations + dismissed ids. The dreamer regenerates `open` each pass (minus the

--- a/src/server.ts
+++ b/src/server.ts
@@ -2075,7 +2075,17 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const goals = os.goals.list({ tenant: os.tenant, status: (url.searchParams.get('status') as GoalStatus) || undefined, query: url.searchParams.get('q') || undefined, limit: 500 });
     // Derived progress per goal (from its linked tasks) for the page's progress bars — keyed by id.
     const progress = Object.fromEntries(goals.map((g) => [g.id, os.goals.progress(g.id)]));
-    return sendJson(res, 200, { goals, counts: os.goals.counts(os.tenant), progress });
+    return sendJson(res, 200, { goals, counts: os.goals.counts(os.tenant), progress, autoPlan: os.settings.autoPlanGoals() });
+  }
+  // Toggle the goal auto-planner (Phase 2) — opt-in, owner/admin. When on, the scheduler drafts a plan for
+  // any stuck active goal (file-only). Placed before the /:id routes so "autoplan" isn't read as a goal id.
+  if (method === 'POST' && p === '/api/goals/autoplan') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req);
+    const on = b.on === true || b.on === 'true';
+    os.settings.setAutoPlanGoals(on, me.email);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'goals.autoplan.set', data: { on } });
+    return sendJson(res, 200, { ok: true, autoPlan: on });
   }
   if (goalComment && method === 'POST') {
     const b = await readBody(req);

--- a/src/state/goals.ts
+++ b/src/state/goals.ts
@@ -126,6 +126,22 @@ export class GoalStore {
   }
 
   /**
+   * The auto-planner's trigger set: active goals that need (re)planning — they have **no OPEN**
+   * (non-terminal) linked task (never planned, or all their work finished but the goal isn't achieved) and
+   * haven't been edited within `graceMs` (so a goal you're still writing isn't grabbed). Oldest-idle first.
+   */
+  stuck(tenant: string, graceMs: number, now: number): Goal[] {
+    return this.db
+      .prepare(
+        `SELECT * FROM goals g WHERE g.tenant = ? AND g.status = 'active' AND g.updated_at < ?
+           AND NOT EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status NOT IN ('done','cancelled'))
+         ORDER BY g.updated_at ASC`,
+      )
+      .all<GoalRow>(tenant, now - graceMs)
+      .map(toGoal);
+  }
+
+  /**
    * The one mutating path for edits. Apply changed fields, bump updated_*, and append one goal_event per
    * meaningful change: a `status` event on transition, a `comment` for a note, an `edit` otherwise.
    */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4048,6 +4048,7 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
   const [progress, setProgress] = useState<Record<string, GoalProgress>>({})
   const [q, setQ] = useState('')
   const [fStatus, setFStatus] = useState<GoalStatus | ''>('') // '' = all
+  const [autoPlan, setAutoPlan] = useState(false) // scheduler auto-plans stuck goals (owner/admin toggle)
   // Selection is URL-driven (#/goals/<id>) so a goal detail is a shareable permalink.
   const selId = goalId || null
   const openGoal = (id: string) => nav('goals', id)
@@ -4082,6 +4083,14 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
     setGoals(r.goals ?? [])
     if (r.counts) setCounts(r.counts)
     setProgress(r.progress ?? {})
+    if (typeof r.autoPlan === 'boolean') setAutoPlan(r.autoPlan)
+  }
+  // Owner/admin toggle: let the scheduler auto-draft plans for stuck goals. Optimistic — revert on error.
+  const toggleAutoPlan = async (next: boolean) => {
+    setHint(''); setAutoPlan(next)
+    const r = await api.setAutoPlanGoals(next)
+    if (r.error) { setAutoPlan(!next); return setHint('⚠ ' + r.error) }
+    if (typeof r.autoPlan === 'boolean') setAutoPlan(r.autoPlan)
   }
   useEffect(() => { load() }, [q, fStatus])
   // Live refresh so an agent moving a goal reflects without a manual reload. Pause while a
@@ -4156,6 +4165,15 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
           The top of the strategy→task ladder. Frame the outcomes the fleet is working toward; agents propose
           goals for you to review, and each one grounds the tasks beneath it.
         </p>
+        {isAdmin && (
+          <label
+            className="flex cursor-pointer items-center gap-1.5 rounded-md border px-2 py-1 text-xs text-muted-foreground"
+            title="Auto-draft a plan for stuck goals (active goals with no open work). File-only — you still review & dispatch. Off by default."
+          >
+            <input type="checkbox" checked={autoPlan} onChange={(e) => toggleAutoPlan(e.target.checked)} />
+            Auto-plan
+          </label>
+        )}
         <div className="relative">
           <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
           <Input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search goals…" className="h-8 w-48 pl-7" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -966,7 +966,8 @@ export const api = {
   /** Direct URL to an attachment's bytes (inline; for download/preview links). */
   taskAttachmentUrl: (taskId: string, attId: string) => `/api/tasks/${taskId}/attachments/${attId}/raw`,
 
-  goals: (q = '', status = '') => call<{ goals: Goal[]; counts: GoalCounts; progress: Record<string, GoalProgress> }>('GET', `/api/goals?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
+  goals: (q = '', status = '') => call<{ goals: Goal[]; counts: GoalCounts; progress: Record<string, GoalProgress>; autoPlan?: boolean }>('GET', `/api/goals?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
+  setAutoPlanGoals: (on: boolean) => call<{ ok: boolean; autoPlan?: boolean; error?: string }>('POST', '/api/goals/autoplan', { on }),
   goal: (id: string) => call<{ goal?: Goal; events?: GoalEvent[]; tasks?: Task[]; progress?: GoalProgress; error?: string }>('GET', `/api/goals/${id}`),
   addGoal: (b: AddGoalReq) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', '/api/goals', b),
   patchGoal: (id: string, b: { title?: string; body?: string; status?: GoalStatus; target?: string | null; owner?: string | null; parentId?: string | null; labels?: string[]; dueAt?: number | null; note?: string }) => call<{ ok: boolean; goal?: Goal; error?: string }>('PATCH', `/api/goals/${id}`, b),


### PR DESCRIPTION
## Goals Phase 2 — the goal auto-planner

"Set the goal, the fleet keeps it moving." When opted in, the scheduler notices a **stuck** active goal and runs the strategist to draft a plan on its own — no more clicking "Plan this goal" for every goal. `docs/goals-plan.md` §Slice 3 / Phase 2.

### What's in
- **Detects** — `GoalStore.stuck()`: active goals with **no open work** (no non-terminal linked task — never planned, or all tasks finished but not achieved) that have sat idle past a grace window (so a goal you're still editing isn't grabbed).
- **Acts** — `Automations.sweepStuckGoals()` on the tick: runs the strategist **file-only** (drafts tasks for review; never auto-dispatches), **as the goal's owner** (human passthrough). Bounded by a per-tick cap, a per-goal cooldown (keyed on the last `goal.planned` audit), and the whole-box concurrency cap — so it can't spam or burst sessions. Audited `goal.autoplanned`.
- **Opt-in** — an **"Auto-plan stuck goals"** toggle on the Goals page (owner/admin), **default OFF** (`settings.autoPlanGoals`) since it spawns agent sessions. Decoupled from Dreaming — a plain deterministic check on the goal's own data. Activity-based stall is a documented future knob.

### Verification
- typecheck + backend + web builds clean; `npm run test:governance` → **68/68**
- Smoke-tested `stuck()`: never-planned + all-done → stuck; open-work / within-grace / draft → excluded; toggle default-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)