### PR TITLE
feat(web): pinnable sidebar nav — each member curates their own Main (v0.122.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.124.0] — 2026-07-13
+### Added
+- **Pinnable sidebar nav — each member curates their own Main.** Every secondary nav item is now pinnable:
+  hover a row and click the pin to promote it into the top **Main** section, or unpin it back down to
+  **Manage**. Main = your pinned set, Manage = everything else, with **Inbox + Agents** as permanent anchors
+  (the app's spine — never unpinnable). Goals, Tasks, and Library join the pinnable set (they were hardwired
+  into Main before), so a tenant that doesn't use Goals can reclaim the slot; they stay pinned by default so
+  nothing changes until you customize.
+  - **Per member, not per workspace** — pins are stored in the member's `member_prefs` blob (alongside
+    notification prefs, without clobbering them) and ride in on `/api/auth/me` so the sidebar renders your
+    layout at first paint (no flash). Saved through `PUT /api/me/nav`.
+  - **Role-aware** — you can only pin pages you're allowed to see (Skills/Files/Audit/Settings stay
+    admin-only), and the collapsed icon rail reflects your pins too.
+
 ## [0.123.1] — 2026-07-13
 ### Changed
 - **`deliverToResident` now resolves and audits the target's turn state before typing a chat follow-up

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.123.1",
+  "version": "0.124.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.123.1",
+      "version": "0.124.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.123.1",
+  "version": "0.124.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -9,7 +9,7 @@
  */
 import { randomBytes } from 'crypto';
 import { Db } from '../state/db';
-import { AgentAccess, Member, MemberIdentity, IdentityProvider, Role, ApprovalLevel, canApprove, NotificationPrefs, sanitizeNotificationPrefs } from '../types';
+import { AgentAccess, Member, MemberIdentity, IdentityProvider, Role, ApprovalLevel, canApprove, NotificationPrefs, sanitizeNotificationPrefs, sanitizeNavPins } from '../types';
 
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // magic links valid for 7 days
 const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // login cookie valid for 30 days
@@ -56,27 +56,54 @@ export class TeamStore {
     return this.db.prepare('SELECT COUNT(*) AS n FROM members').get<{ n: number }>()!.n;
   }
 
