### PR TITLE
fix(media): Atlas works for image + video poll fix; Atlas primary (v0.127.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.127.0] — 2026-07-13
+### Changed
+- **Atlas Cloud is now the primary media backend — one interface for image AND video.** When an Atlas
+  key is set it's used for image generation ahead of OpenRouter (fal still leads for video), so a single
+  Atlas key powers both. (`resolveImageBackend`, `SettingsStore.imageGenBackend`)
+### Fixed
+- **Atlas image generation now works.** The adapter used a wrong OpenAI-style `/v1/images/generations`
+  endpoint; Atlas actually uses a custom **async** API — `POST /api/v1/model/generateImage` → a
+  prediction id → poll `GET /api/v1/model/prediction/{id}` until `data.status` is completed, image URL at
+  `data.outputs[0]`. Rewrote the adapter to submit + poll-to-completion (bounded; image renders in
+  seconds) and download the result. Default model is a real id (`google/nano-banana-2/text-to-image`);
+  validated live end-to-end. (`src/edge/image-gen.ts`)
+- **Atlas video no longer hangs on a failed/finished render.** The poll read a top-level `status`, but
+  Atlas nests the prediction under **`data`** (`data.status`/`data.error`/`data.outputs`) — so a `failed`
+  render (e.g. a content-policy block) was mis-read as still `rendering` until it timed out, and a
+  completed one wasn't detected. Now reads the nested object, treats failed/error/cancelled as terminal
+  (surfacing Atlas's message), and takes the video URL from `data.outputs[0]` directly. Atlas errors are
+  carried in a `msg` field, now parsed. (`src/edge/video-gen.ts`)
+
 ## [0.126.0] — 2026-07-13
 ### Added
 - **Video generation — agents can now produce video.** New `video_generate` MCP tool: an agent gives a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.126.0",
+  "version": "0.127.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.126.0",
+      "version": "0.127.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.126.0",
+  "version": "0.127.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/image-gen.ts
+++ b/src/edge/image-gen.ts
@@ -54,13 +54,14 @@ export interface ImageBackendConfig {
   defaultModel?: string; // workspace override for the default model
 }
 
-/** Pick a backend from configured keys. OpenRouter wins when both are set (verified cost telemetry). */
+/** Pick a backend from configured keys. Atlas is PRIMARY when set (one Atlas interface covers image +
+ *  video); OpenRouter is the fallback. */
 export function resolveImageBackend(cfg: ImageBackendConfig): ImageBackend | undefined {
-  if (cfg.openRouterKey && cfg.openRouterKey.trim()) {
-    return new OpenRouterBackend(cfg.openRouterKey.trim(), cfg.defaultModel);
-  }
   if (cfg.atlasKey && cfg.atlasKey.trim()) {
     return new AtlasBackend(cfg.atlasKey.trim(), cfg.atlasBaseUrl, cfg.defaultModel);
+  }
+  if (cfg.openRouterKey && cfg.openRouterKey.trim()) {
+    return new OpenRouterBackend(cfg.openRouterKey.trim(), cfg.defaultModel);
   }
   return undefined;
 }
@@ -146,34 +147,67 @@ class OpenRouterBackend implements ImageBackend {
   }
 }
 
