### PR TITLE
feat(insights): root-cause diagnosis analyst (v0.165.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.165.0] — 2026-07-13
+### Added
+- **Root-cause diagnosis on the Insights scorecard.** The scorecard says *which* agent is struggling; a
+  **Diagnose** button (on any agent below 50% with ≥2 failed/stopped runs) now answers *why*. New
+  `src/edge/diagnosis.ts` spawns a governed headless **analyst** agent that reads that agent's recent
+  FAILED / STOPPED / PARTIAL runs, finds the recurring failure pattern, hypothesizes the root cause, and
+  writes a short **Pattern · Likely cause · Suggested fix · Evidence** page to the Knowledge Base
+  (`operations/diagnosis/<agent>`) + reports — same governed pattern as the consolidation gardener, on
+  demand (it costs a run). The scorecard then shows a **diagnosis →** link for any agent that has one.
+  `POST /api/insights/diagnose`; audited `insights.diagnose`. Gardener-powered half of the intelligence
+  layer, on top of the deterministic scorecard/friction/measurement.
+
 ## [0.164.0] — 2026-07-13
 ### Added
 - **Answer an agent's question by replying to the Slack/Discord DM.** When an agent uses `ask_human`, the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.164.0",
+  "version": "0.165.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.164.0",
+      "version": "0.165.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.164.0",
+  "version": "0.165.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/diagnosis.ts
+++ b/src/edge/diagnosis.ts
@@ -1,0 +1,127 @@
+/**
+ * Root-cause **diagnosis** — the gardener-powered half of the Insights layer. The deterministic scorecard
+ * (src/edge/insights.ts) says *which* agent is struggling and by how much; this answers **why**. On demand
+ * (a "Diagnose" button on a struggling scorecard row) it spawns a governed headless **analyst** agent that
+ * reads that agent's recent FAILED / STOPPED runs, finds the recurring failure pattern, hypothesizes the
+ * root cause, and writes a short diagnosis to a KB page (`operations/diagnosis/<agent>`) + reports.
+ *
+ * Same shape as the consolidation gardener (a spawned claude-code agent reusing all governance/audit) — no
+ * in-process LLM client. Deliberately on-demand, not automatic: it costs a run, and an owner asks for it
+ * about a specific agent. The scorecard then links to the diagnosis page. See src/edge/insights.ts.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AgentOS } from '../kernel';
+import type { TerminalManager } from '../terminal';
+import type { AgentManifest } from '../types';
+
+export const ANALYST_ID = 'analyst';
+const WINDOW_MS = 45 * 24 * 3_600_000; // look back far enough to gather a struggling agent's failures
+const MAX_ITEMS = 30;
+const MIN_ITEMS = 2; // need at least a couple of failures to find a pattern
+
+export interface DiagnoseResult { spawned: boolean; reason?: string; sessionId?: string; items?: number; slug?: string }
+
+interface EpRow { content: string; metadata: string; created_at: number }
+
+export function diagnosisSlug(agentId: string): string {
+  return `diagnosis/${agentId.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}`;
+}
+
+export class Diagnosis {
+  constructor(private readonly os: AgentOS, private readonly tm: TerminalManager) {}
+
+  /** Gather `agentId`'s recent non-success runs and spawn the analyst to diagnose the root cause. */
+  async run(agentId: string, by: string): Promise<DiagnoseResult> {
+    if (!this.os.agents.get(agentId)) return { spawned: false, reason: `unknown agent ${agentId}` };
+    const db = this.os.db;
+    const since = Date.now() - WINDOW_MS;
+    const rows = db
+      .prepare("SELECT content, metadata, created_at FROM memories WHERE agent_id = ? AND tags LIKE '%\"episode\"%' AND created_at > ? ORDER BY created_at DESC LIMIT 120")
+      .all<EpRow>(agentId, since);
+    const failures = rows.filter((r) => {
+      let o = '';
+      try { o = String((JSON.parse(r.metadata || '{}') as { outcome?: unknown }).outcome ?? ''); } catch { /* ignore */ }
+      return o === 'failure' || o === 'stopped' || o === 'partial';
+    }).slice(0, MAX_ITEMS);
+
+    if (failures.length < MIN_ITEMS) {
+      return { spawned: false, reason: `only ${failures.length} recent non-success runs for ${agentId} (need ${MIN_ITEMS})`, items: failures.length };
+    }
+
+    this.ensureAgent();
+    failures.reverse();
+    const slug = diagnosisSlug(agentId);
+    const task = this.buildTask(agentId, failures, slug);
+    const session = this.tm.createSession(ANALYST_ID, `Diagnose ${agentId} — ${failures.length} failed runs`, task, by, true /* headless */, undefined, undefined, by /* run-as the requester */);
+    this.os.audit.append({ ts: Date.now(), runId: session.id, tenant: this.os.tenant, principal: by, type: 'insights.diagnose', data: { agent: agentId, items: failures.length, sessionId: session.id, slug } });
+    return { spawned: true, sessionId: session.id, items: failures.length, slug };
+  }
+
+  private buildTask(agentId: string, rows: EpRow[], slug: string): string {
+    const items = rows.map((r, i) => {
+      let outcome = '';
+      try { outcome = String((JSON.parse(r.metadata || '{}') as { outcome?: unknown }).outcome ?? ''); } catch { /* ignore */ }
+      return `--- [${i + 1}]${outcome ? ` outcome=${outcome}` : ''} ---\n${r.content.trim()}`;
+    });
+    return [
+      `You are diagnosing why the agent **${agentId}** keeps struggling. Below are its recent FAILED / STOPPED /`,
+      `PARTIAL runs (end-of-session recaps). Find the RECURRING failure pattern, hypothesize the ROOT CAUSE,`,
+      `and recommend a concrete FIX — follow your CLAUDE.md method.`,
+      ``,
+      items.join('\n\n'),
+      ``,
+      `--- end of runs ---`,
+      `Now write your diagnosis to the Knowledge Base with \`kb_write\` at section \`operations\`, slug \`${slug}\`,`,
+      `title \`Diagnosis: ${agentId}\`. Keep it short and actionable: **Pattern**, **Likely cause**, **Suggested fix**,`,
+      `and a one-line **Evidence** citing how many runs show it. Then \`report\` a one-line summary.`,
+    ].join('\n');
+  }
+
+  /** Provision the analyst agent into the data home on first use. Idempotent (mirrors the consolidator). */
+  private ensureAgent(): void {
+    if (this.os.agents.get(ANALYST_ID)?.dir) return;
+    const base = this.os.paths?.userAgents ?? path.join(process.cwd(), 'data', 'agents');
+    const dir = path.join(base, ANALYST_ID);
+    fs.mkdirSync(dir, { recursive: true });
+    const manifestPath = path.join(dir, 'agent.json');
+    if (!fs.existsSync(manifestPath)) fs.writeFileSync(manifestPath, JSON.stringify(MANIFEST, null, 2));
+    if (!fs.existsSync(path.join(dir, 'CLAUDE.md'))) fs.writeFileSync(path.join(dir, 'CLAUDE.md'), CLAUDE_MD);
+    this.os.registerAgent({ ...MANIFEST, dir });
+  }
+}
+
+const MANIFEST: AgentManifest = {
+  id: ANALYST_ID,
+  version: '1.0.0',
+  description: 'Fleet analyst — diagnoses why a struggling agent keeps failing, root-cause + fix, into the KB.',
+  category: 'System',
+  principal: 'svc-analyst',
+  policyContext: 'default@v3',
+  runtime: 'claude-code',
+  model: 'claude-opus-4-8',
+  budget: { usdCap: 1, tokenCap: 200_000, wallClockMs: 600_000 },
+};
+
+const CLAUDE_MD = `# Fleet analyst (root-cause)
+
+You are Agent OS's **analyst**. You are handed the recent FAILED / STOPPED / PARTIAL runs of a single
+agent that's underperforming, and you diagnose **why** — so a human can fix the actual cause instead of
+guessing.
+
+## Method
+1. **Read the runs in your task.** Look for the RECURRING thread — the same error, the same blocker, the
+   same wrong assumption showing up across multiple runs. One-off flukes are noise; you want the pattern.
+2. **Name the likely ROOT CAUSE.** Not the symptom ("the run stopped") but the cause ("the Atlas image API
+   rate-limits on retry and the agent has no backoff", "it keeps needing a host that was never granted",
+   "the task is ambiguous and it guesses"). Be specific and evidence-based; say "unclear" if the runs
+   genuinely don't show one rather than inventing.
+3. **Recommend a concrete FIX** — a policy/host/tuning change, a CLAUDE.md instruction, a missing tool, a
+   clearer task. Something the owner can act on.
+4. **Write it with \`kb_write\`** to the section/slug/title given in your task. Keep it SHORT and skimmable:
+   **Pattern** · **Likely cause** · **Suggested fix** · **Evidence** (how many runs show it). Overwrite the
+   page if it exists (it's the living diagnosis for this agent).
+5. **Finish with \`report\`** — a one-line summary (e.g. "researcher: 5/7 media-tool runs hit Atlas
+   rate-limits — add backoff or switch backend").
+
+You only read the batch in your task and write one KB page. Nothing you do needs a human's connectors.`;

