### PR TITLE
feat(web): render published HTML files in the Library (v0.134.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.134.0] — 2026-07-13
+### Added
+- **The Library now renders published HTML files as a live page**, not as raw source. HTML deliverables
+  (dashboards, reports, one-off pages an agent builds) were already stored and served with the right
+  `text/html` Content-Type — but the console preview pane showed their escaped source in a `<pre>` because
+  `text/html` matched the generic text path. HTML artifacts now render in an `<iframe>` (same treatment as
+  PDF), with an "Open full page ↗" link to view them standalone. The frame is **sandboxed to a null origin**
+  (`allow-scripts allow-popups allow-forms`, deliberately *not* `allow-same-origin`): interactive HTML/JS
+  runs, but the page can't reach the parent DOM, the session cookie, or the same-origin API. HTML artifacts
+  also get a distinct code-file icon in the gallery. (`ArtifactBody`/`ArtifactIcon` in `web/src/App.tsx`.)
+
 ## [0.133.0] — 2026-07-13
 ### Added
 - **`schedule` now resumes the scheduling conversation by default.** When an agent defers a follow-up

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.133.0",
+  "version": "0.134.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.133.0",
+      "version": "0.134.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.133.0",
+  "version": "0.134.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, FileCode, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink } from 'lucide-react'
 import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, Pin, PinOff, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -3303,6 +3303,7 @@ const isImageMime = (m: string) => m.startsWith('image/')
 const isVideoMime = (m: string) => m.startsWith('video/')
 const isPdfMime = (m: string) => m === 'application/pdf'
 const isMarkdownArt = (a: Artifact) => a.mime.startsWith('text/markdown') || /\.(md|markdown)$/i.test(a.filename)
+const isHtmlArt = (a: Artifact) => a.mime.startsWith('text/html') || /\.html?$/i.test(a.filename)
 const isTextMime = (m: string) => m.startsWith('text/') || m === 'application/json'
 
 /** Tailwind has no typography plugin here, so map Markdown elements to readable styled ones. */
@@ -3390,15 +3391,17 @@ function ArtifactIcon({ a, className }: { a: Artifact; className?: string }) {
   if (isImageMime(a.mime)) return <ImageIcon className={className ?? 'h-4 w-4 text-sky-500'} />
   if (isVideoMime(a.mime)) return <Film className={className ?? 'h-4 w-4 text-orange-500'} />
   if (isMarkdownArt(a)) return <FileText className={className ?? 'h-4 w-4 text-violet-500'} />
+  if (isHtmlArt(a)) return <FileCode className={className ?? 'h-4 w-4 text-amber-500'} />
   return <FileIcon className={className ?? 'h-4 w-4 text-muted-foreground'} />
 }
 
-/** Renders an artifact's contents by type: image inline, video in a player, PDF in an iframe,
+/** Renders an artifact's contents by type: image inline, video in a player, PDF/HTML in an iframe,
  *  Markdown rendered, text/JSON in a pre, anything else a download prompt. */
 function ArtifactBody({ a }: { a: Artifact }) {
   const raw = api.artifactRawUrl(a.id)
   const [text, setText] = useState<string | null>(null)
-  const wantsText = isMarkdownArt(a) || isTextMime(a.mime)
+  // HTML renders in an iframe (not as text), even though its mime matches isTextMime.
+  const wantsText = !isHtmlArt(a) && (isMarkdownArt(a) || isTextMime(a.mime))
   useEffect(() => {
     if (!wantsText) { setText(null); return }
     let live = true
@@ -3409,6 +3412,22 @@ function ArtifactBody({ a }: { a: Artifact }) {
   if (isImageMime(a.mime)) return <img src={raw} alt={a.title} className="max-h-[70vh] max-w-full rounded-lg border" />
   if (isVideoMime(a.mime)) return <video src={raw} controls className="max-h-[72vh] w-full rounded-lg border bg-black" />
   if (isPdfMime(a.mime)) return <iframe src={raw} title={a.title} className="h-[72vh] w-full rounded-lg border" />
+  if (isHtmlArt(a)) return (
+    // Sandboxed to a null origin: scripts run (for interactive dashboards/charts) but the page can't
+    // reach the parent DOM, the session cookie, or the same-origin API. No allow-same-origin — that
+    // would let the frame drop its own sandbox.
+    <div className="space-y-2">
+      <iframe
+        src={raw}
+        title={a.title}
+        sandbox="allow-scripts allow-popups allow-forms"
+        className="h-[72vh] w-full rounded-lg border bg-white"
+      />
+      <div className="text-right">
+        <a href={raw} target="_blank" rel="noreferrer" className="text-xs text-primary underline">Open full page ↗</a>
+      </div>
+    </div>
+  )
   if (wantsText) {
     if (text === null) return <div className="text-sm text-muted-foreground">Loading…</div>
     if (isMarkdownArt(a)) return <div className="max-w-3xl text-sm"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{text}</ReactMarkdown></div>


### PR DESCRIPTION
## What

The Library preview pane now **renders published HTML files as a live page** instead of showing their raw source.

HTML deliverables (dashboards, reports, one-off pages an agent builds and `publish`es) were already stored and served with the correct `text/html` Content-Type — but the console showed their escaped source in a `<pre>`, because `text/html` matched the generic `isTextMime` text path in `ArtifactBody`.

## Change (`web/src/App.tsx`)

- Add `isHtmlArt(a)` (`text/html` mime or `.html`/`.htm` filename).
- Render HTML in an `<iframe>` — same treatment PDFs already get — with an **"Open full page ↗"** link to view it standalone.
- The iframe is **sandboxed to a null origin**: `sandbox="allow-scripts allow-popups allow-forms"`, deliberately **not** `allow-same-origin`. Interactive HTML/JS runs (charts, dashboards), but the frame can't reach the parent DOM, the session cookie, or the same-origin API — and can't drop its own sandbox.
- Exclude HTML from the text-fetch path so it no longer falls into the `<pre>` branch.
- Distinct code-file icon (`FileCode`) for HTML in the gallery list.

## Verification

- `npm run typecheck` — clean
- `cd web && npm run build` — clean
- `npm run test:governance` — 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)