### PR TITLE
feat(web): live Atlas model dropdown for default image/video models (v0.130.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.129.0] — 2026-07-13
+## [0.130.0] — 2026-07-13
+### Added
+- **Default-model pickers are now live dropdowns (Settings → Integrations → Media generation).** The image
+  and video "Default model" fields became comboboxes backed by the **live Atlas catalog** — a new
+  admin-only `GET /api/integrations/atlas/models` fetches `GET /api/v1/models` with the stored key, filters
+  to `TEXT-TO-IMAGE` (~47) and `TEXT-TO-VIDEO` (~47) models, and caches per-key for 5 min. The console
+  renders them as native `<datalist>` suggestions on the model inputs, so you can **pick from the current
+  catalog or still type any id** (free text preserved). The list refreshes when the Atlas key changes; a
+  fetch failure or missing key falls back to a plain free-text field. Agents can still override the model
+  per call — this only sets the fleet default.
 ### Added
 - **One-click GitHub App setup — no more manual walkthrough.** The **Connections → Creds → GitHub** card
   now creates the company GitHub App for you via GitHub's **App-manifest flow**: click **Create GitHub App**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.129.0",
+      "version": "0.130.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2689,6 +2689,15 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     return sendJson(res, 200, integrationsView(os));
   }
+  // Live Atlas catalog for the default-model pickers (dropdown + free text). Fetched with the stored
+  // key, filtered to text-to-image / text-to-video, cached briefly so the settings page stays snappy.
+  if (method === 'GET' && p === '/api/integrations/atlas/models') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const key = os.settings.atlasKey();
+    if (!key) return sendJson(res, 200, { configured: false, image: [], video: [] });
+    const cat = await fetchAtlasModels(key);
+    return sendJson(res, 200, { configured: true, ...cat });
+  }
   if (method === 'PUT' && p === '/api/settings/integrations') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const b = await readBody(req);
@@ -4128,6 +4137,44 @@ async function probeOllama(target: string): Promise<{ reachable: boolean; url: s
     return { reachable: true, url: base, installed, version: String((v as { version?: string }).version ?? ''), models };
   } catch {
     return { reachable: false, url: base, installed };
+  }
+}
+
+/**
+ * The Atlas catalog, split into the text-to-image and text-to-video model ids the default-model
+ * pickers offer (a `{ model, displayName, categories }[]` under `data`). Cached per key for a few
+ * minutes so opening Settings doesn't re-hit Atlas each render; a key change misses the cache (keyed
+ * by the key itself) and refetches. Best-effort: any failure returns empty lists (the field stays a
+ * plain free-text input).
+ */
+type AtlasModel = { id: string; label: string };
+const atlasModelCache = new Map<string, { at: number; image: AtlasModel[]; video: AtlasModel[] }>();
+const ATLAS_MODEL_TTL_MS = 5 * 60 * 1000;
+async function fetchAtlasModels(key: string): Promise<{ image: AtlasModel[]; video: AtlasModel[] }> {
+  const cached = atlasModelCache.get(key);
+  if (cached && Date.now() - cached.at < ATLAS_MODEL_TTL_MS) return { image: cached.image, video: cached.video };
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 6000);
+  try {
+    const r = await fetch('https://api.atlascloud.ai/api/v1/models', {
+      headers: { authorization: `Bearer ${key}` },
+      signal: ctrl.signal,
+    });
+    if (!r.ok) return cached ? { image: cached.image, video: cached.video } : { image: [], video: [] };
+    const body = (await r.json()) as { data?: Array<{ model?: string; displayName?: string; categories?: string[] }> };
+    const rows = Array.isArray(body?.data) ? body.data : [];
+    const pick = (cat: string): AtlasModel[] =>
+      rows
+        .filter((m) => m.model && Array.isArray(m.categories) && m.categories.includes(cat))
+        .map((m) => ({ id: String(m.model), label: String(m.displayName || m.model) }))
+        .sort((a, b) => a.label.localeCompare(b.label));
+    const out = { at: Date.now(), image: pick('TEXT-TO-IMAGE'), video: pick('TEXT-TO-VIDEO') };
+    atlasModelCache.set(key, out);
+    return { image: out.image, video: out.video };
+  } catch {
+    return cached ? { image: cached.image, video: cached.video } : { image: [], video: [] };
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8825,6 +8825,8 @@ function IntegrationsSettings({ me }: { me: Member }) {
   const [video, setVideo] = useState<IntegrationsResp['video']>({ fal: false, atlas: false, backend: null, defaultModel: '', configured: false })
   const [falKey, setFalKey] = useState('')
   const [vidModel, setVidModel] = useState('')
+  // Live Atlas catalog for the default-model comboboxes (dropdown suggestions; the fields stay free text).
+  const [atlasModels, setAtlasModels] = useState<{ image: { id: string; label: string }[]; video: { id: string; label: string }[] }>({ image: [], video: [] })
   const [chatRouter, setChatRouter] = useState(true)
   const [chatIdle, setChatIdle] = useState(30)
   const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
@@ -8861,6 +8863,10 @@ function IntegrationsSettings({ me }: { me: Member }) {
     api.slackStatus().then((s) => { if (s && !s.error) setSlackState(s) }).catch(() => {})
     api.discordStatus().then((s) => { if (s && !s.error) setDiscordState(s) }).catch(() => {})
   }
+  // Pull the Atlas model catalog (best-effort — empty lists just mean the picker is plain free text).
+  const loadAtlasModels = () => {
+    api.atlasModels().then((m) => { if (m && !m.error) setAtlasModels({ image: m.image ?? [], video: m.video ?? [] }) }).catch(() => {})
+  }
   // After a token change the server re-dials the Socket-Mode / Gateway connection live (no restart) —
   // but the handshake (auth check → WebSocket → READY) can take several seconds. A single poll would
   // catch a mid-handshake "Disconnected" and make the panel look broken (and tempt a needless server
@@ -8891,6 +8897,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
       apply(r)
     }).catch(() => {})
     loadStatus()
