### PR TITLE
fix(media): timeouts + transient retry + correct error attribution for image tools (v0.155.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.156.0] — 2026-07-13
+### Fixed
+- **`image_generate`/`image_edit` no longer fail ~1-in-3 on a transient hiccup — and the error names the
+  right subsystem.** Three defects in the image path (`src/edge/image-gen.ts`, `src/memory/memory-mcp.ts`):
+  - **Timeouts.** Every vendor `fetch` now has an explicit `AbortSignal.timeout` — 30s submit, 15s per
+    poll, 60s image download — so a hung socket can't hang the tool.
+  - **Retry on transient failures.** Submit + download retry up to 3× with exponential backoff + jitter on
+    a network error/timeout, **429**, or **5xx**; a single poll that blips is tolerated until the render
+    deadline. **Not** retried (a real answer): any 4xx / content-policy rejection or an explicit vendor
+    `failed` status. Retryability lives in one place (`VendorError.retryable`), and the existing
+    model-fallback path keys off the same signal, so a bad model still falls back instead of blind-retrying.
+  - **Correct error attribution.** A network failure during image generation used to report itself as
+    `memory error: fetch failed` (wrong subsystem). The tool wrapper now names the actual tool
+    (`image_generate error: …`) and appends the **vendor** + whether the failure is **transient**, so the
+    agent retries the retryable ones and fixes input on the rest instead of guessing.
+  - The 90s render timeout is now actionable — it says how long it waited and that the prediction may still
+    be in flight (check the Library before regenerating), not a bare "timed out".
+  See `docs/agent-mcp-tools.md` → "Media tool resilience". Verified live (normal gen, transient-retry with
+  correct `retryable`/`vendor`, and the model-fallback path all pass).
+
 ## [0.155.0] — 2026-07-13
 ### Changed
 - **Dreaming page — plain-language, outcomes-first redesign.** The page read like a settings screen

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -66,6 +66,29 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 
+### Media tool resilience — timeouts + retries (`image_generate` / `image_edit`)
+
+The image backend (`src/edge/image-gen.ts`) treats every vendor call as fallible:
+
+- **Timeouts (`AbortSignal.timeout`).** No call can hang a tool: 30s on submit/`generateImage`, 15s per
+  prediction poll, 60s on the image download. A hung socket aborts and becomes a retryable error.
+- **Bounded retry with backoff + jitter (3 attempts).** The submit and the download are retried on
+  **transient** failures only — a network error/timeout, a **429**, or a **5xx**. Backoff is exponential
+  with full jitter (~0.2s → ~4s cap). A single prediction poll that hits a transient error is *tolerated*
+  (the loop keeps polling until the 90s render deadline) rather than aborting the whole call.
+- **What is NOT retried (a real answer, surfaced as-is).** Any **4xx** (bad request / content-policy
+  rejection), an explicit vendor **`failed`/`error`/`cancelled`** prediction status, or a **rejected model
+  id**. Retryability is decided in one place — `VendorError.retryable` — and the existing model-fallback
+  path (`withModelFallback`) keys off the same error, so a bad default model still falls back to the
+  built-in rather than being retried blindly.
+- **Actionable timeout.** When the 90s render deadline is hit, the error says how long it waited and that
+  the prediction (by id) *may still be in flight* — "check the Library before regenerating" — not a bare
+  "timed out".
+- **Error attribution.** A failure carries the **vendor** and a **retryable** flag out through
+  `TerminalManager.generateImage`/`editImage` to the tool response, which prefixes the **actual tool**
+  name (`image_generate error: …`, not `memory error: …`) and appends whether a plain retry is worthwhile.
+  So the agent retries the transient ones and fixes the input on the terminal ones instead of guessing.
+
 ### `notify` — deliberately looping in one teammate (inbox scoping)
 
 Every session's inbox cards — an agent's `update`/`report`, its `ask` question, a `notification`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.155.0",
