### PR TITLE
feat(landing): icons + brand marks across the landing page (v0.175.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.175.2] — 2026-07-13
+### Changed
+- **Visuals/icons across the landing page** (`public/landing.html`). Added tasteful inline-SVG iconography
+  to the previously text-only sections, matching the existing line-icon style: an accent-tinted icon on each
+  **hero stat** (connector link · generation sparkles · governance shield · 24/7 clock); an icon on every
+  **ladder rung** (Goal target · Tasks board · Sessions terminal); a per-step icon on each **governance-gate**
+  row (scales · check · database · fingerprint · loop · audit-doc, alongside the sequence number); and a
+  header icon on every **integration card** plus recognizable monochrome **brand marks** in the key chips
+  (Slack, Discord, GitHub, Google Drive). All icons inherit the accent color so they adapt in dark mode.
+  Re-reviewed with the design-review harness: no overflow at desktop/tablet/mobile and **zero axe-core
+  accessibility violations**, in both light and dark themes.
+
 ## [0.175.1] — 2026-07-13
 ### Fixed
 - **Generic end-cards no longer leak into the digest (or episodes).** The no-report detection matched only

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.175.1",
+  "version": "0.175.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.175.1",
+      "version": "0.175.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.175.1",
+  "version": "0.175.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/public/landing.html
+++ b/public/landing.html
@@ -657,6 +657,37 @@
     white-space: nowrap;
   }
   .tag.hot { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 30%, var(--line)); background: var(--accent-tint); }
+  .tag { display: inline-flex; align-items: center; }
+  .tag .bi { width: 12px; height: 12px; flex: 0 0 auto; margin-right: 0.4rem; }
+
+  /* ---------- ICON TREATMENTS ---------- */
+  .stat-ico {
+    width: 36px; height: 36px; border-radius: 10px;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: var(--accent-tint); color: var(--accent);
+    margin-bottom: 0.75rem;
+  }
+  .stat-ico svg { width: 19px; height: 19px; display: block; }
+
+  .rk-row { display: flex; align-items: center; gap: 0.65rem; }
+  .rung-ico {
+    width: 32px; height: 32px; border-radius: 9px; flex: 0 0 auto;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: var(--accent-tint); color: var(--accent);
+  }
+  .rung-ico svg { width: 18px; height: 18px; display: block; }
+
+  .gstep .gi { color: var(--accent); display: inline-flex; flex: 0 0 auto; }
+  .gstep .gi svg { width: 16px; height: 16px; display: block; }
+
+  .integ-top { display: flex; align-items: center; gap: 0.85rem; margin-bottom: 0.1rem; }
+  .integ-ico {
+    width: 42px; height: 42px; border-radius: 12px; flex: 0 0 auto;
+    display: inline-flex; align-items: center; justify-content: center;
+    background: var(--accent-tint); color: var(--accent);
+  }
+  .integ-ico svg { width: 22px; height: 22px; display: block; }
+  .integ-top h4 { margin: 0; }
 
   /* ---------- CLOSING ---------- */
   .closing-wrap { padding-top: clamp(4rem, 9vw, 7rem); padding-bottom: clamp(3rem, 7vw, 5rem); }
@@ -804,10 +835,22 @@
       </div>
 
       <div class="stats">
-        <div class="stat fade"><div class="num"><span class="accent">1,000+</span></div><div class="lbl">app connectors via Composio — plus native Slack, Discord, GitHub</div></div>
-        <div class="stat fade d1"><div class="num">400+</div><div class="lbl">image &amp; video models agents can generate and edit with</div></div>
-        <div class="stat fade d2"><div class="num">1</div><div class="lbl">gate every real action passes through — policy, budget, audit</div></div>
-        <div class="stat fade d3"><div class="num">24/7</div><div class="lbl">unattended runs from cron, webhooks, and a @mention</div></div>
+        <div class="stat fade">
+          <span class="stat-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.1 0l2.8-2.8a5 5 0 0 0-7.1-7.1L11 4.9"/><path d="M14 11a5 5 0 0 0-7.1 0l-2.8 2.8a5 5 0 0 0 7.1 7.1L13 19.1"/></svg></span>
+          <div class="num"><span class="accent">1,000+</span></div><div class="lbl">app connectors via Composio — plus native Slack, Discord, GitHub</div>
+        </div>
+        <div class="stat fade d1">
+          <span class="stat-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="m12 3 1.9 4.6L18.5 9.5 13.9 11.4 12 16l-1.9-4.6L5.5 9.5l4.6-1.9z"/><path d="m18 15 .8 2 2 .8-2 .8L18 21l-.8-2-2-.8 2-.8z"/></svg></span>
+          <div class="num">400+</div><div class="lbl">image &amp; video models agents can generate and edit with</div>
+        </div>
+        <div class="stat fade d2">
+          <span class="stat-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l7 3v5c0 5-3 8-7 10-4-2-7-5-7-10V6z"/><path d="M9 12l2 2 4-4"/></svg></span>
+          <div class="num">1</div><div class="lbl">gate every real action passes through — policy, budget, audit</div>
+        </div>
+        <div class="stat fade d3">
+          <span class="stat-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3.5 2"/></svg></span>
+          <div class="num">24/7</div><div class="lbl">unattended runs from cron, webhooks, and a @mention</div>
+        </div>
       </div>
     </div>
   </header>
