### PR TITLE
feat(digest): post the daily digest to Discord too (v0.149.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.149.0] — 2026-07-13
+### Added
+- **Daily digest now posts to Discord too (and Slack, and both).** The end-of-day digest was Slack-only,
+  but a tenant may run Discord instead — the live instapods tenant has a Discord bot and no Slack, so the
+  digest couldn't post at all there. `Digest.postNow` now fans out to **every configured chat platform**:
+  Slack (if a bot token + `digestChannel`) and/or Discord (if a bot token + `digestDiscordChannel`, a
+  channel id — Discord posts by id, no name lookup). New `renderDiscord` uses Discord markdown and honours
+  the 2000-char cap (trims to the daily KB page). The once-per-day `digest.posted` guard and EOD hour gate
+  are unchanged and cover both platforms; per-platform failures are audited (`digest.error`) without
+  blocking the other. Settings → Learning shows a channel field per configured platform. New setting
+  `digestDiscordChannel`; `discordChannel`/`discordConfigured` added to `GET`/`PUT /api/dreaming`.
+
 ## [0.148.0] — 2026-07-13
 ### Added
 - **Task blocker chips on the Kanban board cards.** A card now shows the tasks it's *blocked by* directly —

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.148.0",
+  "version": "0.149.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.148.0",
+      "version": "0.149.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.148.0",
+  "version": "0.149.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/digest.ts
+++ b/src/edge/digest.ts
@@ -12,12 +12,14 @@
  *     already produces these; the digest is the delivery they never had.
  *
  * Delivery, all sharing existing seams: a dated KB journal page (`operations/daily/<date>`, browsable +
- * revisioned) and one combined Slack post at end of day. The render is pure + on-demand (the console
- * "today" view and the KB page rebuild live); only the Slack post is time-gated — once per server-local
+ * revisioned) and one combined post to every configured chat platform (Slack and/or Discord) at end of
+ * day. The render is pure + on-demand (the console "today" view and the KB page rebuild live); only the
+ * chat post is time-gated — once per server-local
  * day past `digestHour`, guarded by a `digest.posted` audit. See docs/daily-digest-plan.md.
  */
 import type { AgentOS } from '../kernel';
-import { postMessage, lookupChannelByName, joinChannel } from '../connectors/slack';
+import { postMessage as slackPost, lookupChannelByName, joinChannel } from '../connectors/slack';
+import { postMessage as discordPost } from '../connectors/discord';
 
 const SECTION = 'operations';
 const SALIENCE = 0.5;          // episodes at/above this importance make the body; the rest count in the tally only
@@ -190,7 +192,32 @@ export function renderMarkdown(os: AgentOS, m: DigestModel): string {
   return out.join('\n');
 }
 
