### PR TITLE
docs(web): new end-user Docs pages — Goals, Media & Library, Identity & GitHub (v0.138.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.138.0] — 2026-07-13
+## [0.138.1] — 2026-07-13
+### Added
+- **Docs: three new end-user Docs pages covering recently shipped surfaces.** The console **Docs**
+  section lagged the last ~20 releases — whole feature areas (media generation, Goals, per-member
+  GitHub/identity) had zero coverage. Added:
+  - **Goals** — set the outcome, the fleet plans the work: goal vs. task, **Plan this goal** (the
+    strategist drafts linked tasks), the opt-in **Auto-plan stuck goals** toggle, sub-goals/roll-up,
+    and detach-on-delete.
+  - **Media & the Library** — the Library as the deliverables gallery (live HTML rendering, PDF,
+    per-artifact cost), `image_generate`/`video_generate`/image-to-video/image edit, and that
+    generation is budget-metered + audited.
+  - **Your identity, chat & GitHub** — **My context** (per-member prompt injection), **Chat IDs**
+    (run-as via Slack/Discord), and **Connect GitHub** (commits/PRs authored as you) with the
+    owner-once GitHub-App setup step.
+  Wired into `web/src/docs/index.ts` between Automations→Shared-planes→Governance. Docs-only web copy;
+  no API or schema change.
 ### Added
 - **`image_edit`: agents can now edit or upscale an existing image, not just generate from scratch.** A new
   governed MCP tool takes a source **`image`** (a Library artifact id, a working-folder file path — written

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.138.0",
+  "version": "0.138.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.138.0",
+      "version": "0.138.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.138.0",
+  "version": "0.138.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/docs/goals.md
+++ b/web/src/docs/goals.md
@@ -1,0 +1,54 @@
+# Goals — set the outcome, the fleet plans the work
+
+A **Task** is one unit of work. A **Goal** is the *outcome* several tasks add up to — "cut support
+first-response time to under an hour", "ship the pricing revamp", "grow the newsletter to 10k". You
+state where you want to be; Agent OS helps turn that into the tasks that get there. Goals live on the
+**Goals** page (under Agents).
+
+## What a goal is
+
+- A **target** — the outcome you're aiming at, ideally something you can tell is done.
+- **Progress** — the linked work and how far along it is.
+- **Linked tasks** — the actual units of work that move the goal, shown in pipeline order with any
+  dependencies (a task waiting on another shows a **waiting on N** chip).
+- Optional **sub-goals** — a big goal can nest smaller ones; tasks roll up to the goal they belong to.
+
+A goal is not a task. It's the thing you'd still care about after any single task is done.
+
+## Planning a goal
+
+You rarely have to break a goal into tasks by hand.
+
+**Plan this goal** (owner/admin, on the goal's page) spawns a governed **strategist** agent. It reads
+the goal, its current progress, and any tasks already linked — works out the **gap** to the target —
+and **files the tasks needed to close it**, linked back to the goal. It drafts; it never dispatches.
+The tasks land in the goal's linked-tasks list for a human to review and kick off.
+
+The strategist can also **propose sub-goals** for a goal too big to plan in one pass, so a sprawling
+outcome decomposes instead of turning into fifty loose tasks.
+
+## Auto-planning (opt-in)
+
+Turn on **Auto-plan stuck goals** (owner/admin, top of the Goals page) and you don't even click Plan.
+The scheduler notices an **active goal with no open work** — never planned, or all its tasks finished
+but the goal isn't achieved — that's sat idle past a short grace window, and runs the strategist for
+you. Same as clicking Plan: it drafts tasks for review and never auto-dispatches.
+
+It's **off by default** (it spawns agent sessions) and deliberately boring — a plain check on the
+goal's own data, rate-limited per goal and per tick so it can't burst runs or grab a goal you're
+still editing.
+
+## From plan to done
+
+Planning fills the goal with **draft tasks**; nothing runs until a human dispatches them (Tasks board,
+or the goal modal). From there it's the normal Tasks flow — an agent-assigned task with auto-dispatch
+spawns a governed session, the agent closes its own loop, and the goal's progress ticks up. See
+**Memory, Knowledge & Tasks** for how the queue works.
+
+Deleting a goal **detaches** its tasks rather than deleting them — real work survives on the board,
+just unlinked.
+
+## Rule of thumb
+
+Reach for a Goal when the outcome outlives any one task and you want the work to keep organizing
+itself toward it. For a single "do this thing", just file a **Task**.

--- a/web/src/docs/identity-and-github.md
+++ b/web/src/docs/identity-and-github.md
@@ -1,0 +1,51 @@
+# Your identity, chat & GitHub
+
+When an agent runs **as you**, it should *be* you — act with your visibility, in your voice, commit
+under your name. That connection is set up once, mostly on your **Profile** page (the sidebar profile
+row, or the gear on the notification bell). The **Team** page is for managing *other* people; your
+Profile is for *you*.
+
+## My context — standing instructions for runs as you
+
+**My context** (Profile → My context) is free text that gets added to the system prompt of **every
+session that runs as you** — your working style, standing preferences, the domain notes you'd otherwise
+repeat. "I prefer terse summaries." "Our fiscal year starts in April." "Always CC me before emailing a
+customer."
+
+It sits *below* the task and the fleet-wide **Company context** — it colors how your runs behave, it
+doesn't override the job or company rules. It's yours: only you edit it, and it only rides on runs that
+act as you. (For facts the *whole team* needs, use **Knowledge**; for the *whole fleet's* standing
+instructions, that's **Company context**, set by an admin.)
+
+## Chat IDs — so chat runs act as you
+
+Address an agent from Slack or Discord and the run should act **as you**, not as a faceless "company"
+identity. That match happens through your **Chat IDs** (Profile → your Slack / Discord / email
+handles). Link them and a `@AgentOS /support …` from you runs with your identity and your visibility.
+If chat replies come back as "company", your handle isn't linked yet — add it on your Profile (you can
+edit your own; admins can also set them on the Team page).
+
+## GitHub — commits and PRs authored as you
+
+By default, agents that touch git commit as the workspace's shared bot. **Connect your own GitHub** and
+that flips: any session running as you authors its commits and pull requests under **your** name, so
+the history reflects who the work was actually for. The bot stays the fallback for runs with no
+connected human.
+
+- **You:** **Connections → Connected → Mine → Connect GitHub** (one click, OAuth). Do this once. If an
+  agent tries to do git work as you before you've connected, it'll nudge you to.
+- **Owner/admin, once per workspace:** set up the company GitHub App first — **Connections → Creds →
+  GitHub → Create GitHub App** walks it in one click (App-manifest flow), then **Install the App** on
+  the repos agents may touch. After that, each teammate connects their own account as above.
+
+Your token is stored under **your** identity (never shared), used only for runs that act as you, and —
+like every credential — never appears in prompts, audit, or approval cards.
+
+## Where this lives
+
+| You want to… | Go to |
+| --- | --- |
+| Set how *your* runs behave | **Profile → My context** |
+| Have chat runs act as you | **Profile → Chat IDs** |
+| Have git commits authored as you | **Connections → Connected → Mine → Connect GitHub** |
+| Manage *other people* (roles, access, invites) | **Team** |

--- a/web/src/docs/index.ts
+++ b/web/src/docs/index.ts
@@ -6,8 +6,11 @@ import gettingStarted from './getting-started.md?raw'
 import coreConcepts from './core-concepts.md?raw'
 import workingWithAgents from './working-with-agents.md?raw'
 import automations from './automations.md?raw'
-import governance from './governance.md?raw'
+import goals from './goals.md?raw'
 import sharedPlanes from './shared-planes.md?raw'
+import mediaAndLibrary from './media-and-library.md?raw'
+import governance from './governance.md?raw'
+import identityAndGithub from './identity-and-github.md?raw'
 import importIntoAos from './import-into-aos.md?raw'
 
 export type DocPage = { slug: string; title: string; body: string }
@@ -18,7 +21,10 @@ export const docPages: DocPage[] = [
   { slug: 'core-concepts', title: 'Core concepts', body: coreConcepts },
   { slug: 'working-with-agents', title: 'Working with agents', body: workingWithAgents },
   { slug: 'automations', title: 'Automations', body: automations },
-  { slug: 'governance', title: 'Governance & approvals', body: governance },
+  { slug: 'goals', title: 'Goals', body: goals },
   { slug: 'shared-planes', title: 'Memory, Knowledge & Tasks', body: sharedPlanes },
+  { slug: 'media-and-library', title: 'Media & the Library', body: mediaAndLibrary },
+  { slug: 'governance', title: 'Governance & approvals', body: governance },
+  { slug: 'identity-and-github', title: 'Your identity & GitHub', body: identityAndGithub },
   { slug: 'import-into-aos', title: 'Import into AOS', body: importIntoAos },
 ]

--- a/web/src/docs/media-and-library.md
+++ b/web/src/docs/media-and-library.md
@@ -1,0 +1,57 @@
+# Media & the Library
+
+Everything an agent *produces* for you — a report, a PDF, a page, an image, a video — is a
+**deliverable**, and every deliverable lands in one place: the **Library**. This page covers where
+deliverables live and how agents create visual media.
+
+## The Library — every deliverable, kept
+
+When an agent finishes something worth keeping, it **publishes** it to the Library and links it from
+its report in your Inbox. The Library is the durable gallery of those snapshots — nothing an agent
+made for you gets lost in a terminal scrollback.
+
+What you get in the preview pane depends on the file:
+
+- **HTML** — a dashboard, report, or one-off page an agent built renders as a **live page**, not raw
+  source, with an **Open full page ↗** link to view it standalone. (It runs sandboxed — interactive
+  HTML/JS works, but the page can't touch your session or the console around it.)
+- **PDF** — rendered inline.
+- **Images / video** — shown in the gallery with the **cost** of generating them.
+- **Text / markdown / data** — shown as content.
+
+Deliverables are read-only snapshots; re-running an agent publishes a new one rather than overwriting.
+
+## Generating images and video
+
+Claude can't draw or film on its own, so agents get two governed tools when your workspace has media
+generation switched on (**Connections → Creds → Media generation**, one Atlas Cloud key powers both):
+
+- **`image_generate`** — text → image. Returns in seconds.
+- **`video_generate`** — text → video, or **image → video**: hand it an image (a Library image from a
+  prior `image_generate`, a file the agent is working with, or a URL) and it animates *that*. Video
+  renders **asynchronously** — usually minutes — and posts an **Inbox card** when the clip is ready.
+
+Agents can also **edit** an existing image (the original is never changed — the edit saves as a new
+Library image). Everything they make lands in the Library like any other deliverable.
+
+## It's governed like everything else
+
+Media generation costs real money, so it runs through the same gateway as every other agent action:
+
+- **Cost-metered** — each generation is estimated and **counts against the budget**; a run can't quietly
+  burn through spend making images.
+- **Audited** — every generation is in the **Audit** log with its cost.
+- **Per-artifact cost** — the Library shows what each image or clip cost to make.
+
+An admin picks the default image/video models (with live per-model pricing) in **Connections → Creds →
+Media generation**; agents can name a specific model when it matters, or let the sensible default stand.
+
+## Asking for media in a prompt
+
+Just ask, the way you'd ask a designer:
+
+- *"Draw a hero image for the launch post — dark, minimal, a single glowing node."*
+- *"Turn that image into a 4-second loop."*
+- *"Build an HTML dashboard of this week's numbers and publish it to the Library."*
+
+The deliverable shows up in the Library and in the run's report.


### PR DESCRIPTION
## What

The console **Docs** section (bundled end-user manual, `web/src/docs/`) lagged the last ~20 releases — whole user-facing surfaces had zero coverage. Adds three new pages:

- **Goals** — set the outcome, the fleet plans the work: goal vs. task, **Plan this goal** (strategist drafts linked tasks), opt-in **Auto-plan stuck goals**, sub-goals/roll-up, detach-on-delete.
- **Media & the Library** — the Library as the deliverables gallery (live HTML rendering, PDF, per-artifact cost) + `image_generate`/`video_generate`/image-to-video/image edit, all budget-metered + audited.
- **Your identity, chat & GitHub** — **My context** (per-member prompt injection), **Chat IDs** (run-as via Slack/Discord), **Connect GitHub** (commits/PRs authored as you) + the owner-once GitHub-App setup.

Wired into `web/src/docs/index.ts` in reading order (Automations → **Goals** → Shared-planes → **Media & Library** → Governance → **Identity & GitHub** → Import).

## Notes

- The Artifacts→Library terminology sweep was already complete (v0.128.3) — no "artifact" strings remained in docs.
- Matched the existing doc voice; cross-linked to Tasks, Knowledge, Company context, Governance.
- Docs-only web copy — no API/schema change. Patch bump to **v0.138.1**.

## Test plan

- `cd web && npm run build` passes (docs bundled via Vite `?raw`).
- No server restart needed — Node serves `web/dist` off disk; browser reload picks up the new pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)