### PR TITLE
feat(profile): per-member context injection + self-service Profile page (v0.135.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.135.0] — 2026-07-13
+### Added
+- **Per-member personal context + a self-service Profile page.** Each member can now add free-text
+  **"My context"** that is injected into the system prompt of every session that runs **as them** (their
+  working style, standing preferences, domain notes) — read at launch by `buildCompanyMd` and labelled as
+  the operator's standing instructions, secondary to the task and the operating notes. Stored in the
+  `member_prefs` blob (trimmed, capped at 8,000 chars), edited at `GET`/`PUT /api/me/context` (self-service,
+  no role gate; audited `member.context.set`). A new **Profile** page (reachable from the sidebar profile
+  row and the bell's gear) collects the member's *own* settings in one place: avatar + name, My context,
+  notification preferences (moved off the notification bell, which is now feed-only), and their chat
+  identities (Slack/Discord/email/GitHub run-as handles — a member may now edit their **own** handles; the
+  `/api/team/:id/identities` routes accept self as well as admin). The **Team** page stays focused on
+  managing *other* people (roster, roles, invites, agent access). (`ProfilePage`/`NotificationsBell` in
+  `web/src/App.tsx`; `TeamStore.memberContext`/`setMemberContext`; `buildCompanyMd` in `src/terminal.ts`.)
+
 ## [0.134.0] — 2026-07-13
 ### Added
 - **The Library now renders published HTML files as a live page**, not as raw source. HTML deliverables

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.134.0",
+  "version": "0.135.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.134.0",
+      "version": "0.135.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.134.0",
+  "version": "0.135.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -13,6 +13,7 @@ import { AgentAccess, Member, MemberIdentity, IdentityProvider, Role, ApprovalLe
 
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // magic links valid for 7 days
 const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // login cookie valid for 30 days
+const MEMBER_CONTEXT_MAX = 8000; // cap a member's personal context so it can't dominate every prompt
 
 interface MemberRow {
   id: string;
@@ -104,6 +105,22 @@ export class TeamStore {
   setNavPins(memberId: string, pins: unknown): string[] {
     const clean = sanitizeNavPins(pins) ?? [];
     this.writeRawPrefs(memberId, { ...this.rawPrefs(memberId), navPins: clean });
+    return clean;
+  }
+
+  /** This member's personal context — free-text they want injected into every session that runs AS
+   *  them (their working style, standing preferences, domain notes). '' when never set. Read at launch
+   *  by `buildCompanyMd`. Self-service: every member owns their own, no role gate. */
+  memberContext(memberId: string): string {
+    const v = this.rawPrefs(memberId).context;
+    return typeof v === 'string' ? v : '';
+  }
+
+  /** Persist a member's personal context (trimmed + capped so it can't bloat every prompt), preserving
+   *  sibling prefs (notifications, navPins) in the same blob. Returns the stored value. */
+  setMemberContext(memberId: string, context: unknown): string {
+    const clean = String(context ?? '').trim().slice(0, MEMBER_CONTEXT_MAX);
+    this.writeRawPrefs(memberId, { ...this.rawPrefs(memberId), context: clean });
     return clean;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -1483,11 +1483,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { link: linkFor(req, issued.token) });
   }
   // Identity map: link/unlink the external accounts a member is known by (Slack/Discord/email/github),
-  // the join key chat triggers use for run-as. Owner/admin only. The id segment excludes the literal
+  // the join key chat triggers use for run-as. Admins manage anyone; a member may edit their OWN handles
+  // (the self-service Chat IDs on the Profile page). The id segment excludes the literal
   // "identities"-suffixed paths from the single-segment member routes below.
   const teamIdentSet = p.match(/^\/api\/team\/([\w-]+)\/identities$/);
   if (method === 'POST' && teamIdentSet) {
-    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (!isAdmin(me) && me.id !== teamIdentSet[1]) return sendJson(res, 403, { error: 'not allowed' });
     const b = await readBody(req);
     const provider = String(b.provider || '') as IdentityProvider;
     if (!IDENTITY_PROVIDERS.includes(provider)) return sendJson(res, 400, { error: 'unknown provider' });
@@ -1505,7 +1506,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   }
   const teamIdentDel = p.match(/^\/api\/team\/([\w-]+)\/identities\/([\w-]+)$/);
   if (method === 'DELETE' && teamIdentDel) {
-    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (!isAdmin(me) && me.id !== teamIdentDel[1]) return sendJson(res, 403, { error: 'not allowed' });
     const provider = teamIdentDel[2] as IdentityProvider;
     if (!IDENTITY_PROVIDERS.includes(provider)) return sendJson(res, 400, { error: 'unknown provider' });
     os.team.clearIdentity(teamIdentDel[1], provider);
@@ -1792,6 +1793,15 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'PUT' && p === '/api/me/prefs') {
     const b = await readBody(req);
     return sendJson(res, 200, os.team.setNotificationPrefs(me.id, b));
+  }
+  // This member's personal context — free-text they inject into every session that runs AS them
+  // (buildCompanyMd reads it at launch). Per person, self-service, not admin-gated. Edited on Profile.
+  if (method === 'GET' && p === '/api/me/context') return sendJson(res, 200, { context: os.team.memberContext(me.id) });
+  if (method === 'PUT' && p === '/api/me/context') {
+    const b = await readBody(req);
+    const context = os.team.setMemberContext(me.id, (b as { context?: unknown }).context);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'member.context.set', data: { chars: context.length } });
+    return sendJson(res, 200, { context });
   }
   // This member's pinned sidebar nav (which secondary items sit up in Main). Per person, not admin-gated
   // — everyone customizes their own. The initial value ships on /api/auth/me; this saves changes.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1300,6 +1300,22 @@ export class TerminalManager {
    *  terminal hyperlinks (OSC 8) aren't clickable — the agent must surface raw URLs as plain text. */
   private buildCompanyMd(selfAgent?: string, actingMember?: string): string {
     const company = this.os.settings.company().companyMd.trim();
+    // Per-member personal context: free-text the human you run AS chose to inject into their sessions
+    // (their working style, standing preferences, domain notes). Self-service, owner-scoped — set on
+    // the Profile page. Only present when acting as a real member who wrote something.
+    let memberCtx = '';
+    if (actingMember) {
+      const ctx = this.os.team.memberContext(actingMember).trim();
+      if (ctx) {
+        const who = this.os.team.getMember(actingMember)?.name || 'the person you run as';
+        memberCtx =
+          `# Personal context from ${who} — the person you are running as\n\n` +
+          `${who} added this to steer sessions run on their behalf. Treat it as their standing ` +
+          'preferences and instructions for how you work for them, secondary to the task at hand and ' +
+          'these operating notes.\n\n' +
+          ctx;
+      }
+    }
     // Close the self-learning loop: the Dreamer's distilled guidance rides in every agent's prompt, so
     // the fleet's accumulated experience shapes each new session. Toggleable in Settings → Self-learning.
     const learned = this.os.settings.applyLearnings() ? this.os.settings.learnedGuidance().trim() : '';
@@ -1431,7 +1447,7 @@ export class TerminalManager {
             .join('\n');
       }
     }