--- a/src/edge/insights.ts
+++ b/src/edge/insights.ts
@@ -12,6 +12,8 @@
  */
 import type { AgentOS } from '../kernel';
 
+import { diagnosisSlug } from './diagnosis';
+
 type Db = AgentOS['db'];
 
 const DAY = 24 * 3_600_000;
@@ -19,7 +21,7 @@ const WINDOW_DAYS = 30;
 const RANK: Record<string, number> = { 'session.reported': 3, 'run.completed': 2, 'session.ended': 1, 'session.stopped': 0 };
 const STOP = new Set(['task', 'outcome', 'session', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none', 'then', 'call', 'test', 'once', 'stop', 'tool', 'tools', 'exactly', 'nothing', 'else']);
 
-export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; rate: number | null; focus: string[] }
+export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
@@ -77,7 +79,10 @@ export function buildInsights(os: AgentOS, now = Date.now()): Insights {
   for (const e of eps) { const a = epByAgent.get(e.agent_id) ?? []; a.push(e.content); epByAgent.set(e.agent_id, a); }
 
   const agents: AgentScore[] = [...tally.entries()]
-    .map(([agent, t]) => ({ agent, runs: t.runs, success: t.success, failed: t.failed, stopped: t.stopped, rate: t.runs ? Math.round((t.success / t.runs) * 100) : null, focus: focusFor(epByAgent.get(agent) ?? []) }))
+    .map(([agent, t]) => {
+      const dx = os.kb.read(os.tenant, 'operations', diagnosisSlug(agent)); // existing root-cause diagnosis, if any
+      return { agent, runs: t.runs, success: t.success, failed: t.failed, stopped: t.stopped, rate: t.runs ? Math.round((t.success / t.runs) * 100) : null, focus: focusFor(epByAgent.get(agent) ?? []), diagnosis: dx ? { at: dx.updatedAt, slug: dx.slug } : undefined };
+    })
     .sort((a, b) => b.runs - a.runs)
     .slice(0, 12);
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -24,6 +24,7 @@ import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
 import { Digest } from './edge/digest';
 import { measureLearning } from './edge/measurement';
 import { buildInsights } from './edge/insights';
+import { Diagnosis } from './edge/diagnosis';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -2379,6 +2380,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/insights') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     return sendJson(res, 200, { insights: buildInsights(os), measurement: measureLearning(os) });
+  }
+  // Root-cause diagnosis: spawn the analyst to work out WHY a struggling agent keeps failing, into a KB page.
+  if (method === 'POST' && p === '/api/insights/diagnose') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req);
+    const agent = String(b.agent || '').trim();
+    if (!agent) return sendJson(res, 400, { error: 'agent required' });
+    try {
+      const r = await new Diagnosis(os, tm).run(agent, me.email);
+      return sendJson(res, r.spawned ? 200 : 400, { ok: r.spawned, ...r });
+    } catch (e) {
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
   }
   // Apply / dismiss a config recommendation (human-gated — nothing auto-applies).
   const recMatch = p.match(/^\/api\/dreaming\/recommendation\/([\w.-]+)\/(apply|dismiss)$/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7999,6 +7999,8 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [state, setState] = useState<DreamingState | null>(null)
   const [measure, setMeasure] = useState<Measurement | null>(null)
   const [insights, setInsights] = useState<Insights | null>(null)
+  const [dxBusy, setDxBusy] = useState('')
+  const [dxHint, setDxHint] = useState('')
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const [result, setResult] = useState<string>('')
@@ -8024,6 +8026,12 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
     const failed = (r.platforms ?? []).filter((p) => !p.posted).map((p) => `${p.platform}: ${p.error}`).join('; ')
     setDigestHint(r.posted ? `posted to ${where} (${r.total} sessions)${failed ? ` — failed ${failed}` : ''}` : `not posted — ${failed || r.reason || r.error || 'nothing to post'}`)
     setTimeout(() => setDigestHint(''), 3000); refresh()
+  }
+  const diagnose = async (agent: string) => {
+    setDxBusy(agent); setDxHint('')
+    const r = await api.diagnose(agent); setDxBusy('')
+    setDxHint(r.error ? `⚠ ${r.error}` : r.spawned ? `Diagnosing ${agent}… the analyst will write it to Knowledge in a minute — refresh to see the link.` : (r.reason ?? 'nothing to diagnose'))
+    setTimeout(() => setDxHint(''), 6000)
   }
   const applyRec = async (id: string) => { setBusy(true); const r = await api.applyRecommendation(id); setBusy(false); if (r.error) return setHint('⚠ ' + r.error); setHint('applied'); setTimeout(() => setHint(''), 1500); refresh() }
   const dismissRec = async (id: string) => { setBusy(true); await api.dismissRecommendation(id); setBusy(false); refresh() }
