### PR TITLE
feat(dreaming): measurement loop — "Is it working?" (v0.159.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,18 @@ new version heading in the same commit.
   error, transient poll → `rendering` (not `failed`), and the image path still passes through the shared
   helpers with no regression.
 
-## [0.158.0] — 2026-07-13
+## [0.159.0] — 2026-07-13
+### Added
+- **Dreaming "Is it working?" — the measurement loop (closes audit finding G1, the reason Pillar 10 was
+  🟡).** The self-learning loop ran, but nothing proved that injected guidance / applied recommendations
+  actually moved outcomes. New `src/edge/measurement.ts` computes, from real session outcomes: a
+  **success-rate trend** over the last 8 weeks (distinct-session counting, matching the reflect pass) and,
+  per **applied recommendation**, the success rate in the window **before vs after** it — with sample
+  sizes and a verdict (improved / declined / flat / too-early). Surfaced as an "Is it working?" card on
+  the Dreaming page (trend bars + "did your changes help?"). Honest about being correlational, not a
+  controlled A/B. On live data it shows the fleet's success rate climbing and the one applied
+  recommendation ("raise effort to high") correlating with +18 pts. `/api/dreaming` returns `measurement`.
+
 ### Added
 - **`ask_agent` — synchronous agent→agent Q&A.** An agent can now ask ANOTHER agent a question (or to
   solve something) and block inline on the answer, without filing a task. `ask_agent({ agent, question })`

--- a/docs/memory-encoding-and-consolidation.md
+++ b/docs/memory-encoding-and-consolidation.md
@@ -143,8 +143,10 @@ server bounce.
 
 ## Not built / next
 
-- **Measurement** — nothing yet proves the injected guidance + consolidated knowledge actually move
-  success rate over time. The signals exist (episodes carry outcome; Dreaming tracks per-pass success);
-  a trend view / A-B of guidance-on vs -off is the natural next chapter.
+- **Measurement** — ✅ **shipped (v1)** as `src/edge/measurement.ts` → the Dreaming page's "Is it working?"
+  card: a real **success-rate trend** over recent weeks + each applied recommendation's **before/after**
+  effect (with sample sizes + a verdict). Correlational, not a controlled A/B — a guidance-on-vs-off
+  experiment (deliberately withholding guidance from a cohort) remains the next depth increment. But the
+  loop now closes with a human: an owner can see whether Dreaming is helping.
 - **Programmatic ranking defaults** — ranking is opt-in; a first-run sensible default (or a
   Dreaming *recommendation* to enable it) would activate levers 3/5 without a manual step.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.158.0",
+  "version": "0.159.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.158.0",
+      "version": "0.159.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.158.0",
+  "version": "0.159.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/measurement.ts
+++ b/src/edge/measurement.ts
@@ -1,0 +1,116 @@
+/**
+ * The **measurement loop** — the arm the four-verb model (Capture · Recall · Distil · Apply) was missing
+ * (audit finding G1, the reason Pillar 10 sits at 🟡). The loop *runs*, but nothing checked whether
+ * **Apply actually moved outcomes**: guidance could be useless — or harmful — and the OS would keep
+ * injecting it forever.
+ *
+ * This computes, from REAL session outcomes:
+ *  - a **success-rate trend** over recent weeks (is the fleet getting better?), and
+ *  - per **intervention** (an applied recommendation), the success rate in the window BEFORE vs AFTER it,
+ *    with a verdict (improved / declined / flat / insufficient).
+ *
+ * It is honest about being **correlational, not a controlled A/B** — sample sizes ride along so a thin
+ * signal reads as thin, and a verdict is withheld below `MIN_N`. Pure over the DB; no writes. The Dreaming
+ * page renders it as "Is it working?", closing the loop with a human in it.
+ */
+import type { AgentOS } from '../kernel';
+
+type Db = AgentOS['db'];
+
+const DAY = 24 * 3_600_000;
+const TREND_WEEKS = 8;
+const IA_WINDOW = 14 * DAY; // before/after window sized per intervention
+const MIN_N = 8;            // fewer terminated sessions than this → no verdict (too little to tell)
+const THRESH_PP = 5;        // ≥ this percentage-point move counts as improved/declined, else flat
+
+export interface TrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
+export interface InterventionEffect {
+  id: string;
+  title: string;
+  at: number;
+  before: { n: number; rate: number | null };
+  after: { n: number; rate: number | null };
+  deltaPp: number | null;
+  verdict: 'improved' | 'declined' | 'flat' | 'insufficient';
+}
+export interface Measurement {
+  trend: TrendBucket[];
+  interventions: InterventionEffect[];
+  recent: { n: number; rate: number | null }; // last 7d
+  prior: { n: number; rate: number | null };  // prior 7d (8–14d ago)
+  deltaPp: number | null;
+}
+
+interface OutRow { run_id: string | null; ts: number; type: string; data: string }
+
+// One canonical terminal row per session (same precedence as the reflect pass): the agent's reported
+// outcome wins, then run.completed, ended, stopped. Prevents multi-event sessions from skewing the rate.
+const RANK: Record<string, number> = { 'session.reported': 3, 'run.completed': 2, 'session.ended': 1, 'session.stopped': 0 };
+
+/** Distinct terminated sessions in [from, to) as { ts, success } — one row per session. */
+function outcomes(db: Db, from: number, to: number): { ts: number; success: boolean }[] {
+  const rows = db
+    .prepare("SELECT run_id, ts, type, data FROM audit_events WHERE ts >= ? AND ts < ? AND type IN ('session.reported','session.ended','session.stopped','run.completed') ORDER BY ts")
+    .all<OutRow>(from, to);
+  const bySession = new Map<string, OutRow>();
+  for (const r of rows) {
+    const key = r.run_id || `anon:${r.ts}`;
+    const cur = bySession.get(key);
+    if (!cur || (RANK[r.type] ?? -1) > (RANK[cur.type] ?? -1)) bySession.set(key, r);
+  }
+  return [...bySession.values()].map((r) => {
+    let outcome = r.type === 'session.stopped' ? 'stopped' : 'unknown';
+    try { outcome = String((JSON.parse(r.data) as { outcome?: unknown }).outcome ?? outcome); } catch { /* keep default */ }
+    return { ts: r.ts, success: outcome === 'success' };
+  });
+}
+
+function rateOf(list: { success: boolean }[]): { n: number; rate: number | null } {
+  const n = list.length;
+  return { n, rate: n ? Math.round((list.filter((x) => x.success).length / n) * 100) : null };
+}
+
+function recTitle(id: string | undefined): string {
+  switch (id) {
+    case 'runtime.effort.high': return 'Raised default effort to “high”';
+    case 'policy.review': return 'Reviewed policy';
+    case 'budget.review': return 'Reviewed budgets';
+    default: return id ? `Applied “${id}”` : 'Applied a change';
+  }
+}
+
+/** Compute the success-rate trend + per-intervention before/after effect. Pure read over the audit log. */
+export function measureLearning(os: AgentOS, now = Date.now()): Measurement {
+  const db = os.db;
+  const all = outcomes(db, now - TREND_WEEKS * 7 * DAY, now);
+
+  const trend: TrendBucket[] = [];
+  for (let i = TREND_WEEKS - 1; i >= 0; i--) {
+    const start = now - (i + 1) * 7 * DAY;
+    const end = now - i * 7 * DAY;
+    const inWk = all.filter((o) => o.ts >= start && o.ts < end);
+    const { n, rate } = rateOf(inWk);
+    trend.push({ start, label: new Date(start).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }), total: n, success: inWk.filter((x) => x.success).length, rate });
+  }
+
+  const recent = rateOf(all.filter((o) => o.ts >= now - 7 * DAY));
+  const prior = rateOf(all.filter((o) => o.ts >= now - 14 * DAY && o.ts < now - 7 * DAY));
+  const deltaPp = recent.rate != null && prior.rate != null ? recent.rate - prior.rate : null;
+
+  // Interventions = applied recommendations (the concrete, outcome-affecting changes a human made). For
+  // each, the success rate BEFORE vs AFTER it — the honest "did that change help?" signal (M2/G1).
+  const applied = db.prepare("SELECT ts, data FROM audit_events WHERE type = 'recommendation.applied' ORDER BY ts DESC LIMIT 10").all<{ ts: number; data: string }>();
+  const interventions: InterventionEffect[] = applied.map((row) => {
+    let id: string | undefined;
+    try { id = String((JSON.parse(row.data) as { id?: unknown }).id ?? '') || undefined; } catch { /* ignore */ }
+    const before = rateOf(outcomes(db, row.ts - IA_WINDOW, row.ts));
+    const after = rateOf(outcomes(db, row.ts, Math.min(now, row.ts + IA_WINDOW)));
+    const d = before.rate != null && after.rate != null ? after.rate - before.rate : null;
+    const verdict: InterventionEffect['verdict'] =
+      before.n < MIN_N || after.n < MIN_N || d == null ? 'insufficient'
+        : d >= THRESH_PP ? 'improved' : d <= -THRESH_PP ? 'declined' : 'flat';
+    return { id: id ?? 'recommendation', title: recTitle(id), at: row.ts, before, after, deltaPp: d, verdict };
+  });
+
+  return { trend, interventions, recent, prior, deltaPp };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -22,6 +22,7 @@ import { DiscordSocket } from './edge/discord-socket';
 import { DreamingEngine } from './edge/dreaming';
 import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
 import { Digest } from './edge/digest';
