### PR TITLE
fix(goals): make a goal's Target field editable (v0.150.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.150.2] — 2026-07-13
+### Fixed
+- **A goal's Target field couldn't be edited** from the goal-detail dialog. The inline `<Input>`'s
+  `onChange` optimistically wrote each keystroke into `detail.goal.target` — the same value its `onBlur`
+  save-guard (`v !== detail.goal.target`) compared against — so the guard was always false and the PATCH
+  never fired. Made the input uncontrolled (`defaultValue` keyed to the goal id, dropping the
+  self-defeating `onChange`) so blur compares the typed value against the unchanged server value and saves.
+
 ## [0.150.1] — 2026-07-13
 ### Changed
 - **The "Learnings" nav is renamed "Dreaming"**, matching the established vocabulary (Pillar 10 is

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.150.1",
+  "version": "0.150.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4525,7 +4525,7 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                   <Field label="Target">
                     {isAdmin
-                      ? <Input value={detail.goal.target ?? ''} placeholder="e.g. < 10 min by Q3" className="h-8" onBlur={(e) => { const v = e.target.value.trim(); if (v !== (detail.goal.target ?? '')) patch(detail.goal.id, { target: v || null }) }} onChange={(e) => setDetail((d) => d ? { ...d, goal: { ...d.goal, target: e.target.value } } : d)} />
+                      ? <Input key={detail.goal.id} defaultValue={detail.goal.target ?? ''} placeholder="e.g. < 10 min by Q3" className="h-8" onBlur={(e) => { const v = e.target.value.trim(); if (v !== (detail.goal.target ?? '')) patch(detail.goal.id, { target: v || null }) }} />
                       : <div className="h-8 text-sm text-muted-foreground">{detail.goal.target || '—'}</div>}
                   </Field>
                   <Field label="Due date">


### PR DESCRIPTION
## Problem
A goal's **Target** field couldn't be edited from the goal-detail dialog — typing in it and blurring silently did nothing.

## Root cause
The inline Target `<Input>` (`web/src/App.tsx`) was controlled and its `onChange` optimistically wrote each keystroke into `detail.goal.target`. That's the *same* value its `onBlur` save-guard compared against:

```js
onBlur={(e) => { const v = e.target.value.trim(); if (v !== (detail.goal.target ?? '')) patch(...) }}
onChange={(e) => setDetail(d => ({ ...d, goal: { ...d.goal, target: e.target.value } }))}
```

By blur time `detail.goal.target` already equalled the typed text, so the guard was always false and `patch()` → `PATCH /api/goals/:id` never fired. The server route and `GoalStore.update` both handle `target` correctly — the break was purely UI.

## Fix
Make the input **uncontrolled** — `defaultValue` keyed to the goal id, dropping the self-defeating `onChange`. Now `detail.goal.target` stays the server value the `onBlur` guard checks against, so a real change saves (and the `key` resets the field when switching goals). Matches how the sibling **Due date** field already behaves.

## Verification
`cd web && npm run build` passes. Web-only change — no server restart needed; a browser reload picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)