### PR TITLE
feat(insights): proactive alerts to the Inbox (v0.166.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.166.0] — 2026-07-13
+### Added
+- **Proactive insight alerts — the intelligence layer comes to you.** Instead of waiting for someone to
+  open Insights, the hourly tick now detects notable conditions and pushes each to the **admins' Inbox**
+  (+ a Slack/Discord DM): a **struggling agent** (≤25% success over ≥4 runs), a **capability that keeps
+  getting rejected** (≥5×), a **fleet success-rate drop** (≥15 points week-over-week), and **approvals
+  piling up** (≥3 pending, oldest ≥4h). New `src/edge/alerts.ts`; each alert has a stable key and a
+  **3-day per-key cooldown** (a persistent problem pings once, not every hour). On by default, toggle on
+  the Insights page (`insights_alerts`); a session-less `notification` card via `TerminalManager.postInsightAlert`;
+  DM via `notifyInsightAlert`; audited `insights.alert` / `insights.alert.notified`. Validated on live data
+  (flags agent-author at 13% and stripe.refund's repeated rejections; the cooldown suppresses a re-fire).
+
 ## [0.165.0] — 2026-07-13
 ### Added
 - **Root-cause diagnosis on the Insights scorecard.** The scorecard says *which* agent is struggling; a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.165.0",
+  "version": "0.166.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.165.0",
+      "version": "0.166.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.165.0",
+  "version": "0.166.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/alerts.ts
+++ b/src/edge/alerts.ts
@@ -1,0 +1,81 @@
+/**
+ * Proactive **insight alerts** — the intelligence layer coming to the owner instead of waiting to be
+ * looked at. On the hourly tick it re-derives the scorecard / friction / measurement and, when something
+ * genuinely warrants a human's attention, pushes an **Inbox card** (+ out-of-band DM) to the admins.
+ *
+ * Deliberately quiet: each alert has a stable `key` and a **cooldown** (a prior `insights.alert` audit for
+ * that key within `COOLDOWN_MS` suppresses a repeat), so a persistent condition pings once, not every hour.
+ * Thresholds are conservative — this is "something's wrong, go look", not a firehose. Pure detection here;
+ * the tick posts the card + DMs. See src/edge/insights.ts, docs/inbox-plan.md.
+ */
+import type { AgentOS } from '../kernel';
+import { buildInsights } from './insights';
+import { measureLearning } from './measurement';
+
+const COOLDOWN_MS = 3 * 24 * 3_600_000; // don't re-alert the same key within 3 days
+
+export interface InsightAlert { key: string; severity: 'high' | 'medium'; title: string; body: string }
+
+/** Detect the conditions worth a human's attention right now (pure — no dedup, no side effects). */
+export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
+  const ins = buildInsights(os, now);
+  const m = measureLearning(os, now);
+  const out: InsightAlert[] = [];
+
+  // Fleet success rate fell sharply week-over-week (enough runs to be real).
+  if (m.deltaPp != null && m.deltaPp <= -15 && m.recent.n >= 10) {
+    out.push({
+      key: 'success-drop',
+      severity: 'high',
+      title: `Fleet success rate dropped ${Math.abs(m.deltaPp)} points`,
+      body: `Success fell to ${m.recent.rate}% this week (${m.recent.n} runs) from ${m.prior.rate}% the week before. Check the Insights page for which agents regressed.`,
+    });
+  }
+
+  // An individual agent is failing badly.
+  for (const a of ins.agents) {
+    if (a.rate != null && a.rate <= 25 && a.runs >= 4 && a.failed + a.stopped >= 3) {
+      out.push({
+        key: `agent-low:${a.agent}`,
+        severity: 'high',
+        title: `${a.agent} is struggling (${a.rate}% success)`,
+        body: `${a.agent} succeeded on only ${a.rate}% of ${a.runs} runs in the last ${ins.windowDays} days (${a.failed} failed, ${a.stopped} stopped). Open Insights and "Diagnose" it to see the root cause.`,
+      });
+    }
+  }
+
+  // A capability keeps getting rejected at approval — decide once.
+  for (const r of ins.friction.rejections) {
+    if (r.count >= 5) {
+      out.push({
+        key: `friction:${r.capability}`,
+        severity: 'medium',
+        title: `"${r.capability}" keeps getting rejected`,
+        body: `${r.count} approvals for \`${r.capability}\` were rejected. If it should never run, deny it outright in Policy; if it's fine, auto-allow it — either way agents stop wasting runs asking.`,
+      });
+    }
+  }
+
+  // Approvals piling up on a human.
+  const oldestH = ins.friction.oldestPendingAgeMs ? Math.round(ins.friction.oldestPendingAgeMs / 3_600_000) : 0;
+  if (ins.friction.pendingApprovals >= 3 && oldestH >= 4) {
+    out.push({
+      key: 'pending-approvals',
+      severity: 'medium',
+      title: `${ins.friction.pendingApprovals} approvals waiting on a human`,
+      body: `${ins.friction.pendingApprovals} approvals are pending (oldest ${oldestH}h). Agents are blocked until someone resolves them — see the Inbox.`,
+    });
+  }
+
+  return out;
+}
+
+/** Detected alerts minus any whose key fired within the cooldown — the ones to actually push now. */
+export function pendingAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
+  return detectAlerts(os, now).filter((a) => {
+    const last = os.db
+      .prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'insights.alert' AND data LIKE ?")
+      .get<{ t: number | null }>(`%"key":"${a.key}"%`);
+    return !last?.t || now - last.t >= COOLDOWN_MS;
+  });
+}

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -34,6 +34,7 @@ const DREAMING_KEY = 'dreaming_every_hours'; // self-learning cadence in hours; 
 const GOALS_INJECT_KEY = 'goals_inject'; // whether active goals ride in every agent's prompt (default on)
 const GOALS_AUTOPLAN_KEY = 'goals_autoplan'; // whether the scheduler auto-plans stuck goals (default OFF — opt-in)
 const DIGEST_ENABLED_KEY = 'digest_enabled'; // whether the end-of-day fleet digest posts to Slack ('on'|'off')