@@ -823,21 +866,21 @@
 
       <div class="ladder">
         <div class="rung fade">
-          <span class="rk">Goal</span>
+          <div class="rk-row"><span class="rung-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="8"/><circle cx="12" cy="12" r="4"/><circle cx="12" cy="12" r="1" fill="currentColor" stroke="none"/></svg></span><span class="rk">Goal</span></div>
           <h3>You set the outcome</h3>
           <p>A strategic, human-owned objective the whole fleet ladders up to. Persistent and versioned — the "why" above all the work.</p>
           <div class="ex">"Grow signups 20%<br>this quarter"</div>
         </div>
         <div class="arrow fade" aria-hidden="true"><span>&rarr;</span></div>
         <div class="rung fade d1">
-          <span class="rk">Tasks</span>
+          <div class="rk-row"><span class="rung-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="4.2" height="16" rx="1"/><rect x="9.9" y="4" width="4.2" height="10" rx="1"/><rect x="16.8" y="4" width="4.2" height="7" rx="1"/></svg></span><span class="rk">Tasks</span></div>
           <h3>The fleet plans the work</h3>
           <p>The strategist breaks the goal into concrete tasks on a shared board, each assigned to the right specialist. You review the plan instead of writing it.</p>
           <div class="ex">audit funnel &middot; rewrite<br>onboarding &middot; A/B pricing</div>
         </div>
         <div class="arrow fade d1" aria-hidden="true"><span>&rarr;</span></div>
         <div class="rung fade d2">
-          <span class="rk">Sessions</span>
+          <div class="rk-row"><span class="rung-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><path d="m7 9 3 3-3 3M13 15h4"/></svg></span><span class="rk">Sessions</span></div>
           <h3>Agents get it done</h3>
           <p>Each task auto-dispatches a governed agent run that does the work and closes its own loop — every side effect still gated, audited, and run as an accountable human.</p>
           <div class="ex">agent working &middot; report<br>filed &middot; goal advanced</div>
@@ -967,12 +1010,12 @@
           <div class="gate-in"><span class="lbl">Effect</span><span>charge&nbsp;$4,000 &middot; deploy&nbsp;prod &middot; email&nbsp;a&nbsp;customer</span></div>
           <div class="gate-rail" aria-hidden="true">&darr;</div>
           <div class="gate-steps">
-            <div class="gstep"><span class="gn">1</span><span class="gt">Policy</span><span class="gd">classifies the risk</span></div>
-            <div class="gstep"><span class="gn">2</span><span class="gt">Approvals</span><span class="gd">a human clears what's risky</span></div>
-            <div class="gstep"><span class="gn">3</span><span class="gt">Budget</span><span class="gd">debits the spend</span></div>
-            <div class="gstep"><span class="gn">4</span><span class="gt">Identity</span><span class="gd">signs it as a real person</span></div>
-            <div class="gstep"><span class="gn">5</span><span class="gt">Idempotency</span><span class="gd">never twice</span></div>
-            <div class="gstep"><span class="gn">6</span><span class="gt">Audit</span><span class="gd">records it forever</span></div>
+            <div class="gstep"><span class="gn">1</span><span class="gi" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v18M5 7l-2 5a3 3 0 0 0 6 0L7 7zM19 7l-2 5a3 3 0 0 0 6 0l-2-5zM7 7h10"/></svg></span><span class="gt">Policy</span><span class="gd">classifies the risk</span></div>
+            <div class="gstep"><span class="gn">2</span><span class="gi" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m8.5 12.5 2.5 2.5 5-5"/><circle cx="12" cy="12" r="9"/></svg></span><span class="gt">Approvals</span><span class="gd">a human clears what's risky</span></div>
+            <div class="gstep"><span class="gn">3</span><span class="gi" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v6c0 1.7 3.6 3 8 3s8-1.3 8-3V6M4 12v6c0 1.7 3.6 3 8 3s8-1.3 8-3v-6"/></svg></span><span class="gt">Budget</span><span class="gd">debits the spend</span></div>
+            <div class="gstep"><span class="gn">4</span><span class="gi" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M8 11c0-2 1.8-4 4-4s4 1.8 4 4M6 14c0-1 .3-2 .7-2.8M18 14c0-1-.3-2-.7-2.8M9 21c-.8-1.3-1-2.6-1-4M15 21c.8-1.3 1-2.8 1-4.5M12 12v6"/></svg></span><span class="gt">Identity</span><span class="gd">signs it as a real person</span></div>
+            <div class="gstep"><span class="gn">5</span><span class="gi" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20 12a8 8 0 1 1-2.3-5.6M20 4v4h-4"/></svg></span><span class="gt">Idempotency</span><span class="gd">never twice</span></div>
+            <div class="gstep"><span class="gn">6</span><span class="gi" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M5 4a1 1 0 0 1 1-1h9l4 4v13a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1z"/><path d="M14 3v5h5M8.5 13l1.5 1.5 3-3M8 18h5"/></svg></span><span class="gt">Audit</span><span class="gd">records it forever</span></div>
           </div>
           <div class="gate-rail" aria-hidden="true">&darr;</div>
           <div class="gate-out">held for owner approval &middot; nothing happens without your say-so</div>
