### PR TITLE
chore: sync package-lock version to 0.150.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.150.1",
+  "version": "0.150.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.150.1",
+      "version": "0.150.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"


### PR DESCRIPTION
The 0.150.2 bump (#256) committed `package.json` but not the lockfile's `version` field, leaving `main` inconsistent. This syncs `package-lock.json` to 0.150.2. No dependency changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)