### PR TITLE
feat(web): show per-model pricing in the Atlas model dropdowns (v0.132.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.132.0] — 2026-07-13
+### Added
+- **Model dropdowns show pricing (Settings → Integrations → Media generation).** The live Atlas catalog
+  route (`GET /api/integrations/atlas/models`) now returns each model's effective (post-discount) base
+  price — **per image** for text-to-image, **per second** for text-to-video — parsed from Atlas's
+  `price.actual.base_price`. The console appends it to each dropdown option (e.g. `Nano Banana 2 — $0.04/image`,
+  `Seedance 2.0 — $0.045/sec`) and shows a hint line under the field when the current value matches a
+  catalog model. Free text + per-call override unchanged; console/route only, no schema change.
+
 ## [0.131.0] — 2026-07-13
 ### Added
 - **Plain `git` now authenticates with the injected token, not just `gh`.** The GitHub token is exported

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.131.0",
+  "version": "0.132.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.131.0",
+      "version": "0.132.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.131.0",
+  "version": "0.132.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4147,9 +4147,17 @@ async function probeOllama(target: string): Promise<{ reachable: boolean; url: s
  * by the key itself) and refetches. Best-effort: any failure returns empty lists (the field stays a
  * plain free-text input).
  */
-type AtlasModel = { id: string; label: string };
+// `priceUsd` is Atlas's effective (post-discount) base price — per image for TEXT-TO-IMAGE, per second
+// for TEXT-TO-VIDEO — so the console can show a cost hint next to each model. null when Atlas omits it.
+type AtlasModel = { id: string; label: string; priceUsd: number | null };
 const atlasModelCache = new Map<string, { at: number; image: AtlasModel[]; video: AtlasModel[] }>();
 const ATLAS_MODEL_TTL_MS = 5 * 60 * 1000;
+type AtlasPrice = { actual?: { base_price?: string | number }; origin?: { base_price?: string | number } };
+function atlasPriceUsd(price?: AtlasPrice): number | null {
+  const raw = price?.actual?.base_price ?? price?.origin?.base_price;
+  const n = raw != null ? Number(raw) : NaN;
+  return Number.isFinite(n) ? n : null;
+}
 async function fetchAtlasModels(key: string): Promise<{ image: AtlasModel[]; video: AtlasModel[] }> {
   const cached = atlasModelCache.get(key);
   if (cached && Date.now() - cached.at < ATLAS_MODEL_TTL_MS) return { image: cached.image, video: cached.video };
@@ -4161,12 +4169,12 @@ async function fetchAtlasModels(key: string): Promise<{ image: AtlasModel[]; vid
       signal: ctrl.signal,
     });
     if (!r.ok) return cached ? { image: cached.image, video: cached.video } : { image: [], video: [] };
-    const body = (await r.json()) as { data?: Array<{ model?: string; displayName?: string; categories?: string[] }> };
+    const body = (await r.json()) as { data?: Array<{ model?: string; displayName?: string; categories?: string[]; price?: AtlasPrice }> };
     const rows = Array.isArray(body?.data) ? body.data : [];
     const pick = (cat: string): AtlasModel[] =>
       rows
         .filter((m) => m.model && Array.isArray(m.categories) && m.categories.includes(cat))
-        .map((m) => ({ id: String(m.model), label: String(m.displayName || m.model) }))
+        .map((m) => ({ id: String(m.model), label: String(m.displayName || m.model), priceUsd: atlasPriceUsd(m.price) }))
         .sort((a, b) => a.label.localeCompare(b.label));
     const out = { at: Date.now(), image: pick('TEXT-TO-IMAGE'), video: pick('TEXT-TO-VIDEO') };
     atlasModelCache.set(key, out);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8826,7 +8826,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
   const [falKey, setFalKey] = useState('')
   const [vidModel, setVidModel] = useState('')
   // Live Atlas catalog for the default-model comboboxes (dropdown suggestions; the fields stay free text).
-  const [atlasModels, setAtlasModels] = useState<{ image: { id: string; label: string }[]; video: { id: string; label: string }[] }>({ image: [], video: [] })
+  const [atlasModels, setAtlasModels] = useState<{ image: { id: string; label: string; priceUsd: number | null }[]; video: { id: string; label: string; priceUsd: number | null }[] }>({ image: [], video: [] })
   const [chatRouter, setChatRouter] = useState(true)
   const [chatIdle, setChatIdle] = useState(30)
   const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
@@ -9285,7 +9285,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
 
           <div className="space-y-3 border-t pt-3">
             <div className="text-xs font-medium text-muted-foreground">Images</div>