-    return [company, AGENT_OS_OPERATING_NOTES, messaging, github, goalsSection, fleet, team, preamble, learned]
+    return [company, memberCtx, AGENT_OS_OPERATING_NOTES, messaging, github, goalsSection, fleet, team, preamble, learned]
       .filter(Boolean)
       .join('\n\n');
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,7 +22,7 @@ import { Xterm } from './Xterm'
 // Terminal font-size bounds (shared by TerminalFrame's state and the ImageDropZone stepper).
 const TERM_FONT_MIN = 8, TERM_FONT_MAX = 40
 
-type Route = 'inbox' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'goals' | 'tasks' | 'memory' | 'kb' | 'skills' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent' | 'docs'
+type Route = 'inbox' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'goals' | 'tasks' | 'memory' | 'kb' | 'skills' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent' | 'docs' | 'profile'
 // The full set of pages, used by the hash router to validate the URL on load. Keep in sync with Route.
 const ROUTES: Route[] = ['inbox', 'sessions', 'agents', 'new-agent', 'connectors', 'team', 'automations', 'goals', 'tasks', 'memory', 'kb', 'skills', 'files', 'artifacts', 'settings', 'audit', 'agent', 'docs']
 type Selected = { tmux: string; title: string } | null
@@ -1119,7 +1119,7 @@ function Console({ me }: { me: Member }) {
 
           <Separator className="my-3" />
           <div className="flex items-center justify-between">
-            <a href={navHref('team')} className="flex min-w-0 items-center gap-2 text-left text-foreground no-underline hover:underline" onClick={onNavClick(() => nav('team'))} title="manage team">
+            <a href={navHref('profile')} className="flex min-w-0 items-center gap-2 text-left text-foreground no-underline hover:underline" onClick={onNavClick(() => nav('profile'))} title="your profile & settings">
               <MemberAvatar member={state?.me ?? me} className="h-7 w-7 text-xs" />
               <span className="min-w-0">
                 <span className="flex items-center gap-1.5 text-sm font-medium leading-tight">
@@ -1153,11 +1153,11 @@ function Console({ me }: { me: Member }) {
           ) : (
             <div className="flex items-center gap-3">
               <h1 className="max-w-[60vw] truncate text-lg font-semibold">
-                {route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connections' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'goals' ? 'Goals' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Library' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'docs' ? 'Docs' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : 'Agents'}
+                {route === 'inbox' ? 'Inbox' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connections' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'goals' ? 'Goals' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Library' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'docs' ? 'Docs' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : route === 'profile' ? 'Profile' : 'Agents'}
               </h1>
             </div>
           )}
