### PR TITLE
fix(dreaming): robustness batch — race guard, retry cap, watermark, state repair (v0.157.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.157.4] — 2026-07-13
+### Fixed
+- **Dreaming robustness batch** (third of the sequenced audit fixes, after timing v0.150.2 + staleness v0.157.1):
+  - **M1 — no lost-update race.** A manual "Review now" and the scheduler tick both call `dream()`, which
+    read-modify-writes `dreaming_state` with an `await` in the middle; concurrently they'd lose a pass's
+    counts and double the marker. Now serialized per tenant (one in-flight pass; the loser no-ops `busy`).
+  - **M3 — bounded digest retry.** `digest.posted` is written only on success, so a day-long Slack/Discord
+    outage re-attempted every hour (flooding audit + rewriting the KB page). Now caps at 3 attempts/day.
+  - **M4 — consolidation no longer drops a failed batch.** The watermark advanced at gardener *kickoff*, so
+    a crashed/killed run lost its episodes+lessons forever. The next run now re-includes a previous run's
+    window if it never reported, and skips if the previous run is still running (no stacking).
+  - **L1 — corrupt state can't spread NaN.** A partial/schema-drifted `dreaming_state` is now normalized on
+    load (numeric totals, object topics, array recent), so the fold's `+=` can't propagate `NaN`.
+  - **L3 — accurate error friction.** The friction "errors" signal now counts `session.error` (real run
+    errors) instead of `episode.error` (memory-store failures), so guidance reflects actual run outcomes.
+  `src/edge/dreaming.ts`, `src/edge/digest.ts`, `src/edge/consolidation.ts`.
+
 ## [0.157.3] — 2026-07-13
 ### Fixed
 - **Select triggers showed a raw id after picking an owner/assignee/goal.** On the Goals and Tasks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.157.3",
