### PR TITLE
Connect GitHub from the profile page + return-to-origin (v0.157.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.156.0] — 2026-07-13
+### Added
+- **Connect GitHub from your profile.** The per-member GitHub connection (the `GithubMineCard` — Connect/
+  Disconnect + live install status) now also appears on the **Profile** page, in a **My git identity**
+  section right above **My chat identities** — the natural, discoverable home for "link my own account"
+  (it also auto-fills your `github` handle below on connect). Same component as Connections → Mine, so one
+  implementation. The OAuth round-trip now **returns you to the page you started on** (profile or
+  Connections) instead of always dumping you on Connections: `/api/github/connect` takes a `return` hash
+  that the callback restores, open-redirect-guarded to safe in-app routes. (`web/src/App.tsx`,
+  `web/src/connectors.tsx` — `GithubMineCard` exported, `src/server.ts` — return-path in the OAuth state;
+  `scripts/github-per-member-test.cjs` now 73/73.)
+
 ## [0.155.0] — 2026-07-13
 ### Changed
 - **Dreaming page — plain-language, outcomes-first redesign.** The page read like a settings screen

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.155.0",
+  "version": "0.156.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.155.0",
+      "version": "0.156.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.155.0",
+  "version": "0.156.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/github-per-member-test.cjs
+++ b/scripts/github-per-member-test.cjs
@@ -179,6 +179,17 @@ async function main() {
   // Good state → exchange (stubbed) → connected.
   r = await call('GET', `/api/github/callback?code=abc&state=${state}`);
   assert(r.status === 302 && (r.headers.get('location') || '').includes('github=connected'), 'valid callback redirects with github=connected');
+  assert((r.headers.get('location') || '') === '/#/connectors?github=connected', 'default connect returns to Connections');
+  // Return path: connecting from the profile page comes back to the profile (open-redirect-guarded).
+  r = await call('GET', '/api/github/connect?return=' + encodeURIComponent('#/profile'));
+  const st2 = new URL((await r.json()).redirectUrl).searchParams.get('state');
+  r = await call('GET', `/api/github/callback?code=abc&state=${st2}`);
+  assert((r.headers.get('location') || '') === '/#/profile?github=connected', 'connect with return=#/profile comes back to the profile');
+  // Open-redirect guard: a hostile return is ignored, falling back to Connections.
+  r = await call('GET', '/api/github/connect?return=' + encodeURIComponent('https://evil.example/x'));
+  const st3 = new URL((await r.json()).redirectUrl).searchParams.get('state');
+  r = await call('GET', `/api/github/callback?code=abc&state=${st3}`);
+  assert((r.headers.get('location') || '').startsWith('/#/connectors'), 'a non-local return path is rejected (no open redirect)');
   me = await (await call('GET', '/api/github/me')).json();
   assert(me.connected === true && me.login === 'octocat', '/me now reports connected as octocat');
   assert(!('token' in me), '/me never leaks the token');

--- a/src/server.ts
+++ b/src/server.ts
@@ -2997,7 +2997,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/github/connect') {
     const gh = new GithubIdentity(os);
     if (!gh.configured()) return sendJson(res, 400, { error: 'GitHub is not set up — an owner/admin must add the App client id + secret in Connections → Creds' });
-    const state = newGithubState(os.tenant, me.id);
+    // Remember where the member started (the profile page or Connections) so the callback returns there.
+    const state = newGithubState(os.tenant, me.id, url.searchParams.get('return') || undefined);
     const redirectUrl = gh.authorizeUrl(githubRedirectUri(req), state);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'github.connect.initiated', data: {} });
     return sendJson(res, 200, { redirectUrl });
@@ -3008,18 +3009,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const code = url.searchParams.get('code') || '';
     const state = url.searchParams.get('state') || '';
     if (url.searchParams.get('error')) return redirect(res, '/#/connectors?github=denied');
