### PR TITLE
feat(web): attach any file to a session, not just images (v0.134.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.136.0] — 2026-07-13
+### Changed
+- **Attach ANY file to a live session, not just images.** The terminal's 📎 attach button, drag-and-drop,
+  and Cmd/Ctrl+V paste now accept a file of any type (PDF, log, CSV, zip, …) instead of rejecting
+  everything that isn't `image/*`. The file lands in the agent's `.inbox/` and its path is typed into the
+  running claude exactly as before — the agent's Read tool opens it. The **original filename is now
+  preserved** (basename sanitized, timestamp-prefixed to stay unique) so the agent sees `.inbox/<ts>-report.pdf`
+  rather than an opaque `pasted-<ts>.png`; a nameless paste still falls back to `pasted-<ts>.<ext>`. The
+  extension is derived from the filename first (then the MIME subtype). Backend storage was already
+  type-agnostic; this drops the frontend `image/*` gate and threads the filename through
+  (`api.attachFile`, `POST /api/sessions/:id/attach-file`, `TerminalManager.attachFile`). The ~12 MB size
+  cap is unchanged.
+
 ## [0.135.0] — 2026-07-13
 ### Added
 - **Image-to-video: agents can now animate an image, not just text→video.** The `video_generate` tool

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.135.0",
+  "version": "0.136.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.135.0",
+      "version": "0.136.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.135.0",
+  "version": "0.136.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1713,9 +1713,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     tm.say(sayMatch[1], String(b.body || ''));
     return sendJson(res, 200, { ok: true });
   }
-  // Operator pasted/dropped a file (image) onto the open terminal: save it into the session's working
-  // folder and type its path into the running claude. Body: { dataB64, ext }. Capped to keep a stray
-  // huge paste from buffering unbounded (readBody has no limit of its own).
+  // Operator pasted/dropped/picked a file (ANY type) onto the open terminal: save it into the session's
+  // working folder and type its path into the running claude. Body: { dataB64, ext, name? }. Capped to
+  // keep a stray huge paste from buffering unbounded (readBody has no limit of its own).
   const attachFileMatch = p.match(/^\/api\/sessions\/([\w-]+)\/attach-file$/);
   if (method === 'POST' && attachFileMatch) {
     const id = attachFileMatch[1];
@@ -1727,7 +1727,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!dataB64) return sendJson(res, 400, { error: 'dataB64 is required' });
     const data = Buffer.from(dataB64, 'base64');
     if (!data.length) return sendJson(res, 400, { error: 'empty or invalid attachment' });
-    const r = tm.attachFile(id, me.email, data, String(b.ext || 'png'));
+    const r = tm.attachFile(id, me.email, data, String(b.ext || 'bin'), b.name ? String(b.name) : undefined);
     return sendJson(res, r.ok ? 200 : 400, r);
   }
   // Stop a running session (kill its tmux, keep the row). Per-member: only the session's owner, or

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2573,25 +2573,30 @@ export class TerminalManager {
   }
 
   /**
-   * Console operator pasted/dropped a file (typically an image) onto a LIVE session. Save it under the
-   * agent's OWN working folder (`.inbox/`) — reachable by the agent's Read tool via a relative path —
-   * and type its relative path into the running claude (no auto-submit) so the operator can add a
-   * question and send. The agent's Read tool can then view the image. Authz is the caller's job
-   * (canViewSession). Returns the in-folder relative path.
+   * Console operator pasted/dropped/picked a file (ANY type — image, PDF, log, zip, …) onto a LIVE
+   * session. Save it under the agent's OWN working folder (`.inbox/`) — reachable by the agent's Read
+   * tool via a relative path — and type its relative path into the running claude (no auto-submit) so
+   * the operator can add a question and send. The agent's Read tool can then open the file. Authz is
+   * the caller's job (canViewSession). `origName` (the browser filename) is preserved when present so
+   * the agent sees a meaningful path (timestamp-prefixed to stay unique); otherwise we fall back to
+   * `pasted-<ts>.<ext>`. Returns the in-folder relative path.
    */
