### PR TITLE
chore(media): media copy says 'Library' (v0.128.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.128.2] — 2026-07-13
+### Changed
+- **Media copy says "Library" (not "Artifacts").** Aligned the video generation strings that lagged the
+  Artifacts→Library rename: the `video_generate` tool description + its return messages, the Settings →
+  Integrations image/video card copy, and the `publish` operating note now all say **Library**. Internal
+  identifiers (`ArtifactStore`, the `artifacts` route) are unchanged — display copy only.
+  (`src/memory/memory-mcp.ts`, `src/terminal.ts`, `web/src/App.tsx`)
+
 ## [0.128.1] — 2026-07-13
 ### Changed
 - **Image integrations UI is Atlas-only now.** The Settings → Integrations image card no longer shows the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.128.1",
+  "version": "0.128.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -174,9 +174,9 @@ const VIDEO_GENERATE_TOOL = {
   description:
     'Generate a video from a text prompt (optionally seeded by an image URL). Use this to CREATE a video — ' +
     'you cannot produce one natively. Video renders ASYNCHRONOUSLY (usually a few minutes): this returns ' +
-    'quickly, and the finished video lands in the Artifacts gallery with an inbox card when ready. If it ' +
+    'quickly, and the finished video lands in the Library with an inbox card when ready. If it ' +
     'finishes fast you get the artifact id inline; otherwise you get a job id and a "rendering" status — ' +
-    'do NOT block waiting, just tell the user it will appear in the gallery shortly. Governed (cost-metered + audited).',
+    'do NOT block waiting, just tell the user it will appear in the Library shortly. Governed (cost-metered + audited).',
   inputSchema: {
     type: 'object',
     properties: {
@@ -1099,9 +1099,9 @@ async function videoGenerate(args: Record<string, unknown>): Promise<string> {
   if (!d.ok) return `Could not generate video: ${d.error ?? 'unknown error'}`;
   const cost = typeof d.costUsd === 'number' ? ` · ~$${d.costUsd.toFixed(3)}` : '';
   if (d.status === 'done' && d.artifact) {
-    return `Video ready with ${d.model ?? 'the default model'}${cost}. Saved to the Artifacts gallery: ${d.artifact.id} (${d.artifact.filename}).`;
+    return `Video ready with ${d.model ?? 'the default model'}${cost}. Saved to the Library: ${d.artifact.id} (${d.artifact.filename}).`;
   }
-  return `Video is rendering with ${d.model ?? 'the default model'}${cost} (job ${d.jobId ?? '?'}). It'll appear in the Artifacts gallery and post an inbox card when done — no need to wait; let the user know it's on the way.`;
+  return `Video is rendering with ${d.model ?? 'the default model'}${cost} (job ${d.jobId ?? '?'}). It'll appear in the Library and post an inbox card when done — no need to wait; let the user know it's on the way.`;
 }
 
 async function slackSend(args: Record<string, unknown>): Promise<string> {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -75,7 +75,7 @@ Your terminal output may not be read. The operator lives in the Inbox:
 - \`report\` exactly once when you finish, with the outcome and a one-line summary, so the result is
   visible without anyone reading the terminal. If the task taught you something durable, pass it in
   \`lessons\` — it's saved to your memory as a note to your future self.
-- \`publish\` real deliverables (a document, PDF, image, chart) to the Artifacts gallery — not scratch
+- \`publish\` real deliverables (a document, PDF, image, chart) to the Library — not scratch
   files.
 
 ## You are one agent in a fleet — don't work alone

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9117,7 +9117,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
             </div>
             <p className="text-xs text-muted-foreground">
               Gives every agent an <code className="text-[11px]">image_generate</code> tool (Claude can't draw natively).
-              Generated images land in the <strong>Artifacts</strong> gallery and the run is cost-metered + audited.
+              Generated images land in the <strong>Library</strong> and the run is cost-metered + audited.
               Powered by <strong>Atlas Cloud</strong> — the same key also drives video below.
             </p>
           </div>
@@ -9165,8 +9165,8 @@ function IntegrationsSettings({ me }: { me: Member }) {
             </div>
             <p className="text-xs text-muted-foreground">
               Gives every agent a <code className="text-[11px]">video_generate</code> tool. Video renders
-              <strong> asynchronously</strong> (usually minutes) — the finished clip lands in the <strong>Artifacts</strong>
-              gallery with an inbox card, cost-metered + audited. Powered by your <strong>Atlas Cloud</strong> key (the same
+              <strong> asynchronously</strong> (usually minutes) — the finished clip lands in the <strong>Library</strong>
+              with an inbox card, cost-metered + audited. Powered by your <strong>Atlas Cloud</strong> key (the same
               one used for images). Optionally add a <strong>fal.ai</strong> key for the widest catalog (Veo, Kling, Seedance…) —
               fal is used when set.
             </p>


### PR DESCRIPTION
Follow-up to the Artifacts→Library rename. My video-generation strings still said "Artifacts gallery" (the image/publish copy was already swept). Aligned: `video_generate` tool description + return messages, the Settings → Integrations image/video card copy, and the `publish` operating note. Display copy only — `ArtifactStore` / the `artifacts` route are unchanged. typecheck ✓ · web build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)