### PR TITLE
feat(digest): daily "what got done today" standup → Slack (v0.146.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.147.0] — 2026-07-13
+### Added
+- **Daily digest — an end-of-day "what got done today" standup, posted to Slack.** A tenant-wide summary
+  in two halves: **📋 Today** (the per-session changelog, grouped by agent) + **🧠 Learned** (Dreaming's
+  distilled guidance + open recommendations). The changelog needs no new capture — every session end
+  already writes a deterministic episode (`writeEpisode` → `composeEpisode`), so the digest is a pure
+  read + render (no LLM). The body thresholds on `episodeSalience` importance so a busy day of low-value
+  test runs doesn't drown the real work; a `done` session with a substantive report title is always
+  included (it may carry no episode yet still shipped a PR). Rides the **Dreaming pass**, not a new timer:
+  the dashboard/KB render live on demand, and only the Slack post is time-gated — once per server-local day
+  past `digestHour` (default 18), guarded by a `digest.posted` audit. Manual **Reflect now** / **Post now**
+  refresh the KB page but the channel is pinged solely by the scheduled end-of-day run. Each day lands a
+  dated, revisioned KB journal page (`operations/daily/<date>`). New config in **Settings → Learning**
+  (enable, channel, hour) with a live "today so far" preview; endpoints `GET /api/digest/today` +
+  `POST /api/digest/post`, and digest fields on `GET`/`PUT /api/dreaming`. See `docs/daily-digest-plan.md`.
+
 ## [0.146.0] — 2026-07-13
 ### Added
 - **Assign a secret to agents from the Secrets page — no manifest edit, no re-entering the value.** Granting
@@ -22,6 +38,19 @@ new version heading in the same commit.
   launch (audited `shell.secret.injected`/`unresolved` with `via:'assignment'`); assignments are cleaned up
   when the secret is deleted. New route `PUT /api/secrets/agents` (owner/admin; unknown agent ids dropped),
   and `GET /api/secrets` now returns each secret's assignment list. Audited `secret.assigned`.
+- **Daily digest — an end-of-day "what got done today" standup, posted to Slack.** A tenant-wide summary
+  in two halves: **📋 Today** (the per-session changelog, grouped by agent) + **🧠 Learned** (Dreaming's
+  distilled guidance + open recommendations). The changelog needs no new capture — every session end
+  already writes a deterministic episode (`writeEpisode` → `composeEpisode`), so the digest is a pure
+  read + render (no LLM). The body thresholds on `episodeSalience` importance so a busy day of low-value
+  test runs doesn't drown the real work; a `done` session with a substantive report title is always
+  included (it may carry no episode yet still shipped a PR). Rides the **Dreaming pass**, not a new timer:
+  the dashboard/KB render live on demand, and only the Slack post is time-gated — once per server-local day
+  past `digestHour` (default 18), guarded by a `digest.posted` audit. Manual **Reflect now** / **Post now**
+  refresh the KB page but the channel is pinged solely by the scheduled end-of-day run. Each day lands a
+  dated, revisioned KB journal page (`operations/daily/<date>`). New config in **Settings → Learning**
+  (enable, channel, hour) with a live "today so far" preview; endpoints `GET /api/digest/today` +
+  `POST /api/digest/post`, and digest fields on `GET`/`PUT /api/dreaming`. See `docs/daily-digest-plan.md`.
 
 ## [0.145.0] — 2026-07-13
 ### Added

