### PR TITLE
fix(dreaming): reflect-loop windowing — cadence, watermark, session count (v0.150.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.150.2] — 2026-07-13
+### Fixed
+- **Dreaming timing — three correctness bugs in the reflect loop's windowing (audit-driven).**
+  1. **Cadence survives restarts (H1).** The scheduler's `lastDream` clock was in-memory, so every
+     restart (frequent — each build/deploy) reset it and the next tick fired a pass immediately,
+     turning "reflect every 24 h" into "reflect on every restart" — and each pass spawns a **billed**
+     consolidator agent. The clock now seeds from the durable `learning.dreamed` audit ts (mirroring the
+     digest's `digest.posted` guard). `src/server.ts`.
+  2. **No more skipped episodes at the window edge (H2).** The pass windowed on the run clock, but
+     episodes are stored asynchronously, so one landing just after a pass could fall into the gap and be
+     counted by neither pass. The window now advances a separate **data high-water mark** (newest ts
+     actually consumed), kept distinct from the cadence clock. Migration-safe (falls back to the old
+     marker). `src/edge/dreaming.ts`.
+  3. **Accurate session count (H3).** A single session emits several terminal audit rows
+     (`session.reported` + `session.ended` + crash sweeps); the pass counted rows, inflating the session
+     total — on live data **106 rows → 70 real sessions** (+51%), which skewed the success rate that
+     drives guidance + the "raise effort" recommendation. Now collapses to one canonical row per session
+     (prefers the agent's reported outcome). `src/edge/dreaming.ts`.
+  Validated against a copy of live data. First of a sequenced set of Dreaming audit fixes.
+
 ## [0.151.0] — 2026-07-13
 ### Fixed
 - **Per-member GitHub: "Connect" no longer shows a false green when the App isn't installed.** Authorizing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.151.0",
+  "version": "0.150.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.151.0",
+      "version": "0.150.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.151.0",
+  "version": "0.150.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -34,10 +34,16 @@ interface DreamState {
   totals: Tally;
   topics: Record<string, { count: number; lastSeen: number }>;
   recent: RecentEntry[];
+  /** High-water mark of the newest activity ts this loop has already consumed (H2). Kept SEPARATE from
+   *  the run clock (`learning.dreamed` audit ts, which drives cadence) so a late-written episode can't
+   *  fall into the gap between a pass's `until` and the next `since` and be silently skipped. Absent on
+   *  states written before this field existed → we fall back to the old marker (see `dream`). */
+  watermark?: number;
 }
 
 interface EpisodeRow { content: string; created_at: number }
-interface AuditRow { type: string; data: string }
+interface OutcomeRow { run_id: string | null; ts: number; type: string; data: string }
+interface FrictionRow { ts: number; type: string; data: string }
 
 const DREAM_SECTION = 'operations';
 const DREAM_SLUG = 'fleet-learnings';
@@ -52,24 +58,41 @@ export class DreamingEngine {
   async dream(by = 'automation:dreamer'): Promise<DreamResult> {
     const db = this.os.db;
     const until = Date.now();
-    const last = db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'learning.dreamed'").get<{ t: number | null }>();
-    const since = last?.t ?? until - 7 * 24 * 3_600_000;
+    const prior = this.load();
+    // H2: window on a durable **data watermark** — the newest activity ts we've already consumed —
+    // NOT the run clock. Migration-safe: states written before `watermark` existed fall back to the old
+    // `learning.dreamed` marker, then to a 7-day cold start.
+    const lastMark = db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'learning.dreamed'").get<{ t: number | null }>();
+    const since = prior?.watermark ?? lastMark?.t ?? until - 7 * 24 * 3_600_000;
     const window = { since, until };
 
     const episodes = db
       .prepare("SELECT content, created_at FROM memories WHERE created_at > ? AND tags LIKE '%\"episode\"%' ORDER BY created_at")
       .all<EpisodeRow>(since);
-    const outcomes = db
-      .prepare("SELECT type, data FROM audit_events WHERE ts > ? AND type IN ('session.reported','session.ended','session.stopped','run.completed')")
-      .all<AuditRow>(since);
+    const outcomeRows = db
+      .prepare("SELECT run_id, ts, type, data FROM audit_events WHERE ts > ? AND type IN ('session.reported','session.ended','session.stopped','run.completed') ORDER BY ts")
+      .all<OutcomeRow>(since);
     const frictionRows = db
-      .prepare("SELECT type, data FROM audit_events WHERE ts > ? AND type IN ('budget.exceeded','episode.error','approval.resolved')")
-      .all<AuditRow>(since);
+      .prepare("SELECT ts, type, data FROM audit_events WHERE ts > ? AND type IN ('budget.exceeded','episode.error','approval.resolved')")
+      .all<FrictionRow>(since);
 
-    if (!episodes.length && !outcomes.length) {
-      const st = this.load();
-      return { skipped: true, window, passes: st?.passes };
+    if (!episodes.length && !outcomeRows.length) {
+      return { skipped: true, window, passes: prior?.passes };
     }
+
+    // H3: collapse the terminal-event rows to ONE canonical row per session — a single session emits
+    // several (`session.reported` AND `session.ended`, plus crash sweeps), which otherwise inflates the
+    // session count and double-tallies the outcome, skewing the success rate that drives guidance +
+    // recommendations. Prefer the agent's own reported outcome (it carries the real outcome), then
+    // run.completed, then ended, then stopped.
+    const OUTCOME_RANK: Record<string, number> = { 'session.reported': 3, 'run.completed': 2, 'session.ended': 1, 'session.stopped': 0 };
+    const bySession = new Map<string, OutcomeRow>();
+    for (const r of outcomeRows) {
+      const key = r.run_id || `anon:${r.ts}`;
+      const cur = bySession.get(key);
+      if (!cur || (OUTCOME_RANK[r.type] ?? -1) > (OUTCOME_RANK[cur.type] ?? -1)) bySession.set(key, r);
+    }
+    const outcomes = [...bySession.values()];
 
     // ── this window's tallies ──
     const win: Tally = { sessions: outcomes.length, episodes: episodes.length, success: 0, failure: 0, partial: 0, stopped: 0, unknown: 0, rejected: 0, budgetStops: 0, errors: 0 };
@@ -84,9 +107,17 @@ export class DreamingEngine {
     }
     const winTopics = topicCounts(episodes);
 
+    // H2: advance the watermark to the newest ts we actually consumed (never `until`), so anything that
+    // landed between that ts and now is picked up next pass instead of falling into a gap.
+    let watermark = since;
+    for (const e of episodes) if (e.created_at > watermark) watermark = e.created_at;
+    for (const r of outcomeRows) if (r.ts > watermark) watermark = r.ts;
+    for (const f of frictionRows) if (f.ts > watermark) watermark = f.ts;
+
     // ── fold into the cumulative state ──
-    const state = this.load() ?? { firstPass: until, passes: 0, totals: zeroTally(), topics: {}, recent: [] };
+    const state = prior ?? { firstPass: until, passes: 0, totals: zeroTally(), topics: {}, recent: [], watermark: since };
     state.passes += 1;
+    state.watermark = watermark;
     for (const k of Object.keys(win) as (keyof Tally)[]) state.totals[k] += win[k];
     for (const [topic, n] of winTopics) {
       const cur = state.topics[topic] ?? { count: 0, lastSeen: 0 };

--- a/src/server.ts
+++ b/src/server.ts
@@ -277,13 +277,24 @@ export function startServer(port = Number(process.env.PORT) || 3010): http.Serve
       }
     }
     const everyHours = os.settings.dreamingEveryHours();
-    if (everyHours && Date.now() - (lastDream.get(os.tenant) || 0) >= everyHours * 3_600_000) {
-      lastDream.set(os.tenant, Date.now());
-      // One "reflect" concept, whether manual or scheduled: the cheap deterministic pass, then the
-      // memory-gardener over new material (it no-ops when there's too little to be worth an agent run).
-      void new DreamingEngine(os).dream('scheduler')
-        .then(() => new Consolidation(os, rt.tm).run('automation:consolidation'))
-        .catch(() => { /* never let the scheduler crash the server */ });
+    if (everyHours) {
+      // H1: DURABLE cadence. `lastDream` is in-memory, so before this fix a restart (frequent on this box
+      // — every build/deploy) emptied it and the next tick fired a pass immediately, turning "reflect
+      // every 24h" into "reflect on every restart" — each pass spawns a BILLED consolidator agent. Seed
+      // the clock once per process from the last real pass (the `learning.dreamed` audit ts) so cadence
+      // survives restarts. (Mirrors how the digest gates on its durable `digest.posted` audit.)
+      if (!lastDream.has(os.tenant)) {
+        const last = os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'learning.dreamed'").get<{ t: number | null }>();
+        lastDream.set(os.tenant, last?.t ?? 0);
+      }
+      if (Date.now() - (lastDream.get(os.tenant) || 0) >= everyHours * 3_600_000) {
+        lastDream.set(os.tenant, Date.now());
+        // One "reflect" concept, whether manual or scheduled: the cheap deterministic pass, then the
+        // memory-gardener over new material (it no-ops when there's too little to be worth an agent run).
+        void new DreamingEngine(os).dream('scheduler')
+          .then(() => new Consolidation(os, rt.tm).run('automation:consolidation'))
+          .catch(() => { /* never let the scheduler crash the server */ });
+      }
     }
     // Daily digest — the "what got done today" standup. Rides this same hourly tick but gates its own
     // Slack post (enabled + channel + past digestHour + not yet posted today); the dashboard/KB render


### PR DESCRIPTION
PR 1 of the sequenced Dreaming-audit fixes (timing). Fixes three correctness bugs found in the audit.

## H1 — cadence resets on every restart
`lastDream` was an in-memory `Map`; a restart (every build/deploy on this box) emptied it, so the next hourly tick fired a pass **immediately** — turning "reflect every 24h" into "reflect on every restart," and **each pass spawns a billed consolidator agent**. Now seeded from the durable `learning.dreamed` audit ts (the same pattern the digest already uses with `digest.posted`). `src/server.ts`.

## H2 — episodes at the window edge silently skipped
The pass windowed on the run clock, but episodes are stored **asynchronously**, so one landing just after a pass could fall into the gap between a pass's `until` and the next `since` and be counted by neither. Now the window advances a separate **data high-water mark** (newest ts actually consumed), kept distinct from the cadence clock. Migration-safe (falls back to the old marker for pre-existing state). `src/edge/dreaming.ts`.

## H3 — session count inflated → skewed success rate
A single session emits several terminal audit rows (`session.reported` + `session.ended` + crash sweeps); the pass counted **rows**, not sessions. On live data that's **106 rows → 70 real sessions (+51%)**, inflating the denominator of the success rate that drives guidance thresholds and the "raise effort to high" recommendation. Now collapses to one canonical row per session (prefers the agent's reported outcome). `src/edge/dreaming.ts`.

## Validation
- Ran the real pass against a **copy** of live instapods data (external memory backend + chat tokens stripped so nothing live is touched): distinct sessions = **70** (was 106), watermark advances, and an immediate second pass correctly **skips** (no re-count).
- `typecheck` + `test:governance` (68/68) green.

## Not in this PR (later in the sequence)
Staleness (guidance/recs from cumulative totals), visibility (passes history, gardener output), robustness (race guard, watermark-on-success, retry cap), and the measurement loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)