### PR TITLE
fix(insights): surface improver proposals (v0.177.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.177.1] — 2026-07-14
+### Fixed
+- **Improver proposals now surface in the scorecard.** The KB store normalizes a slug's `/` to `-`, so the
+  improver's `proposed/<agent>` page is stored as `proposed-<agent>`; `pendingProposals` matched the raw
+  `proposed/` prefix and so never listed any draft (Apply/Dismiss buttons never appeared). Match the
+  normalized prefix. Apply/Dismiss themselves were already correct (read normalizes identically). Caught on
+  the first live instapods dry-run — the improver ran and wrote the draft, but the UI couldn't see it.
+
 ## [0.177.0] — 2026-07-14
 ### Added
 - **Insights improvement tiles v2 — "generate the fix" (Agents domain).** The scorecard already says an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.177.0",
+  "version": "0.177.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.177.0",
+      "version": "0.177.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.177.0",
+  "version": "0.177.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -125,11 +125,13 @@ function manifestToSnapshot(ag: AgentManifest, claudeMd: string): AgentConfigSna
 }
 
 /** Agent ids that currently have an improver-drafted CLAUDE.md proposal awaiting review (Apply/Dismiss).
- *  Derived from the KB `operations/proposed/*` pages — the proposal store — so no extra table. */
+ *  Derived from the KB proposal pages — no extra table. NB: the KB store normSeg's a slug's `/` to `-`, so
+ *  `proposalSlug()`'s `proposed/<agent>` is stored as `proposed-<agent>`; match that normalized form (the
+ *  read-based apply/dismiss are unaffected — they normalize the same way). */
 function pendingProposals(os: AgentOS): string[] {
   return os.kb.list(os.tenant, 'operations')
-    .filter((pg) => pg.slug.startsWith('proposed/'))
-    .map((pg) => pg.slug.slice('proposed/'.length))
+    .filter((pg) => pg.slug.startsWith('proposed-'))
+    .map((pg) => pg.slug.slice('proposed-'.length))
     .filter((id) => !!os.agents.get(id));
 }
 


### PR DESCRIPTION
Follow-up to #301, caught on the first live instapods dry-run. The improver ran and wrote its drafted CLAUDE.md, but no Apply/Dismiss appeared: the KB store normSeg's a slug's `/` to `-`, so `proposed/<agent>` is stored as `proposed-<agent>`, and `pendingProposals` matched the raw `proposed/` prefix. Match the normalized form. Apply/Dismiss were already correct (read normalizes identically).

- typecheck clean · governance 68/68