### PR TITLE
Per-member git: nudge unconnected members + make plain `git` (not just `gh`) authenticate (v0.131.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ new version heading in the same commit.
 
 ## [0.130.0] — 2026-07-13
 ### Added
+- **Plain `git` now authenticates with the injected token, not just `gh`.** The GitHub token is exported
+  as `GH_TOKEN`/`GITHUB_TOKEN` (which `gh` reads natively), but `git push`/`clone` over HTTPS doesn't use
+  those on its own — so previously only half the toolchain was authenticated. Launch now also installs a
+  **github.com-scoped git credential helper** via `GIT_CONFIG_*` env vars (no file writes, session-scoped,
+  reads `$GH_TOKEN` at call time so a rotated token still works; resets any inherited helper first, uses the
+  `x-access-token` username GitHub expects). So a session that has a token — a member's own or the agent
+  bot's — can `git push` **and** `gh pr create` transparently. No-op when no token is present or for non-
+  github.com/SSH remotes. (`TerminalManager.configureGitCredentials`; verified against real `git`.)
 - **Sessions now nudge an unconnected member to link their GitHub.** When a session runs **as** someone
   who hasn't linked their own GitHub account, the launch context tells the agent so — so if the task
   involves pushing code or opening a PR, the agent `ask`s the right person to fix it instead of silently

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.130.0] — 2026-07-13
+### Added
+- **Sessions now nudge an unconnected member to link their GitHub.** When a session runs **as** someone
+  who hasn't linked their own GitHub account, the launch context tells the agent so — so if the task
+  involves pushing code or opening a PR, the agent `ask`s the right person to fix it instead of silently
+  committing as the shared bot (or failing auth). Two cases, two messages: if the workspace **GitHub App is
+  configured**, it points them at the **1-click Connect GitHub** (Connections → Connected → Mine); if **no
+  App is set up**, it asks an **owner/admin** to create one first (Connections → Creds → GitHub → Create
+  GitHub App). Fires only when acting as a real member who isn't connected — a connected member's token is
+  injected and just works, and a pure automation (no run-as person) gets no personal steer. Contextual, so
+  it only reaches a human when git is actually relevant. (`TerminalManager.buildCompanyMd`;
+  `scripts/github-per-member-test.cjs` now 53/53.)
+
 ## [0.129.0] — 2026-07-13
 ### Added
 - **One-click GitHub App setup — no more manual walkthrough.** The **Connections → Creds → GitHub** card

--- a/docs/per-member-github-plan.md
+++ b/docs/per-member-github-plan.md
@@ -85,6 +85,16 @@ by the PreToolUse Bash gate-hook exactly as before — this only changes *which 
 `state` is a random token held in a short-lived in-process map keyed to `{ tenant, memberId, exp }`;
 the callback additionally requires `state.memberId === me.id` (defence-in-depth against a leaked state).
 
+## Nudging an unconnected member (v0.130.0)
+
+The feature is otherwise passive — an unconnected member's session just falls back to the bot token. To
+close that discovery gap, `buildCompanyMd` adds a **git-identity steer** to the launch context when the
+run-as member hasn't linked GitHub: if the App is configured it points the agent to have them **Connect
+GitHub** in one click; if the App isn't set up it asks an owner/admin to create it first. The agent
+raises it via `ask` only when the task actually touches git, so it's contextual rather than a blanket
+ping. No steer when the member is connected (token injected, just works) or when there's no run-as person
+(a pure automation). Covered by `scripts/github-per-member-test.cjs` §6.
+
 ## Identity note
 
 v1 records the GitHub `login` as the member's `github` external-id. Logins can change; a stable numeric

