### PR TITLE
feat(dreaming): owner insights — per-agent scorecard + friction map (v0.161.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.160.0] — 2026-07-13
+## [0.161.0] — 2026-07-13
+### Added
+- **Dreaming as an owner-intelligence layer — per-agent scorecard + friction map.** Beyond the
+  agent-facing guidance, Dreaming now surfaces the two questions an owner asks first. New
+  `src/edge/insights.ts` computes deterministically over the audit log: a **fleet scorecard** (each
+  agent's runs, success rate, and what it actually works on, last 30 days — session outcomes joined to
+  the real agent, not the run-as principal) and a **friction map** (capabilities that keep getting
+  rejected at approval → deny or auto-allow; approvals waiting on a human). Rendered as two cards high on
+  the Dreaming page. Also exposed standalone at **`GET /api/insights`** (with the measurement bundle) so
+  an owner dashboard can consume the intelligence directly, decoupled from the page. On live data it
+  flags e.g. `stripe.refund` rejected 30× and each agent's win rate.
+
 ### Changed
 - **`docs/PILLARS.md`: added Pillar 17 — Media (generate · edit · understand).** The media capabilities had
   shipped but weren't reflected in the pillar map. Added the summary-table row + a full detail section

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.160.0",
+  "version": "0.161.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.160.0",
+      "version": "0.161.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.160.0",
+  "version": "0.161.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/insights.ts
+++ b/src/edge/insights.ts
@@ -1,0 +1,96 @@
+/**
+ * Owner **insights** — Dreaming as an analyst for the human, not just a self-tuning loop. Where the
+ * reflect pass distils guidance for *agents* and the measurement loop answers "is it working?", this
+ * answers the two questions an owner asks first:
+ *
+ *  - **Per-agent scorecard** — who's my MVP, who's struggling, and what does each work on. (last 30d)
+ *  - **Friction map** — which capabilities keep getting rejected at approval (deny them outright or
+ *    auto-allow?), and how many approvals are piling up on a human.
+ *
+ * Deterministic + pure over the DB — the always-on baseline (the LLM gardener can layer qualitative
+ * root-cause on top later). Rendered on the Dreaming page. See docs/PILLARS.md §10.
+ */
+import type { AgentOS } from '../kernel';
+
+type Db = AgentOS['db'];
+
+const DAY = 24 * 3_600_000;
+const WINDOW_DAYS = 30;
+const RANK: Record<string, number> = { 'session.reported': 3, 'run.completed': 2, 'session.ended': 1, 'session.stopped': 0 };
+const STOP = new Set(['task', 'outcome', 'session', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none', 'then', 'call', 'test', 'once', 'stop', 'tool', 'tools', 'exactly', 'nothing', 'else']);
+
+export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; rate: number | null; focus: string[] }
+export interface RejectedCapability { capability: string; count: number }
+export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
+export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
+
+interface OutRow { run_id: string | null; ts: number; type: string; data: string; agent: string }
+interface EpRow { agent_id: string; content: string }
+
+/** Top few focus keywords for one agent's episode first-lines (what it actually spends runs on). */
+function focusFor(contents: string[]): string[] {
+  const counts = new Map<string, number>();
+  for (const c of contents) {
+    const line = (c.split('\n').map((l) => l.trim()).find(Boolean) ?? '').replace(/^Task:\s*/i, '');
+    const seen = new Set<string>();
+    for (const w of line.toLowerCase().match(/[a-z][a-z0-9-]{3,}/g) ?? []) {
+      if (STOP.has(w) || seen.has(w)) continue;
+      seen.add(w);
+      counts.set(w, (counts.get(w) ?? 0) + 1);
+    }
+  }
+  return [...counts].sort((a, b) => b[1] - a[1]).slice(0, 3).map(([w]) => w);
+}
+
+export function buildInsights(os: AgentOS, now = Date.now()): Insights {
+  const db = os.db;
+  const since = now - WINDOW_DAYS * DAY;
+
+  // Per-agent outcomes: session terminal events joined to the session's real agent, one canonical row per
+  // session (principal is unreliable — it can be the run-as member). Then tally by agent.
+  const rows = db
+    .prepare(
+      "SELECT a.run_id, a.ts, a.type, a.data, s.agent FROM audit_events a JOIN term_sessions s ON s.id = a.run_id " +
+        "WHERE a.ts >= ? AND a.type IN ('session.reported','session.ended','session.stopped','run.completed') ORDER BY a.ts",
+    )
+    .all<OutRow>(since);
+  const bySession = new Map<string, OutRow>();
+  for (const r of rows) {
+    const cur = bySession.get(r.run_id || `x:${r.ts}`);
+    if (!cur || (RANK[r.type] ?? -1) > (RANK[cur.type] ?? -1)) bySession.set(r.run_id || `x:${r.ts}`, r);
+  }
+  const tally = new Map<string, { runs: number; success: number; failed: number; stopped: number }>();
+  for (const r of bySession.values()) {
+    let outcome = r.type === 'session.stopped' ? 'stopped' : 'unknown';
+    try { outcome = String((JSON.parse(r.data) as { outcome?: unknown }).outcome ?? outcome); } catch { /* keep */ }
+    const t = tally.get(r.agent) ?? { runs: 0, success: 0, failed: 0, stopped: 0 };
+    t.runs++;
+    if (outcome === 'success') t.success++;
+    else if (outcome === 'failure') t.failed++;
+    else if (outcome === 'stopped') t.stopped++;
+    tally.set(r.agent, t);
+  }
+
+  // Per-agent focus from this window's episodes.
+  const eps = db.prepare("SELECT agent_id, content FROM memories WHERE created_at >= ? AND tags LIKE '%\"episode\"%'").all<EpRow>(since);
+  const epByAgent = new Map<string, string[]>();
+  for (const e of eps) { const a = epByAgent.get(e.agent_id) ?? []; a.push(e.content); epByAgent.set(e.agent_id, a); }
+
+  const agents: AgentScore[] = [...tally.entries()]
+    .map(([agent, t]) => ({ agent, runs: t.runs, success: t.success, failed: t.failed, stopped: t.stopped, rate: t.runs ? Math.round((t.success / t.runs) * 100) : null, focus: focusFor(epByAgent.get(agent) ?? []) }))
+    .sort((a, b) => b.runs - a.runs)
+    .slice(0, 12);
+
+  // Friction: capabilities rejected at approval (deny or auto-allow?), + approvals waiting on a human.
+  const rejections = db
+    .prepare("SELECT capability, count(*) AS count FROM approvals WHERE status = 'rejected' GROUP BY capability ORDER BY count DESC LIMIT 8")
+    .all<RejectedCapability>();
+  const pending = db.prepare("SELECT count(*) AS n, MIN(created_at) AS oldest FROM approvals WHERE status = 'pending'").get<{ n: number; oldest: number | null }>();
+  const friction: FrictionMap = {
+    rejections,
+    pendingApprovals: pending?.n ?? 0,
+    oldestPendingAgeMs: pending?.oldest ? now - pending.oldest : null,
+  };
+
+  return { windowDays: WINDOW_DAYS, agents, friction };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,7 @@ import { DreamingEngine } from './edge/dreaming';
 import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
 import { Digest } from './edge/digest';
 import { measureLearning } from './edge/measurement';
+import { buildInsights } from './edge/insights';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -2358,8 +2359,15 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined,
       applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open, state,
       measurement: measureLearning(os), // "Is it working?" — success-rate trend + per-intervention before/after (G1)
+      insights: buildInsights(os), // owner insights — per-agent scorecard + friction map
       digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
     });