@@ -8135,16 +8143,24 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
             <div className="space-y-1">
               {insights.agents.map((a) => {
                 const rateCls = a.rate == null ? 'text-muted-foreground' : a.rate >= 70 ? 'text-emerald-600' : a.rate >= 40 ? 'text-amber-600' : 'text-red-600'
+                const struggling = a.rate != null && a.rate < 50 && (a.failed + a.stopped) >= 2
                 return (
                   <div key={a.agent} className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 border-b py-1.5 text-xs last:border-0">
                     <a className="w-40 shrink-0 truncate font-medium underline-offset-2 hover:underline" href={`#/agents/${a.agent}`}>{a.agent}</a>
                     <span className={`w-10 shrink-0 tabular-nums font-medium ${rateCls}`}>{a.rate == null ? '—' : `${a.rate}%`}</span>
                     <span className="text-muted-foreground">{a.runs} run{a.runs === 1 ? '' : 's'}{a.failed ? ` · ${a.failed} failed` : ''}{a.stopped ? ` · ${a.stopped} stopped` : ''}</span>
                     {a.focus.length > 0 && <span className="text-muted-foreground">· {a.focus.join(', ')}</span>}
+                    <span className="ml-auto shrink-0">
+                      {a.diagnosis
+                        ? <a href="#/kb" className="text-emerald-600 underline underline-offset-2" title={`updated ${new Date(a.diagnosis.at).toLocaleString()}`}>diagnosis →</a>
+                        : struggling && <button onClick={() => diagnose(a.agent)} disabled={dxBusy === a.agent} className="text-primary underline underline-offset-2 disabled:opacity-50">{dxBusy === a.agent ? 'diagnosing…' : 'diagnose'}</button>}
+                    </span>
                   </div>
                 )
               })}
             </div>
