### PR TITLE
feat(links): clickable links to KB, Library & other console areas (v0.151.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.154.0] — 2026-07-13
+### Added
+- **Clickable links to KB pages, the Library, and other console areas — everywhere a reference is
+  written.** A single `[[section/slug]]` wiki-link convention (the syntax the KB editor already
+  advertised but never rendered) now resolves to a real link, and a bare `[[library]]` / `[[tasks]]`
+  etc. links to that nav area.
+  - **Markdown surfaces** (KB pages, task/goal bodies, artifacts, docs): a new `remarkWikiLinks` remark
+    plugin rewrites `[[…]]` → `#/kb/…` (or an area route) alongside remark-gfm's existing URL autolink;
+    code spans are left untouched. `web/src/App.tsx`.
+  - **Raw-text surfaces** (inbox cards — notification/approval/question bodies — and memory notes,
+    which render pre-formatted, not markdown): a new `InlineLinks` renderer linkifies markdown links,
+    `[[wiki]]` refs, bare URLs, and in-app `#/route` paths inline. Previously these were plain,
+    non-clickable text. `web/src/App.tsx`.
+  - **Terminal**: MCP tool responses now carry **absolute** console URLs — `kb_write`/`kb_read`/
+    `kb_search` return the page's `#/kb/…` link, `publish` returns the artifact link, `library_list`
+    a Library link — built from `AOS_URL`, so the browser terminal's WebLinks addon renders them
+    clickable with no terminal-side change. `src/memory/memory-mcp.ts`.
+  - **Dreaming** now emits its KB reference as `[[operations/fleet-learnings]]`, clickable in the
+    Memory card via `InlineLinks`. `src/edge/dreaming.ts`.
+  - Not covered (need a public base URL threaded into edge engines, which have none today): the daily
+    **digest** Slack/Discord overflow footer and the session-activity primitive inspector still show
+    plain `section/slug` text.
+
 ## [0.153.0] — 2026-07-13
 ### Added
 - **Company-bot GitHub token — every session can push, no per-agent PAT needed.** Add the GitHub App's

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.153.0",
+  "version": "0.154.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.153.0",
+      "version": "0.154.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.153.0",
+  "version": "0.154.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -154,7 +154,7 @@ export class DreamingEngine {
       const t = state.totals;
       const rate = t.sessions ? Math.round((t.success / t.sessions) * 100) : 0;
       const topTopics = topTopicList(state.topics, 6).map(([k]) => k).join(', ') || '—';
-      const summary = `Fleet self-learning (pass ${state.passes}, since ${new Date(state.firstPass).toISOString().slice(0, 10)}): ${t.sessions} sessions, ${rate}% success. Recurring topics: ${topTopics}. Friction so far: ${t.rejected} approvals rejected, ${t.budgetStops} budget stops, ${t.errors} errors. Details: KB ${DREAM_SECTION}/${DREAM_SLUG}.`;
+      const summary = `Fleet self-learning (pass ${state.passes}, since ${new Date(state.firstPass).toISOString().slice(0, 10)}): ${t.sessions} sessions, ${rate}% success. Recurring topics: ${topTopics}. Friction so far: ${t.rejected} approvals rejected, ${t.budgetStops} budget stops, ${t.errors} errors. Details: [[${DREAM_SECTION}/${DREAM_SLUG}]].`;
       const rec = await this.os.memory.store({ tenant: this.os.tenant, agentId: 'dreamer', content: summary, tags: ['dreaming', 'learned'], type: 'Insight', importance: 0.6, scope: 'tenant', metadata: { passes: state.passes, window, sessions: win.sessions } });
       insightId = rec.id;
     } catch { /* best-effort */ }

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -12,6 +12,12 @@
  * transport), and uses the global `fetch`. Spawned by claude with AOS_URL/SESSION/AGENT in env.
  */
 const AOS_URL = (process.env.AOS_URL || 'http://127.0.0.1:3010').replace(/\/$/, '');
+// Absolute console deep-links agents can hand to a human. Being absolute (AOS_URL is the deployment's
+// real public origin) they're clickable in the browser terminal (xterm WebLinks) and autolink in the
+// console's markdown/inbox renderers. Mirrors the web app's hash routes (#/kb/<section>/<slug>, etc.).
+const consoleLink = (route: string, detail?: string): string =>
+  `${AOS_URL}/#/${route}${detail ? '/' + detail.split('/').map(encodeURIComponent).join('/') : ''}`;
+const kbLink = (section: string, slug: string): string => consoleLink('kb', `${section}/${slug}`);
 const SESSION = process.env.SESSION || '';
 const AGENT = process.env.AGENT || '';
 // Per-session bearer (0d): the server requires this on the session-scoped loopback routes, so this