+  }
+  // The OS intelligence layer, standalone — per-agent scorecard + friction map + the "is it working?"
+  // measurement, decoupled from the Dreaming page so an owner dashboard can consume it directly.
+  if (method === 'GET' && p === '/api/insights') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { insights: buildInsights(os), measurement: measureLearning(os) });
   }
   // Apply / dismiss a config recommendation (human-gated — nothing auto-applies).
   const recMatch = p.match(/^\/api\/dreaming\/recommendation\/([\w.-]+)\/(apply|dismiss)$/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -7795,6 +7795,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [recs, setRecs] = useState<Recommendation[]>([])
   const [state, setState] = useState<DreamingState | null>(null)
   const [measure, setMeasure] = useState<Measurement | null>(null)
+  const [insights, setInsights] = useState<Insights | null>(null)
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const [result, setResult] = useState<string>('')
@@ -7803,7 +7804,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [preview, setPreview] = useState<DigestModel | null>(null)
 
   const refresh = () => {
-    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); if (r.digest) setDigest(r.digest) }).catch(() => {})
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); if (r.digest) setDigest(r.digest) }).catch(() => {})
     api.digestToday().then((r) => { if (!r.error) setPreview(r) }).catch(() => {})
   }
   const saveDigest = async (patch: Partial<DigestConfig>) => {
@@ -7919,6 +7920,53 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
           </Card>
         )
       })()}
