### PR TITLE
feat(media): per-artifact generation cost + true image format (v0.122.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.122.0] — 2026-07-13
+### Added
+- **Generation cost shows on each artifact in the gallery.** A generated image (and, later, video) now
+  records the USD it cost to produce (`artifacts.cost_usd`, new nullable column) — the per-request cost
+  the backend reports, split evenly across the images in the request so the gallery total sums back to
+  what was spent. The **Artifacts** page shows it inline on each card and the detail pane (`$0.0336` for
+  sub-cent amounts, `$0.42` otherwise). Published (non-generated) files carry no cost.
+  (`src/state/db.ts`, `src/state/artifacts.ts`, `src/terminal.ts`, `web/src/App.tsx`, `web/src/lib/api.ts`)
+### Fixed
+- **Generated images are saved with their true format.** The base64 return path hardcoded `.png`/`image/png`,
+  so a model that returned JPEG (e.g. OpenRouter's Gemini image models) was persisted as a mislabeled
+  `.png`. `image-gen` now sniffs the real format from the bytes' magic numbers (JPEG/PNG/WebP/GIF) and
+  names the file + mime from that, falling back to the content-type/URL hint only when the bytes are
+  unrecognized. (`src/edge/image-gen.ts`)
+
 ## [0.121.0] — 2026-07-13
 ### Added
 - **Goals Phase 2 — the goal auto-planner ("set the goal, the fleet keeps it moving").** When opted in, the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.121.0",
+  "version": "0.122.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.121.0",
+      "version": "0.122.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.121.0",
+  "version": "0.122.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/image-gen.ts
+++ b/src/edge/image-gen.ts
@@ -74,23 +74,35 @@ const EXT_BY_MIME: Record<string, string> = {
   'image/gif': 'gif',
 };
 
-/** Turn one vendor image entry (a URL or inline base64) into raw bytes + a file extension. */
+/** Turn one vendor image entry (a URL or inline base64) into raw bytes + a file extension. The ext is
+ *  sniffed from the actual bytes (magic numbers) first — vendors mislabel format (e.g. return JPEG on a
+ *  model we'd otherwise assume is PNG), and the ext drives both the filename and the stored mime, so
+ *  trusting a content-type/URL hint would persist a wrong `.png`/`image/png` over real JPEG. */
 async function toBytes(entry: { url?: string; b64_json?: string; b64?: string }): Promise<GeneratedImage> {
   const b64 = entry.b64_json ?? entry.b64;
   if (b64) {
     const comma = b64.indexOf(','); // tolerate a data: URI prefix
     const raw = comma >= 0 && b64.slice(0, comma).includes('base64') ? b64.slice(comma + 1) : b64;
-    return { bytes: Buffer.from(raw, 'base64'), ext: 'png' };
+    const bytes = Buffer.from(raw, 'base64');
+    return { bytes, ext: sniffExt(bytes, 'png') };
   }
   if (entry.url) {
     const res = await fetch(entry.url);
     if (!res.ok) throw new Error(`fetching generated image failed (${res.status})`);
     const ct = (res.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
     const buf = Buffer.from(await res.arrayBuffer());
-    const ext = EXT_BY_MIME[ct] || extFromUrl(entry.url) || 'png';
-    return { bytes: buf, ext };
+    return { bytes: buf, ext: sniffExt(buf, EXT_BY_MIME[ct] || extFromUrl(entry.url) || 'png') };
   }
   throw new Error('vendor returned an image with neither a url nor base64 data');
+}
+
+/** Detect the real image format from the leading magic bytes, falling back to a hint when unknown. */
+function sniffExt(buf: Buffer, fallback: string): string {
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) return 'jpg';
+  if (buf.length >= 8 && buf[0] === 0x89 && buf[1] === 0x50 && buf[2] === 0x4e && buf[3] === 0x47) return 'png';
+  if (buf.length >= 12 && buf.toString('latin1', 0, 4) === 'RIFF' && buf.toString('latin1', 8, 12) === 'WEBP') return 'webp';
+  if (buf.length >= 4 && buf.toString('latin1', 0, 4) === 'GIF8') return 'gif';
+  return fallback;
 }
 
 function extFromUrl(url: string): string | undefined {

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -29,6 +29,8 @@ export interface Artifact {
   relPath: string;
   mime: string;
   bytes: number;
+  /** USD this artifact cost to generate (image/video); undefined for published (non-generated) files. */
+  costUsd?: number;
   createdAt: number;
 }
 
@@ -45,6 +47,7 @@ interface ArtifactRow {
   rel_path: string;
   mime: string;
   bytes: number;
+  cost_usd: number | null;
   created_at: number;
 }
 
@@ -104,18 +107,24 @@ export class ArtifactStore {
       rel_path: path.join(id, filename),
       mime: mimeOf(filename),
       bytes: st.size,
+      cost_usd: null, // published files aren't generated → no cost
       created_at: Date.now(),
     };
+    this.insertRow(row);
+    return { ok: true, artifact: toArtifact(row) };
+  }
+
+  /** Single INSERT both publish + ingest share, so the column list lives in one place. */
+  private insertRow(row: ArtifactRow): void {
     this.db
       .prepare(
-        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, cost_usd, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         row.id, row.session_id, row.agent, row.source, row.kind, row.title, row.description,
-        row.folder, row.filename, row.rel_path, row.mime, row.bytes, row.created_at,
+        row.folder, row.filename, row.rel_path, row.mime, row.bytes, row.cost_usd, row.created_at,
       );
-    return { ok: true, artifact: toArtifact(row) };
   }
 
   /**
@@ -134,6 +143,7 @@ export class ArtifactStore {
     filename: string;
     bytes: Buffer;
     kind?: string;
+    costUsd?: number; // USD this artifact cost to generate (surfaced in the gallery)
   }): PublishResult {
     if (!this.dir) return { ok: false, error: 'no data home configured (artifacts disabled)' };
     const filename = path.basename(input.filename) || 'image.png';
@@ -155,17 +165,10 @@ export class ArtifactStore {
       rel_path: path.join(id, filename),
       mime: mimeOf(filename),
       bytes: input.bytes.length,
+      cost_usd: typeof input.costUsd === 'number' ? input.costUsd : null,
       created_at: Date.now(),
     };
-    this.db
-      .prepare(
-        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        row.id, row.session_id, row.agent, row.source, row.kind, row.title, row.description,
-        row.folder, row.filename, row.rel_path, row.mime, row.bytes, row.created_at,
-      );
+    this.insertRow(row);
     return { ok: true, artifact: toArtifact(row) };
   }
 
@@ -242,6 +245,7 @@ function toArtifact(r: ArtifactRow): Artifact {
     relPath: r.rel_path,
     mime: r.mime,
     bytes: r.bytes,
+    costUsd: r.cost_usd ?? undefined,
     createdAt: r.created_at,
   };
 }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -669,6 +669,10 @@ function migrate(db: Db): void {
   // browsable tree. Pure organizing metadata — the on-disk <id>/<filename> layout is unchanged.
   // Existing artifacts default to '' (root).
   addColumn(db, 'artifacts', 'folder', "TEXT NOT NULL DEFAULT ''");
+
+  // Generated-media cost: the USD a generated artifact (image/video) cost to produce, so the gallery
+  // can show what each deliverable spent. NULL for published (non-generated) artifacts. Nullable REAL.
+  addColumn(db, 'artifacts', 'cost_usd', 'REAL');
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2227,12 +2227,16 @@ export class TerminalManager {
     const source = srow?.run_as ?? srow?.spawned_by ?? undefined;
     const shortPrompt = prompt.length > 60 ? prompt.slice(0, 57) + '…' : prompt;
     const stamp = Date.now();
+    const costUsd = result.costUsd ?? estimateUsd;
+    // Cost is per-REQUEST; split it evenly across the images so each artifact carries its share and the
+    // gallery total sums back to what the request spent.
+    const perImageUsd = +(costUsd / result.images.length).toFixed(6);
     const out: { id: string; filename: string; mime: string }[] = [];
     result.images.forEach((img, i) => {
       const filename = `image-${stamp}${result.images.length > 1 ? `-${i + 1}` : ''}.${img.ext}`;
       const r = this.os.artifacts.ingest({
         sessionId, agent, source, title: shortPrompt, description: prompt,
-        folder: 'generated-images', filename, bytes: img.bytes, kind: 'image',
+        folder: 'generated-images', filename, bytes: img.bytes, kind: 'image', costUsd: perImageUsd,
       });
       if (!r.ok) return;
       const a = r.artifact;
@@ -2245,7 +2249,6 @@ export class TerminalManager {
     });
     if (!out.length) return { ok: false, error: 'generation succeeded but no image could be stored' };
 
-    const costUsd = result.costUsd ?? estimateUsd;
     this.audit(sessionId, agent, 'image.generated', { model: result.model, backend: backend.name, count: out.length, costUsd, costSource: result.costUsd != null ? 'actual' : 'estimate', artifactIds: out.map((o) => o.id), prompt: shortPrompt });
     return { ok: true, artifacts: out, model: result.model, costUsd };
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2993,6 +2993,9 @@ function Field({ label, help, children }: { label: string; help?: string; childr
 const fmtSize = (n: number): string =>
   n < 1024 ? `${n} B` : n < 1024 * 1024 ? `${(n / 1024).toFixed(1)} KB` : `${(n / 1024 / 1024).toFixed(1)} MB`
 
+/** Generated-media cost in USD — sub-cent amounts keep 4 decimals so a $0.0336 image doesn't read $0.03. */
+const fmtCost = (usd: number): string => (usd < 0.01 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`)
+
 /** Browse + edit files in the instance's data home. The server confines every path to the
  *  home root; navigation (folders/breadcrumb) + a text editor, plus upload (button or drag-drop),
  *  download, new-folder and delete. */
@@ -3440,7 +3443,7 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
                       <Badge variant="secondary" className="px-1.5 py-0 text-[10px] font-normal">{a.agent}</Badge>
                       <span className="truncate font-mono">{a.filename}</span>
                     </div>
-                    <div className="mt-0.5 text-[11px] text-muted-foreground">{fmtSize(a.bytes)} · {new Date(a.createdAt).toLocaleString()}</div>
+                    <div className="mt-0.5 text-[11px] text-muted-foreground">{fmtSize(a.bytes)}{a.costUsd != null ? ` · ${fmtCost(a.costUsd)}` : ''} · {new Date(a.createdAt).toLocaleString()}</div>
                   </div>
                 </div>
               </a>
@@ -3462,6 +3465,7 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
                       <span className="font-mono">{selected.filename}</span>
                       {selected.folder && <span className="inline-flex items-center gap-0.5"><Folder className="h-3 w-3" /><span className="font-mono">{selected.folder}/</span></span>}
                       <span>· {fmtSize(selected.bytes)}</span>
+                      {selected.costUsd != null && <span>· <span title="Generation cost">{fmtCost(selected.costUsd)}</span></span>}
                       <span>· session <span className="font-mono">{selected.sessionId}</span></span>
                     </div>
                   </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -197,6 +197,8 @@ export interface Artifact {
   relPath: string
   mime: string
   bytes: number
+  /** USD this artifact cost to generate (image/video); absent for published (non-generated) files. */
+  costUsd?: number
   createdAt: number
 }
 


### PR DESCRIPTION
Follow-up to the image_generation feature (#207), driven by the live end-to-end test.

## Added — cost per artifact in the gallery
Each generated image now records what it cost. New nullable `artifacts.cost_usd` column; `ArtifactStore.ingest` accepts `costUsd`; `TerminalManager.generateImage` splits the backend's **per-request** cost evenly across the images so the gallery total sums back to what the request spent. The **Artifacts** page shows it inline on each card and in the detail pane (`$0.0336` for sub-cent, `$0.42` otherwise). Published (non-generated) files carry no cost. Flows to the agent `artifacts_list` too (same `Artifact` shape).

## Fixed — true image format
The live test surfaced it: OpenRouter's Gemini image model returned **JPEG** bytes, but the base64 path hardcoded `.png`/`image/png`, persisting a mislabeled file. `image-gen` now **sniffs the real format from magic bytes** (JPEG/PNG/WebP/GIF) and derives the filename + mime from that, using the content-type/URL hint only as a fallback.

## Test
- `typecheck` ✓ · `web build` ✓ · `governance 68/68` ✓
- Migration is additive + idempotent (`addColumn` guards on `PRAGMA table_info`); existing artifacts get `NULL` cost.
- Will re-run the live end-to-end after deploy to confirm cost shows + the file lands as real JPEG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)