+const INSIGHTS_ALERTS_KEY = 'insights_alerts'; // proactive intelligence alerts → admins' Inbox ('on'|'off', default on)
 const DIGEST_CHANNEL_KEY = 'digest_channel'; // Slack channel (id or name) the EOD digest posts to; '' = unset
 const DIGEST_DISCORD_CHANNEL_KEY = 'digest_discord_channel'; // Discord channel id the EOD digest posts to; '' = unset
 const DIGEST_HOUR_KEY = 'digest_hour'; // server-local hour (0–23) the EOD digest fires at; default 18
@@ -467,6 +468,15 @@ export class SettingsStore {
   setDigestEnabled(on: boolean, by?: string): boolean {
     this.set(DIGEST_ENABLED_KEY, on ? 'on' : 'off', by);
     return this.digestEnabled();
+  }
+  /** Whether the intelligence layer pushes proactive alerts (struggling agent, recurring rejections, …) to
+   *  the admins' Inbox. Default ON (it's the point — the OS comes to you), throttled per-key server-side. */
+  insightsAlertsEnabled(): boolean {
+    return this.getRow(INSIGHTS_ALERTS_KEY)?.value !== 'off';
+  }
+  setInsightsAlertsEnabled(on: boolean, by?: string): boolean {
+    this.set(INSIGHTS_ALERTS_KEY, on ? 'on' : 'off', by);
+    return this.insightsAlertsEnabled();
   }
   /** The Slack channel (id like `C123…` or a name like `#fleet`) the digest posts to; '' when unset. */
   digestChannel(): string {

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,7 +11,8 @@ import * as crypto from 'crypto';
 import * as nodeOs from 'node:os';
 import { AgentOS, loadAgentOS } from './kernel';
 import { VERSION } from './version';
-import { TenantRegistry, TenantRuntime, notifyLoginLink } from './tenant-registry';
+import { TenantRegistry, TenantRuntime, notifyLoginLink, notifyInsightAlert } from './tenant-registry';
+import { pendingAlerts } from './edge/alerts';
 import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
 import { TerminalManager, AGENT_OS_OPERATING_NOTES } from './terminal';
@@ -303,6 +304,19 @@ export function startServer(port = Number(process.env.PORT) || 3010): http.Serve
     // Slack post (enabled + channel + past digestHour + not yet posted today); the dashboard/KB render
     // live on demand, so nothing here is needed to keep them fresh. No-op unless the tenant opted in.
     void new Digest(os).maybePostEod().catch(() => { /* never let the digest crash the scheduler */ });
+    // Proactive intelligence alerts — the OS comes to the owner. Detect notable conditions (struggling
+    // agent, recurring rejections, success drop), push each NEW one (past its per-key cooldown) as an
+    // admins' Inbox card + DM. No-op if disabled or nothing warrants attention.
+    if (os.settings.insightsAlertsEnabled()) {
+      try {
+        const origin = registry.consoleOrigin(os.tenant);
+        for (const alert of pendingAlerts(os)) {
+          rt.tm.postInsightAlert(alert);
+          os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'insights.alert', data: { key: alert.key, severity: alert.severity } });
+          void notifyInsightAlert(os, rt.slack, rt.discord, origin, alert).catch(() => { /* DM is best-effort */ });
+        }
+      } catch { /* never let alerting crash the scheduler */ }
+    }
   }), 3_600_000);
   upkeep.unref?.();
 