+  "version": "0.156.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.155.0",
+      "version": "0.156.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.155.0",
+  "version": "0.156.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/image-gen.ts
+++ b/src/edge/image-gen.ts
@@ -104,11 +104,22 @@ async function toBytes(entry: { url?: string; b64_json?: string; b64?: string })
     return { bytes, ext: sniffExt(bytes, 'png') };
   }
   if (entry.url) {
-    const res = await fetch(entry.url);
-    if (!res.ok) throw new Error(`fetching generated image failed (${res.status})`);
-    const ct = (res.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
-    const buf = Buffer.from(await res.arrayBuffer());
-    return { bytes: buf, ext: sniffExt(buf, EXT_BY_MIME[ct] || extFromUrl(entry.url) || 'png') };
+    const url = entry.url;
+    // Download with a timeout + bounded retry: a hung/interrupted body read is transient. The whole read
+    // lives inside the retried fn so a stalled arrayBuffer() (aborted by the signal) also retries.
+    const { buf, ct } = await withRetry(async () => {
+      try {
+        const res = await timedFetch(url, {}, DOWNLOAD_TIMEOUT_MS, 'image download');
+        if (!res.ok) throw new VendorError(`fetching generated image failed (${res.status})`, retryableStatus(res.status), 'image download', res.status);
+        const ct = (res.headers.get('content-type') || '').split(';')[0].trim().toLowerCase();
+        const buf = Buffer.from(await res.arrayBuffer());
+        return { buf, ct };
+      } catch (e) {
+        if (e instanceof VendorError) throw e;
+        throw new VendorError(`image download failed (${e instanceof Error ? e.message : String(e)})`, true, 'image download');
+      }
+    });
+    return { bytes: buf, ext: sniffExt(buf, EXT_BY_MIME[ct] || extFromUrl(url) || 'png') };
   }
   throw new Error('vendor returned an image with neither a url nor base64 data');
 }
@@ -127,6 +138,80 @@ function extFromUrl(url: string): string | undefined {
   if (!m) return undefined;
   const e = m[1].toLowerCase();
   return e === 'jpeg' ? 'jpg' : e;
+}
+
+// ── network resilience: timeouts + bounded retry ─────────────────────────────
+// Every vendor call gets an explicit deadline (a hung socket must never hang the tool) and TRANSIENT
+// failures (network reset, timeout, 429, 5xx) are retried with exponential backoff + jitter. A 4xx
+// (bad request / content policy / rejected model) or an explicit vendor `failed` prediction status is a
+// REAL answer — surfaced on the first occurrence, never retried. `VendorError.retryable` is the single
+// source of truth both the retry loop and the surfaced message consult (so "worth retrying" is decided
+// in exactly one place, and the existing model-fallback path keys off the message the same way).
+const SUBMIT_TIMEOUT_MS = 30_000; // POST generate / submit
+const POLL_TIMEOUT_MS = 15_000; // one prediction poll
+const DOWNLOAD_TIMEOUT_MS = 60_000; // pull the finished image bytes (can be large)
+const RETRY_ATTEMPTS = 3;
+
+/** A vendor-call error that knows its HTTP status, which vendor raised it, and whether retrying could
+ *  plausibly help. Carried out to TerminalManager so the tool response can tell the agent what to do. */
+export class VendorError extends Error {
+  constructor(message: string, readonly retryable: boolean, readonly vendor: string, readonly status?: number) {
+    super(message);
+    this.name = 'VendorError';
+  }
+}
+
+/** 429 (rate limit) and 5xx (vendor-side) are transient; every other status is a definitive answer. */
+function retryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Exponential backoff with full jitter (~0.2–0.4s, ~0.4–0.8s, … capped at 4s) to avoid synchronized retries. */
+function backoffMs(attempt: number): number {
+  const base = Math.min(4000, 400 * 2 ** attempt);
+  return Math.round(base / 2 + Math.random() * (base / 2));
+}
+
+/** One fetch with an explicit timeout, normalizing a network error / timeout into a RETRYABLE VendorError. */
+async function timedFetch(url: string, init: RequestInit, timeoutMs: number, vendor: string): Promise<Response> {
+  try {
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+  } catch (e) {
+    const timedOut = e instanceof Error && (e.name === 'TimeoutError' || e.name === 'AbortError');
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new VendorError(
+      timedOut ? `${vendor} request timed out after ${Math.round(timeoutMs / 1000)}s` : `${vendor} request failed (${detail})`,
+      true,
+      vendor,
+    );
+  }
+}
+
+/** Run a vendor call up to RETRY_ATTEMPTS times, retrying ONLY on a retryable VendorError (transient
+ *  network/timeout/429/5xx). A terminal error (4xx, content policy, `failed` status, bad model) throws on
+ *  its first occurrence so it surfaces as-is. */
+async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
+  let last: unknown;
+  for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      last = e;
+      const retryable = e instanceof VendorError && e.retryable;
+      if (!retryable || attempt === RETRY_ATTEMPTS - 1) throw e;
+      await sleep(backoffMs(attempt));
+    }
+  }
+  throw last;
+}
+
+/** Normalize any thrown error into { message, retryable, vendor } for the caller (TerminalManager → the
+ *  tool response), so the agent is told which subsystem failed and whether a plain retry is worthwhile. */
+export function imageErrorInfo(e: unknown): { message: string; retryable?: boolean; vendor?: string } {
+  if (e instanceof VendorError) return { message: e.message, retryable: e.retryable, vendor: e.vendor };
+  return { message: e instanceof Error ? e.message : String(e) };
 }
 
 // ── OpenRouter ──────────────────────────────────────────────────────────────
