### PR TITLE
feat(insights): improvement tiles across the OS (v0.173.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.173.0] — 2026-07-13
+### Added
+- **Improvement tiles on Insights — what to make better across the whole OS.** A grid of six deterministic
+  tiles (`src/edge/improvements.ts`), one per domain, each detecting the top opportunity + a one-tap action
+  into the surface where you fix it: **Agents** (underperformers → review CLAUDE.md / prompts), **KB**
+  (dead + long-stale pages), **Goals** (active goals with no progress in 7+ days), **Skills** (proposals
+  awaiting publish), **Memory** (never-recalled aged memories to prune), **Automations** (last run errored,
+  or enabled-but-idle cron). Opportunities sort first; a healthy domain shows a ✓. Bundled into
+  `GET /api/insights` so the owner dashboard gets them too. v1 is detect + navigate/reuse-existing-actions;
+  per-domain LLM "generate the fix" can layer on later. Validated on live data (flagged the 3 underperforming
+  agents; other domains clean). `src/server.ts`, `web/src/App.tsx`.
+
 ## [0.172.0] — 2026-07-13
 ### Added
 - **"Clear & refresh today" for the daily digest.** A button on the Insights digest card (and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.172.0",
+  "version": "0.173.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.172.0",
+      "version": "0.173.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.172.0",
+  "version": "0.173.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/improvements.ts
+++ b/src/edge/improvements.ts
@@ -1,0 +1,95 @@
+/**
+ * Owner **improvement tiles** — the intelligence layer pointing at *what to make better*, across the whole
+ * OS, not just what happened. One deterministic tile per domain (agents · KB · goals · skills · memory ·
+ * automations): it detects the top improvement opportunity, counts it, and offers a one-tap action into
+ * the surface where you fix it (reusing existing pages/actions). Pure over the DB — cheap, always-on.
+ *
+ * v1 is detect + navigate/reuse; LLM "generate the fix" per domain (rewrite a weak CLAUDE.md, draft a
+ * skill, merge duplicate memories) layers on later. Rendered on the Insights page + bundled into
+ * `GET /api/insights`. See src/edge/insights.ts.
+ */
+import type { AgentOS } from '../kernel';
+import type { Insights } from './insights';
+
+const DAY = 24 * 3_600_000;
+type Db = AgentOS['db'];
+
+export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations';
+export interface ImprovementTile {
+  domain: ImprovementDomain;
+  count: number;                 // opportunities found (0 = nothing to improve)
+  title: string;                 // "3 agents underperforming"
+  detail: string;                // one-line explanation of the opportunity
+  actionLabel: string;           // button label
+  href: string;                  // where to act (console route)
+}
+
+function num(db: Db, sql: string, ...args: (number | string)[]): number {
+  return db.prepare(sql).get<{ n: number }>(...args)?.n ?? 0;
+}
+
+/** Build the six improvement tiles from current OS state (agents come from the already-computed scorecard). */
+export function buildImprovements(os: AgentOS, insights: Insights, now = Date.now()): ImprovementTile[] {
+  const db = os.db;
+  const tiles: ImprovementTile[] = [];
+
+  // 1) Agents — underperformers whose instructions (CLAUDE.md / starter prompts / tuning) likely need work.
+  const weak = insights.agents.filter((a) => a.rate != null && a.rate < 50 && a.runs >= 3);
+  tiles.push({
+    domain: 'agents', count: weak.length,
+    title: weak.length ? `${weak.length} agent${weak.length === 1 ? '' : 's'} underperforming` : 'Agents are healthy',
+    detail: weak.length ? `Below 50% success: ${weak.slice(0, 3).map((a) => `${a.agent} (${a.rate}%)`).join(', ')}${weak.length > 3 ? '…' : ''}. Diagnose them, then tune their CLAUDE.md / starter prompts.` : 'No agent is below 50% success over the last 30 days.',
+    actionLabel: 'Review agents', href: '#/agents',
+  });
+
+  // 2) KB — dead pages (never read) + stale pages (long unread) to archive or refresh.
+  const kbDead = num(db, "SELECT count(*) AS n FROM kb_pages WHERE read_count = 0 AND created_at < ?", now - 30 * DAY);
+  const kbStale = num(db, "SELECT count(*) AS n FROM kb_pages WHERE last_read_at IS NOT NULL AND last_read_at < ?", now - 90 * DAY);
+  tiles.push({
+    domain: 'kb', count: kbDead + kbStale,
+    title: kbDead + kbStale ? `${kbDead + kbStale} KB page${kbDead + kbStale === 1 ? '' : 's'} to tidy` : 'Knowledge base is fresh',
+    detail: kbDead + kbStale ? `${kbDead} never read (30+ days old), ${kbStale} unread in 90+ days — archive the dead ones, refresh the stale.` : 'No dead or long-stale pages.',
+    actionLabel: 'Open Knowledge', href: '#/kb',
+  });
+
+  // 3) Goals — active goals with no progress recently (stuck) that a human/strategist should nudge.
+  const stuck = num(db,
+    "SELECT count(*) AS n FROM goals g WHERE g.status = 'active' AND COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) < ?",
+    now - 7 * DAY);
+  tiles.push({
+    domain: 'goals', count: stuck,
+    title: stuck ? `${stuck} goal${stuck === 1 ? '' : 's'} stuck` : 'Goals are moving',
+    detail: stuck ? `${stuck} active goal${stuck === 1 ? '' : 's'} with no progress in 7+ days — plan the next tasks or re-scope.` : 'Every active goal has recent progress.',
+    actionLabel: 'Open Goals', href: '#/goals',
+  });
+
+  // 4) Skills — proposals the fleet drafted, awaiting an owner to publish (or refine).
+  const proposed = os.skills.list().filter((s) => s.proposed).length;
+  tiles.push({
+    domain: 'skills', count: proposed,
+    title: proposed ? `${proposed} skill${proposed === 1 ? '' : 's'} proposed` : 'No skills waiting',
+    detail: proposed ? `${proposed} agent-drafted skill${proposed === 1 ? '' : 's'} awaiting review — publish the good ones so the whole fleet can use them.` : 'No proposed skills to review right now.',
+    actionLabel: 'Review skills', href: '#/skills',
+  });
+
+  // 5) Memory — never-recalled aged memories that just add noise; prune to sharpen recall.
+  const prunable = num(db, "SELECT count(*) AS n FROM memories WHERE recall_count = 0 AND created_at < ?", now - 30 * DAY);
+  tiles.push({
+    domain: 'memory', count: prunable,
+    title: prunable ? `${prunable} memories to prune` : 'Memory is tidy',
+    detail: prunable ? `${prunable} memories never recalled in 30+ days — pruning noise sharpens what recall surfaces.` : 'No stale never-recalled memories.',
+    actionLabel: 'Open Memory', href: '#/memory',
+  });
+
+  // 6) Automations — enabled ones whose last run errored, or cron that has gone quiet.
+  const failing = num(db, "SELECT count(*) AS n FROM automations a WHERE a.enabled = 1 AND a.last_session_id IS NOT NULL AND EXISTS (SELECT 1 FROM audit_events e WHERE e.run_id = a.last_session_id AND e.type = 'session.error')");
+  const idle = num(db, "SELECT count(*) AS n FROM automations a WHERE a.enabled = 1 AND a.type = 'cron' AND (a.last_fired_at IS NULL OR a.last_fired_at < ?)", now - 14 * DAY);
+  tiles.push({
+    domain: 'automations', count: failing + idle,
+    title: failing + idle ? `${failing + idle} automation${failing + idle === 1 ? '' : 's'} need attention` : 'Automations are healthy',
+    detail: failing + idle ? `${failing} whose last run errored, ${idle} enabled but quiet for 14+ days — fix or retire them.` : 'No failing or idle automations.',
+    actionLabel: 'Open Automations', href: '#/automations',
+  });
+
+  return tiles;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -25,6 +25,7 @@ import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
 import { Digest } from './edge/digest';
 import { measureLearning } from './edge/measurement';
 import { buildInsights } from './edge/insights';
+import { buildImprovements } from './edge/improvements';
 import { Diagnosis } from './edge/diagnosis';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
@@ -2397,19 +2398,21 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const effort = os.settings.runtimeDefaults().effort;
     const openRecs = recsStored.open.filter((r) => !recommendationResolved(r, effort));
     if (openRecs.length !== recsStored.open.length) os.settings.setRecommendations({ open: openRecs, dismissed: recsStored.dismissed }, 'system');
+    const dreamInsights = buildInsights(os);
     return sendJson(res, 200, {
       everyHours: os.settings.dreamingEveryHours(), lastDreamedAt: last?.t ?? undefined,
       applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: openRecs, state, alertsEnabled: os.settings.insightsAlertsEnabled(),
       measurement: measureLearning(os), // "Is it working?" — success-rate trend + per-intervention before/after (G1)
-      insights: buildInsights(os), // owner insights — per-agent scorecard + friction map
+      insights: dreamInsights, improvements: buildImprovements(os, dreamInsights), // scorecard + friction + improvement tiles
       digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
     });
   }
-  // The OS intelligence layer, standalone — per-agent scorecard + friction map + the "is it working?"
-  // measurement, decoupled from the Dreaming page so an owner dashboard can consume it directly.
+  // The OS intelligence layer, standalone — per-agent scorecard + friction map + improvement tiles + the
+  // "is it working?" measurement, decoupled from the Dreaming page so an owner dashboard can consume it.
   if (method === 'GET' && p === '/api/insights') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    return sendJson(res, 200, { insights: buildInsights(os), measurement: measureLearning(os) });
+    const ins = buildInsights(os);
+    return sendJson(res, 200, { insights: ins, improvements: buildImprovements(os, ins), measurement: measureLearning(os) });
   }
   // Root-cause diagnosis: spawn the analyst to work out WHY a struggling agent keeps failing, into a KB page.
   if (method === 'POST' && p === '/api/insights/diagnose') {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -8298,6 +8298,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [state, setState] = useState<DreamingState | null>(null)
   const [measure, setMeasure] = useState<Measurement | null>(null)
   const [insights, setInsights] = useState<Insights | null>(null)
+  const [improvements, setImprovements] = useState<ImprovementTile[]>([])
   const [dxBusy, setDxBusy] = useState('')
   const [dxHint, setDxHint] = useState('')
   const [alertsOn, setAlertsOn] = useState(true)
@@ -8310,7 +8311,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [preview, setPreview] = useState<DigestModel | null>(null)
 
   const refresh = () => {
-    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setImprovements(r.improvements ?? []); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
     api.digestToday().then((r) => { if (!r.error) setPreview(r) }).catch(() => {})
   }
   const saveDigest = async (patch: Partial<DigestConfig>) => {
@@ -8387,6 +8388,26 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
         </div>
         {result && <div className="rounded-md border bg-muted/40 p-2 text-xs">{result}</div>}
       </div>
+
+      {/* Improvement tiles — one per OS domain, opportunities first. Full width above the masonry. */}
+      {improvements.length > 0 && (
+        <div>
+          <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">Improvements</div>
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
+            {[...improvements].sort((a, b) => b.count - a.count).map((t) => (
+              <a key={t.domain} href={t.href} className={`flex flex-col rounded-lg border p-3 transition-colors hover:bg-muted/50 ${t.count > 0 ? '' : 'opacity-60'}`}>
+                <div className="flex items-baseline justify-between">
+                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{t.domain}</span>
+                  {t.count > 0 ? <span className="text-lg font-semibold tabular-nums">{t.count}</span> : <CheckCircle2 className="h-4 w-4 text-emerald-600" />}
+                </div>
+                <div className="mt-0.5 text-sm font-medium leading-tight">{t.title}</div>
+                <div className="mt-1 line-clamp-3 text-[11px] leading-snug text-muted-foreground">{t.detail}</div>
+                <div className="mt-2 text-[11px] font-medium text-primary">{t.actionLabel} →</div>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Cards in a responsive 2-column masonry so more intelligence fits above the fold (single column on
           narrow screens). break-inside-avoid keeps each card whole; mb-4 spaces them within a column. */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -273,6 +273,8 @@ export interface AgentScore { agent: string; runs: number; success: number; fail
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
+export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations'
+export interface ImprovementTile { domain: ImprovementDomain; count: number; title: string; detail: string; actionLabel: string; href: string }
 export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
 export interface MeasureIntervention { id: string; title: string; at: number; before: { n: number; rate: number | null }; after: { n: number; rate: number | null }; deltaPp: number | null; verdict: 'improved' | 'declined' | 'flat' | 'insufficient' }
 export interface Measurement {
@@ -1090,7 +1092,7 @@ export const api = {
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
   planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; improvements?: ImprovementTile[]; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),


### PR DESCRIPTION
Turns Insights from *what happened* into *what to improve* — a grid of six deterministic tiles, one per OS domain, each detecting the top opportunity + a one-tap action.

| Tile | Detects | Action |
|---|---|---|
| Agents | underperformers (<50%, ≥3 runs) | Review agents → CLAUDE.md/prompts |
| KB | dead (never-read 30d+) + stale (unread 90d+) | Open Knowledge |
| Goals | active goals, no progress 7d+ | Open Goals |
| Skills | proposals awaiting publish | Review skills |
| Memory | never-recalled memories 30d+ | Open Memory |
| Automations | last run errored / idle cron | Open Automations |

Opportunities sort first; a clean domain shows a ✓. Bundled into `GET /api/insights` for the dashboard. **v1 = detect + navigate/reuse** existing actions; LLM "generate the fix" per domain layers on later.

## Validation
On live data it flags the 3 underperforming agents (researcher 38%, coding 38%, agent-author 13%); KB/Goals/Skills/Memory/Automations show clean on this tenant. typecheck + web build + governance (68/68). Will agent-browser–verify the live render after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)