### PR TITLE
fix(insights): surface improver proposals (v0.177.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.177.1] — 2026-07-14
+### Fixed
+- **Improver proposals now surface in the scorecard.** The KB store normalizes a slug's `/` to `-`, so the
+  improver's `proposed/<agent>` page is stored as `proposed-<agent>`; `pendingProposals` matched the raw
+  `proposed/` prefix and so never listed any draft (Apply/Dismiss buttons never appeared). Match the
+  normalized prefix. Apply/Dismiss themselves were already correct (read normalizes identically). Caught on
+  the first live instapods dry-run — the improver ran and wrote the draft, but the UI couldn't see it.
+
 ## [0.177.0] — 2026-07-14
 ### Added
 - **Insights improvement tiles v2 — "generate the fix" (Agents domain).** The scorecard already says an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.176.3] — 2026-07-14
+## [0.177.0] — 2026-07-14
+### Added
+- **Insights improvement tiles v2 — "generate the fix" (Agents domain).** The scorecard already says an
+  agent is underperforming (which) and Diagnose says why; a new **draft fix** action closes the loop. It
+  spawns a governed headless **improver** agent (`src/edge/improver.ts`, same shape as the analyst /
+  consolidation gardener) that reads the target's current CLAUDE.md + its recent failed/stopped runs + any
+  diagnosis, then writes a **revised CLAUDE.md as a review-gated proposal** — a KB page at
+  `operations/proposed/<agent>` whose body IS the proposed system prompt. Nothing changes live: the owner
+  reviews the draft in Knowledge and **Applies** it (committed as a reversible agent revision) or
+  **Dismisses** it, from the Fleet scorecard. Reuses existing rails end to end — KB stores/versions the
+  draft, agent-revisions applies + can roll it back, `report` posts the owner Inbox card. Routes:
+  `POST /api/insights/improve`, `POST /api/insights/proposal/:agent/{apply,dismiss}`; pending proposals are
+  surfaced in the `/api/insights` + `/api/dreaming` payloads. (Skills + Memory domains follow.)
 ### Fixed
 - **Reflect-pass honesty** (`src/edge/dreaming.ts`) — two gaps in what Insights reports about itself:
   - **Chat sessions no longer dilute the self-learning success rate.** The reflect pass tallied every

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.176.3",
+  "version": "0.177.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.176.3",
+      "version": "0.177.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.177.0",
+  "version": "0.177.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.177.0",
+      "version": "0.177.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.177.0",
+  "version": "0.177.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.176.3",
+  "version": "0.177.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/improver.ts
+++ b/src/edge/improver.ts
@@ -1,0 +1,150 @@
+/**
+ * **Improver** — the generative half of the Agents improvement tile ("generate the fix"). The scorecard
+ * says an agent is underperforming and Diagnosis says *why*; this DRAFTS the fix: a governed headless
+ * **improver** agent reads the target's current CLAUDE.md + its recent failures (+ any diagnosis) and
+ * writes an improved CLAUDE.md **as a proposal** — a KB page at `operations/proposed/<agent>` whose body
+ * IS the proposed system prompt verbatim. Nothing changes live: an owner reviews the draft and **Applies**
+ * (commit it as an agent revision) or **Dismisses** (discard the page). See src/server.ts proposal routes.
+ *
+ * Same governed-spawn shape as Diagnosis / the consolidation gardener (a real claude-code session reusing
+ * every gate + audit) — no in-process LLM. On-demand only: it costs a run, and an owner asks for it about
+ * a specific agent. The proposal-for-review posture reuses existing rails end to end — KB stores + versions
+ * the draft, agent-revisions applies + can roll it back, `report` posts the owner Inbox card.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AgentOS } from '../kernel';
+import type { TerminalManager } from '../terminal';
+import type { AgentManifest } from '../types';
+import { diagnosisSlug } from './diagnosis';
+
+export const IMPROVER_ID = 'improver';
+const PROPOSAL_SECTION = 'operations';
+const WINDOW_MS = 45 * 24 * 3_600_000;
+const MAX_ITEMS = 20;
+
+export interface ImproveResult { spawned: boolean; reason?: string; sessionId?: string; items?: number; slug?: string }
+
+interface EpRow { content: string; metadata: string; created_at: number }
+
+/** KB slug the improver writes its proposed CLAUDE.md to (the review artifact). */
+export function proposalSlug(agentId: string): string {
+  return `proposed/${agentId.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}`;
+}
+
+export class Improver {
+  constructor(private readonly os: AgentOS, private readonly tm: TerminalManager) {}
+
+  /** Spawn the improver to DRAFT a better CLAUDE.md for `agentId` (does not change it live). */
+  async improveAgent(agentId: string, by: string): Promise<ImproveResult> {
+    const target = this.os.agents.get(agentId);
+    if (!target?.dir) return { spawned: false, reason: `unknown agent ${agentId}` };
+
+    const claudeFile = path.join(target.dir, 'CLAUDE.md');
+    const currentMd = fs.existsSync(claudeFile) ? fs.readFileSync(claudeFile, 'utf8') : '';
+    if (!currentMd.trim()) return { spawned: false, reason: `${agentId} has no CLAUDE.md to improve` };
+
+    const db = this.os.db;
+    const since = Date.now() - WINDOW_MS;
+    const rows = db
+      .prepare("SELECT content, metadata, created_at FROM memories WHERE agent_id = ? AND tags LIKE '%\"episode\"%' AND created_at > ? ORDER BY created_at DESC LIMIT 120")
+      .all<EpRow>(agentId, since);
+    const failures = rows.filter((r) => {
+      let o = '';
+      try { o = String((JSON.parse(r.metadata || '{}') as { outcome?: unknown }).outcome ?? ''); } catch { /* ignore */ }
+      return o === 'failure' || o === 'stopped' || o === 'partial';
+    }).slice(0, MAX_ITEMS);
+
+    // An existing root-cause diagnosis is the best fuel — reference it so the rewrite targets the real cause.
+    const diagnosis = this.os.kb.read(this.os.tenant, PROPOSAL_SECTION, diagnosisSlug(agentId));
+
+    this.ensureAgent();
+    failures.reverse();
+    const slug = proposalSlug(agentId);
+    const task = this.buildTask(agentId, currentMd, failures, diagnosis?.body, slug);
+    const session = this.tm.createSession(IMPROVER_ID, `Draft an improved CLAUDE.md for ${agentId}`, task, by, true /* headless */, undefined, undefined, by /* run-as the requester */);
+    this.os.audit.append({ ts: Date.now(), runId: session.id, tenant: this.os.tenant, principal: by, type: 'insights.improve', data: { agent: agentId, items: failures.length, sessionId: session.id, slug } });
+    return { spawned: true, sessionId: session.id, items: failures.length, slug };
+  }
+
+  private buildTask(agentId: string, currentMd: string, rows: EpRow[], diagnosis: string | undefined, slug: string): string {
+    const items = rows.map((r, i) => {
+      let outcome = '';
+      try { outcome = String((JSON.parse(r.metadata || '{}') as { outcome?: unknown }).outcome ?? ''); } catch { /* ignore */ }
+      return `--- [${i + 1}]${outcome ? ` outcome=${outcome}` : ''} ---\n${r.content.trim()}`;
+    });
+    const lines = [
+      `You are drafting an improved system prompt (**CLAUDE.md**) for the agent **${agentId}**, which has been`,
+      `underperforming. Below is its CURRENT CLAUDE.md, then its recent FAILED / STOPPED / PARTIAL runs, and`,
+      diagnosis ? `a prior root-cause DIAGNOSIS. Use the diagnosis as your primary guide.` : `(no prior diagnosis exists — infer the recurring failure pattern yourself).`,
+      ``,
+      `=== CURRENT CLAUDE.md (${currentMd.length} chars) ===`,
+      currentMd.trim(),
+      `=== end current CLAUDE.md ===`,
+      ``,
+    ];
+    if (diagnosis) lines.push(`=== ROOT-CAUSE DIAGNOSIS ===`, diagnosis.trim(), `=== end diagnosis ===`, ``);
+    if (items.length) lines.push(`=== RECENT NON-SUCCESS RUNS (${items.length}) ===`, items.join('\n\n'), `=== end runs ===`, ``);
+    lines.push(
+      `Now produce a REVISED CLAUDE.md that fixes the recurring cause — clearer method, guardrails against the`,
+      `specific failures, tighter instructions. **Preserve** what already works (identity, tools, structure);`,
+      `change only what the evidence says is wrong. Keep it the same document, improved — not a rewrite from`,
+      `scratch, and not longer for its own sake.`,
+      ``,
+      `**Write the FULL revised CLAUDE.md** — and nothing else, no commentary — with \`kb_write\` at section`,
+      `\`${PROPOSAL_SECTION}\`, slug \`${slug}\`, title \`Proposed CLAUDE.md: ${agentId}\`. The page BODY must be`,
+      `exactly the new CLAUDE.md an owner would approve verbatim.`,
+      ``,
+      `Then \`report\` a 2-3 line summary of WHAT you changed and WHY (the owner reads this to decide whether to`,
+      `Apply). Say the owner can review the draft in Knowledge and Apply/Dismiss it from Insights.`,
+    );
+    return lines.join('\n');
+  }
+
+  /** Provision the improver agent into the data home on first use (idempotent; mirrors the analyst). */
+  private ensureAgent(): void {
+    if (this.os.agents.get(IMPROVER_ID)?.dir) return;
+    const base = this.os.paths?.userAgents ?? path.join(process.cwd(), 'data', 'agents');
+    const dir = path.join(base, IMPROVER_ID);
+    fs.mkdirSync(dir, { recursive: true });
+    const manifestPath = path.join(dir, 'agent.json');
+    if (!fs.existsSync(manifestPath)) fs.writeFileSync(manifestPath, JSON.stringify(MANIFEST, null, 2));
+    if (!fs.existsSync(path.join(dir, 'CLAUDE.md'))) fs.writeFileSync(path.join(dir, 'CLAUDE.md'), CLAUDE_MD);
+    this.os.registerAgent({ ...MANIFEST, dir });
+  }
+}
+
+const MANIFEST: AgentManifest = {
+  id: IMPROVER_ID,
+  version: '1.0.0',
+  description: 'Fleet improver — drafts a better CLAUDE.md for an underperforming agent, as a review-gated proposal.',
+  category: 'System',
+  principal: 'svc-improver',
+  policyContext: 'default@v3',
+  runtime: 'claude-code',
+  model: 'claude-opus-4-8',
+  budget: { usdCap: 1, tokenCap: 200_000, wallClockMs: 600_000 },
+};
+
+const CLAUDE_MD = `# Fleet improver (system-prompt rewriter)
+
+You are Agent OS's **improver**. You are handed one underperforming agent's CURRENT CLAUDE.md, its recent
+FAILED / STOPPED / PARTIAL runs, and (usually) a root-cause diagnosis. You draft a **better CLAUDE.md** for
+it — a proposal an owner reviews before anything goes live.
+
+## Method
+1. **Anchor on the cause.** If a diagnosis is provided, fix THAT. Otherwise read the runs and find the
+   recurring failure thread yourself (the same wrong assumption / missing guardrail / ambiguity across runs).
+2. **Revise, don't replace.** Keep the agent's identity, its tools, and the parts that already work. Change
+   only what the evidence says is wrong — add the missing guardrail, sharpen the vague step, cut what
+   misleads. The result should read as the same agent, improved. Don't pad it to look thorough.
+3. **Write the full revised document** with \`kb_write\` to the exact section/slug/title in your task. The
+   page BODY is the new CLAUDE.md **verbatim** — no preamble, no "here's what I changed" inside it. An owner
+   will approve the body as-is.
+4. **Then \`report\`** 2-3 lines: what you changed and why. That is the owner's decision aid — be concrete
+   ("added a retry/backoff rule for the Atlas 429s that stopped 4 runs"; "removed the contradictory
+   'always ask' vs 'never interrupt' guidance"). Point them to Knowledge to read the draft and Insights to
+   Apply or Dismiss.
+
+You only read the batch in your task and write one KB page + one report. You never edit the target agent's
+files directly — Apply is a human's click. Nothing you do needs anyone's connectors.`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import { measureLearning } from './edge/measurement';
 import { buildInsights } from './edge/insights';
 import { buildImprovements } from './edge/improvements';
 import { Diagnosis } from './edge/diagnosis';