--- a/docs/daily-digest-plan.md
+++ b/docs/daily-digest-plan.md
@@ -1,0 +1,163 @@
+# Daily Digest ("Today") — plan
+
+A tenant-wide daily standup: **what the fleet did today**, browsable as a dashboard and posted to
+Slack at end of day. One line or two per session, rolled up.
+
+**Decisions locked:**
+- Capture = automatic at session end (no agent action, no LLM) — already ships via `writeEpisode`.
+- Audience = **tenant-wide** (one fleet digest to a shared channel).
+- The digest is a **step in the Dreaming pass**, not a standalone timer — shares its tick, KB home, Slack seam.
+- **One combined Slack post**, two sections: **📋 Today** (per-session changelog) + **🧠 Learned**
+  (Dreaming guidance/recommendations). The changelog is the new render; the guidance is Dreaming's existing output.
+- **EOD trigger:** post once per tenant-local day at `digestHour` (default 18), guarded by a
+  `digest.posted` audit; the dashboard + KB page refresh on **every** pass, only the Slack post is gated.
+- **Body thresholds on `episodeSalience.importance`** — salient episodes in the body, full tally in the
+  header. (Live dry-run showed ~half a busy day is low-importance `stopped` test runs; without a
+  threshold the digest reads as noise.)
+- **Manual "Reflect now" refreshes only** — it does not post to Slack; the channel is pinged solely by
+  the scheduled EOD trigger. (No surprise posts from a button.)
+- **Empty day** → skip the Slack post, still write the dated KB page (keeps the record continuous).
+- Config lives in a **new `Settings → Dreaming` section** (not under Memory) — houses the existing
+  self-learning controls + the new digest config.
+
+## The key insight: capture already ships
+
+Every session already writes a deterministic "what this session did" line at end:
+
+- `TerminalManager.writeEpisode` (`src/terminal.ts:2851`) fires on every teardown — the Stop-hook fast
+  path (`markTurnIdle` → `teardownUnattended` → `markEnded`), the idle backstop, and `stop`/crash paths.
+- `composeEpisode` (`src/terminal.ts:3238`) builds the line **with zero LLM cost**: it prefers the
+  agent's own `report` summary; failing that it summarizes the audit stream into
+  `"Task: … · Outcome: success · Activity: 3 edits, 1 pr.opened, 2 approvals."`. Graded by
+  `episodeSalience` (effort + friction + outcome → `importance`).
+- Stored via `os.memory.store({ tags: ['episode','session-end'], type:'Insight', importance,
+  metadata:{ sessionId, outcome, source, salience } })`, which lands in the `memories` table (the
+  provider mirrors external backends back into it — `MirroredMemoryProvider`).
+
+So the per-session changelog line **exists today**. The digest is a pure **read + render** over
+`memories` (episodes) joined to `term_sessions` (agent, title, run_as, start/end) and `audit_events`
+(approvals, PRs, tasks closed, budget stops). No new capture, no new tool, no model call.
+
+This is the same input the **Dreaming** pass already consumes (`src/edge/dreaming.ts` reads
+`memories WHERE tags LIKE '%"episode"%'`) — the digest is Dreaming's daily-window sibling, but a flat
+render rather than a compounding reflection.
+
+## Data — nothing new required, one optional durable artifact
+
+Query for "today" (tenant, `[dayStart, dayEnd)` in the tenant's local day):
+
+```
+episodes  = memories WHERE tags LIKE '%"episode"%' AND created_at IN [start,end)
+sessions  = term_sessions WHERE started_at IN [start,end)   -- agent, task/title, run_as, status
+signals   = audit_events IN [start,end): counts of approval.*, git.pr.opened, task.updated(done),
+            budget stops, session.error/episode.error
+```
+
+Everything is already persisted and indexed by time. **No schema change.**
+
+Optional (recommended): at EOD, render the digest into a **dated KB journal page** —
+`KbStore.write({ section:'operations', slug:'daily/<YYYY-MM-DD>', … })` (`src/state/kb.ts:44`). That
+makes each day a durable, revisioned, browsable artifact on the console **Knowledge** page and gives
+the Slack post a permalink to "see the full day." Pure render of the query, so it's rebuildable.
+
+## Render — deterministic, matches the Dreaming style
+
+`renderDigest(os, day) → { markdown, slackBlocks, stats }` in a new `src/edge/digest.ts`:
+
+- **Header:** `Fleet — Mon Jul 13 · 14 sessions · 11 success / 2 partial / 1 stopped`.
+- **By agent:** group episodes by `agent`; per agent, its session lines (title + outcome emoji),
+  most-salient first (`importance` desc). Cap N per agent, "+3 more" overflow.
+- **Highlights:** cross-fleet counts from `signals` — PRs opened, approvals granted/rejected, tasks
+  closed, budget stops, errors.
+- Skip zero-signal noise (episodes that `composeEpisode` already returns `null` for never land).
+
+No LLM. If we later want a one-paragraph narrative, that's an opt-in layer (a scheduled
+`digest-writer` agent via `kb_write`), exactly how the "kb-gardener" layers on Dreaming.
+
+## Fold into Dreaming — one "reflect" pass, three steps
+
+The digest is **not** a second scheduler. It rides the pass that already exists:
+
+- **Scheduled** (`src/server.ts:282`): `DreamingEngine.dream() → Consolidation.run()` fires every
+  `dreamingEveryHours`. Add a third step: `renderDigest() → maybe post`. The chain becomes
+  **reflect (dream) → learn (consolidate) → report (digest)**.
+- **Manual** (`POST /api/dreaming/run`, `src/server.ts:2322`): same third step appended, so "Reflect
+  now" also refreshes today's digest.
+
+New module `src/edge/digest.ts` exports `renderDigest(os, day)` (pure read+render, above) and a thin
+`Digest.run(os, slack)` that renders today, writes the dated KB page, and — if it's time — posts to
+Slack. Delivery, all reusing existing seams:
+
+1. **Console "Today" dashboard** — new page (primary nav, near Audit) reading `GET /api/digest/today`
+   (owner/admin). Live view of the current day; date-picker pages back via the KB journal pages.
+2. **EOD Slack post — combined with Dreaming's learnings in one message.** Dreaming already produces a
+   distilled guidance string (`DreamResult.guidance`) + a `fleet-learnings` KB page but posts nothing to
+   Slack today. The digest supplies the delivery both halves ride:
+   > **Today** — 14 sessions · 11 ✓ / 2 partial / 1 stopped … *(digest render)*
+   > **Learned** — recurring friction: approvals on `git.push`; recommend auto-allow … *(dreaming guidance)*
+
+   `Digest.run` composes `renderDigest(today).slack` + the `guidance` returned by the same pass's
+   `dream()`, `postMessage` (`src/connectors/slack.ts:38`) to the configured channel, writes the KB
+   page, and stamps `digest.posted` as the **once-per-day idempotency guard** (mirrors `learning.dreamed`).
+
+### The cadence tension (needs a decision — see Open questions)
+
+Dreaming runs every `dreamingEveryHours` (may be <24h or >24h); the digest's Slack post is a
+**once-a-day, at-a-set-hour** event. So the digest step must gate its *Slack post* independently of the
+pass firing: render/refresh the dashboard + KB page on **every** pass (cheap), but only `postMessage`
+when (a) the tenant-local hour ≥ `digestHour` and (b) no `digest.posted` audit exists for today. The
+dashboard is always current; the Slack ping happens once, at EOD.
+
+## Config — Settings → Digest
+
+Stored in `settings` (hot-read via `settings.ts`): `digestEnabled`, `digestChannel` (Slack id/name),
+`digestHour` (tenant-local EOD, default 18), `digestScope` (fixed `tenant` for now). If `digestChannel`
+is unset → skip the Slack post, still render dashboard + KB page (fail-soft, no hard Slack dependency).
+
+## Endpoints / surfaces (all reuse existing patterns)
+
+- `GET /api/digest/today?date=YYYY-MM-DD` — owner/admin, returns `{ markdown, stats, byAgent }`.
+- Digest refresh is driven by the Dreaming pass — no separate `/api/digest/run`; "Reflect now" covers it.
+  (A "Post digest to Slack now" button, if wanted, is a small `POST /api/digest/post`.)
+- Settings read/write via the existing `settings.ts` plane.
+
+## Build / ship notes
+
+- New: `src/edge/digest.ts` (`renderDigest` + `Digest.run`), a `GET /api/digest/*` handler, a Settings
+  block, and the console **Today** page (`web/src`). Append the digest step to **both** the scheduled
+  chain (`src/server.ts:282`) and the manual `/api/dreaming/run` (`src/server.ts:2322`).
+- Server/API + tick = `npm run build` **+ restart** to take effect; web = `cd web && npm run build`.
+- No new scheduler, no new MCP tool, no schema migration, no model dependency.
+
+## What shipped (v0.146.0)
+
+- `src/edge/digest.ts` — `buildDigest` (pure read) + `renderSlack`/`renderMarkdown` + `Digest`
+  (`today`/`refresh`/`postNow`/`maybePostEod`). Validated against a copy of the live instapods data:
+  20 sessions rendered correctly, low-value test runs thresholded out, engineer's 3 PRs + the staged
+  newsletter surfaced.
+- **Salience rule (refined against real data):** body = episodes with `importance ≥ 0.5` **OR** any
+  `done` session with a substantive (non-placeholder, ≥5-char) report title. The `OR` matters — several
+  real `done` sessions ("Shipped PR #333") carried no end-of-session episode (importance 0) yet are
+  exactly what the digest is for; a pure importance threshold dropped them.
+- **Timezone = server-local** (the deploy box's tz). A per-tenant tz can layer on later.
+- **UI:** digest config + a live "today so far" preview live in the existing **Settings → Learning**
+  (Dreaming) tab — no new nav tab. A standalone **"Today" dashboard** page is deferred (the KB
+  `operations/daily/<date>` page already gives a browsable daily record, and the preview covers the
+  at-a-glance need).
+- Wired into both the hourly upkeep tick (`maybePostEod`) and manual `/api/dreaming/run` (KB refresh, no
+  Slack). Routes: `GET /api/digest/today`, `POST /api/digest/post`, digest fields on `/api/dreaming`.
+
+## Open questions
+
+- **EOD trigger vs. every-pass** — post once at a set `digestHour` (needs a tenant tz + once-per-day
+  `digest.posted` guard), or just let the last Dreaming pass of the day carry the post? The former is a
+  real "end of day summary"; the latter is simpler but fires whenever the cadence lands.
+- **One message or two** — combine digest + Dreaming guidance in a single Slack post (lean: yes), or
+  keep "what happened" and "what we learned" as separate messages?
+- **Manual "Reflect now" → Slack?** Should hitting `/api/dreaming/run` also *post* to Slack, or only
+  refresh the dashboard/KB page and leave the Slack ping to the scheduled EOD trigger? (lean: refresh
+  only; never surprise the channel from a manual button.)
+- **Day boundary / timezone** — tenant's configured tz (fallback server local). "today" = `[00:00,
+  24:00)` local.
+- **Empty day** — post a terse "quiet day, 0 sessions" or skip the Slack post entirely? (lean: skip
+  Slack, still write the KB page so the date exists).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.146.0",
+  "version": "0.147.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.146.0",
+      "version": "0.147.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.146.0",
+  "version": "0.147.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/digest.ts
+++ b/src/edge/digest.ts
@@ -1,0 +1,258 @@
+/**
+ * The **daily digest** — a tenant-wide "what got done today" standup.
+ *
+ * Two halves in one artifact:
+ *  1. **📋 Today** — the per-session changelog, grouped by agent. The lines are already written for us:
+ *     every session end stores an **episode** (`TerminalManager.writeEpisode` → `composeEpisode`), a
+ *     deterministic "what this session did" summary graded by `episodeSalience`. The digest just reads
+ *     today's episodes/sessions and rolls them up — no LLM, no new capture. The body thresholds on that
+ *     salience score so a busy day of low-value test runs doesn't drown the real work (header keeps the
+ *     full tally).
+ *  2. **🧠 Learned** — the Dreaming pass's distilled `learnedGuidance` + open recommendations. Dreaming
+ *     already produces these; the digest is the delivery they never had.
+ *
+ * Delivery, all sharing existing seams: a dated KB journal page (`operations/daily/<date>`, browsable +
+ * revisioned) and one combined Slack post at end of day. The render is pure + on-demand (the console
+ * "today" view and the KB page rebuild live); only the Slack post is time-gated — once per server-local
+ * day past `digestHour`, guarded by a `digest.posted` audit. See docs/daily-digest-plan.md.
+ */
+import type { AgentOS } from '../kernel';
+import { postMessage, lookupChannelByName, joinChannel } from '../connectors/slack';
+
+const SECTION = 'operations';
+const SALIENCE = 0.5;          // episodes at/above this importance make the body; the rest count in the tally only
+const PER_AGENT = 6;           // cap body lines per agent (overflow → "+N more")
+
+export interface DigestModel {
+  iso: string;                 // YYYY-MM-DD (server-local)
+  label: string;               // e.g. "Wed Jul 13"
+  total: number;
+  buckets: { success: number; partial: number; failure: number; stopped: number; running: number; other: number };
+  byAgent: { agent: string; lines: { title: string; outcome: string; importance: number }[]; more: number }[];
+  signals: { tasksCreated: number; tasksCompleted: number; approvals: number; rejected: number; errors: number; budgetStops: number };
+  guidance: string[];          // a few distilled Dreaming imperatives
+  recommendations: string[];   // open recommendation titles
+}
+
+interface SessionRow { id: string; agent: string; status: string; title: string; importance: number | null; outcome: string | null }
+interface AuditRow { type: string; data: string }
+
+/** Server-local day bounds + labels for `now`. Time is the deploy box's tz (single-box deployment). */
+export function localDayBounds(now = new Date()): { start: number; end: number; iso: string; label: string } {
+  const d = new Date(now.getTime());
+  d.setHours(0, 0, 0, 0);
+  const start = d.getTime();
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const iso = `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  const label = d.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+  return { start, end: start + 24 * 3_600_000, iso, label };
+}
+
+/** Read today's sessions + episodes + audit signals into a structured model. Pure over the DB. */
+export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
+  const { start, end, iso, label } = localDayBounds(now);
+  const db = os.db;
+
+  // Each session ⋈ its end-of-session episode (importance + outcome). One episode per session in
+  // practice; MAX/any is fine if a stray second one exists.
+  const rows = db.prepare(
+    `SELECT s.id, s.agent, s.status, s.title,
+            MAX(m.importance) AS importance,
+            MAX(json_extract(m.metadata,'$.outcome')) AS outcome
+       FROM term_sessions s
+       LEFT JOIN memories m
+         ON m.tags LIKE '%"episode"%' AND json_extract(m.metadata,'$.sessionId') = s.id
+      WHERE s.created_at >= ? AND s.created_at < ?
+      GROUP BY s.id`,
+  ).all<SessionRow>(start, end);
+
+  const buckets = { success: 0, partial: 0, failure: 0, stopped: 0, running: 0, other: 0 };
+  const perAgent = new Map<string, { title: string; outcome: string; importance: number }[]>();
+  for (const r of rows) {
+    const outcome = (r.outcome || (r.status === 'done' ? 'success' : r.status) || 'unknown').toLowerCase();
+    if (outcome in buckets) (buckets as Record<string, number>)[outcome]++; else buckets.other++;
+    const importance = r.importance ?? 0;
+    const title = (r.title || '').trim();
+    // A placeholder title carries no signal ("test", too-short) — never body-worthy.
+    const placeholder = title.length < 5 || /^(test|teste|untitled)$/i.test(title);
+    // Body inclusion: a salient episode (importance ≥ threshold) OR a session that simply COMPLETED with a
+    // real report title. The latter matters because a `done` interactive/member session may not carry an
+    // end-of-session episode (importance 0), yet "Shipped PR #333" is exactly what the digest is for. The
+    // noise we drop is low-importance `stopped`/`running` test runs and placeholder titles.
+    const salient = !placeholder && (importance >= SALIENCE || r.status === 'done');
+    if (salient) {
+      const list = perAgent.get(r.agent) ?? [];
+      // Rank a done-with-no-episode session just under the salience line so real episodes sort first.
+      list.push({ title, outcome, importance: importance || (r.status === 'done' ? SALIENCE - 0.01 : 0) });
+      perAgent.set(r.agent, list);
+    }
+  }
+
+  const byAgent = [...perAgent.entries()]
+    .map(([agent, all]) => {
+      const sorted = all.sort((a, b) => b.importance - a.importance);
+      return { agent, lines: sorted.slice(0, PER_AGENT), more: Math.max(0, sorted.length - PER_AGENT) };
+    })
+    .sort((a, b) => b.lines.length - a.lines.length || a.agent.localeCompare(b.agent));
+
+  // Governance / throughput signals from the audit stream.
+  const signals = { tasksCreated: 0, tasksCompleted: 0, approvals: 0, rejected: 0, errors: 0, budgetStops: 0 };
+  const audit = db.prepare(
+    `SELECT type, data FROM audit_events WHERE ts >= ? AND ts < ?
+       AND type IN ('task.created','task.completed','approval.auto_approved','approval.resolved','budget.exceeded','episode.error','session.error')`,
+  ).all<AuditRow>(start, end);
+  for (const a of audit) {
+    switch (a.type) {
+      case 'task.created': signals.tasksCreated++; break;
+      case 'task.completed': signals.tasksCompleted++; break;
+      case 'approval.auto_approved': signals.approvals++; break;
+      case 'approval.resolved': { let approved = true; try { approved = (JSON.parse(a.data) as { approved?: boolean }).approved !== false; } catch { /* keep default */ } approved ? signals.approvals++ : signals.rejected++; break; }
+      case 'budget.exceeded': signals.budgetStops++; break;
+      case 'episode.error': case 'session.error': signals.errors++; break;
+    }
+  }
+
+  // The Dreaming half — distilled imperatives + open recommendation titles (already persisted).
+  const guidance = os.settings.learnedGuidance()
+    .split('\n').map((l) => l.trim()).filter((l) => l.startsWith('- ')).map((l) => l.slice(2).trim()).slice(0, 3);
+  const recommendations = os.settings.recommendations().open.map((r) => r.title).slice(0, 3);
+
+  return { iso, label, total: rows.length, buckets, byAgent, signals, guidance, recommendations };
+}
+
+/** Compact tally line — "18 sessions · 7 ✓ · 1 partial · 1 ✗ · 9 stopped". */
+function tally(m: DigestModel): string {
+  const b = m.buckets;
+  const parts: string[] = [`${m.total} session${m.total === 1 ? '' : 's'}`];
+  if (b.success) parts.push(`${b.success} ✓`);
+  if (b.partial) parts.push(`${b.partial} partial`);
+  if (b.failure) parts.push(`${b.failure} ✗`);
+  if (b.stopped) parts.push(`${b.stopped} stopped`);
+  if (b.running) parts.push(`${b.running} running`);
+  return parts.join(' · ');
+}
+
+const MARK: Record<string, string> = { success: '✓', partial: '◐', failure: '✗', stopped: '·', running: '…' };
+
+function signalLine(m: DigestModel): string {
+  const s = m.signals;
+  const parts: string[] = [];
+  if (s.tasksCreated || s.tasksCompleted) parts.push(`${s.tasksCompleted}/${s.tasksCreated} tasks done`);
+  if (s.approvals) parts.push(`${s.approvals} approved`);
+  if (s.rejected) parts.push(`${s.rejected} rejected`);
+  if (s.budgetStops) parts.push(`${s.budgetStops} budget stops`);
+  if (s.errors) parts.push(`${s.errors} errors`);
+  return parts.join(' · ');
+}
+
+/** Slack mrkdwn (`*bold*`, `_italic_`). One combined message: 📋 Today + 🧠 Learned. */
+export function renderSlack(os: AgentOS, m: DigestModel): string {
+  const name = os.tenant.charAt(0).toUpperCase() + os.tenant.slice(1);
+  const out: string[] = [`*📋 ${name} — ${m.label}*`, `_${tally(m)}_`];
+  const sig = signalLine(m);
+  if (sig) out.push(`_${sig}_`);
+  out.push('');
+  if (!m.byAgent.length) out.push('_No notable sessions today._');
+  for (const a of m.byAgent) {
+    out.push(`*${a.agent}*`);
+    for (const l of a.lines) out.push(`• ${l.title} ${MARK[l.outcome] ?? ''}`.trimEnd());
+    if (a.more) out.push(`• _+${a.more} more_`);
+  }
+  if (m.guidance.length || m.recommendations.length) {
+    out.push('', '*🧠 Learned*');
+    for (const g of m.guidance) out.push(`• ${g}`);
+    for (const r of m.recommendations) out.push(`⚠️ _Recommend:_ ${r}`);
+  }
+  return out.join('\n');
+}
+
+/** GitHub-flavoured markdown for the dated KB journal page. */
+export function renderMarkdown(os: AgentOS, m: DigestModel): string {
+  const out: string[] = [
+    `_Fleet daily digest — auto-generated from today's session episodes + the self-learning pass. Rebuilds on demand._`,
+    ``,
+    `**${m.label}** · ${tally(m)}`,
+  ];
+  const sig = signalLine(m);
+  if (sig) out.push(``, `_${sig}_`);
+  out.push(``, `## What got done`);
+  if (!m.byAgent.length) out.push(`- (no notable sessions today)`);
+  for (const a of m.byAgent) {
+    out.push(``, `### ${a.agent}`);
+    for (const l of a.lines) out.push(`- ${MARK[l.outcome] ?? ''} ${l.title}`.replace('  ', ' '));
+    if (a.more) out.push(`- _+${a.more} more_`);
+  }
+  if (m.guidance.length || m.recommendations.length) {
+    out.push(``, `## Learned (Dreaming)`);
+    for (const g of m.guidance) out.push(`- ${g}`);
+    for (const r of m.recommendations) out.push(`- ⚠️ **Recommend:** ${r}`);
+  }
+  return out.join('\n');
+}
+
+export interface PostResult { posted: boolean; reason?: string; error?: string; channel?: string; total: number; iso: string }
+
+export class Digest {
+  constructor(private readonly os: AgentOS) {}
+
+  /** Today's model — the console/dashboard read path. */
+  today(now = new Date()): DigestModel {
+    return buildDigest(this.os, now);
+  }
+
+  /** Write (or refresh) today's dated KB journal page from the current model. No Slack. Best-effort. */
+  refresh(by = 'scheduler', now = new Date()): DigestModel {
+    const m = buildDigest(this.os, now);
+    try {
+      const page = this.os.kb.write({
+        tenant: this.os.tenant, section: SECTION, slug: `daily/${m.iso}`,
+        title: `Daily digest — ${m.label}`, body: renderMarkdown(this.os, m),
+        tags: ['digest', 'operations'], summary: `${m.total} sessions`, author: by,
+      });
+      this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'kb.written', data: { id: page.id, section: page.section, slug: page.slug, rev: page.rev } });
+    } catch { /* KB write is a nicety — never throw */ }
+    return m;
+  }
+
+  /** Render today, refresh the KB page, and post the combined digest to the configured Slack channel.
+   *  Ignores the hour/once-per-day gate (that's `maybePostEod`'s job) — this is the manual "post now"
+   *  path too. Empty day → refresh the KB page but skip the Slack post (no channel noise on a quiet day). */
+  async postNow(by = 'scheduler', now = new Date()): Promise<PostResult> {
+    const m = this.refresh(by, now);
+    const base = { total: m.total, iso: m.iso };
+    if (m.total === 0) return { ...base, posted: false, reason: 'no sessions today' };
+
+    const token = this.os.settings.slackBotToken();
+    if (!token) return { ...base, posted: false, error: 'Slack is not configured' };
+    const ref = this.os.settings.digestChannel();
+    if (!ref) return { ...base, posted: false, error: 'no digest channel set' };
+
+    let channelId = ref;
+    if (!/^[CGD][A-Z0-9]{6,}$/.test(ref)) {
+      const found = await lookupChannelByName(token, ref);
+      if ('error' in found) return { ...base, posted: false, error: `channel "${ref}": ${found.error}` };
+      channelId = found.channel;
+    }
+    await joinChannel(token, channelId).catch(() => undefined); // best-effort (public channels)
+
+    const r = await postMessage(token, channelId, renderSlack(this.os, m));
+    if ('error' in r) {
+      this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'digest.error', data: { channel: ref, error: r.error } });
+      return { ...base, posted: false, channel: ref, error: r.error };
+    }
+    this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'digest.posted', data: { channel: ref, total: m.total, iso: m.iso } });
+    return { ...base, posted: true, channel: ref };
+  }
+
+  /** The scheduled EOD hook (called from the hourly upkeep tick). Posts once per server-local day, only
+   *  when enabled, a channel is set, the hour has arrived, and today hasn't been posted yet. */
+  async maybePostEod(now = new Date()): Promise<PostResult | null> {
+    const s = this.os.settings;
+    if (!s.digestEnabled() || !s.digestChannel()) return null;
+    if (now.getHours() < s.digestHour()) return null;
+    const { start, iso } = localDayBounds(now);
+    const last = this.os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'digest.posted'").get<{ t: number | null }>();
+    if (last?.t && last.t >= start) return null; // already posted today
+    return this.postNow('scheduler', now).catch((e) => ({ posted: false, error: e instanceof Error ? e.message : String(e), total: 0, iso }));
+  }
+}

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -31,6 +31,9 @@ const RUNTIME_DEFAULTS_KEY = 'runtime_defaults'; // workspace-wide model/effort/
 const DREAMING_KEY = 'dreaming_every_hours'; // self-learning cadence in hours; 0/unset = off
 const GOALS_INJECT_KEY = 'goals_inject'; // whether active goals ride in every agent's prompt (default on)
 const GOALS_AUTOPLAN_KEY = 'goals_autoplan'; // whether the scheduler auto-plans stuck goals (default OFF — opt-in)
