### PR TITLE
fix(insights): drop already-resolved recommendations at read time (v0.167.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.167.1] — 2026-07-13
+### Fixed
+- **Resolved recommendations no longer linger on Insights.** Recommendations regenerate only when a full
+  reflect pass runs, so a card could persist after a human already acted between passes — e.g. "Raise
+  default effort to high" kept showing after effort was set to `high` in Settings (no pass had run since
+  it was proposed). `/api/dreaming` now drops any open recommendation whose condition is already resolved
+  (`recommendationResolved` — currently the effort rec when effort is already high/xhigh/max) and persists
+  the cleanup, so a stale card can't nag between passes. `src/edge/dreaming.ts`, `src/server.ts`.
+
 ## [0.167.0] — 2026-07-13
 ### Changed
 - **Tasks Board, redesigned around live sessions.** The Kanban is reframed as a dispatch board — columns

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.167.0",
+  "version": "0.167.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.167.0",
+      "version": "0.167.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.167.0",
+  "version": "0.167.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -298,6 +298,18 @@ export function deriveGuidance(s: DreamState): string {
 }
 
 /**
+ * Whether an OPEN recommendation's condition is already resolved, so it should no longer be shown.
+ * Recommendations are regenerated only when a full reflect pass runs; between passes a leftover can
+ * linger after a human has already acted (e.g. they set effort to `high` in Settings). This drops those
+ * at read time so a stale card can't nag. Only recs with a clean "resolved?" signal are pruned; advisory
+ * ones (policy/budget) clear on the next pass.
+ */
+export function recommendationResolved(rec: Recommendation, currentEffort: string | undefined): boolean {
+  if (rec.id === 'runtime.effort.high') return currentEffort === 'high' || currentEffort === 'xhigh' || currentEffort === 'max';
+  return false;
+}
+
+/**
  * Propose config tuning from cumulative friction — each is a human-gated suggestion, never auto-applied.
  * `apply` present → directly applyable (a reversible runtime-defaults change); otherwise advisory.
  */

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,7 @@ import { classifyActivity, clipText, ActivityCategory, ActivityEffect } from './
 import { Automation, Automations, nextCronRun, derivedConcurrencyCap } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
-import { DreamingEngine } from './edge/dreaming';
+import { DreamingEngine, recommendationResolved } from './edge/dreaming';
 import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
 import { Digest } from './edge/digest';
 import { measureLearning } from './edge/measurement';
@@ -2381,9 +2381,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // history on the Dreaming page. Topics are omitted (large); pass the compact bits the UI renders.
     const raw = os.settings.dreamingState() as { firstPass?: number; passes?: number; totals?: Record<string, number>; recent?: unknown[] } | null;
     const state = raw ? { firstPass: raw.firstPass, passes: raw.passes, totals: raw.totals, recent: raw.recent } : undefined;
+    // Drop any open recommendation whose condition is already resolved (e.g. effort set to "high" in
+    // Settings after the pass proposed it) — recs regenerate only on a full pass, so this prevents a stale
+    // card lingering between passes. Persist the cleanup so it's actually cleared, not just hidden.
+    const recsStored = os.settings.recommendations();
+    const effort = os.settings.runtimeDefaults().effort;
+    const openRecs = recsStored.open.filter((r) => !recommendationResolved(r, effort));
+    if (openRecs.length !== recsStored.open.length) os.settings.setRecommendations({ open: openRecs, dismissed: recsStored.dismissed }, 'system');
     return sendJson(res, 200, {
       everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined,
-      applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: os.settings.recommendations().open, state, alertsEnabled: os.settings.insightsAlertsEnabled(),
+      applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: openRecs, state, alertsEnabled: os.settings.insightsAlertsEnabled(),
       measurement: measureLearning(os), // "Is it working?" — success-rate trend + per-intervention before/after (G1)
       insights: buildInsights(os), // owner insights — per-agent scorecard + friction map
       digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },


### PR DESCRIPTION
**Reported:** the "Raise default effort to high" recommendation kept showing even though the workspace default is already `high`.

**Cause:** recommendations regenerate only when a full reflect pass runs. On this tenant the last pass was Jul 7 (which proposed the card, with old lifetime numbers); effort was set to `high` in Settings on Jul 13; no pass has run since, so the stale card lingered.

**Fix:** `/api/dreaming` now filters open recommendations through `recommendationResolved` and drops any whose condition is already met (currently `runtime.effort.high` when effort is high/xhigh/max), persisting the cleanup so it's actually cleared, not just hidden. Advisory recs (policy/budget) still clear on the next pass as before.

## Validation
On a copy of live state (effort=high) the stale `runtime.effort.high` rec is dropped and the advisory ones kept. typecheck + governance (68/68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)