### PR TITLE
fix(slack): don't reply /agent help to plain channel messages (v0.141.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.141.2] — 2026-07-13
+### Fixed
+- **Slack: a plain message in a channel the bot sits in no longer gets the `/agent` help list.** The app
+  subscribes to `message.channels` so plain in-thread follow-ups reach thread-continuity — but that also
+  delivers a `message` event for *every* channel post, and a non-continuation one fell through to
+  `fireSlack` → the `/agent` router, which replied "👋 Address an agent…" to ordinary channel chatter. The
+  socket now only starts a fresh run on an explicit **@mention** (`app_mention`) or a **DM** (`im`/`mpim`);
+  a plain channel message matters only as a thread continuation, otherwise it's dropped silently. Brings
+  Slack to parity with Discord, whose parser already ignores non-mention guild messages.
+
 ## [0.141.1] — 2026-07-13
 ### Fixed
 - **Unattended (automation/cron/task) sessions no longer leak a live pane after they finish.** An agent that

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.141.1",
+  "version": "0.141.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.141.1",
+      "version": "0.141.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.141.1",
+  "version": "0.141.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -182,6 +182,14 @@ export class SlackSocket {
       return;
     }
 
+    // Not a thread continuation. A plain channel `message` (no @mention) only reached us because the app
+    // subscribes to `message.channels` FOR that continuity — it's just chatter in a channel the bot
+    // happens to sit in, never a fresh trigger. Only an explicit @mention (`app_mention`) or a DM
+    // (`im`/`mpim`) starts a new run; otherwise drop it silently so we don't spam the `/agent` router's
+    // help list into the channel. (Mirrors Discord, whose parser already drops non-mention guild messages.)
+    const isDm = ev.channelType === 'im' || ev.channelType === 'mpim';
+    if (ev.eventType !== 'app_mention' && !isDm) return;
+
     const result = this.autos.fireSlack(
       {
         eventType: ev.eventType,


### PR DESCRIPTION
## Problem
Sending a plain message to a Slack channel the bot sits in (no @mention) triggered the `/agent` router's help list:

> 👋 Address an agent with `/<agent>` followed by your request. Available: …

This should only happen on an explicit @mention or a DM.

## Root cause
The Slack app subscribes to `message.channels` so that plain in-thread follow-up replies reach thread-continuity (documented in CLAUDE.md). But that subscription also delivers a `message` event for **every** post in a channel the bot is in. `parseSlackEvent` accepts any `message`, and in `dispatch` a non-continuation one fell straight through `continueSlackThread` (→ `none`) into `fireSlack` → `routeChat`, which posts the help list for an unaddressed message.

Discord never had this bug — `parseDiscordMessage` already returns `null` for a guild message that doesn't @-mention the bot.

## Fix
After the thread-continuity check, only start a fresh run on an explicit **@mention** (`app_mention`) or a **DM** (`im`/`mpim`). A plain channel `message` now matters only as a thread continuation; otherwise it's dropped silently. Brings Slack to parity with Discord.

## Verification
- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run test:governance` → 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)