-// ── Atlas Cloud (OpenAI-compatible images endpoint) ──────────────────────────
+// ── Atlas Cloud ──────────────────────────────────────────────────────────────
+// Atlas is NOT OpenAI-compatible for media — it's a custom ASYNC API shared by image + video:
+// POST /api/v1/model/generateImage → a prediction id (data.id), then poll
+// GET /api/v1/model/prediction/{id} until data.status is completed/failed (image url at data.outputs[0]).
+// Image renders in seconds, so we submit + poll-to-completion INSIDE generate() to keep the sync
+// ImageBackend contract. (Video uses the same endpoints via its own async job model in video-gen.ts.)
+
+interface AtlasPrediction {
+  id?: string;
+  status?: string;
+  outputs?: unknown[] | null;
+  error?: string;
+}
 
 class AtlasBackend implements ImageBackend {
   readonly name = 'atlas' as const;
   readonly defaultModel: string;
   private readonly base: string;
   constructor(private readonly key: string, baseUrl?: string, defaultModel?: string) {
-    this.base = (baseUrl?.trim() || 'https://api.atlascloud.ai/v1').replace(/\/+$/, '');
-    this.defaultModel = defaultModel?.trim() || 'flux.2';
+    this.base = (baseUrl?.trim() || 'https://api.atlascloud.ai').replace(/\/+$/, '');
+    this.defaultModel = defaultModel?.trim() || 'google/nano-banana-2/text-to-image';
+  }
+
+  private headers(): Record<string, string> {
+    return { Authorization: `Bearer ${this.key}`, 'content-type': 'application/json' };
   }
 
   async generate(req: ImageGenRequest): Promise<ImageGenResult> {
     const model = req.model?.trim() || this.defaultModel;
-    const body: Record<string, unknown> = { model, prompt: req.prompt, n: req.n };
+    const body: Record<string, unknown> = { model, prompt: req.prompt };
     if (req.size) body.size = req.size;
-    const res = await fetch(`${this.base}/images/generations`, {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${this.key}`, 'content-type': 'application/json' },
-      body: JSON.stringify(body),
-    });
-    const d = (await res.json().catch(() => ({}))) as OpenRouterResponse;
-    if (!res.ok) throw new Error(errMsg(d, res.status));
-    const entries = d.data ?? d.images ?? [];
-    if (!entries.length) throw new Error('Atlas returned no images');
-    const images = await Promise.all(entries.map(toBytes));
-    // Atlas doesn't reliably report cost in-band; caller falls back to the per-image estimate.
-    return { images, model, costUsd: typeof d.usage?.cost === 'number' ? d.usage.cost : undefined };
+    // Submit
+    const sres = await fetch(`${this.base}/api/v1/model/generateImage`, { method: 'POST', headers: this.headers(), body: JSON.stringify(body) });
+    const sbody = (await sres.json().catch(() => ({}))) as { data?: AtlasPrediction; message?: string } & AtlasPrediction;
+    if (!sres.ok) throw new Error(atlasErr(sbody, sres.status));
+    const id = sbody.data?.id ?? sbody.id;
+    if (!id) throw new Error('Atlas did not return a prediction id');
+    // Poll to completion (image is fast — bounded internal poll keeps the sync contract).
+    const deadline = Date.now() + 90_000;
+    for (;;) {
+      await new Promise((r) => setTimeout(r, 2000));
+      const pres = await fetch(`${this.base}/api/v1/model/prediction/${id}`, { headers: this.headers() });
+      const pbody = (await pres.json().catch(() => ({}))) as { data?: AtlasPrediction; message?: string } & AtlasPrediction;
+      if (!pres.ok) throw new Error(atlasErr(pbody, pres.status));
+      const d: AtlasPrediction = pbody.data ?? pbody;
+      const st = (d.status || '').toLowerCase();
+      if (st === 'failed' || st === 'error' || st === 'cancelled' || st === 'canceled') throw new Error(d.error || pbody.message || (pbody as { msg?: string }).msg || `Atlas image ${st || 'failed'}`);
+      if (st === 'completed' || st === 'succeeded') {
+        const urls = (d.outputs || []).filter((o): o is string => typeof o === 'string');
+        if (!urls.length) throw new Error('Atlas completed but returned no image URL');
+        const images = await Promise.all(urls.map((url) => toBytes({ url })));
+        return { images, model, costUsd: undefined }; // Atlas doesn't return cost in-band → caller estimates
+      }
+      if (Date.now() > deadline) throw new Error('Atlas image timed out');
+    }
   }
+}
+
+function atlasErr(body: { error?: string; message?: string; msg?: string }, status: number): string {
+  const msg = body.error || body.message || body.msg; // Atlas uses `msg` for errors
+  return msg ? `Atlas image error (${status}): ${msg}` : `Atlas image error (${status})`;
 }
 
 function errMsg(d: OpenRouterResponse, status: number): string {

--- a/src/edge/video-gen.ts
+++ b/src/edge/video-gen.ts
@@ -100,9 +100,9 @@ function extFromUrl(url: string): string {
 }
 
 function errText(body: unknown, status: number): string {
-  const b = body as { error?: { message?: string } | string; detail?: string; message?: string } | undefined;
+  const b = body as { error?: { message?: string } | string; detail?: string; message?: string; msg?: string } | undefined;
   const e = b?.error;
-  const msg = (typeof e === 'string' ? e : e?.message) || b?.detail || b?.message;
+  const msg = (typeof e === 'string' ? e : e?.message) || b?.detail || b?.message || b?.msg; // Atlas uses `msg`
   return msg ? `video backend error (${status}): ${msg}` : `video backend error (${status})`;
 }
 
@@ -172,6 +172,14 @@ interface AtlasRef {
   base: string;
 }
 
+/** The Atlas prediction object — nested under `data` in the poll response. */
+interface AtlasPrediction {
+  id?: string;
+  status?: string; // rendering-ish | completed | succeeded | failed | error | cancelled
+  outputs?: unknown[] | null;
+  error?: string;
+}
+
 class AtlasVideoBackend implements VideoBackend {
   readonly name = 'atlas' as const;
   readonly defaultModel: string;
@@ -202,12 +210,19 @@ class AtlasVideoBackend implements VideoBackend {
   async poll(providerRef: string): Promise<VideoPollResult> {
     const ref = JSON.parse(providerRef) as AtlasRef;
     const res = await fetch(`${ref.base}/api/v1/model/prediction/${ref.predictionId}`, { headers: this.headers() });
-    const d = (await res.json().catch(() => ({}))) as { status?: string; data?: { outputs?: unknown[] } } & Record<string, unknown>;
-    if (!res.ok) return { status: 'failed', error: errText(d, res.status) };
+    const body = (await res.json().catch(() => ({}))) as { data?: AtlasPrediction } & AtlasPrediction & Record<string, unknown>;
+    if (!res.ok) return { status: 'failed', error: errText(body, res.status) };
+    // Atlas nests the prediction under `data` (status/error/outputs live there, NOT at the top level).
+    const d: AtlasPrediction = body.data ?? body;
     const st = (d.status || '').toLowerCase();
-    if (st === 'failed' || st === 'error') return { status: 'failed', error: `atlas status ${st}` };
+    if (st === 'failed' || st === 'error' || st === 'cancelled' || st === 'canceled') {
+      return { status: 'failed', error: d.error || (body as { message?: string }).message || `atlas status ${st || 'failed'}` };
+    }
     if (st !== 'completed' && st !== 'succeeded') return { status: 'rendering' };
-    const url = findVideoUrl(d);
+    // Atlas documents the result at data.outputs[0] — read it directly (a signed URL may lack a .mp4
+    // extension, so don't rely on extension-sniffing); fall back to a recursive search.
+    const direct = Array.isArray(d.outputs) ? d.outputs.find((o): o is string => typeof o === 'string' && /^https?:\/\//.test(o)) : undefined;
+    const url = direct ?? findVideoUrl(d);
     if (!url) return { status: 'failed', error: 'atlas completed but no video URL in the result' };
     return { status: 'done', video: { url, ext: extFromUrl(url) } };
   }

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -211,10 +211,10 @@ export class SettingsStore {
   imageGenConfigured(): boolean {
     return !!this.openRouterKey() || !!this.atlasKey();
   }
-  /** Which backend a run would use (OpenRouter wins when both set) — for the console + status. */
+  /** Which backend a run would use (Atlas is primary when set; else OpenRouter) — for the console + status. */
   imageGenBackend(): 'openrouter' | 'atlas' | null {
-    if (this.openRouterKey()) return 'openrouter';
     if (this.atlasKey()) return 'atlas';
+    if (this.openRouterKey()) return 'openrouter';
     return null;
   }
   /** Whether each image key is set (never returns the secret) + the default model + last editor. */


### PR DESCRIPTION
Found while live-testing video on Atlas (per the dogfood run).

## Fixed
**Atlas image generation now works.** The adapter hit a wrong OpenAI-style `/v1/images/generations` endpoint (404). Atlas is actually a **custom async API**: `POST /api/v1/model/generateImage` → prediction id → poll `GET /api/v1/model/prediction/{id}` until `data.status` completed, image URL at `data.outputs[0]`. Rewrote to submit + poll-to-completion (bounded; image is seconds) + download. Real default model `google/nano-banana-2/text-to-image`. **Validated live: PNG 1.8 MB in 19s.**

**Atlas video no longer hangs on a failed/finished render.** The poll read a top-level `status`, but Atlas nests the prediction under **`data`** — so a content-policy-blocked render was mis-read as `rendering` until it timed out. Now reads `data.status`/`data.error`/`data.outputs[0]`, treats failed/error/cancelled as terminal (surfacing Atlas's message), and parses Atlas's `msg` error field. **Validated live: the failed render now returns `{status:'failed', error:'…content policy…'}`.**

## Changed
**Atlas is now the primary media backend** (`make atlas primary`) — one Atlas key powers both image and video (Atlas preferred over OpenRouter for image; fal still leads for video when set).

## Test
- `typecheck` ✓ · `web build` ✓ · `governance 68/68` ✓
- Both adapters exercised against the **live Atlas API** (image success + video failure-detection). Full video *success* (submit→completed→download→ingest) will be confirmed in the post-deploy live e2e with a content-safe prompt.

Model-catalog note: Atlas image/video model ids are namespaced (`google/nano-banana-2/text-to-image`, `bytedance/seedance-2.0/text-to-video`), discoverable at `GET /api/v1/models`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)