### PR TITLE
fix(insights): correct chat-agent scoring + crash-vs-failure (v0.174.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.174.0] — 2026-07-13
+### Fixed
+- **Success-rate metric no longer misjudges chat agents or conflates crashes with failures** (found via a
+  false "docs-bot is struggling (14%)" alert). Three corrections across the scorecard, measurement, and
+  alerts:
+  1. **Chat sessions excluded from the success rate.** Chat-triggered (`chat:`) sessions are conversational
+     Q&A that don't call `report`, so they were dragging chat-heavy agents to a fake-low rate. They're now
+     kept out of the rate denominator and surfaced separately as a **chats** count.
+  2. **Crashes distinguished from failures.** A `crashed` session (process/pane died — infra) is surfaced
+     as its own **crashed** count, not lumped into failures; the scorecard is now based on all terminated
+     sessions so hard crashes (which emit no terminal event) are actually counted.
+  3. **Alerts split accordingly.** The "struggling" alert now requires **real failures** (≥2), so a chat- or
+     crash-heavy agent won't trip it; a new **"runs keep crashing"** alert (≥3 crashes) points at infra /
+     task-scoping instead of blaming the agent. On real data docs-bot flips from a misleading "14% struggling"
+     to an accurate "6 runs crashing." `src/edge/insights.ts`, `measurement.ts`, `alerts.ts`.
+
 ## [0.173.0] — 2026-07-13
 ### Added
 - **Improvement tiles on Insights — what to make better across the whole OS.** A grid of six deterministic

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.173.0",
+  "version": "0.174.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.173.0",
+      "version": "0.174.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.173.0",
+  "version": "0.174.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/alerts.ts
+++ b/src/edge/alerts.ts
@@ -34,12 +34,24 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
 
   // An individual agent is failing badly.
   for (const a of ins.agents) {
-    if (a.rate != null && a.rate <= 25 && a.runs >= 4 && a.failed + a.stopped >= 3) {
+    // Struggling = genuinely FAILING its work. Rate is over work runs (chat excluded upstream); require
+    // real failures so a chat-heavy or crash-heavy agent doesn't trip a false "struggling" alarm.
+    if (a.rate != null && a.rate <= 30 && a.runs >= 4 && a.failed >= 2) {
       out.push({
         key: `agent-low:${a.agent}`,
         severity: 'high',
-        title: `${a.agent} is struggling (${a.rate}% success)`,
-        body: `${a.agent} succeeded on only ${a.rate}% of ${a.runs} runs in the last ${ins.windowDays} days (${a.failed} failed, ${a.stopped} stopped). Open Insights and "Diagnose" it to see the root cause.`,
+        title: `${a.agent} is failing (${a.rate}% success)`,
+        body: `${a.agent} succeeded on only ${a.rate}% of ${a.runs} work runs in the last ${ins.windowDays} days (${a.failed} failed). Open Insights and "Diagnose" it to see the root cause.`,
+      });
+    }
+    // Crashing = the process/pane keeps dying (infra: too heavy / OOM / timeout) — a different fix than
+    // "the agent does bad work". Kept distinct so it doesn't read as poor agent quality.
+    else if (a.crashed >= 3) {
+      out.push({
+        key: `agent-crash:${a.agent}`,
+        severity: 'high',
+        title: `${a.agent}'s runs keep crashing`,
+        body: `${a.crashed} of ${a.agent}'s runs crashed in the last ${ins.windowDays} days — the process died mid-run (usually too-heavy work, OOM, or a timeout), not a task failure. Scope its tasks smaller, or give it more headroom.`,
       });
     }
   }

--- a/src/edge/insights.ts
+++ b/src/edge/insights.ts
@@ -18,15 +18,14 @@ type Db = AgentOS['db'];
 
 const DAY = 24 * 3_600_000;
 const WINDOW_DAYS = 30;
-const RANK: Record<string, number> = { 'session.reported': 3, 'run.completed': 2, 'session.ended': 1, 'session.stopped': 0 };
 const STOP = new Set(['task', 'outcome', 'session', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none', 'then', 'call', 'test', 'once', 'stop', 'tool', 'tools', 'exactly', 'nothing', 'else']);
 
-export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
+export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
 
-interface OutRow { run_id: string | null; ts: number; type: string; data: string; agent: string }
+interface OutRow { run_id: string; agent: string; spawned_by: string | null; status: string; outcome: string | null }
 interface EpRow { agent_id: string; content: string }
 
 /** Top few focus keywords for one agent's episode first-lines (what it actually spends runs on). */
@@ -48,26 +47,30 @@ export function buildInsights(os: AgentOS, now = Date.now()): Insights {
   const db = os.db;
   const since = now - WINDOW_DAYS * DAY;
 
-  // Per-agent outcomes: session terminal events joined to the session's real agent, one canonical row per
-  // session (principal is unreliable — it can be the run-as member). Then tally by agent.
+  // Base the tally on every TERMINATED session in the window (not just those that emitted a terminal
+  // audit event) — so a HARD crash (process/pane died, no `session.ended`) is still counted; its outcome
+  // comes from a per-session subquery, or falls back to the row's `status` (e.g. crashed). Excludes
+  // still-running sessions.
   const rows = db
     .prepare(
-      "SELECT a.run_id, a.ts, a.type, a.data, s.agent FROM audit_events a JOIN term_sessions s ON s.id = a.run_id " +
-        "WHERE a.ts >= ? AND a.type IN ('session.reported','session.ended','session.stopped','run.completed') ORDER BY a.ts",
+      "SELECT s.id AS run_id, s.agent, s.spawned_by, s.status, " +
+        "(SELECT CASE WHEN a.type = 'session.stopped' THEN 'stopped' ELSE COALESCE(json_extract(a.data,'$.outcome'),'unknown') END " +
+        "   FROM audit_events a WHERE a.run_id = s.id AND a.type IN ('session.reported','session.ended','session.stopped','run.completed') " +
+        "   ORDER BY CASE a.type WHEN 'session.reported' THEN 3 WHEN 'run.completed' THEN 2 WHEN 'session.ended' THEN 1 ELSE 0 END DESC LIMIT 1) AS outcome " +
+        "FROM term_sessions s WHERE s.created_at >= ? AND s.status != 'running'",
     )
     .all<OutRow>(since);
-  const bySession = new Map<string, OutRow>();
+  const tally = new Map<string, { runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number }>();
   for (const r of rows) {
-    const cur = bySession.get(r.run_id || `x:${r.ts}`);
-    if (!cur || (RANK[r.type] ?? -1) > (RANK[cur.type] ?? -1)) bySession.set(r.run_id || `x:${r.ts}`, r);
-  }
-  const tally = new Map<string, { runs: number; success: number; failed: number; stopped: number }>();
-  for (const r of bySession.values()) {
-    let outcome = r.type === 'session.stopped' ? 'stopped' : 'unknown';
-    try { outcome = String((JSON.parse(r.data) as { outcome?: unknown }).outcome ?? outcome); } catch { /* keep */ }
-    const t = tally.get(r.agent) ?? { runs: 0, success: 0, failed: 0, stopped: 0 };
+    const t = tally.get(r.agent) ?? { runs: 0, success: 0, failed: 0, stopped: 0, crashed: 0, chats: 0 };
+    // Chat-triggered sessions are conversational Q&A — they don't call `report`, so counting them in the
+    // success rate unfairly penalises chat-heavy agents (they'd all look like they're "failing"). Track
+    // them separately and keep them OUT of the rate denominator.
+    if ((r.spawned_by ?? '').startsWith('chat:')) { t.chats++; tally.set(r.agent, t); continue; }
+    const outcome = r.outcome ?? 'unknown';
     t.runs++;
-    if (outcome === 'success') t.success++;
+    if (r.status === 'crashed') t.crashed++;          // crash = infra died, surfaced distinctly from a `failure`
+    else if (outcome === 'success') t.success++;
     else if (outcome === 'failure') t.failed++;
     else if (outcome === 'stopped') t.stopped++;
     tally.set(r.agent, t);
@@ -81,9 +84,10 @@ export function buildInsights(os: AgentOS, now = Date.now()): Insights {
   const agents: AgentScore[] = [...tally.entries()]
     .map(([agent, t]) => {
       const dx = os.kb.read(os.tenant, 'operations', diagnosisSlug(agent)); // existing root-cause diagnosis, if any
-      return { agent, runs: t.runs, success: t.success, failed: t.failed, stopped: t.stopped, rate: t.runs ? Math.round((t.success / t.runs) * 100) : null, focus: focusFor(epByAgent.get(agent) ?? []), diagnosis: dx ? { at: dx.updatedAt, slug: dx.slug } : undefined };
+      return { agent, runs: t.runs, success: t.success, failed: t.failed, stopped: t.stopped, crashed: t.crashed, chats: t.chats, rate: t.runs ? Math.round((t.success / t.runs) * 100) : null, focus: focusFor(epByAgent.get(agent) ?? []), diagnosis: dx ? { at: dx.updatedAt, slug: dx.slug } : undefined };
     })
-    .sort((a, b) => b.runs - a.runs)
+    // Rank by activity — work runs, then chats — so a chat-only agent still appears.
+    .sort((a, b) => (b.runs + b.chats) - (a.runs + a.chats))
     .slice(0, 12);
 
   // Friction: capabilities rejected at approval (deny or auto-allow?), + approvals waiting on a human.

--- a/src/edge/measurement.ts
+++ b/src/edge/measurement.ts
@@ -49,8 +49,10 @@ const RANK: Record<string, number> = { 'session.reported': 3, 'run.completed': 2
 
 /** Distinct terminated sessions in [from, to) as { ts, success } — one row per session. */
 function outcomes(db: Db, from: number, to: number): { ts: number; success: boolean }[] {
+  // Exclude chat-triggered sessions — they're conversational and rarely `report` a success outcome, so
+  // they'd deflate the fleet success rate (matches the scorecard's chat exclusion).
   const rows = db
-    .prepare("SELECT run_id, ts, type, data FROM audit_events WHERE ts >= ? AND ts < ? AND type IN ('session.reported','session.ended','session.stopped','run.completed') ORDER BY ts")
+    .prepare("SELECT a.run_id, a.ts, a.type, a.data FROM audit_events a JOIN term_sessions s ON s.id = a.run_id WHERE a.ts >= ? AND a.ts < ? AND a.type IN ('session.reported','session.ended','session.stopped','run.completed') AND (s.spawned_by IS NULL OR s.spawned_by NOT LIKE 'chat:%') ORDER BY a.ts")
     .all<OutRow>(from, to);
   const bySession = new Map<string, OutRow>();
   for (const r of rows) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8476,12 +8476,12 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
             <div className="space-y-1">
               {insights.agents.map((a) => {
                 const rateCls = a.rate == null ? 'text-muted-foreground' : a.rate >= 70 ? 'text-emerald-600' : a.rate >= 40 ? 'text-amber-600' : 'text-red-600'
-                const struggling = a.rate != null && a.rate < 50 && (a.failed + a.stopped) >= 2
+                const struggling = a.rate != null && a.rate < 50 && (a.failed + a.stopped + a.crashed) >= 2
                 return (
                   <div key={a.agent} className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 border-b py-1.5 text-xs last:border-0">
                     <a className="w-40 shrink-0 truncate font-medium underline-offset-2 hover:underline" href={`#/agents/${a.agent}`}>{a.agent}</a>
                     <span className={`w-10 shrink-0 tabular-nums font-medium ${rateCls}`}>{a.rate == null ? '—' : `${a.rate}%`}</span>
-                    <span className="text-muted-foreground">{a.runs} run{a.runs === 1 ? '' : 's'}{a.failed ? ` · ${a.failed} failed` : ''}{a.stopped ? ` · ${a.stopped} stopped` : ''}</span>
+                    <span className="text-muted-foreground">{a.runs} run{a.runs === 1 ? '' : 's'}{a.failed ? ` · ${a.failed} failed` : ''}{a.crashed ? ` · ${a.crashed} crashed` : ''}{a.stopped ? ` · ${a.stopped} stopped` : ''}{a.chats ? ` · ${a.chats} chats` : ''}</span>
                     {a.focus.length > 0 && <span className="text-muted-foreground">· {a.focus.join(', ')}</span>}
                     <span className="ml-auto shrink-0">
                       {a.diagnosis

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -269,7 +269,7 @@ export interface DreamingState {
   totals?: { sessions: number; success: number; failure: number; partial: number; stopped: number; unknown: number; rejected: number; budgetStops: number; errors: number }
   recent?: DreamingReview[]
 }
-export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
+export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }


### PR DESCRIPTION
Found by investigating a false "docs-bot is struggling (14%)" alert — a real trust bug in the intelligence layer.

## The problem
docs-bot had 0 failures. Its 14% was two artifacts: 16 of 22 runs were chat Q&A that never call report(success), and a few crashes (process died on heavy runs) read the same as agent failures.

## The fix (scorecard / measurement / alerts)
1. Chat sessions excluded from the success rate — surfaced as a separate chats count.
2. Crashes distinguished from failures — own crashed count; scorecard now based on all terminated sessions so hard crashes (no terminal event) are counted.
3. Alerts split — "struggling" now needs real failures (>=2); a new "runs keep crashing" (>=3) alert points at infra/task-scoping.

## Validated on real instawp data
docs-bot: 13% / 15 work runs / 6 crashed / 0 failed / 16 chats → the struggling alert no longer fires; the crash alert does, with the right message. No regression on non-chat agents. governance 68/68.