### PR TITLE
fix(media): apply timeout/retry resilience to video_generate (v0.158.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.158.0] — 2026-07-13
+### Fixed
+- **Same timeout/retry resilience now applies to `video_generate`.** The video backend
+  (`src/edge/video-gen.ts`, fal + Atlas) previously had no timeouts and would mark a whole render
+  **failed** on a single transient poll blip. The image resilience helpers were extracted to a shared
+  `src/edge/vendor-fetch.ts` (`timedFetch` + `withRetry` + `VendorError`) and applied to video:
+  - **Timeouts** on every call — 30s submit, 15s per poll, 60s mp4 download.
+  - **Bounded retry** (3×, backoff + jitter) around the submit and the mp4 download on transient failures
+    (network/timeout, 429, 5xx).
+  - **Poll blips no longer kill the job.** A transient poll error now returns `rendering`, so the job
+    survives and the **next Automations tick re-polls** (bounded by `VIDEO_MAX_POLLS`/TTL) instead of a
+    one-off network hiccup marking a paid render `failed`. An explicit vendor `failed`/`cancelled` status
+    or a 4xx still fails as-is.
+  - **Error attribution**: a submit failure now carries the vendor + retryable flag out to
+    `video_generate error: …` (not `memory error: …`), telling the agent whether to retry.
+  Docs updated in `docs/agent-mcp-tools.md`. Verified live: normal submit, transient submit → retryable
+  error, transient poll → `rendering` (not `failed`), and the image path still passes through the shared
+  helpers with no regression.
+
 ## [0.157.4] — 2026-07-13
 ### Fixed
 - **Dreaming robustness batch** (third of the sequenced audit fixes, after timing v0.150.2 + staleness v0.157.1):

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -66,28 +66,33 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 carries `destructiveHint`. All schemas set `additionalProperties:false`; enum fields (`type`,
 `outcome`) and numeric bounds (`importance`, `limit`) are constrained in-schema.
 
-### Media tool resilience — timeouts + retries (`image_generate` / `image_edit`)
+### Media tool resilience — timeouts + retries (`image_generate` / `image_edit` / `video_generate`)
 
-The image backend (`src/edge/image-gen.ts`) treats every vendor call as fallible:
+Both media backends share `src/edge/vendor-fetch.ts` (`timedFetch` + `withRetry` + `VendorError`) and
+treat every vendor call as fallible:
 
-- **Timeouts (`AbortSignal.timeout`).** No call can hang a tool: 30s on submit/`generateImage`, 15s per
-  prediction poll, 60s on the image download. A hung socket aborts and becomes a retryable error.
+- **Timeouts (`AbortSignal.timeout`).** No call can hang a tool: **30s** on submit, **15s** per prediction
+  poll, **60s** on the media download. A hung socket aborts and becomes a retryable error.
 - **Bounded retry with backoff + jitter (3 attempts).** The submit and the download are retried on
   **transient** failures only — a network error/timeout, a **429**, or a **5xx**. Backoff is exponential
-  with full jitter (~0.2s → ~4s cap). A single prediction poll that hits a transient error is *tolerated*
-  (the loop keeps polling until the 90s render deadline) rather than aborting the whole call.
+  with full jitter (~0.2s → ~4s cap).
+- **Poll blips are tolerated, not fatal.** For images, a transient poll error keeps polling until the 90s
+  render deadline. For **video** (polled across Automations ticks), a transient poll error returns
+  `rendering` so the job survives and the **next tick re-polls** (bounded by `VIDEO_MAX_POLLS` / TTL),
+  instead of the old behavior where one blip marked the whole render `failed`.
 - **What is NOT retried (a real answer, surfaced as-is).** Any **4xx** (bad request / content-policy
   rejection), an explicit vendor **`failed`/`error`/`cancelled`** prediction status, or a **rejected model
