### PR TITLE
fix(insights): reflect-pass honesty (v0.176.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.176.3] — 2026-07-14
+### Fixed
+- **Reflect-pass honesty** (`src/edge/dreaming.ts`) — two gaps in what Insights reports about itself:
+  - **Chat sessions no longer dilute the self-learning success rate.** The reflect pass tallied every
+    terminal session, but a chat reply rarely calls `report`, so it landed as `unknown`/`ended` and dragged
+    the RATE down — the same rate that drives the "slow down" guidance and the raise-effort recommendation.
+    Now the outcome tally excludes `spawned_by LIKE 'chat:%'` sessions (parity with the scorecard /
+    measurement / alerts, which were already fixed). Friction counts (rejections/budget/errors) stay whole.
+    On live instawp this dropped the 7-day denominator 194→183.
+  - **Skipped and errored reflect passes are now audited** (`learning.skipped`). Previously a pass that
+    found no activity, no-opped as `busy`, or *threw* vanished silently (the scheduler `.catch`es it), so
+    "ran and found nothing" / "ran and errored" looked identical to "never ran" in the Insights history.
+
 ## [0.176.2] — 2026-07-13
 ### Changed
 - **Hero product visual + template polish on the landing page** (`public/landing.html`). Replaced the plain

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.176.2",
+  "version": "0.176.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.176.2",
+      "version": "0.176.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.176.2",
+  "version": "0.176.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -73,11 +73,29 @@ export class DreamingEngine {
   private static inFlight = new Set<string>();
   async dream(by = 'automation:dreamer'): Promise<DreamResult> {
     if (DreamingEngine.inFlight.has(this.os.tenant)) {
+      this.markPass(by, { skipped: 'busy' });
       return { skipped: true, busy: true, window: { since: 0, until: Date.now() }, passes: this.load()?.passes };
     }
     DreamingEngine.inFlight.add(this.os.tenant);
-    try { return await this.dreamInner(by); }
-    finally { DreamingEngine.inFlight.delete(this.os.tenant); }
+    try {
+      return await this.dreamInner(by);
+    } catch (err) {
+      // A reflect pass that THREW used to vanish (the scheduler `.catch`es it silently), so "ran and
+      // errored" looked identical to "never ran". Leave a durable marker either way.
+      this.markPass(by, { error: String((err as Error)?.message ?? err) });
+      throw err;
+    } finally {
+      DreamingEngine.inFlight.delete(this.os.tenant);
+    }
+  }
+
+  /** One durable audit line per reflect pass that did NOT complete — skipped (no activity / busy) or
+   *  errored — so the Insights history distinguishes "ran, found nothing" and "errored" from "never ran".
+   *  A completed pass emits its own richer `learning.dreamed`; this only covers the no-op/failure tails. */
+  private markPass(by: string, data: Record<string, unknown>): void {
+    try {
+      this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: by, type: 'learning.skipped', data });
+    } catch { /* best-effort telemetry — never let it break the pass */ }
   }
 
   /** Run one reflection pass: fold activity since the last pass into the cumulative state, re-render. */
@@ -95,14 +113,19 @@ export class DreamingEngine {
     const episodes = db
       .prepare("SELECT content, created_at FROM memories WHERE created_at > ? AND tags LIKE '%\"episode\"%' ORDER BY created_at")
       .all<EpisodeRow>(since);
+    // Exclude CHAT sessions from the outcome tally (parity with the scorecard/measurement/alerts): a chat
+    // reply rarely calls `report`, so it lands as `unknown`/`ended` and drags the success RATE down — the
+    // rate that drives guidance ("slow down") + the effort recommendation. Work sessions only. Friction
+    // (rejections/budget/errors) below is left whole — a rejected approval is friction whoever hit it.
     const outcomeRows = db
-      .prepare("SELECT run_id, ts, type, data FROM audit_events WHERE ts > ? AND type IN ('session.reported','session.ended','session.stopped','run.completed') ORDER BY ts")
+      .prepare("SELECT run_id, ts, type, data FROM audit_events WHERE ts > ? AND type IN ('session.reported','session.ended','session.stopped','run.completed') AND (run_id IS NULL OR run_id NOT IN (SELECT id FROM term_sessions WHERE spawned_by LIKE 'chat:%')) ORDER BY ts")
       .all<OutcomeRow>(since);
     const frictionRows = db
       .prepare("SELECT ts, type, data FROM audit_events WHERE ts > ? AND type IN ('budget.exceeded','session.error','approval.resolved')")
       .all<FrictionRow>(since);
 
     if (!episodes.length && !outcomeRows.length) {
+      this.markPass(by, { skipped: 'no-activity', window });
       return { skipped: true, window, passes: prior?.passes };
     }
 


### PR DESCRIPTION
Closes two gaps in what the Insights self-learning pass reports **about itself** — both flagged in the recent Dreaming audit.

## 1. Chat sessions no longer dilute the success rate
The reflect pass tallied every terminal session. A chat reply rarely calls `report`, so it landed as `unknown`/`ended` and dragged the RATE down — the same rate that drives the "slow down" guidance and the raise-effort recommendation. This is the *last* place chat sessions were still counted; the scorecard, measurement loop and alerts were already fixed.

Outcome tally now excludes `spawned_by LIKE 'chat:%'`. Friction (rejections / budget / errors) is left whole — a rejected approval is friction whoever hit it.

**Validated on live instawp:** 7-day outcome denominator 194 → 183 (11 chat outcome rows excluded).

## 2. Skipped / errored passes are now audited
A pass that found no activity, no-opped as `busy`, or *threw* vanished silently (the scheduler `.catch`es it) — so "ran, found nothing" and "ran, errored" looked identical to "never ran". Each now leaves a durable `learning.skipped` audit line (with a reason / error), alongside the existing `learning.dreamed` for completed passes.

- `npm run typecheck` clean
- `npm run test:governance` 68/68