### PR TITLE
feat(digest): links + cleaner formatting; fix inflated errors + noisy topics (v0.176.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.176.0] — 2026-07-13
+### Changed
+- **Daily digest — links + cleaner formatting, and two accuracy fixes.**
+  - **Links.** The Slack/Discord post now links the header + each **agent name** to the console
+    (`/#/agents/<agent>`) and adds an **"Open the full report in Agent OS →"** footer — sourced from the
+    tenant's public URL (`consoleOrigin` for the scheduled post, the request origin for "Post now"). The KB
+    journal page links agents too. Blank line between agents for readability.
+  - **"N errors" no longer inflated by memory-store failures.** The header counted `episode.error` (a
+    flaky-memory-backend signal) as fleet errors — a tenant on an external backend showed e.g. "26 errors"
+    on a clean day. Now counts only `session.error` (real run errors).
+  - **"Frequently works on" topics de-noised.** The Dreaming topic extraction now filters procedural words
+    (slack, check, report, completed, summary, …) so guidance surfaces real work areas, not plumbing.
+  `src/edge/digest.ts`, `src/edge/dreaming.ts`, `src/server.ts`.
+
 ## [0.175.2] — 2026-07-13
 ### Changed
 - **Visuals/icons across the landing page** (`public/landing.html`). Added tasteful inline-SVG iconography

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.175.2",
+  "version": "0.176.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.175.2",
+      "version": "0.176.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.175.2",
+  "version": "0.176.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/digest.ts
+++ b/src/edge/digest.ts
@@ -106,8 +106,10 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
   // Governance / throughput signals from the audit stream.
   const signals = { tasksCreated: 0, tasksCompleted: 0, approvals: 0, rejected: 0, errors: 0, budgetStops: 0 };
   const audit = db.prepare(
+    // `session.error` = a real run error; `episode.error` (a memory-STORE failure) is deliberately excluded
+    // so a flaky memory backend doesn't inflate the header with "N errors" that aren't the fleet's doing.
     `SELECT type, data FROM audit_events WHERE ts >= ? AND ts < ?
-       AND type IN ('task.created','task.completed','approval.auto_approved','approval.resolved','budget.exceeded','episode.error','session.error')`,
+       AND type IN ('task.created','task.completed','approval.auto_approved','approval.resolved','budget.exceeded','session.error')`,
   ).all<AuditRow>(start, end);
   for (const a of audit) {
     switch (a.type) {
@@ -116,7 +118,7 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
       case 'approval.auto_approved': signals.approvals++; break;
       case 'approval.resolved': { let approved = true; try { approved = (JSON.parse(a.data) as { approved?: boolean }).approved !== false; } catch { /* keep default */ } approved ? signals.approvals++ : signals.rejected++; break; }
       case 'budget.exceeded': signals.budgetStops++; break;
-      case 'episode.error': case 'session.error': signals.errors++; break;
+      case 'session.error': signals.errors++; break;
     }
   }
 
@@ -210,24 +212,30 @@ function signalLine(m: DigestModel): string {
   return parts.join(' · ');
 }
 
-/** Slack mrkdwn (`*bold*`, `_italic_`). One combined message: 📋 Today + 🧠 Learned. */
-export function renderSlack(os: AgentOS, m: DigestModel): string {
+/** Slack mrkdwn (`*bold*`, `_italic_`, `<url|text>` links). One combined message: 📋 Today + 🧠 Learned.
+ *  `origin` (the tenant's public console URL) turns agent names into links + adds a footer to the full
+ *  report; omitted → plain text (still valid). */
+export function renderSlack(os: AgentOS, m: DigestModel, origin?: string): string {
   const name = os.tenant.charAt(0).toUpperCase() + os.tenant.slice(1);
-  const out: string[] = [`*📋 ${name} — ${m.label}*`, `_${tally(m)}_`];
+  const link = (path: string, text: string) => (origin ? `<${origin}/#/${path}|${text}>` : text);
+  const out: string[] = [`*📋 ${link('insights', `${name} — ${m.label}`)}*`, `_${tally(m)}_`];
   const sig = signalLine(m);
   if (sig) out.push(`_${sig}_`);
   out.push('');
   if (!m.byAgent.length) out.push('_No notable sessions today._');
   for (const a of m.byAgent) {
-    out.push(`*${a.agent}*`);
+    out.push(`*${link(`agents/${a.agent}`, a.agent)}*`);
     for (const l of a.lines) out.push(`• ${l.title}${l.count ? ` (×${l.count})` : ''} ${MARK[l.outcome] ?? ''}`.trimEnd());
     if (a.more) out.push(`• _+${a.more} more_`);
+    out.push(''); // breathing room between agents
   }
   if (m.guidance.length || m.recommendations.length) {
-    out.push('', '*🧠 Learned*');
+    out.push('*🧠 Learned*');
     for (const g of m.guidance) out.push(`• ${g}`);
     for (const r of m.recommendations) out.push(`⚠️ _Recommend:_ ${r}`);
+    out.push('');
   }
+  out.push(`_${link('insights', 'Open the full report in Agent OS →')}_`);
   return out.join('\n');
 }
 