-  id**. Retryability is decided in one place — `VendorError.retryable` — and the existing model-fallback
-  path (`withModelFallback`) keys off the same error, so a bad default model still falls back to the
-  built-in rather than being retried blindly.
-- **Actionable timeout.** When the 90s render deadline is hit, the error says how long it waited and that
-  the prediction (by id) *may still be in flight* — "check the Library before regenerating" — not a bare
-  "timed out".
+  id**. Retryability is decided in one place — `VendorError.retryable` — and the image model-fallback path
+  (`withModelFallback`) keys off the same error, so a bad default model still falls back to the built-in
+  rather than being retried blindly.
+- **Actionable image timeout.** When the 90s image render deadline is hit, the error says how long it
+  waited and that the prediction (by id) *may still be in flight* — "check the Library before
+  regenerating" — not a bare "timed out".
 - **Error attribution.** A failure carries the **vendor** and a **retryable** flag out through
-  `TerminalManager.generateImage`/`editImage` to the tool response, which prefixes the **actual tool**
-  name (`image_generate error: …`, not `memory error: …`) and appends whether a plain retry is worthwhile.
-  So the agent retries the transient ones and fixes the input on the terminal ones instead of guessing.
+  `TerminalManager.generateImage`/`editImage`/`generateVideo` to the tool response, which prefixes the
+  **actual tool** name (`image_generate error: …` / `video_generate error: …`, not `memory error: …`) and
+  appends whether a plain retry is worthwhile. So the agent retries the transient ones and fixes the input
+  on the terminal ones instead of guessing.
 
 ### `notify` — deliberately looping in one teammate (inbox scoping)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.157.4",
