### PR TITLE
fix(links): open internal #/route links in the same tab (v0.157.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.157.2] — 2026-07-13
+### Fixed
+- **Internal links open in the same tab, not a new one.** The markdown renderer's `<a>` hardcoded
+  `target="_blank"` for every link, so a `[[wiki]]`/`#/route` link inside a KB page, task/goal body,
+  artifact, or doc spawned a new tab instead of navigating in place via the hash router. It now only
+  opens external `http(s)` URLs in a new tab; in-app `#…` links stay in the same tab — matching the
+  `InlineLinks` behaviour already used in inbox cards and memory notes. `web/src/App.tsx`.
+
 ## [0.157.1] — 2026-07-13
 ### Fixed
 - **Dreaming staleness — guidance and topics no longer nag or accumulate forever.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.157.1",
+  "version": "0.157.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.157.1",
+      "version": "0.157.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.157.1",
+  "version": "0.157.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3411,7 +3411,12 @@ const mdComponents = {
   ul: (p: any) => <ul className="my-2 list-disc space-y-1 pl-5" {...p} />,
   ol: (p: any) => <ol className="my-2 list-decimal space-y-1 pl-5" {...p} />,
   li: (p: any) => <li className="leading-relaxed" {...p} />,
-  a: (p: any) => <a className="text-primary underline" target="_blank" rel="noreferrer" {...p} />,
+  // In-app links (`#/route`, `#anchor`) navigate in the SAME tab via the hash router; only external
+  // URLs open a new tab. Mirrors InlineLinks so wiki-links behave the same in every surface.
+  a: ({ href, ...p }: any) => {
+    const internal = typeof href === 'string' && href.startsWith('#')
+    return <a href={href} className="text-primary underline" {...(internal ? {} : { target: '_blank', rel: 'noreferrer' })} {...p} />
+  },
   blockquote: (p: any) => <blockquote className="my-2 border-l-2 pl-3 text-muted-foreground" {...p} />,
   code: ({ inline, ...p }: any) => inline
     ? <code className="rounded bg-muted px-1 py-0.5 font-mono text-[0.85em]" {...p} />


### PR DESCRIPTION
Internal in-app links now navigate in the **same tab**; only external URLs open a new tab.

The markdown renderer's `<a>` (`mdComponents.a`) hardcoded `target="_blank"` for *every* link, so a `[[wiki]]` / `#/route` link inside a KB page, task/goal body, artifact, or doc spawned a new tab instead of routing in place. It now opens only external `http(s)` URLs in a new tab; in-app `#…` links stay same-tab — matching the `InlineLinks` behaviour already used in inbox cards and memory notes.

- `web/src/App.tsx` — conditional `target` on `mdComponents.a`.
- typecheck ✓ · web build ✓ · governance 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)