@@ -1004,11 +1047,14 @@
 
       <div class="integ-grid">
         <div class="integ-card fade">
-          <h4>Slack &amp; Discord, natively</h4>
+          <div class="integ-top">
+            <span class="integ-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M20 11.5a7.5 7.5 0 0 1-10.9 6.7L4 19.5l1.4-4.3A7.5 7.5 0 1 1 20 11.5z"/><path d="M8.5 10.5h7M8.5 13.5h4"/></svg></span>
+            <h4>Slack &amp; Discord, natively</h4>
+          </div>
           <p>@mention an agent by name in Slack or Discord and it runs <b>as you</b>, in the thread, with your permissions — no public URL, no new app to learn. Follow-ups stay in the same conversation with full context, and it replies right where you asked.</p>
           <div class="chips">
-            <span class="tag hot">Slack</span>
-            <span class="tag hot">Discord</span>
+            <span class="tag hot"><svg class="bi" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6 15a2 2 0 1 1-2-2h2v2zm1 0a2 2 0 0 1 4 0v5a2 2 0 0 1-4 0v-5zM9 6a2 2 0 1 1 2-2v2H9zm0 1a2 2 0 0 1 0 4H4a2 2 0 0 1 0-4h5zm9 2a2 2 0 1 1 2 2h-2V9zm-1 0a2 2 0 0 1-4 0V4a2 2 0 0 1 4 0v5zm-2 9a2 2 0 1 1-2 2v-2h2zm0-1a2 2 0 0 1 0-4h5a2 2 0 0 1 0 4h-5z"/></svg>Slack</span>
+            <span class="tag hot"><svg class="bi" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.3 5.3A16 16 0 0 0 15.4 4l-.2.4a15 15 0 0 1 3.4 1.1 14 14 0 0 0-12.4 0A15 15 0 0 1 9.6 4.4L9.4 4a16 16 0 0 0-3.9 1.3C3 9 2.4 12.6 2.7 16.1A16 16 0 0 0 7.5 18.5l.6-1c-.5-.2-1-.5-1.5-.8l.4-.3a11.4 11.4 0 0 0 9.8 0l.4.3c-.5.3-1 .6-1.5.8l.6 1a16 16 0 0 0 4.8-2.4c.4-4.1-.6-7.7-2.8-10.8zM9.2 14c-.8 0-1.4-.7-1.4-1.6s.6-1.6 1.4-1.6 1.5.8 1.5 1.6-.7 1.6-1.5 1.6zm5.6 0c-.8 0-1.4-.7-1.4-1.6s.6-1.6 1.4-1.6 1.5.8 1.5 1.6-.7 1.6-1.5 1.6z"/></svg>Discord</span>
             <span class="tag">runs as the sender</span>
             <span class="tag">threaded replies</span>
             <span class="tag">no public URL</span>
@@ -1016,7 +1062,10 @@
         </div>
 
         <div class="integ-card fade d1">
-          <h4>Automations that run without you</h4>
+          <div class="integ-top">
+            <span class="integ-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="13" r="8"/><path d="M12 9.5V13l2.5 1.5M12 2.5V5M4.5 5 3 3.5M19.5 5 21 3.5"/></svg></span>
+            <h4>Automations that run without you</h4>
+          </div>
           <p>Fire an agent on a <b>cron schedule</b>, from an incoming <b>webhook</b>, or from a chat message — all unattended, all governed. The whole fleet is reachable by name with a single mention, so a per-agent trigger becomes optional, not required.</p>
           <div class="chips">
             <span class="tag">cron</span>
