### PR TITLE
Company-bot GitHub token — retire per-agent PATs (v0.153.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.152.0] — 2026-07-13
+### Added
+- **Company-bot GitHub token — every session can push, no per-agent PAT needed.** Add the GitHub App's
+  **App ID** + a generated **private key** (Connections → Creds → GitHub → *Company-bot token*) and the OS
+  mints short-lived, org-scoped **installation access tokens** (acting as the App bot) that `git push` /
+  open PRs on every installed repo. Injected as `GH_TOKEN` at launch for any session that doesn't already
+  have a credential — so the per-agent `GH_TOKEN` PATs (and shared fallback PATs) can be **retired**: remove
+  them and those agents fall through to the bot automatically. **Precedence:** a connected member's own
+  token > an explicit agent `GH_TOKEN` (shellSecret/assigned) > the bot baseline — so human attribution and
+  curated per-agent creds still win where they exist. The token is vault-cached (`github_bot_token`) so the
+  synchronous launch path reads it without a network call, auto-refreshed near expiry; saving the creds
+  mints once to validate + pre-warm (audited `github.bot_token.minted`/`.failed`), and the card shows a
+  **Company-bot token: active** badge. Reuses the existing minter (`appJwt`/`mintInstallationToken`/
+  `InstallationTokenCache`). (`src/connectors/github.ts`, `src/edge/github-identity.ts`, `src/terminal.ts`,
+  `src/governance/settings.ts`, `src/server.ts`, `web/src/App.tsx`, `web/src/lib/api.ts`;
+  `scripts/github-per-member-test.cjs` now 70/70. See `docs/per-member-github-plan.md`.)
+
 ## [0.151.0] — 2026-07-13
 ### Fixed
 - **Per-member GitHub: "Connect" no longer shows a false green when the App isn't installed.** Authorizing

--- a/docs/per-member-github-plan.md
+++ b/docs/per-member-github-plan.md
@@ -47,6 +47,27 @@ web flow against the company's GitHub App (or a classic OAuth App — the flow i
    - the member's `login` in `member_identities` (provider `github`) — the non-secret, queryable handle
      that also powers attribution + the Team page's Chat-IDs row.
 