-          <NotificationsBell items={notifyItems} unread={notifyUnread} prefs={prefs} onOpen={openNotification} onMarkAllRead={markAllNotificationsRead} onSavePrefs={savePrefs} />
+          <NotificationsBell items={notifyItems} unread={notifyUnread} onOpen={openNotification} onMarkAllRead={markAllNotificationsRead} onOpenSettings={() => nav('profile')} />
         </div>
 
         <div className={`min-h-0 flex-1 ${fullBleed ? '' : 'overflow-y-auto p-6'}`}>
@@ -1167,6 +1167,7 @@ function Console({ me }: { me: Member }) {
           {route === 'inbox' && <InboxPage messages={messages} me={me} members={members} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} onOpenGoal={(id) => nav('goals', id)} />}
           {route === 'connectors' && <ConnectionsPage me={me} tab={detail} onTab={(t) => nav('connectors', t)} />}
           {route === 'team' && <TeamPage me={me} onProfileChange={refreshState} />}
+          {route === 'profile' && <ProfilePage me={state?.me ?? me} prefs={prefs} onSavePrefs={savePrefs} onProfileChange={refreshState} />}
           {route === 'automations' && <AutomationsPage me={me} agents={state?.agents ?? []} serverTz={state?.serverTz} onOpen={openTerminal} nav={nav} />}
           {route === 'goals' && <GoalsPage me={me} goalId={detail} nav={nav} />}
           {route === 'tasks' && <TasksPage me={me} agents={state?.agents ?? []} taskId={detail} onOpen={openTerminal} nav={nav} />}
