### PR TITLE
docs: document per-secret agent assignment (shell injection)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,15 @@ Key modules:
   only — headless keeps `--dangerously-skip-permissions`; unset → `auto`, which only tunes the fallback for
   tools the gate hook doesn't govern, never the gate itself). It also resolves the agent's opt-in
   **`shellSecrets`** (manifest list of vault keys, e.g. `["GH_TOKEN"]`) via `injectShellSecrets` and
-  exports each as a shell env var — the ONLY path a vault secret reaches the interactive shell (so a
-  plain CLI like `gh` authenticates); connectors still get theirs via the MCP bag. Agent-scoped
-  principal (widening to `*`), audited `shell.secret.injected`/`unresolved`, opt-in per agent. Then
+  exports each as a shell env var (so a plain CLI like `gh` authenticates); connectors still get theirs
+  via the MCP bag. Agent-scoped principal (widening to `*`), audited `shell.secret.injected`/`unresolved`.
+  A **second, admin-driven path** exports the same way: `injectAssignedSecrets` reads the
+  **`secret_assignments`** table — the inverse view of `shellSecrets`, managed from **Settings → Secrets**
+  (assign a stored secret to agents rather than declaring keys in each manifest). An assignment names the
+  secret by its `(owner-principal, key)`, so one canonical value fans out to many agents without a
+  per-agent copy; injection resolves that owner's value and exports it (audited
+  `shell.secret.injected`/`unresolved` with `via:'assignment'`). Both paths are **injection only** — an
+  assignment never widens who can `secret_get` a value. Then
   **`injectMemberGithub`** runs right after: if the run's **run-as member** linked their own GitHub
   account (per-member OAuth — `src/edge/github-identity.ts`, `docs/per-member-github-plan.md`), THEIR
   vault-stored user token OVERRIDES the agent bot's `GH_TOKEN`/`GITHUB_TOKEN`, so git/PRs are authored as