--- a/docs/per-member-github-plan.md
+++ b/docs/per-member-github-plan.md
@@ -64,6 +64,13 @@ company-bot `GH_TOKEN` when an agent opts in via `shellSecrets`), we call **`inj
 Precedence is deliberate and documented inline: **member token > agent bot token**. Both remain governed
 by the PreToolUse Bash gate-hook exactly as before — this only changes *which identity* the shell holds.
 
+**Both `git` and `gh` (v0.130.0).** `gh` reads `GH_TOKEN`/`GITHUB_TOKEN` natively, but plain `git push`
+over HTTPS does not — so `configureGitCredentials` also installs a **github.com-scoped git credential
+helper** via `GIT_CONFIG_*` env vars (git ≥2.31; no file writes; reads `$GH_TOKEN` at call time). It
+resets any inherited helper first and returns the `x-access-token` username GitHub expects. Runs whenever
+a token was injected (member or bot), so the whole toolchain authenticates; no-op otherwise and for
+non-github.com/SSH remotes.
+
 ## Token lifecycle
 
 - **Store:** vault, `principal = member id`, key `github_user`, JSON blob (encrypted).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.129.0",
+      "version": "0.130.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.129.0",
+  "version": "0.130.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/github-per-member-test.cjs
+++ b/scripts/github-per-member-test.cjs
@@ -248,6 +248,17 @@ async function main() {
   assert(!/Git identity/.test(md), 'no run-as member → no git-identity steer');
   gid.clear(ownerId);
 
+  // ─── 7) git credential helper (plain `git`, not just `gh`) ──────────────────
+  console.log('\n\x1b[1m7) git credential helper (git + gh both authenticate)\x1b[0m');
+  const genv = { GH_TOKEN: 'gho_abc' };
+  tm.configureGitCredentials(genv);
+  assert(genv.GIT_CONFIG_COUNT === '2', 'sets GIT_CONFIG_COUNT for two entries');
+  assert(genv.GIT_CONFIG_KEY_0 === 'credential.https://github.com.helper' && genv.GIT_CONFIG_VALUE_0 === '', 'entry 0 resets any inherited github.com helper');
+  assert(genv.GIT_CONFIG_KEY_1 === 'credential.https://github.com.helper' && /username=x-access-token/.test(genv.GIT_CONFIG_VALUE_1) && /\$GH_TOKEN/.test(genv.GIT_CONFIG_VALUE_1), 'entry 1 is a github.com helper that echoes x-access-token + $GH_TOKEN');
+  const noTok = {};
+  tm.configureGitCredentials(noTok);
+  assert(noTok.GIT_CONFIG_COUNT === undefined, 'no GH_TOKEN → no git credential config (nothing to authenticate with)');
+
   server.close();
   registry.forEach && registry.forEach((x) => { try { x.tm.shutdown && x.tm.shutdown(); } catch { /* */ } });
 

--- a/scripts/github-per-member-test.cjs
+++ b/scripts/github-per-member-test.cjs
@@ -223,6 +223,31 @@ async function main() {
   r = await fetch(base + '/api/github/manifest', { headers: { cookie: `aos_sid=${macc.sid}` } });
   assert(r.status === 403, 'non-admin is forbidden from the manifest setup');
 
+  // ─── 6) Launch-context git-identity steer (buildCompanyMd) ──────────────────
+  console.log('\n\x1b[1m6) Launch-context git steer (unconnected member is pointed at the fix)\x1b[0m');
+  osx.agents.set('coder', { id: 'coder', runtime: 'claude-code', description: 'A coding agent', dir: '/tmp/x' });
+  // App configured (from section 5) but the owner hasn't linked → steer to the 1-click connect.
+  gid.clear(ownerId);
+  let md = tm.buildCompanyMd('coder', ownerId);
+  assert(/Git identity — you are not yet acting as a person on GitHub/.test(md), 'configured + unlinked → "connect your GitHub" steer');
+  assert(/Connect GitHub/.test(md) && !/Create GitHub App/.test(md), 'unlinked steer points at the 1-click member connect, not the admin setup');
+
+  // App NOT configured → steer to ask an owner/admin to set it up.
+  osx.settings.setGithubClientId('', 'owner@test'); gid.setClientSecret('', 'owner@test');
+  md = tm.buildCompanyMd('coder', ownerId);
+  assert(/GitHub is not set up for this workspace/.test(md) && /Create GitHub App/.test(md), 'unconfigured → "ask an owner/admin to set up the App" steer');
+
+  // Connected member → no steer at all (their token is injected and just works).
+  osx.settings.setGithubClientId('Iv1.x', 'owner@test'); gid.setClientSecret('sec', 'owner@test');
+  gid.save(ownerId, { token: 'gho_live', login: 'octocat', connectedAt: Date.now() });
+  md = tm.buildCompanyMd('coder', ownerId);
+  assert(!/Git identity/.test(md), 'connected member → no git-identity steer');
+
+  // No run-as identity (pure automation) → no personal steer.
+  md = tm.buildCompanyMd('coder');
+  assert(!/Git identity/.test(md), 'no run-as member → no git-identity steer');
+  gid.clear(ownerId);
+
   server.close();
   registry.forEach && registry.forEach((x) => { try { x.tm.shutdown && x.tm.shutdown(); } catch { /* */ } });
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -944,7 +944,7 @@ export class TerminalManager {
     const env = this.sessionEnv(o.id, o.agent, o.task, o.secret);
     // Build the per-session connector + company payloads once (Composio is minted here).
     const mcpJson = this.buildMcpConfigJson(o.id, o.agent, o.actingMember, o.secret, o.hasSlack, o.hasDiscord);
-    const companyMd = this.buildCompanyMd(o.agent);
+    const companyMd = this.buildCompanyMd(o.agent, o.actingMember);
     this.materializeSkills(o.id, o.agent, manifest.dir);
     // Unattended (automation/cron/task) runs are now an attachable interactive TUI, not `claude -p` — so a
     // human can take one over mid-run by simply attaching (no kill, no resume). The launcher's UNATTENDED
@@ -1288,7 +1288,7 @@ export class TerminalManager {
    *  We tack on OS-owned operating notes after the user's content. The terminal here is a browser
    *  xterm (over ttyd) running the TUI on the alternate screen with mouse reporting on, so embedded
    *  terminal hyperlinks (OSC 8) aren't clickable — the agent must surface raw URLs as plain text. */
-  private buildCompanyMd(selfAgent?: string): string {
+  private buildCompanyMd(selfAgent?: string, actingMember?: string): string {
     const company = this.os.settings.company().companyMd.trim();
     // Close the self-learning loop: the Dreamer's distilled guidance rides in every agent's prompt, so
     // the fleet's accumulated experience shapes each new session. Toggleable in Settings → Self-learning.
@@ -1353,6 +1353,29 @@ export class TerminalManager {
         'a Composio action only if no native tool covers what you need.\n\n' +
         chatLines.join('\n')
       : '';
+    // Per-member git steer: when this run acts AS a person who hasn't linked their own GitHub, tell the
+    // agent how to fix git attribution — so a session that needs to push/PR points the human at the
+    // 1-click connect (or at an owner/admin, if the workspace App isn't set up yet) instead of silently
+    // committing as a shared bot (or failing auth). Only when acting as a real member, and only the
+    // actionable case (not connected) — a connected member's token is injected and just works.
+    let github = '';
+    if (actingMember) {
+      const gh = new GithubIdentity(this.os);
+      if (!gh.load(actingMember)) {
+        const who = this.os.team.getMember(actingMember)?.name || 'the person you run as';
+        github = gh.configured()
+          ? '# Git identity — you are not yet acting as a person on GitHub\n\n' +
+            `You are running as **${who}**, who hasn't linked their GitHub account — so any \`git push\` or ` +
+            'pull request would be authored by the shared workspace app, not them. If this task involves ' +
+            'committing code or opening a PR, use `ask` to tell them to connect their GitHub in one click: ' +
+            '**Connections → Connected → Mine → Connect GitHub**. Once they do, commits land under their own name.'
+          : '# Git identity — GitHub is not set up for this workspace\n\n' +
+            "No company GitHub App is configured, so `git`/`gh` can't act as a specific person (a push would " +
+            'use the shared bot token if one exists, else fail to authenticate). If this task needs to push ' +
+            'code or open a PR, use `ask` to have an owner or admin set up the GitHub App in one click ' +
+            `(**Connections → Creds → GitHub → Create GitHub App**), then ask **${who}** to connect their account.`;
+      }
+    }
     // Launch-time recall preamble (Settings → Memory, off by default): seed the prompt with this
     // agent's most salient memories so a cold session isn't blind, instead of relying on it to call
     // `recall`. Reads the local `memories` ledger directly (node:sqlite is synchronous) — the same
