### PR TITLE
feat(digest): filter agent self-maintenance lines (v0.176.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.176.1] — 2026-07-13
+### Changed
+- **Digest drops agent self-maintenance lines.** A report about an agent editing its OWN prompt (e.g.
+  *"Rewrote my CLAUDE.md rev 5…"*) is self-maintenance, not fleet work, so it no longer clutters the "what
+  got done" changelog (still counted in the header tally). Detected on the reported **line** — `\b(my|its|
+  their|own) (claude.md|system prompt|starter prompts|instructions)\b` — not the `agent.config.updated`
+  audit event, because a session that did real work AND incidentally touched its config (e.g. a "QA PASS on
+  PR #2613" run) would otherwise be wrongly dropped. `src/edge/digest.ts`.
+
 ## [0.176.0] — 2026-07-13
 ### Changed
 - **Daily digest — links + cleaner formatting, and two accuracy fixes.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.176.0",
+  "version": "0.176.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.176.0",
+      "version": "0.176.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.176.0",
+  "version": "0.176.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/digest.ts
+++ b/src/edge/digest.ts
@@ -86,7 +86,11 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
     const taskish = /^(task:|ask ←|ask\b)/i.test(line);
     // Drop generic end-card text and stubs — a no-report session whose title is also generic must not leak.
     const placeholder = line.length < 5 || /^(test|teste|untitled)$/i.test(line) || !isRealReport(line);
-    const include = !placeholder && !askSession && !taskish && (hasReport || importance >= SALIENCE || r.status === 'done');
+    // Drop agent SELF-MAINTENANCE — a report about editing its OWN prompt ("Rewrote my CLAUDE.md rev 5")
+    // isn't fleet work. Detected on the reported LINE (not the audit event, which also fires when a session
+    // did real work AND incidentally touched its config — dropping those would lose the real work).
+    const selfMaint = /\b(my|its|their|own)\s+(claude\.?md|system prompt|starter prompts?|instructions?)\b/i.test(line);
+    const include = !placeholder && !askSession && !taskish && !selfMaint && (hasReport || importance >= SALIENCE || r.status === 'done');
     if (include) {
       const list = perAgent.get(r.agent) ?? [];
       // A real report ranks at/above the salience line; a done-with-no-report just under it.


### PR DESCRIPTION
Drops agent self-maintenance lines (e.g. compass's *"Rewrote my CLAUDE.md (rev 5)…"*) from the digest changelog — it's the agent tuning itself, not fleet work. Still counted in the header tally.

**Detected on the reported line**, not the `agent.config.updated` audit event — because on real instawp data, sessions that did genuine work (a *"QA PASS on PR #2613"* run) *also* emitted `agent.config.updated` (incidental self-edit), so an audit-based exclusion would wrongly drop the QA line.

Validated against the actual instawp report bodies: compass's *"Rewrote my CLAUDE.md"* → **DROP**; qa's *"QA PASS on PR #2613"* → **KEEP**. typecheck + governance (68/68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)