### PR TITLE
fix(digest): generic end-cards leaking into digest + episodes (v0.175.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.175.1] — 2026-07-13
+### Fixed
+- **Generic end-cards no longer leak into the digest (or episodes).** The no-report detection matched only
+  the literal `'Session ended.'`, but the launcher actually writes **"The session ended."** and **"The
+  session ended unexpectedly (the process died)."** — so those (and their `×N` dedupes) were showing up as
+  digest lines for agents that didn't `report`. Detection is now a robust `isRealReport` check applied in
+  the digest AND in `composeEpisode` (the same bug polluted episode memories). No-report sessions fall back
+  to their title (then get task/placeholder-filtered) instead of surfacing "The session ended."
+  `src/edge/digest.ts`, `src/terminal.ts`.
+
 ## [0.175.0] — 2026-07-13
 ### Changed
 - **Comprehensive rewrite of the marketing landing page** (`public/landing.html`, served off disk at

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.175.0",
+  "version": "0.175.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.175.0",
+      "version": "0.175.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.175.0",
+  "version": "0.175.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/digest.ts
+++ b/src/edge/digest.ts
@@ -78,14 +78,14 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
     if (outcome in buckets) (buckets as Record<string, number>)[outcome]++; else buckets.other++;
     const importance = r.importance ?? 0;
     // Fix 1: the line is the first sentence(s) of the agent's REPORT (rich), not the clipped title.
-    const report = (r.report ?? '').trim();
-    const hasReport = !!report && report !== '(no summary)' && report !== 'Session ended.';
+    const hasReport = isRealReport(r.report);
     const line = digestLine(r.report, r.title);
     // Fix 3: drop lines that describe the TASK rather than the result — a session with no report falls
     // back to its incoming task ("Task: …"), and inter-agent `ask` sessions ("Ask ← foo") aren't work.
     const askSession = (r.spawned_by ?? '').startsWith('ask:');
     const taskish = /^(task:|ask ←|ask\b)/i.test(line);
-    const placeholder = line.length < 5 || /^(test|teste|untitled)$/i.test(line);
+    // Drop generic end-card text and stubs — a no-report session whose title is also generic must not leak.
+    const placeholder = line.length < 5 || /^(test|teste|untitled)$/i.test(line) || !isRealReport(line);
     const include = !placeholder && !askSession && !taskish && (hasReport || importance >= SALIENCE || r.status === 'done');
     if (include) {
       const list = perAgent.get(r.agent) ?? [];
@@ -131,13 +131,19 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
 const LINE_MAX = 200; // digest lines can breathe — Slack/Discord/KB all handle it (vs the 72-char title)
 const DEDUP_STOP = new Set(['task', 'with', 'this', 'that', 'from', 'into', 'have', 'been', 'were', 'they', 'will', 'just', 'also', 'done', 'made', 'make', 'need', 'some', 'more', 'than', 'only', 'each', 'both', 'over', 'when', 'then', 'sent', 'added', 'set', 'the', 'and', 'for']);
 
+/** Whether a `completed`-card body is the agent's own summary vs a GENERIC end card — the launcher writes
+ *  "The session ended.", "The session ended unexpectedly (the process died).", or "(no summary)" when the
+ *  agent never `report`ed. Those carry no signal and must NOT become a digest line / count as a report. */
+export function isRealReport(body: string | null | undefined): boolean {
+  const b = (body ?? '').trim();
+  return !!b && !/^\(no summary\)$/i.test(b) && !/^the session ended\b/i.test(b) && !/^session ended\.?$/i.test(b);
+}
+
 /** The digest line for a session — the first sentence(s) of the agent's REPORT (rich), else the title.
  *  Clipped to a sentence/word boundary near LINE_MAX so we never chop mid-outcome the way the 72-char
  *  title did ("…root cause was…"). */
 function digestLine(report: string | null, title: string): string {
-  const body = (report ?? '').trim();
-  const real = !!body && body !== '(no summary)' && body !== 'Session ended.';
-  const src = real ? body : (title || '');
+  const src = isRealReport(report) ? (report as string).trim() : (title || '');
   const firstLine = src.split('\n').map((s) => s.trim()).find(Boolean) ?? '';
   const collapsed = firstLine.replace(/\s+/g, ' ').trim();
   if (collapsed.length <= LINE_MAX) return collapsed;

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3589,7 +3589,9 @@ function composeEpisode(
 ): { content: string; outcome: string; source: 'report' | 'audit'; importance: number; signals: SalienceSignals } | null {
   const taskLine = task.trim() ? `Task: ${task.trim()}` : '';
   const body = (report?.body ?? '').trim();
-  const hasReport = !!body && body !== '(no summary)' && body !== 'Session ended.';
+  // A real agent summary vs the launcher's generic end card ("The session ended." / "…unexpectedly (the
+  // process died)." / "(no summary)") — the latter carries no signal, so fall through to the audit summary.
+  const hasReport = !!body && !/^\(no summary\)$/i.test(body) && !/^the session ended\b/i.test(body) && !/^session ended\.?$/i.test(body);
   if (hasReport) {
     // The agent's own summary wins — even if the session was later stopped, its report stands.
     const outcome = report?.outcome || 'unknown';


### PR DESCRIPTION
From the refreshed instawp digest — a bug I introduced in the digest-quality PR.

**Symptom:** lines like *"The session ended."* and *"The session ended unexpectedly (the process died)."* (and their ×N dedupes) appeared for blog-optimizer / customer-bot / consolidator — agents that never called `report`.

**Cause:** the no-report check matched only the literal `'Session ended.'`, but the launcher writes **"The session ended."** / **"…unexpectedly (the process died)."** / `(no summary)`.

**Fix:** a robust `isRealReport()` check, applied in the digest **and** in `composeEpisode` (the same bug polluted episode memories). No-report sessions now fall back to their title (then task/placeholder-filtered) instead of surfacing the generic end card.

Validated against the exact leaked strings (all drop; real content stays). typecheck + governance (68/68).