@@ -2369,7 +2383,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const state = raw ? { firstPass: raw.firstPass, passes: raw.passes, totals: raw.totals, recent: raw.recent } : undefined;
     return sendJson(res, 200, {
       everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined,
-      applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open, state,
+      applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open, state, alertsEnabled: os.settings.insightsAlertsEnabled(),
       measurement: measureLearning(os), // "Is it working?" — success-rate trend + per-intervention before/after (G1)
       insights: buildInsights(os), // owner insights — per-agent scorecard + friction map
       digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
@@ -2422,6 +2436,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const b = await readBody(req);
     if (b.everyHours !== undefined) os.settings.setDreamingEveryHours(Number(b.everyHours) || 0, me.email);
     if (typeof b.applyLearnings === 'boolean') os.settings.setApplyLearnings(b.applyLearnings, me.email);
+    if (typeof b.alertsEnabled === 'boolean') os.settings.setInsightsAlertsEnabled(b.alertsEnabled, me.email);
     if (b.digest && typeof b.digest === 'object') {
       const d = b.digest as { enabled?: boolean; channel?: string; discordChannel?: string; hour?: number };
       if (typeof d.enabled === 'boolean') os.settings.setDigestEnabled(d.enabled, me.email);

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -16,6 +16,7 @@ import { AgentOS, loadAgentOS, readRootConfig, RootConfig } from './kernel';
 import { exampleCapabilities } from './capabilities/examples';
 import { TerminalManager, ApprovalNotice, QuestionNotice, MemberNotice, SessionEventNotice } from './terminal';
 import { Automations } from './edge/automations';
+import { InsightAlert } from './edge/alerts';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
 import { Member, Task } from './types';
@@ -399,6 +400,20 @@ export async function notifyTaskEvent(os: AgentOS, tm: Pick<TerminalManager, 'po
   const text = (p: ChatPlatform) => `📋 ${card.title} — \`${t.title}\` (${t.id}).\nOpen it in the ${chatLink(p, url, 'Agent OS console')}.`;
   const dms = await deliverDM(slack, discord, os, recipients, text);
   os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.notified', data: { id: t.id, event: card.event, recipients: recipients.length, dms } });
+}
+
+/**
+ * DM the admins about a proactive insight alert (the Inbox card is posted separately by the tick). The
+ * intelligence layer coming to the human — a struggling agent, a capability that keeps getting rejected.
+ */
+export async function notifyInsightAlert(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, alert: InsightAlert): Promise<void> {
+  const recipients = resolveRecipients(os, { kind: 'admins' });
+  if (!recipients.length) return;
+  const url = consolePage(consoleOrigin, 'insights');
+  const icon = alert.severity === 'high' ? '🚨' : '⚠️';
+  const text = (p: ChatPlatform) => `${icon} ${alert.title}\n${alert.body}\nOpen ${chatLink(p, url, 'Insights')}.`;
+  const dms = await deliverDM(slack, discord, os, recipients, text);
+  os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'insights.alert.notified', data: { key: alert.key, recipients: recipients.length, dms } });
 }
 
 /**

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2120,6 +2120,17 @@ export class TerminalManager {
     });
   }
 
+  /** Post a proactive **insight alert** to the admins' Inbox — a session-less `notification` card the
+   *  intelligence layer raises when something warrants attention (a struggling agent, recurring rejections).
+   *  Keyed by `insight:<key>` so it's a stable, de-dupable row. */
+  postInsightAlert(input: { key: string; title: string; body: string; severity: string }): void {
+    this.addMessage({
+      type: 'notification', sessionId: `insight:${input.key}`, agent: 'insights', title: input.title,
+      body: input.body, status: 'open', args: { key: input.key, severity: input.severity },
+      audienceKind: 'admins',
+    });
+  }
+
   /**
    * Post an inbox card for an agent's goal PROPOSAL (a draft goal an owner/admin must review + activate),
    * addressed to an explicit {@link Audience} (admins). Like {@link postTaskCard} it uses the `goal:<id>`

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8001,6 +8001,8 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [insights, setInsights] = useState<Insights | null>(null)
   const [dxBusy, setDxBusy] = useState('')
   const [dxHint, setDxHint] = useState('')
+  const [alertsOn, setAlertsOn] = useState(true)
+  const toggleAlerts = async (on: boolean) => { setAlertsOn(on); await api.setInsightAlerts(on) }
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const [result, setResult] = useState<string>('')
@@ -8009,7 +8011,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [preview, setPreview] = useState<DigestModel | null>(null)
 
   const refresh = () => {
-    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); if (r.digest) setDigest(r.digest) }).catch(() => {})
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
     api.digestToday().then((r) => { if (!r.error) setPreview(r) }).catch(() => {})
   }
   const saveDigest = async (patch: Partial<DigestConfig>) => {
@@ -8185,6 +8187,14 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
             )}
           </CardContent>
         </Card>
+      )}
+
+      {/* Proactive alerts toggle — the OS pushes problems to the Inbox instead of waiting to be looked at. */}
+      {insights && (
+        <label className="flex items-start gap-2 px-1 text-xs text-muted-foreground">
+          <input type="checkbox" checked={alertsOn} onChange={(e) => toggleAlerts(e.target.checked)} className="mt-0.5" />
+          <span><strong className="text-foreground">Alert me in the Inbox</strong> when something needs attention — a struggling agent, a capability that keeps getting rejected, a drop in success rate. Throttled per issue (won’t re-nag), DM’d to admins too.</span>
+        </label>
       )}
 
       {/* 1. What it figured out — the payoff, first. */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1090,11 +1090,12 @@ export const api = {
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
   planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),
   setApplyLearnings: (applyLearnings: boolean) => call<{ ok: boolean; applyLearnings: boolean; error?: string }>('PUT', '/api/dreaming', { applyLearnings }),
+  setInsightAlerts: (alertsEnabled: boolean) => call<{ ok: boolean; error?: string }>('PUT', '/api/dreaming', { alertsEnabled }),
   // One "reflect" pass: cheap deterministic tally + the memory-gardener over new material (nested `consolidation`).
   dreamingRun: () => call<{ ok: boolean; skipped?: boolean; sessions?: number; episodes?: number; kbPageId?: string; insightId?: string; guidance?: string; consolidation?: { spawned?: boolean; reason?: string; sessionId?: string; items?: number }; error?: string }>('POST', '/api/dreaming/run'),
   // Daily digest — the "what got done today" standup (rides the Dreaming pass; posts to Slack at EOD).


### PR DESCRIPTION
The intelligence layer comes to the owner instead of waiting to be looked at.

## What
On the hourly tick, `src/edge/alerts.ts` detects conditions worth attention and pushes each to the **admins' Inbox** (+ Slack/Discord DM):
- **Struggling agent** — ≤25% success over ≥4 runs (with ≥3 failed/stopped)
- **Capability keeps getting rejected** — ≥5× at approval (deny or auto-allow)
- **Fleet success-rate drop** — ≥15 points week-over-week
- **Approvals piling up** — ≥3 pending, oldest ≥4h

Each alert has a stable key + a **3-day per-key cooldown**, so a persistent problem pings **once**, not every hour. On by default; toggle on the Insights page.

- Card: `TerminalManager.postInsightAlert` (session-less `notification`, audience `admins`)
- DM: `notifyInsightAlert` (resolve admins → `deliverDM`)
- Audited `insights.alert` (the dedup marker) + `insights.alert.notified`

## Validation
On a copy of live data it flags **agent-author (13%)** and **stripe.refund's repeated rejections**; after firing a key, `pendingAlerts` drops it (cooldown works). typecheck + web build + governance (68/68).

## Note
Completes the "proactive" axis of the intelligence layer. Remaining from the menu: **cost intelligence**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)