### PR TITLE
feat(inbox): `ask` can address a specific teammate, not just the operator (v0.144.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.144.0] — 2026-07-13
+### Added
+- **`ask` can now address a SPECIFIC teammate, not just the run's operator.** An agent could already `notify`
+  any member with fire-and-forget info; now `ask({ question, to })` routes a BLOCKING question — "ask for a
+  detail", "get a confirmation before a risky step" — to a named teammate (name/email) and waits for THEIR
+  answer. Omit `to` and it behaves exactly as before (asks the session operator). The question card + the
+  out-of-band DM target that member (`{ kind: 'member' }` audience via `notifyQuestionAsked`), and
+  `canViewQuestion` now grants the addressed member (plus owner/admin oversight) the right to answer it — so
+  a question sent to someone who is neither the run's owner nor an admin actually reaches a person who can
+  reply. New nullable `questions.audience_id` column records the addressee (NULL = the default operator
+  routing). Reuses the existing questions/inbox/DM machinery end-to-end.
+
 ## [0.143.1] — 2026-07-13
 ### Fixed
 - **A cron automation missed in its scheduled minute is no longer silently dropped for the whole day.** A

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -18,7 +18,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `kb_write` | `POST /api/kb/write` | `KbStore.write` | W | versioned; author `agent:<id>`; `section` may nest with `/` (`engineering/backend`) → folder tree |
 | `kb_history` | `GET /api/kb/history` | `KbStore.history` | R | newest-first revisions |
 | `kb_revert` | `POST /api/kb/revert` | `KbStore.revert` | W | itself a new revision; audited `kb.reverted` |
-| `ask` | `POST /api/ask` + poll | questions | W (blocking) | blocks ~1h polling for the human answer; DMs the run-as human out-of-band (`question.notified`) + mirrors to the chat thread so it isn't missed |
+| `ask` | `POST /api/ask` + poll | questions | W (blocking) | blocks ~1h polling for the human answer; DMs the addressee out-of-band (`question.notified`) + mirrors to the chat thread so it isn't missed. Default addressee = the run's operator (`sessionOwner`); optional `to` (name/email) routes the question to a SPECIFIC other member instead (card + DM target them, and `canViewQuestion` grants them the answer) — the "ask a teammate for info / a confirmation" channel |
 | `check_inbox` | `GET /api/inbox` | `TerminalManager.sessionInbox` | R | non-blocking pull of this session's feed |
 | `report` | `POST /api/report` | messages | W | `outcome` enum |
 | `update` | `POST /api/update` | messages | W | non-blocking progress note (session-owner scoped) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.143.1",
+  "version": "0.144.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.143.1",
+      "version": "0.144.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.143.1",
+  "version": "0.144.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -406,13 +406,19 @@ const TOOLS = [
   {
     name: 'ask',
     description:
-      "Ask the human operator a question and WAIT for their answer. Use when you're blocked on a decision " +
-      'only they can make (which option, missing detail, risky judgement call). The question appears in their ' +
-      'Inbox; this call blocks until they reply, then returns their answer. Prefer this over guessing.',
+      "Ask a human a question and WAIT for their answer. Use when you're blocked on a decision only a person " +
+      'can make (which option, a missing detail, a confirmation before a risky step). The question appears in ' +
+      'their Inbox (and DMs them); this call blocks until they reply, then returns their answer. Prefer this ' +
+      "over guessing. By default it goes to the operator you're working for. Set `to` (a teammate's name or " +
+      'email) to ask a SPECIFIC other person instead — e.g. confirm a detail with the account owner, or get ' +
+      'info only they have. Same blocking behaviour; their reply comes back to you.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
-      properties: { question: { type: 'string', description: 'A specific, self-contained question.' } },
+      properties: {
+        question: { type: 'string', description: 'A specific, self-contained question.' },
+        to: { type: 'string', description: 'Optional. A teammate to ask instead of the operator — their name or email (e.g. "Alex Rivera" or "alex@acme.com"). Omit to ask the human who owns this run.' },
+      },
       required: ['question'],
     },
   },