+import { Improver, proposalSlug } from './edge/improver';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -121,6 +122,15 @@ function manifestToSnapshot(ag: AgentManifest, claudeMd: string): AgentConfigSna
     examplePrompts: ag.examplePrompts ?? [], shellSecrets: ag.shellSecrets ?? [],
     claudeMd,
   };
+}
+
+/** Agent ids that currently have an improver-drafted CLAUDE.md proposal awaiting review (Apply/Dismiss).
+ *  Derived from the KB `operations/proposed/*` pages — the proposal store — so no extra table. */
+function pendingProposals(os: AgentOS): string[] {
+  return os.kb.list(os.tenant, 'operations')
+    .filter((pg) => pg.slug.startsWith('proposed/'))
+    .map((pg) => pg.slug.slice('proposed/'.length))
+    .filter((id) => !!os.agents.get(id));
 }
 
 /** Read the agent's current on-disk snapshot (manifest fields + CLAUDE.md), to record as the "before". */
@@ -2404,6 +2414,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       applyLearnings: os.settings.applyLearnings(), guidance: os.settings.learnedGuidance(), recommendations: openRecs, state, alertsEnabled: os.settings.insightsAlertsEnabled(),
       measurement: measureLearning(os), // "Is it working?" — success-rate trend + per-intervention before/after (G1)
       insights: dreamInsights, improvements: buildImprovements(os, dreamInsights), // scorecard + friction + improvement tiles