+const DIGEST_ENABLED_KEY = 'digest_enabled'; // whether the end-of-day fleet digest posts to Slack ('on'|'off')
+const DIGEST_CHANNEL_KEY = 'digest_channel'; // Slack channel (id or name) the EOD digest posts to; '' = unset
+const DIGEST_HOUR_KEY = 'digest_hour'; // server-local hour (0–23) the EOD digest fires at; default 18
 const DREAMING_STATE_KEY = 'dreaming_state'; // compounding self-learning state (cumulative totals/topics/recent)
 const LEARNED_GUIDANCE_KEY = 'learned_guidance'; // distilled imperatives injected into every agent's prompt
 const LEARNED_APPLY_KEY = 'learned_guidance_apply'; // 'off' to stop injecting (default on once guidance exists)
@@ -431,6 +434,46 @@ export class SettingsStore {
   }
   setDreamingState(state: Record<string, unknown>, by?: string): void {
     this.set(DREAMING_STATE_KEY, JSON.stringify(state), by);
+  }
+
+  // ── daily digest (the "what got done today" standup) ─────────────────────────────
+  // A tenant-wide end-of-day summary — the per-session changelog (from episodes) + Dreaming's learned
+  // guidance — posted once a day to a Slack channel. It rides the same hourly upkeep tick as Dreaming;
+  // the dashboard/KB render live on demand, only the Slack post is time-gated (digestHour + a once-per-
+  // day `digest.posted` audit guard). Time is server-local (the deploy box's tz); a per-tenant tz can
+  // layer on later. Enabled only takes effect once a channel is set.
+
+  /** Whether the EOD digest posts to Slack. Off by default (opt-in — it posts to a channel). */
+  digestEnabled(): boolean {
+    return this.getRow(DIGEST_ENABLED_KEY)?.value === 'on';
+  }
+  setDigestEnabled(on: boolean, by?: string): boolean {
+    this.set(DIGEST_ENABLED_KEY, on ? 'on' : 'off', by);
+    return this.digestEnabled();
+  }
+  /** The Slack channel (id like `C123…` or a name like `#fleet`) the digest posts to; '' when unset. */
+  digestChannel(): string {
+    return this.getRow(DIGEST_CHANNEL_KEY)?.value?.trim() ?? '';
+  }
+  setDigestChannel(channel: string, by?: string): void {
+    this.set(DIGEST_CHANNEL_KEY, channel.trim(), by);
+  }
+  /** Server-local hour (0–23) the EOD digest fires at; default 18 (6pm). */
+  digestHour(): number {
+    const n = Number(this.getRow(DIGEST_HOUR_KEY)?.value);
+    return Number.isInteger(n) && n >= 0 && n <= 23 ? n : 18;
+  }
+  setDigestHour(hour: number, by?: string): number {
+    const n = Number(hour);
+    const clamped = Number.isFinite(n) ? Math.min(Math.max(Math.floor(n), 0), 23) : 18;
+    this.set(DIGEST_HOUR_KEY, String(clamped), by);
+    return this.digestHour();
+  }
+  /** Who last touched the digest config (never a secret — the channel is not sensitive). */
+  digestMeta(): { updatedAt?: number; updatedBy?: string } {
+    const rows = [this.getRow(DIGEST_ENABLED_KEY), this.getRow(DIGEST_CHANNEL_KEY), this.getRow(DIGEST_HOUR_KEY)].filter(Boolean) as SettingRow[];
+    const newest = rows.sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0))[0];
+    return { updatedAt: newest?.updated_at, updatedBy: newest?.updated_by ?? undefined };
   }
 
   // ── learned guidance (the closed loop) ───────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
 import { DreamingEngine } from './edge/dreaming';
 import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