-  // ── per-member notification preferences ──────────────────────────────────────
-  /** This member's notification prefs, merged over the defaults (missing row → all defaults). */
-  notificationPrefs(memberId: string): NotificationPrefs {
+  // ── per-member preferences (member_prefs: one JSON blob per member) ───────────
+  /** The member's raw prefs blob — notification fields live flat at the top level, `navPins` alongside.
+   *  Every accessor reads/writes through this so one concern (e.g. saving notif prefs) never clobbers a
+   *  sibling (e.g. the pinned nav). Missing/corrupt row → empty object. */
+  private rawPrefs(memberId: string): Record<string, unknown> {
     const row = this.db.prepare('SELECT prefs FROM member_prefs WHERE member_id = ?').get<{ prefs: string }>(memberId);
-    if (!row) return sanitizeNotificationPrefs(undefined);
+    if (!row) return {};
     try {
-      return sanitizeNotificationPrefs(JSON.parse(row.prefs));
+      const o = JSON.parse(row.prefs);
+      return o && typeof o === 'object' ? (o as Record<string, unknown>) : {};
     } catch {
-      return sanitizeNotificationPrefs(undefined);
+      return {};
     }
   }
 
-  /** Persist a member's notification prefs (sanitized over the defaults) and return the resolved set. */
-  setNotificationPrefs(memberId: string, prefs: unknown): NotificationPrefs {
-    const clean = sanitizeNotificationPrefs(prefs);
+  private writeRawPrefs(memberId: string, blob: Record<string, unknown>): void {
     this.db
       .prepare(
         `INSERT INTO member_prefs (member_id, prefs, updated_at) VALUES (?, ?, ?)
          ON CONFLICT(member_id) DO UPDATE SET prefs = excluded.prefs, updated_at = excluded.updated_at`,
       )
-      .run(memberId, JSON.stringify(clean), Date.now());
+      .run(memberId, JSON.stringify(blob), Date.now());
+  }
+
+  /** This member's notification prefs, merged over the defaults (missing row → all defaults). */
+  notificationPrefs(memberId: string): NotificationPrefs {
+    return sanitizeNotificationPrefs(this.rawPrefs(memberId));
+  }
+
+  /** Persist a member's notification prefs (sanitized over the defaults) and return the resolved set.
+   *  Spreads over the existing blob so a sibling key (navPins) survives. */
+  setNotificationPrefs(memberId: string, prefs: unknown): NotificationPrefs {
+    const clean = sanitizeNotificationPrefs(prefs);
+    this.writeRawPrefs(memberId, { ...this.rawPrefs(memberId), ...clean });
+    return clean;
+  }
+
+  /** The nav items this member has pinned to the sidebar's Main section, or `null` if never set
+   *  (the client then applies its default pin layout). See `sanitizeNavPins`. */
+  navPins(memberId: string): string[] | null {
+    return sanitizeNavPins(this.rawPrefs(memberId).navPins);
+  }
+
+  /** Persist the member's pinned nav (sanitized, deduped), preserving notification prefs in the same
+   *  blob. Returns the resolved list. */
+  setNavPins(memberId: string, pins: unknown): string[] {
+    const clean = sanitizeNavPins(pins) ?? [];
+    this.writeRawPrefs(memberId, { ...this.rawPrefs(memberId), navPins: clean });
     return clean;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -316,7 +316,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const headers: Record<string, string> = { 'content-type': 'application/json; charset=utf-8' };
     if (sid) headers['set-cookie'] = sessionCookie(sid);
     res.writeHead(200, headers);
-    res.end(JSON.stringify({ member: m }));
+    // navPins rides along on the auth payload (not a separate fetch) so the sidebar's pinned layout is
+    // known at first shell paint — no flash of the default nav before a follow-up request lands.
+    res.end(JSON.stringify({ member: m, navPins: os.team.navPins(m.id) }));
     return;
   }
   // Per-tenant console branding (accent colour + favicon badge). PUBLIC + display-only (no secrets):
@@ -1749,6 +1751,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'PUT' && p === '/api/me/prefs') {
     const b = await readBody(req);
     return sendJson(res, 200, os.team.setNotificationPrefs(me.id, b));
+  }
+  // This member's pinned sidebar nav (which secondary items sit up in Main). Per person, not admin-gated
+  // — everyone customizes their own. The initial value ships on /api/auth/me; this saves changes.
+  if (method === 'PUT' && p === '/api/me/nav') {
+    const b = await readBody(req);
+    return sendJson(res, 200, { pinned: os.team.setNavPins(me.id, (b as { pinned?: unknown }).pinned) });
   }
 
   // Dismiss the whole Activity feed at once (soft hide). Leaves action-required items (pending

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,26 @@ export function sanitizeNotificationPrefs(input: unknown): NotificationPrefs {
 }
 
 /**
+ * Which secondary nav items a member has pinned to the sidebar's primary ("Main") section — a
+ * per-member preference stored alongside notification prefs in `member_prefs`. Values are opaque
+ * nav-item keys owned by the console (`goals`, `tasks`, `memory`, …); the server only validates
+ * shape (array of short, deduped strings). `null` means "never set" so the client falls back to its
+ * default pin layout; `[]` means the member explicitly pinned nothing. The Inbox + Agents anchors
+ * are not pinnable and never appear here.
+ */
+export function sanitizeNavPins(input: unknown): string[] | null {
+  if (!Array.isArray(input)) return null;
+  const out: string[] = [];
+  for (const v of input) {
+    if (typeof v !== 'string') continue;
+    const s = v.trim();
+    if (s && s.length <= 32 && !out.includes(s)) out.push(s);
+    if (out.length >= 40) break;
+  }
+  return out;
+}
+
+/**
  * The external accounts a member is known by on other platforms — the join key that lets a chat
  * trigger (Slack/Discord) run AS the right person. One external id maps to at most one member
  * (enforced by the table's `(provider, external_id)` primary key), so run-as is never ambiguous.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent } from 'react'
 import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink } from 'lucide-react'
-import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, type LucideIcon } from 'lucide-react'
+import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, Pin, PinOff, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import { Button, buttonVariants } from '@/components/ui/button'
@@ -682,6 +682,32 @@ function UpdateNotice() {
   )
 }
 
+/** The sidebar's secondary nav — every item here is pinnable to Main or lives under the Manage group.
+ *  Inbox + Agents are permanent anchors (the app's spine, always in Main) and are deliberately NOT in
+ *  this list; Sessions is the middle switcher; Feedback is an external link. `route` drives active
+ *  state; `adminOnly` hides the item entirely from members who can't view that page (so they can't pin
+ *  what they can't see). Order here is the canonical order items render in, whether in Main or Manage. */
+type NavKey = 'goals' | 'tasks' | 'artifacts' | 'automations' | 'kb' | 'memory' | 'skills' | 'connectors' | 'team' | 'files' | 'audit' | 'settings' | 'docs'
+interface NavMeta { key: NavKey; route: Route; label: string; icon: ReactNode; adminOnly?: boolean }
+const PINNABLE_NAV: NavMeta[] = [
+  { key: 'goals',       route: 'goals',       label: 'Goals',       icon: <Target className="h-4 w-4" /> },
+  { key: 'tasks',       route: 'tasks',       label: 'Tasks',       icon: <ListChecks className="h-4 w-4" /> },
+  { key: 'artifacts',   route: 'artifacts',   label: 'Library',     icon: <Package className="h-4 w-4" /> },
+  { key: 'automations', route: 'automations', label: 'Automations', icon: <Zap className="h-4 w-4" /> },
+  { key: 'kb',          route: 'kb',          label: 'Knowledge',   icon: <BookText className="h-4 w-4" /> },
+  { key: 'memory',      route: 'memory',      label: 'Memory',      icon: <Brain className="h-4 w-4" /> },
+  { key: 'skills',      route: 'skills',      label: 'Skills',      icon: <Sparkles className="h-4 w-4" />, adminOnly: true },
+  { key: 'connectors',  route: 'connectors',  label: 'Connections', icon: <Plug className="h-4 w-4" /> },
+  { key: 'team',        route: 'team',        label: 'Team',        icon: <Users className="h-4 w-4" /> },
+  { key: 'files',       route: 'files',       label: 'Files',       icon: <FolderTree className="h-4 w-4" />, adminOnly: true },
+  { key: 'audit',       route: 'audit',       label: 'Audit',       icon: <ScrollText className="h-4 w-4" />, adminOnly: true },
+  { key: 'settings',    route: 'settings',    label: 'Settings',    icon: <Building2 className="h-4 w-4" />, adminOnly: true },
+  { key: 'docs',        route: 'docs',        label: 'Docs',        icon: <BookOpen className="h-4 w-4" /> },
+]
+/** The default pin layout applied when a member has never customized (navPins === null): the three
+ *  workspace surfaces that used to be hardwired into Main. Everything else starts under Manage. */
+const DEFAULT_PINNED_NAV: NavKey[] = ['goals', 'tasks', 'artifacts']
+
 function Console({ me }: { me: Member }) {
   const [state, setState] = useState<StateResp | null>(null)
   const [sessions, setSessions] = useState<Session[]>([])
@@ -723,10 +749,25 @@ function Console({ me }: { me: Member }) {
   // of falling back to a blank page.
   const editAgent = route === 'agent' ? detail : ''
 
+  // Per-member pinned nav: which secondary items sit up in Main vs. under Manage. Seeded from the
+  // navPins that rode in on /api/auth/me (null → the default layout), toggled optimistically and
+  // persisted through saveNavPins. Only items this role can see are pinnable, so a member can't pin a
+  // page they can't view.
+  const isAdmin = me.role === 'owner' || me.role === 'admin'
+  const visibleNav = PINNABLE_NAV.filter((n) => !n.adminOnly || isAdmin)
+  const [pinned, setPinned] = useState<Set<string>>(() => new Set(me.navPins ?? DEFAULT_PINNED_NAV))
+  const togglePin = (key: string) => {
+    const next = new Set(pinned)
+    next.has(key) ? next.delete(key) : next.add(key)
+    setPinned(next)
+    api.saveNavPins([...next]).catch(() => { /* keep the optimistic value */ })
+  }
+  const pinnedNav = visibleNav.filter((n) => pinned.has(n.key))
+  const manageNav = visibleNav.filter((n) => !pinned.has(n.key))
+
   // Secondary "Manage" nav is collapsed by default so the Agents list stays high; it auto-opens
-  // when you're on one of its pages.
-  const manageRoutes: Route[] = ['automations', 'memory', 'skills', 'connectors', 'team', 'files', 'settings', 'docs']
-  const onManage = manageRoutes.includes(route)
+  // when you're on one of its (unpinned) pages.
+  const onManage = manageNav.some((n) => n.route === route)
   const [manageOpen, setManageOpen] = useState(onManage)
   useEffect(() => { if (onManage) setManageOpen(true) }, [onManage])
   const [sidebarCollapsed, setSidebarCollapsed] = useState(() => localStorage.getItem('aos_sidebar_collapsed') === '1')
@@ -971,9 +1012,9 @@ function Console({ me }: { me: Member }) {
           <nav className="mt-2 flex flex-col items-center gap-1">
             <Button render={<a href={navHref('inbox')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'inbox' ? 'text-primary' : 'text-muted-foreground'}`} title="Inbox" onClick={onNavClick(() => nav('inbox'))}><InboxIcon className="h-4 w-4" /></Button>
             <Button render={<a href={navHref('agents')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'agents' || route === 'agent' ? 'text-primary' : 'text-muted-foreground'}`} title="Agents" onClick={onNavClick(() => nav('agents'))}><Bot className="h-4 w-4" /></Button>
-            <Button render={<a href={navHref('goals')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'goals' ? 'text-primary' : 'text-muted-foreground'}`} title="Goals" onClick={onNavClick(() => nav('goals'))}><Target className="h-4 w-4" /></Button>
-            <Button render={<a href={navHref('tasks')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'tasks' ? 'text-primary' : 'text-muted-foreground'}`} title="Tasks" onClick={onNavClick(() => nav('tasks'))}><ListChecks className="h-4 w-4" /></Button>
-            <Button render={<a href={navHref('artifacts')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'artifacts' ? 'text-primary' : 'text-muted-foreground'}`} title="Library" onClick={onNavClick(() => nav('artifacts'))}><Package className="h-4 w-4" /></Button>
+            {pinnedNav.map((n) => (
+              <Button key={n.key} render={<a href={navHref(n.route)} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === n.route ? 'text-primary' : 'text-muted-foreground'}`} title={n.label} onClick={onNavClick(() => nav(n.route))}>{n.icon}</Button>
+            ))}
             <Button render={<a href={navHref('sessions')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'sessions' ? 'text-primary' : 'text-muted-foreground'}`} title="Sessions" onClick={onNavClick(() => nav('sessions'))}><TerminalSquare className="h-4 w-4" /></Button>
           </nav>
         </aside>
@@ -996,9 +1037,9 @@ function Console({ me }: { me: Member }) {
           <nav className="space-y-1">
             <NavItem icon={<InboxIcon className="h-4 w-4" />} label="Inbox" active={route === 'inbox'} badge={pendingApprovals || undefined} href={navHref('inbox')} onClick={() => nav('inbox')} />
             <NavItem icon={<Bot className="h-4 w-4" />} label="Agents" active={route === 'agents' || route === 'agent'} href={navHref('agents')} onClick={() => nav('agents')} />
-            <NavItem icon={<Target className="h-4 w-4" />} label="Goals" active={route === 'goals'} href={navHref('goals')} onClick={() => nav('goals')} />
-            <NavItem icon={<ListChecks className="h-4 w-4" />} label="Tasks" active={route === 'tasks'} href={navHref('tasks')} onClick={() => nav('tasks')} />
-            <NavItem icon={<Package className="h-4 w-4" />} label="Library" active={route === 'artifacts'} href={navHref('artifacts')} onClick={() => nav('artifacts')} />
+            {pinnedNav.map((n) => (
+              <NavItem key={n.key} icon={n.icon} label={n.label} active={route === n.route} href={navHref(n.route)} onClick={() => nav(n.route)} pinned onTogglePin={() => togglePin(n.key)} />
+            ))}
           </nav>
         </div>
 
@@ -1052,24 +1093,9 @@ function Console({ me }: { me: Member }) {
           </button>
           {manageOpen && (
             <nav className="mb-1 space-y-1">
-              <NavItem icon={<Zap className="h-4 w-4" />} label="Automations" active={route === 'automations'} href={navHref('automations')} onClick={() => nav('automations')} />
-              <NavItem icon={<BookText className="h-4 w-4" />} label="Knowledge" active={route === 'kb'} href={navHref('kb')} onClick={() => nav('kb')} />
-              <NavItem icon={<Brain className="h-4 w-4" />} label="Memory" active={route === 'memory'} href={navHref('memory')} onClick={() => nav('memory')} />
-              {(me.role === 'owner' || me.role === 'admin') && (
-                <NavItem icon={<Sparkles className="h-4 w-4" />} label="Skills" active={route === 'skills'} href={navHref('skills')} onClick={() => nav('skills')} />
-              )}
-              <NavItem icon={<Plug className="h-4 w-4" />} label="Connections" active={route === 'connectors'} href={navHref('connectors')} onClick={() => nav('connectors')} />
-              <NavItem icon={<Users className="h-4 w-4" />} label="Team" active={route === 'team'} href={navHref('team')} onClick={() => nav('team')} />
-              {(me.role === 'owner' || me.role === 'admin') && (
-                <NavItem icon={<FolderTree className="h-4 w-4" />} label="Files" active={route === 'files'} href={navHref('files')} onClick={() => nav('files')} />
-              )}
-              {(me.role === 'owner' || me.role === 'admin') && (
-                <NavItem icon={<ScrollText className="h-4 w-4" />} label="Audit" active={route === 'audit'} href={navHref('audit')} onClick={() => nav('audit')} />
-              )}
-              {(me.role === 'owner' || me.role === 'admin') && (
-                <NavItem icon={<Building2 className="h-4 w-4" />} label="Settings" active={route === 'settings'} href={navHref('settings')} onClick={() => nav('settings')} />
-              )}
-              <NavItem icon={<BookOpen className="h-4 w-4" />} label="Docs" active={route === 'docs'} href={navHref('docs')} onClick={() => nav('docs')} />
+              {manageNav.map((n) => (
+                <NavItem key={n.key} icon={n.icon} label={n.label} active={route === n.route} href={navHref(n.route)} onClick={() => nav(n.route)} pinned={false} onTogglePin={() => togglePin(n.key)} />
+              ))}
               <a
                 href={FEEDBACK_URL}
                 target="_blank"
@@ -1357,17 +1383,33 @@ function NotificationsBell({ items, unread, prefs, onOpen, onMarkAllRead, onSave
   )
 }
 
-function NavItem({ icon, label, active, badge, href, onClick }: { icon: ReactNode; label: string; active: boolean; badge?: number; href: string; onClick: () => void }) {
+/** A sidebar nav row. When `onTogglePin` is provided the row grows a hover-only pin button on the
+ *  right — `pinned` items show "unpin" (send down to Manage), unpinned ones show "pin" (promote to
+ *  Main). The button lives above the anchor and swallows the click so toggling never navigates. */
+function NavItem({ icon, label, active, badge, href, onClick, pinned, onTogglePin }: { icon: ReactNode; label: string; active: boolean; badge?: number; href: string; onClick: () => void; pinned?: boolean; onTogglePin?: () => void }) {
   return (
-    <a
-      href={href}
-      onClick={onNavClick(onClick)}
-      className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm no-underline hover:bg-muted ${active ? 'bg-muted font-medium text-primary' : 'text-foreground'}`}
-    >
-      {icon}
-      <span className="flex-1 text-left">{label}</span>
-      {badge ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{badge}</Badge> : null}
-    </a>
+    <div className="group relative">
+      <a
+        href={href}
+        onClick={onNavClick(onClick)}
+        className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm no-underline hover:bg-muted ${active ? 'bg-muted font-medium text-primary' : 'text-foreground'}`}
+      >
+        {icon}
+        <span className="flex-1 text-left">{label}</span>
+        {badge ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{badge}</Badge> : null}
+      </a>
+      {onTogglePin && (
+        <button
+          type="button"
+          onClick={(e) => { e.preventDefault(); e.stopPropagation(); onTogglePin() }}
+          className="absolute right-1 top-1/2 -translate-y-1/2 rounded p-1 text-muted-foreground opacity-0 transition-opacity hover:bg-background hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+          title={pinned ? 'Unpin from Main (moves to Manage)' : 'Pin to Main'}
+          aria-label={pinned ? `Unpin ${label} from Main` : `Pin ${label} to Main`}
+        >
+          {pinned ? <PinOff className="h-3.5 w-3.5" /> : <Pin className="h-3.5 w-3.5" />}
+        </button>
+      )}
+    </div>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -8,6 +8,10 @@ export interface Member {
   createdAt: number
   /** Profile picture as a `data:image/…;base64,…` URL; absent → show the member's initial. */
   avatar?: string
+  /** This member's pinned sidebar nav (secondary items promoted to Main). Client-only: delivered on
+   *  /api/auth/me for `me`, never populated for other members. `null`/absent → apply the default layout;
+   *  `[]` → the member explicitly pinned nothing. */
+  navPins?: string[] | null
 }
 export type IdentityProvider = 'slack' | 'discord' | 'email' | 'github'
 export const IDENTITY_PROVIDERS: IdentityProvider[] = ['slack', 'discord', 'email', 'github']
@@ -848,7 +852,10 @@ export const api = {
   me: async (): Promise<Member | null> => {
     const res = await fetch('/api/auth/me')
     if (res.status === 401) return null
-    return (await res.json()).member as Member
+    const body = await res.json()
+    // navPins ships beside `member` on this payload — fold it onto the member so the sidebar has the
+    // pinned layout at first paint without a second request.
+    return { ...(body.member as Member), navPins: body.navPins ?? null }
   },
   logout: () => call<{ ok: boolean }>('POST', '/api/auth/logout'),
   /** Self-service recovery: ask the server to send a fresh sign-in link. Always resolves ok (neutral
@@ -896,6 +903,8 @@ export const api = {
   /** This member's own notification preferences (bell/toast/sound/DM + which event kinds). */
   notificationPrefs: () => call<NotificationPrefs>('GET', '/api/me/prefs'),
   saveNotificationPrefs: (prefs: NotificationPrefs) => call<NotificationPrefs>('PUT', '/api/me/prefs', prefs),
+  /** Persist this member's pinned sidebar nav (the keys promoted to Main). Returns the resolved list. */
+  saveNavPins: (pinned: string[]) => call<{ pinned: string[] }>('PUT', '/api/me/nav', { pinned }),
 
   team: () => call<TeamResp>('GET', '/api/team'),
   audit: (f: { session?: string; type?: string; principal?: string; limit?: number } = {}) => {


### PR DESCRIPTION
## What

Every secondary sidebar nav item is now **pinnable** per member. Hover a row and click the pin to promote it into the top **Main** section, or unpin it back down to **Manage**.

- **Main = your pinned set. Manage = everything else.** One rule, two permanent anchors: **Inbox + Agents** are the app's spine and can't be unpinned.
- **Goals, Tasks, Artifacts** join the pinnable set (they were hardwired into Main). They stay pinned **by default**, so nothing changes visually until a member customizes — but a tenant that doesn't use Goals can now reclaim the slot.

## How

- **Per member, not per workspace.** Pins live in the member's `member_prefs` JSON blob, alongside notification prefs. `team.ts` now reads/writes that blob through `rawPrefs`/`writeRawPrefs` helpers so saving notif prefs never clobbers pins and vice versa. `sanitizeNavPins` (in `types.ts`) caps/dedupes/trims; `null` = never set (client applies the default layout), `[]` = explicitly nothing pinned.
- **No flash.** `navPins` rides in on `/api/auth/me`, so the sidebar renders the member's layout at first shell paint. Changes save through `PUT /api/me/nav`.
- **Role-aware.** Only pages a role can view are pinnable (Skills/Files/Audit/Settings stay admin-only). The collapsed icon rail reflects pins too.
- Nav is now data-driven from a single `PINNABLE_NAV` metadata list (Main, Manage, and the collapsed rail all render from it).

## Verify

- `npm run typecheck`, `cd web && npm run build`, `npm run build` — all clean.
- `npm run test:governance` — 68/68 ✓.
- Isolated in-process store test (added then removed): confirms `null` when unset, dedupe/trim/non-string drop on set, and that a notif-prefs save preserves pins **and** a navPins save preserves notif prefs, and `[]` persists distinct from `null`. All 8 assertions pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)