+## Company-bot baseline — the universal git credential (Model C, v0.152.0)
+
+Per-member login attributes git to the human, but it requires each member to connect and doesn't cover
+automation runs (no human). Per-agent `GH_TOKEN` PATs cover those, but they're long-lived static secrets,
+one per agent. Both are workarounds for a missing baseline. The installed App can provide it: with the
+App's **App ID** (setting `github_app_id`) + **RSA private key** (vault `github_private_key`), the OS mints
+short-lived, org-scoped **installation access tokens** (`ghs_…`, acting as the App bot) that push on every
+installed repo — so **every session can git-push with no per-agent PAT**.
+
+`GithubIdentity.ensureBotToken` signs an App JWT, resolves the installation id from `listInstallations`
+(cached in `github_installation_id`; re-resolved if the App is reinstalled), mints, and caches the token in
+the vault (`github_bot_token`, principal `*`) so the **synchronous** launch path reads it without a network
+call. `injectGithubBaseline` injects it at launch, refreshing in the background near expiry. Saving the
+credentials (`PUT /api/settings/integrations`) mints once to validate + pre-warm (audited
+`github.bot_token.minted` / `.failed`); the Creds card shows a **Company-bot token: active** badge.
+
+**Precedence (highest wins):** connected **member** token → explicit **agent** `GH_TOKEN` (shellSecret /
+assigned) → **bot** baseline. So the bot fills the gap for agents without a PAT and members who haven't
+connected; an agent's curated PAT is respected; a connected human's token still authors their commits.
+This lets per-agent PATs be retired: remove them and those agents fall through to the bot automatically.
+
 ## Launch wiring — run-as picks the credential
 
 In `TerminalManager.launchClaudeCode`, right after the agent-scoped `injectShellSecrets` (which sets the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.151.0",
+  "version": "0.152.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.151.0",
+      "version": "0.152.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.151.0",
+  "version": "0.152.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/github-per-member-test.cjs
+++ b/scripts/github-per-member-test.cjs
@@ -32,6 +32,7 @@ const assert = (c, n, d) => (c ? ok(n) : bad(n, d));
 // ── Stub GitHub's HTTP surface. Everything else falls through to a 404 so an unrelated background
 //    fetch can't crash the run (there shouldn't be any during these routes). ──────────────────────
 let refreshCount = 0;
+let botMintCount = 0;
 let installState = 'installed'; // 'installed' | 'none' — toggles the /user/installations stub
 const realFetch = global.fetch.bind(global); // the test drives the local server over REAL http
 global.fetch = async (urlIn, opts = {}) => {
@@ -53,6 +54,12 @@ global.fetch = async (urlIn, opts = {}) => {
       : { installations: [{ id: 77, account: { login: 'InstaWP' }, app_slug: 'x' }] });
   }
   if (/\/user\/installations\/\d+\/repositories/.test(url)) return json({ total_count: 5, repositories: [] });
+  // Company-bot minter: list App installations, then mint an installation (bot) token.
+  if (url === 'https://api.github.com/app/installations') return json([{ id: 555, account: { login: 'InstaWP' }, repository_selection: 'all' }]);
+  if (/\/app\/installations\/\d+\/access_tokens$/.test(url)) {
+    botMintCount++;
+    return json({ token: 'ghs_bot_' + botMintCount, expires_at: new Date(Date.now() + 3600_000).toISOString() });
+  }
   if (/\/app-manifests\/[^/]+\/conversions$/.test(url)) {
     return json({ id: 42, slug: 'agent-os-instapods', client_id: 'Iv1.manifest', client_secret: 'manifest-secret', html_url: 'https://github.com/apps/agent-os-instapods', webhook_secret: 'whsec_x', pem: '-----BEGIN-----' });
   }
@@ -275,6 +282,43 @@ async function main() {
   const noTok = {};
   tm.configureGitCredentials(noTok);
   assert(noTok.GIT_CONFIG_COUNT === undefined, 'no GH_TOKEN → no git credential config (nothing to authenticate with)');
+
+  // ─── 8) Company-bot installation token (Model C) ────────────────────────────
+  console.log('\n\x1b[1m8) Company-bot installation token (the universal baseline)\x1b[0m');
+  const gid2 = new GithubIdentity(osx);
+  assert(gid2.botConfigured() === false, 'bot not configured until App ID + private key set');
+  // A real RSA key so appJwt can actually sign (the stub doesn't verify the signature).
+  const { generateKeyPairSync } = require('crypto');
+  const { privateKey: pem } = generateKeyPairSync('rsa', { modulusLength: 2048, publicKeyEncoding: { type: 'spki', format: 'pem' }, privateKeyEncoding: { type: 'pkcs1', format: 'pem' } });
+  gid2.setAppId('4286232', 'owner@test');
+  gid2.setPrivateKey(pem, 'owner@test');
+  assert(gid2.botConfigured() === true, 'botConfigured once App ID + private key present');
+  assert(gid2.privateKey().includes('BEGIN RSA'), 'private key stored in the vault');
+  botMintCount = 0;
+  const bot = await gid2.ensureBotToken();
+  assert(bot && bot.token.startsWith('ghs_bot_') && botMintCount === 1, 'ensureBotToken mints an installation token');
+  assert(osx.settings.githubInstallationId() === '555', 'installation id auto-resolved + stored from listInstallations');
+  assert(gid2.loadBotToken().token === bot.token, 'bot token cached in the vault (sync-readable at launch)');
+  const bot2 = await gid2.ensureBotToken();
+  assert(botMintCount === 1 && bot2.token === bot.token, 'a fresh cached token is reused (no re-mint)');
+
+  // Injection precedence: bot fills GH_TOKEN when unset; an explicit agent PAT wins; a member overrides.
+  const be1 = {};
+  tm.injectGithubBaseline(be1, 'coder', 'sessB1');
+  assert(be1.GH_TOKEN === bot.token && be1.GITHUB_TOKEN === bot.token, 'bot token injected as GH_TOKEN when no agent credential');
+  const be2 = { GH_TOKEN: 'gho_agentPAT' };
+  tm.injectGithubBaseline(be2, 'coder', 'sessB2');
+  assert(be2.GH_TOKEN === 'gho_agentPAT', 'explicit agent GH_TOKEN wins over the bot baseline');
+  // Member override still trumps the bot: baseline sets bot, then member token replaces it.
+  gid2.save(ownerId, { token: 'gho_member', login: 'octocat', connectedAt: Date.now() });
+  const be3 = {};
+  tm.injectGithubBaseline(be3, 'coder', 'sessB3');
+  tm.injectMemberGithub(be3, 'coder', ownerId, 'sessB3');
+  assert(be3.GH_TOKEN === 'gho_member', 'connected member token overrides the bot baseline (attribution)');
+  gid2.clear(ownerId);
+  // Removing the private key drops the cached bot token + resolved installation.
+  gid2.setPrivateKey('', 'owner@test');
+  assert(gid2.loadBotToken() === undefined && osx.settings.githubInstallationId() === '', 'clearing the private key drops the cached token + installation id');
 
   server.close();
   registry.forEach && registry.forEach((x) => { try { x.tm.shutdown && x.tm.shutdown(); } catch { /* */ } });

--- a/src/edge/github-identity.ts
+++ b/src/edge/github-identity.ts
@@ -11,14 +11,20 @@
  * Constructed on demand from the pieces the caller already holds (`os.secrets`, `os.settings`,
  * `os.tenant`) — no kernel wiring, so the blast radius stays small.
  */
-import { authorizeUrl, exchangeUserCode, refreshUserToken, githubUser, UserToken } from '../connectors/github';
+import { authorizeUrl, exchangeUserCode, refreshUserToken, githubUser, UserToken, listInstallations, mintInstallationToken } from '../connectors/github';
 
 /** The vault key (per-member principal) holding the JSON token blob. */
 const USER_BLOB_KEY = 'github_user';
 /** The vault key (tenant-wide `*` principal) holding the App's OAuth client secret. */
 const CLIENT_SECRET_KEY = 'github_client_secret';
+/** The vault key (tenant-wide `*`) holding the App's RSA private key — the company-bot minter's credential. */
+const PRIVATE_KEY_KEY = 'github_private_key';
+/** The vault key (tenant-wide `*`) caching the current installation (bot) token so launch reads it sync. */
+const BOT_TOKEN_KEY = 'github_bot_token';
 /** Refresh an expiring token this many ms before it actually expires. */
 const REFRESH_SKEW_MS = 10 * 60_000;
+/** The bot (installation) token lasts ~1 h; refresh with a wide skew so an injected token has plenty of life. */
+const BOT_REFRESH_SKEW_MS = 25 * 60_000;
 
 /** The stored per-member credential. Only `token`/`refreshToken` are secret; `login`/`expiresAt` are metadata. */
 export interface MemberGithub {
@@ -28,6 +34,12 @@ export interface MemberGithub {
   expiresAt?: number;
   login: string;
   connectedAt: number;
+}
+
+/** The cached company-bot installation token — an org-scoped credential every session can use as GH_TOKEN. */
+export interface BotToken {
+  token: string;
+  expiresAt: number;
 }
 
 /** The minimal slice of AgentOS this store needs — kept structural so it's trivial to construct/test. */
@@ -43,6 +55,10 @@ interface GithubDeps {
     setGithubClientId(v: string, by?: string): void;
     githubAppSlug(): string;
     setGithubAppSlug(v: string, by?: string): void;
+    githubAppId(): string;
+    setGithubAppId(v: string, by?: string): void;
+    githubInstallationId(): string;
+    setGithubInstallationId(v: string, by?: string): void;
   };
 }
 
@@ -70,6 +86,94 @@ export class GithubIdentity {
     this.os.settings.setGithubClientId(app.clientId, by);
     this.setClientSecret(app.clientSecret, by);
     this.os.settings.setGithubAppSlug(app.slug, by);
+  }
+
+  // ── company-bot (installation token) — the universal git baseline ────────────
+  // The App's App ID (setting) + RSA private key (vault) let us mint short-lived, org-scoped
+  // **installation access tokens** that act as the App bot on every installed repo — the credential a
+  // session uses when the run-as human hasn't linked their own GitHub and the agent has no PAT. Minting
+  // is a network call, but the launch path is synchronous, so we cache the current token in the vault
+  // (like member tokens) and read it sync at launch, refreshing in the background — see loadBotToken /
+  // ensureBotToken. Deleting the private key drops the cache too.
+  appId(): string {
+    return this.os.settings.githubAppId();
+  }
+  setAppId(v: string, by?: string): void {
+    this.os.settings.setGithubAppId(v, by);
+  }
+  privateKey(): string {
+    return this.os.secrets.getSync(this.os.tenant, '*', PRIVATE_KEY_KEY) ?? '';
+  }
+  setPrivateKey(value: string, by?: string): void {
+    const v = value.trim();
+    if (v) {
+      this.os.secrets.set(this.os.tenant, PRIVATE_KEY_KEY, v, { principal: '*', updatedBy: by });
+    } else {
+      // Clearing the key detaches the bot entirely — drop the cached token + resolved installation.
+      this.os.secrets.delete(this.os.tenant, PRIVATE_KEY_KEY, '*');
+      this.os.secrets.delete(this.os.tenant, BOT_TOKEN_KEY, '*');
+      this.os.settings.setGithubInstallationId('', by);
+    }
+  }
+  /** App id + private key present — the minimum to mint an installation (bot) token. */
+  botConfigured(): boolean {
+    return !!this.appId() && !!this.privateKey();
+  }
+
+  /** Read the cached bot token (sync — the launch path reads it synchronously). */
+  loadBotToken(): BotToken | undefined {
+    const raw = this.os.secrets.getSync(this.os.tenant, '*', BOT_TOKEN_KEY);
+    if (!raw) return undefined;
+    try {
+      const j = JSON.parse(raw) as BotToken;
+      return typeof j?.token === 'string' && typeof j?.expiresAt === 'number' ? j : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  botNeedsRefresh(blob: BotToken, nowMs: number = Date.now()): boolean {
+    return blob.expiresAt - BOT_REFRESH_SKEW_MS <= nowMs;
+  }
+
+  /**
+   * Return a live bot token, minting + caching one if missing/expiring. Resolves the installation id
+   * from `listInstallations` on first use (a single-org App has exactly one). Returns undefined when the
+   * bot isn't configured or a mint fails hard (a stale cached token is kept so callers can still try it).
+   * Async: the sync launch path fires-and-forgets this while injecting the current cached token.
+   */
+  async ensureBotToken(nowMs: number = Date.now(), by?: string): Promise<BotToken | undefined> {
+    if (!this.botConfigured()) return undefined;
+    const cached = this.loadBotToken();
+    if (cached && !this.botNeedsRefresh(cached, nowMs)) return cached;
+    const appId = this.appId();
+    const pem = this.privateKey();
+    let instId = this.os.settings.githubInstallationId();
+    if (!instId) {
+      const li = await listInstallations(appId, pem);
+      if ('error' in li) return cached;
+      if (!li.installations.length) return cached;
+      instId = String(li.installations[0].id);
+      this.os.settings.setGithubInstallationId(instId, by);
+    }
+    const minted = await mintInstallationToken(appId, pem, instId);
+    if ('error' in minted) {
+      // A stale installation id (App reinstalled) → re-resolve once and retry.
+      this.os.settings.setGithubInstallationId('', by);
+      const li = await listInstallations(appId, pem);
+      if ('error' in li || !li.installations.length) return cached;
+      const retryId = String(li.installations[0].id);
+      this.os.settings.setGithubInstallationId(retryId, by);
+      const retry = await mintInstallationToken(appId, pem, retryId);
+      if ('error' in retry) return cached;
+      return this.saveBotToken(retry, by);
+    }
+    return this.saveBotToken(minted, by);
+  }
+
+  private saveBotToken(minted: { token: string; expiresAt: number }, by?: string): BotToken {
+    const blob: BotToken = { token: minted.token, expiresAt: minted.expiresAt };
+    this.os.secrets.set(this.os.tenant, BOT_TOKEN_KEY, JSON.stringify(blob), { principal: '*', updatedBy: by });
+    return blob;
   }
   /** Both halves present — the minimum to run the OAuth flow. */
   configured(): boolean {

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -20,6 +20,8 @@ const SLACK_BOT_TOKEN_KEY = 'slack_bot_token'; // xoxb-… (chat.postMessage, us
 const DISCORD_BOT_TOKEN_KEY = 'discord_bot_token'; // Bot … (Gateway connect + post messages)
 const GITHUB_CLIENT_ID_KEY = 'github_client_id'; // the company GitHub App / OAuth App client id (per-member OAuth)
 const GITHUB_APP_SLUG_KEY = 'github_app_slug'; // the created App's slug (from the manifest flow) → the Install-on-repos link
+const GITHUB_APP_ID_KEY = 'github_app_id'; // the GitHub App's numeric App ID (for the company-bot installation-token minter)
+const GITHUB_INSTALLATION_ID_KEY = 'github_installation_id'; // the App installation to mint bot tokens against (auto-resolved)
 const IMAGE_OPENROUTER_KEY = 'image_openrouter_key'; // OpenRouter Unified Image API key (default backend)
 const IMAGE_ATLAS_KEY = 'image_atlas_key'; // Atlas Cloud key (alt backend; covers video later)
 const IMAGE_MODEL_KEY = 'image_default_model'; // workspace default image model id (backend-specific); '' = adapter default
@@ -221,6 +223,20 @@ export class SettingsStore {
   }
   setGithubAppSlug(slug: string, by?: string): void {
     this.set(GITHUB_APP_SLUG_KEY, slug.trim(), by);
+  }
+  /** The GitHub App's numeric App ID — the App-level credential the company-bot minter signs a JWT as. */
+  githubAppId(): string {
+    return this.getRow(GITHUB_APP_ID_KEY)?.value?.trim() ?? '';
+  }
+  setGithubAppId(v: string, by?: string): void {
+    this.set(GITHUB_APP_ID_KEY, v.trim(), by);
+  }
+  /** The installation to mint bot tokens against (auto-resolved from listInstallations), or ''. */
+  githubInstallationId(): string {
+    return this.getRow(GITHUB_INSTALLATION_ID_KEY)?.value?.trim() ?? '';
+  }
+  setGithubInstallationId(v: string, by?: string): void {
+    this.set(GITHUB_INSTALLATION_ID_KEY, v.trim(), by);
   }
 
   // ── image generation ─────────────────────────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -2913,6 +2913,18 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       if (!b.githubClientId.trim()) os.settings.setGithubAppSlug('', me.email);
     }
     if (typeof b.githubClientSecret === 'string') new GithubIdentity(os).setClientSecret(b.githubClientSecret, me.email);
+    // Company-bot (installation-token) credentials: App ID → setting, RSA private key → vault. When both
+    // are set, pre-warm + VALIDATE by minting a bot token now, so the admin gets immediate feedback and
+    // the first session doesn't have to wait on a cold mint. Audited github.bot_token.minted / .failed.
+    if (typeof b.githubAppId === 'string') new GithubIdentity(os).setAppId(b.githubAppId, me.email);
+    if (typeof b.githubPrivateKey === 'string') new GithubIdentity(os).setPrivateKey(b.githubPrivateKey, me.email);
+    if (typeof b.githubAppId === 'string' || typeof b.githubPrivateKey === 'string') {
+      const ghb = new GithubIdentity(os);
+      if (ghb.botConfigured()) {
+        const bot = await ghb.ensureBotToken(Date.now(), me.email).catch(() => undefined);
+        os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: bot ? 'github.bot_token.minted' : 'github.bot_token.failed', data: { installationId: os.settings.githubInstallationId() || null } });
+      }
+    }
     // Image generation backend keys (OpenRouter default / Atlas alt) + optional default model.
     if (typeof b.openRouterKey === 'string') os.settings.setOpenRouterKey(b.openRouterKey, me.email);
     if (typeof b.atlasKey === 'string') os.settings.setAtlasKey(b.atlasKey, me.email);
@@ -4232,7 +4244,7 @@ function integrationsView(os: AgentOS): {
   webhook: { set: boolean };
   slack: { appToken: boolean; botToken: boolean; configured: boolean };
   discord: { botToken: boolean; configured: boolean };
-  github: { clientId: boolean; clientSecret: boolean; configured: boolean; slug: string; installUrl: string };
+  github: { clientId: boolean; clientSecret: boolean; configured: boolean; slug: string; installUrl: string; appId: boolean; privateKey: boolean; botReady: boolean };
   image: { openRouter: boolean; atlas: boolean; backend: 'openrouter' | 'atlas' | null; defaultModel: string; configured: boolean };
   video: { fal: boolean; atlas: boolean; backend: 'fal' | 'atlas' | null; defaultModel: string; configured: boolean };
   chatRouter: boolean;
@@ -4251,7 +4263,7 @@ function integrationsView(os: AgentOS): {
     webhook: { set: os.settings.composioWebhookSet() },
     slack: { appToken: slack.appToken, botToken: slack.botToken, configured: os.settings.slackConfigured() },
     discord: { botToken: discord.botToken, configured: os.settings.discordConfigured() },
-    github: { clientId: !!gh.clientId(), clientSecret: !!gh.clientSecret(), configured: gh.configured(), slug: gh.appSlug(), installUrl: gh.appSlug() ? `https://github.com/apps/${gh.appSlug()}/installations/new` : '' },
+    github: { clientId: !!gh.clientId(), clientSecret: !!gh.clientSecret(), configured: gh.configured(), slug: gh.appSlug(), installUrl: gh.appSlug() ? `https://github.com/apps/${gh.appSlug()}/installations/new` : '', appId: !!gh.appId(), privateKey: !!gh.privateKey(), botReady: !!gh.loadBotToken() },
     image: { openRouter: image.openRouter, atlas: image.atlas, backend: image.backend, defaultModel: image.defaultModel, configured: os.settings.imageGenConfigured() },
     video: { fal: video.fal, atlas: video.atlas, backend: video.backend, defaultModel: video.defaultModel, configured: os.settings.videoGenConfigured() },
     chatRouter: os.settings.chatRouterEnabled(),

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1014,8 +1014,12 @@ export class TerminalManager {
     // Secrets ASSIGNED to this agent from the Secrets page — the inverse view of `shellSecrets`,
     // granted centrally rather than declared in the manifest. Same env-var injection, additive.
     this.injectAssignedSecrets(env, o.agent, o.id);
+    // Company-bot git baseline: when the App is configured, fill GH_TOKEN with a short-lived, org-scoped
+    // installation token so EVERY session can push — no per-agent PAT needed. Only fills the gap: an
+    // explicit agent GH_TOKEN (shellSecret/assigned) still wins, and a connected member overrides below.
+    this.injectGithubBaseline(env, o.agent, o.id);
     // Per-member git: if THIS run's run-as human has linked their own GitHub account, their token
-    // OVERRIDES the agent bot's GH_TOKEN — so git push / gh pr are authored as the actual person.
+    // OVERRIDES the bot/agent GH_TOKEN — so git push / gh pr are authored as the actual person.
     this.injectMemberGithub(env, o.agent, o.actingMember, o.id);
     // Whatever set GH_TOKEN above (member token or agent bot), teach plain `git` to use it too — `gh`
     // reads GH_TOKEN natively but `git push` over HTTPS does not, so without this only half the toolchain
@@ -3153,6 +3157,34 @@ export class TerminalManager {
       }
       env[key] = value;
       this.audit(sessionId, agent, 'shell.secret.injected', { key, principal, via: 'assignment' });
+    }
+  }
+
+  /**
+   * Company-bot git baseline (Model C — docs/per-member-github-plan.md). When the GitHub App is
+   * configured with an App ID + private key, inject a short-lived, org-scoped **installation token** as
+   * `GH_TOKEN`/`GITHUB_TOKEN` so every session can `git push` / `gh pr` on the App's installed repos —
+   * the universal default that lets per-agent PATs be retired. Fills the gap ONLY: if an agent already
+   * set `GH_TOKEN` (a curated shellSecret/assigned PAT) we leave it, and a connected member's token
+   * overrides afterwards. Reads the vault-cached token synchronously (mint is a network call the sync
+   * launch path can't await); a near-expiry token is injected as-is while a fire-and-forget refresh
+   * rewrites the cache for the next launch. Audited.
+   */
+  private injectGithubBaseline(env: Record<string, string>, agent: string, sessionId: string): void {
+    if (env.GH_TOKEN) return; // an explicit agent credential wins over the bot baseline
+    const gh = new GithubIdentity(this.os);
+    const blob = gh.loadBotToken();
+    if (!blob) {
+      // No cached token yet but the bot IS configured → mint one for the NEXT launch (best-effort).
+      if (gh.botConfigured()) void gh.ensureBotToken().catch(() => { /* next launch retries */ });
+      return;
+    }
+    env.GH_TOKEN = blob.token;
+    env.GITHUB_TOKEN = blob.token;
+    this.audit(sessionId, agent, 'github.bot_token.injected', { expiresAt: blob.expiresAt });
+    if (gh.botNeedsRefresh(blob)) {
+      this.audit(sessionId, agent, 'github.bot_token.stale', { expiresAt: blob.expiresAt });
+      void gh.ensureBotToken().catch(() => { /* best-effort; next launch retries */ });
     }
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9309,9 +9309,11 @@ function IntegrationsSettings({ me }: { me: Member }) {
   const [slackState, setSlackState] = useState<SlackStatus | null>(null)
   const [discord, setDiscord] = useState<IntegrationsResp['discord']>({ botToken: false, configured: false })
   const [discordState, setDiscordState] = useState<DiscordStatus | null>(null)
-  const [github, setGithub] = useState<IntegrationsResp['github']>({ clientId: false, clientSecret: false, configured: false, slug: '', installUrl: '' })
+  const [github, setGithub] = useState<IntegrationsResp['github']>({ clientId: false, clientSecret: false, configured: false, slug: '', installUrl: '', appId: false, privateKey: false, botReady: false })
   const [ghId, setGhId] = useState('')
   const [ghSecret, setGhSecret] = useState('')
+  const [ghAppId, setGhAppId] = useState('')
+  const [ghPem, setGhPem] = useState('')
   const [githubFlash, setGithubFlash] = useState<'created' | 'error' | null>(null)
   const [image, setImage] = useState<IntegrationsResp['image']>({ openRouter: false, atlas: false, backend: null, defaultModel: '', configured: false })
   const [atKey, setAtKey] = useState('')
@@ -9336,7 +9338,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
   // Defensive defaults so an older backend (one that predates a field) never white-screens the page.
   const SLACK_DEFAULT = { appToken: false, botToken: false, configured: false }
   const DISCORD_DEFAULT = { botToken: false, configured: false }
-  const GITHUB_DEFAULT = { clientId: false, clientSecret: false, configured: false, slug: '', installUrl: '' }
+  const GITHUB_DEFAULT = { clientId: false, clientSecret: false, configured: false, slug: '', installUrl: '', appId: false, privateKey: false, botReady: false }
   const IMAGE_DEFAULT = { openRouter: false, atlas: false, backend: null, defaultModel: '', configured: false } as const
   const VIDEO_DEFAULT = { fal: false, atlas: false, backend: null, defaultModel: '', configured: false } as const
   const apply = (r: IntegrationsResp) => {
@@ -9403,12 +9405,12 @@ function IntegrationsSettings({ me }: { me: Member }) {
     }
   }, [])
 
-  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; githubClientId?: string; githubClientSecret?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }, label: string) => {
+  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; githubClientId?: string; githubClientSecret?: string; githubAppId?: string; githubPrivateKey?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }, label: string) => {
     setBusy(true); setHint('')
     const r = await api.saveIntegrations(body)
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
-    setKey(''); setWh(''); setAppTok(''); setBotTok(''); setDiscordTok(''); setGhId(''); setGhSecret(''); setAtKey(''); setFalKey('')
+    setKey(''); setWh(''); setAppTok(''); setBotTok(''); setDiscordTok(''); setGhId(''); setGhSecret(''); setGhAppId(''); setGhPem(''); setAtKey(''); setFalKey('')
     apply(r)
     setHint(label); setTimeout(() => setHint(''), 1500)
     // The Socket-Mode / Gateway connection re-dials on the server when tokens change — poll until the
@@ -9691,6 +9693,55 @@ function IntegrationsSettings({ me }: { me: Member }) {
               </a>
             </div>
           )}
+
+          {/* Company-bot baseline: App ID + private key → a shared installation token every session can
+              push with, so per-agent PATs can be retired. Optional but recommended once the App is installed. */}
+          <details className="rounded-md border" open={github.configured && !github.botReady}>
+            <summary className="cursor-pointer select-none px-3 py-2 text-xs font-medium hover:bg-muted/40">
+              <span className="text-foreground">Company-bot token</span>{' '}
+              {github.botReady
+                ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px] text-emerald-600">active</Badge>
+                : <span className="text-[11px] text-muted-foreground">— optional, lets every session push without a per-agent token</span>}
+            </summary>
+            <div className="space-y-3 border-t p-3">
+              <p className="text-[11px] text-muted-foreground">
+                Add the App's <strong>App ID</strong> and a generated <strong>private key</strong> (App settings → <em>Private keys</em> → Generate) and the OS mints
+                a short-lived, org-scoped <strong>installation token</strong> as the App bot. Every session can then <code className="text-[11px]">git push</code> /
+                open PRs on the installed repos <strong>with no per-agent PAT</strong> — a connected member's own token still takes precedence for attribution.
+              </p>
+              <Field label="App ID">
+                <Input
+                  value={ghAppId}
+                  onChange={(e) => setGhAppId(e.target.value.trim())}
+                  placeholder={github.appId ? 'saved — type a new App ID to replace' : 'e.g. 4286232 (App settings → About)'}
+                  className="font-mono text-xs"
+                />
+              </Field>
+              <Field label="Private key (.pem)">
+                <Textarea
+                  value={ghPem}
+                  onChange={(e) => setGhPem(e.target.value)}
+                  placeholder={github.privateKey ? '•••• (saved) — paste a new key to replace' : '-----BEGIN RSA PRIVATE KEY-----\n…'}
+                  className="min-h-[80px] font-mono text-[11px]"
+                />
+              </Field>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  onClick={() => save({ ...(ghAppId.trim() ? { githubAppId: ghAppId.trim() } : {}), ...(ghPem.trim() ? { githubPrivateKey: ghPem.trim() } : {}) }, 'saved')}
+                  disabled={busy || (!ghAppId.trim() && !ghPem.trim())}
+                >
+                  Save bot credentials
+                </Button>
+                {(github.appId || github.privateKey) && (
+                  <Button variant="ghost" onClick={() => save({ githubAppId: '', githubPrivateKey: '' }, 'removed')} disabled={busy}>Remove</Button>
+                )}
+              </div>
+              {github.appId && github.privateKey && !github.botReady && (
+                <p className="text-[11px] text-destructive">⚠ Credentials saved but a bot token couldn't be minted — check the App ID matches the key and the App is installed on at least one account.</p>
+              )}
+            </div>
+          </details>
 
           {/* Manual / OAuth-App creds — the fallback. Collapsed once an App is configured. */}
           <details className="rounded-md border" open={!github.configured}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -796,7 +796,7 @@ export interface IntegrationsResp {
   discord: { botToken: boolean; configured: boolean }
   /** Per-member GitHub App OAuth — whether the client id / secret are set (never the secret itself),
    *  plus the created App's slug + the install-on-repos link (empty until an App is created). */
-  github: { clientId: boolean; clientSecret: boolean; configured: boolean; slug: string; installUrl: string }
+  github: { clientId: boolean; clientSecret: boolean; configured: boolean; slug: string; installUrl: string; appId: boolean; privateKey: boolean; botReady: boolean }
   /** Image generation backend — which keys are set (never the keys), the active backend, default model. */
   image: { openRouter: boolean; atlas: boolean; backend: 'openrouter' | 'atlas' | null; defaultModel: string; configured: boolean }
   /** Video generation backend — which keys are set (never the keys), the active backend, default model. */
@@ -1119,7 +1119,7 @@ export const api = {
     call<{ ok?: boolean; error?: string }>('POST', '/api/connections/disconnect', body),
   integrations: () => call<IntegrationsResp>('GET', '/api/settings/integrations'),
   atlasModels: () => call<{ configured: boolean; image: { id: string; label: string; priceUsd: number | null }[]; video: { id: string; label: string; priceUsd: number | null }[]; error?: string }>('GET', '/api/integrations/atlas/models'),
-  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; githubClientId?: string; githubClientSecret?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
+  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; githubClientId?: string; githubClientSecret?: string; githubAppId?: string; githubPrivateKey?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
   // Per-member GitHub (user-to-server OAuth): each member links their OWN account so run-as sessions
   // push / open PRs as the actual human. `connect` returns the authorize URL to navigate to.
   githubMe: () => call<GithubMe>('GET', '/api/github/me'),


### PR DESCRIPTION
## What

**Model C** — the universal git baseline. With the GitHub App's **App ID + private key**, the OS mints short-lived, org-scoped **installation access tokens** (acting as the App bot) that push on every installed repo. This is the credential that lets you **retire the per-agent `GH_TOKEN` PATs** (and shared fallback PATs): every session gets a working `GH_TOKEN` from the bot, so removing a PAT just makes that agent fall through to it.

## Precedence (highest wins)

**connected member token → explicit agent `GH_TOKEN` (shellSecret/assigned) → bot baseline.** So human attribution wins where a member connected; a deliberately-curated agent PAT is respected; the bot fills every other gap (unconnected members, automation runs with no human).

## How

- `src/connectors/github.ts` — reuses the existing `appJwt` / `listInstallations` / `mintInstallationToken`.
- `src/edge/github-identity.ts` — `ensureBotToken` (sign JWT → resolve installation id from `listInstallations`, cached in `github_installation_id`, re-resolved if the App is reinstalled → mint), vault-cached (`github_bot_token`, principal `*`) so the **synchronous** launch path reads it without a network call.
- `src/terminal.ts` — `injectGithubBaseline` between shellSecrets and the member override; fills `GH_TOKEN` only when unset; fire-and-forget refresh near expiry.
- `src/server.ts` — PUT integrations accepts `githubAppId` + `githubPrivateKey`; mints once on save to **validate + pre-warm** (audited `github.bot_token.minted`/`.failed`); `integrationsView.github` gains `appId`/`privateKey`/`botReady`.
- `web/` — a **Company-bot token** subsection in the Creds card (App ID + private-key inputs, "active" badge).

## Testing

- `scripts/github-per-member-test.cjs` — **70/70**, incl. mint+cache+reuse, installation-id auto-resolve, and the full precedence matrix (bot fills gap / agent PAT wins / member overrides / clearing the key drops the cache).
- typecheck, both builds, governance (68/68), context-injection (28/28) green.
- **Verified live against the real App** (id 4286232) on instawp: minted a `ghs_` installation token that write-probed `InstaWP/cli` + `client-app` successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)