+import { Digest } from './edge/digest';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -284,6 +285,10 @@ export function startServer(port = Number(process.env.PORT) || 3010): http.Serve
         .then(() => new Consolidation(os, rt.tm).run('automation:consolidation'))
         .catch(() => { /* never let the scheduler crash the server */ });
     }
+    // Daily digest — the "what got done today" standup. Rides this same hourly tick but gates its own
+    // Slack post (enabled + channel + past digestHour + not yet posted today); the dashboard/KB render
+    // live on demand, so nothing here is needed to keep them fresh. No-op unless the tenant opted in.
+    void new Digest(os).maybePostEod().catch(() => { /* never let the digest crash the scheduler */ });
   }), 3_600_000);
   upkeep.unref?.();
 
@@ -2289,7 +2294,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/dreaming') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const last = os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'learning.dreamed'").get<{ t: number | null }>();
-    return sendJson(res, 200, { everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined, applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open });
+    const lastPosted = os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'digest.posted'").get<{ t: number | null }>();
+    return sendJson(res, 200, {
+      everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined,
+      applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open,
+      digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
+    });
   }
   // Apply / dismiss a config recommendation (human-gated — nothing auto-applies).
   const recMatch = p.match(/^\/api\/dreaming\/recommendation\/([\w.-]+)\/(apply|dismiss)$/);