+            {dxHint && <div className="text-[11px] text-muted-foreground">{dxHint}</div>}
+            <p className="text-[11px] text-muted-foreground">A <strong>diagnose</strong> spawns the analyst to read a struggling agent's failed runs and write a root-cause + fix to <a className="underline" href="#/kb">Knowledge</a>.</p>
           </CardContent>
         </Card>
       )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -269,7 +269,7 @@ export interface DreamingState {
   totals?: { sessions: number; success: number; failure: number; partial: number; stopped: number; unknown: number; rejected: number; budgetStops: number; errors: number }
   recent?: DreamingReview[]
 }
-export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; rate: number | null; focus: string[] }
+export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
@@ -1101,6 +1101,8 @@ export const api = {
   setDigest: (digest: { enabled?: boolean; channel?: string; discordChannel?: string; hour?: number }) => call<{ ok: boolean; digest: DigestConfig; error?: string }>('PUT', '/api/dreaming', { digest }),
   digestToday: () => call<DigestModel & { error?: string }>('GET', '/api/digest/today'),
   digestPost: () => call<{ ok: boolean; posted: boolean; reason?: string; total: number; iso: string; error?: string; platforms?: { platform: 'slack' | 'discord'; posted: boolean; channel: string; error?: string }[] }>('POST', '/api/digest/post'),
+  // Spawn the analyst to diagnose why a struggling agent keeps failing (writes a KB page).
+  diagnose: (agent: string) => call<{ ok: boolean; spawned: boolean; reason?: string; sessionId?: string; items?: number; slug?: string; error?: string }>('POST', '/api/insights/diagnose', { agent }),
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),


### PR DESCRIPTION
The gardener-powered half of the intelligence layer — the scorecard says *which* agent struggles; this answers *why*.

## What
A **Diagnose** button on the Insights scorecard (shown for any agent below 50% with ≥2 failed/stopped runs). It spawns a governed headless **analyst** agent (`src/edge/diagnosis.ts`) that reads that agent's recent FAILED / STOPPED / PARTIAL runs, finds the recurring failure pattern, hypothesizes the **root cause**, and writes a short **Pattern · Likely cause · Suggested fix · Evidence** page to the Knowledge Base (`operations/diagnosis/<agent>`) + reports. Same governed, audited pattern as the consolidation gardener — on demand (it costs a run). The scorecard then shows a **diagnosis →** link for any agent that has one.

`POST /api/insights/diagnose`; audited `insights.diagnose`. On-demand by design (an owner asks about a specific agent), not auto-spawned.

## Validation
- A written diagnosis page surfaces as the scorecard link (KB slug round-trips through normalization); the unknown/clean-agent guard returns **without** spawning. The spawn itself mirrors the proven consolidator (not unit-testable in the harness — no claude backend).
- typecheck + web build + governance (68/68).

## Note
This is where the intelligence layer starts using the LLM gardener for qualitative insight, atop the deterministic scorecard / friction / measurement. `GET /api/insights` continues to feed the owner dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)