-            <Field label="Default image model" help={atlasModels.image.length ? `Optional — choose from Atlas's ${atlasModels.image.length} text-to-image models, or type any id. Blank = Atlas's built-in default; agents can still override per call.` : "Optional — an Atlas image model id used when an agent doesn't name one. Blank = Atlas's built-in default. Add a key to load the catalog."}>
+            <Field label="Default image model" help={atlasModels.image.length ? `Optional — choose from Atlas's ${atlasModels.image.length} text-to-image models (price shown per image), or type any id. Blank = Atlas's built-in default; agents can still override per call.` : "Optional — an Atlas image model id used when an agent doesn't name one. Blank = Atlas's built-in default. Add a key to load the catalog."}>
               <Input
                 list="atlas-image-models"
                 value={imgModel}
@@ -9295,14 +9295,15 @@ function IntegrationsSettings({ me }: { me: Member }) {
                 className="font-mono text-xs"
               />
               <datalist id="atlas-image-models">
-                {atlasModels.image.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
+                {atlasModels.image.map((m) => <option key={m.id} value={m.id}>{m.priceUsd != null ? `${m.label} — $${+m.priceUsd.toFixed(3)}/image` : m.label}</option>)}
               </datalist>
+              {(() => { const m = atlasModels.image.find((x) => x.id === imgModel.trim()); return m && m.priceUsd != null ? <p className="mt-1 text-[11px] text-muted-foreground">{m.label} · <strong>${+m.priceUsd.toFixed(3)}</strong> per image</p> : null })()}
             </Field>
           </div>
 
           <div className="space-y-3 border-t pt-3">
             <div className="text-xs font-medium text-muted-foreground">Video</div>
-            <Field label="Default video model" help={atlasModels.video.length ? `Optional — choose from Atlas's ${atlasModels.video.length} text-to-video models, or type any id (e.g. a fal-ai/… id when fal is the backend). Blank = the active backend's built-in default.` : 'Optional — a backend-specific model id used when an agent doesn\'t name one. Blank = the active backend\'s built-in default.'}>
+            <Field label="Default video model" help={atlasModels.video.length ? `Optional — choose from Atlas's ${atlasModels.video.length} text-to-video models (price shown per second of video), or type any id (e.g. a fal-ai/… id when fal is the backend). Blank = the active backend's built-in default.` : 'Optional — a backend-specific model id used when an agent doesn\'t name one. Blank = the active backend\'s built-in default.'}>
               <Input
                 list="atlas-video-models"
                 value={vidModel}
@@ -9312,8 +9313,9 @@ function IntegrationsSettings({ me }: { me: Member }) {
                 className="font-mono text-xs"
               />
               <datalist id="atlas-video-models">
-                {atlasModels.video.map((m) => <option key={m.id} value={m.id}>{m.label}</option>)}
+                {atlasModels.video.map((m) => <option key={m.id} value={m.id}>{m.priceUsd != null ? `${m.label} — $${+m.priceUsd.toFixed(3)}/sec` : m.label}</option>)}
               </datalist>
+              {(() => { const m = atlasModels.video.find((x) => x.id === vidModel.trim()); return m && m.priceUsd != null ? <p className="mt-1 text-[11px] text-muted-foreground">{m.label} · <strong>${+m.priceUsd.toFixed(3)}</strong> per second of video</p> : null })()}
             </Field>
             <Field label="fal.ai API key (optional)" help="fal.ai → dashboard → Keys. Widest video catalog (Veo, Kling, Seedance…) via one key. When set, fal handles video instead of Atlas.">
               <Input

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1052,7 +1052,7 @@ export const api = {
   disconnectApp: (body: { id: string; scope: 'company' | 'personal' }) =>
     call<{ ok?: boolean; error?: string }>('POST', '/api/connections/disconnect', body),
   integrations: () => call<IntegrationsResp>('GET', '/api/settings/integrations'),
-  atlasModels: () => call<{ configured: boolean; image: { id: string; label: string }[]; video: { id: string; label: string }[]; error?: string }>('GET', '/api/integrations/atlas/models'),
+  atlasModels: () => call<{ configured: boolean; image: { id: string; label: string; priceUsd: number | null }[]; video: { id: string; label: string; priceUsd: number | null }[]; error?: string }>('GET', '/api/integrations/atlas/models'),
   saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; githubClientId?: string; githubClientSecret?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
   // Per-member GitHub (user-to-server OAuth): each member links their OWN account so run-as sessions
   // push / open PRs as the actual human. `connect` returns the authorize URL to navigate to.


### PR DESCRIPTION
## What
The live Atlas model dropdowns (added in v0.130.0) now show **pricing** next to each model.

- **Server:** `GET /api/integrations/atlas/models` returns each model's effective (post-discount) base price from Atlas's `price.actual.base_price` — **per image** for text-to-image, **per second** for text-to-video (falls back to `origin.base_price`, `null` when absent).
- **Web:** each dropdown option reads e.g. `Nano Banana 2 — $0.04/image` / `Seedance 2.0 — $0.045/sec`, and a hint line under the field shows the selected model's price when the current value matches a catalog id.

Free text + per-call model override unchanged. Console + one route field; no schema change (server restart needed on the live box for the new price field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)