@@ -231,7 +237,10 @@ Key modules:
   also dispatches an `autoDispatch` hand-off immediately (parity with the console) instead of waiting for the tick. Secrets
   (shared credential handoff): `secret_put`/`secret_get`/`secret_list` — an agent stores a password/key
   tenant-wide under a KEY (approval-gated `secret.put`; value kept out of audit/approval-card/policy args,
-  encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. Agents
+  encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. (Complementary,
+  admin-side: **Settings → Secrets** can *assign* a stored secret to agents — `PUT /api/secrets/agents`,
+  the `secret_assignments` table — so it's injected into each assigned agent's shell at launch, the
+  central-grant inverse of manifest `shellSecrets`. Injection only, not a `secret_get` grant.) Agents
   (build + self-improve): `agent_create` (spin up a new governed teammate) and the **self-only**
   `agent_update`/`agent_history`/`agent_revert` — an agent refines its OWN listing (description, starter
   prompts, tuning) + CLAUDE.md system prompt and can roll back a bad self-edit; every change snapshots a

--- a/docs/PILLARS.md
+++ b/docs/PILLARS.md
@@ -32,7 +32,7 @@ Capabilities`), the taxonomy north-star that sits beside [`governance-model.md`]
 | 5 | Policy | ✅ | JSON rule engine + console editor (owner-edit, live hot-reload, persisted). **Learnable from the Inbox** — an approval's owner-only "Always" adds an `allow` rule (safely, after all `never` rules). Single ruleset per workspace; no dry-run simulator |
 | 6 | Audit Logs | ✅ | JSONL system-of-record + SQLite mirror + console **Audit** viewer (filter by session/type/principal) |
 | 7 | Automations | ✅ | Cron + webhook + native **Slack & Discord** triggers spawn governed sessions, run-as the sending member; a **generic `/agent` chat router** reaches any agent by name with no per-agent automation (replies threaded); **agent-scheduled one-shots** (`schedule`/`unschedule` MCP tools → `type:'once'`, bounded + human-cancellable) let an agent defer a future run of itself; email inbound still out |
-| 8 | Secrets | 🟡 | Encrypted-at-rest vault (AES-256-GCM) + console UI; connectors resolve `secret:` refs at launch; no key rotation yet |
+| 8 | Secrets | 🟡 | Encrypted-at-rest vault (AES-256-GCM) + console UI; connectors resolve `secret:` refs at launch; agents get shell env vars via manifest `shellSecrets` or per-secret agent assignment; no key rotation yet |
 | 9 | Memory layer | 🟡 | Per-agent + **shared workspace-wide** `remember`/`recall` (+ agent self-correction via `revise`/`forget`, recall returns ids) MCP server + console **Memory hub** (Overview / Memories / Self-learning tabs) live; three backends — sqlite (keyword, or hybrid keyword+vector with embeddings), libsql (native vectors), automem — switchable live in Settings → Memory backend. **Episodic↔semantic encoding loop** ships: graded auto session-end **episodes** (salience-weighted by effort+friction+outcome), deliberate **lessons** (the `report` `lessons` field), **retrieval reinforcement** (rank ↑ frequently-recalled, recency from last-use, prune the never-recalled), prune+dedupe maintenance, and tenant-scoped sharing; ANN still pending. See [`memory-encoding-and-consolidation.md`](./memory-encoding-and-consolidation.md) |
 | 10 | Dreaming / Self-learning | 🟡 | A periodic Dreamer reflects on recent episodes + outcomes + friction, **compounds** them into persisted cumulative state (growing KB page + shared memory Insight), and closes the loop two ways: (a) distilled **guidance injected into every agent's prompt** at launch, and (b) **approval-gated config recommendations** a human Applies/Dismisses. Plus the **consolidation gardener** (a governed headless `consolidator` agent that abstracts recent episodes+lessons into shared memories + KB pages) — now the second half of one **"reflect"** pass (deterministic tally then gardener), surfaced as a single **Reflect now** button in the Memory hub → Self-learning. The whole system is framed by four verbs (Capture · Recall · Distil · Apply) in [`memory-model.md`](./memory-model.md); mechanism in [`memory-encoding-and-consolidation.md`](./memory-encoding-and-consolidation.md) |
 | 11 | Company Settings | 🟡 | Company context (markdown) edited in console, appended to every claude-code agent's system prompt. Tenant branding not folded in yet |
@@ -284,6 +284,15 @@ console panel (set/replace/delete; values are write-only, never shown back).
 lives solely in the connector subprocess's env for the session's life. Principal defaults to the acting member
 (widening to `*`); an unresolved reference is blanked + audited (`connector.secret.unresolved`), never leaking
 the `secret:…` marker. So agents still get *tools*, never raw keys — the cred is decrypted inside the boundary.
+
+**Secrets into an agent's shell.** Distinct from connector refs (which reach a subprocess), a claude-code
+agent's *own* shell can get vault values as env vars at launch — so a plain CLI (`gh`, `psql`) authenticates —
+via two injection paths, both audited `shell.secret.injected`/`unresolved` and **injection only** (never a
+`secret_get` read grant): (1) the agent's manifest **`shellSecrets`** list (`injectShellSecrets`, self-declared
+per agent); and (2) **agent assignment** (`injectAssignedSecrets` over the `secret_assignments` table) — the
+inverse view, where an owner/admin assigns a stored secret to agents from **Settings → Secrets** (`PUT
+/api/secrets/agents`) instead of editing each manifest. An assignment names the secret by its `(owner-principal,
+key)`, so one canonical value fans out to many agents without a per-agent copy.
 
 **Gaps.** Master-key **rotation + re-encryption** (rotating today invalidates sealed values). A one-click
 "migrate this connector's raw creds into the vault" console action (today the admin sets the secret + edits

--- a/docs/access-model.md
+++ b/docs/access-model.md
@@ -34,7 +34,7 @@ GitHub API" is confronted with five mechanisms that overlap on some axes and div
 | **Connectors** | MCP server specs (`stdio`/`http`) + creds, materialised into `.mcp.json` at launch | org **or** personal (shareable) | connector row `env`/`headers`, resolved from vault via `secret:KEY` refs | **Yes** — `mcp__*` calls hit `gate-hook.sh` → `/api/gate` |
 | **Built-in MCP** (`agentos`) | The OS's *own* tools (memory/kb/tasks/ask/secret…) over loopback | every session | session bearer | **No** by design (hook exits 0) — the OS itself, scoped + audited server-side |
 | **Agent-specific MCPs** | *Not a real manifest field today.* A per-agent tool = a **personal connector** | member | vault | (would be, via connectors) |
-| **Bespoke** (`shellSecrets` + vault + raw bash/ssh/curl) | Vault key → shell env var so a CLI (`gh`, `ssh`) authenticates | agent (widening to `*`) | vault | **Partially** — the *injection* is ungated; the *bash command* is gated only as `shell.exec` text |
+| **Bespoke** (`shellSecrets` + vault + raw bash/ssh/curl) | Vault key → shell env var so a CLI (`gh`, `ssh`) authenticates — configured per agent via manifest `shellSecrets` **or** per-secret **agent assignment** (Settings → Secrets, `secret_assignments`) | agent (widening to `*`) | vault | **Partially** — the *injection* is ungated; the *bash command* is gated only as `shell.exec` text |
 
 Three structural observations fall out of that table:
 

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -102,6 +102,12 @@ meant for the team, and manage/rotate them from the console **Secrets** page (ag
 `updated_by = agent:<id>`). Not yet done: generic cross-plane redaction (scrubbing a leaked value out
 of memory/KB/inbox if an agent ignores the read-once guidance) — tracked as a follow-up.
 
+Complementary admin path (not an agent tool): from **Settings → Secrets** an owner/admin can *assign* a
+stored secret to specific agents (`PUT /api/secrets/agents`, `secret_assignments` table), and the OS
+injects it as a shell env var into each assigned agent's session at launch — the central-grant inverse of
+a manifest's `shellSecrets`, so a plain CLI (`gh`, `psql`) authenticates. Injection only: an assignment
+does **not** widen `secret_get` read access.
+
 ### `schedule` — governance model
 
 A scheduled run is a **time-shift of work the agent is already authorized to do**: same agent, same


### PR DESCRIPTION
Documentation-only. Brings the docs in line with the shipped v0.146.0 feature — assign a stored secret to agents from **Settings → Secrets**, injected as a shell env var at launch (the inverse view of manifest `shellSecrets`).

- **CLAUDE.md** — removes the now-inaccurate "`shellSecrets` is the ONLY path a vault secret reaches the shell" claim; documents `injectAssignedSecrets` + the `secret_assignments` table as the second, admin-driven injection path; adds a note on the secrets MCP bullet.
- **docs/PILLARS.md §8** — new "Secrets into an agent's shell" paragraph + updated summary-table row.
- **docs/agent-mcp-tools.md** — cross-references the admin assignment path (injection only, not a `secret_get` grant).
- **docs/access-model.md** — annotates the Bespoke/`shellSecrets` row.

No code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)