@@ -149,15 +234,19 @@ class OpenRouterBackend implements ImageBackend {
     const model = req.model?.trim() || this.defaultModel;
     const body: Record<string, unknown> = { model, prompt: req.prompt, n: req.n };
     if (req.size) body.size = req.size;
-    const res = await fetch('https://openrouter.ai/api/v1/images', {
-      method: 'POST',
-      headers: { Authorization: `Bearer ${this.key}`, 'content-type': 'application/json' },
-      body: JSON.stringify(body),
+    const d = await withRetry(async () => {
+      const res = await timedFetch('https://openrouter.ai/api/v1/images', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${this.key}`, 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      }, SUBMIT_TIMEOUT_MS, 'OpenRouter');
+      const j = (await res.json().catch(() => ({}))) as OpenRouterResponse;
+      if (!res.ok) throw new VendorError(errMsg(j, res.status), retryableStatus(res.status), 'OpenRouter', res.status);
+      const entries = j.data ?? j.images ?? [];
+      if (!entries.length) throw new VendorError('OpenRouter returned no images', true, 'OpenRouter');
+      return j;
     });
-    const d = (await res.json().catch(() => ({}))) as OpenRouterResponse;
-    if (!res.ok) throw new Error(errMsg(d, res.status));
     const entries = d.data ?? d.images ?? [];
-    if (!entries.length) throw new Error('OpenRouter returned no images');
     const images = await Promise.all(entries.map(toBytes));
     return { images, model, costUsd: typeof d.usage?.cost === 'number' ? d.usage.cost : undefined };
   }
@@ -250,27 +339,50 @@ class AtlasBackend implements ImageBackend {
   /** Submit a generateImage body then poll the prediction to completion (image renders in seconds, so a
    *  bounded internal poll keeps the sync ImageBackend contract). Shared by generate + editImage. */
   private async submitAndPoll(body: Record<string, unknown>, model: string): Promise<ImageGenResult> {
-    const sres = await fetch(`${this.base}/api/v1/model/generateImage`, { method: 'POST', headers: this.headers(), body: JSON.stringify(body) });
-    const sbody = (await sres.json().catch(() => ({}))) as { data?: AtlasPrediction; message?: string } & AtlasPrediction;
-    if (!sres.ok) throw new Error(atlasErr(sbody, sres.status));
-    const id = sbody.data?.id ?? sbody.id;
-    if (!id) throw new Error('Atlas did not return a prediction id');
-    const deadline = Date.now() + 90_000;
+    // Submit with a timeout + bounded retry (transient network/429/5xx). A 4xx (incl. a rejected model,
+    // which the model-fallback path then handles by message) throws on the first try and surfaces as-is.
+    const sbody = await withRetry(async () => {
+      const res = await timedFetch(`${this.base}/api/v1/model/generateImage`, { method: 'POST', headers: this.headers(), body: JSON.stringify(body) }, SUBMIT_TIMEOUT_MS, 'Atlas');
+      const b = (await res.json().catch(() => ({}))) as { data?: AtlasPrediction; message?: string } & AtlasPrediction;
+      if (!res.ok) throw new VendorError(atlasErr(b, res.status), retryableStatus(res.status), 'Atlas', res.status);
+      if (!(b.data?.id ?? b.id)) throw new VendorError('Atlas accepted the request but returned no prediction id', true, 'Atlas');
+      return b;
+    });
+    const id = sbody.data?.id ?? sbody.id!;
+
+    const start = Date.now();
+    const deadline = start + 90_000;
     for (;;) {
-      await new Promise((r) => setTimeout(r, 2000));
-      const pres = await fetch(`${this.base}/api/v1/model/prediction/${id}`, { headers: this.headers() });
-      const pbody = (await pres.json().catch(() => ({}))) as { data?: AtlasPrediction; message?: string } & AtlasPrediction;
-      if (!pres.ok) throw new Error(atlasErr(pbody, pres.status));
+      await sleep(2000);
+      let pbody: { data?: AtlasPrediction; message?: string; msg?: string } & AtlasPrediction;
+      try {
+        const pres = await timedFetch(`${this.base}/api/v1/model/prediction/${id}`, { headers: this.headers() }, POLL_TIMEOUT_MS, 'Atlas');
+        pbody = (await pres.json().catch(() => ({}))) as typeof pbody;
+        if (!pres.ok) {
+          if (retryableStatus(pres.status) && Date.now() < deadline) continue; // transient 5xx/429 → keep polling
+          throw new VendorError(atlasErr(pbody, pres.status), false, 'Atlas', pres.status); // terminal
+        }
+      } catch (e) {
+        // A single poll that hit a network error / timeout is not fatal — keep polling until the deadline;
+        // only a terminal (retryable=false) error or the clock running out gives up.
+        if (e instanceof VendorError && e.retryable && Date.now() < deadline) continue;
+        throw e;
+      }
       const d: AtlasPrediction = pbody.data ?? pbody;
       const st = (d.status || '').toLowerCase();
-      if (st === 'failed' || st === 'error' || st === 'cancelled' || st === 'canceled') throw new Error(d.error || pbody.message || (pbody as { msg?: string }).msg || `Atlas image ${st || 'failed'}`);
+      if (st === 'failed' || st === 'error' || st === 'cancelled' || st === 'canceled') {
+        throw new VendorError(d.error || pbody.message || pbody.msg || `Atlas image ${st || 'failed'}`, false, 'Atlas'); // a real answer — never retry
+      }
       if (st === 'completed' || st === 'succeeded') {
         const urls = (d.outputs || []).filter((o): o is string => typeof o === 'string');
-        if (!urls.length) throw new Error('Atlas completed but returned no image URL');
+        if (!urls.length) throw new VendorError('Atlas completed but returned no image URL', true, 'Atlas');
         const images = await Promise.all(urls.map((url) => toBytes({ url })));
         return { images, model, costUsd: undefined }; // Atlas doesn't return cost in-band → caller estimates
       }
-      if (Date.now() > deadline) throw new Error('Atlas image timed out');
+      if (Date.now() > deadline) {
+        const waited = Math.round((Date.now() - start) / 1000);
+        throw new VendorError(`Atlas image timed out after ${waited}s waiting for the render — the prediction (${id}) may still be in flight; try again shortly or check the Library before regenerating.`, true, 'Atlas');
+      }
     }
   }
 }

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -1149,12 +1149,23 @@ async function imageGenerate(args: Record<string, unknown>): Promise<string> {
     headers: H({ 'content-type': 'application/json' }),
     body: JSON.stringify(body),
   });
-  const d = (await res.json()) as { ok?: boolean; error?: string; artifacts?: { id: string; filename: string }[]; model?: string; costUsd?: number; warning?: string };
-  if (!d.ok) return `Could not generate image: ${d.error ?? 'unknown error'}`;
+  const d = (await res.json()) as { ok?: boolean; error?: string; vendor?: string; retryable?: boolean; artifacts?: { id: string; filename: string }[]; model?: string; costUsd?: number; warning?: string };
+  if (!d.ok) return `image_generate error: ${mediaErrorHint(d)}`;
   const list = (d.artifacts ?? []).map((a) => `${a.id} (${a.filename})`).join(', ');
   const cost = typeof d.costUsd === 'number' ? ` · ~$${d.costUsd.toFixed(3)}` : '';
   const warn = d.warning ? ` ⚠ ${d.warning}` : '';
   return `Generated ${d.artifacts?.length ?? 0} image(s) with ${d.model ?? 'the default model'}${cost}. Saved to the Library: ${list}.${warn}`;
+}
+
+/** A consistent failure suffix for a media call — names the vendor and says whether a plain retry is
+ *  worthwhile, so the agent acts on it (retry the transient ones, fix the input on the terminal ones)
+ *  instead of blindly re-calling. */
+function mediaErrorHint(d: { error?: string; vendor?: string; retryable?: boolean }): string {
+  const vendor = d.vendor ? ` [${d.vendor}]` : '';
+  const advice = d.retryable === true ? ' — transient, so you may retry once or twice'
+    : d.retryable === false ? ' — not transient; do NOT just retry, fix the input/model or surface it'
+    : '';
+  return `${d.error ?? 'unknown error'}${vendor}${advice}`;
 }
 
 async function imageEdit(args: Record<string, unknown>): Promise<string> {
@@ -1174,8 +1185,8 @@ async function imageEdit(args: Record<string, unknown>): Promise<string> {
     headers: H({ 'content-type': 'application/json' }),
     body: JSON.stringify(body),
   });
-  const d = (await res.json()) as { ok?: boolean; error?: string; artifacts?: { id: string; filename: string }[]; model?: string; costUsd?: number; warning?: string };
-  if (!d.ok) return `Could not edit image: ${d.error ?? 'unknown error'}`;
+  const d = (await res.json()) as { ok?: boolean; error?: string; vendor?: string; retryable?: boolean; artifacts?: { id: string; filename: string }[]; model?: string; costUsd?: number; warning?: string };
+  if (!d.ok) return `image_edit error: ${mediaErrorHint(d)}`;
   const list = (d.artifacts ?? []).map((a) => `${a.id} (${a.filename})`).join(', ');
   const cost = typeof d.costUsd === 'number' ? ` · ~$${d.costUsd.toFixed(3)}` : '';
   const what = operation === 'remove-background' ? 'Removed background' : scale && scale > 1 ? `Upscaled ${scale}×` : 'Edited';
@@ -2176,7 +2187,9 @@ async function handle(req: JsonRpc): Promise<void> {
         : `unknown tool: ${name}`;
       send({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text }] } });
     } catch (e) {
-      send({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: `memory error: ${e instanceof Error ? e.message : String(e)}` }], isError: true } });
+      // Name the tool that actually failed — not every tool is "memory" (an image/video generation network
+      // error was reporting itself as a memory failure, sending the agent to the wrong subsystem).
+      send({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text: `${name ?? 'tool'} error: ${e instanceof Error ? e.message : String(e)}` }], isError: true } });
     }
     return;
   }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -22,7 +22,7 @@ import { ChatPlatform, chatLink, consolePage } from './governance/chat-links';
 import { SkillSummary, CatalogSkill } from './governance/skills';
 import { browseRepo, RemoteCatalog } from './governance/skill-registry';
 import { claudeSupportsReloadSkills } from './edge/claude-cli';
-import { DEFAULT_IMAGE_COST_USD, resolveImageBackend } from './edge/image-gen';
+import { DEFAULT_IMAGE_COST_USD, resolveImageBackend, imageErrorInfo } from './edge/image-gen';
 import { DEFAULT_VIDEO_COST_PER_SEC_USD, DEFAULT_VIDEO_DURATION_SEC, resolveVideoBackend, videoBackend, VideoBackend } from './edge/video-gen';
 import { understandMedia } from './edge/media-understand';
 
@@ -2502,7 +2502,7 @@ export class TerminalManager {
    *  3. each image lands as an `image` artifact + an owner-scoped inbox card, and the run is audited
    *     with the REAL cost when the backend reports it (OpenRouter `usage.cost`), else the estimate.
    */
-  async generateImage(sessionId: string, input: { prompt: string; model?: string; size?: string; n?: number }): Promise<{ ok: boolean; artifacts?: { id: string; filename: string; mime: string }[]; model?: string; costUsd?: number; warning?: string; error?: string }> {
+  async generateImage(sessionId: string, input: { prompt: string; model?: string; size?: string; n?: number }): Promise<{ ok: boolean; artifacts?: { id: string; filename: string; mime: string }[]; model?: string; costUsd?: number; warning?: string; error?: string; retryable?: boolean; vendor?: string }> {
     const agent = this.sessionAgent(sessionId);
     if (!agent) return { ok: false, error: 'unknown session' };
     if (!this.os.artifacts.enabled) return { ok: false, error: 'artifacts store is disabled (no data home)' };
@@ -2528,9 +2528,9 @@ export class TerminalManager {
     try {
       result = await backend.generate({ prompt, model: input.model, size: input.size, n });
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      this.audit(sessionId, agent, 'image.failed', { model, n, error: msg });
-      return { ok: false, error: msg };
+      const info = imageErrorInfo(e);
+      this.audit(sessionId, agent, 'image.failed', { model, n, error: info.message, vendor: info.vendor, retryable: info.retryable });
+      return { ok: false, error: info.message, retryable: info.retryable, vendor: info.vendor };
     }
 
     const srow = this.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(sessionId);
@@ -2575,7 +2575,7 @@ export class TerminalManager {
    * `operation` (a named preset — 'remove-background', a transparent-PNG cutout, no prompt) ⇒ that preset;
    * else `scale` (>1) upscales (prompt ignored); else `prompt` drives an image-to-image edit. Atlas-only.
    */
-  async editImage(sessionId: string, input: { image: string; prompt?: string; scale?: number; model?: string; operation?: 'remove-background' }): Promise<{ ok: boolean; artifacts?: { id: string; filename: string; mime: string }[]; model?: string; costUsd?: number; warning?: string; error?: string }> {
+  async editImage(sessionId: string, input: { image: string; prompt?: string; scale?: number; model?: string; operation?: 'remove-background' }): Promise<{ ok: boolean; artifacts?: { id: string; filename: string; mime: string }[]; model?: string; costUsd?: number; warning?: string; error?: string; retryable?: boolean; vendor?: string }> {
     const agent = this.sessionAgent(sessionId);
     if (!agent) return { ok: false, error: 'unknown session' };
     if (!this.os.artifacts.enabled) return { ok: false, error: 'artifacts store is disabled (no data home)' };
@@ -2606,9 +2606,9 @@ export class TerminalManager {
     try {
       result = await backend.editImage({ images: [resolved.url], prompt, model: input.model, scale: input.scale, operation: input.operation });
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      this.audit(sessionId, agent, 'image.failed', { model, op, error: msg });
-      return { ok: false, error: msg };
+      const info = imageErrorInfo(e);
+      this.audit(sessionId, agent, 'image.failed', { model, op, error: info.message, vendor: info.vendor, retryable: info.retryable });
+      return { ok: false, error: info.message, retryable: info.retryable, vendor: info.vendor };
     }
 
     const srow = this.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(sessionId);


### PR DESCRIPTION
## Problem
`image_generate` failed roughly 1-in-3 with `memory error: fetch failed` or `Could not generate image: Atlas image timed out`, and the agent's only recourse was to blindly re-call. Three defects in `src/edge/image-gen.ts` + `src/memory/memory-mcp.ts`.

## Fixes
### 1. Timeouts (no more hung sockets)
Every vendor `fetch` now carries an explicit `AbortSignal.timeout`: **30s** submit/`generateImage`, **15s** per prediction poll, **60s** image download (bytes can be large). Covers OpenRouter generate, Atlas submit, Atlas poll, and the image download in `toBytes`.

### 2. Bounded retry on transient failures
Submit + download retry up to **3×** with **exponential backoff + full jitter** on a **network error / timeout, 429, or 5xx**. A single prediction poll that blips is *tolerated* (keep polling until the 90s render deadline) rather than aborting the whole call.

**Not retried — a real answer, surfaced as-is:** any **4xx** (bad request / content policy), an explicit vendor **`failed`/`error`/`cancelled`** status, or a **rejected model id**. Retryability is decided in exactly one place — `VendorError.retryable` — and the existing `withModelFallback` path keys off the same error, so a bad default model still *falls back* (not blind-retries).

### 3. Correct error attribution
- The generic MCP wrapper reported every tool error as `memory error: …` — an image network failure looked like a memory failure. It now names the **actual tool** (`image_generate error: …`).
- The failure carries the **vendor** + a **retryable** flag out through `TerminalManager.generateImage`/`editImage` → the tool response appends whether a plain retry is worthwhile (*"transient, you may retry"* vs *"not transient; fix the input/model"*).
- The 90s render timeout is now **actionable**: says how long it waited and that the prediction (by id) may still be in flight — "check the Library before regenerating".

Docs: new "Media tool resilience" section in `docs/agent-mcp-tools.md`.

## Verified (live, in-process through the real adapter)
1. **Normal** generate → unaffected (1.1 MB image).
2. **Transient** (unreachable host) → retried, then surfaced `retryable=true, vendor=Atlas: "Atlas request failed (fetch failed)"`.
3. **Model-fallback** → bad `google/` still falls back to `nano-banana-2` (`fallbackFrom=google/`).
4. `typecheck`, `build`, `test:governance` (68/68) pass.

Video-gen (`video-gen.ts`) intentionally out of scope — the ask was the image path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)