@@ -1064,13 +1070,18 @@ async function recall(args: Record<string, unknown>): Promise<string> {
 async function ask(args: Record<string, unknown>): Promise<string> {
   const question = String(args.question ?? '').trim();
   if (!question) return 'No question provided.';
+  const to = args.to ? String(args.to).trim() : undefined;
   const res = await fetch(AOS_URL + '/api/ask', {
     method: 'POST',
     headers: H({ 'content-type': 'application/json' }),
-    body: JSON.stringify({ session: SESSION, agent: AGENT, question }),
+    body: JSON.stringify({ session: SESSION, agent: AGENT, question, to: to || undefined }),
   });
-  const { id } = (await res.json()) as { id?: string };
+  const posted = (await res.json()) as { id?: string; error?: string; to?: string };
+  if (posted.error) return `Could not ask: ${posted.error}`;
+  const id = posted.id;
   if (!id) return 'Could not post the question.';
+  // Who we're waiting on, for the parking copy — the named teammate when `to` was given, else the operator.
+  const who = posted.to || to || 'the operator';
   // Poll the inbox for the human's answer. An INTERACTIVE run waits ~1h (a human is at the terminal and
   // may take a while). An UNATTENDED run (automation/cron/task) has nobody attached, so an hour-long block
   // just strands the session and holds its memory — the question is already in the operator's Inbox +
@@ -1083,17 +1094,17 @@ async function ask(args: Record<string, unknown>): Promise<string> {
     await sleep(2000);
     const r = await fetch(`${AOS_URL}/api/ask/${id}`);
     const d = (await r.json()) as { status?: string; answer?: string };
-    if (d.status === 'answered') return d.answer || '(the operator gave no answer)';
-    if (d.status === 'cancelled') return 'The operator dismissed this question without answering. Proceed using your best judgement, or ask again if you are still blocked.';
+    if (d.status === 'answered') return d.answer || `(${who} gave no answer)`;
+    if (d.status === 'cancelled') return `${who} dismissed this question without answering. Proceed using your best judgement, or ask again if you are still blocked.`;
   }
   if (UNATTENDED) {
-    return 'No operator is available on this unattended run (automation/cron/task), and none answered in ' +
-      `the ${UNATTENDED_ASK_WAIT_S}s window. Your question is recorded in the operator's Inbox and they have been ` +
+    return `Nobody answered in the ${UNATTENDED_ASK_WAIT_S}s window on this unattended run (automation/cron/task). ` +
+      `Your question is recorded in ${who === 'the operator' ? "the operator's" : `${who}'s`} Inbox and they have been ` +
       'notified, so it is NOT lost. Do NOT proceed with any risky or irreversible action on a guess. Wrap up ' +
       'now: call `report` to summarise what you did and note that you are blocked on this question, then end the ' +
-      'run. The operator will follow up (e.g. by answering and re-running you).';
+      'run. They will follow up (e.g. by answering and re-running you).';
   }
-  return 'No answer yet (timed out waiting on the operator). Proceed using your best judgement or ask again.';
+  return `No answer yet (timed out waiting on ${who}). Proceed using your best judgement or ask again.`;
 }
 
 async function slackReply(args: Record<string, unknown>): Promise<string> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -736,7 +736,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true });
   }
 
