### PR TITLE
fix(insights): use full content width (v0.168.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.168.2] — 2026-07-13
+### Fixed
+- **Insights page now uses the full content width.** It carried a `max-w-5xl` cap with no `mx-auto`, so it
+  sat left-aligned and left the right side empty — worse when the sidebar was collapsed. Removed the cap so
+  it fills the available width, and the card masonry now scales to a **third column on very wide screens**
+  (`columns-1 md:columns-2 2xl:columns-3`).
+
 ## [0.168.1] — 2026-07-13
 ### Changed
 - **Overview layout refinements.** The four KPI tiles are now compact single-row cards (icon · figure ·

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.168.1",
+  "version": "0.168.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.168.1",
+      "version": "0.168.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.168.1",
+  "version": "0.168.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8252,7 +8252,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const nextAt = last && everyN > 0 ? last + everyN * 3_600_000 : undefined
   const lessons = guidance.split('\n').map((l) => l.trim()).filter((l) => l.startsWith('- ')).map((l) => l.slice(2).trim())
   return (
-    <div className="max-w-5xl space-y-4">
+    <div className="space-y-4">
       {/* Hero — one plain sentence + a live status line, outcomes up top. */}
       <div className="space-y-2">
         <p className="text-sm text-muted-foreground">The OS automatically reviews what your agents did and gets smarter — spotting what works, what’s going wrong, and steering every agent accordingly. Nothing to set up.</p>
@@ -8268,7 +8268,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
 
       {/* Cards in a responsive 2-column masonry so more intelligence fits above the fold (single column on
           narrow screens). break-inside-avoid keeps each card whole; mb-4 spaces them within a column. */}
-      <div className="columns-1 lg:columns-2 lg:gap-4 [&>*]:mb-4 [&>*]:break-inside-avoid">
+      <div className="columns-1 md:columns-2 2xl:columns-3 gap-4 [&>*]:mb-4 [&>*]:break-inside-avoid">
 
       {/* Is it working? — the measurement loop: success-rate trend + did each applied change help. */}
       {measure && (measure.recent.rate != null || measure.trend.some((b) => b.rate != null)) && (() => {


### PR DESCRIPTION
**Reported:** the Insights page doesn't use the full width, especially with the sidebar collapsed.

**Cause:** the page container had `max-w-5xl` with no `mx-auto`, so it sat left-aligned in the full-width `p-6` content area and left the right side empty. Collapsing the sidebar just grew the empty space.

**Fix:** removed the max-width cap so the page fills the available width; the card masonry now scales to a **third column on very wide screens** (`columns-1 md:columns-2 2xl:columns-3`).

Web-only. Not screenshot-verified (local multi-tenant host routing + no playwright package blocked an automated capture) — but the cause/fix is structural and high-confidence. Happy to iterate once you see it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)