+  "version": "0.158.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.157.4",
+      "version": "0.158.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.157.4",
+  "version": "0.158.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/image-gen.ts
+++ b/src/edge/image-gen.ts
@@ -18,6 +18,8 @@
  * gallery stores bytes and vendor URLs (e.g. FLUX's) can expire within minutes.
  */
 
+import { VendorError, retryableStatus, timedFetch, withRetry, vendorErrorInfo, sleep } from './vendor-fetch';
+
 /** A conservative default per-image cost, used ONLY for the pre-generation policy gate (the money-cap
  *  rule) when the backend can't be asked ahead of time. The AUDIT records the real cost when known. */
 export const DEFAULT_IMAGE_COST_USD = 0.05;
@@ -140,79 +142,13 @@ function extFromUrl(url: string): string | undefined {
   return e === 'jpeg' ? 'jpg' : e;
 }
 
-// ── network resilience: timeouts + bounded retry ─────────────────────────────
-// Every vendor call gets an explicit deadline (a hung socket must never hang the tool) and TRANSIENT
-// failures (network reset, timeout, 429, 5xx) are retried with exponential backoff + jitter. A 4xx
-// (bad request / content policy / rejected model) or an explicit vendor `failed` prediction status is a
-// REAL answer — surfaced on the first occurrence, never retried. `VendorError.retryable` is the single
-// source of truth both the retry loop and the surfaced message consult (so "worth retrying" is decided
-// in exactly one place, and the existing model-fallback path keys off the message the same way).
+// ── network resilience: timeouts + bounded retry (shared helpers in ./vendor-fetch) ──────────────────
 const SUBMIT_TIMEOUT_MS = 30_000; // POST generate / submit
 const POLL_TIMEOUT_MS = 15_000; // one prediction poll
 const DOWNLOAD_TIMEOUT_MS = 60_000; // pull the finished image bytes (can be large)
-const RETRY_ATTEMPTS = 3;
 
-/** A vendor-call error that knows its HTTP status, which vendor raised it, and whether retrying could
- *  plausibly help. Carried out to TerminalManager so the tool response can tell the agent what to do. */
-export class VendorError extends Error {
-  constructor(message: string, readonly retryable: boolean, readonly vendor: string, readonly status?: number) {
-    super(message);
-    this.name = 'VendorError';
-  }
-}
-
-/** 429 (rate limit) and 5xx (vendor-side) are transient; every other status is a definitive answer. */
-function retryableStatus(status: number): boolean {
-  return status === 429 || status >= 500;
-}
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-
-/** Exponential backoff with full jitter (~0.2–0.4s, ~0.4–0.8s, … capped at 4s) to avoid synchronized retries. */
-function backoffMs(attempt: number): number {
-  const base = Math.min(4000, 400 * 2 ** attempt);
-  return Math.round(base / 2 + Math.random() * (base / 2));
-}
-
-/** One fetch with an explicit timeout, normalizing a network error / timeout into a RETRYABLE VendorError. */
-async function timedFetch(url: string, init: RequestInit, timeoutMs: number, vendor: string): Promise<Response> {
-  try {
-    return await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
-  } catch (e) {
-    const timedOut = e instanceof Error && (e.name === 'TimeoutError' || e.name === 'AbortError');
-    const detail = e instanceof Error ? e.message : String(e);
-    throw new VendorError(
-      timedOut ? `${vendor} request timed out after ${Math.round(timeoutMs / 1000)}s` : `${vendor} request failed (${detail})`,
-      true,
-      vendor,
-    );
-  }
-}
-
-/** Run a vendor call up to RETRY_ATTEMPTS times, retrying ONLY on a retryable VendorError (transient
- *  network/timeout/429/5xx). A terminal error (4xx, content policy, `failed` status, bad model) throws on
- *  its first occurrence so it surfaces as-is. */
-async function withRetry<T>(fn: () => Promise<T>): Promise<T> {
-  let last: unknown;
-  for (let attempt = 0; attempt < RETRY_ATTEMPTS; attempt++) {
-    try {
-      return await fn();
-    } catch (e) {
-      last = e;
-      const retryable = e instanceof VendorError && e.retryable;
-      if (!retryable || attempt === RETRY_ATTEMPTS - 1) throw e;
-      await sleep(backoffMs(attempt));
-    }
-  }
-  throw last;
-}
-
-/** Normalize any thrown error into { message, retryable, vendor } for the caller (TerminalManager → the
- *  tool response), so the agent is told which subsystem failed and whether a plain retry is worthwhile. */
-export function imageErrorInfo(e: unknown): { message: string; retryable?: boolean; vendor?: string } {
-  if (e instanceof VendorError) return { message: e.message, retryable: e.retryable, vendor: e.vendor };
-  return { message: e instanceof Error ? e.message : String(e) };
-}
+/** Back-compat alias for `TerminalManager` (image path); identical to the shared `vendorErrorInfo`. */
+export const imageErrorInfo = vendorErrorInfo;
 
 // ── OpenRouter ──────────────────────────────────────────────────────────────
 

--- a/src/edge/vendor-fetch.ts
+++ b/src/edge/vendor-fetch.ts
@@ -1,0 +1,69 @@
+/**
+ * Shared vendor-call resilience for the media backends (image-gen, video-gen): explicit timeouts +
+ * bounded retry with exponential backoff + jitter. A hung socket must never hang a tool, and TRANSIENT
+ * failures (network reset, timeout, 429, 5xx) are retried; a 4xx / content-policy rejection / explicit
+ * vendor `failed` status is a REAL answer, surfaced as-is. `VendorError.retryable` is the single source of
+ * truth both the retry loop and the surfaced message consult.
+ */
+
+/** A vendor-call error that knows its HTTP status, which vendor raised it, and whether retrying could
+ *  plausibly help. Carried out to TerminalManager so the tool response can tell the agent what to do. */
+export class VendorError extends Error {
+  constructor(message: string, readonly retryable: boolean, readonly vendor: string, readonly status?: number) {
+    super(message);
+    this.name = 'VendorError';
+  }
+}
+
+/** 429 (rate limit) and 5xx (vendor-side) are transient; every other status is a definitive answer. */
+export function retryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Exponential backoff with full jitter (~0.2–0.4s, ~0.4–0.8s, … capped at 4s) to avoid synchronized retries. */
+export function backoffMs(attempt: number): number {
+  const base = Math.min(4000, 400 * 2 ** attempt);
+  return Math.round(base / 2 + Math.random() * (base / 2));
+}
+
+/** One fetch with an explicit timeout, normalizing a network error / timeout into a RETRYABLE VendorError. */
+export async function timedFetch(url: string, init: RequestInit, timeoutMs: number, vendor: string): Promise<Response> {
+  try {
+    return await fetch(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+  } catch (e) {
+    const timedOut = e instanceof Error && (e.name === 'TimeoutError' || e.name === 'AbortError');
+    const detail = e instanceof Error ? e.message : String(e);
+    throw new VendorError(
+      timedOut ? `${vendor} request timed out after ${Math.round(timeoutMs / 1000)}s` : `${vendor} request failed (${detail})`,
+      true,
+      vendor,
+    );
+  }
+}
+
+/** Run a vendor call up to `attempts` times, retrying ONLY on a retryable VendorError (transient
+ *  network/timeout/429/5xx). A terminal error (4xx, content policy, `failed` status, bad model) throws on
+ *  its first occurrence so it surfaces as-is. */
+export async function withRetry<T>(fn: () => Promise<T>, attempts = 3): Promise<T> {
+  let last: unknown;
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      last = e;
+      const retryable = e instanceof VendorError && e.retryable;
+      if (!retryable || attempt === attempts - 1) throw e;
+      await sleep(backoffMs(attempt));
+    }
+  }
+  throw last;
+}
+
+/** Normalize any thrown error into { message, retryable, vendor } for the caller (TerminalManager → the
+ *  tool response), so the agent is told which subsystem failed and whether a plain retry is worthwhile. */
+export function vendorErrorInfo(e: unknown): { message: string; retryable?: boolean; vendor?: string } {
+  if (e instanceof VendorError) return { message: e.message, retryable: e.retryable, vendor: e.vendor };
+  return { message: e instanceof Error ? e.message : String(e) };
+}