-export interface PostResult { posted: boolean; reason?: string; error?: string; channel?: string; total: number; iso: string }
+/** Discord message content — standard markdown (`**bold**`), same two sections as Slack. Discord hard-
+ *  caps a message at 2000 chars, so the body is trimmed with a "…more in the daily page" tail if long. */
+export function renderDiscord(os: AgentOS, m: DigestModel): string {
+  const name = os.tenant.charAt(0).toUpperCase() + os.tenant.slice(1);
+  const out: string[] = [`**📋 ${name} — ${m.label}**`, tally(m)];
+  const sig = signalLine(m);
+  if (sig) out.push(sig);
+  out.push('');
+  if (!m.byAgent.length) out.push('_No notable sessions today._');
+  for (const a of m.byAgent) {
+    out.push(`**${a.agent}**`);
+    for (const l of a.lines) out.push(`• ${l.title} ${MARK[l.outcome] ?? ''}`.trimEnd());
+    if (a.more) out.push(`• _+${a.more} more_`);
+  }
+  if (m.guidance.length || m.recommendations.length) {
+    out.push('', '**🧠 Learned**');
+    for (const g of m.guidance) out.push(`• ${g}`);
+    for (const r of m.recommendations) out.push(`⚠️ **Recommend:** ${r}`);
+  }
+  const text = out.join('\n');
+  if (text.length <= 2000) return text;
+  return text.slice(0, 1900).replace(/\n[^\n]*$/, '') + '\n… _full digest in the daily Knowledge page_';
+}
+
+export interface PostResult { posted: boolean; reason?: string; error?: string; channel?: string; total: number; iso: string; platforms?: PlatformPost[] }
+export interface PlatformPost { platform: 'slack' | 'discord'; posted: boolean; channel: string; error?: string }
 
 export class Digest {
   constructor(private readonly os: AgentOS) {}
@@ -214,41 +241,66 @@ export class Digest {
     return m;
   }
 
-  /** Render today, refresh the KB page, and post the combined digest to the configured Slack channel.
-   *  Ignores the hour/once-per-day gate (that's `maybePostEod`'s job) — this is the manual "post now"
-   *  path too. Empty day → refresh the KB page but skip the Slack post (no channel noise on a quiet day). */
+  /** Whether at least one chat platform is set up to receive the digest (a bot token + a channel). */
+  hasTarget(): boolean {
+    const s = this.os.settings;
+    return (!!s.slackBotToken() && !!s.digestChannel()) || (!!s.discordBotToken() && !!s.digestDiscordChannel());
+  }
+
+  /** Render today, refresh the KB page, and post the combined digest to EVERY configured chat platform
+   *  (Slack and/or Discord — whichever has a bot token + a channel). Ignores the hour/once-per-day gate
+   *  (that's `maybePostEod`'s job) — this is the manual "post now" path too. Empty day → refresh the KB
+   *  page but skip the posts (no channel noise on a quiet day). */
   async postNow(by = 'scheduler', now = new Date()): Promise<PostResult> {
     const m = this.refresh(by, now);
     const base = { total: m.total, iso: m.iso };
     if (m.total === 0) return { ...base, posted: false, reason: 'no sessions today' };
+    if (!this.hasTarget()) return { ...base, posted: false, error: 'no chat platform configured (set a Slack or Discord channel)' };
 
+    const platforms: PlatformPost[] = [];
+    const s = this.os.settings;
+    if (s.slackBotToken() && s.digestChannel()) platforms.push(await this.postSlack(m));
+    if (s.discordBotToken() && s.digestDiscordChannel()) platforms.push(await this.postDiscord(m));
+
+    const posted = platforms.some((p) => p.posted);
+    for (const p of platforms.filter((p) => !p.posted)) {
+      this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'digest.error', data: { platform: p.platform, channel: p.channel, error: p.error } });
+    }
+    if (posted) {
+      this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'digest.posted', data: { total: m.total, iso: m.iso, platforms: platforms.filter((p) => p.posted).map((p) => ({ platform: p.platform, channel: p.channel })) } });
+    }
+    return { ...base, posted, platforms, error: posted ? undefined : platforms[0]?.error };
+  }
+
+  /** Post to Slack: resolve the channel (id or name), best-effort join, send the mrkdwn render. */
+  private async postSlack(m: DigestModel): Promise<PlatformPost> {
     const token = this.os.settings.slackBotToken();
-    if (!token) return { ...base, posted: false, error: 'Slack is not configured' };
     const ref = this.os.settings.digestChannel();
-    if (!ref) return { ...base, posted: false, error: 'no digest channel set' };
-
     let channelId = ref;
     if (!/^[CGD][A-Z0-9]{6,}$/.test(ref)) {
       const found = await lookupChannelByName(token, ref);
-      if ('error' in found) return { ...base, posted: false, error: `channel "${ref}": ${found.error}` };
+      if ('error' in found) return { platform: 'slack', posted: false, channel: ref, error: `channel "${ref}": ${found.error}` };
       channelId = found.channel;
     }
     await joinChannel(token, channelId).catch(() => undefined); // best-effort (public channels)
+    const r = await slackPost(token, channelId, renderSlack(this.os, m));
+    return 'error' in r ? { platform: 'slack', posted: false, channel: ref, error: r.error } : { platform: 'slack', posted: true, channel: ref };
+  }
 