@@ -1027,18 +1076,24 @@
         </div>
 
         <div class="integ-card fade">
-          <h4>1,000+ apps, one connector</h4>
+          <div class="integ-top">
+            <span class="integ-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1.6"/><rect x="14" y="3" width="7" height="7" rx="1.6"/><rect x="3" y="14" width="7" height="7" rx="1.6"/><rect x="14" y="14" width="7" height="7" rx="1.6"/></svg></span>
+            <h4>1,000+ apps, one connector</h4>
+          </div>
           <p>Through <b>Composio</b>, agents act across a thousand-plus apps — CRMs, payments, calendars, docs, tickets — with OAuth handled for them. Plus direct connectors for GitHub, Google Drive, and any MCP server you point them at.</p>
           <div class="chips">
             <span class="tag hot">Composio &middot; 1,000+ apps</span>
-            <span class="tag">GitHub</span>
-            <span class="tag">Google Drive</span>
+            <span class="tag"><svg class="bi" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.7.4-1.3.7-1.6-2.6-.3-5.3-1.3-5.3-5.7 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 5.3 18 5.6 18 5.6c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.4-2.7 5.4-5.3 5.7.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>GitHub</span>
+            <span class="tag"><svg class="bi" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M8.4 3 1.6 15l3.4 6 6.8-12L8.4 3zm7.2 0H9.9l6.8 12h5.7L15.6 3zM6.2 16 3 21h13.6l3.2-5H6.2z"/></svg>Google Drive</span>
             <span class="tag">any MCP server</span>
           </div>
         </div>
 
         <div class="integ-card fade d1">
-          <h4>See, draw, and film</h4>
+          <div class="integ-top">
+            <span class="integ-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="16" rx="2"/><circle cx="8.5" cy="9.5" r="1.5"/><path d="m4 17 4.5-4.5 4 4L15 14l5 5"/></svg></span>
+            <h4>See, draw, and film</h4>
+          </div>
           <p>Agents get the senses the model lacks — <b>generate</b> images and video from a prompt, <b>edit</b> and upscale them, and <b>watch</b> a clip to answer questions about it. 400+ models, every render cost-metered and dropped into the Library.</p>
           <div class="chips">
             <span class="tag">image gen &amp; edit</span>
@@ -1049,7 +1104,10 @@
         </div>
 
         <div class="integ-card fade">
-          <h4>An encrypted secrets vault</h4>
+          <div class="integ-top">
+            <span class="integ-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/><path d="M12 14v2.5"/></svg></span>
+            <h4>An encrypted secrets vault</h4>
+          </div>
           <p>Store credentials once, sealed with AES-256-GCM at rest. Connectors and agent shells resolve them at launch, so a plain CLI authenticates and an agent gets <b>tools, never raw keys</b>. Grant a secret to specific agents from one panel.</p>
           <div class="chips">
             <span class="tag">AES-256-GCM</span>
@@ -1059,7 +1117,10 @@
         </div>
 
         <div class="integ-card fade d1">
-          <h4>Team, roles, and identity</h4>
+          <div class="integ-top">
+            <span class="integ-ico" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="9" cy="8" r="3.2"/><path d="M3.5 20a5.5 5.5 0 0 1 11 0"/><path d="M16 5.4a3.2 3.2 0 0 1 0 5.2M17.5 14.4A5.5 5.5 0 0 1 20.5 19"/></svg></span>
+            <h4>Team, roles, and identity</h4>
+          </div>
           <p>Owners, admins, and members with magic-link login and per-agent assignment. Link a teammate to their Slack, Discord, or GitHub so their <b>own</b> identity — and their approval authority — carries into every run they trigger.</p>
           <div class="chips">
             <span class="tag">owner / admin / member</span>


### PR DESCRIPTION
Adds visuals/icons to the landing page (`public/landing.html`), building on the comprehensive rewrite in #294.

### What's new
- **Hero stat strip** — an accent-tinted icon per stat (connector link · generation sparkles · governance shield · 24/7 clock).
- **How-it-works ladder** — an icon on each rung (Goal target · Tasks board · Sessions terminal).
- **Governance gate** — a per-step icon alongside the sequence number (scales · check · database · fingerprint · loop · audit-doc).
- **Integration cards** — a themed header icon on all six, plus recognizable monochrome **brand marks** in the key chips: Slack, Discord, GitHub, Google Drive.

All icons are inline SVG in the existing line-icon style and inherit the accent color, so they adapt in dark mode.

### Review
design-review harness (Playwright + axe-core), light **and** dark:
- No horizontal overflow at desktop / tablet / mobile
- **Zero axe-core accessibility violations**

Version → **0.175.2**; CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)