@@ -1414,7 +1420,7 @@ async function publish(args: Record<string, unknown>): Promise<string> {
   const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
   const where = args.folder ? ` under "${String(args.folder)}"` : '';
   return d.ok
-    ? `Published "${filePath}" to the Library${where} (id ${d.id}). The operator has been notified.`
+    ? `Published "${filePath}" to the Library${where} (id ${d.id}). The operator has been notified.\nView it: ${consoleLink('artifacts', d.id)}`
     : `Could not publish: ${d.error ?? 'unknown error'}`;
 }
 
@@ -1492,7 +1498,7 @@ async function kbSearch(args: Record<string, unknown>): Promise<string> {
   const folders = data.sections?.length ? `\n\nExisting folders (reuse one when filing a new page): ${data.sections.join(', ')}` : '';
   if (!pages.length) return `No knowledge-base pages found.${folders}`;
   return pages
-    .map((p) => `- ${p.section}/${p.slug} — ${p.title}${p.tags?.length ? ` [${p.tags.join(', ')}]` : ''}`)
+    .map((p) => `- ${p.section}/${p.slug} — ${p.title}${p.tags?.length ? ` [${p.tags.join(', ')}]` : ''}  ${kbLink(p.section, p.slug)}`)
     .join('\n') + '\n(Use kb_read with a section + slug to open a page.)' + folders;
 }
 
@@ -1506,7 +1512,7 @@ async function kbRead(args: Record<string, unknown>): Promise<string> {
   const data = (await res.json()) as { page?: KbPageLite };
   const p = data.page;
   if (!p) return 'Page not found.';
-  return `# ${p.title}  (${p.section}/${p.slug}, rev ${p.rev})\n${p.tags?.length ? `tags: ${p.tags.join(', ')}\n` : ''}\n${p.body ?? ''}`;
+  return `# ${p.title}  (${p.section}/${p.slug}, rev ${p.rev})\n${kbLink(p.section, p.slug)}\n${p.tags?.length ? `tags: ${p.tags.join(', ')}\n` : ''}\n${p.body ?? ''}`;
 }
 
 async function kbWrite(args: Record<string, unknown>): Promise<string> {
@@ -1523,7 +1529,7 @@ async function kbWrite(args: Record<string, unknown>): Promise<string> {
   });
   const data = (await res.json()) as { ok?: boolean; section?: string; slug?: string; rev?: number; error?: string };
   if (!data.ok) return `Could not write the page: ${data.error ?? 'unknown error'}`;
-  return `Saved ${data.section}/${data.slug} (rev ${data.rev}). The change is versioned — any edit is revertable.`;
+  return `Saved ${data.section}/${data.slug} (rev ${data.rev}). The change is versioned — any edit is revertable.\nOpen it: ${kbLink(data.section!, data.slug!)}`;
 }
 
 interface KbRevLite { rev: number; author: string; summary?: string; title: string; createdAt: number }