+      proposals: pendingProposals(os), // agents with a drafted-CLAUDE.md proposal awaiting Apply/Dismiss
       digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
     });
   }
@@ -2412,7 +2423,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/insights') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const ins = buildInsights(os);
-    return sendJson(res, 200, { insights: ins, improvements: buildImprovements(os, ins), measurement: measureLearning(os) });
+    return sendJson(res, 200, { insights: ins, improvements: buildImprovements(os, ins), measurement: measureLearning(os), proposals: pendingProposals(os) });
   }
   // Root-cause diagnosis: spawn the analyst to work out WHY a struggling agent keeps failing, into a KB page.
   if (method === 'POST' && p === '/api/insights/diagnose') {
@@ -2426,6 +2437,49 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     } catch (e) {
       return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
     }
+  }
+  // Generate-the-fix: spawn the improver to DRAFT a better CLAUDE.md for an underperforming agent. The
+  // draft lands as a review-gated KB proposal (`operations/proposed/<agent>`) — nothing changes live until
+  // an owner Applies it below. The counterpart to Diagnose ("why") — this is "here's the fix, your call".
+  if (method === 'POST' && p === '/api/insights/improve') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req);
+    const agent = String(b.agent || '').trim();
+    if (!agent) return sendJson(res, 400, { error: 'agent required' });
+    try {
+      const r = await new Improver(os, tm).improveAgent(agent, me.email);
+      return sendJson(res, r.spawned ? 200 : 400, { ok: r.spawned, ...r });
+    } catch (e) {
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  // Apply / dismiss the improver's drafted CLAUDE.md proposal for an agent (owner/admin — nothing
+  // auto-applies). Apply commits the KB draft as a new agent revision (reversible in the agent's history);
+  // both actions discard the proposal page.
+  const propMatch = p.match(/^\/api\/insights\/proposal\/([\w.-]+)\/(apply|dismiss)$/);
+  if (propMatch && method === 'POST') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const [, agentId, action] = propMatch;
+    const page = os.kb.read(os.tenant, 'operations', proposalSlug(agentId));
+    if (!page) return sendJson(res, 404, { error: 'no pending proposal for this agent' });
+    if (action === 'dismiss') {
+      os.kb.remove(page.id);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'insights.improve.dismissed', data: { agent: agentId } });
+      return sendJson(res, 200, { ok: true });
+    }
+    // apply — write the proposed body as the agent's CLAUDE.md, snapshot a revision, drop the draft page.
+    if (!os.paths) return sendJson(res, 200, { ok: false, error: 'editing agents requires a data home' });
+    const ag = os.agents.get(agentId);
+    if (!ag?.dir) return sendJson(res, 404, { error: `unknown agent "${agentId}"` });
+    const proposed = page.body;
+    if (!proposed.trim()) return sendJson(res, 400, { error: 'proposal is empty' });
+    const before = readAgentSnapshot(ag);
+    const next = applyAgentSnapshot(os, ag, { ...before, claudeMd: proposed });
+    const rev = os.agentRevisions.commit(os.tenant, agentId, before, manifestToSnapshot(next, proposed), `applied improver proposal (by ${me.email})`, me.email);
+    tm.refreshAgentSkills?.(agentId); // if it has a live resident session, no-op otherwise
+    os.kb.remove(page.id);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'insights.improve.applied', data: { agent: agentId, rev, chars: proposed.length } });
+    return sendJson(res, 200, { ok: true, agent: agentId, rev });
   }
   // Apply / dismiss a config recommendation (human-gated — nothing auto-applies).
   const recMatch = p.match(/^\/api\/dreaming\/recommendation\/([\w.-]+)\/(apply|dismiss)$/);

