### PR TITLE
fix(web): Profile page loads instead of bouncing to Inbox (v0.138.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.138.1] — 2026-07-13
+### Fixed
+- **The Profile page now loads instead of bouncing to the Inbox.** `profile` was added to the `Route`
+  type but not to the runtime `ROUTES` allow-list the hash router validates against, so navigating to
+  `#/profile` fell through to the unknown-route fallback (`inbox`). Added `profile` to `ROUTES`. (`web/src/App.tsx`.)
+
 ## [0.138.0] — 2026-07-13
 ### Added
 - **`image_edit`: agents can now edit or upscale an existing image, not just generate from scratch.** A new

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.138.0",
+  "version": "0.138.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.138.0",
+      "version": "0.138.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.138.0",
+  "version": "0.138.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -24,7 +24,7 @@ const TERM_FONT_MIN = 8, TERM_FONT_MAX = 40
 
 type Route = 'inbox' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'goals' | 'tasks' | 'memory' | 'kb' | 'skills' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent' | 'docs' | 'profile'
 // The full set of pages, used by the hash router to validate the URL on load. Keep in sync with Route.
-const ROUTES: Route[] = ['inbox', 'sessions', 'agents', 'new-agent', 'connectors', 'team', 'automations', 'goals', 'tasks', 'memory', 'kb', 'skills', 'files', 'artifacts', 'settings', 'audit', 'agent', 'docs']
+const ROUTES: Route[] = ['inbox', 'sessions', 'agents', 'new-agent', 'connectors', 'team', 'automations', 'goals', 'tasks', 'memory', 'kb', 'skills', 'files', 'artifacts', 'settings', 'audit', 'agent', 'docs', 'profile']
 type Selected = { tmux: string; title: string } | null
 
 /** Mirror of the server rule: owner approves anything, admin approves head-level only. */


### PR DESCRIPTION
`profile` was added to the `Route` type in #231 but not to the runtime `ROUTES` allow-list the hash router validates against, so navigating to `#/profile` fell through to the unknown-route fallback (`inbox`). One-line fix: add `profile` to `ROUTES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)