+    loadAtlasModels()
     // The GitHub App-manifest flow redirects back here with ?github=created|error — surface a banner
     // and re-read integrations (a just-created App now shows configured + the install link), then
     // scrub the flag from the URL so a refresh doesn't re-show it.
@@ -8915,6 +8922,8 @@ function IntegrationsSettings({ me }: { me: Member }) {
     const wantSlack = body.slackAppToken !== undefined || body.slackBotToken !== undefined
     const wantDiscord = body.discordBotToken !== undefined
     if (wantSlack || wantDiscord) pollReconnect({ slack: wantSlack, discord: wantDiscord })
+    // A new/removed Atlas key changes which catalog we can fetch — refresh the pickers.
+    if (body.atlasKey !== undefined) loadAtlasModels()
   }
 
   if (!isAdmin) return <div className="text-sm text-muted-foreground">Owner or admin access required.</div>
@@ -9276,27 +9285,35 @@ function IntegrationsSettings({ me }: { me: Member }) {
 
           <div className="space-y-3 border-t pt-3">
             <div className="text-xs font-medium text-muted-foreground">Images</div>
-            <Field label="Default image model" help="Optional — an Atlas image model id used when an agent doesn't name one. Blank = Atlas's built-in default. Full catalog: GET /api/v1/models on Atlas.">
+            <Field label="Default image model" help={atlasModels.image.length ? `Optional — choose from Atlas's ${atlasModels.image.length} text-to-image models, or type any id. Blank = Atlas's built-in default; agents can still override per call.` : "Optional — an Atlas image model id used when an agent doesn't name one. Blank = Atlas's built-in default. Add a key to load the catalog."}>
               <Input
+                list="atlas-image-models"
                 value={imgModel}
                 onChange={(e) => setImgModel(e.target.value)}
                 onBlur={() => { if (imgModel.trim() !== (image.defaultModel || '')) save({ imageDefaultModel: imgModel.trim() }, 'default model saved') }}
-                placeholder="e.g. google/nano-banana-2/text-to-image · openai/gpt-image-1.5/text-to-image · black-forest-labs/flux-2-pro/text-to-image"
+                placeholder={atlasModels.image.length ? 'choose or type a model id…' : 'e.g. google/nano-banana-2/text-to-image'}
                 className="font-mono text-xs"
               />
+              <datalist id="atlas-image-models">
+                {atlasModels.image.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
+              </datalist>
             </Field>
           </div>
 
           <div className="space-y-3 border-t pt-3">
             <div className="text-xs font-medium text-muted-foreground">Video</div>
-            <Field label="Default video model" help="Optional — a backend-specific model id used when an agent doesn't name one. Blank = the active backend's built-in default.">
+            <Field label="Default video model" help={atlasModels.video.length ? `Optional — choose from Atlas's ${atlasModels.video.length} text-to-video models, or type any id (e.g. a fal-ai/… id when fal is the backend). Blank = the active backend's built-in default.` : 'Optional — a backend-specific model id used when an agent doesn\'t name one. Blank = the active backend\'s built-in default.'}>
               <Input
+                list="atlas-video-models"
                 value={vidModel}
                 onChange={(e) => setVidModel(e.target.value)}
                 onBlur={() => { if (vidModel.trim() !== (video.defaultModel || '')) save({ videoDefaultModel: vidModel.trim() }, 'default model saved') }}
-                placeholder="e.g. bytedance/seedance-2.0/text-to-video (Atlas) or fal-ai/veo3/fast (fal)"
+                placeholder={atlasModels.video.length ? 'choose or type a model id…' : 'e.g. bytedance/seedance-2.0/text-to-video (Atlas) or fal-ai/veo3/fast (fal)'}
                 className="font-mono text-xs"
               />
+              <datalist id="atlas-video-models">
+                {atlasModels.video.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
+              </datalist>
             </Field>
             <Field label="fal.ai API key (optional)" help="fal.ai → dashboard → Keys. Widest video catalog (Veo, Kling, Seedance…) via one key. When set, fal handles video instead of Atlas.">
               <Input

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1052,6 +1052,7 @@ export const api = {
   disconnectApp: (body: { id: string; scope: 'company' | 'personal' }) =>
     call<{ ok?: boolean; error?: string }>('POST', '/api/connections/disconnect', body),
   integrations: () => call<IntegrationsResp>('GET', '/api/settings/integrations'),
+  atlasModels: () => call<{ configured: boolean; image: { id: string; label: string }[]; video: { id: string; label: string }[]; error?: string }>('GET', '/api/integrations/atlas/models'),
   saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; githubClientId?: string; githubClientSecret?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
   // Per-member GitHub (user-to-server OAuth): each member links their OWN account so run-as sessions
   // push / open PRs as the actual human. `connect` returns the authorize URL to navigate to.


### PR DESCRIPTION
## What
The **Default model** fields in Settings → Integrations → Media generation were plain free-text. They're now **comboboxes backed by the live Atlas catalog** — dropdown of current models *plus* free text (you can still type any id).

## How
- **Server:** new admin-only `GET /api/integrations/atlas/models` fetches `GET https://api.atlascloud.ai/api/v1/models` with the stored key, filters `data[]` to `categories` containing `TEXT-TO-IMAGE` (~47) and `TEXT-TO-VIDEO` (~47), returns `{ id, label }[]` (label = `displayName`). Cached per-key for 5 min; any failure / missing key returns empty lists.
- **Web:** the two model `<Input>`s get `list=…` + a `<datalist>` of the fetched models. Native combobox = dropdown suggestions with free-text fallback. List refreshes on mount and whenever the Atlas key changes.

## Notes
- Verified the catalog shape against the live endpoint: `{ data: [{ model, displayName, categories }] }`, 418 models total, filter yields 47 image + 47 video.
- Free text preserved — agents can still override the model per call; this only sets the fleet default.
- Console + one new read route; no schema change. Server route needs a restart to take effect on the live box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)