+
+      {/* Fleet scorecard — per-agent performance (owner intelligence). */}
+      {insights && insights.agents.length > 0 && (
+        <Card>
+          <CardContent className="space-y-2 p-4">
+            <div>
+              <div className="text-sm font-medium">Fleet scorecard <span className="text-[11px] font-normal text-muted-foreground">— per agent, last {insights.windowDays} days</span></div>
+              <p className="text-xs text-muted-foreground">Who’s carrying the load, who’s struggling, and what each agent actually spends its runs on.</p>
+            </div>
+            <div className="space-y-1">
+              {insights.agents.map((a) => {
+                const rateCls = a.rate == null ? 'text-muted-foreground' : a.rate >= 70 ? 'text-emerald-600' : a.rate >= 40 ? 'text-amber-600' : 'text-red-600'
+                return (
+                  <div key={a.agent} className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 border-b py-1.5 text-xs last:border-0">
+                    <a className="w-40 shrink-0 truncate font-medium underline-offset-2 hover:underline" href={`#/agents/${a.agent}`}>{a.agent}</a>
+                    <span className={`w-10 shrink-0 tabular-nums font-medium ${rateCls}`}>{a.rate == null ? '—' : `${a.rate}%`}</span>
+                    <span className="text-muted-foreground">{a.runs} run{a.runs === 1 ? '' : 's'}{a.failed ? ` · ${a.failed} failed` : ''}{a.stopped ? ` · ${a.stopped} stopped` : ''}</span>
+                    {a.focus.length > 0 && <span className="text-muted-foreground">· {a.focus.join(', ')}</span>}
+                  </div>
+                )
+              })}
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Friction — what keeps getting rejected / waiting on a human (owner intelligence). */}
+      {insights && (insights.friction.rejections.length > 0 || insights.friction.pendingApprovals > 0) && (
+        <Card>
+          <CardContent className="space-y-2 p-4">
+            <div>
+              <div className="text-sm font-medium">Friction <span className="text-[11px] font-normal text-muted-foreground">— where the fleet keeps getting blocked</span></div>
+              <p className="text-xs text-muted-foreground">Capabilities that keep getting rejected at approval (decide once — deny outright, or auto-allow in <a className="underline" href="#/settings">Policy</a>), and approvals waiting on a person.</p>
+            </div>
+            {insights.friction.rejections.map((r) => (
+              <div key={r.capability} className="flex items-baseline gap-2 text-xs">
+                <Badge variant="outline" className="px-1.5 py-0 text-[10px] font-normal text-red-600">rejected {r.count}×</Badge>
+                <span className="font-mono">{r.capability}</span>
+                <span className="text-muted-foreground">— always rejected; deny it or auto-allow so agents stop trying</span>
+              </div>
+            ))}
+            {insights.friction.pendingApprovals > 0 && (
+              <div className="text-xs text-amber-600">{insights.friction.pendingApprovals} approval{insights.friction.pendingApprovals === 1 ? '' : 's'} waiting on a human{insights.friction.oldestPendingAgeMs ? ` (oldest ${Math.round(insights.friction.oldestPendingAgeMs / 3_600_000)}h)` : ''} — see the <a className="underline" href="#/inbox">Inbox</a>.</div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {/* 1. What it figured out — the payoff, first. */}
       <Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -269,6 +269,10 @@ export interface DreamingState {
   totals?: { sessions: number; success: number; failure: number; partial: number; stopped: number; unknown: number; rejected: number; budgetStops: number; errors: number }
   recent?: DreamingReview[]
 }
+export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; rate: number | null; focus: string[] }
+export interface RejectedCapability { capability: string; count: number }
+export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
+export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
 export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
 export interface MeasureIntervention { id: string; title: string; at: number; before: { n: number; rate: number | null }; after: { n: number; rate: number | null }; deltaPp: number | null; verdict: 'improved' | 'declined' | 'flat' | 'insufficient' }
 export interface Measurement {
@@ -1084,7 +1088,7 @@ export const api = {
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
   planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),


### PR DESCRIPTION
First step toward **Dreaming as an owner-intelligence layer** (not just a self-tuning loop).

## What
New `src/edge/insights.ts` computes deterministically over the audit log:
- **Fleet scorecard** — per agent (last 30d): runs, success rate, and what it actually works on. Session outcomes are joined to the **real agent** (`term_sessions.agent`), not the run-as principal, and deduped one row per session (matching the reflect pass).
- **Friction map** — capabilities that keep getting **rejected at approval** (decide once: deny outright or auto-allow), plus approvals **waiting on a human**.

Rendered as two cards high on the Dreaming page. Also exposed standalone at **`GET /api/insights`** (bundled with the measurement) so the **owner dashboard** can consume the intelligence directly, decoupled from the page.

## On live data
- Friction: **`stripe.refund` rejected 30×** — a clear deny/auto-allow decision.
- Scorecard: engineer 59% (17 runs), strategist 100% (4), **agent-author 13%** (8) — instantly shows who's struggling.

typecheck + web build + governance (68/68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)