@@ -1398,7 +1421,7 @@ export class TerminalManager {
             .join('\n');
       }
     }
-    return [company, AGENT_OS_OPERATING_NOTES, messaging, goalsSection, fleet, team, preamble, learned]
+    return [company, AGENT_OS_OPERATING_NOTES, messaging, github, goalsSection, fleet, team, preamble, learned]
       .filter(Boolean)
       .join('\n\n');
   }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -976,6 +976,10 @@ export class TerminalManager {
     // Per-member git: if THIS run's run-as human has linked their own GitHub account, their token
     // OVERRIDES the agent bot's GH_TOKEN — so git push / gh pr are authored as the actual person.
     this.injectMemberGithub(env, o.agent, o.actingMember, o.id);
+    // Whatever set GH_TOKEN above (member token or agent bot), teach plain `git` to use it too — `gh`
+    // reads GH_TOKEN natively but `git push` over HTTPS does not, so without this only half the toolchain
+    // authenticates. A github.com-scoped credential helper closes that gap.
+    this.configureGitCredentials(env);
     // Phase 2c: granted Host connections' SSH keys → a session ssh_config + ssh/scp PATH shim, so the
     // agent's plain `ssh` authenticates to a host without ever handling the key. (Local-lane only.)
     this.injectHostCredentials(env, o.agent, o.actingMember, o.id);
@@ -2828,6 +2832,25 @@ export class TerminalManager {
       this.audit(sessionId, agent, 'github.token.stale', { login: blob.login, principal: actingMember });
       void gh.ensureFresh(actingMember).catch(() => { /* best-effort; next launch retries */ });
     }
+  }
+
+  /**
+   * Make plain `git` authenticate with the injected `GH_TOKEN` too — not just `gh`. `gh` reads
+   * `GH_TOKEN`/`GITHUB_TOKEN` from the env natively, but `git push`/`clone` over HTTPS does not, so
+   * without a credential helper only half the toolchain would work. We install a **github.com-scoped**
+   * helper entirely via `GIT_CONFIG_*` env vars (git ≥2.31) — no file writes, session-scoped, and it
+   * reads `$GH_TOKEN` at call time so a rotated token still works. The empty helper (index 0) first
+   * RESETS any inherited system/global helper for that host so ours is the only one consulted; the
+   * username `x-access-token` is what GitHub expects for App/user tokens. No-op when no token was set
+   * (nothing to authenticate with) or for non-github.com remotes (SSH hosts keep their own keys).
+   */
+  private configureGitCredentials(env: Record<string, string>): void {
+    if (!env.GH_TOKEN) return;
+    env.GIT_CONFIG_COUNT = '2';
+    env.GIT_CONFIG_KEY_0 = 'credential.https://github.com.helper';
+    env.GIT_CONFIG_VALUE_0 = '';
+    env.GIT_CONFIG_KEY_1 = 'credential.https://github.com.helper';
+    env.GIT_CONFIG_VALUE_1 = '!f() { test "$1" = get && printf "username=x-access-token\\npassword=%s\\n" "$GH_TOKEN"; }; f';
   }
 
   /** Find the real `ssh`/`scp` on the PARENT PATH (which never includes a session shim dir), so the


### PR DESCRIPTION
Two closely-related refinements to the per-member GitHub feature.

## 1. Sessions nudge an unconnected member to link their GitHub

Previously the feature was passive: if a session ran **as** someone who hadn't linked their GitHub, `injectMemberGithub` silently did nothing and nobody was told. Now the launch context (`buildCompanyMd`) adds a **git-identity steer** so the agent knows — and if the task involves pushing code or opening a PR, it `ask`s the right person:

- **App configured, member not connected** → "ask them to **Connect GitHub** in one click (Connections → Connected → Mine)."
- **App not configured** → "ask an **owner/admin** to set up the GitHub App first (Connections → Creds → Create GitHub App)."

Fires only when acting as a real, unconnected member — a connected member's token is injected and just works, and a pure automation (no run-as person) gets no personal steer. Contextual, so a human is pinged only when git is actually relevant.

## 2. Plain `git` authenticates too — not just `gh`

We inject the token as `GH_TOKEN`/`GITHUB_TOKEN`, which **`gh` reads natively** — but `git push`/`clone` over HTTPS does **not** use those on its own, so previously only half the toolchain was authenticated. Launch now also installs a **github.com-scoped git credential helper** via `GIT_CONFIG_*` env vars (git ≥2.31): no file writes, session-scoped, reads `$GH_TOKEN` at call time (so a rotated token still works), resets any inherited helper first, and returns the `x-access-token` username GitHub expects. Runs whenever a token is present (member or bot); no-op otherwise and for non-github.com/SSH remotes.

**Verified against real `git` 2.50** — `git credential fill` for `github.com` returns `username=x-access-token` + the token.

## Surface
- `src/terminal.ts` — `buildCompanyMd` (now member-aware) + `configureGitCredentials`

## Testing
- `scripts/github-per-member-test.cjs` — **57/57** (adds §6 steer: configured-unlinked → connect, unconfigured → ask admin, connected → silent, no-run-as → silent; §7 credential helper: env shape + no-token no-op).
- Also verified the existing `context-injection-test.cjs` (28/28) and governance (68/68) still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)