-    const r = await postMessage(token, channelId, renderSlack(this.os, m));
-    if ('error' in r) {
-      this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'digest.error', data: { channel: ref, error: r.error } });
-      return { ...base, posted: false, channel: ref, error: r.error };
-    }
-    this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'digest.posted', data: { channel: ref, total: m.total, iso: m.iso } });
-    return { ...base, posted: true, channel: ref };
+  /** Post to Discord: send the markdown render to the configured channel id (Discord has no name lookup). */
+  private async postDiscord(m: DigestModel): Promise<PlatformPost> {
+    const token = this.os.settings.discordBotToken();
+    const channel = this.os.settings.digestDiscordChannel();
+    const r = await discordPost(token, channel, renderDiscord(this.os, m));
+    return 'error' in r ? { platform: 'discord', posted: false, channel, error: r.error } : { platform: 'discord', posted: true, channel };
   }
 
   /** The scheduled EOD hook (called from the hourly upkeep tick). Posts once per server-local day, only
-   *  when enabled, a channel is set, the hour has arrived, and today hasn't been posted yet. */
+   *  when enabled, at least one chat platform is configured, the hour has arrived, and today hasn't been
+   *  posted yet. */
   async maybePostEod(now = new Date()): Promise<PostResult | null> {
     const s = this.os.settings;
-    if (!s.digestEnabled() || !s.digestChannel()) return null;
+    if (!s.digestEnabled() || !this.hasTarget()) return null;
     if (now.getHours() < s.digestHour()) return null;
     const { start, iso } = localDayBounds(now);
     const last = this.os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'digest.posted'").get<{ t: number | null }>();

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -33,6 +33,7 @@ const GOALS_INJECT_KEY = 'goals_inject'; // whether active goals ride in every a
 const GOALS_AUTOPLAN_KEY = 'goals_autoplan'; // whether the scheduler auto-plans stuck goals (default OFF — opt-in)
 const DIGEST_ENABLED_KEY = 'digest_enabled'; // whether the end-of-day fleet digest posts to Slack ('on'|'off')
 const DIGEST_CHANNEL_KEY = 'digest_channel'; // Slack channel (id or name) the EOD digest posts to; '' = unset
+const DIGEST_DISCORD_CHANNEL_KEY = 'digest_discord_channel'; // Discord channel id the EOD digest posts to; '' = unset
 const DIGEST_HOUR_KEY = 'digest_hour'; // server-local hour (0–23) the EOD digest fires at; default 18
 const DREAMING_STATE_KEY = 'dreaming_state'; // compounding self-learning state (cumulative totals/topics/recent)
 const LEARNED_GUIDANCE_KEY = 'learned_guidance'; // distilled imperatives injected into every agent's prompt
@@ -458,6 +459,13 @@ export class SettingsStore {
   setDigestChannel(channel: string, by?: string): void {
     this.set(DIGEST_CHANNEL_KEY, channel.trim(), by);
   }
+  /** The Discord channel id the digest posts to; '' when unset. (Discord has no name lookup — id only.) */
+  digestDiscordChannel(): string {
+    return this.getRow(DIGEST_DISCORD_CHANNEL_KEY)?.value?.trim() ?? '';
+  }
+  setDigestDiscordChannel(channel: string, by?: string): void {
+    this.set(DIGEST_DISCORD_CHANNEL_KEY, channel.trim(), by);
+  }
   /** Server-local hour (0–23) the EOD digest fires at; default 18 (6pm). */
   digestHour(): number {
     const n = Number(this.getRow(DIGEST_HOUR_KEY)?.value);
@@ -471,7 +479,7 @@ export class SettingsStore {
   }
   /** Who last touched the digest config (never a secret — the channel is not sensitive). */
   digestMeta(): { updatedAt?: number; updatedBy?: string } {
-    const rows = [this.getRow(DIGEST_ENABLED_KEY), this.getRow(DIGEST_CHANNEL_KEY), this.getRow(DIGEST_HOUR_KEY)].filter(Boolean) as SettingRow[];
+    const rows = [this.getRow(DIGEST_ENABLED_KEY), this.getRow(DIGEST_CHANNEL_KEY), this.getRow(DIGEST_DISCORD_CHANNEL_KEY), this.getRow(DIGEST_HOUR_KEY)].filter(Boolean) as SettingRow[];
     const newest = rows.sort((a, b) => (b.updated_at ?? 0) - (a.updated_at ?? 0))[0];
     return { updatedAt: newest?.updated_at, updatedBy: newest?.updated_by ?? undefined };
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2298,7 +2298,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, {
       everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined,
       applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open,
-      digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
+      digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
     });
   }
   // Apply / dismiss a config recommendation (human-gated — nothing auto-applies).
@@ -2330,12 +2330,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (b.everyHours !== undefined) os.settings.setDreamingEveryHours(Number(b.everyHours) || 0, me.email);
     if (typeof b.applyLearnings === 'boolean') os.settings.setApplyLearnings(b.applyLearnings, me.email);
     if (b.digest && typeof b.digest === 'object') {
-      const d = b.digest as { enabled?: boolean; channel?: string; hour?: number };
+      const d = b.digest as { enabled?: boolean; channel?: string; discordChannel?: string; hour?: number };
       if (typeof d.enabled === 'boolean') os.settings.setDigestEnabled(d.enabled, me.email);
       if (d.channel !== undefined) os.settings.setDigestChannel(String(d.channel), me.email);
+      if (d.discordChannel !== undefined) os.settings.setDigestDiscordChannel(String(d.discordChannel), me.email);
       if (d.hour !== undefined) os.settings.setDigestHour(Number(d.hour), me.email);
     }
-    return sendJson(res, 200, { ok: true, everyHours: os.settings.dreamingEveryHours(), applyLearnings: os.settings.applyLearnings(), digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), hour: os.settings.digestHour() } });
+    return sendJson(res, 200, { ok: true, everyHours: os.settings.dreamingEveryHours(), applyLearnings: os.settings.applyLearnings(), digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour() } });
   }
   // The daily digest — today's model for the console dashboard (owner/admin), live from the DB.
   if (method === 'GET' && p === '/api/digest/today') {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7689,15 +7689,17 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   }
   const saveDigest = async (patch: Partial<DigestConfig>) => {
     const next = { ...digest, ...patch }; setDigest(next); setDigestHint('')
-    const r = await api.setDigest({ enabled: next.enabled, channel: next.channel, hour: next.hour })
+    const r = await api.setDigest({ enabled: next.enabled, channel: next.channel, discordChannel: next.discordChannel ?? '', hour: next.hour })
     if (r.error) return setDigestHint('⚠ ' + r.error)
     if (r.digest) setDigest((d) => ({ ...d, ...r.digest })); setDigestHint('saved'); setTimeout(() => setDigestHint(''), 1500)
   }
   const postDigest = async () => {
     setBusy(true); setDigestHint('')
     const r = await api.digestPost(); setBusy(false)
-    if (r.error) return setDigestHint('⚠ ' + r.error)
-    setDigestHint(r.posted ? `posted to ${r.channel} (${r.total} sessions)` : `not posted — ${r.reason ?? 'nothing to post'}`)
+    if (r.error && !r.platforms?.length) return setDigestHint('⚠ ' + r.error)
+    const where = (r.platforms ?? []).filter((p) => p.posted).map((p) => p.platform).join(' + ')
+    const failed = (r.platforms ?? []).filter((p) => !p.posted).map((p) => `${p.platform}: ${p.error}`).join('; ')
+    setDigestHint(r.posted ? `posted to ${where} (${r.total} sessions)${failed ? ` — failed ${failed}` : ''}` : `not posted — ${failed || r.reason || r.error || 'nothing to post'}`)
     setTimeout(() => setDigestHint(''), 3000); refresh()
   }
   const applyRec = async (id: string) => { setBusy(true); const r = await api.applyRecommendation(id); setBusy(false); if (r.error) return setHint('⚠ ' + r.error); setHint('applied'); setTimeout(() => setHint(''), 1500); refresh() }