--- a/src/server.ts
+++ b/src/server.ts
@@ -125,11 +125,13 @@ function manifestToSnapshot(ag: AgentManifest, claudeMd: string): AgentConfigSna
 }
 
 /** Agent ids that currently have an improver-drafted CLAUDE.md proposal awaiting review (Apply/Dismiss).
- *  Derived from the KB `operations/proposed/*` pages — the proposal store — so no extra table. */
+ *  Derived from the KB proposal pages — no extra table. NB: the KB store normSeg's a slug's `/` to `-`, so
+ *  `proposalSlug()`'s `proposed/<agent>` is stored as `proposed-<agent>`; match that normalized form (the
+ *  read-based apply/dismiss are unaffected — they normalize the same way). */
 function pendingProposals(os: AgentOS): string[] {
   return os.kb.list(os.tenant, 'operations')
-    .filter((pg) => pg.slug.startsWith('proposed/'))
-    .map((pg) => pg.slug.slice('proposed/'.length))
+    .filter((pg) => pg.slug.startsWith('proposed-'))
+    .map((pg) => pg.slug.slice('proposed-'.length))
     .filter((id) => !!os.agents.get(id));
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8301,6 +8301,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [improvements, setImprovements] = useState<ImprovementTile[]>([])
   const [dxBusy, setDxBusy] = useState('')
   const [dxHint, setDxHint] = useState('')
+  const [proposals, setProposals] = useState<string[]>([])
   const [alertsOn, setAlertsOn] = useState(true)
   const toggleAlerts = async (on: boolean) => { setAlertsOn(on); await api.setInsightAlerts(on) }
   const [busy, setBusy] = useState(false)
@@ -8311,7 +8312,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [preview, setPreview] = useState<DigestModel | null>(null)
 
   const refresh = () => {
-    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setImprovements(r.improvements ?? []); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setImprovements(r.improvements ?? []); setProposals(r.proposals ?? []); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
     api.digestToday().then((r) => { if (!r.error) setPreview(r) }).catch(() => {})
   }
   const saveDigest = async (patch: Partial<DigestConfig>) => {
@@ -8341,6 +8342,21 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
     const r = await api.diagnose(agent); setDxBusy('')
     setDxHint(r.error ? `⚠ ${r.error}` : r.spawned ? `Diagnosing ${agent}… the analyst will write it to Knowledge in a minute — refresh to see the link.` : (r.reason ?? 'nothing to diagnose'))
     setTimeout(() => setDxHint(''), 6000)
+  }
+  const improve = async (agent: string) => {
+    setDxBusy(agent); setDxHint('')
+    const r = await api.improveAgent(agent); setDxBusy('')
+    setDxHint(r.error ? `⚠ ${r.error}` : r.spawned ? `Drafting a better CLAUDE.md for ${agent}… the improver will post a report + a proposal you can review — refresh in a minute.` : (r.reason ?? 'nothing to draft'))
+    setTimeout(() => setDxHint(''), 7000)
+  }
+  const applyProposal = async (agent: string) => {
+    setDxBusy(agent); const r = await api.applyProposal(agent); setDxBusy('')
+    setDxHint(r.error ? `⚠ ${r.error}` : `Applied — ${agent}'s CLAUDE.md updated (rev ${r.rev ?? '?'}), reversible in its history.`)
+    setTimeout(() => setDxHint(''), 6000); refresh()
+  }
+  const dismissProposal = async (agent: string) => {
+    setDxBusy(agent); await api.dismissProposal(agent); setDxBusy('')
+    setDxHint(`Dismissed the draft for ${agent}.`); setTimeout(() => setDxHint(''), 4000); refresh()
   }
   const applyRec = async (id: string) => { setBusy(true); const r = await api.applyRecommendation(id); setBusy(false); if (r.error) return setHint('⚠ ' + r.error); setHint('applied'); setTimeout(() => setHint(''), 1500); refresh() }
   const dismissRec = async (id: string) => { setBusy(true); await api.dismissRecommendation(id); setBusy(false); refresh() }
@@ -8483,17 +8499,28 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                     <span className={`w-10 shrink-0 tabular-nums font-medium ${rateCls}`}>{a.rate == null ? '—' : `${a.rate}%`}</span>
                     <span className="text-muted-foreground">{a.runs} run{a.runs === 1 ? '' : 's'}{a.failed ? ` · ${a.failed} failed` : ''}{a.crashed ? ` · ${a.crashed} crashed` : ''}{a.stopped ? ` · ${a.stopped} stopped` : ''}{a.chats ? ` · ${a.chats} chats` : ''}</span>
                     {a.focus.length > 0 && <span className="text-muted-foreground">· {a.focus.join(', ')}</span>}
-                    <span className="ml-auto shrink-0">
-                      {a.diagnosis
-                        ? <a href="#/kb" className="text-emerald-600 underline underline-offset-2" title={`updated ${new Date(a.diagnosis.at).toLocaleString()}`}>diagnosis →</a>
-                        : struggling && <button onClick={() => diagnose(a.agent)} disabled={dxBusy === a.agent} className="text-primary underline underline-offset-2 disabled:opacity-50">{dxBusy === a.agent ? 'diagnosing…' : 'diagnose'}</button>}
+                    <span className="ml-auto flex shrink-0 items-baseline gap-2">
+                      {proposals.includes(a.agent) ? (
+                        <>
+                          <a href={`#/kb`} className="text-emerald-600 underline underline-offset-2" title="Read the drafted CLAUDE.md in Knowledge">review draft →</a>
+                          <button onClick={() => applyProposal(a.agent)} disabled={dxBusy === a.agent} className="text-emerald-600 underline underline-offset-2 disabled:opacity-50">{dxBusy === a.agent ? '…' : 'apply'}</button>
+                          <button onClick={() => dismissProposal(a.agent)} disabled={dxBusy === a.agent} className="text-muted-foreground underline underline-offset-2 disabled:opacity-50">dismiss</button>
+                        </>
+                      ) : (
+                        <>
+                          {a.diagnosis
+                            ? <a href="#/kb" className="text-emerald-600 underline underline-offset-2" title={`updated ${new Date(a.diagnosis.at).toLocaleString()}`}>diagnosis →</a>
+                            : struggling && <button onClick={() => diagnose(a.agent)} disabled={dxBusy === a.agent} className="text-primary underline underline-offset-2 disabled:opacity-50">{dxBusy === a.agent ? 'diagnosing…' : 'diagnose'}</button>}
+                          {struggling && <button onClick={() => improve(a.agent)} disabled={dxBusy === a.agent} className="text-primary underline underline-offset-2 disabled:opacity-50">{dxBusy === a.agent ? '…' : 'draft fix'}</button>}
+                        </>
+                      )}
                     </span>
                   </div>
                 )
               })}
             </div>
             {dxHint && <div className="text-[11px] text-muted-foreground">{dxHint}</div>}