@@ -243,7 +251,7 @@ export function renderMarkdown(os: AgentOS, m: DigestModel): string {
   out.push(``, `## What got done`);
   if (!m.byAgent.length) out.push(`- (no notable sessions today)`);
   for (const a of m.byAgent) {
-    out.push(``, `### ${a.agent}`);
+    out.push(``, `### [${a.agent}](#/agents/${a.agent})`);
     for (const l of a.lines) out.push(`- ${MARK[l.outcome] ?? ''} ${l.title}${l.count ? ` (×${l.count})` : ''}`.replace('  ', ' '));
     if (a.more) out.push(`- _+${a.more} more_`);
   }
@@ -257,26 +265,30 @@ export function renderMarkdown(os: AgentOS, m: DigestModel): string {
 
 /** Discord message content — standard markdown (`**bold**`), same two sections as Slack. Discord hard-
  *  caps a message at 2000 chars, so the body is trimmed with a "…more in the daily page" tail if long. */
-export function renderDiscord(os: AgentOS, m: DigestModel): string {
+export function renderDiscord(os: AgentOS, m: DigestModel, origin?: string): string {
   const name = os.tenant.charAt(0).toUpperCase() + os.tenant.slice(1);
+  const link = (path: string, text: string) => (origin ? `[${text}](${origin}/#/${path})` : text);
   const out: string[] = [`**📋 ${name} — ${m.label}**`, tally(m)];
   const sig = signalLine(m);
   if (sig) out.push(sig);
   out.push('');
   if (!m.byAgent.length) out.push('_No notable sessions today._');
   for (const a of m.byAgent) {
-    out.push(`**${a.agent}**`);
+    out.push(`**${link(`agents/${a.agent}`, a.agent)}**`);
     for (const l of a.lines) out.push(`• ${l.title}${l.count ? ` (×${l.count})` : ''} ${MARK[l.outcome] ?? ''}`.trimEnd());
     if (a.more) out.push(`• _+${a.more} more_`);
+    out.push('');
   }
   if (m.guidance.length || m.recommendations.length) {
-    out.push('', '**🧠 Learned**');
+    out.push('**🧠 Learned**');
     for (const g of m.guidance) out.push(`• ${g}`);
     for (const r of m.recommendations) out.push(`⚠️ **Recommend:** ${r}`);
+    out.push('');
   }
+  out.push(link('insights', 'Open the full report in Agent OS →'));
   const text = out.join('\n');
   if (text.length <= 2000) return text;
-  return text.slice(0, 1900).replace(/\n[^\n]*$/, '') + '\n… _full digest in the daily Knowledge page_';
+  return text.slice(0, 1900).replace(/\n[^\n]*$/, '') + `\n… ${link('kb', 'full digest in Knowledge')}`;
 }
 
 export interface PostResult { posted: boolean; reason?: string; error?: string; channel?: string; total: number; iso: string; platforms?: PlatformPost[] }
@@ -330,7 +342,7 @@ export class Digest {
    *  (Slack and/or Discord — whichever has a bot token + a channel). Ignores the hour/once-per-day gate
    *  (that's `maybePostEod`'s job) — this is the manual "post now" path too. Empty day → refresh the KB
    *  page but skip the posts (no channel noise on a quiet day). */
-  async postNow(by = 'scheduler', now = new Date()): Promise<PostResult> {
+  async postNow(by = 'scheduler', now = new Date(), origin?: string): Promise<PostResult> {
     const m = this.refresh(by, now);
     const base = { total: m.total, iso: m.iso };
     if (m.total === 0) return { ...base, posted: false, reason: 'no sessions today' };
@@ -338,8 +350,8 @@ export class Digest {
 
     const platforms: PlatformPost[] = [];
     const s = this.os.settings;
-    if (s.slackBotToken() && s.digestChannel()) platforms.push(await this.postSlack(m));
-    if (s.discordBotToken() && s.digestDiscordChannel()) platforms.push(await this.postDiscord(m));
+    if (s.slackBotToken() && s.digestChannel()) platforms.push(await this.postSlack(m, origin));
+    if (s.discordBotToken() && s.digestDiscordChannel()) platforms.push(await this.postDiscord(m, origin));
 
     const posted = platforms.some((p) => p.posted);
     for (const p of platforms.filter((p) => !p.posted)) {
@@ -352,7 +364,7 @@ export class Digest {
   }
 
   /** Post to Slack: resolve the channel (id or name), best-effort join, send the mrkdwn render. */
-  private async postSlack(m: DigestModel): Promise<PlatformPost> {
+  private async postSlack(m: DigestModel, origin?: string): Promise<PlatformPost> {
     const token = this.os.settings.slackBotToken();
     const ref = this.os.settings.digestChannel();
     let channelId = ref;
@@ -362,22 +374,22 @@ export class Digest {
       channelId = found.channel;
     }
     await joinChannel(token, channelId).catch(() => undefined); // best-effort (public channels)
-    const r = await slackPost(token, channelId, renderSlack(this.os, m));
+    const r = await slackPost(token, channelId, renderSlack(this.os, m, origin));
     return 'error' in r ? { platform: 'slack', posted: false, channel: ref, error: r.error } : { platform: 'slack', posted: true, channel: ref };
   }
 
   /** Post to Discord: send the markdown render to the configured channel id (Discord has no name lookup). */
-  private async postDiscord(m: DigestModel): Promise<PlatformPost> {
+  private async postDiscord(m: DigestModel, origin?: string): Promise<PlatformPost> {
     const token = this.os.settings.discordBotToken();
     const channel = this.os.settings.digestDiscordChannel();
-    const r = await discordPost(token, channel, renderDiscord(this.os, m));
+    const r = await discordPost(token, channel, renderDiscord(this.os, m, origin));
     return 'error' in r ? { platform: 'discord', posted: false, channel, error: r.error } : { platform: 'discord', posted: true, channel };
   }
 
   /** The scheduled EOD hook (called from the hourly upkeep tick). Posts once per server-local day, only
    *  when enabled, at least one chat platform is configured, the hour has arrived, and today hasn't been
    *  posted yet. */
-  async maybePostEod(now = new Date()): Promise<PostResult | null> {
+  async maybePostEod(now = new Date(), origin?: string): Promise<PostResult | null> {
     const s = this.os.settings;
     if (!s.digestEnabled() || !this.hasTarget()) return null;
     if (now.getHours() < s.digestHour()) return null;
@@ -392,6 +404,6 @@ export class Digest {
     // with `digest.error` rows and rewriting the KB page hourly. Give up after MAX_POST_ATTEMPTS today.
     const fails = this.os.db.prepare("SELECT count(*) AS n FROM audit_events WHERE type = 'digest.error' AND ts >= ?").get<{ n: number }>(floor);
     if ((fails?.n ?? 0) >= MAX_POST_ATTEMPTS) return null;
-    return this.postNow('scheduler', now).catch((e) => ({ posted: false, error: e instanceof Error ? e.message : String(e), total: 0, iso }));
+    return this.postNow('scheduler', now, origin).catch((e) => ({ posted: false, error: e instanceof Error ? e.message : String(e), total: 0, iso }));
   }
 }

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -58,7 +58,10 @@ const RECENT_PASSES = 7;                       // window for guidance/recommenda
 const TOPIC_HALFLIFE_MS = 21 * 24 * 3_600_000; // a topic's weight halves every 3 weeks since last seen (recency-favouring, so current work outranks an old burst)
 const TOPIC_MAX_AGE_MS = 90 * 24 * 3_600_000;  // drop a topic entirely if unseen this long
 const TOPIC_CAP = 300;                          // hard cap on stored topic keys (keep the top by recency-weight)
-const STOP = new Set(['task', 'outcome', 'session', 'after', 'then', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'run', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none']);
+const STOP = new Set(['task', 'outcome', 'session', 'after', 'then', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'run', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none',
+  // Procedural / plumbing words — they describe HOW an agent worked, not WHAT the fleet works on, so they
+  // drown the real topics ("slack, check, report, completed, summary" is a useless "frequently works on").
+  'slack', 'discord', 'chat', 'check', 'checked', 'report', 'reported', 'completed', 'complete', 'summary', 'daily', 'sent', 'posted', 'update', 'updated', 'dashboard', 'message', 'notified', 'agent', 'agents', 'human', 'review', 'reviewed', 'ended', 'started', 'verified', 'read']);
 
 export class DreamingEngine {
   constructor(private readonly os: AgentOS) {}

--- a/src/server.ts
+++ b/src/server.ts
@@ -304,7 +304,7 @@ export function startServer(port = Number(process.env.PORT) || 3010): http.Serve
     // Daily digest — the "what got done today" standup. Rides this same hourly tick but gates its own
     // Slack post (enabled + channel + past digestHour + not yet posted today); the dashboard/KB render
     // live on demand, so nothing here is needed to keep them fresh. No-op unless the tenant opted in.
-    void new Digest(os).maybePostEod().catch(() => { /* never let the digest crash the scheduler */ });
+    void new Digest(os).maybePostEod(new Date(), registry.consoleOrigin(os.tenant)).catch(() => { /* never let the digest crash the scheduler */ });
     // Proactive intelligence alerts — the OS comes to the owner. Detect notable conditions (struggling
     // agent, recurring rejections, success drop), push each NEW one (past its per-key cooldown) as an
     // admins' Inbox card + DM. No-op if disabled or nothing warrants attention.
@@ -2474,7 +2474,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'POST' && p === '/api/digest/post') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     try {
-      const r = await new Digest(os).postNow(me.email);
+      const r = await new Digest(os).postNow(me.email, new Date(), publicOrigin(req));
       return sendJson(res, 200, { ok: true, ...r });
     } catch (e) {
       return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });


### PR DESCRIPTION
From the live instawp Slack digest — better formatting + links (requested), plus two accuracy fixes I spotted.

## Links + formatting
- Header and **each agent name** now link to the console (`/#/agents/<agent>`); an **"Open the full report in Agent OS →"** footer links to Insights. Sourced from the tenant's public URL (`consoleOrigin` for the scheduled post, request origin for "Post now"). KB journal page links agents too.
- Blank line between agents for readability.

## Two accuracy fixes
- **"26 errors" was phantom.** The header counted `episode.error` (memory-**store** failures — a flaky external backend), not agent errors. On instawp today: 26 episode.error, **0 session.error**. Now counts only real `session.error`.
- **"Frequently works on: slack, check, report, completed, summary"** — the topic extraction surfaced plumbing words. Added them (and similar) to the stopword set so guidance shows real work areas.

## Validation
Rendered the new Slack digest: linked bold header, linked agent names, footer link, no phantom errors. typecheck + governance (68/68). Will deploy to both boxes + refresh instawp to see it live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)