@@ -1586,10 +1592,11 @@ async function artifactsList(args: Record<string, unknown>): Promise<string> {
   // The Library's existing folders (all agents) so a `publish` files into the established tree rather
   // than inventing a new folder. Shown even when you personally have nothing published yet.
   const folders = data.folders?.length ? `\n\nLibrary folders (pass one as \`folder\` to publish): ${data.folders.join(', ')}` : '';
-  if (!arts.length) return `You have not published any deliverables yet.${folders}`;
+  const browse = `\n\nBrowse the Library: ${consoleLink('artifacts')}`;
+  if (!arts.length) return `You have not published any deliverables yet.${folders}${browse}`;
   return arts
     .map((a) => `- ${a.title}${a.description ? ` — ${a.description}` : ''} (${a.kind}, ${a.filename}${a.folder ? `, in ${a.folder}/` : ''})`)
-    .join('\n') + folders;
+    .join('\n') + folders + browse;
 }
 
 async function schedule(args: Record<string, unknown>): Promise<string> {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2809,7 +2809,7 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
         <Bell className="mt-0.5 h-4 w-4 shrink-0 text-indigo-600" />
         <div className="min-w-0 flex-1">
           <MsgHeading m={m}><span className="shrink-0 text-indigo-600">· waiting for you</span></MsgHeading>
-          <div className="mt-1 whitespace-pre-line break-words text-xs text-muted-foreground">{m.body}</div>
+          <div className="mt-1 whitespace-pre-line break-words text-xs text-muted-foreground"><InlineLinks text={m.body} /></div>
         </div>
         {time}
         <div className="flex shrink-0 gap-1">
@@ -2846,7 +2846,7 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
             </MsgHeading>
             <div className="mt-1 break-words text-sm font-medium">{m.title}</div>
             {m.policyReason && <div className="mt-0.5 break-words text-xs text-muted-foreground"><span className="text-amber-700">why:</span> {m.policyReason}</div>}
-            {m.body && <div className="mt-0.5 whitespace-pre-line break-words text-xs text-muted-foreground">{m.body}</div>}
+            {m.body && <div className="mt-0.5 whitespace-pre-line break-words text-xs text-muted-foreground"><InlineLinks text={m.body} /></div>}
             <div className="mt-1 break-all font-mono text-[10px] text-muted-foreground/80">{JSON.stringify(m.args ?? {})}</div>
           </div>
           {time}
@@ -2878,7 +2878,7 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
         <HelpCircle className="mt-0.5 h-4 w-4 shrink-0 text-sky-600" />
         <div className="min-w-0 flex-1">
           <MsgHeading m={m}><span className="shrink-0 text-sky-600">· asks</span></MsgHeading>
-          <div className="mt-1 whitespace-pre-line break-words text-sm">{m.body}</div>
+          <div className="mt-1 whitespace-pre-line break-words text-sm"><InlineLinks text={m.body} /></div>
         </div>
         <a href={navHref('sessions', 'aos-' + m.sessionId)} className="shrink-0 pt-0.5 text-[11px] text-muted-foreground underline hover:text-foreground" onClick={onNavClick(open)}>open</a>
         {time}
@@ -3315,6 +3315,93 @@ const isMarkdownArt = (a: Artifact) => a.mime.startsWith('text/markdown') || /\.
 const isHtmlArt = (a: Artifact) => a.mime.startsWith('text/html') || /\.html?$/i.test(a.filename)
 const isTextMime = (m: string) => m.startsWith('text/') || m === 'application/json'
 
+// ── Internal links ─────────────────────────────────────────────────────────────────────────────
+// A single convention makes references to KB pages, the Library, and other console areas clickable
+// wherever agents or humans write them. `[[section/slug]]` (the syntax the KB editor advertises) →
+// the KB page; a bare `[[area]]` (library, tasks, …) → that nav route. Two renderers share the same
+// target resolver: `remarkWikiLinks` for full-markdown surfaces (KB/task/goal/artifact/docs) and
+// `InlineLinks` for raw-text surfaces (inbox cards, memory notes) that must stay pre-formatted.
+
+/** Known single-word wiki targets that map to a top-level route rather than a KB page. */
+const WIKI_AREA: Record<string, string> = {
+  library: '#/artifacts', artifacts: '#/artifacts', knowledge: '#/kb', kb: '#/kb',
+  tasks: '#/tasks', goals: '#/goals', memory: '#/memory', skills: '#/skills',
+  agents: '#/agents', inbox: '#/inbox', audit: '#/audit', settings: '#/settings',
+}
+/** Resolve a `[[…]]` wiki target to an in-app hash route. `section/slug` (possibly nested) → a KB
+ *  page; a bare known area word → its route; anything else falls back to a KB path. Per-segment
+ *  encoding mirrors {@link encodeDetail} so real slashes stay readable. */
+function wikiHref(target: string): string {
+  const inner = target.trim().replace(/^\/+|\/+$/g, '')
+  const area = WIKI_AREA[inner.toLowerCase()]
+  if (area) return area
+  return '#/kb/' + inner.split('/').map(encodeURIComponent).join('/')
+}
+
+const WIKI_RE = /\[\[([^\]]+?)\]\]/g
+
+/** remark plugin: rewrite `[[section/slug]]` / `[[section/slug|label]]` into real links, skipping code
+ *  spans and existing links. Runs alongside remark-gfm (which already autolinks bare URLs). */
+function remarkWikiLinks() {
+  return (tree: any) => {
+    const walk = (node: any) => {
+      if (!node || !Array.isArray(node.children)) return
+      const out: any[] = []
+      for (const child of node.children) {
+        if (child.type === 'code' || child.type === 'inlineCode' || child.type === 'link') { out.push(child); continue }
+        if (child.type === 'text' && child.value.includes('[[')) { out.push(...splitWikiNodes(child.value)); continue }
+        walk(child); out.push(child)
+      }
+      node.children = out
+    }
+    walk(tree)
+  }
+}
+function splitWikiNodes(value: string): any[] {
+  const nodes: any[] = []
+  let last = 0
+  WIKI_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = WIKI_RE.exec(value))) {
+    if (m.index > last) nodes.push({ type: 'text', value: value.slice(last, m.index) })
+    const [target, label] = m[1].split('|')
+    nodes.push({ type: 'link', url: wikiHref(target), children: [{ type: 'text', value: (label ?? target).trim() }] })
+    last = m.index + m[0].length
+  }
+  if (last < value.length) nodes.push({ type: 'text', value: value.slice(last) })
+  return nodes.length ? nodes : [{ type: 'text', value }]
+}
+
+// Markdown link · `[[wiki]]` · bare http(s) URL · in-app `#/route`, in priority order.
+const INLINE_LINK_RE = /\[([^\]]+)\]\((https?:\/\/[^\s)]+|#\/[^\s)]+)\)|\[\[([^\]]+?)\]\]|(https?:\/\/[^\s<>()]+)|(#\/[A-Za-z0-9/_%-]+)/g
+
+/** Render a plain string with clickable links (markdown links, `[[wiki]]` refs, bare URLs, in-app
+ *  `#/route` paths) for surfaces that show raw text rather than full markdown — inbox cards, memory
+ *  notes. Click propagation is stopped so a link inside a clickable card doesn't also open the card. */
+function InlineLinks({ text }: { text?: string | null }): ReactNode {
+  if (!text) return text ?? null
+  const parts: ReactNode[] = []
+  let last = 0, key = 0
+  INLINE_LINK_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = INLINE_LINK_RE.exec(text))) {
+    if (m.index > last) parts.push(text.slice(last, m.index))
+    let href = m[0], label = m[0]
+    if (m[1] !== undefined) { label = m[1]; href = m[2] }                                   // [txt](url)
+    else if (m[3] !== undefined) { const [t, l] = m[3].split('|'); href = wikiHref(t); label = (l ?? t).trim() }  // [[wiki]]
+    else if (m[4] !== undefined) { href = label = m[4] }                                    // bare URL
+    else if (m[5] !== undefined) { href = label = m[5] }                                    // #/route
+    const external = /^https?:/.test(href)
+    parts.push(
+      <a key={`il${key++}`} href={href} className="text-primary underline" onClick={(e) => e.stopPropagation()}
+        {...(external ? { target: '_blank', rel: 'noreferrer' } : {})}>{label}</a>,
+    )
+    last = m.index + m[0].length
+  }
+  if (last < text.length) parts.push(text.slice(last))
+  return <>{parts}</>
+}
+
 /** Tailwind has no typography plugin here, so map Markdown elements to readable styled ones. */
 const mdComponents = {
   h1: (p: any) => <h1 className="mb-3 mt-4 text-xl font-semibold" {...p} />,
@@ -3439,7 +3526,7 @@ function ArtifactBody({ a }: { a: Artifact }) {
   )
   if (wantsText) {
     if (text === null) return <div className="text-sm text-muted-foreground">Loading…</div>
-    if (isMarkdownArt(a)) return <div className="max-w-3xl text-sm"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{text}</ReactMarkdown></div>
+    if (isMarkdownArt(a)) return <div className="max-w-3xl text-sm"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{text}</ReactMarkdown></div>
     return <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs leading-relaxed">{text}</pre>
   }
   return (
@@ -4525,7 +4612,7 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
             ) : (
               <div className="space-y-3.5">
                 <div className="font-mono text-xs text-muted-foreground">{detail.goal.id}{detail.goal.createdBy ? ` · by ${nameOf(detail.goal.createdBy)}` : ''}</div>
-                {detail.goal.body && <div className="max-h-56 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap [&_pre]:break-words"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{detail.goal.body}</ReactMarkdown></div>}
+                {detail.goal.body && <div className="max-h-56 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap [&_pre]:break-words"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{detail.goal.body}</ReactMarkdown></div>}
 
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                   <Field label="Status">
@@ -5134,7 +5221,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
             ) : (
               <div className="space-y-3.5">
                 <div className="font-mono text-xs text-muted-foreground">{detail.task.id}{detail.task.owner ? ` · as ${nameOf(detail.task.owner)}` : ''}</div>
-                {detail.task.body && <div className="max-h-56 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap [&_pre]:break-words"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{detail.task.body}</ReactMarkdown></div>}
+                {detail.task.body && <div className="max-h-56 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap [&_pre]:break-words"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{detail.task.body}</ReactMarkdown></div>}
 
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
                   <Field label="Status">
@@ -6009,7 +6096,7 @@ function DocsPage({ selected, onSelect }: { selected: string; onSelect: (slug: s
         </div>
       </div>
       <div className="min-w-0 max-w-3xl flex-1">
-        <Card><CardContent className="p-6 text-sm"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{sel.body}</ReactMarkdown></CardContent></Card>
+        <Card><CardContent className="p-6 text-sm"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{sel.body}</ReactMarkdown></CardContent></Card>
       </div>
     </div>
   )
@@ -6149,7 +6236,7 @@ function KnowledgeBasePage({ me, permalink, nav }: { me: Member; permalink: stri
                     <span className="flex gap-2"><button className="underline" onClick={() => revert(viewRev.rev)}>Revert to this</button><button className="underline" onClick={() => setViewRev(null)}>Back to current</button></span>
                   </div>
                 )}
-                <Card><CardContent className="p-4"><div className="text-sm"><ReactMarkdown remarkPlugins={[remarkGfm]} components={mdComponents}>{viewRev ? viewRev.body : sel.body}</ReactMarkdown></div></CardContent></Card>
+                <Card><CardContent className="p-4"><div className="text-sm"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{viewRev ? viewRev.body : sel.body}</ReactMarkdown></div></CardContent></Card>
                 {showHist && (
                   <Card><CardContent className="space-y-1 p-3">
                     <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">Revisions</div>
@@ -6482,7 +6569,7 @@ function MemoryCard({ m, agentId, me, onChanged }: { m: MemoryRecord; agentId: s
           )}
         </div>
         {/* Content — whitespace-pre-wrap so multi-line episodes (Task / Outcome / summary) stay readable. */}
-        <div className="whitespace-pre-wrap break-words text-sm leading-relaxed">{m.content}</div>
+        <div className="whitespace-pre-wrap break-words text-sm leading-relaxed"><InlineLinks text={m.content} /></div>
         {/* Footer: tags · importance · source · match · timestamp. */}
         <div className="mt-2 flex flex-wrap items-center gap-1.5 text-[11px] text-muted-foreground">
           {tagsShown.map((t) => (


### PR DESCRIPTION
## What

Make internal references — **KB pages, the Library, and other console areas** — render as clickable links wherever agents or humans write them. One `[[section/slug]]` wiki-link convention (the syntax the KB editor already advertised but never rendered), plus bare `[[library]]`/`[[tasks]]` area refs.

## Surfaces

- **Markdown** (KB pages, task/goal bodies, artifacts, docs): new `remarkWikiLinks` plugin rewrites `[[…]]` → `#/kb/…` (or an area route), alongside remark-gfm's existing bare-URL autolink; code spans left untouched.
- **Raw-text cards** (inbox notification/approval/question bodies + memory notes — pre-formatted, not markdown): new `InlineLinks` renderer linkifies markdown links, `[[wiki]]` refs, bare URLs, and in-app `#/route` paths inline. These were previously plain, non-clickable text.
- **Terminal**: MCP tool responses now carry **absolute** `AOS_URL`-based console links (`kb_write`/`kb_read`/`kb_search` → the page's `#/kb/…`; `publish` → the artifact; `library_list` → the Library), so the browser terminal's existing xterm WebLinks addon makes them clickable — **no terminal-side change**.
- **Dreaming** emits its KB reference as `[[operations/fleet-learnings]]`, clickable in the Memory card.

## Also verified — "do normal links render?"

- ✅ Markdown surfaces already linkified `[text](url)` + bare URLs (`mdComponents.a`).
- ✅ Terminal already linkifies `http(s)://` URLs (`WebLinksAddon`).
- ❌ (fixed here) Inbox card bodies + memory notes were plain text — now linkified.

## Not covered (noted in CHANGELOG)

The daily **digest** Slack/Discord overflow footer and the session-activity primitive inspector still show plain `section/slug` — both need a public base URL threaded into the edge engines (`AgentOS`/dreaming/digest have none today). Deferred as a separate change.

## Verification

- `react-markdown` keeps the `#/kb/…` href (rendered through the real lib — not stripped by its URL sanitizer).
- Inline tokenizer + remark mdast transform pass representative-input tests (wiki ±label, area shortcut, absolute URL, `#/route`, markdown link, nested paths, code-span exclusion).
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)