### PR TITLE
feat(digest): "Clear & refresh today" (v0.172.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.172.0] — 2026-07-13
+### Added
+- **"Clear & refresh today" for the daily digest.** A button on the Insights digest card (and
+  `POST /api/digest/refresh`) that regenerates today's digest from current data — re-renders the dated KB
+  journal page and **resets the once-per-day post guard** so the scheduled EOD post re-sends the fresh
+  version. Useful right after tuning the digest, or to rebuild a stale day. The reset is append-only: it
+  writes a `digest.cleared` marker, and the post/​retry guard now floors on the later of midnight and the
+  last clear (`Digest.clearAndRefresh` / `postFloor`). `src/edge/digest.ts`, `src/server.ts`.
+
 ## [0.171.0] — 2026-07-13
 ### Added
 - **Tasks: "Live" filter** — a toggle in the Tasks filter bar (beside Overdue) that narrows every view to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.171.0",
+  "version": "0.172.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.171.0",
+      "version": "0.172.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.171.0",
+  "version": "0.172.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/digest.ts
+++ b/src/edge/digest.ts
@@ -298,6 +298,22 @@ export class Digest {
     return m;
   }
 
+  /** The "posted today" floor: the later of midnight and the last **clear** for today. A clear resets the
+   *  once-per-day post guard + the retry counter, so a "Clear & refresh" lets the scheduled post re-fire. */
+  private postFloor(now = new Date()): number {
+    const { start } = localDayBounds(now);
+    const cleared = this.os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'digest.cleared' AND ts >= ?").get<{ t: number | null }>(start);
+    return Math.max(start, cleared?.t ?? 0);
+  }
+
+  /** Manually **clear & refresh** today's digest: mark it cleared (append-only — resets the post guard so
+   *  the EOD post re-fires) and re-render the dated KB page from the current data. Returns the fresh model
+   *  (for the console preview). Useful after tuning the digest, or to regenerate a stale day. */
+  clearAndRefresh(by = 'system', now = new Date()): DigestModel {
+    this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'digest.cleared', data: { iso: localDayBounds(now).iso } });
+    return this.refresh(by, now);
+  }
+
   /** Whether at least one chat platform is set up to receive the digest (a bot token + a channel). */
   hasTarget(): boolean {
     const s = this.os.settings;
@@ -359,13 +375,16 @@ export class Digest {
     const s = this.os.settings;
     if (!s.digestEnabled() || !this.hasTarget()) return null;
     if (now.getHours() < s.digestHour()) return null;
-    const { start, iso } = localDayBounds(now);
+    const { iso } = localDayBounds(now);
+    // The "today" floor is the later of midnight and the last **clear** — so a "Clear & refresh today"
+    // resets the once-per-day guard AND the retry counter, letting the EOD post re-fire cleanly.
+    const floor = this.postFloor(now);
     const last = this.os.db.prepare("SELECT MAX(ts) AS t FROM audit_events WHERE type = 'digest.posted'").get<{ t: number | null }>();
-    if (last?.t && last.t >= start) return null; // already posted today
+    if (last?.t && last.t >= floor) return null; // already posted since the floor
     // M3: cap retries on a platform outage. `digest.posted` is only written on success, so without this a
     // day-long Slack/Discord outage would re-render + re-attempt every hour until midnight, flooding audit
     // with `digest.error` rows and rewriting the KB page hourly. Give up after MAX_POST_ATTEMPTS today.
-    const fails = this.os.db.prepare("SELECT count(*) AS n FROM audit_events WHERE type = 'digest.error' AND ts >= ?").get<{ n: number }>(start);
+    const fails = this.os.db.prepare("SELECT count(*) AS n FROM audit_events WHERE type = 'digest.error' AND ts >= ?").get<{ n: number }>(floor);
     if ((fails?.n ?? 0) >= MAX_POST_ATTEMPTS) return null;
     return this.postNow('scheduler', now).catch((e) => ({ posted: false, error: e instanceof Error ? e.message : String(e), total: 0, iso }));
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2477,6 +2477,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
     }
   }