-    if (!code || !takeGithubState(state, os.tenant, me.id)) return redirect(res, '/#/connectors?github=error');
+    const st = code ? takeGithubState(state, os.tenant, me.id) : null;
+    if (!st) return redirect(res, '/#/connectors?github=error');
     const gh = new GithubIdentity(os);
     const r = await gh.completeConnect(me.id, code, githubRedirectUri(req), me.email);
     if ('error' in r) {
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'github.user.connect_failed', data: { error: r.error } });
-      return redirect(res, '/#/connectors?github=error');
+      return redirect(res, githubReturnRedirect(st.returnTo, 'error'));
     }
     // Record the login as this member's `github` identity — the queryable, non-secret handle for
     // attribution + the Team page's Chat-IDs row.
     os.team.setIdentity(me.id, 'github', r.login, me.email);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'github.user.connected', data: { login: r.login } });
-    return redirect(res, '/#/connectors?github=connected');
+    return redirect(res, githubReturnRedirect(st.returnTo, 'connected'));
   }
   if (method === 'POST' && p === '/api/github/disconnect') {
     const gh = new GithubIdentity(os);
@@ -4131,21 +4133,28 @@ function allowLinkRequest(email: string, req: http.IncomingMessage): boolean {
 // a restart mid-flow just makes the member retry). Keyed by the random state string, so it's safe
 // across tenants; we still bind {tenant, memberId} and re-check them at the callback.
 const GH_STATE_TTL_MS = 10 * 60 * 1000;
-const githubOauthStates = new Map<string, { tenant: string; memberId: string; exp: number }>();
-function newGithubState(tenant: string, memberId: string): string {
+const githubOauthStates = new Map<string, { tenant: string; memberId: string; exp: number; returnTo?: string }>();
+function newGithubState(tenant: string, memberId: string, returnTo?: string): string {
   const state = crypto.randomBytes(24).toString('hex');
   const now = Date.now();
   // Opportunistically evict expired entries so the map can't grow unbounded.
   for (const [k, v] of githubOauthStates) if (v.exp < now) githubOauthStates.delete(k);
-  githubOauthStates.set(state, { tenant, memberId, exp: now + GH_STATE_TTL_MS });
+  githubOauthStates.set(state, { tenant, memberId, exp: now + GH_STATE_TTL_MS, returnTo });
   return state;
 }
-/** Consume a state (single-use): valid only if present, unexpired, and bound to this tenant + member. */
-function takeGithubState(state: string, tenant: string, memberId: string): boolean {
+/** Consume a state (single-use): returns the stored entry only if present, unexpired, and bound to
+ *  this tenant + member; else null. */
+function takeGithubState(state: string, tenant: string, memberId: string): { returnTo?: string } | null {
   const hit = githubOauthStates.get(state);
-  if (!hit) return false;
+  if (!hit) return null;
   githubOauthStates.delete(state);
-  return hit.exp >= Date.now() && hit.tenant === tenant && hit.memberId === memberId;
+  if (hit.exp >= Date.now() && hit.tenant === tenant && hit.memberId === memberId) return { returnTo: hit.returnTo };
+  return null;
+}
+/** Build a post-OAuth redirect to a SAFE in-app hash route (open-redirect guard), tagged with the flag. */
+function githubReturnRedirect(returnTo: string | undefined, flag: string): string {
+  const safe = returnTo && /^#\/[\w/-]*$/.test(returnTo) ? returnTo : '#/connectors';
+  return `/${safe}?github=${flag}`;
 }
 /** This server's public origin (`proto://host`), honouring an nginx/Tailscale X-Forwarded-Proto/Host. */
 function publicOrigin(req: http.IncomingMessage): string {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,7 +15,7 @@ import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuIte
 import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
-import { ConnectorsPage } from '@/connectors'
+import { ConnectorsPage, GithubMineCard } from '@/connectors'
 import { docPages } from '@/docs'
 import { Xterm } from './Xterm'
 
@@ -4130,6 +4130,16 @@ function ProfilePage({ me, prefs, onSavePrefs, onProfileChange }: {
           <label className="flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={prefs.sound} onChange={() => onSavePrefs({ ...prefs, sound: !prefs.sound })} /><span>Play a sound</span></label>
           <label className="flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={prefs.dm} onChange={() => onSavePrefs({ ...prefs, dm: !prefs.dm })} /><span>Also DM me on Slack/Discord</span></label>
         </div>
+      </section>
+
+      {/* Git identity — connect your own GitHub (OAuth). Reuses the same card as Connections → Mine. */}
+      <section className="space-y-2">
+        <div className="text-[11px] uppercase tracking-wider text-muted-foreground">My git identity</div>
+        <p className="text-sm text-muted-foreground">
+          Connect your GitHub so agents running as <strong>you</strong> commit and open PRs under your name
+          (not a shared bot). One click — it also fills your GitHub handle below.
+        </p>
+        <GithubMineCard />
       </section>
 
       {/* Chat identities — own handles (self-service) */}

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -496,7 +496,7 @@ function ProposedHostRow({ h, me, busy, onPublish, onDismiss }: {
 
 /** The viewer's own GitHub link — Connect/Disconnect their personal git identity (per-member run-as).
  *  Self-contained: fetches its own state so the Mine section can drop it in without threading props. */
-function GithubMineCard() {
+export function GithubMineCard() {
   const [st, setSt] = useState<GithubMe | null>(null)
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState('')
@@ -512,7 +512,9 @@ function GithubMineCard() {
   }, [])
   const connect = async () => {
     setBusy(true); setErr('')
-    const r = await api.githubConnect()
+    // Return to the page the member started on (profile or Connections) after the OAuth round-trip.
+    const returnTo = (window.location.hash || '#/connectors').split('?')[0]
+    const r = await api.githubConnect(returnTo)
     setBusy(false)
     if (r.error) return setErr(r.error)
     if (r.redirectUrl) window.location.href = r.redirectUrl

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1137,7 +1137,7 @@ export const api = {
   // Per-member GitHub (user-to-server OAuth): each member links their OWN account so run-as sessions
   // push / open PRs as the actual human. `connect` returns the authorize URL to navigate to.
   githubMe: () => call<GithubMe>('GET', '/api/github/me'),
-  githubConnect: () => call<{ redirectUrl?: string; error?: string }>('GET', '/api/github/connect'),
+  githubConnect: (returnTo?: string) => call<{ redirectUrl?: string; error?: string }>('GET', `/api/github/connect${returnTo ? `?return=${encodeURIComponent(returnTo)}` : ''}`),
   githubDisconnect: () => call<{ ok?: boolean; error?: string }>('POST', '/api/github/disconnect', {}),
   // One-click App setup: returns GitHub's form-POST target + the pre-filled manifest to submit to it.
   githubManifest: (org?: string) => call<{ postUrl?: string; manifest?: string; error?: string }>('GET', `/api/github/manifest${org ? `?org=${encodeURIComponent(org)}` : ''}`),


### PR DESCRIPTION
## What

Surfaces the per-member **GitHub connection** on the **Profile** page — the natural, discoverable home for "link my own account." It appears in a new **My git identity** section right above **My chat identities** (which already has a manual `github` handle field that connecting now auto-fills).

Reuses the exact same `GithubMineCard` (Connect/Disconnect + live install status) as Connections → Mine — one implementation, exported and rendered in both places, no drift.

## Bonus: return-to-origin

Previously the OAuth round-trip always dumped you on the Connections page. Now `/api/github/connect` takes a `return` hash that the callback restores, so connecting **from the profile lands back on the profile**. Open-redirect-guarded — only safe in-app hash routes (`#/…`) are honored; anything else falls back to Connections.

## Surface
- `web/src/connectors.tsx` — export `GithubMineCard`, pass the current hash to `connect()`
- `web/src/App.tsx` — render it on `ProfilePage`
- `web/src/lib/api.ts` — `githubConnect(returnTo?)`
- `src/server.ts` — `return` in the OAuth state + `githubReturnRedirect` (open-redirect guard)

## Testing
- `scripts/github-per-member-test.cjs` — **73/73**, incl. default→Connections, `return=#/profile`→profile, and a hostile `return`→rejected (no open redirect).
- typecheck, both builds, governance (68/68) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)