### PR TITLE
feat(sessions): fork a session into a new branch (v0.152.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.152.0] — 2026-07-13
+### Added
+- **Fork a session.** A new **Fork** action (⑃) on the Sessions list branches any claude-code session with
+  a conversation into a NEW, independent session that inherits the parent's full context — like
+  `claude --resume` but into a separate branch rather than continuing in place, so the original transcript
+  is left completely untouched and the two diverge from the branch point. The fork gets its own session id,
+  tmux pane, and a new claude session id; it runs in the SAME agent folder (the transcript is keyed to it)
+  and inherits the parent's run-as identity, with the forking member as provenance. Works on a finished or
+  in-flight run alike (forking reads the transcript, not the live pane). Verified empirically that
+  `claude --resume <parent> --fork-session --session-id <new>` honors our chosen id and preserves context.
+  (`forkSession` + `forkable` flag in `src/terminal.ts`, the `FORK_FROM` launch path in
+  `terminal/claude-launch.sh` — checked AFTER `RESUME` so a reattach resumes the branch instead of
+  re-forking, `POST /api/sessions/:id/fork` in `src/server.ts`, `web/src/App.tsx`, `web/src/lib/api.ts`.)
+
 ## [0.150.2] — 2026-07-13
 ### Fixed
 - **Dreaming timing — three correctness bugs in the reflect loop's windowing (audit-driven).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.150.2",
+  "version": "0.152.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.150.2",
+      "version": "0.152.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.150.2",
+  "version": "0.152.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -1845,6 +1845,18 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const r = tm.claimSession(id, me.email);
     return sendJson(res, r.ok ? 200 : 400, r);
   }
