### PR TITLE
feat(media): image-to-video — animate any session image via video_generate (v0.134.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.135.0] — 2026-07-13
+### Added
+- **Image-to-video: agents can now animate an image, not just text→video.** The `video_generate` tool
+  takes an optional **`image`** that accepts **any** place a session's image lives:
+  a **Library artifact id** (e.g. from a prior `image_generate`), a **file path in the agent's working
+  folder** (a file it wrote *or* one uploaded into the terminal session — resolved strictly under the
+  agent folder via the same containment `publish` uses), or an **http(s) URL** (passed through to the
+  vendor to fetch). Local files/artifacts are read and sent inline as a base64 data URL (no public hosting
+  needed); when an image is supplied without a named model, an **image-to-video model** is chosen
+  automatically (Atlas `bytedance/seedance-2.0/image-to-video`, fal `…/veo3/fast/image-to-video`). Fixes the
+  Atlas seed field (`image`, not `image_url`) so the seed actually applies. Same governance as text→video
+  (cost-metered, audited, async job → Library). Verified against the live Atlas API (base64 seed → prediction id).
+
 ## [0.134.0] — 2026-07-13
 ### Added
 - **The Library now renders published HTML files as a live page**, not as raw source. HTML deliverables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.134.0",
+  "version": "0.135.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.134.0",
+      "version": "0.135.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.134.0",
+  "version": "0.135.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/video-gen.ts
+++ b/src/edge/video-gen.ts
@@ -47,6 +47,8 @@ export interface VideoPollResult {
 export interface VideoBackend {
   readonly name: 'fal' | 'atlas';
   readonly defaultModel: string;
+  /** The model used when an image seed is supplied but no model is named (image-to-video variant). */
+  readonly imageModel: string;
   submit(req: VideoGenRequest): Promise<VideoSubmitResult>;
   poll(providerRef: string): Promise<VideoPollResult>;
 }
@@ -126,8 +128,12 @@ interface FalRef {
 class FalVideoBackend implements VideoBackend {
   readonly name = 'fal' as const;
   readonly defaultModel: string;
+  readonly imageModel: string;
   constructor(private readonly key: string, defaultModel?: string) {
     this.defaultModel = defaultModel?.trim() || 'fal-ai/veo3/fast';
+    // fal exposes image-to-video as a sub-endpoint of the same family; veo3/fast/image-to-video is the
+    // safe default when an image seed is given without an explicit model.
+    this.imageModel = 'fal-ai/veo3/fast/image-to-video';
   }
 
   private headers(): Record<string, string> {
@@ -135,7 +141,7 @@ class FalVideoBackend implements VideoBackend {
   }
 
   async submit(req: VideoGenRequest): Promise<VideoSubmitResult> {
-    const model = req.model?.trim() || this.defaultModel;
+    const model = req.model?.trim() || (req.imageUrl ? this.imageModel : this.defaultModel);
     const body: Record<string, unknown> = { prompt: req.prompt };
     if (req.durationSec) body.duration = String(req.durationSec); // fal video models mostly take a string seconds
     if (req.imageUrl) body.image_url = req.imageUrl;
@@ -183,10 +189,12 @@ interface AtlasPrediction {
 class AtlasVideoBackend implements VideoBackend {
   readonly name = 'atlas' as const;
   readonly defaultModel: string;
+  readonly imageModel: string;
   private readonly base: string;
   constructor(private readonly key: string, baseUrl?: string, defaultModel?: string) {
     this.base = (baseUrl?.trim() || 'https://api.atlascloud.ai').replace(/\/+$/, '');
     this.defaultModel = defaultModel?.trim() || 'bytedance/seedance-2.0/text-to-video';
+    this.imageModel = 'bytedance/seedance-2.0/image-to-video';
   }
 
   private headers(): Record<string, string> {
@@ -194,10 +202,11 @@ class AtlasVideoBackend implements VideoBackend {
   }
 
   async submit(req: VideoGenRequest): Promise<VideoSubmitResult> {
-    const model = req.model?.trim() || this.defaultModel;
+    const model = req.model?.trim() || (req.imageUrl ? this.imageModel : this.defaultModel);
     const body: Record<string, unknown> = { model, prompt: req.prompt };
     if (req.durationSec) body.duration = req.durationSec;
-    if (req.imageUrl) body.image_url = req.imageUrl;
+    // Atlas takes the seed frame as `image` (URL, Base64 data URL, or asset://<id>) — NOT `image_url`.
+    if (req.imageUrl) body.image = req.imageUrl;
     const res = await fetch(`${this.base}/api/v1/model/generateVideo`, { method: 'POST', headers: this.headers(), body: JSON.stringify(body) });
     const d = (await res.json().catch(() => ({}))) as { id?: string; prediction_id?: string; data?: { id?: string } };
     if (!res.ok) throw new Error(errText(d, res.status));

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -172,18 +172,21 @@ const IMAGE_GENERATE_TOOL = {
 const VIDEO_GENERATE_TOOL = {
   name: 'video_generate',
   description:
-    'Generate a video from a text prompt (optionally seeded by an image URL). Use this to CREATE a video — ' +
-    'you cannot produce one natively. Video renders ASYNCHRONOUSLY (usually a few minutes): this returns ' +
-    'quickly, and the finished video lands in the Library with an inbox card when ready. If it ' +
+    'Generate a video from a text prompt, OR animate an existing image (image-to-video). Use this to ' +
+    'CREATE a video — you cannot produce one natively. Video renders ASYNCHRONOUSLY (usually a few minutes): ' +
+    'this returns quickly, and the finished video lands in the Library with an inbox card when ready. If it ' +
     'finishes fast you get the artifact id inline; otherwise you get a job id and a "rendering" status — ' +
-    'do NOT block waiting, just tell the user it will appear in the Library shortly. Governed (cost-metered + audited).',
+    'do NOT block waiting, just tell the user it will appear in the Library shortly. To animate an image, pass ' +
+    '`image` and describe the motion in `prompt`. `image` accepts ANY of: a Library artifact id (e.g. from a ' +
+    'prior image_generate), a file path in your working folder (a file you wrote OR one uploaded into the ' +
+    'session), or an http(s) image URL. Governed (cost-metered + audited).',
   inputSchema: {
     type: 'object',
     properties: {
-      prompt: { type: 'string', description: 'What the video should show — subject, action, camera, style.' },
-      model: { type: 'string', description: 'Optional model id (backend-specific, e.g. a fal.ai model). Omit to use the workspace default.' },
+      prompt: { type: 'string', description: 'What the video should show — subject, action, camera, style. For image-to-video, describe the desired motion.' },
+      model: { type: 'string', description: 'Optional model id (backend-specific). Omit to use the workspace default (an image-to-video model is chosen automatically when `image` is set).' },
       durationSec: { type: 'number', description: 'Desired clip length in seconds (1–60; default 5). The model may clamp it.' },
-      imageUrl: { type: 'string', description: 'Optional image URL to animate (image-to-video seed).' },
+      image: { type: 'string', description: 'Optional image to animate (image-to-video). A Library artifact id, a file path in your working folder (written or uploaded), or an http(s) image URL.' },
     },
     required: ['prompt'],
   },
@@ -1094,7 +1097,7 @@ async function videoGenerate(args: Record<string, unknown>): Promise<string> {
   const body: Record<string, unknown> = { session: SESSION, prompt };
   if (typeof args.model === 'string' && args.model.trim()) body.model = args.model.trim();
   if (args.durationSec !== undefined) body.durationSec = Number(args.durationSec);
-  if (typeof args.imageUrl === 'string' && args.imageUrl.trim()) body.imageUrl = args.imageUrl.trim();
+  if (typeof args.image === 'string' && args.image.trim()) body.image = args.image.trim();
   const res = await fetch(AOS_URL + '/api/agent/video/generate', {
     method: 'POST',
     headers: H({ 'content-type': 'application/json' }),

--- a/src/server.ts
+++ b/src/server.ts
@@ -884,7 +884,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       prompt: String(b.prompt || ''),
       model: b.model ? String(b.model) : undefined,
       durationSec: b.durationSec !== undefined ? Number(b.durationSec) : undefined,
-      imageUrl: b.imageUrl ? String(b.imageUrl) : undefined,
+      image: b.image ? String(b.image) : b.imageUrl ? String(b.imageUrl) : undefined,
     });
     return sendJson(res, out.ok ? 200 : 400, out);
   }

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -265,7 +265,7 @@ function normFolder(s?: string): string {
 
 /** Resolve `rel` under `root`, rejecting escapes lexically AND after symlink resolution. The
  *  target must already exist (you publish/serve real files). Mirrors server.ts `safeResolve`. */
-function containedPath(root: string, rel: string): string | null {
+export function containedPath(root: string, rel: string): string | null {
   let realRoot: string;
   try {
     realRoot = fs.realpathSync(root);
@@ -287,7 +287,7 @@ function containedPath(root: string, rel: string): string | null {
 
 /** Content-type by extension — self-contained so the store has no server dependency. Covers the
  *  deliverable formats (Markdown/PDF/images/video/text) the gallery previews; default = octet-stream. */
-function mimeOf(file: string): string {
+export function mimeOf(file: string): string {
   const e = path.extname(file).toLowerCase();
   const map: Record<string, string> = {
     '.md': 'text/markdown; charset=utf-8',

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -12,6 +12,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { AgentOS } from './kernel';
 import { Db } from './state/db';
+import { containedPath, mimeOf } from './state/artifacts';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
 import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval } from './governance/enricher';
@@ -2362,6 +2363,47 @@ export class TerminalManager {
   }
 
   /**
+   * Resolve an agent-supplied image reference for image-to-video into something a vendor accepts inline
+   * (a `data:` URL or a passthrough http URL). Supports every place a session's image can live:
+   *   1. an http(s) or data: URL           → passed straight through
+   *   2. a path in the agent's WORKING FOLDER → raw files AND terminal-uploaded files (resolved strictly
+   *      under `manifest.dir` via `containedPath`, the same containment `publish` uses — no escapes)
+   *   3. a LIBRARY artifact id              → a prior generation / published deliverable
+   * File-path is tried before artifact-id so a real file always wins; a bare id (no matching file) falls
+   * through to the Library. Non-image inputs and unresolvable refs are rejected. Inlining as base64 means
+   * the agent needs no public hosting step for something it just made or was handed.
+   */
+  private resolveImageRef(agent: string, ref: string): { url: string } | { error: string } {
+    if (/^https?:\/\//i.test(ref) || ref.startsWith('data:')) return { url: ref };
+    const toDataUrl = (absPath: string, mime: string): { url: string } | { error: string } => {
+      if (!/^image\//.test(mime)) return { error: `"${ref}" is ${mime}, not an image` };
+      try {
+        return { url: `data:${mime};base64,${fs.readFileSync(absPath).toString('base64')}` };
+      } catch (e) {
+        return { error: `could not read "${ref}": ${e instanceof Error ? e.message : String(e)}` };
+      }
+    };
+    // (2) a file in the agent's own working folder — covers files it wrote AND files uploaded via the
+    // terminal, both of which live under its cwd. containedPath returns null for a non-existent path.
+    const dir = this.os.agents.get(agent)?.dir;
+    if (dir) {
+      const abs = containedPath(dir, ref);
+      if (abs) {
+        try {
+          if (fs.statSync(abs).isFile()) return toDataUrl(abs, mimeOf(abs));
+        } catch { /* not a readable file → fall through to Library id */ }
+      }
+    }
+    // (3) a Library artifact id (a prior generation or published deliverable)
+    const a = this.os.artifacts.get(ref);
+    if (a) {
+      const rp = this.os.artifacts.readPath(ref);
+      if (rp) return toDataUrl(rp.absPath, a.mime || rp.mime);
+    }
+    return { error: `couldn't resolve image "${ref}" — pass an http(s) URL, a file path in your working folder, or a Library artifact id` };
+  }
+
+  /**
    * Generate a video from a prompt (the `video_generate` MCP path). Video is ASYNC — renders take
    * minutes — so this SUBMITS the job, persists it to `video_jobs`, and briefly polls for the fast
    * case; anything not finished by the short cap is completed later by `pollVideoJobs()` (driven by the
@@ -2369,8 +2411,9 @@ export class TerminalManager {
    * `artifact` (kind='video') + an owner-scoped inbox card, audited `video.generated`. Governed exactly
    * like images: classified `video.generate` with the estimated `amountUsd` (per-second × duration), so
    * the money-cap rule applies. Cost is an estimate (video is per-second and rarely returned in-band).
+   * An optional `image` seed (URL or artifact id) switches it to image-to-video via `backend.imageModel`.
    */
-  async generateVideo(sessionId: string, input: { prompt: string; model?: string; durationSec?: number; imageUrl?: string }): Promise<{ ok: boolean; status?: 'done' | 'rendering'; jobId?: string; artifact?: { id: string; filename: string; mime: string }; model?: string; costUsd?: number; error?: string }> {
+  async generateVideo(sessionId: string, input: { prompt: string; model?: string; durationSec?: number; image?: string }): Promise<{ ok: boolean; status?: 'done' | 'rendering'; jobId?: string; artifact?: { id: string; filename: string; mime: string }; model?: string; costUsd?: number; error?: string }> {
     const agent = this.sessionAgent(sessionId);
     if (!agent) return { ok: false, error: 'unknown session' };
     if (!this.os.artifacts.enabled) return { ok: false, error: 'artifacts store is disabled (no data home)' };
@@ -2381,15 +2424,26 @@ export class TerminalManager {
     const backend = resolveVideoBackend(this.videoBackendConfig());
     if (!backend) return { ok: false, error: 'video generation is not configured — set a fal.ai (or Atlas Cloud) key in Settings → Integrations' };
 
+    // An optional image seed turns this into image-to-video. The ref is either an http(s) URL (passed
+    // through) or a Library artifact id (a prior generation) — resolved to a base64 data URL the vendor
+    // accepts inline, so an agent can animate an image it just made without any public hosting.
+    let imageUrl: string | undefined;
+    const imageRef = (input.image || '').trim();
+    if (imageRef) {
+      const resolved = this.resolveImageRef(agent, imageRef);
+      if ('error' in resolved) return { ok: false, error: resolved.error };
+      imageUrl = resolved.url;
+    }
+
     const estimateUsd = +(durationSec * DEFAULT_VIDEO_COST_PER_SEC_USD).toFixed(4);
-    const model = input.model?.trim() || backend.defaultModel;
-    const gate = this.gate(sessionId, agent, 'video.generate', { prompt, model, durationSec, amountUsd: estimateUsd }, `generate a ${durationSec}s video with ${model}`);
+    const model = input.model?.trim() || (imageUrl ? backend.imageModel : backend.defaultModel);
+    const gate = this.gate(sessionId, agent, 'video.generate', { prompt, model, durationSec, imageToVideo: !!imageUrl, amountUsd: estimateUsd }, `generate a ${durationSec}s ${imageUrl ? 'image-to-video' : 'video'} with ${model}`);
     if (gate.decision === 'deny') return { ok: false, error: 'blocked by policy' };
     if (gate.decision === 'pending') return { ok: false, error: 'this generation needs human approval — an approval request was filed; retry once it is approved' };
 
     let submit;
     try {
-      submit = await backend.submit({ prompt, model: input.model, durationSec, imageUrl: input.imageUrl });
+      submit = await backend.submit({ prompt, model, durationSec, imageUrl });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       this.audit(sessionId, agent, 'video.failed', { model, error: msg });


### PR DESCRIPTION
## What
`video_generate` can now **animate an image** (image-to-video), not just generate from text. The new optional **`image`** accepts every place a session's image can live:

1. **Library artifact id** — e.g. an image a prior `image_generate` produced
2. **A file path in the agent's working folder** — a file the agent wrote **or one uploaded into the terminal session** (resolved *strictly* under the agent folder via the same `containedPath` containment `publish` uses — no escapes)
3. **An http(s) URL**

Local files and Library artifacts are read and sent **inline as a base64 data URL**, so the agent needs no public hosting step for something it just made or was handed. When `image` is set without a named model, an **image-to-video model is auto-selected** (Atlas `bytedance/seedance-2.0/image-to-video`, fal `…/veo3/fast/image-to-video`).

## Fixes
- Atlas seed field was `image_url`; the schema wants **`image`** — the seed now actually applies.

## Governance / safety
- Same path as text→video: classified `video.generate` with the per-second cost estimate (money-cap gate), audited, async job → Library.
- Working-folder resolution reuses `containedPath` (lexical + symlink-real containment), so an agent can't read outside its own folder.

## Verified
- Against the **live Atlas API**: base64 data-URL seed + `bytedance/seedance-2.0/image-to-video` → **HTTP 200 + prediction id**. Confirmed the base64 inline path decodes (dimension check fires only post-decode).
- `npm run typecheck`, `npm run build`, `npm run test:governance` (68/68) all pass.

No schema/DB change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)