-            <p className="text-[11px] text-muted-foreground">A <strong>diagnose</strong> spawns the analyst to read a struggling agent's failed runs and write a root-cause + fix to <a className="underline" href="#/kb">Knowledge</a>.</p>
+            <p className="text-[11px] text-muted-foreground"><strong>Diagnose</strong> spawns the analyst to find WHY an agent struggles (→ <a className="underline" href="#/kb">Knowledge</a>); <strong>draft fix</strong> spawns the improver to rewrite its CLAUDE.md as a proposal you <strong>apply</strong> (reversible) or <strong>dismiss</strong>.</p>
           </CardContent>
         </Card>
       )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1092,7 +1092,7 @@ export const api = {
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
   planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; improvements?: ImprovementTile[]; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; improvements?: ImprovementTile[]; proposals?: string[]; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),
@@ -1108,6 +1108,10 @@ export const api = {
   digestRefresh: () => call<DigestModel & { ok: boolean; error?: string }>('POST', '/api/digest/refresh'),
   // Spawn the analyst to diagnose why a struggling agent keeps failing (writes a KB page).
   diagnose: (agent: string) => call<{ ok: boolean; spawned: boolean; reason?: string; sessionId?: string; items?: number; slug?: string; error?: string }>('POST', '/api/insights/diagnose', { agent }),
+  // Spawn the improver to DRAFT a better CLAUDE.md (lands as a review-gated proposal), then apply/dismiss it.
+  improveAgent: (agent: string) => call<{ ok: boolean; spawned: boolean; reason?: string; sessionId?: string; items?: number; slug?: string; error?: string }>('POST', '/api/insights/improve', { agent }),
+  applyProposal: (agent: string) => call<{ ok: boolean; rev?: number; error?: string }>('POST', `/api/insights/proposal/${encodeURIComponent(agent)}/apply`),
+  dismissProposal: (agent: string) => call<{ ok: boolean; error?: string }>('POST', `/api/insights/proposal/${encodeURIComponent(agent)}/dismiss`),
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),


### PR DESCRIPTION
Follow-up to #301, caught on the first live instapods dry-run. The improver ran and wrote its drafted CLAUDE.md, but no Apply/Dismiss appeared: the KB store normSeg's a slug's `/` to `-`, so `proposed/<agent>` is stored as `proposed-<agent>`, and `pendingProposals` matched the raw `proposed/` prefix. Match the normalized form. Apply/Dismiss were already correct (read normalizes the same way).

- typecheck clean · governance 68/68