+  "version": "0.157.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.157.3",
+      "version": "0.157.4",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.157.3",
+  "version": "0.157.4",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/consolidation.ts
+++ b/src/edge/consolidation.ts
@@ -40,8 +40,23 @@ export class Consolidation {
   async run(by = 'automation:consolidation'): Promise<ConsolidateResult> {
     const db = this.os.db;
     const until = Date.now();
-    const last = db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'learning.consolidated'").get<{ t: number | null }>();
-    const since = last?.t ?? until - WINDOW_FALLBACK_MS;
+    // The watermark advances at KICKOFF (below), so a gardener run that crashed / was killed / hit its
+    // budget would otherwise drop its batch forever (M4). Inspect the PREVIOUS run first: if it's still
+    // running, don't stack a second one; if it never reported (didn't finish), re-include its window
+    // instead of skipping past it — the fresh run then supersedes the failed marker.
+    const prevRow = db.prepare("SELECT ts, data FROM audit_events WHERE type = 'learning.consolidated' ORDER BY ts DESC LIMIT 1").get<{ ts: number; data: string }>();
+    let since = until - WINDOW_FALLBACK_MS;
+    if (prevRow) {
+      since = prevRow.ts;
+      let prev: { sessionId?: string; window?: { since?: number } } = {};
+      try { prev = JSON.parse(prevRow.data) as typeof prev; } catch { /* keep ts */ }
+      if (prev.sessionId) {
+        const st = db.prepare("SELECT status FROM term_sessions WHERE id = ?").get<{ status: string }>(prev.sessionId);
+        if (st?.status === 'running') return { spawned: false, reason: 'previous consolidation still running', window: { since, until } };
+        const reported = db.prepare("SELECT 1 FROM audit_events WHERE run_id = ? AND type = 'session.reported' LIMIT 1").get(prev.sessionId);
+        if (!reported && Number.isFinite(Number(prev.window?.since))) since = Number(prev.window!.since);
+      }
+    }
     const window = { since, until };
 
     // Raw material: episodes (what happened) + lessons (what an agent already chose to keep), fleet-wide,

--- a/src/edge/digest.ts
+++ b/src/edge/digest.ts
@@ -24,6 +24,7 @@ import { postMessage as discordPost } from '../connectors/discord';
 const SECTION = 'operations';
 const SALIENCE = 0.5;          // episodes at/above this importance make the body; the rest count in the tally only
 const PER_AGENT = 6;           // cap body lines per agent (overflow → "+N more")
+const MAX_POST_ATTEMPTS = 3;   // scheduled EOD post retries per day before giving up (M3 — bound outage churn)
 
 export interface DigestModel {
   iso: string;                 // YYYY-MM-DD (server-local)
@@ -305,6 +306,11 @@ export class Digest {
     const { start, iso } = localDayBounds(now);
     const last = this.os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'digest.posted'").get<{ t: number | null }>();
     if (last?.t && last.t >= start) return null; // already posted today
+    // M3: cap retries on a platform outage. `digest.posted` is only written on success, so without this a
+    // day-long Slack/Discord outage would re-render + re-attempt every hour until midnight, flooding audit
+    // with `digest.error` rows and rewriting the KB page hourly. Give up after MAX_POST_ATTEMPTS today.
+    const fails = this.os.db.prepare("SELECT count(*) AS n FROM audit_events WHERE type = 'digest.error' AND ts >= ?").get<{ n: number }>(start);
+    if ((fails?.n ?? 0) >= MAX_POST_ATTEMPTS) return null;
     return this.postNow('scheduler', now).catch((e) => ({ posted: false, error: e instanceof Error ? e.message : String(e), total: 0, iso }));
   }
 }

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -24,6 +24,7 @@ export interface DreamResult {
   kbPageId?: string;
   insightId?: string;
   guidance?: string;
+  busy?: boolean; // another pass for this tenant was already running (M1) — this call no-opped
 }
 
 interface Tally { sessions: number; episodes: number; success: number; failure: number; partial: number; stopped: number; unknown: number; rejected: number; budgetStops: number; errors: number }
@@ -62,8 +63,22 @@ const STOP = new Set(['task', 'outcome', 'session', 'after', 'then', 'with', 'th
 export class DreamingEngine {
   constructor(private readonly os: AgentOS) {}
 
-  /** Run one reflection pass: fold activity since the last pass into the cumulative state, re-render. */
+  /** Serialize passes per tenant (M1). A manual "Review now" and the scheduler tick both call `dream()`,
+   *  which does read-modify-write on `dreaming_state` with an `await` in the middle — concurrently they'd
+   *  lose an update and double the `learning.dreamed` marker. One pass in flight per tenant; the loser
+   *  no-ops with `busy`. In-memory is enough: within one process both callers share this set. */
+  private static inFlight = new Set<string>();
   async dream(by = 'automation:dreamer'): Promise<DreamResult> {
+    if (DreamingEngine.inFlight.has(this.os.tenant)) {
+      return { skipped: true, busy: true, window: { since: 0, until: Date.now() }, passes: this.load()?.passes };
+    }
+    DreamingEngine.inFlight.add(this.os.tenant);
+    try { return await this.dreamInner(by); }
+    finally { DreamingEngine.inFlight.delete(this.os.tenant); }
+  }
+
+  /** Run one reflection pass: fold activity since the last pass into the cumulative state, re-render. */
+  private async dreamInner(by = 'automation:dreamer'): Promise<DreamResult> {
     const db = this.os.db;
     const until = Date.now();
     const prior = this.load();
@@ -81,7 +96,7 @@ export class DreamingEngine {
       .prepare("SELECT run_id, ts, type, data FROM audit_events WHERE ts > ? AND type IN ('session.reported','session.ended','session.stopped','run.completed') ORDER BY ts")
       .all<OutcomeRow>(since);
     const frictionRows = db
-      .prepare("SELECT ts, type, data FROM audit_events WHERE ts > ? AND type IN ('budget.exceeded','episode.error','approval.resolved')")
+      .prepare("SELECT ts, type, data FROM audit_events WHERE ts > ? AND type IN ('budget.exceeded','session.error','approval.resolved')")
       .all<FrictionRow>(since);
 
     if (!episodes.length && !outcomeRows.length) {
@@ -110,7 +125,7 @@ export class DreamingEngine {
     }
     for (const f of frictionRows) {
       if (f.type === 'budget.exceeded') win.budgetStops++;
-      else if (f.type === 'episode.error') win.errors++;
+      else if (f.type === 'session.error') win.errors++; // L3: real run errors, not memory-store (`episode.error`) failures
       else if (parse(f.data).approved === false) win.rejected++;
     }
     const winTopics = topicCounts(episodes);
@@ -174,8 +189,26 @@ export class DreamingEngine {
 
   private load(): DreamState | null {
     const raw = this.os.settings.dreamingState();
-    return raw ? (raw as unknown as DreamState) : null;
+    return raw ? normalizeState(raw as Record<string, unknown>) : null;
   }
+}
+
+/** L1: repair a partial / schema-drifted / corrupt `dreaming_state` into a well-formed shape, so the
+ *  fold's `state.totals[k] += win[k]` can never hit an `undefined` field and spew `NaN` into every
+ *  downstream number (rate, guidance, the page). Non-numeric fields fall back to safe defaults. */
+function normalizeState(raw: Record<string, unknown>): DreamState {
+  const num = (v: unknown, d: number) => (Number.isFinite(Number(v)) ? Number(v) : d);
+  const rt = (raw.totals ?? {}) as Record<string, unknown>;
+  const totals = zeroTally();
+  for (const k of Object.keys(totals) as (keyof Tally)[]) totals[k] = num(rt[k], 0);
+  const topics: DreamState['topics'] = {};
+  for (const [k, v] of Object.entries((raw.topics ?? {}) as Record<string, unknown>)) {
+    const o = (v ?? {}) as { count?: unknown; lastSeen?: unknown };
+    if (Number.isFinite(Number(o.count))) topics[k] = { count: num(o.count, 0), lastSeen: num(o.lastSeen, 0) };
+  }
+  const recent = Array.isArray(raw.recent) ? (raw.recent as RecentEntry[]) : [];
+  const watermark = Number.isFinite(Number(raw.watermark)) ? Number(raw.watermark) : undefined;
+  return { firstPass: num(raw.firstPass, Date.now()), passes: num(raw.passes, 0), totals, topics, recent, watermark };
 }
 
 function zeroTally(): Tally {


### PR DESCRIPTION
PR 3 of the sequenced Dreaming-audit fixes (robustness). Five contained correctness fixes.

- **M1 — lost-update race.** Manual "Review now" + the scheduler both call `dream()`, which read-modify-writes `dreaming_state` with an `await` in the middle → concurrently they lose a pass's counts and double the marker. Now **serialized per tenant** (one in-flight pass; the loser no-ops with `busy`).
- **M3 — digest retry storm.** `digest.posted` is only written on success, so a day-long Slack/Discord outage re-attempted **every hour** until midnight (flooding audit + rewriting the KB page). Now **caps at 3 attempts/day**.
- **M4 — consolidation dropped failed batches.** The watermark advanced at gardener **kickoff**, so a crashed/killed run lost its episodes+lessons forever. The next run now **re-includes a previous run's window if it never reported**, and **skips if the previous run is still running** (no stacking).
- **L1 — corrupt state spread NaN.** A partial/schema-drifted `dreaming_state` is now **normalized on load** (numeric totals, object topics, array recent), so the fold's `+=` can't propagate `NaN` into every downstream number.
- **L3 — wrong error signal.** Friction "errors" now counts `session.error` (real run errors) instead of `episode.error` (memory-**store** failures), so guidance reflects actual outcomes.

## Validation
- Concurrent `dream()` on a copy of live data → exactly **one** `busy` no-op; a deliberately corrupted `dreaming_state` → **repaired to all-finite** (no NaN). M3/M4/L3 verified by typecheck + review (need an outage/crash to exercise live).
- `typecheck` + `test:governance` (68/68) green.

## Remaining after this
Visibility deepening (gardener output link, scheduled skip/error surfacing, digest history) and the measurement loop (G1 — the 🟡→✅ move). L4 (`parse()` swallow) left as accepted — there's no better behavior when audit data won't parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)