@@ -1289,24 +1290,21 @@ function ToastHost({ toasts, onOpen, onDismiss }: { toasts: ToastItem[]; onOpen:
 
 /** The header notification bell: a count badge + a dropdown of recent notifications, plus a per-member
  *  settings panel. Reuses the already-polled `messages` (via `items`), so it adds no new request cost. */
-function NotificationsBell({ items, unread, prefs, onOpen, onMarkAllRead, onSavePrefs }: {
+function NotificationsBell({ items, unread, onOpen, onMarkAllRead, onOpenSettings }: {
   items: NotifyItem[]
   unread: number
-  prefs: NotificationPrefs
   onOpen: (m: Msg) => void
   onMarkAllRead: () => void
-  onSavePrefs: (p: NotificationPrefs) => void
+  onOpenSettings: () => void
 }) {
   const [open, setOpen] = useState(false)
-  const [showPrefs, setShowPrefs] = useState(false)
   const recent = items.slice(0, 12)
-  const toggleEvent = (k: NotifyKind) => onSavePrefs({ ...prefs, events: { ...prefs.events, [k]: !prefs.events[k] } })
   return (
     <div className="relative">
       <button
         className="relative rounded-md p-2 text-muted-foreground hover:bg-muted hover:text-foreground"
         title="Notifications"
-        onClick={() => { setOpen((o) => !o); setShowPrefs(false) }}
+        onClick={() => setOpen((o) => !o)}
       >
         <Bell className="h-5 w-5" />
         {unread > 0 && (
@@ -1327,35 +1325,12 @@ function NotificationsBell({ items, unread, prefs, onOpen, onMarkAllRead, onSave
                     Mark all read
                   </button>
                 )}
-                <button className={`rounded p-1 hover:bg-muted ${showPrefs ? 'text-foreground' : 'text-muted-foreground'}`} title="Notification settings" onClick={() => setShowPrefs((s) => !s)}>
+                <button className="rounded p-1 text-muted-foreground hover:bg-muted hover:text-foreground" title="Notification settings" onClick={() => { setOpen(false); onOpenSettings() }}>
                   <Cog className="h-3.5 w-3.5" />
                 </button>
               </div>
             </div>
-            {showPrefs ? (
-              <div className="space-y-2 p-3 text-sm">
-                <p className="text-xs font-medium text-muted-foreground">Notify me about</p>
-                {(Object.keys(NOTIFY_META) as NotifyKind[]).map((k) => (
-                  <label key={k} className="flex cursor-pointer items-center gap-2">
-                    <input type="checkbox" checked={prefs.events[k]} onChange={() => toggleEvent(k)} />
-                    <span>{NOTIFY_META[k].label}</span>
-                  </label>
-                ))}
-                <div className="my-1 border-t" />
-                <label className="flex cursor-pointer items-center gap-2">
-                  <input type="checkbox" checked={prefs.toasts} onChange={() => onSavePrefs({ ...prefs, toasts: !prefs.toasts })} />
-                  <span>Show pop-in toasts</span>
-                </label>
-                <label className="flex cursor-pointer items-center gap-2">
-                  <input type="checkbox" checked={prefs.sound} onChange={() => onSavePrefs({ ...prefs, sound: !prefs.sound })} />
-                  <span>Play a sound</span>
-                </label>
-                <label className="flex cursor-pointer items-center gap-2">
-                  <input type="checkbox" checked={prefs.dm} onChange={() => onSavePrefs({ ...prefs, dm: !prefs.dm })} />
-                  <span>Also DM me on Slack/Discord</span>
-                </label>
-              </div>
-            ) : recent.length === 0 ? (
+            {recent.length === 0 ? (
               <div className="px-3 py-8 text-center text-sm text-muted-foreground">You're all caught up.</div>
             ) : (
               <ul className="max-h-96 overflow-y-auto">
@@ -3946,6 +3921,105 @@ function IdentityEditor({ member, identities, onChange }: { member: Member; iden
         When a Slack/Discord message triggers an automation, the OS runs it <strong>as the member whose handle matches the sender</strong>
         {' '}— their connectors + inbox. Slack also falls back to matching the sender's profile email.
       </p>
+    </div>
+  )
+}
+
+/** The logged-in member's own profile & personal settings — self-service, every role edits their own.
+ *  Their avatar/name, the free-text "context" injected into every session run as them, notification
+ *  preferences (moved off the bell), and their chat handles (run-as join keys). Managing OTHER people
+ *  (roles, invites, access) stays on the Team page. */
+function ProfilePage({ me, prefs, onSavePrefs, onProfileChange }: {
+  me: Member
+  prefs: NotificationPrefs
+  onSavePrefs: (p: NotificationPrefs) => void
+  onProfileChange: () => void
+}) {
+  const [context, setContext] = useState('')
+  const [savedContext, setSavedContext] = useState('') // last persisted value → drives the dirty check
+  const [savingCtx, setSavingCtx] = useState(false)
+  const [ctxSaved, setCtxSaved] = useState(false)
+  const [identities, setIdentities] = useState<MemberIdentity[]>([])
+
+  useEffect(() => { api.myContext().then((r) => { setContext(r.context || ''); setSavedContext(r.context || '') }).catch(() => {}) }, [])
+  const loadIdentities = () => api.team().then((d) => setIdentities(d.identities?.[me.id] ?? [])).catch(() => {})
+  useEffect(() => { loadIdentities() }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const saveContext = async () => {
+    setSavingCtx(true); setCtxSaved(false)
+    try {
+      const r = await api.saveMyContext(context)
+      setContext(r.context); setSavedContext(r.context); setCtxSaved(true); setTimeout(() => setCtxSaved(false), 2000)
+    } finally { setSavingCtx(false) }
+  }
+  const toggleEvent = (k: NotifyKind) => onSavePrefs({ ...prefs, events: { ...prefs.events, [k]: !prefs.events[k] } })
+  const dirty = context !== savedContext
+
+  return (
+    <div className="max-w-3xl space-y-8">
+      {/* Identity */}
+      <section className="flex items-center gap-4">
+        <EditableAvatar member={me} canEdit sizeClass="h-16 w-16 text-xl" onChanged={onProfileChange} />
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-lg font-semibold">
+            <span className="truncate">{me.name}</span>
+            <RoleBadge role={me.role} />
+          </div>
+          <div className="truncate text-sm text-muted-foreground">{me.email}</div>
+        </div>
+      </section>
+
+      {/* Personal context (the new feature) */}
+      <section className="space-y-2">
+        <div className="text-[11px] uppercase tracking-wider text-muted-foreground">My context</div>
+        <p className="text-sm text-muted-foreground">
+          Free text added to the system prompt of every session that runs <strong>as you</strong> — your
+          working style, standing preferences, or domain notes. Agents treat it as your instructions for
+          how to work on your behalf. Leave it blank to inject nothing.
+        </p>
+        <Textarea
+          value={context}
+          onChange={(e) => setContext(e.target.value)}
+          placeholder={"e.g. I prefer concise PRs with a short summary up top. Always run the typecheck before pushing. Ping me on Slack for anything customer-facing."}
+          className="min-h-[180px] font-mono text-xs"
+          maxLength={8000}
+        />
+        <div className="flex items-center gap-3">
+          <Button size="sm" onClick={saveContext} disabled={!dirty || savingCtx}>{savingCtx ? 'Saving…' : 'Save context'}</Button>
+          {ctxSaved && <span className="text-xs text-emerald-600">Saved</span>}
+          <span className="ml-auto text-[11px] text-muted-foreground">{context.length.toLocaleString()}/8,000</span>
+        </div>
+      </section>
+
+      {/* Notifications (moved off the bell) */}
+      <section className="space-y-2">
+        <div className="text-[11px] uppercase tracking-wider text-muted-foreground">Notifications</div>
+        <p className="text-xs font-medium text-muted-foreground">Notify me about</p>
+        <div className="grid gap-1.5 sm:grid-cols-2">
+          {(Object.keys(NOTIFY_META) as NotifyKind[]).map((k) => (
+            <label key={k} className="flex cursor-pointer items-center gap-2 text-sm">
+              <input type="checkbox" checked={prefs.events[k]} onChange={() => toggleEvent(k)} />
+              <span>{NOTIFY_META[k].label}</span>
+            </label>
+          ))}
+        </div>
+        <div className="my-1 border-t" />
+        <div className="grid gap-1.5 sm:grid-cols-2">
+          <label className="flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={prefs.toasts} onChange={() => onSavePrefs({ ...prefs, toasts: !prefs.toasts })} /><span>Show pop-in toasts</span></label>
+          <label className="flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={prefs.sound} onChange={() => onSavePrefs({ ...prefs, sound: !prefs.sound })} /><span>Play a sound</span></label>
+          <label className="flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={prefs.dm} onChange={() => onSavePrefs({ ...prefs, dm: !prefs.dm })} /><span>Also DM me on Slack/Discord</span></label>
+        </div>
+      </section>
+
+      {/* Chat identities — own handles (self-service) */}
+      <section className="space-y-2">
+        <div className="text-[11px] uppercase tracking-wider text-muted-foreground">My chat identities</div>
+        <p className="text-sm text-muted-foreground">
+          Link your own Slack / Discord / email / GitHub handles so a chat message from you runs its agent
+          as <strong>you</strong> — with your connectors, inbox, and git identity.
+        </p>
+        <IdentityEditor member={me} identities={identities} onChange={loadIdentities} />
+      </section>
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -920,6 +920,9 @@ export const api = {
   /** This member's own notification preferences (bell/toast/sound/DM + which event kinds). */
   notificationPrefs: () => call<NotificationPrefs>('GET', '/api/me/prefs'),
   saveNotificationPrefs: (prefs: NotificationPrefs) => call<NotificationPrefs>('PUT', '/api/me/prefs', prefs),
+  // This member's personal context (free-text injected into every session run as them).
+  myContext: () => call<{ context: string }>('GET', '/api/me/context'),
+  saveMyContext: (context: string) => call<{ context: string }>('PUT', '/api/me/context', { context }),
   /** Persist this member's pinned sidebar nav (the keys promoted to Main). Returns the resolved list. */
   saveNavPins: (pinned: string[]) => call<{ pinned: string[] }>('PUT', '/api/me/nav', { pinned }),
 


### PR DESCRIPTION
## What

Two related additions requested together:

1. **Per-member context injection** — each member can add free-text **"My context"** that gets injected into the system prompt of every session that runs **as them** (their working style, standing preferences, domain notes). Read at launch by `buildCompanyMd` and labelled as the operator's standing instructions, secondary to the task and the operating notes.

2. **A self-service Profile page** — the member's *own* settings collected in one place, with the notification prefs **moved off the bell** (now feed-only) and settings pulled out of the Team page.

## How

**Backend**
- `TeamStore.memberContext` / `setMemberContext` — stored in the existing `member_prefs` JSON blob (sibling to notification prefs / navPins), trimmed and capped at 8,000 chars.
- `GET` / `PUT /api/me/context` — self-service, no role gate; audited `member.context.set`.
- `buildCompanyMd` (`src/terminal.ts`) injects the acting member's context as a labelled section when a session runs as a real member.
- `/api/team/:id/identities` (POST/DELETE) now accept **self** as well as admin, so a member can link their own chat handles.

**Web (`web/src/App.tsx`)**
- New **Profile** page: avatar + name, My context editor, notification preferences, and My Chat IDs (reusing `IdentityEditor`). Reached from the sidebar profile row and the bell's gear.
- `NotificationsBell` is now feed-only; its settings gear navigates to Profile.
- **Team** page unchanged in purpose — managing *other* people (roster, roles, invites, agent access).

## Test
- `npm run typecheck` ✓, `cd web && npm run build` ✓, `npm run test:governance` → 68/68 ✓
- Isolated TeamStore test: trim, persistence, sibling-pref preservation, 8k cap, clear — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)