### PR TITLE
style(insights): 2-column masonry layout (v0.166.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.166.1] — 2026-07-13
+### Changed
+- **Insights page uses a responsive 2-column (masonry) layout** so more of the intelligence fits above the
+  fold — the status hero stays full-width, then the cards (Is it working?, scorecard, friction, guidance,
+  recommendations, review history, digest, settings) flow into two columns on wide screens and a single
+  column on narrow ones. `break-inside-avoid` keeps each card whole; page widened `max-w-3xl` → `max-w-5xl`.
+
 ## [0.166.0] — 2026-07-13
 ### Added
 - **Proactive insight alerts — the intelligence layer comes to you.** Instead of waiting for someone to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.166.0",
+  "version": "0.166.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.166.0",
+      "version": "0.166.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.166.0",
+  "version": "0.166.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8068,7 +8068,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const nextAt = last && everyN > 0 ? last + everyN * 3_600_000 : undefined
   const lessons = guidance.split('\n').map((l) => l.trim()).filter((l) => l.startsWith('- ')).map((l) => l.slice(2).trim())
   return (
-    <div className="max-w-3xl space-y-4">
+    <div className="max-w-5xl space-y-4">
       {/* Hero — one plain sentence + a live status line, outcomes up top. */}
       <div className="space-y-2">
         <p className="text-sm text-muted-foreground">The OS automatically reviews what your agents did and gets smarter — spotting what works, what’s going wrong, and steering every agent accordingly. Nothing to set up.</p>
@@ -8081,6 +8081,10 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
         </div>
         {result && <div className="rounded-md border bg-muted/40 p-2 text-xs">{result}</div>}
       </div>
+
+      {/* Cards in a responsive 2-column masonry so more intelligence fits above the fold (single column on
+          narrow screens). break-inside-avoid keeps each card whole; mb-4 spaces them within a column. */}
+      <div className="columns-1 lg:columns-2 lg:gap-4 [&>*]:mb-4 [&>*]:break-inside-avoid">
 
       {/* Is it working? — the measurement loop: success-rate trend + did each applied change help. */}
       {measure && (measure.recent.rate != null || measure.trend.some((b) => b.rate != null)) && (() => {
@@ -8330,6 +8334,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
           <p className="text-[11px] text-muted-foreground">{everyN > 0 ? `Automatic review every ${everyN}h.` : 'Automatic review is off — the OS only reviews when you click “Review now”.'} Each review is deterministic and free; a deeper write-up of shared knowledge runs only when there’s enough new activity to be worth it.</p>
         </CardContent>
       </Card>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
The Insights page now has a lot of cards. This flows them into a responsive **2-column masonry** so more fits above the fold.

- Status hero stays full-width; cards below use `columns-1 lg:columns-2` with `break-inside-avoid` (each card stays whole), single column on narrow screens.
- Page widened `max-w-3xl` → `max-w-5xl`.

Web-only; typecheck + build clean. Not screenshot-verified — standard CSS-columns masonry; happy to switch to an explicit fixed 2-column grid or adjust card grouping once you see it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)