-  // ask-human: the agent posts a question (→ inbox) and polls until a human answers it.
+  // ask-human: the agent posts a question (→ inbox) and polls until a human answers it. Optional `to`
+  // addresses it to a SPECIFIC teammate (name/email/id) instead of the run's operator.
   if (method === 'POST' && p === '/api/ask') {
     const b = await readBody(req);
     const session = String(b.session || '');
@@ -745,7 +746,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     const question = String(b.question || '').trim();
     if (!question) return sendJson(res, 400, { error: 'question is required' });
-    return sendJson(res, 200, tm.askQuestion(session, agent, question));
+    const to = b.to ? String(b.to).trim() : undefined;
+    const out = tm.askQuestion(session, agent, question, to);
+    return sendJson(res, out.error ? 400 : 200, out);
   }
   const askMatch = p.match(/^\/api\/ask\/([\w-]+)$/);
   if (method === 'GET' && askMatch) return sendJson(res, 200, tm.questionStatus(askMatch[1]));

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -578,6 +578,10 @@ function migrate(db: Db): void {
   addColumn(db, 'messages', 'audience_kind', 'TEXT');  // Audience.kind | NULL = fall back to session visibility
   addColumn(db, 'messages', 'audience_id', 'TEXT');    // the audience's member id / approval level (kind-dependent)
 
+  // Who a question is addressed to: a member id when the agent `ask`ed a SPECIFIC teammate (not the run's
+  // operator). NULL = the default sessionOwner routing. Lets `canViewQuestion` grant that member the answer.
+  addColumn(db, 'questions', 'audience_id', 'TEXT');
+
   // Execution mode for automations (older DBs predate it — default preserves their interactive behavior).
   addColumn(db, 'automations', 'mode', "TEXT NOT NULL DEFAULT 'interactive'");
   addColumn(db, 'automations', 'filter', 'TEXT'); // composio: trigger slug / slack: event type|channel to match ('' = any)

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -314,7 +314,8 @@ export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmU
  * `admins` audience so the question still reaches someone. Best-effort, off the ask hot path. Audited once.
  */
 export async function notifyQuestionAsked(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: QuestionNotice): Promise<void> {
-  let targets = resolveRecipients(os, { kind: 'sessionOwner', id: notice.sessionId });
+  // A question `ask`ed to a SPECIFIC teammate DMs that member; otherwise the run's operator.
+  let targets = resolveRecipients(os, notice.to ? { kind: 'member', id: notice.to } : { kind: 'sessionOwner', id: notice.sessionId });
   if (!targets.length) targets = resolveRecipients(os, { kind: 'admins' });
   if (!targets.length) return;
   const inbox = consolePage(consoleOrigin, 'inbox');

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -310,6 +310,9 @@ export interface QuestionNotice {
   sessionId: string;
   agent: string;
   prompt: string;
+  /** Resolved member id when the agent `ask`ed a SPECIFIC teammate (not the run's operator); the
+   *  registry DMs them instead of the sessionOwner. Undefined = the default sessionOwner routing. */
+  to?: string;
 }
 
 /** What the member-notifier sink receives when an agent deliberately notifies a specific teammate via
@@ -611,10 +614,14 @@ export class TerminalManager {
     return this.canViewRow(r ? r.spawned_by : null, r ? r.run_as : null, viewer);
   }
 
-  /** Whether `viewer` may act on a pending question (resolves its session, then the inbox rule). */
+  /** Whether `viewer` may act on a pending question. A question `ask`ed to a SPECIFIC teammate
+   *  (`audience_id` set) is answerable by that member (its `member` audience) OR by owner/admin oversight;
+   *  otherwise it resolves through its session's provenance/run-as like the rest of the inbox. */
   canViewQuestion(questionId: string, viewer: Member): boolean {
-    const q = this.db.prepare('SELECT run_id FROM questions WHERE id = ?').get<{ run_id: string }>(questionId);
-    return !!q && this.canViewSession(q.run_id, viewer);
+    const q = this.db.prepare('SELECT run_id, audience_id FROM questions WHERE id = ?').get<{ run_id: string; audience_id: string | null }>(questionId);
+    if (!q) return false;
+    if (q.audience_id && this.canViewAudience('member', q.audience_id, viewer)) return true;
+    return this.canViewSession(q.run_id, viewer);
   }
 
   /**
@@ -2020,19 +2027,34 @@ export class TerminalManager {
 
   // ── session lifecycle → inbox ────────────────────────────────────────────────
   /** Agent asks the human a question (the ask-human channel). Returns the question id to poll. */
-  askQuestion(sessionId: string, agent: string, prompt: string): { id: string } {
+  /**
+   * The agent posts a blocking question (→ inbox card + out-of-band DM) and polls {@link questionStatus}
+   * until answered. By default it's addressed to the session OPERATOR (the `sessionOwner` audience). Pass
+   * `to` (a teammate name / email / member id) to route it to a SPECIFIC other member instead — the
+   * "ask a teammate for info / a confirmation" channel — and both the inbox card and the DM target them,
+   * and {@link canViewQuestion} grants them the answer. Returns `{ error }` when `to` matches no member.
+   */
+  askQuestion(sessionId: string, agent: string, prompt: string, to?: string): { id?: string; error?: string; to?: string } {
+    let target: Member | undefined;
+    if (to && to.trim()) {
+      target = this.resolveMember(to);
+      if (!target) return { error: `no teammate matches "${to}"` };
+    }
     const id = randomUUID().slice(0, 8);
     this.db
-      .prepare('INSERT INTO questions (id, run_id, tenant, agent, prompt, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
-      .run(id, sessionId, this.os.tenant, agent, prompt, 'pending', Date.now());
-    this.addMessage({ type: 'question', sessionId, agent, title: `Question — ${agent}`, body: prompt, status: 'pending', questionId: id, audienceKind: 'sessionOwner', audienceId: sessionId });
-    this.audit(sessionId, agent, 'question.asked', { questionId: id, prompt });
-    // Out-of-band ping (like approvals): DM the person the run acts for so a blocking `ask` doesn't sit
-    // unseen in the console. And if the run was triggered from chat, mirror the question into that
-    // thread. Both best-effort, off the hot path.
-    try { this.questionNotifier?.({ sessionId, agent, prompt }); } catch { /* notifications are advisory */ }
+      .prepare('INSERT INTO questions (id, run_id, tenant, agent, prompt, status, audience_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(id, sessionId, this.os.tenant, agent, prompt, 'pending', target?.id ?? null, Date.now());
+    // Card audience: the addressed teammate when `to` is set, else the session operator.
+    const audienceKind = target ? 'member' : 'sessionOwner';
+    const audienceId = target ? target.id : sessionId;
+    this.addMessage({ type: 'question', sessionId, agent, title: `Question — ${agent}`, body: prompt, status: 'pending', questionId: id, audienceKind, audienceId });
+    this.audit(sessionId, agent, 'question.asked', { questionId: id, prompt, ...(target ? { to: target.id } : {}) });
+    // Out-of-band ping (like approvals): DM the person the run acts for — or the addressed teammate — so a
+    // blocking `ask` doesn't sit unseen in the console. And if the run was triggered from chat, mirror the
+    // question into that thread. Both best-effort, off the hot path.
+    try { this.questionNotifier?.({ sessionId, agent, prompt, to: target?.id }); } catch { /* notifications are advisory */ }
     try { this.chatMirror?.(sessionId, (p) => `❓ ${agent} needs your input:\n${prompt}\n\nAnswer in the ${chatLink(p, consolePage(this.publicOrigin, 'inbox'), 'Agent OS Inbox')}.`); } catch { /* advisory */ }
-    return { id };
+    return { id, to: target?.email };
   }
 
   /** A human answers a pending question (from the inbox). */


### PR DESCRIPTION
## What

An agent session can now send a **blocking** inbox question to **any** teammate — not only the human who owns the run. This completes the "reach another member" surface: `notify` already handled fire-and-forget info; `ask` now handles *ask-for-information* and *confirmation* against a specific person.

```
ask({ question })                     // unchanged → asks the operator
ask({ question, to: "alex@acme.com" }) // blocks on Alex's answer
notify({ to, message })               // unchanged → fire-and-forget info
```

## How

Reuses the existing questions / inbox-audience / DM machinery — no new subsystem:

- **`askQuestion(session, agent, prompt, to?)`** resolves `to` (name/email/id) via the same `resolveMember` `notify` uses; the question card's audience becomes `{ kind: 'member' }` (was always `sessionOwner`). Unresolvable `to` → `{ error }` (400).
- **`notifyQuestionAsked`** DMs the addressed member (`{ kind: 'member' }`) instead of the operator when `to` is set.
- **`canViewQuestion`** now grants the addressed member (plus owner/admin oversight) the right to answer — so a question sent to a plain member who isn't the run's owner actually reaches someone who can reply.
- New nullable **`questions.audience_id`** column records the addressee (NULL = default operator routing).
- MCP `ask` tool gains an optional `to` param; the poll/park copy addresses whomever was asked.

## Test

Isolated in-process test (throwaway `AGENT_OS_HOME`) covering: routing to a named teammate, notifier target, the addressed member *can* answer while an unrelated member *cannot*, owner oversight, unresolved-`to` error, the default (no-`to`) path staying operator-scoped, and a successful answer round-trip. `npm run build`, `npm run typecheck`, and `npm run test:governance` (68/68) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)