### PR TITLE
feat(web): background runs don't auto-open a terminal tab + bg marker (v0.129.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.129.0] — 2026-07-13
+### Changed
+- **Background (headless) runs no longer auto-open a terminal tab.** A headless session runs to
+  completion unattended — it isn't something you sit and watch — so it no longer auto-pops into the
+  terminal tab strip while you're viewing another session. It still appears in the sessions list and
+  can be opened explicitly (or taken over), either of which pins its tab. Interactive runs are
+  unchanged. Also adds a small **bg marker** (a `Cpu` glyph) beside headless sessions in the sidebar
+  Sessions list so background runs are distinguishable at a glance. Console-only, no API change.
+
 ## [0.128.4] — 2026-07-13
 ### Changed
 - **Settings → Integrations: one "Media generation" card for image + video.** The two separate cards

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.128.4",
+  "version": "0.129.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.128.4",
+      "version": "0.129.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.128.4",
+  "version": "0.129.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -991,6 +991,11 @@ function Console({ me }: { me: Member }) {
         <span className="min-w-0 flex-1">
           <span className="flex items-center gap-1">
             <span className={`min-w-0 flex-1 truncate text-[13px] leading-tight ${active ? 'font-medium text-primary' : ''}`}>{s.title}</span>
+            {s.headless && (
+              <span title="background run — headless, runs unattended to completion (won't auto-open a terminal tab)" className="shrink-0 text-amber-500/80">
+                <Cpu className="h-3 w-3" />
+              </span>
+            )}
             {waiting.has(s.id) && <WaitingBell className="h-3 w-3" />}
           </span>
           <span className="block truncate text-[11px] leading-tight text-muted-foreground">{s.agent}</span>
@@ -2281,7 +2286,11 @@ function SessionsPage({
     // The currently-open session stays force-visible so explicitly opening someone else's run (e.g. an
     // admin taking over) still shows its tab and can't orphan the iframe.
     const mine = (s: Session) => s.spawnedBy === me.id || s.runAs === me.id || s.tmux === selected.tmux
-    const liveTabs = orderTabs(sessions.filter((s) => isLive(s) && visible(s) && mine(s)))
+    // A background (headless) run doesn't auto-pop a terminal tab — it isn't something you sit and watch;
+    // it runs to completion unattended. It still shows in the sessions list (with a bg marker) and can be
+    // opened explicitly or taken over — either of which makes it `selected`/`claimedBy`, so it pins here.
+    const autoTab = (s: Session) => !s.headless || !!s.claimedBy || s.tmux === selected.tmux
+    const liveTabs = orderTabs(sessions.filter((s) => isLive(s) && visible(s) && mine(s) && autoTab(s)))
     const endedTabs = sessions.filter((s) => !isLive(s))
     const selectedEnded = endedTabs.find((s) => s.tmux === selected.tmux)
     const collapsibleEnded = endedTabs.filter((s) => s.tmux !== selected.tmux && visible(s) && mine(s))


### PR DESCRIPTION
## What

Two console-only changes to how **background (headless) runs** appear in the sessions UI:

1. **No auto-opened terminal tab.** The terminal tab strip auto-populates a tab for every live session you own. A headless run is unattended (runs to completion, nothing to watch/steer), so it no longer pops a tab there while you're viewing another session. It still shows in the sidebar Sessions list; opening it explicitly or taking it over makes it `selected`/`claimedBy`, which pins its tab as before. Interactive runs are unchanged.
2. **bg marker in the sidebar Sessions list.** A small `Cpu` glyph now sits beside headless sessions in the sidebar switcher, so a background run is distinguishable from an interactive one at a glance (the full Sessions page already had a `Headless` ModeBadge; the compact sidebar had no indicator).

## Where

- `web/src/App.tsx` — `renderNavSession` (sidebar bg glyph) and `liveTabs`/`autoTab` (tab-strip suppression).

## Validation

`npm run typecheck` ✅ · `cd web && npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)