+  // Clear & refresh today's digest: re-render the KB page from current data + reset the once-per-day post
+  // guard (so the scheduled EOD post re-fires). Returns the fresh model for the console preview.
+  if (method === 'POST' && p === '/api/digest/refresh') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { ok: true, ...new Digest(os).clearAndRefresh(me.email) });
+  }
   // One "reflect" action: the cheap deterministic pass, then the memory-gardener over new material
   // (spawns a headless agent that grows shared memories + KB; no-ops when there's too little).
   if (method === 'POST' && p === '/api/dreaming/run') {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8328,6 +8328,13 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
     setDigestHint(r.posted ? `posted to ${where} (${r.total} sessions)${failed ? ` — failed ${failed}` : ''}` : `not posted — ${failed || r.reason || r.error || 'nothing to post'}`)
     setTimeout(() => setDigestHint(''), 3000); refresh()
   }
+  const refreshDigest = async () => {
+    setBusy(true); setDigestHint('')
+    const r = await api.digestRefresh(); setBusy(false)
+    if (r.error) return setDigestHint('⚠ ' + r.error)
+    setPreview(r); setDigestHint(`refreshed (${r.total} sessions) — regenerated from current data; the scheduled post will re-send`)
+    setTimeout(() => setDigestHint(''), 4000); refresh()
+  }
   const diagnose = async (agent: string) => {
     setDxBusy(agent); setDxHint('')
     const r = await api.diagnose(agent); setDxBusy('')
@@ -8595,6 +8602,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
             <Field label="Post at (hour, 0–23)" help="Server-local. Fires on the next hourly tick past this hour.">
               <Input value={String(digest.hour)} onChange={(e) => setDigest({ ...digest, hour: Number(e.target.value) || 0 })} onBlur={() => saveDigest({ hour: digest.hour })} className="w-20 font-mono text-xs" placeholder="18" />
             </Field>
+            <Button variant="outline" onClick={refreshDigest} disabled={busy}><RefreshCw className="mr-1 h-4 w-4" />Clear &amp; refresh today</Button>
             <Button variant="outline" onClick={postDigest} disabled={busy}><Send className="mr-1 h-4 w-4" />Post now</Button>
             {digestHint && <span className="font-mono text-xs text-muted-foreground">{digestHint}</span>}
           </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1102,6 +1102,8 @@ export const api = {
   setDigest: (digest: { enabled?: boolean; channel?: string; discordChannel?: string; hour?: number }) => call<{ ok: boolean; digest: DigestConfig; error?: string }>('PUT', '/api/dreaming', { digest }),
   digestToday: () => call<DigestModel & { error?: string }>('GET', '/api/digest/today'),
   digestPost: () => call<{ ok: boolean; posted: boolean; reason?: string; total: number; iso: string; error?: string; platforms?: { platform: 'slack' | 'discord'; posted: boolean; channel: string; error?: string }[] }>('POST', '/api/digest/post'),
+  // Clear & refresh today's digest — re-render the KB page + reset the once-per-day post guard.
+  digestRefresh: () => call<DigestModel & { ok: boolean; error?: string }>('POST', '/api/digest/refresh'),
   // Spawn the analyst to diagnose why a struggling agent keeps failing (writes a KB page).
   diagnose: (agent: string) => call<{ ok: boolean; spawned: boolean; reason?: string; sessionId?: string; items?: number; slug?: string; error?: string }>('POST', '/api/insights/diagnose', { agent }),
 


### PR DESCRIPTION
A **Clear & refresh today** button on the Insights digest card (+ `POST /api/digest/refresh`) that regenerates today's digest from current data — re-renders the dated KB journal page and **resets the once-per-day post guard** so the scheduled EOD post re-sends the fresh version. Useful right after tuning the digest (like today's quality fixes) or to rebuild a stale day.

Append-only reset: writes a `digest.cleared` marker; the post + retry guard now floors on the later of midnight and the last clear (`Digest.clearAndRefresh` / `postFloor`).

Validated on a copy: clear writes the marker + refreshes the model; the guard treats today as un-posted afterward. typecheck + web build + governance (68/68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)