### PR TITLE
feat(session): auto-close idle member sessions (configurable, default 48h) (v0.145.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.145.0] — 2026-07-13
+### Added
+- **Idle member sessions now auto-close (configurable, default 48 h).** A member's own attachable session
+  holds a `claude` process like any other, but — unlike a resident chat (idle-reaped in minutes) or an
+  unattended automation run (torn down at turn-end) — nothing ever reaped it. A forgotten, detached one
+  lingered for days, wasting RAM and (now that the concurrency cap is on) permanently occupying a cap slot,
+  so scheduled work starved. `reapIdleSessions` gains a third sweep: a member (`headless=0`, non-resident,
+  unclaimed) session idle past the timeout — nobody attached, not blocked on a person — is closed
+  (`status=stopped`), and it stays **Resumable** (a deliberate console re-open clears the block), so it's a
+  janitor, not a guillotine. Tunable at **Settings → Runtime defaults → "Auto-close idle sessions after
+  (hours)"** (`interactiveIdleTimeoutHours`, default 48, `0` = off; clamped 1 h–30 days) via the extended
+  `GET/PUT /api/settings/concurrency` (audited `settings.interactiveIdle.updated`). New
+  `scripts/idle-reaper-test.cjs` (12 assertions: reaps a stale detached session; leaves recent / attached /
+  claimed / unattended / recently-active / disabled cases alone).
+
 ## [0.144.0] — 2026-07-13
 ### Added
 - **`ask` can now address a SPECIFIC teammate, not just the run's operator.** An agent could already `notify`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.144.0",