@@ -7778,17 +7780,24 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
         <CardContent className="space-y-3 p-4">
           <div>
             <div className="text-sm font-medium">Daily digest <span className="text-[11px] font-normal text-muted-foreground">— the end-of-day standup</span></div>
-            <p className="text-xs text-muted-foreground">A tenant-wide <strong>“what got done today”</strong> summary — the per-session changelog (from session episodes) plus the learned guidance above — posted to Slack once a day. It rides the same reflect pass; the preview below renders live. Manual <em>Post now</em> and <em>Reflect now</em> never surprise the channel — only the scheduled end-of-day run posts.</p>
+            <p className="text-xs text-muted-foreground">A tenant-wide <strong>“what got done today”</strong> summary — the per-session changelog (from session episodes) plus the learned guidance above — posted to Slack and/or Discord once a day. It rides the same reflect pass; the preview below renders live. Manual <em>Post now</em> and <em>Reflect now</em> never surprise the channel — only the scheduled end-of-day run posts.</p>
           </div>
           <label className="flex items-center gap-2 text-sm">
             <input type="checkbox" checked={digest.enabled} onChange={(e) => saveDigest({ enabled: e.target.checked })} />
-            Post the daily digest to Slack automatically
+            Post the daily digest to chat automatically
           </label>
-          {!digest.slackConfigured && <div className="text-[11px] text-amber-600">Slack isn’t configured — set the bot token in <a className="underline" href="#/settings">Integrations</a> first.</div>}
+          {!digest.slackConfigured && !digest.discordConfigured && <div className="text-[11px] text-amber-600">No chat platform is configured — set a Slack or Discord bot token in <a className="underline" href="#/settings">Integrations</a> first.</div>}
           <div className="flex flex-wrap items-end gap-3">
