### PR TITLE
fix(web): closing a tab drops the session from the left sidebar too (v0.124.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.124.1] — 2026-07-13
+### Fixed
+- **Closing a terminal tab now removes the session from the left sidebar too.** Closing a tab detaches it
+  from the terminal strip but leaves the session running — however the sidebar's "Sessions" switcher never
+  consulted `hiddenTabs`, so a "closed" session lingered there (and could be reopened from it), out of sync
+  with the strip. The sidebar list now applies the same `hiddenTabs` filter the strip does (keeping the
+  currently-open session visible), so a closed tab leaves both viewports while staying alive and reopenable
+  from **All sessions**.
+
 ## [0.124.0] — 2026-07-13
 ### Added
 - **Pinnable sidebar nav — each member curates their own Main.** Every secondary nav item is now pinnable:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.124.0",
+  "version": "0.124.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.124.0",
+      "version": "0.124.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.124.0",
+  "version": "0.124.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -964,8 +964,10 @@ function Console({ me }: { me: Member }) {
   // (spawnedBy is my member id) OR ones a trigger spawned that run AS me (runAs): a Task I own that
   // auto-dispatched, a chat message I sent. Those have a `task:`/`automation:` provenance, so keying
   // only off spawnedBy hid them from their owner's sidebar. Running first, then newest first.
+  // Closing a tab (hiddenTabs) drops it here too — mirroring the terminal strip's `visible()` — so a
+  // "closed" session leaves both viewports; the still-open one always stays. Reopen it from All sessions.
   const mySessions = sessions
-    .filter((s) => s.spawnedBy === me.id || s.runAs === me.id)
+    .filter((s) => (s.spawnedBy === me.id || s.runAs === me.id) && (!hiddenTabs.has(s.tmux) || s.tmux === selected?.tmux))
     .sort((a, b) => {
       const rank = (s: Session) => (isLive(s) ? 0 : 1) // live first; all terminal (dead) states tie
       return rank(a) - rank(b) || b.createdAt - a.createdAt


### PR DESCRIPTION
## What

Closing a terminal tab now removes the session from the **left sidebar** switcher, not just the terminal strip.

## Why

Closing a tab hides it from the strip via `hiddenTabs` but leaves the session running (reopen from All sessions). The bug: the sidebar's "Sessions" switcher (`mySessions`) never consulted `hiddenTabs`, so a "closed" session lingered there — out of sync with the strip, and still reopenable from it. Reported: a closed tab "goes away from the viewports but is still visible in the sidebar."

## Fix

Apply the same `hiddenTabs` filter the strip's `visible()` already uses (line 2276) to `mySessions` (`App.tsx:967`), keeping the currently-open session pinned so nothing vanishes underneath you. A closed tab now leaves **both** viewports — terminal strip and sidebar — while staying alive and reopenable from **All sessions**.

## Verification

`cd web && npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)