### PR TITLE
fix(scheduler): cron catch-up window so a missed occurrence isn't dropped (v0.143.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.143.1] — 2026-07-13
+### Fixed
+- **A cron automation missed in its scheduled minute is no longer silently dropped for the whole day.** A
+  cron fires in exactly ONE minute (`cronMatches(now)`); if that minute was skipped — the box was over the
+  concurrency cap, or mid-restart/deploy — the scheduler deferred it but, unlike a `once`/`task`, by the next
+  tick `cronMatches` was false so the occurrence was lost until the next day. On a chronically over-cap box
+  this dropped a daily report every single day (observed: instawp's "Daily Support Quality Review" hadn't
+  fired for 3 days — each 09:00 UTC minute the box sat at 9–10 alive sessions against a cap of 8). `tick()`
+  now fires the most-recent *owed* occurrence within a bounded catch-up window (`CRON_CATCHUP_MIN`, 2 h),
+  retrying each tick until headroom appears or the window closes — so a cap-deferral or a deploy over the
+  scheduled minute self-heals, while a long outage never replays a stale backlog (only the single latest
+  occurrence is owed, and it's abandoned once older than the window). New `recentCronOccurrence()` helper +
+  `scripts/cron-catchup-test.cjs` (15 assertions incl. the exact over-cap→catch-up path).
+
 ## [0.143.0] — 2026-07-13
 ### Added
 - **Whole-box concurrency cap is now ON by default (Phase 1 of `docs/concurrency-cap-plan.md`).** Every live

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.143.0",
+  "version": "0.143.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.143.0",
+      "version": "0.143.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.143.0",
+  "version": "0.143.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/cron-catchup-test.cjs
+++ b/scripts/cron-catchup-test.cjs
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+/* Cron catch-up test — proves a cron occurrence missed in its exact minute (over the concurrency cap, or
+ * a restart) is retried within a bounded window instead of dropped until the next day, while never
+ * double-firing or replaying a stale backlog. Isolated home; fire() is stubbed so no real session spawns. */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-cron-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+delete process.env.AOS_MAX_CONCURRENT_SESSIONS;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+const { Automations, parseCron, recentCronOccurrence, CRON_CATCHUP_MIN } = require(path.join(ROOT, 'dist/edge/automations.js'));
+
+// Local-time occurrence helpers so cronMatches (which reads LOCAL hours/minutes) is TZ-independent.
+const at = (h, m) => new Date(2026, 0, 15, h, m, 0, 0).getTime();       // 2026-01-15 hh:mm local
+const dayBefore = (ms) => ms - 24 * 3600 * 1000;
+
+console.log('\n\x1b[1m1) recentCronOccurrence (the catch-up detector)\x1b[0m');
+const spec9 = parseCron('0 9 * * *');
+assert(recentCronOccurrence(spec9, new Date(at(9, 0)), 120) === at(9, 0), 'exact minute → that minute');
+assert(recentCronOccurrence(spec9, new Date(at(9, 30)), 120) === at(9, 0), '30 min late → still 09:00 (owed)');
+assert(recentCronOccurrence(spec9, new Date(at(11, 0)), 120) === at(9, 0), 'exactly 120 min late → 09:00 (window edge)');
+assert(recentCronOccurrence(spec9, new Date(at(11, 1)), 120) === null, '121 min late → null (window closed)');
+assert(recentCronOccurrence(spec9, new Date(at(8, 59)), 120) === null, 'before the occurrence → null');
+const specMin = parseCron('* * * * *');
+assert(recentCronOccurrence(specMin, new Date(at(9, 37)), 120) === at(9, 37), 'every-minute cron → current minute');
+
+console.log('\n\x1b[1m2) tick() end-to-end: catch-up under the concurrency cap\x1b[0m');
+const aos = loadAgentOS();
+const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+const autos = new Automations(aos, tm);
+aos.settings.setMaxConcurrentSessions(8, 'tester'); // cap = 8 (matches the instawp box)
+
+const ID = 'au_test';
+aos.db.prepare("INSERT INTO automations (id, agent_id, name, type, mode, schedule, task, enabled, created_at) VALUES (?,?,?,?,?,?,?,?,?)")
+  .run(ID, 'compass', 'Daily Support Quality Review', 'cron', 'headless', '0 9 * * *', 'Review support quality.', 1, at(9, 0) - 5 * 86400000);
+const setLF = (ms) => aos.db.prepare("UPDATE automations SET last_fired_at = ? WHERE id = ?").run(ms, ID);
+const getLF = () => aos.db.prepare("SELECT last_fired_at l FROM automations WHERE id = ?").get(ID).l;
+
+// Stub fire() to record the call + stamp last_fired_at like the real one, without spawning a session.
+let fired = [];
+let simNow = 0;
+autos.fire = function (a) { fired.push(a.id); aos.db.prepare("UPDATE automations SET last_fired_at = ? WHERE id = ?").run(simNow, a.id); return { ok: true, session: 'stub' }; };
+const runTick = (ms, alive) => { simNow = ms; tm.aliveSessionCount = () => alive; fired = []; autos.tick(new Date(ms)); return fired.includes(ID); };
+
+// Baseline: fired yesterday at 09:00.
+setLF(dayBefore(at(9, 0)));
+assert(runTick(at(9, 0), 3) === true, 'on time + headroom (3<8) → fires');
+assert(getLF() === at(9, 0), 'last_fired_at stamped to 09:00');
+assert(runTick(at(9, 0) + 30_000, 3) === false, 'same occurrence, later tick → no double-fire');
+
+// The bug scenario: over cap during the 09:00 minute, then headroom appears later.
+setLF(dayBefore(at(9, 0)));                    // reset: owed today's 09:00
+assert(runTick(at(9, 0), 9) === false, 'over cap at 09:00 (9>=8) → deferred, not fired');
+assert(getLF() === dayBefore(at(9, 0)), 'deferred → last_fired_at NOT advanced');
+assert(runTick(at(9, 5), 9) === false, 'still over cap at 09:05 → still deferred');
+assert(runTick(at(9, 20), 4) === true, 'headroom at 09:20 → CATCH-UP fires (was dropped before the fix)');
+assert(runTick(at(9, 21), 4) === false, 'caught-up occurrence → not fired again');
+
+// Window bound: if headroom never comes within CRON_CATCHUP_MIN, the stale occurrence is abandoned.
+setLF(dayBefore(at(9, 0)));
+assert(runTick(at(11, 1), 3) === false, `past the ${CRON_CATCHUP_MIN}-min window (121 min late) → abandoned, not fired late`);
+
+console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}CRON CATCH-UP: ${pass}/${pass + fail} passed\x1b[0m`);
+try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
+process.exit(fail === 0 ? 0 : 1);

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -99,6 +99,32 @@ export function nextCronRun(expr: string, from: Date = new Date()): number | nul
   return null;
 }
 
+/** How far back (minutes) a cron occurrence is still worth catching up. A cron fires in ONE scheduled
+ *  minute; if that minute is skipped — over the concurrency cap, or the box was mid-restart/deploy — the
+ *  old scheduler dropped it until the next day. The catch-up window lets `tick()` keep retrying that
+ *  occurrence until headroom appears, bounded so a long outage never fires an ancient/absurdly-stale run
+ *  (only the single most-recent occurrence is ever owed — no backlog replay). 2 h is generous enough to
+ *  cover a deploy window and many cap-relief ticks, tight enough that a daily 09:00 report never fires in
+ *  the afternoon. */
+export const CRON_CATCHUP_MIN = 120;
+
+/**
+ * The most recent minute (epoch ms) at or before `from` that `spec` matches, scanned back at most
+ * `windowMin` minutes; null if it didn't fire within the window. Minute-grained to match the tick. Used by
+ * the scheduler to detect a cron occurrence it still owes (missed its exact minute) vs one already run —
+ * combined with `lastFiredAt`, it fires at most once per occurrence.
+ */
+export function recentCronOccurrence(spec: CronSpec, from: Date, windowMin: number): number | null {
+  const d = new Date(from.getTime());
+  d.setSeconds(0, 0);
+  const start = d.getTime();
+  for (let i = 0; i <= windowMin; i++) {
+    const t = start - i * 60_000;
+    if (cronMatches(spec, new Date(t))) return t;
+  }
+  return null;
+}
+
 // ── the automation object ─────────────────────────────────────────────────────────
 
 /**
@@ -739,10 +765,10 @@ export class Automations {
     // Advance any in-flight async video renders (poll → ingest on completion). Fire-and-forget: it's
     // async, tick is sync, and a poll error must never break the scheduler loop.
     void this.tm.pollVideoJobs().catch(() => {});
-    const minute = Math.floor(now.getTime() / 60_000);
     // Whole-box concurrency cap (#137). Count sessions already alive and stop firing NEW scheduler spawns
-    // once we hit the ceiling — a deferred cron/one-shot isn't stamped `lastFiredAt` (and a `once` isn't
-    // disabled), so it simply RE-FIRES next tick. No queue needed. 0 = unlimited. The cap is now ON by
+    // once we hit the ceiling. A deferred spawn isn't stamped `lastFiredAt` (and a `once` isn't disabled),
+    // so it retries next tick: a `once`/`task` stays due indefinitely; a `cron` is retried only within its
+    // catch-up window (see the cron branch below). No queue needed. 0 = unlimited. The cap is now ON by
     // default (RAM-derived) rather than opt-in — resolved live so a Settings change needs no restart.
     const cap = this.concurrencyCap();
     let running = cap > 0 ? this.tm.aliveSessionCount() : 0;
@@ -770,9 +796,15 @@ export class Automations {
       } catch {
         continue; // validated at write time; never let one bad row kill the loop
       }
-      if (!cronMatches(spec, now)) continue;
-      if (a.lastFiredAt && Math.floor(a.lastFiredAt / 60_000) === minute) continue; // already fired this minute
-      if (overCap()) { deferred++; continue; } // over cap → not stamped, so it re-fires next tick
+      // Which scheduled occurrence (if any) is currently OWED — usually this very minute, but an OLDER one
+      // when a prior tick deferred it over the cap or the box was down through its minute. Without this a
+      // cron only ever fires in its exact minute: hit the cap or a restart there and it's silently dropped
+      // until the next day (the real cause of the "not firing for 3 days" report on a chronically over-cap
+      // box). The catch-up window bounds the retry so a long outage can't unleash stale/backlogged runs.
+      const due = recentCronOccurrence(spec, now, CRON_CATCHUP_MIN);
+      if (due == null) continue;                                                   // nothing due within the window
+      if (a.lastFiredAt && Math.floor(a.lastFiredAt / 60_000) >= Math.floor(due / 60_000)) continue; // that occurrence already ran
+      if (overCap()) { deferred++; continue; } // over cap → not stamped; retried next tick until the window closes
       const r = this.fire(a, { guard: true });
       if (r.ok) running++;
     }


### PR DESCRIPTION
## Problem

An enabled cron automation stops firing for days. Confirmed on instawp: **"Daily Support Quality Review"** (`0 9 * * *`) last fired 2026-07-10 and missed 07-11/12/13 — the exact 3 days reported.

## Root cause

A cron fires in exactly ONE minute (`cronMatches(spec, now)` is only true at 09:00:xx). In `tick()`:

```js
if (!cronMatches(spec, now)) continue;      // only 09:00
if (a.lastFiredAt && …=== minute) continue;
if (overCap()) { deferred++; continue; }    // comment says "re-fires next tick" — FALSE for cron
```

The "re-fires next tick" comment holds for `once`/`task` (they stay due), **but not for cron** — by 09:01 `cronMatches` is false, so a deferral is a permanent miss until tomorrow. instawp runs chronically at 9–10 alive sessions against `AOS_MAX_CONCURRENT_SESSIONS=8`, so the 09:00 cron loses the cap race **every day**. Same failure hits any cron whose minute coincides with a restart/deploy.

Audit evidence — `scheduler.deferred` at the 09:00 window on each missed day: `{cap:8, running:9}` (07-13), `{cap:8, running:10}` (07-11/12).

## Fix

`tick()` now fires the most-recent **owed** occurrence within a bounded catch-up window rather than only the exact minute:

```js
const due = recentCronOccurrence(spec, now, CRON_CATCHUP_MIN);   // owed occurrence, or null
if (due == null) continue;
if (a.lastFiredAt && floor(lastFiredAt/60000) >= floor(due/60000)) continue;  // already ran it
if (overCap()) { deferred++; continue; }   // retry next tick, still within the window
```

- **Self-heals** a cap-deferral or a deploy/downtime that straddled the scheduled minute — retries every tick until headroom appears.
- **Bounded** (`CRON_CATCHUP_MIN = 2h`): a long outage never replays a stale backlog — only the single latest occurrence is owed, and it's abandoned once older than the window (a daily 09:00 report never fires in the afternoon).
- **No double-fire**: dedup on `last_fired_at >= the owed occurrence's minute`.

## Verification

- `npm run typecheck` ✓ · `npm run test:governance` → 68/68 ✓
- New `scripts/cron-catchup-test.cjs` → **15/15**, including the exact scenario: over cap at 09:00 → deferred → **catch-up fires at 09:20 when headroom appears** → not re-fired → abandoned past the window.

## Note on the immediate unblock
Deploying this lets today's occurrence catch up **if** headroom appears within 2 h. If the box stays over cap, an operator "Run now" (which bypasses the cap) still forces it. Longer term, instawp is chronically over its cap of 8 — worth either raising the cap or trimming the stale idle member sessions inflating the count (that's the Phase 2 admission-queue / capacity territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)