@@ -2319,7 +2329,28 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const b = await readBody(req);
     if (b.everyHours !== undefined) os.settings.setDreamingEveryHours(Number(b.everyHours) || 0, me.email);
     if (typeof b.applyLearnings === 'boolean') os.settings.setApplyLearnings(b.applyLearnings, me.email);
-    return sendJson(res, 200, { ok: true, everyHours: os.settings.dreamingEveryHours(), applyLearnings: os.settings.applyLearnings() });
+    if (b.digest && typeof b.digest === 'object') {
+      const d = b.digest as { enabled?: boolean; channel?: string; hour?: number };
+      if (typeof d.enabled === 'boolean') os.settings.setDigestEnabled(d.enabled, me.email);
+      if (d.channel !== undefined) os.settings.setDigestChannel(String(d.channel), me.email);
+      if (d.hour !== undefined) os.settings.setDigestHour(Number(d.hour), me.email);
+    }
+    return sendJson(res, 200, { ok: true, everyHours: os.settings.dreamingEveryHours(), applyLearnings: os.settings.applyLearnings(), digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), hour: os.settings.digestHour() } });
+  }
+  // The daily digest — today's model for the console dashboard (owner/admin), live from the DB.
+  if (method === 'GET' && p === '/api/digest/today') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, new Digest(os).today());
+  }
+  // Post today's digest to Slack now (manual "post now" button). Refreshes the KB page even on a quiet day.
+  if (method === 'POST' && p === '/api/digest/post') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    try {
+      const r = await new Digest(os).postNow(me.email);
+      return sendJson(res, 200, { ok: true, ...r });
+    } catch (e) {
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
   }
   // One "reflect" action: the cheap deterministic pass, then the memory-gardener over new material
   // (spawns a headless agent that grows shared memories + KB; no-ops when there's too little).