+  "version": "0.145.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.144.0",
+      "version": "0.145.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.144.0",
+  "version": "0.145.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/idle-reaper-test.cjs
+++ b/scripts/idle-reaper-test.cjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/* Idle-interactive reaper test — a detached member (headless=0) session idle past the configurable
+ * timeout is closed (status→stopped), while recent/attached/claimed/disabled cases are left alone.
+ * Isolated home; backend kill/hasClient stubbed so no real tmux is needed. */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-reap-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+
+const aos = loadAgentOS();
+const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+// Stub the backend so the sweep is deterministic without a real tmux server.
+let attached = new Set();               // tmux names with a "client" attached
+const killed = [];
+tm.backend.hasClient = (_space, tmux) => attached.has(tmux);
+tm.backend.kill = (_space, tmux) => { killed.push(tmux); };
+tm.backend.aliveNames = () => new Set(); // sweeps 1/2 no-op; we're testing sweep 3
+
+const H = 3600_000;
+let n = 0;
+const mkSession = (o) => {
+  const id = 'ts_' + (++n);
+  const cols = { id, agent: 'website-bot', title: 't', task: 'x', tmux: 'aos-' + id, status: 'running',
+    headless: 0, resident: 0, claimed_by: null, last_activity: null, spawned_by: 'm_alice',
+    created_at: Date.now(), updated_at: Date.now(), ...o };
+  aos.db.prepare("INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,resident,claimed_by,last_activity,spawned_by,created_at,updated_at) VALUES (@id,@agent,@title,@task,@tmux,@status,@headless,@resident,@claimed_by,@last_activity,@spawned_by,@created_at,@updated_at)").run(cols);
+  return id;
+};
+const statusOf = (id) => aos.db.prepare("SELECT status s FROM term_sessions WHERE id=?").get(id).s;
+
+console.log('\n\x1b[1m1) Settings.interactiveIdleTimeoutHours\x1b[0m');
+assert(aos.settings.interactiveIdleTimeoutHours() === 48, 'unset → 48h default');
+assert(aos.settings.setInteractiveIdleTimeoutHours(72) === 72, 'set 72 → 72');
+assert(aos.settings.setInteractiveIdleTimeoutHours(0) === 0, 'set 0 → 0 (disabled)');
+assert(aos.settings.setInteractiveIdleTimeoutHours(99999) === 24 * 30, 'clamps to 30 days max');
+
+console.log('\n\x1b[1m2) reaper sweep (timeout = 48h)\x1b[0m');
+aos.settings.setInteractiveIdleTimeoutHours(48);
+
+const stale = mkSession({ created_at: Date.now() - 96 * H });                 // 4 days idle → reap
+const recent = mkSession({ created_at: Date.now() - 2 * H });                 // 2h → keep
+const attachedStale = mkSession({ created_at: Date.now() - 96 * H, tmux: 'aos-ATTACHED' }); attached.add('aos-ATTACHED'); // in use → keep
+const claimedStale = mkSession({ created_at: Date.now() - 96 * H, claimed_by: 'm_bob' }); // human owns it → keep
+const unattended = mkSession({ created_at: Date.now() - 96 * H, headless: 1 });   // sweep-2 territory, not sweep 3 → keep here
+const activeByLastAct = mkSession({ created_at: Date.now() - 96 * H, last_activity: Date.now() - 1 * H }); // recent turn → keep
+
+tm.reapIdleSessions();
+
+assert(statusOf(stale) === 'stopped', 'detached 4-day-idle member session → stopped');
+assert(killed.includes('aos-' + stale), 'its pane was killed');
+assert(statusOf(recent) === 'running', 'recent (2h) session → left running');
+assert(statusOf(attachedStale) === 'running', 'attached session (client present) → left running');
+assert(statusOf(claimedStale) === 'running', 'claimed take-over → left running');
+assert(statusOf(unattended) === 'running', 'headless=1 unattended → not touched by sweep 3');
+assert(statusOf(activeByLastAct) === 'running', 'old but recent last_activity → left running');
+
+console.log('\n\x1b[1m3) disabled (timeout = 0) reaps nothing\x1b[0m');
+aos.settings.setInteractiveIdleTimeoutHours(0);
+const stale2 = mkSession({ created_at: Date.now() - 200 * H });
+tm.reapIdleSessions();
+assert(statusOf(stale2) === 'running', 'timeout 0 → even a 200h-idle session is left alone');
+
+console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}IDLE REAPER: ${pass}/${pass + fail} passed\x1b[0m`);
+try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
+process.exit(fail === 0 ? 0 : 1);

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -57,6 +57,7 @@ const EMAIL_ORG_DOMAINS_KEY = 'email_org_domains'; // internal email domains (JS
 const CHAT_ROUTER_KEY = 'chat_router_enabled'; // generic Slack/Discord `/agent` router fallback ('off' disables)
 const CHAT_IDLE_MIN_KEY = 'chat_idle_timeout_min'; // resident (warm) chat session idle-kill, minutes
 const MAX_CONCURRENT_KEY = 'max_concurrent_sessions'; // whole-box concurrency cap override; unset → RAM-derived default, 0 → unlimited
+const INTERACTIVE_IDLE_HOURS_KEY = 'interactive_idle_timeout_hours'; // auto-close a detached member session idle past this; unset → 48h, 0 → off
 const KILL_SWITCH_KEY = 'kill_switch'; // workspace-wide emergency stop (JSON KillSwitchState)
 const SUPPRESSED_BUILTINS_KEY = 'suppressed_builtins'; // built-in agent ids an admin deleted (JSON string[]); boot won't re-seed them
 
@@ -667,6 +668,26 @@ export class SettingsStore {
     if (n == null || !Number.isFinite(v) || v < 0) this.set(MAX_CONCURRENT_KEY, '', by); // clear → derived default
     else this.set(MAX_CONCURRENT_KEY, String(Math.floor(v)), by);
     return this.maxConcurrentSessions();
+  }
+
+  /** How long a detached member (interactive) session may sit idle before the reaper closes it. Unlike a
+   *  resident chat session (minutes) or an unattended run (turn-end), a member's own attachable session has
+   *  no auto-teardown — a forgotten one holds a `claude` process for days, hogging RAM and a concurrency-cap
+   *  slot. Default **48 h**; clamped 1 h–30 days. `0` disables the reaper. The session is only closed when
+   *  nobody's attached and it isn't blocked on a person, and it stays Resumable, so this is a janitor, not a
+   *  guillotine. */
+  interactiveIdleTimeoutHours(): number {
+    const n = Number(this.getRow(INTERACTIVE_IDLE_HOURS_KEY)?.value);
+    if (!Number.isFinite(n)) return 48; // unset → default
+    if (n <= 0) return 0;               // explicit 0 → disabled
+    return Math.min(Math.max(Math.round(n), 1), 24 * 30);
+  }
+
+  setInteractiveIdleTimeoutHours(hours: number, by?: string): number {
+    const n = Number(hours);
+    const clamped = !Number.isFinite(n) || n < 0 ? 48 : n === 0 ? 0 : Math.min(Math.max(Math.round(n), 1), 24 * 30);
+    this.set(INTERACTIVE_IDLE_HOURS_KEY, String(clamped), by);
+    return this.interactiveIdleTimeoutHours();
   }
 
   // ── kill switch (workspace emergency stop) ───────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -2686,19 +2686,29 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const value = os.settings.maxConcurrentSessions(); // operator override (null = unset)
     const resolved = autos.concurrencyCap();           // effective cap the scheduler enforces (0 = unlimited)
     const source = envLocked ? 'env' : value != null ? 'setting' : 'derived';
-    return sendJson(res, 200, { value, resolved, derived: derivedConcurrencyCap(), source, envLocked, alive: tm.aliveSessionCount() });
+    return sendJson(res, 200, { value, resolved, derived: derivedConcurrencyCap(), source, envLocked, alive: tm.aliveSessionCount(), idleHours: os.settings.interactiveIdleTimeoutHours() });
   }
   if (method === 'PUT' && p === '/api/settings/concurrency') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    const b = await readBody(req) as { value?: unknown };
-    // `null`/'' clears the override (→ derived default); 0 = unlimited; N>0 = cap. Reject non-numeric junk.
-    const raw = b.value;
-    const clear = raw === null || raw === undefined || raw === '';
-    const n = clear ? null : Number(raw);
-    if (!clear && (!Number.isFinite(n as number) || (n as number) < 0)) return sendJson(res, 400, { error: 'value must be a non-negative integer, 0 (unlimited), or null (use default)' });
-    const saved = os.settings.setMaxConcurrentSessions(clear ? null : (n as number), me.email);
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.concurrency.updated', data: { value: saved } });
-    return sendJson(res, 200, { ok: true, value: saved, resolved: autos.concurrencyCap(), derived: derivedConcurrencyCap() });
+    const b = await readBody(req) as { value?: unknown; idleHours?: unknown };
+    // Cap: `null`/'' clears the override (→ derived default); 0 = unlimited; N>0 = cap. Only touched when the
+    // key is present, so a PUT that only sets idleHours leaves the cap alone.
+    if ('value' in b) {
+      const raw = b.value;
+      const clear = raw === null || raw === '';
+      const n = clear ? null : Number(raw);
+      if (!clear && (!Number.isFinite(n as number) || (n as number) < 0)) return sendJson(res, 400, { error: 'value must be a non-negative integer, 0 (unlimited), or null (use default)' });
+      const saved = os.settings.setMaxConcurrentSessions(clear ? null : (n as number), me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.concurrency.updated', data: { value: saved } });
+    }
+    // Idle-interactive reaper timeout (hours): 0 = off; else clamped 1h–30d. Present-only, same as above.
+    if ('idleHours' in b) {
+      const h = Number(b.idleHours);
+      if (!Number.isFinite(h) || h < 0) return sendJson(res, 400, { error: 'idleHours must be a non-negative number (0 = off)' });
+      const savedH = os.settings.setInteractiveIdleTimeoutHours(h, me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.interactiveIdle.updated', data: { idleHours: savedH } });
+    }
+    return sendJson(res, 200, { ok: true, value: os.settings.maxConcurrentSessions(), resolved: autos.concurrencyCap(), derived: derivedConcurrencyCap(), idleHours: os.settings.interactiveIdleTimeoutHours() });
   }
 
   // ── UI branding (per-tenant accent colour + favicon badge) — owner/admin edits ──

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1217,6 +1217,35 @@ export class TerminalManager {
         this.teardownUnattended(r.id, space, r.tmux, r.status === 'done' ? 'done-orphan' : 'idle-backstop');
       } catch { /* one bad row must not stop the sweep */ }
     }
+
+    // (3) idle INTERACTIVE (member) sessions. A member's own attachable session holds a `claude` process
+    // too, but — unlike a resident chat (sweep 1) or an unattended run (turn-end / sweep 2) — nothing ever
+    // reaps it. A forgotten, detached one lingers for DAYS, wasting RAM and (now that the cap is on)
+    // permanently hogging a concurrency-cap slot so scheduled work starves. Reap one idle past the
+    // configurable timeout (Settings, default 48 h) with NO client attached and no pending human block; it
+    // stays Resumable (a deliberate console re-open clears `blockResume`), so this is a janitor, not a
+    // guillotine. Skip claimed take-overs — a human owns that lifecycle. `0` disables. Uses
+    // COALESCE(last_activity, created_at): a member session rarely stamps last_activity, so age is the
+    // fallback clock. Runs regardless of `aliveNames()` (kill is harmless on an already-dead pane).
+    const idleHours = this.os.settings.interactiveIdleTimeoutHours();
+    if (idleHours > 0) {
+      const idleCutoff = Date.now() - idleHours * 3600_000;
+      const stale = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent FROM term_sessions WHERE headless = 0 AND resident = 0 AND claimed_by IS NULL AND status = 'running' AND COALESCE(last_activity, created_at) < ?")
+        .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string }>(idleCutoff);
+      for (const r of stale) {
+        try {
+          const space = this.spaceFor(r.run_as ?? r.spawned_by);
+          if (this.backend.hasClient(space, r.tmux) === true) continue; // someone's attached — it's in use
+          if (this.hasPendingHumanBlock(r.id)) continue;               // blocked on a person — leave it
+          this.backend.kill(space, r.tmux);
+          this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), r.id);
+          this.cancelPendingQuestions(r.id, 'system');
+          this.cancelPendingApprovals(r.id, 'system');
+          this.blockResume(r.id); // stay stopped against a ttyd auto-reconnect; a deliberate Resume clears it
+          this.audit(r.id, r.agent, 'session.reaped', { reason: 'idle-interactive', idleHours });
+        } catch { /* one bad row must not stop the sweep */ }
+      }
+    }
   }
 
   /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8620,7 +8620,8 @@ function RuntimeDefaultsSettings({ me }: { me: Member }) {
  *  raise/lower it or lift it entirely. Effective value resolves env → this setting → derived default. */
 function ConcurrencySettings({ me }: { me: Member }) {
   const [data, setData] = useState<Concurrency | null>(null)
-  const [input, setInput] = useState('') // '' = use default; '0' = unlimited; N = cap
+  const [input, setInput] = useState('')   // '' = use default; '0' = unlimited; N = cap
+  const [idle, setIdle] = useState('')      // hours; '0' = off
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const canEdit = me.role === 'owner' || me.role === 'admin'
@@ -8629,13 +8630,19 @@ function ConcurrencySettings({ me }: { me: Member }) {
     if (r.error) return
     setData(r)
     setInput(r.value == null ? '' : String(r.value)) // box reflects only an explicit operator override
+    setIdle(String(r.idleHours))
   }).catch(() => {})
   useEffect(() => { load() }, [])
 
-  const dirty = data != null && input.trim() !== (data.value == null ? '' : String(data.value))
+  const capDirty = data != null && input.trim() !== (data.value == null ? '' : String(data.value))
+  const idleDirty = data != null && idle.trim() !== String(data.idleHours)
+  const dirty = capDirty || idleDirty
   const save = async () => {
     setBusy(true); setHint('')
-    const r = await api.saveConcurrency(input.trim() === '' ? null : Number(input))
+    const body: { value?: number | null; idleHours?: number } = {}
+    if (capDirty) body.value = input.trim() === '' ? null : Number(input)
+    if (idleDirty) body.idleHours = Number(idle)
+    const r = await api.saveConcurrency(body)
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
     setHint('saved — applies on the next scheduler tick'); setTimeout(() => setHint(''), 2500)
@@ -8674,13 +8681,32 @@ function ConcurrencySettings({ me }: { me: Member }) {
               disabled={!canEdit || !!data?.envLocked}
               className="h-8 w-40 font-mono text-xs"
             />
-            <Button onClick={save} disabled={!canEdit || busy || !dirty || !!data?.envLocked}>{dirty ? 'Save' : 'Saved'}</Button>
-            {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
+            <span className="text-[11px] text-muted-foreground">
+              blank = default{data ? ` (${data.derived})` : ''}, 0 = unlimited
+              {data?.envLocked && <> · pinned by <span className="font-mono">AOS_MAX_CONCURRENT_SESSIONS</span></>}
+            </span>
+          </div>
+        </div>
+        <div className="space-y-1.5 border-t pt-4">
+          <label className="text-xs font-medium text-muted-foreground">Auto-close idle sessions after (hours)</label>
+          <div className="flex items-center gap-3">
+            <Input
+              type="number" min={0} step={1} value={idle}
+              onChange={(e) => setIdle(e.target.value)}
+              placeholder="48"
+              disabled={!canEdit}
+              className="h-8 w-40 font-mono text-xs"
+            />
+            <span className="text-[11px] text-muted-foreground">detached member sessions only; 0 = never · they stay Resumable</span>
           </div>
           <p className="text-[11px] text-muted-foreground">
-            Blank = the RAM-derived default{data ? ` (${data.derived})` : ''}. <span className="font-mono">0</span> = unlimited (no cap).
-            {data?.envLocked && <> Pinned by the <span className="font-mono">AOS_MAX_CONCURRENT_SESSIONS</span> env var — clear it to edit here.</>}
+            A forgotten interactive session holds a <span className="font-mono">claude</span> process and a cap slot for days. This closes one
+            left idle this long (nobody attached) so it stops starving scheduled work.
           </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button onClick={save} disabled={!canEdit || busy || !dirty}>{dirty ? 'Save' : 'Saved'}</Button>
+          {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
         </div>
       </CardContent>
     </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -50,6 +50,8 @@ export interface Concurrency {
   source: 'env' | 'setting' | 'derived'
   envLocked: boolean
   alive: number
+  /** Auto-close a detached member session idle past this many hours (0 = off; default 48). */
+  idleHours: number
 }
 
 export interface AgentInfo {
@@ -1060,7 +1062,7 @@ export const api = {
   runtimeDefaults: () => call<RuntimeTuning & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/runtime-defaults'),
   saveRuntimeDefaults: (tuning: RuntimeTuning) => call<{ ok: boolean; error?: string } & RuntimeTuning>('PUT', '/api/settings/runtime-defaults', tuning),
   concurrency: () => call<Concurrency & { error?: string }>('GET', '/api/settings/concurrency'),
-  saveConcurrency: (value: number | null) => call<{ ok: boolean; error?: string; value?: number | null; resolved?: number; derived?: number }>('PUT', '/api/settings/concurrency', { value }),
+  saveConcurrency: (body: { value?: number | null; idleHours?: number }) => call<{ ok: boolean; error?: string; value?: number | null; resolved?: number; derived?: number; idleHours?: number }>('PUT', '/api/settings/concurrency', body),
 
   governance: () => call<GovernanceThresholds & { hostGovernanceEnabled?: boolean; updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/governance'),
   saveGovernance: (t: GovernanceThresholds & { hostGovernanceEnabled?: boolean }) => call<{ ok: boolean; error?: string; hostGovernanceEnabled?: boolean } & GovernanceThresholds>('PUT', '/api/settings/governance', t),


### PR DESCRIPTION
## Why
The recurring squeeze behind the cron misses. A member's own attachable session holds a `claude` process like any other, but — unlike a resident chat (reaped in minutes) or an unattended run (torn down at turn-end) — **nothing ever reaped it**. On instawp, ~5 member sessions idle **2.7–4 days** pinned the box at **11 running vs cap 8**, so scheduled crons permanently lost the cap race (the [cron catch-up fix](../pull/245) retries, but there was never headroom).

## What
`reapIdleSessions` gains a third sweep — the missing janitor for interactive sessions:

- Targets a **member** session only: `headless=0`, `resident=0`, `claimed_by IS NULL`, `status='running'`, idle past the timeout (`COALESCE(last_activity, created_at)` — member sessions rarely stamp `last_activity`, so age is the fallback clock).
- Skips anything **in use or owned**: a client attached (`hasClient`), blocked on a person, or a claimed take-over.
- Closes it to `status='stopped'` + `blockResume` — but it stays **Resumable** (a deliberate console re-open clears the block). Janitor, not guillotine.

Configurable at **Settings → Runtime defaults → "Auto-close idle sessions after (hours)"** — `interactiveIdleTimeoutHours`, **default 48**, `0` = off, clamped 1 h–30 days. Extended `GET/PUT /api/settings/concurrency` (audited `settings.interactiveIdle.updated`).

## Effect on deploy
On instawp this reaps the 5 stale sessions (all >48 h idle) on the first sweep → running 11→6 → the cron cap unblocks and today's Daily Support Quality Review catches up within its window.

## Verification
- `typecheck` ✓ · `web build` ✓ · `test:governance` 68/68 ✓
- New `scripts/idle-reaper-test.cjs` → **12/12**: reaps a stale detached session (+ kills its pane); leaves recent / attached / claimed / `headless=1` unattended / recently-active / disabled (`0`) cases alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)