+import { measureLearning } from './edge/measurement';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -2356,6 +2357,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, {
       everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined,
       applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open, state,
+      measurement: measureLearning(os), // "Is it working?" — success-rate trend + per-intervention before/after (G1)
       digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
     });
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -7794,6 +7794,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [guidance, setGuidance] = useState('')
   const [recs, setRecs] = useState<Recommendation[]>([])
   const [state, setState] = useState<DreamingState | null>(null)
+  const [measure, setMeasure] = useState<Measurement | null>(null)
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const [result, setResult] = useState<string>('')
@@ -7802,7 +7803,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [preview, setPreview] = useState<DigestModel | null>(null)
 
   const refresh = () => {
-    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); if (r.digest) setDigest(r.digest) }).catch(() => {})
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); if (r.digest) setDigest(r.digest) }).catch(() => {})
     api.digestToday().then((r) => { if (!r.error) setPreview(r) }).catch(() => {})
   }
   const saveDigest = async (patch: Partial<DigestConfig>) => {
@@ -7866,6 +7867,58 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
         </div>
         {result && <div className="rounded-md border bg-muted/40 p-2 text-xs">{result}</div>}
       </div>
+
+      {/* Is it working? — the measurement loop: success-rate trend + did each applied change help. */}
+      {measure && (measure.recent.rate != null || measure.trend.some((b) => b.rate != null)) && (() => {
+        const maxRate = Math.max(1, ...measure.trend.map((b) => b.rate ?? 0))
+        const dv = measure.deltaPp
+        const V: Record<string, { label: string; cls: string }> = {
+          improved: { label: 'improved', cls: 'text-emerald-600' }, declined: { label: 'declined', cls: 'text-red-600' },
+          flat: { label: 'no change', cls: 'text-muted-foreground' }, insufficient: { label: 'too early to tell', cls: 'text-muted-foreground' },
+        }
+        return (
+          <Card>
+            <CardContent className="space-y-3 p-4">
+              <div>
+                <div className="text-sm font-medium">Is it working?</div>
+                <p className="text-xs text-muted-foreground">Whether the fleet is actually getting better, and whether each change you applied moved the needle. This is a correlation over real runs, not a controlled test — the run counts are shown so a thin signal reads as thin.</p>
+              </div>
+              {measure.recent.rate != null && (
+                <div className="text-sm">
+                  Success rate <strong>{measure.recent.rate}%</strong> <span className="text-xs text-muted-foreground">last 7 days ({measure.recent.n} runs)</span>
+                  {dv != null && <span className={`ml-1 text-xs ${dv > 0 ? 'text-emerald-600' : dv < 0 ? 'text-red-600' : 'text-muted-foreground'}`}>{dv > 0 ? '▲' : dv < 0 ? '▼' : '■'} {dv > 0 ? '+' : ''}{dv} pts vs the week before</span>}
+                </div>
+              )}
+              <div className="space-y-1">
+                {measure.trend.filter((b) => b.total > 0).map((b) => (
+                  <div key={b.start} className="flex items-center gap-2 text-[11px]">
+                    <span className="w-12 shrink-0 text-muted-foreground">{b.label}</span>
+                    <div className="h-3 flex-1 overflow-hidden rounded bg-muted">
+                      <div className="h-full rounded bg-emerald-500/70" style={{ width: `${Math.round(((b.rate ?? 0) / maxRate) * 100)}%` }} />
+                    </div>
+                    <span className="w-16 shrink-0 tabular-nums text-muted-foreground">{b.rate ?? 0}% · {b.total}</span>
+                  </div>
+                ))}
+              </div>
+              {measure.interventions.length > 0 && (
+                <div className="space-y-1.5 border-t pt-2">
+                  <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Did your changes help?</div>
+                  {measure.interventions.map((iv, i) => (
+                    <div key={i} className="flex flex-wrap items-baseline gap-x-2 text-xs">
+                      <span className="font-medium">{iv.title}</span>
+                      <span className="text-muted-foreground">{new Date(iv.at).toLocaleDateString()}</span>
+                      {iv.before.rate != null && iv.after.rate != null
+                        ? <span className="text-muted-foreground">{iv.before.rate}% → {iv.after.rate}%{iv.deltaPp != null && ` (${iv.deltaPp > 0 ? '+' : ''}${iv.deltaPp} pts)`} · {iv.before.n}/{iv.after.n} runs</span>
+                        : <span className="text-muted-foreground">not enough runs yet</span>}
+                      <span className={`font-medium ${V[iv.verdict].cls}`}>{V[iv.verdict].label}</span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        )
+      })()}
 
       {/* 1. What it figured out — the payoff, first. */}
       <Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -269,6 +269,15 @@ export interface DreamingState {
   totals?: { sessions: number; success: number; failure: number; partial: number; stopped: number; unknown: number; rejected: number; budgetStops: number; errors: number }
   recent?: DreamingReview[]
 }
+export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
+export interface MeasureIntervention { id: string; title: string; at: number; before: { n: number; rate: number | null }; after: { n: number; rate: number | null }; deltaPp: number | null; verdict: 'improved' | 'declined' | 'flat' | 'insufficient' }
+export interface Measurement {
+  trend: MeasureTrendBucket[]
+  interventions: MeasureIntervention[]
+  recent: { n: number; rate: number | null }
+  prior: { n: number; rate: number | null }
+  deltaPp: number | null
+}
 export interface DigestConfig {
   enabled: boolean
   channel: string
@@ -1075,7 +1084,7 @@ export const api = {
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
   planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),


### PR DESCRIPTION
Closes audit finding **G1** — the reason Pillar 10 sat at 🟡: the four-verb loop (Capture · Recall · Distil · Apply) ran, but **nothing proved Apply actually moved outcomes**.

## What
`src/edge/measurement.ts` computes, from real session outcomes:
- an **8-week success-rate trend** (distinct-session counting, matching the reflect pass), and
- per **applied recommendation**, the success rate in the window **before vs after** it — with sample sizes and a verdict (improved / declined / flat / too-early).

Surfaced as an **"Is it working?"** card on the Dreaming page (trend bars + "did your changes help?"). Honest that it's **correlational, not a controlled A/B** — run counts ride along so a thin signal reads as thin.

## On live data
Fleet success rate trends **4% → 44%** over recent weeks; the one applied recommendation ("raise effort to high") correlates with **18% → 36% (+18 pts), verdict: improved**.

`/api/dreaming` returns `measurement`. typecheck + web build + governance (68/68). PILLARS/encoding doc updated to mark measurement shipped.

## Note
This is the last of the sequenced Dreaming-audit fixes. It's also the first genuinely *owner-facing* insight from Dreaming — a springboard for a broader insights direction under discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)