@@ -2333,6 +2364,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       } catch (e) {
         consolidation = { spawned: false, reason: e instanceof Error ? e.message : String(e) };
       }
+      // Refresh today's digest KB page off the freshly-updated guidance — but never post to Slack from a
+      // manual reflect (the channel is pinged only by the scheduled EOD trigger).
+      try { new Digest(os).refresh(me.email); } catch { /* best-effort */ }
       return sendJson(res, 200, { ok: true, ...dream, consolidation });
     } catch (e) {
       return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage } from '@/connectors'
@@ -7643,10 +7643,27 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const [result, setResult] = useState<string>('')
+  const [digest, setDigest] = useState<DigestConfig>({ enabled: false, channel: '', hour: 18 })
+  const [digestHint, setDigestHint] = useState('')
+  const [preview, setPreview] = useState<DigestModel | null>(null)
 
   const refresh = () => {
-    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []) }).catch(() => {})
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); if (r.digest) setDigest(r.digest) }).catch(() => {})
     api.memoryOverview().then((r) => { if (!r.error) setActivity(r.activity ?? []) }).catch(() => {})
+    api.digestToday().then((r) => { if (!r.error) setPreview(r) }).catch(() => {})
+  }
+  const saveDigest = async (patch: Partial<DigestConfig>) => {
+    const next = { ...digest, ...patch }; setDigest(next); setDigestHint('')
+    const r = await api.setDigest({ enabled: next.enabled, channel: next.channel, hour: next.hour })
+    if (r.error) return setDigestHint('⚠ ' + r.error)
+    if (r.digest) setDigest((d) => ({ ...d, ...r.digest })); setDigestHint('saved'); setTimeout(() => setDigestHint(''), 1500)
+  }
+  const postDigest = async () => {
+    setBusy(true); setDigestHint('')
+    const r = await api.digestPost(); setBusy(false)
+    if (r.error) return setDigestHint('⚠ ' + r.error)
+    setDigestHint(r.posted ? `posted to ${r.channel} (${r.total} sessions)` : `not posted — ${r.reason ?? 'nothing to post'}`)
+    setTimeout(() => setDigestHint(''), 3000); refresh()
   }
   const applyRec = async (id: string) => { setBusy(true); const r = await api.applyRecommendation(id); setBusy(false); if (r.error) return setHint('⚠ ' + r.error); setHint('applied'); setTimeout(() => setHint(''), 1500); refresh() }
   const dismissRec = async (id: string) => { setBusy(true); await api.dismissRecommendation(id); setBusy(false); refresh() }
