### PR TITLE
docs(web): document Company context — flat text, no file imports (v0.136.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.136.1] — 2026-07-13
+### Added
+- **Docs: "Company context" concept in the console Docs → Core concepts page.** Explains what the
+  fleet-wide Company context is and, in answer to a recurring question, that it's **flat text** — it
+  can't `@import` or read other markdown files. Points reference docs to **Knowledge**, procedures to
+  **Skills**, and one-agent context to that agent's own `CLAUDE.md`.
+
 ## [0.136.0] — 2026-07-13
 ### Changed
 - **Attach ANY file to a live session, not just images.** The terminal's 📎 attach button, drag-and-drop,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.136.0",
+  "version": "0.136.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.136.0",
+      "version": "0.136.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.136.0",
+  "version": "0.136.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/docs/core-concepts.md
+++ b/web/src/docs/core-concepts.md
@@ -37,6 +37,18 @@ A durable item in the shared queue between "something should happen" and "a sess
 
 A file an agent published — report, PDF, image, doc — is a **deliverable**. Snapshots, kept forever, listed under **Library**.
 
+## Company context — *standing instructions for the whole fleet*
+
+Set under **Settings → Company context**, this markdown is added to *every* agent's system prompt at launch — the fleet-wide "here's who we are and how we work" that rides along on every run. Use it for durable, universal context: your company's name and mission, tone, hard rules ("never email a customer without review"), and pointers to where the details live.
+
+**It's flat text, not a file loader.** The Company context can't `@import`, link to, or otherwise read other markdown files — whatever you paste in the box is exactly, and only, what agents see. So don't try to reference separate `.md` files from it. To give agents *reference documents* they can pull on demand:
+
+- **Reference docs, runbooks, policies →** put them in **Knowledge** (the shared wiki agents search with their own tools), then point at them by name from the Company context: *"For refund rules, search Knowledge for 'refund policy'."*
+- **Step-by-step procedures →** make a **Skill** (shared with the whole fleet at launch).
+- **Just one agent →** put it in that agent's own instructions (its `CLAUDE.md`), not the fleet-wide Company context.
+
+Keep Company context short and stable; let **Knowledge** carry the volume.
+
 ## Memory vs. Knowledge
 
 Both persist, but they're different organs — see **Memory, Knowledge & Tasks** for when each applies. Short version: **Memory** is what an *agent* remembers (its own notes); **Knowledge** is what the *company* knows (the shared wiki both humans and agents edit).


### PR DESCRIPTION
## What

Adds a **Company context** concept to the console **Docs → Core concepts** page, answering a recurring user question: *can the Company context markdown read/import other `.md` files?*

**It can't.** The Company context is a flat block appended to every agent's system prompt at launch (`--append-system-prompt-file`) — there is no `@import` / file-reference handling anywhere in the launch path. The new doc says so plainly and redirects:

- reference docs / runbooks / policies → **Knowledge** (searchable by agents), pointed at by name from the Company context
- step-by-step procedures → **Skills**
- one-agent context → that agent's own `CLAUDE.md`

## Why

Users were trying to `@`-reference separate markdown files from the Company context box and expecting them to load. Documenting the flat-text reality + the right alternative (Knowledge) closes the confusion.

## Verify

- `cd web && npm run build` ✓ (docs bundled via `?raw`, no server restart needed to view — reload the browser)
- Docs-only content change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)