-            <Field label="Slack channel" help="Channel id (C…) or name (#fleet). The bot auto-joins public channels.">
-              <Input value={digest.channel} onChange={(e) => setDigest({ ...digest, channel: e.target.value })} onBlur={() => saveDigest({ channel: digest.channel })} className="w-44 font-mono text-xs" placeholder="#fleet" />
-            </Field>
+            {digest.slackConfigured && (
+              <Field label="Slack channel" help="Channel id (C…) or name (#fleet). The bot auto-joins public channels.">
+                <Input value={digest.channel} onChange={(e) => setDigest({ ...digest, channel: e.target.value })} onBlur={() => saveDigest({ channel: digest.channel })} className="w-44 font-mono text-xs" placeholder="#fleet" />
+              </Field>
+            )}
+            {digest.discordConfigured && (
+              <Field label="Discord channel id" help="The numeric channel id (Discord posts by id, not name).">
+                <Input value={digest.discordChannel ?? ''} onChange={(e) => setDigest({ ...digest, discordChannel: e.target.value })} onBlur={() => saveDigest({ discordChannel: digest.discordChannel ?? '' })} className="w-44 font-mono text-xs" placeholder="123456789012345678" />
+              </Field>
+            )}
             <Field label="Post at (hour, 0–23)" help="Server-local. Fires on the next hourly tick past this hour.">
               <Input value={String(digest.hour)} onChange={(e) => setDigest({ ...digest, hour: Number(e.target.value) || 0 })} onBlur={() => saveDigest({ hour: digest.hour })} className="w-20 font-mono text-xs" placeholder="18" />
             </Field>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -261,8 +261,10 @@ export interface Recommendation {
 export interface DigestConfig {
   enabled: boolean
   channel: string
+  discordChannel?: string
   hour: number
   slackConfigured?: boolean
+  discordConfigured?: boolean
   lastPostedAt?: number
 }
 export interface DigestModel {
@@ -1064,9 +1066,9 @@ export const api = {
   // One "reflect" pass: cheap deterministic tally + the memory-gardener over new material (nested `consolidation`).
   dreamingRun: () => call<{ ok: boolean; skipped?: boolean; sessions?: number; episodes?: number; kbPageId?: string; insightId?: string; guidance?: string; consolidation?: { spawned?: boolean; reason?: string; sessionId?: string; items?: number }; error?: string }>('POST', '/api/dreaming/run'),
   // Daily digest — the "what got done today" standup (rides the Dreaming pass; posts to Slack at EOD).
-  setDigest: (digest: { enabled?: boolean; channel?: string; hour?: number }) => call<{ ok: boolean; digest: DigestConfig; error?: string }>('PUT', '/api/dreaming', { digest }),
+  setDigest: (digest: { enabled?: boolean; channel?: string; discordChannel?: string; hour?: number }) => call<{ ok: boolean; digest: DigestConfig; error?: string }>('PUT', '/api/dreaming', { digest }),
   digestToday: () => call<DigestModel & { error?: string }>('GET', '/api/digest/today'),
-  digestPost: () => call<{ ok: boolean; posted: boolean; reason?: string; channel?: string; total: number; iso: string; error?: string }>('POST', '/api/digest/post'),
+  digestPost: () => call<{ ok: boolean; posted: boolean; reason?: string; total: number; iso: string; error?: string; platforms?: { platform: 'slack' | 'discord'; posted: boolean; channel: string; error?: string }[] }>('POST', '/api/digest/post'),
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),


### PR DESCRIPTION
## Why

The daily digest (#249) posts to **Slack only** — but a tenant may run Discord instead. The **live instapods tenant has a Discord bot and no Slack configured**, so the digest couldn't post at all there. This wires Discord.

## What

`Digest.postNow` now fans out to **every configured chat platform**:
- **Slack** — bot token + `digestChannel` (id or name; auto-joins public channels)
- **Discord** — bot token + `digestDiscordChannel` (a **channel id** — Discord posts by id, no name lookup)

Post to both, either, or neither. Per-platform failures are audited (`digest.error`) without blocking the other; the once-per-day `digest.posted` guard + EOD hour gate are unchanged and cover both.

- `renderDiscord` — Discord markdown (`**bold**`), honours the 2000-char cap (trims with a pointer to the daily KB page)
- `settings` — `digestDiscordChannel`; `discordChannel`/`discordConfigured` on `GET`/`PUT /api/dreaming`
- `web` — Settings → Learning shows a channel field per *configured* platform; the "Post now" hint lists which platforms it hit

## Validation
- `renderDiscord` rendered against a copy of live instapods data (1709 chars, under the cap, output looks right).
- **Safety:** the copy carries the real Discord bot token, so I verified `postNow` with no channel set → `hasTarget=false` → returns "no chat platform configured" and posts **nowhere**. No accidental post to the live server.
- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` (68/68) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)