--- a/src/edge/video-gen.ts
+++ b/src/edge/video-gen.ts
@@ -20,10 +20,17 @@
  * JSON, so `video_jobs` stays vendor-neutral.
  */
 
+import { VendorError, retryableStatus, timedFetch, withRetry } from './vendor-fetch';
+
 /** Conservative per-second + duration defaults for the pre-render policy gate (the money-cap rule). The
  *  audit records the actual cost when a backend reports it, else this estimate. */
 export const DEFAULT_VIDEO_COST_PER_SEC_USD = 0.1;
 export const DEFAULT_VIDEO_DURATION_SEC = 5;
+
+// Timeouts for the vendor calls (retry/backoff via ./vendor-fetch). Submit is a single POST; each poll is
+// one status check — a transient poll failure is NOT fatal (the background tick just re-polls next round).
+const SUBMIT_TIMEOUT_MS = 30_000;
+const POLL_TIMEOUT_MS = 15_000;
 
 export interface VideoGenRequest {
   prompt: string;
@@ -145,29 +152,45 @@ class FalVideoBackend implements VideoBackend {
     const body: Record<string, unknown> = { prompt: req.prompt };
     if (req.durationSec) body.duration = String(req.durationSec); // fal video models mostly take a string seconds
     if (req.imageUrl) body.image_url = req.imageUrl;
-    const res = await fetch(`https://queue.fal.run/${model}`, { method: 'POST', headers: this.headers(), body: JSON.stringify(body) });
-    const d = (await res.json().catch(() => ({}))) as FalSubmitResponse & Record<string, unknown>;
-    if (!res.ok) throw new Error(errText(d, res.status));
-    if (!d.status_url || !d.response_url) throw new Error('fal did not return status/response URLs');
-    const ref: FalRef = { model, statusUrl: d.status_url, responseUrl: d.response_url };
+    const d = await withRetry(async () => {
+      const res = await timedFetch(`https://queue.fal.run/${model}`, { method: 'POST', headers: this.headers(), body: JSON.stringify(body) }, SUBMIT_TIMEOUT_MS, 'fal');
+      const j = (await res.json().catch(() => ({}))) as FalSubmitResponse & Record<string, unknown>;
+      if (!res.ok) throw new VendorError(errText(j, res.status), retryableStatus(res.status), 'fal', res.status);
+      if (!j.status_url || !j.response_url) throw new VendorError('fal did not return status/response URLs', true, 'fal');
+      return j;
+    });
+    const ref: FalRef = { model, statusUrl: d.status_url!, responseUrl: d.response_url! };
     return { providerRef: JSON.stringify(ref) };
   }
 
   async poll(providerRef: string): Promise<VideoPollResult> {
     const ref = JSON.parse(providerRef) as FalRef;
-    const sres = await fetch(ref.statusUrl, { headers: this.headers() });
-    const s = (await sres.json().catch(() => ({}))) as FalStatusResponse;
-    if (!sres.ok) return { status: 'failed', error: errText(s, sres.status) };
-    const st = (s.status || '').toUpperCase();
-    if (st === 'IN_QUEUE' || st === 'IN_PROGRESS') return { status: 'rendering' };
-    if (st && st !== 'COMPLETED') return { status: 'failed', error: `fal status ${st}` };
-    // COMPLETED → fetch the result body and find the video URL
-    const rres = await fetch(ref.responseUrl, { headers: this.headers() });
-    const r = (await rres.json().catch(() => ({}))) as Record<string, unknown>;
-    if (!rres.ok) return { status: 'failed', error: errText(r, rres.status) };
-    const url = findVideoUrl(r);
-    if (!url) return { status: 'failed', error: 'fal completed but no video URL in the result' };
-    return { status: 'done', video: { url, ext: extFromUrl(url) } };
+    try {
+      const sres = await timedFetch(ref.statusUrl, { headers: this.headers() }, POLL_TIMEOUT_MS, 'fal');
+      const s = (await sres.json().catch(() => ({}))) as FalStatusResponse;
+      if (!sres.ok) {
+        if (retryableStatus(sres.status)) return { status: 'rendering' }; // transient → let the next tick re-poll
+        return { status: 'failed', error: errText(s, sres.status) };
+      }
+      const st = (s.status || '').toUpperCase();
+      if (st === 'IN_QUEUE' || st === 'IN_PROGRESS') return { status: 'rendering' };
+      if (st && st !== 'COMPLETED') return { status: 'failed', error: `fal status ${st}` };
+      // COMPLETED → fetch the result body and find the video URL
+      const rres = await timedFetch(ref.responseUrl, { headers: this.headers() }, POLL_TIMEOUT_MS, 'fal');
+      const r = (await rres.json().catch(() => ({}))) as Record<string, unknown>;
+      if (!rres.ok) {
+        if (retryableStatus(rres.status)) return { status: 'rendering' };
+        return { status: 'failed', error: errText(r, rres.status) };
+      }
+      const url = findVideoUrl(r);
+      if (!url) return { status: 'failed', error: 'fal completed but no video URL in the result' };
+      return { status: 'done', video: { url, ext: extFromUrl(url) } };
+    } catch (e) {
+      // A single poll that hit a network error / timeout is not fatal — the job stays 'rendering' and the
+      // background tick re-polls (bounded by VIDEO_MAX_POLLS / TTL). Only a terminal status fails the job.
+      if (e instanceof VendorError && e.retryable) return { status: 'rendering' };
+      return { status: 'failed', error: e instanceof Error ? e.message : String(e) };
+    }
   }
 }
 