-  attachFile(sessionId: string, by: string, data: Buffer, ext: string): { ok: boolean; path?: string; error?: string } {
+  attachFile(sessionId: string, by: string, data: Buffer, ext: string, origName?: string): { ok: boolean; path?: string; error?: string } {
     const row = this.db.prepare('SELECT agent, tmux, status, spawned_by, run_as FROM term_sessions WHERE id = ?')
       .get<{ agent: string; tmux: string; status: string; spawned_by: string | null; run_as: string | null }>(sessionId);
     if (!row) return { ok: false, error: 'unknown session' };
     if (row.status !== 'running') return { ok: false, error: 'session is not live — attachments need a running session' };
     const manifest = this.os.agents.get(row.agent);
     if (!manifest?.dir) return { ok: false, error: 'agent has no working folder' };
-    const safeExt = (ext || 'png').toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 5) || 'bin';
+    const safeExt = (ext || 'bin').toLowerCase().replace(/[^a-z0-9]/g, '').slice(0, 8) || 'bin';
+    // Prefer the real filename (basename only, sanitized) so a report.pdf stays report.pdf; a
+    // timestamp prefix keeps concurrent same-name uploads from clobbering each other.
+    const clean = (origName || '').split(/[\\/]/).pop()!.replace(/[^A-Za-z0-9._-]/g, '_').replace(/^\.+/, '').slice(0, 80);
     let rel: string;
     try {
       const dir = path.join(manifest.dir, '.inbox');
       fs.mkdirSync(dir, { recursive: true });
-      const name = `pasted-${Date.now()}.${safeExt}`;
+      const name = clean && /\.[A-Za-z0-9]+$/.test(clean) ? `${Date.now()}-${clean}` : `pasted-${Date.now()}.${safeExt}`;
       fs.writeFileSync(path.join(dir, name), data);
       rel = path.join('.inbox', name);
     } catch (e) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, FileCode, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, FileCode, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink, Paperclip } from 'lucide-react'
 import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, Pin, PinOff, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -1748,7 +1748,7 @@ function TerminalHelpModal({ open, onClose }: { open: boolean; onClose: () => vo
     { keys: `${mod} + V  ·  right-click`, desc: 'Paste into the terminal.' },
     { keys: 'Mouse wheel', desc: 'Scroll back through output. Inside a full-screen app (claude) it scrolls that app.' },
     { keys: 'Click a link', desc: 'URLs in the output are clickable — opens in a new tab.' },
-    { keys: 'Paste / drop an image', desc: 'Sends the image to the agent (it can’t travel over the raw terminal).' },
+    { keys: 'Paste / drop a file', desc: 'Sends the file (any type) to the agent (it can’t travel over the raw terminal).' },
   ]
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
@@ -1855,11 +1855,11 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
 }
 
 /** Wraps the first-party terminal (<Xterm>) with the console chrome: the font stepper, the "how to use"
- *  help modal, and the paths to get an IMAGE into the remote session — which the pty can't carry. Three
- *  ways in: a 📎 button, drag-and-drop onto the pane, and Cmd/Ctrl+V (image paste). Each uploads the
- *  bytes; the server saves them in the agent's folder and types the path into the running claude. Now
- *  that the terminal is same-document (no iframe), drops/pastes over it bubble to our window handlers
- *  directly — no cross-document interception needed. */
+ *  help modal, and the paths to get a FILE (any type — image, PDF, log, zip, …) into the remote session,
+ *  which the pty can't carry. Three ways in: a 📎 button, drag-and-drop onto the pane, and Cmd/Ctrl+V
+ *  (file paste). Each uploads the bytes; the server saves them in the agent's folder and types the path
+ *  into the running claude. Now that the terminal is same-document (no iframe), drops/pastes over it
+ *  bubble to our window handlers directly — no cross-document interception needed. */
 function ImageDropZone({ session, children, onActivity, fontSize, setFontSize }: {
   session?: Session; children: ReactNode; onActivity?: () => void
   fontSize: number; setFontSize: (f: number | ((s: number) => number)) => void
@@ -1877,29 +1877,31 @@ function ImageDropZone({ session, children, onActivity, fontSize, setFontSize }:
   const upload = async (file: File) => {
     if (!session?.id) return
     if (!live) { setToast({ kind: 'err', text: 'session is not live — start it first' }); return }
-    if (!file.type.startsWith('image/')) { setToast({ kind: 'err', text: 'only images can be attached' }); return }
-    setToast({ kind: 'busy', text: `uploading ${file.name || 'image'}…` })
+    setToast({ kind: 'busy', text: `uploading ${file.name || 'file'}…` })
     try {
       const buf = await file.arrayBuffer()
       let bin = ''
       const bytes = new Uint8Array(buf)
       for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i])
       const dataB64 = btoa(bin)
-      const ext = (file.type.split('/')[1] || 'png').split('+')[0]
-      const r = await api.attachFile(session.id, dataB64, ext)
+      // Extension from the filename first (any file type), then the MIME subtype, else 'bin'.
+      const nameExt = file.name.includes('.') ? file.name.split('.').pop() || '' : ''
+      const ext = (nameExt || file.type.split('/')[1] || 'bin').split('+')[0]
+      const r = await api.attachFile(session.id, dataB64, ext, file.name || undefined)
       setToast(r.ok ? { kind: 'ok', text: `attached → ${r.path} (added to the prompt)` } : { kind: 'err', text: r.error || 'upload failed' })
     } catch (e) {
       setToast({ kind: 'err', text: e instanceof Error ? e.message : 'upload failed' })
     }
   }
 
-  // Image paste. Capture phase so it runs BEFORE xterm's own textarea paste handler when the terminal is
-  // focused (an image has no text, so xterm would do nothing with it anyway — but capturing lets us claim
-  // it cleanly). A text paste has no image item, so it falls through to xterm untouched.
+  // File paste. Capture phase so it runs BEFORE xterm's own textarea paste handler when the terminal is
+  // focused (a pasted file has no text, so xterm would do nothing with it anyway — but capturing lets us
+  // claim it cleanly). A text paste has only string items (kind !== 'file'), so it falls through to
+  // xterm untouched.
   useEffect(() => {
     if (!session?.id) return
     const onPaste = (e: ClipboardEvent) => {
-      const item = Array.from(e.clipboardData?.items || []).find((it) => it.kind === 'file' && it.type.startsWith('image/'))
+      const item = Array.from(e.clipboardData?.items || []).find((it) => it.kind === 'file')
       const file = item?.getAsFile()
       if (file) { e.preventDefault(); e.stopPropagation(); void upload(file) }
     }
@@ -1934,7 +1936,7 @@ function ImageDropZone({ session, children, onActivity, fontSize, setFontSize }:
   uploadRef.current = upload
 
   // Font size flows to <Xterm> as a live prop (it reflows internally), so no imperative poking needed —
-  // and the terminal is same-document now, so image paste/drop bubble to the window handlers above.
+  // and the terminal is same-document now, so file paste/drop bubble to the window handlers above.
 
   // auto-dismiss the toast (keep errors a touch longer)
   useEffect(() => {
@@ -1968,7 +1970,7 @@ function ImageDropZone({ session, children, onActivity, fontSize, setFontSize }:
         ><HelpCircle className="h-3.5 w-3.5" /> Help</button>
       </div>
       <TerminalHelpModal open={help} onClose={() => setHelp(false)} />
-      {/* top-right session toolbar: browse the agent's folder + attach an image */}
+      {/* top-right session toolbar: browse the agent's folder + attach a file */}
       <div className="absolute right-2 top-2 z-10 flex items-center gap-1.5">
         {session?.agent && (
           <a
@@ -1979,13 +1981,13 @@ function ImageDropZone({ session, children, onActivity, fontSize, setFontSize }:
             <FolderTree className="h-3.5 w-3.5" /> Files
           </a>
         )}
-        {/* 📎 attach button — opens a file picker; always works regardless of focus */}
+        {/* 📎 attach button — opens a file picker (any file type); always works regardless of focus */}
         <label
           className="flex cursor-pointer items-center gap-1 rounded bg-neutral-800/90 px-2 py-1 text-xs text-neutral-200 shadow hover:bg-neutral-700"
-          title="attach an image to this session (or drag-drop / paste one onto the terminal)"
+          title="attach a file (any type) to this session (or drag-drop / paste one onto the terminal)"
         >
-          <ImageIcon className="h-3.5 w-3.5" /> Attach image
-          <input type="file" accept="image/*" className="hidden"
+          <Paperclip className="h-3.5 w-3.5" /> Attach file
+          <input type="file" className="hidden"
             onChange={(e) => { const f = e.target.files?.[0]; if (f) void upload(f); e.currentTarget.value = '' }} />
         </label>
       </div>
@@ -1997,11 +1999,11 @@ function ImageDropZone({ session, children, onActivity, fontSize, setFontSize }:
           onDragOver={(e) => e.preventDefault()}
           onDrop={(e) => {
             e.preventDefault(); setDrag(false)
-            const file = Array.from(e.dataTransfer.files).find((f) => f.type.startsWith('image/'))
+            const file = Array.from(e.dataTransfer.files)[0]
             if (file) void upload(file)
           }}
         >
-          Drop image to send it to the agent
+          Drop a file to send it to the agent
         </div>
       )}
       {/* result toast */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -903,10 +903,11 @@ export const api = {
   sessionTranscript: (id: string) => call<{ text?: string; error?: string }>('GET', `/api/sessions/${id}/transcript`),
   /** The agent-os primitives this session used — a classified timeline + grouped counts. */
   sessionActivity: (id: string) => call<SessionActivityResp>('GET', `/api/sessions/${id}/activity`),
-  /** Upload a pasted/dropped image into a live session; the server saves it in the agent's folder and
-   *  types the path into the running claude. `dataB64` is base64 (no data: prefix); `ext` e.g. 'png'. */
-  attachFile: (id: string, dataB64: string, ext: string) =>
-    call<{ ok: boolean; path?: string; error?: string }>('POST', `/api/sessions/${id}/attach-file`, { dataB64, ext }),
+  /** Upload a pasted/dropped/picked file (ANY type) into a live session; the server saves it in the
+   *  agent's folder and types the path into the running claude. `dataB64` is base64 (no data: prefix);
+   *  `ext` e.g. 'pdf'; `name` is the original filename, preserved when given. */
+  attachFile: (id: string, dataB64: string, ext: string, name?: string) =>
+    call<{ ok: boolean; path?: string; error?: string }>('POST', `/api/sessions/${id}/attach-file`, { dataB64, ext, name }),
   resolve: (id: string, approved: boolean) => call<{ ok: boolean; error?: string }>('POST', '/api/approvals/' + id, { approved }),
   /** Approve this attempt AND add a persistent policy `allow` rule for its capability (owner-only). */
   alwaysApprove: (id: string) => call<{ ok: boolean; ruleAdded?: boolean; note?: string; error?: string }>('POST', `/api/approvals/${id}/always`),


### PR DESCRIPTION
## What

Lets the console operator attach **any file type** to a live terminal session — not just images. The 📎 attach button, drag-and-drop onto the pane, and Cmd/Ctrl+V paste previously rejected everything that wasn't `image/*`.

## Why

Agents frequently need a PDF, log, CSV, config, or zip handed to them mid-session. The upload path (save into the agent's `.inbox/`, type the path into the running claude for its Read tool) was already type-agnostic on the backend — only the frontend gated to images.

## Changes

- **Frontend (`web/src/App.tsx`)** — dropped the `image/*` file-input filter and the `file.type.startsWith('image/')` checks in the upload/paste/drop handlers; derive the extension from the filename first (then MIME); relabelled the button/help/overlay from "image" to "file" (📎 `Paperclip` icon).
- **Original filename preserved** — the file now lands as `.inbox/<ts>-report.pdf` (basename sanitized, timestamp-prefixed to stay unique) instead of an opaque `pasted-<ts>.png`; a nameless paste still falls back to `pasted-<ts>.<ext>`. Threaded through `api.attachFile` → `POST /api/sessions/:id/attach-file` → `TerminalManager.attachFile`.
- The ~12 MB size cap is unchanged.

## Testing

- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)