### PR TITLE
fix(terminal): deliverToResident resolves + audits turn state before typing (v0.121.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.123.1] — 2026-07-13
+### Changed
+- **`deliverToResident` now resolves and audits the target's turn state before typing a chat follow-up
+  into it — the reliance on claude's message queue is intentional, not incidental.** Typing into a live
+  resident TUI is always safe (an idle claude runs the message now; a mid-turn claude *queues* it and
+  drains it at the next turn boundary — verified against the live TUI: injected keystrokes land as "queued
+  messages" and never interrupt), so delivery is unchanged. What's new is that we now classify the state
+  and record it on the `chat.delivered` audit event as `{ turn, queued }`:
+  - **`blocked`** — authoritative from the DB: a pending `ask`/approval whose turn can't end until a human
+    responds, so the follow-up necessarily queues behind it (`hasPendingHumanBlock`). This wins over any
+    pane reading, so a session that merely *looks* idle while parked on a human is never mislabeled.
+  - **`busy` / `idle`** — a best-effort read of the live pane (`residentTurnState`) that keys on claude's
+    working chrome (the "esc to interrupt" hint, the live `↓ N tokens` / `(12s …)` counter, or follow-ups
+    already queued). It only *labels* the audit — no delivery behaviour depends on it.
+  - **`unknown`** — the pane couldn't be read (launcher backend / unreachable socket); delivers as before.
+
 ## [0.123.0] — 2026-07-13
 ### Changed
 - **"Artifacts" → "Library" (agent-facing rename).** Claude Code ships its own native `Artifact` tool, so

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.123.0",
+  "version": "0.123.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.123.0",
+      "version": "0.123.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.123.0",
+  "version": "0.123.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -985,6 +985,15 @@ export class TerminalManager {
    * Deliver a thread follow-up to a LIVE resident chat session by typing it into the running claude
    * (tmux send-keys) — the warm, fast path (no cold reload). Bumps the idle clock. Returns false when
    * the session isn't a live resident or the keystrokes couldn't be delivered (caller then revives).
+   *
+   * Turn-state check: typing into a claude TUI is always safe — an idle claude runs the message now, a
+   * BUSY (mid-turn) claude QUEUES it and drains it at the next turn boundary (verified against the live
+   * TUI: mid-turn keystrokes land as "queued messages", they never interrupt). We deliver in every case
+   * because that queueing is exactly the hand-off we want; but we now resolve WHICH state we delivered
+   * into and record it, so the reliance on claude's queue is intentional and auditable — not incidental.
+   * The one authoritative state is `blocked` (a pending ask/approval whose turn can't end until a human
+   * responds, so the follow-up necessarily queues behind it); idle-vs-generating is a best-effort pane
+   * read that only labels the audit and never gates delivery.
    */
   deliverToResident(sessionId: string, text: string): boolean {
     const row = this.db.prepare('SELECT tmux, status, resident, run_as, spawned_by FROM term_sessions WHERE id = ?')
@@ -993,13 +1002,35 @@ export class TerminalManager {
     if (!this.isAlive(sessionId)) return false;
     const body = (text || '').replace(/\r?\n+/g, ' ').trim(); // one-line: a stray newline would submit early
     if (!body) return false;
-    const ok = this.backend.injectText(this.spaceFor(row.run_as ?? row.spawned_by), row.tmux, body, true);
+    const space = this.spaceFor(row.run_as ?? row.spawned_by);
+    const turn: 'idle' | 'busy' | 'blocked' | 'unknown' =
+      this.hasPendingHumanBlock(sessionId) ? 'blocked' : this.residentTurnState(space, row.tmux);
+    const ok = this.backend.injectText(space, row.tmux, body, true);
     if (ok) {
       this.db.prepare('UPDATE term_sessions SET last_activity = ?, updated_at = ? WHERE id = ?').run(Date.now(), Date.now(), sessionId);
       const agent = this.sessionAgent(sessionId) ?? '';
-      this.audit(sessionId, agent, 'chat.delivered', { chars: body.length });
+      // `queued` = the message will wait for claude to finish the current turn before it's read.
+      this.audit(sessionId, agent, 'chat.delivered', { chars: body.length, turn, queued: turn === 'busy' || turn === 'blocked' });
     }
     return ok;
+  }
+
+  /**
+   * Best-effort read of a live resident's turn state from its pane: 'busy' while a turn is generating
+   * (claude renders a live token/elapsed counter, an "esc to interrupt" hint, or shows follow-ups already
+   * queued behind the running turn), else 'idle', and 'unknown' when the pane can't be read (the launcher
+   * backend / an unreachable socket → capturePane returns null). This is a HEURISTIC on claude's TUI
+   * chrome, so it only LABELS the audit in `deliverToResident` — no behaviour depends on it (a follow-up
+   * is safe to type in any state; claude runs it when idle and queues it when busy).
+   */
+  private residentTurnState(space: string, tmux: string): 'idle' | 'busy' | 'unknown' {
+    const pane = this.backend.capturePane(space, tmux);
+    if (pane == null) return 'unknown';
+    // Any one of: the "esc to interrupt" hint, the live "↓ N tokens" counter, an elapsed "(12s …)" timer
+    // beside the spinner, or follow-ups already "queued messages" behind the running turn. A finished
+    // turn's summary line (e.g. "Cooked for 13s", no parens) is deliberately NOT matched.
+    if (/esc to interrupt|·\s*↓\s*[\d.]+\s*tokens?|queued messages?|\(\d+\s*s(\s|·|\))/i.test(pane)) return 'busy';
+    return 'idle';
   }
 
   /**


### PR DESCRIPTION
## What

`deliverToResident` types a resident chat follow-up straight into the live claude TUI (tmux `send-keys`). This adds an explicit **turn-state check** at the injection point so the reliance on claude's message queue is intentional and observable, not incidental.

I first **tested the underlying behaviour** by driving a real claude TUI via `send-keys` while it was mid-turn: the injected keystrokes land as **"queued messages"** and **never interrupt** the running turn — claude drains them at the next turn boundary. So typing is always safe; the gap was that the reliance was implicit and the delivery under-audited.

## Change

`deliverToResident` now resolves the target's turn state and records it on the `chat.delivered` audit event as `{ turn, queued }`:

- **`blocked`** — authoritative from the DB (`hasPendingHumanBlock`: a pending `ask`/approval whose turn can't end until a human responds → the follow-up necessarily queues behind it). This **wins over any pane reading**, so a session parked on a human that merely *looks* idle is never mislabeled.
- **`busy` / `idle`** — a best-effort read of the live pane (`residentTurnState`) keyed on claude's working chrome (the "esc to interrupt" hint, the live `↓ N tokens` / `(12s …)` counter, or already-queued follow-ups). **Labels the audit only — no delivery behaviour depends on it**, so a future claude TUI change can at worst mislabel, never misbehave.
- **`unknown`** — pane unreadable (launcher backend / unreachable socket); delivers exactly as before.

Delivery is **unchanged** — `injectText` still fires in every state. This is a hardening + observability change, not a behavioural gate.

## Testing

- `npm run typecheck` ✓ · `npm run build` ✓ · `npm run test:governance` → 68/68 ✓
- The `residentTurnState` regex validated against **real captured panes** (including the `(46s)`-only generating state → busy, and a completed `Cooked for 13s` summary line → idle).
- In-process harness (isolated `AGENT_OS_HOME`, stubbed backend) exercised all four states end-to-end:

| Case | Pane | DB | `turn` / `queued` | delivered |
|------|------|----|-------------------|-----------|
| idle | status bar | — | `idle` / `false` | ✓ |
| busy | `Precipitating… (46s)` | — | `busy` / `true` | ✓ |
| blocked | *looks idle* | pending question | `blocked` / `true` | ✓ |
| unknown | `capturePane→null` | — | `unknown` / `false` | ✓ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)