@@ -207,32 +230,45 @@ class AtlasVideoBackend implements VideoBackend {
     if (req.durationSec) body.duration = req.durationSec;
     // Atlas takes the seed frame as `image` (URL, Base64 data URL, or asset://<id>) — NOT `image_url`.
     if (req.imageUrl) body.image = req.imageUrl;
-    const res = await fetch(`${this.base}/api/v1/model/generateVideo`, { method: 'POST', headers: this.headers(), body: JSON.stringify(body) });
-    const d = (await res.json().catch(() => ({}))) as { id?: string; prediction_id?: string; data?: { id?: string } };
-    if (!res.ok) throw new Error(errText(d, res.status));
-    const id = d.id || d.prediction_id || d.data?.id;
-    if (!id) throw new Error('Atlas did not return a prediction id');
+    const d = await withRetry(async () => {
+      const res = await timedFetch(`${this.base}/api/v1/model/generateVideo`, { method: 'POST', headers: this.headers(), body: JSON.stringify(body) }, SUBMIT_TIMEOUT_MS, 'Atlas');
+      const j = (await res.json().catch(() => ({}))) as { id?: string; prediction_id?: string; data?: { id?: string } };
+      if (!res.ok) throw new VendorError(errText(j, res.status), retryableStatus(res.status), 'Atlas', res.status);
+      if (!(j.id || j.prediction_id || j.data?.id)) throw new VendorError('Atlas accepted the request but returned no prediction id', true, 'Atlas');
+      return j;
+    });
+    const id = d.id || d.prediction_id || d.data?.id!;
     const ref: AtlasRef = { predictionId: id, base: this.base };
     return { providerRef: JSON.stringify(ref) };
   }
 
   async poll(providerRef: string): Promise<VideoPollResult> {
     const ref = JSON.parse(providerRef) as AtlasRef;
-    const res = await fetch(`${ref.base}/api/v1/model/prediction/${ref.predictionId}`, { headers: this.headers() });
-    const body = (await res.json().catch(() => ({}))) as { data?: AtlasPrediction } & AtlasPrediction & Record<string, unknown>;
-    if (!res.ok) return { status: 'failed', error: errText(body, res.status) };
-    // Atlas nests the prediction under `data` (status/error/outputs live there, NOT at the top level).
-    const d: AtlasPrediction = body.data ?? body;
-    const st = (d.status || '').toLowerCase();
-    if (st === 'failed' || st === 'error' || st === 'cancelled' || st === 'canceled') {
-      return { status: 'failed', error: d.error || (body as { message?: string }).message || `atlas status ${st || 'failed'}` };
+    try {
+      const res = await timedFetch(`${ref.base}/api/v1/model/prediction/${ref.predictionId}`, { headers: this.headers() }, POLL_TIMEOUT_MS, 'Atlas');
+      const body = (await res.json().catch(() => ({}))) as { data?: AtlasPrediction } & AtlasPrediction & Record<string, unknown>;
+      if (!res.ok) {
+        if (retryableStatus(res.status)) return { status: 'rendering' }; // transient → let the next tick re-poll
+        return { status: 'failed', error: errText(body, res.status) };
+      }
+      // Atlas nests the prediction under `data` (status/error/outputs live there, NOT at the top level).
+      const d: AtlasPrediction = body.data ?? body;
+      const st = (d.status || '').toLowerCase();
+      if (st === 'failed' || st === 'error' || st === 'cancelled' || st === 'canceled') {
+        return { status: 'failed', error: d.error || (body as { message?: string }).message || `atlas status ${st || 'failed'}` };
+      }
+      if (st !== 'completed' && st !== 'succeeded') return { status: 'rendering' };
+      // Atlas documents the result at data.outputs[0] — read it directly (a signed URL may lack a .mp4
+      // extension, so don't rely on extension-sniffing); fall back to a recursive search.
+      const direct = Array.isArray(d.outputs) ? d.outputs.find((o): o is string => typeof o === 'string' && /^https?:\/\//.test(o)) : undefined;
+      const url = direct ?? findVideoUrl(d);
+      if (!url) return { status: 'failed', error: 'atlas completed but no video URL in the result' };
+      return { status: 'done', video: { url, ext: extFromUrl(url) } };
+    } catch (e) {
+      // A single poll that hit a network error / timeout is not fatal — stay 'rendering' and let the tick
+      // poller re-poll (bounded by VIDEO_MAX_POLLS / TTL). Only a terminal status/error fails the job.
+      if (e instanceof VendorError && e.retryable) return { status: 'rendering' };
+      return { status: 'failed', error: e instanceof Error ? e.message : String(e) };
     }
-    if (st !== 'completed' && st !== 'succeeded') return { status: 'rendering' };
-    // Atlas documents the result at data.outputs[0] — read it directly (a signed URL may lack a .mp4
-    // extension, so don't rely on extension-sniffing); fall back to a recursive search.
-    const direct = Array.isArray(d.outputs) ? d.outputs.find((o): o is string => typeof o === 'string' && /^https?:\/\//.test(o)) : undefined;
-    const url = direct ?? findVideoUrl(d);
-    if (!url) return { status: 'failed', error: 'atlas completed but no video URL in the result' };
-    return { status: 'done', video: { url, ext: extFromUrl(url) } };
   }
 }

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -1206,8 +1206,8 @@ async function videoGenerate(args: Record<string, unknown>): Promise<string> {
     headers: H({ 'content-type': 'application/json' }),
     body: JSON.stringify(body),
   });
-  const d = (await res.json()) as { ok?: boolean; error?: string; status?: string; jobId?: string; artifact?: { id: string; filename: string }; model?: string; costUsd?: number };
-  if (!d.ok) return `Could not generate video: ${d.error ?? 'unknown error'}`;
+  const d = (await res.json()) as { ok?: boolean; error?: string; vendor?: string; retryable?: boolean; status?: string; jobId?: string; artifact?: { id: string; filename: string }; model?: string; costUsd?: number };
+  if (!d.ok) return `video_generate error: ${mediaErrorHint(d)}`;
   const cost = typeof d.costUsd === 'number' ? ` · ~$${d.costUsd.toFixed(3)}` : '';
   if (d.status === 'done' && d.artifact) {
     return `Video ready with ${d.model ?? 'the default model'}${cost}. Saved to the Library: ${d.artifact.id} (${d.artifact.filename}).`;

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -23,6 +23,7 @@ import { SkillSummary, CatalogSkill } from './governance/skills';
 import { browseRepo, RemoteCatalog } from './governance/skill-registry';
 import { claudeSupportsReloadSkills } from './edge/claude-cli';
 import { DEFAULT_IMAGE_COST_USD, resolveImageBackend, imageErrorInfo } from './edge/image-gen';
+import { VendorError, retryableStatus, timedFetch, withRetry, vendorErrorInfo } from './edge/vendor-fetch';
 import { DEFAULT_VIDEO_COST_PER_SEC_USD, DEFAULT_VIDEO_DURATION_SEC, resolveVideoBackend, videoBackend, VideoBackend } from './edge/video-gen';
 import { understandMedia } from './edge/media-understand';
 
@@ -2736,7 +2737,7 @@ export class TerminalManager {
    * the money-cap rule applies. Cost is an estimate (video is per-second and rarely returned in-band).
    * An optional `image` seed (URL or artifact id) switches it to image-to-video via `backend.imageModel`.
    */
-  async generateVideo(sessionId: string, input: { prompt: string; model?: string; durationSec?: number; image?: string }): Promise<{ ok: boolean; status?: 'done' | 'rendering'; jobId?: string; artifact?: { id: string; filename: string; mime: string }; model?: string; costUsd?: number; error?: string }> {
+  async generateVideo(sessionId: string, input: { prompt: string; model?: string; durationSec?: number; image?: string }): Promise<{ ok: boolean; status?: 'done' | 'rendering'; jobId?: string; artifact?: { id: string; filename: string; mime: string }; model?: string; costUsd?: number; error?: string; retryable?: boolean; vendor?: string }> {
     const agent = this.sessionAgent(sessionId);
     if (!agent) return { ok: false, error: 'unknown session' };
     if (!this.os.artifacts.enabled) return { ok: false, error: 'artifacts store is disabled (no data home)' };
@@ -2768,9 +2769,9 @@ export class TerminalManager {
     try {
       submit = await backend.submit({ prompt, model, durationSec, imageUrl });
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      this.audit(sessionId, agent, 'video.failed', { model, error: msg });
-      return { ok: false, error: msg };
+      const info = vendorErrorInfo(e);
+      this.audit(sessionId, agent, 'video.failed', { model, error: info.message, vendor: info.vendor, retryable: info.retryable });
+      return { ok: false, error: info.message, retryable: info.retryable, vendor: info.vendor };
     }
 
     const srow = this.db.prepare('SELECT spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ spawned_by: string | null; run_as: string | null }>(sessionId);
@@ -2819,12 +2820,21 @@ export class TerminalManager {
       this.postVideoCard(job, undefined, `Video failed — ${error}`);
       return { status: 'failed', error };
     }
-    // Done → download the mp4 and ingest it as an artifact.
+    // Done → download the mp4 (timeout + bounded retry; a stalled/interrupted download is transient) and
+    // ingest it as an artifact.
     let bytes: Buffer;
     try {
-      const res = await fetch(poll.video.url);
-      if (!res.ok) throw new Error(`downloading the finished video failed (${res.status})`);
-      bytes = Buffer.from(await res.arrayBuffer());
+      const url = poll.video.url;
+      bytes = await withRetry(async () => {
+        try {
+          const res = await timedFetch(url, {}, 60_000, 'video download');
+          if (!res.ok) throw new VendorError(`downloading the finished video failed (${res.status})`, retryableStatus(res.status), 'video download', res.status);
+          return Buffer.from(await res.arrayBuffer());
+        } catch (e) {
+          if (e instanceof VendorError) throw e;
+          throw new VendorError(`video download failed (${e instanceof Error ? e.message : String(e)})`, true, 'video download');
+        }
+      });
     } catch (e) {
       const error = e instanceof Error ? e.message : String(e);
       this.os.videoJobs.markFailed(jobId, error);


### PR DESCRIPTION
## What
Follow-up to the image resilience fix (#263) — same treatment for `video_generate`, which had **no timeouts** and would mark a whole render **failed** on a single transient poll blip.

## How
- **Extracted** the shared helpers to `src/edge/vendor-fetch.ts` (`timedFetch` + `withRetry` + `VendorError`); `image-gen.ts` now imports them (no behavior change, verified no regression).
- **video-gen.ts** (fal + Atlas):
  - **Timeouts** on every call — 30s submit, 15s per poll, 60s mp4 download (the download lives in `terminal.advanceVideoJob`).
  - **Bounded retry** (3×, backoff+jitter) around the submit and the mp4 download on transient failures (network/timeout, 429, 5xx).
  - **Poll blips no longer kill the job.** A transient poll error now returns `{status:'rendering'}`, so the job survives and the **next Automations tick re-polls** (bounded by `VIDEO_MAX_POLLS`/TTL) — instead of a one-off network hiccup marking a *paid* render `failed`. An explicit vendor `failed`/`cancelled` status or a 4xx still fails as-is.
  - **Error attribution**: submit failures carry vendor + retryable out through `generateVideo` → `video_generate error: …` (not `memory error: …`).

## Verified (live, in-process)
- **Normal** video submit → returns providerRef.
- **Transient submit** (unreachable host) → retried, `retryable=true, vendor=Atlas`.
- **Transient poll** → returns `rendering` (not `failed`) ✅ — the key fix.
- **Image path** still works through the shared helpers (no regression).
- `typecheck`, `build`, `test:governance` (68/68) pass.

Docs: "Media tool resilience" section in `docs/agent-mcp-tools.md` now covers video.

🤖 Generated with [Claude Code](https://claude.com/claude-code)