+  // Fork a session: branch it into a NEW independent session that inherits the parent's full conversation
+  // (claude --resume <parent> --fork-session), leaving the parent untouched. Optionally seeded with a
+  // follow-up task. Same per-member gate as stop/take-over — you can fork any run you're allowed to see.
+  const forkMatch = p.match(/^\/api\/sessions\/([\w-]+)\/fork$/);
+  if (method === 'POST' && forkMatch) {
+    const id = forkMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to fork this session' });
+    const b = await readBody(req);
+    const r = tm.forkSession(id, me.id, b.task ? String(b.task) : undefined);
+    return sendJson(res, r.ok ? 200 : 400, r.ok ? { id: r.session!.id, tmux: r.session!.tmux } : { error: r.error });
+  }
   // Human verdict on a finished run — 👍/👎 (or null to clear). The ground-truth signal for the agent
   // maturity score. Same per-member gate as stop: you can rate any run you're allowed to see.
   const rateMatch = p.match(/^\/api\/sessions\/([\w-]+)\/rate$/);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -158,6 +158,11 @@ export interface Session {
    * offers a Resume affordance once it's no longer live.
    */
   resumable?: boolean;
+  /** True when this session can be FORKED — branched into a new independent session that inherits its
+   *  full conversation (`claude --resume <parent> --fork-session`). Requires a claude-code runtime and a
+   *  persisted `claude_session_id` (a conversation to branch from). Unlike `resumable`, a headless run is
+   *  forkable too — forking reads the transcript, it doesn't need the parent's live launch env. */
+  forkable?: boolean;
   /** Raw provenance: member id, or `automation:<id>`/`task:<id>`/`chat:<name>` when a trigger spawned it. */
   spawnedBy?: string;
   /** Human-readable provenance for the console (member name/email, or the automation's name). */
@@ -247,6 +252,7 @@ interface SessionRow {
   status: SessionStatus;
   spawned_by: string | null;
   run_as: string | null;
+  claude_session_id: string | null;
   headless: number | null;
   claimed_by: string | null;
   claimed_at: number | null;
@@ -479,6 +485,7 @@ export class TerminalManager {
       ...toSession(r),
       alive: alive ? alive.has(r.tmux) : undefined,
       resumable: resumable.has(r.id),
+      forkable: !!r.claude_session_id && this.os.agents.get(r.agent)?.runtime === 'claude-code',
       spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as),
       sourceKind: this.sourceKind(r.spawned_by),
       runAsLabel: this.runAsLabel(r.run_as),
@@ -965,6 +972,49 @@ export class TerminalManager {
   }
 
   /**
+   * FORK a session: start a NEW, independent session that BRANCHES from an existing conversation. The
+   * fork inherits the parent's full context (`claude --resume <parent> --fork-session`) but gets its own
+   * session id, tmux pane, and a NEW claude session id — so it diverges from the branch point while the
+   * parent transcript is left completely untouched. Always an interactive, attachable run (a human is
+   * branching to explore/steer), optionally seeded with a `task` (the follow-up that kicks off the
+   * branch). Same agent + folder as the parent (the transcript is keyed to that folder); run-as identity
+   * is inherited from the parent (it's the same conversation continued), with the forking member as
+   * provenance. Returns the new session, or an error when the parent isn't a forkable claude-code run.
+   */
+  forkSession(sourceId: string, by: string, task?: string): { ok: boolean; session?: Session; error?: string } {
+    const src = this.db.prepare('SELECT agent, claude_session_id, run_as FROM term_sessions WHERE id = ?')
+      .get<{ agent: string; claude_session_id: string | null; run_as: string | null }>(sourceId);
+    if (!src) return { ok: false, error: 'unknown session' };
+    const manifest = this.os.agents.get(src.agent);
+    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be forked' };
+    if (!src.claude_session_id) return { ok: false, error: 'this session has no conversation to fork yet' };
+
+    const id = randomUUID().slice(0, 8);
+    const tmux = `aos-${id}`;
+    // The fork's OWN new conversation id (distinct from the parent's) — `--fork-session --session-id`
+    // copies the parent history into it, leaving the parent's transcript intact.
+    const claudeSessionId = randomUUID();
+    // Inherit the branch identity (connectors/Composio/uid follow run_as); fall back to the forker when
+    // the parent had none. Provenance (`spawned_by`) is the forking member — this fork was console-driven.
+    const actingMember = src.run_as ?? (by || undefined);
+    const secret = randomBytes(24).toString('hex');
+    const seed = (task || '').trim();
+    const title = `fork of ${sourceId}${seed ? ' · ' + (seed.length > 48 ? seed.slice(0, 47) + '…' : seed) : ''}`;
+    const now = Date.now();
+    const session: Session = { id, agent: src.agent, title, task: seed, tmux, status: 'running', createdAt: now, updatedAt: now };
+    this.db
+      .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, resident, last_activity, headless, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(id, src.agent, title, seed, tmux, 'running', by ?? null, actingMember ?? null, secret, claudeSessionId, 0, null, 0, now, now);
+    this.audit(id, src.agent, 'session.forked', { from: sourceId, fromClaudeId: src.claude_session_id, claudeSessionId, runAs: actingMember ?? null, by });
+    this.launchClaudeCode({
+      id, agent: src.agent, task: seed, secret, actingMember, spawnedBy: by,
+      hasSlack: false, hasDiscord: false, headless: false, resident: false, resume: false,
+      claudeSessionId, forkFrom: src.claude_session_id,
+    });
+    return { ok: true, session };
+  }
+
+  /**
    * Spawn the claude-code runtime for a session row (in its agent folder, governed by the gate hook).
    * Factored out of `createSession` so `reviveResident` can re-launch the SAME row (same id/tmux/secret/
    * claude id) after the warm session was reaped — with `resume: true` it continues the transcript.
@@ -975,6 +1025,10 @@ export class TerminalManager {
     id: string; agent: string; task: string; secret: string;
     actingMember?: string; spawnedBy?: string; hasSlack: boolean; hasDiscord: boolean;
     headless: boolean; resident: boolean; resume: boolean; claudeSessionId: string;
+    // Fork: branch this NEW session (claudeSessionId) off an existing conversation (forkFrom). The
+    // launcher's FORK_FROM branch runs `claude --resume <forkFrom> --fork-session --session-id
+    // <claudeSessionId>` on first launch; a reattach (resume:true) resumes the fork's own branch.
+    forkFrom?: string;
   }): void {
     const manifest = this.os.agents.get(o.agent);
     if (!manifest?.dir) return;
@@ -1009,6 +1063,10 @@ export class TerminalManager {
     // follow-up or a console reconnect) instead of starting fresh.
     env.CLAUDE_SESSION_ID = o.claudeSessionId;
     if (o.resume) env.RESUME = '1';
+    // Fork: on FIRST launch, branch off the parent conversation. RESUME is never set alongside forkFrom
+    // (a fork's first run resumes nothing), and the launcher checks RESUME before FORK_FROM, so a later
+    // reattach — which sets RESUME=1 from the persisted env — resumes THIS branch instead of re-forking.
+    if (o.forkFrom) env.FORK_FROM = o.forkFrom;
     // The agent's opt-in shell secrets (vault keys → shell env vars, e.g. GH_TOKEN for `gh`).
     this.injectShellSecrets(env, o.agent, manifest, o.id);
     // Secrets ASSIGNED to this agent from the Secrets page — the inverse view of `shellSecrets`,

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -277,10 +277,23 @@ if [ "${RESUME:-}" = "1" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
   # Reconnect to a stopped session: reopen the SAME conversation (no task re-seed — it's already
   # in the transcript). If resume fails (e.g. claude never persisted a turn before it was stopped),
   # fall back to a fresh session under the same id, seeded with the original task.
+  # RESUME is checked BEFORE FORK_FROM on purpose: a forked session persists FORK_FROM in its launch
+  # env, but a later reattach must resume THIS branch in place (RESUME=1), never re-fork the parent.
   notify_resumed
   dim "resuming claude session $CLAUDE_SESSION_ID …"
   echo
   claude --resume "$CLAUDE_SESSION_ID" "${COMMON_ARGS[@]}" \
+    || claude --session-id "$CLAUDE_SESSION_ID" "${COMMON_ARGS[@]}" "$TASK"
+elif [ -n "${FORK_FROM:-}" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
+  # FORK (first launch only): branch a NEW conversation ($CLAUDE_SESSION_ID) off an existing one
+  # ($FORK_FROM). `--fork-session` copies the parent's history into OUR chosen new id and leaves the
+  # parent transcript untouched, so both diverge independently. Seeded with $TASK — the follow-up
+  # instruction that kicks off the branch (may be empty → just opens the forked conversation). A later
+  # reconnect sets RESUME=1 (handled above), so the fork happens exactly once. If the fork fails (e.g.
+  # the parent transcript is gone), fall back to a fresh session under the new id seeded with $TASK.
+  dim "forking claude session $FORK_FROM → $CLAUDE_SESSION_ID …"
+  echo
+  claude --resume "$FORK_FROM" --fork-session --session-id "$CLAUDE_SESSION_ID" "${COMMON_ARGS[@]}" ${TASK:+"$TASK"} \
     || claude --session-id "$CLAUDE_SESSION_ID" "${COMMON_ARGS[@]}" "$TASK"
 elif [ -n "${CLAUDE_SESSION_ID:-}" ]; then
   claude --session-id "$CLAUDE_SESSION_ID" "${COMMON_ARGS[@]}" "$TASK"

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -74,6 +74,17 @@ const takeOverAndOpen = (s: Session, onOpen: (tmux: string, title: string) => vo
   void api.goInteractive(s.id).finally(() => onOpen(s.tmux, s.agent + ' · ' + s.id))
 }
 
+/** A claude-code session with a persisted conversation can be FORKED — branched into a new independent
+ *  session that inherits the parent's full context. Offered regardless of live/done (forking reads the
+ *  transcript, not the live pane), so you can branch a finished run or an in-flight one alike. */
+const canFork = (s: Session): boolean => Boolean(s.forkable)
+
+/** Fork a session from the console: branch it server-side (parent untouched), THEN open the NEW session's
+ *  terminal so the user lands in the forked conversation ready to steer it down a different path. */
+const forkAndOpen = (s: Session, onOpen: (tmux: string, title: string) => void): void => {
+  void api.forkSession(s.id).then((r) => { if (r.tmux) onOpen(r.tmux, s.agent + ' · fork') })
+}
+
 /** Coarse provenance category of a session, from its raw `spawnedBy` (`automation:`/`task:`/`chat:`
  *  prefixes, else a member started it directly). Drives the Source filter on the sessions list. */
 type SessionSource = 'member' | 'automation' | 'task' | 'chat'
@@ -2245,6 +2256,11 @@ function SessionsPage({
               <Terminal className="h-3 w-3" />
             </button>
           )}
+          {canFork(s) && (
+            <button className="rounded p-0.5 text-violet-400 hover:bg-neutral-600 hover:text-violet-300" onClick={() => forkAndOpen(s, onOpen)} title="fork — branch a new session that inherits this conversation (the original is left untouched)">
+              <GitBranch className="h-3 w-3" />
+            </button>
+          )}
           {isLive(s) && (
             <button className="rounded p-0.5 text-amber-400 hover:bg-neutral-600 hover:text-amber-300" onClick={() => onStop(s.id)} title="stop — kill this session's shell">
               <Square className="h-3 w-3" />
@@ -2467,6 +2483,11 @@ function SessionsPage({
                     <Terminal className="h-3 w-3" /> Take over
                   </Button>
                 )}
+                {canFork(s) && (
+                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-violet-600" onClick={() => forkAndOpen(s, onOpen)} title="fork — branch a new session that inherits this conversation (the original is left untouched)">
+                    <GitBranch className="h-3 w-3" /> Fork
+                  </Button>
+                )}
                 {isLive(s) && (
                   <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-amber-600" onClick={() => onStop(s.id)} title="kill this session's shell">
                     <X className="h-3 w-3" /> Stop
@@ -2523,7 +2544,7 @@ function SessionsPage({
               <div className={`shrink-0 transition-opacity ${!isLive(s) ? (s.rating ? '' : 'opacity-40 group-hover:opacity-100') : 'invisible'}`}>
                 {!isLive(s) && <RunRating session={s} onRate={onRate} />}
               </div>
-              <div className="flex w-32 shrink-0 items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+              <div className="flex w-40 shrink-0 items-center justify-end gap-1 opacity-0 transition-opacity group-hover:opacity-100">
                 {canResume(s) && (
                   <Button size="icon" variant="ghost" className="h-7 w-7 text-emerald-600" onClick={() => resumeAndOpen(s, onOpen)} title="resume — reopen and continue this session (claude --resume)">
                     <Play className="h-3.5 w-3.5" />
@@ -2532,6 +2553,11 @@ function SessionsPage({
                 {canGoInteractive(s) && (
                   <Button size="icon" variant="ghost" className="h-7 w-7 text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — attach to this live run and steer it; nothing is interrupted">
                     <Terminal className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+                {canFork(s) && (
+                  <Button size="icon" variant="ghost" className="h-7 w-7 text-violet-600" onClick={() => forkAndOpen(s, onOpen)} title="fork — branch a new session that inherits this conversation (the original is left untouched)">
+                    <GitBranch className="h-3.5 w-3.5" />
                   </Button>
                 )}
                 {isLive(s) && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -152,6 +152,10 @@ export interface Session {
   /** True when this session can be resurrected in place via `claude --resume` on re-open (interactive
    *  session with a persisted launch env). Headless runs are never resumable. */
   resumable?: boolean
+  /** True when this session can be FORKED — branched into a new independent session that inherits its
+   *  full conversation (`claude --resume <parent> --fork-session`). Requires a claude-code runtime and a
+   *  persisted conversation. Unlike `resumable`, a finished/headless run is forkable too. */
+  forkable?: boolean
   spawnedBy?: string
   spawnedByLabel?: string
   /** Normalized origin category — how this session was initiated. `manual` = a console member; the
@@ -953,6 +957,9 @@ export const api = {
   /** Take over a headless run: convert it to an attachable interactive session (claude --resume). Kills
    *  the in-flight `-p` turn if still streaming; then open the terminal to watch/steer. */
   goInteractive: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/interactive`),
+  /** Fork a session into a NEW branch that inherits its full conversation; returns the new session's
+   *  id/tmux so the caller can open its terminal. Optional `task` seeds the branch's first instruction. */
+  forkSession: (id: string, task?: string) => call<{ id?: string; tmux?: string; error?: string }>('POST', `/api/sessions/${id}/fork`, { task }),
   deleteSession: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/sessions/' + id),
   attach: (id: string) => call<{ url?: string; error?: string }>('GET', `/api/sessions/${id}/attach`),
   sessionTranscript: (id: string) => call<{ text?: string; error?: string }>('GET', `/api/sessions/${id}/transcript`),


### PR DESCRIPTION
## What

Adds a **Fork** action to the Sessions list. Forking branches any claude-code session that has a conversation into a **new, independent session** that inherits the parent's full context — like `claude --resume`, but into a *separate branch* rather than continuing in place. The original transcript is left completely untouched; the two diverge from the branch point.

The fork gets its own session id, tmux pane, and a new claude session id. It runs in the **same agent folder** (claude keys transcripts to the cwd) and inherits the parent's **run-as identity** (it's the same conversation continued), with the forking member as provenance. Offered on both finished and in-flight runs — forking reads the transcript, not the live pane.

## How

- **`terminal/claude-launch.sh`** — a new `FORK_FROM` branch runs `claude --resume <parent> --fork-session --session-id <new>` on first launch. It's checked **after** `RESUME` on purpose: a fork persists `FORK_FROM` in its launch env, but a later reattach sets `RESUME=1`, so the reconnect resumes *this* branch in place and never re-forks the parent.
- **`src/terminal.ts`** — `forkSession(sourceId, by, task?)` reads the parent row, mints a new session, audits `session.forked`, and launches via a new `launchClaudeCode({ forkFrom })` option. Adds a `forkable` flag to the `Session` DTO (true for a claude-code runtime with a persisted `claude_session_id`).
- **`src/server.ts`** — `POST /api/sessions/:id/fork` (optional `{ task }` seed), same per-member gate as stop/take-over (`canViewSession`).
- **web** — Fork buttons on all three sessions-list layouts (tab strip, card, table row) + `api.forkSession`.

## Verification

- **Empirically confirmed** that `claude --resume <parent> --fork-session --session-id <chosen>` **honors the chosen id** (the docs suggested otherwise) and preserves the parent's context — a forked session correctly recalled a fact from the parent, parent transcript left intact.
- `npm run typecheck`, `cd web && npm run build`, `npm run demo`, and `npm run test:governance` (**68/68**) all pass.
- Launcher validated under bash 3.2 (`bash -n`) incl. the `${TASK:+…}` empty/set expansion under `set -u`.

## Notes / deploy

Touches server + store + MCP-adjacent launch script + the agent-facing launcher, so making it live needs a **rebuild + restart** (the launcher `claude-launch.sh` change and the `/api/sessions/:id/fork` route both require it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)