@@ -7718,6 +7735,49 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
               ? <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-md border bg-muted/40 p-3 text-[11px] leading-relaxed">{guidance}</pre>
               : <div className="text-xs text-muted-foreground">No guidance yet — run a pass (above) once agents have done some work.</div>}
           </div>
+        </CardContent>
+      </Card>
+
+      {/* The daily digest: a "what got done today" standup posted to Slack at end of day. */}
+      <Card>
+        <CardContent className="space-y-3 p-4">
+          <div>
+            <div className="text-sm font-medium">Daily digest <span className="text-[11px] font-normal text-muted-foreground">— the end-of-day standup</span></div>
+            <p className="text-xs text-muted-foreground">A tenant-wide <strong>“what got done today”</strong> summary — the per-session changelog (from session episodes) plus the learned guidance above — posted to Slack once a day. It rides the same reflect pass; the preview below renders live. Manual <em>Post now</em> and <em>Reflect now</em> never surprise the channel — only the scheduled end-of-day run posts.</p>
+          </div>
+          <label className="flex items-center gap-2 text-sm">
+            <input type="checkbox" checked={digest.enabled} onChange={(e) => saveDigest({ enabled: e.target.checked })} />
+            Post the daily digest to Slack automatically
+          </label>
+          {!digest.slackConfigured && <div className="text-[11px] text-amber-600">Slack isn’t configured — set the bot token in <a className="underline" href="#/settings">Integrations</a> first.</div>}
+          <div className="flex flex-wrap items-end gap-3">
+            <Field label="Slack channel" help="Channel id (C…) or name (#fleet). The bot auto-joins public channels.">
+              <Input value={digest.channel} onChange={(e) => setDigest({ ...digest, channel: e.target.value })} onBlur={() => saveDigest({ channel: digest.channel })} className="w-44 font-mono text-xs" placeholder="#fleet" />
+            </Field>
+            <Field label="Post at (hour, 0–23)" help="Server-local. Fires on the next hourly tick past this hour.">
+              <Input value={String(digest.hour)} onChange={(e) => setDigest({ ...digest, hour: Number(e.target.value) || 0 })} onBlur={() => saveDigest({ hour: digest.hour })} className="w-20 font-mono text-xs" placeholder="18" />
+            </Field>
+            <Button variant="outline" onClick={postDigest} disabled={busy}><Send className="mr-1 h-4 w-4" />Post now</Button>
+            {digestHint && <span className="font-mono text-xs text-muted-foreground">{digestHint}</span>}
+          </div>
+          <div className="text-[11px] text-muted-foreground">{digest.lastPostedAt ? `Last posted: ${new Date(digest.lastPostedAt).toLocaleString()}.` : 'Not posted yet.'}</div>
+          {preview && (
+            <div>
+              <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">Today so far — preview</div>
+              <div className="rounded-md border bg-muted/40 p-3 text-xs">
+                <div className="font-medium">📋 {preview.label} · {preview.total} session{preview.total === 1 ? '' : 's'} · {preview.buckets.success} ✓{preview.buckets.failure ? ` · ${preview.buckets.failure} ✗` : ''}{preview.buckets.stopped ? ` · ${preview.buckets.stopped} stopped` : ''}</div>
+                {preview.byAgent.length === 0
+                  ? <div className="mt-1 text-muted-foreground">No notable sessions yet today.</div>
+                  : preview.byAgent.map((a) => (
+                      <div key={a.agent} className="mt-2">
+                        <div className="font-medium">{a.agent}</div>
+                        {a.lines.map((l, i) => <div key={i} className="truncate text-muted-foreground">• {l.title}</div>)}
+                        {a.more > 0 && <div className="text-muted-foreground">• +{a.more} more</div>}
+                      </div>
+                    ))}
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -258,6 +258,23 @@ export interface Recommendation {
   link?: string
   createdAt: number
 }
+export interface DigestConfig {
+  enabled: boolean
+  channel: string
+  hour: number
+  slackConfigured?: boolean
+  lastPostedAt?: number
+}
+export interface DigestModel {
+  iso: string
+  label: string
+  total: number
+  buckets: { success: number; partial: number; failure: number; stopped: number; running: number; other: number }
+  byAgent: { agent: string; lines: { title: string; outcome: string; importance: number }[]; more: number }[]
+  signals: { tasksCreated: number; tasksCompleted: number; approvals: number; rejected: number; errors: number; budgetStops: number }
+  guidance: string[]
+  recommendations: string[]
+}
 export interface KbRevision {
   id: string
   pageId: string
@@ -1039,13 +1056,17 @@ export const api = {
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
   planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),
   setApplyLearnings: (applyLearnings: boolean) => call<{ ok: boolean; applyLearnings: boolean; error?: string }>('PUT', '/api/dreaming', { applyLearnings }),
   // One "reflect" pass: cheap deterministic tally + the memory-gardener over new material (nested `consolidation`).
   dreamingRun: () => call<{ ok: boolean; skipped?: boolean; sessions?: number; episodes?: number; kbPageId?: string; insightId?: string; guidance?: string; consolidation?: { spawned?: boolean; reason?: string; sessionId?: string; items?: number }; error?: string }>('POST', '/api/dreaming/run'),
+  // Daily digest — the "what got done today" standup (rides the Dreaming pass; posts to Slack at EOD).
+  setDigest: (digest: { enabled?: boolean; channel?: string; hour?: number }) => call<{ ok: boolean; digest: DigestConfig; error?: string }>('PUT', '/api/dreaming', { digest }),
+  digestToday: () => call<DigestModel & { error?: string }>('GET', '/api/digest/today'),
+  digestPost: () => call<{ ok: boolean; posted: boolean; reason?: string; channel?: string; total: number; iso: string; error?: string }>('POST', '/api/digest/post'),
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),


### PR DESCRIPTION
## What

A tenant-wide **end-of-day digest** — "what got done today" — posted to Slack, in two halves:

- **📋 Today** — the per-session changelog, grouped by agent.
- **🧠 Learned** — Dreaming's distilled guidance + open recommendations.

### The key insight: no new capture, no LLM
Every session end already writes a deterministic episode (`writeEpisode` → `composeEpisode`) graded by `episodeSalience`. The digest is a pure **read + render** over those episodes ⋈ sessions ⋈ audit signals.

### Rides the Dreaming pass, not a new timer
The dashboard/KB render live on demand; only the Slack post is time-gated — **once per server-local day** past `digestHour` (default 18), guarded by a `digest.posted` audit. Manual **Reflect now** / **Post now** refresh the KB page but never surprise the channel (only the scheduled EOD run posts). Each day lands a dated, revisioned KB page at `operations/daily/<date>`.

### Salience (refined against real data)
Body = episodes with `importance ≥ 0.5` **OR** any `done` session with a substantive report title. The `OR` matters: several real `done` sessions ("Shipped PR #333") carried no episode yet are exactly what the digest is for; a pure importance threshold dropped them.

## Changes
- `src/edge/digest.ts` — `buildDigest` + `renderSlack`/`renderMarkdown` + `Digest` (`today`/`refresh`/`postNow`/`maybePostEod`)
- `settings` — `digestEnabled`/`digestChannel`/`digestHour`
- `server` — `maybePostEod` on the hourly tick; KB refresh on `/api/dreaming/run`; `GET /api/digest/today`, `POST /api/digest/post`, digest fields on `/api/dreaming`
- `web` — config + live "today so far" preview in **Settings → Learning**
- `docs/daily-digest-plan.md`

## Validation
- Rendered against a **copy** of live instapods data (20 sessions) — noise thresholded out, engineer's 3 PRs + staged newsletter surfaced. Live DB untouched.
- **Authenticated in-process round-trip** of all three routes (`GET /api/digest/today` 200, `PUT` persists, `POST /api/digest/post` safely no-ops without Slack).
- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` (68/68) all green.

## Notes / deferred
- Timezone = **server-local** (single-box deploy); per-tenant tz can layer on later.
- Standalone **"Today" dashboard** nav page deferred — the KB daily page + the Settings preview cover the need for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)