### PR TITLE
feat(insights): improvement tiles v2 — Memory preview cleanup (v0.178.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.177.1] — 2026-07-14
+## [0.178.0] — 2026-07-14
+### Added
+- **Insights improvement tiles v2 — Memory domain ("preview cleanup").** The Memory tile is now generative:
+  a **Preview cleanup** action shows exactly what a maintenance pass would prune (never-recalled aged
+  memories) and merge (duplicates) — the real counts + sample items, per agent — **without deleting
+  anything**, so an owner reviews before applying. **Apply** then runs the same plan; **Cancel** discards
+  it. The review-gated, on-demand counterpart to the blind scheduled `maintain` in Settings → Memory.
+  Deterministic (a query + cosine via the existing `planConsolidation`, no spawned agent — unlike the
+  Agents CLAUDE.md rewrite): `src/edge/memory-cleanup.ts` reads the local `memories` table (the SQL
+  readers' source of truth) and mirrors `maintain`'s prune + merge SQL so preview and apply agree exactly.
+  Route `GET|POST /api/insights/memory/cleanup`; audited `memory.maintained` (`via: 'insights-cleanup'`).
 ### Fixed
 - **Improver proposals now surface in the scorecard.** The KB store normalizes a slug's `/` to `-`, so the
   improver's `proposed/<agent>` page is stored as `proposed-<agent>`; `pendingProposals` matched the raw

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.177.1",
+  "version": "0.178.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.177.1",
+      "version": "0.178.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.177.1",
+  "version": "0.178.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/memory-cleanup.ts
+++ b/src/edge/memory-cleanup.ts
@@ -1,0 +1,127 @@
+/**
+ * Memory improvement tile — **"generate the fix" for the memory plane** (Memory domain of Insights v2).
+ *
+ * The tile detects noise (never-recalled aged memories + duplicates); this turns that into a REVIEWABLE
+ * cleanup: a deterministic **preview** of exactly what a maintenance pass would prune + merge, so an owner
+ * eyeballs it before anything is deleted — then **applies** it. The blind `os.memory.maintain` (Settings →
+ * Memory) deletes on a schedule with no preview; this is the review-gated, on-demand counterpart.
+ *
+ * Pure over the local `memories` table (the SQL readers' source of truth — Dreaming/consolidation read it
+ * the same way, and the mirror keeps it populated under an external backend), reusing `planConsolidation`
+ * and mirroring `maintain`'s prune + merge SQL so preview and apply agree exactly. No LLM: pruning and
+ * dedupe are a query + cosine, so unlike the Agents CLAUDE.md rewrite this needs no spawned agent.
+ */
+import type { AgentOS } from '../kernel';
+import type { MemoryMaintenance } from '../types';
+import { planConsolidation, unpackF32, type ConsolidateRow } from '../memory/embedding';
+
+const DAY = 86_400_000;
+const SAMPLE = 8; // items shown per section for eyeballing (apply acts on the FULL set, not the sample)
+
+export interface CleanupOpts { pruneAfterDays: number; keepImportance: number; dedupeThreshold?: number }
+export interface PruneItem { id: string; agent: string; snippet: string; ageDays: number; importance: number | null }
+export interface MergeGroup { agent: string; keepSnippet: string; drop: number }
+export interface MemoryCleanupPlan {
+  opts: CleanupOpts;
+  prune: { total: number; sample: PruneItem[] };
+  merge: { groups: number; drops: number; sample: MergeGroup[] };
+}
+
+interface Row { id: string; agent_id: string; content: string; importance: number | null; recall_count: number; created_at: number; embedding: Uint8Array | null }
+
+/** Resolve the cleanup policy: the saved maintenance config where set, else safe defaults (30d / 0.5). */
+export function cleanupOpts(os: AgentOS): CleanupOpts {
+  const m = os.settings.memoryConfig()?.maintenance;
+  return {
+    pruneAfterDays: m?.pruneAfterDays && m.pruneAfterDays > 0 ? m.pruneAfterDays : 30,
+    keepImportance: m?.keepImportance ?? 0.5,
+    dedupeThreshold: m?.dedupeThreshold ?? undefined, // undefined → exact-content duplicates only
+  };
+}
+
+function snippet(s: string, n = 90): string {
+  const one = s.trim().replace(/\s+/g, ' ');
+  return one.length > n ? one.slice(0, n - 1) + '…' : one;
+}
+
+/** Compute the prune list + merge groups for this tenant WITHOUT mutating anything (the review artifact). */
+export function planMemoryCleanup(os: AgentOS, opts = cleanupOpts(os), now = Date.now()): MemoryCleanupPlan {
+  const db = os.db;
+  const cutoff = now - opts.pruneAfterDays * DAY;
+  const pruneRows = db
+    .prepare('SELECT id, agent_id, content, importance, created_at FROM memories WHERE tenant = ? AND created_at < ? AND recall_count = 0 AND (importance IS NULL OR importance < ?) ORDER BY created_at')
+    .all<Row>(os.tenant, cutoff, opts.keepImportance);
+  const prune = {
+    total: pruneRows.length,
+    sample: pruneRows.slice(0, SAMPLE).map((r) => ({
+      id: r.id, agent: r.agent_id, snippet: snippet(r.content),
+      ageDays: Math.floor((now - r.created_at) / DAY), importance: r.importance,
+    })),
+  };
+
+  // Merge groups, per agent (matches maintain's per-(tenant,agent) grouping). The pruned rows are excluded
+  // so we never propose merging something that's about to be deleted.
+  const pruneSet = new Set(pruneRows.map((r) => r.id));
+  const rows = db
+    .prepare('SELECT id, agent_id, content, importance, recall_count, created_at, embedding FROM memories WHERE tenant = ?')
+    .all<Row>(os.tenant);
+  const byAgent = new Map<string, Row[]>();
+  for (const r of rows) {
+    if (pruneSet.has(r.id)) continue;
+    const arr = byAgent.get(r.agent_id) ?? [];
+    if (!byAgent.has(r.agent_id)) byAgent.set(r.agent_id, arr);
+    arr.push(r);
+  }
+  const groups: MergeGroup[] = [];
+  let drops = 0;
+  for (const [agent, arr] of byAgent) {
+    const consolidate: ConsolidateRow[] = arr.map((r) => ({
+      id: r.id, content: r.content, importance: r.importance ?? undefined,
+      recallCount: r.recall_count ?? 0, ts: r.created_at,
+      vec: r.embedding ? unpackF32(r.embedding) : undefined,
+    }));
+    const byId = new Map(arr.map((r) => [r.id, r]));
+    for (const op of planConsolidation(consolidate, opts.dedupeThreshold)) {
+      drops += op.dropIds.length;
+      groups.push({ agent, keepSnippet: snippet(byId.get(op.keepId)?.content ?? ''), drop: op.dropIds.length });
+    }
+  }
+  groups.sort((a, b) => b.drop - a.drop);
+  return { opts, prune, merge: { groups: groups.length, drops, sample: groups.slice(0, SAMPLE) } };
+}
+
+/** Execute the cleanup for real — same SQL as `maintain`, but scoped to this tenant + audited distinctly. */
+export function applyMemoryCleanup(os: AgentOS, opts = cleanupOpts(os), by = 'system', now = Date.now()): { pruned: number; merged: number } {
+  const db = os.db;
+  let pruned = 0;
+  let merged = 0;
+
+  const cutoff = now - opts.pruneAfterDays * DAY;
+  pruned = db
+    .prepare('DELETE FROM memories WHERE tenant = ? AND created_at < ? AND recall_count = 0 AND (importance IS NULL OR importance < ?)')
+    .run(os.tenant, cutoff, opts.keepImportance).changes;
+
+  const rows = db
+    .prepare('SELECT id, agent_id, content, importance, recall_count, created_at, embedding FROM memories WHERE tenant = ?')
+    .all<Row>(os.tenant);
+  const byAgent = new Map<string, ConsolidateRow[]>();
+  for (const r of rows) {
+    const arr = byAgent.get(r.agent_id) ?? [];
+    if (!byAgent.has(r.agent_id)) byAgent.set(r.agent_id, arr);
+    arr.push({
+      id: r.id, content: r.content, importance: r.importance ?? undefined,
+      recallCount: r.recall_count ?? 0, ts: r.created_at,
+      vec: r.embedding ? unpackF32(r.embedding) : undefined,
+    });
+  }
+  for (const arr of byAgent.values()) {
+    for (const op of planConsolidation(arr, opts.dedupeThreshold)) {
+      db.prepare('UPDATE memories SET importance = ?, recall_count = ? WHERE id = ?').run(op.importance ?? null, op.recallCount, op.keepId);
+      merged += db.prepare(`DELETE FROM memories WHERE id IN (${op.dropIds.map(() => '?').join(',')})`).run(...op.dropIds).changes;
+    }
+  }
+  if (pruned || merged) {
+    os.audit.append({ ts: now, runId: '-', tenant: os.tenant, principal: by, type: 'memory.maintained', data: { pruned, merged, via: 'insights-cleanup', opts } });
+  }
+  return { pruned, merged };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { buildInsights } from './edge/insights';
 import { buildImprovements } from './edge/improvements';
 import { Diagnosis } from './edge/diagnosis';
 import { Improver, proposalSlug } from './edge/improver';
+import { planMemoryCleanup, applyMemoryCleanup, cleanupOpts } from './edge/memory-cleanup';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -2482,6 +2483,15 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.kb.remove(page.id);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'insights.improve.applied', data: { agent: agentId, rev, chars: proposed.length } });
     return sendJson(res, 200, { ok: true, agent: agentId, rev });
+  }
+  // Memory domain "generate the fix": PREVIEW exactly what a cleanup would prune + merge (deterministic,
+  // no mutation) so the owner reviews before deleting; POST applies the same plan. The review-gated
+  // counterpart to the blind scheduled maintain in Settings → Memory.
+  if (p === '/api/insights/memory/cleanup' && (method === 'GET' || method === 'POST')) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (method === 'GET') return sendJson(res, 200, { ok: true, plan: planMemoryCleanup(os) });
+    const r = applyMemoryCleanup(os, cleanupOpts(os), me.email);
+    return sendJson(res, 200, { ok: true, ...r });
   }
   // Apply / dismiss a config recommendation (human-gated — nothing auto-applies).
   const recMatch = p.match(/^\/api\/dreaming\/recommendation\/([\w.-]+)\/(apply|dismiss)$/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -8302,6 +8302,8 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [dxBusy, setDxBusy] = useState('')
   const [dxHint, setDxHint] = useState('')
   const [proposals, setProposals] = useState<string[]>([])
+  const [cleanup, setCleanup] = useState<MemoryCleanupPlan | null>(null)
+  const [cleanupBusy, setCleanupBusy] = useState(false)
   const [alertsOn, setAlertsOn] = useState(true)
   const toggleAlerts = async (on: boolean) => { setAlertsOn(on); await api.setInsightAlerts(on) }
   const [busy, setBusy] = useState(false)
@@ -8358,6 +8360,16 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
     setDxBusy(agent); await api.dismissProposal(agent); setDxBusy('')
     setDxHint(`Dismissed the draft for ${agent}.`); setTimeout(() => setDxHint(''), 4000); refresh()
   }
+  const previewCleanup = async () => {
+    setCleanupBusy(true); const r = await api.memoryCleanupPreview(); setCleanupBusy(false)
+    if (r.error || !r.plan) return setDxHint(`⚠ ${r.error ?? 'could not build a plan'}`)
+    setCleanup(r.plan)
+  }
+  const applyCleanup = async () => {
+    setCleanupBusy(true); const r = await api.memoryCleanupApply(); setCleanupBusy(false); setCleanup(null)
+    setDxHint(r.error ? `⚠ ${r.error}` : `Cleaned up memory — pruned ${r.pruned ?? 0}, merged ${r.merged ?? 0}.`)
+    setTimeout(() => setDxHint(''), 6000); refresh()
+  }
   const applyRec = async (id: string) => { setBusy(true); const r = await api.applyRecommendation(id); setBusy(false); if (r.error) return setHint('⚠ ' + r.error); setHint('applied'); setTimeout(() => setHint(''), 1500); refresh() }
   const dismissRec = async (id: string) => { setBusy(true); await api.dismissRecommendation(id); setBusy(false); refresh() }
   useEffect(() => { refresh() /* eslint-disable-next-line react-hooks/exhaustive-deps */ }, [])
@@ -8410,18 +8422,65 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
         <div>
           <div className="mb-2 text-[11px] uppercase tracking-wider text-muted-foreground">Improvements</div>
           <div className="grid grid-cols-2 gap-3 md:grid-cols-3 xl:grid-cols-6">
-            {[...improvements].sort((a, b) => b.count - a.count).map((t) => (
-              <a key={t.domain} href={t.href} className={`flex flex-col rounded-lg border p-3 transition-colors hover:bg-muted/50 ${t.count > 0 ? '' : 'opacity-60'}`}>
-                <div className="flex items-baseline justify-between">
-                  <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{t.domain}</span>
-                  {t.count > 0 ? <span className="text-lg font-semibold tabular-nums">{t.count}</span> : <CheckCircle2 className="h-4 w-4 text-emerald-600" />}
-                </div>
-                <div className="mt-0.5 text-sm font-medium leading-tight">{t.title}</div>
-                <div className="mt-1 line-clamp-3 text-[11px] leading-snug text-muted-foreground">{t.detail}</div>
-                <div className="mt-2 text-[11px] font-medium text-primary">{t.actionLabel} →</div>
-              </a>
-            ))}
+            {[...improvements].sort((a, b) => b.count - a.count).map((t) => {
+              const inner = (
+                <>
+                  <div className="flex items-baseline justify-between">
+                    <span className="text-[10px] uppercase tracking-wider text-muted-foreground">{t.domain}</span>
+                    {t.count > 0 ? <span className="text-lg font-semibold tabular-nums">{t.count}</span> : <CheckCircle2 className="h-4 w-4 text-emerald-600" />}
+                  </div>
+                  <div className="mt-0.5 text-sm font-medium leading-tight">{t.title}</div>
+                  <div className="mt-1 line-clamp-3 text-[11px] leading-snug text-muted-foreground">{t.detail}</div>
+                </>
+              )
+              const cls = `flex flex-col rounded-lg border p-3 text-left transition-colors hover:bg-muted/50 ${t.count > 0 ? '' : 'opacity-60'}`
+              // Memory tile is generative: preview the exact prune/merge plan in place rather than navigate.
+              if (t.domain === 'memory' && t.count > 0) return (
+                <button key={t.domain} onClick={previewCleanup} disabled={cleanupBusy} className={`${cls} disabled:opacity-50`}>
+                  {inner}
+                  <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview cleanup →'}</div>
+                </button>
+              )
+              return (
+                <a key={t.domain} href={t.href} className={cls}>
+                  {inner}
+                  <div className="mt-2 text-[11px] font-medium text-primary">{t.actionLabel} →</div>
+                </a>
+              )
+            })}
           </div>
+          {cleanup && (
+            <div className="mt-3 rounded-lg border bg-muted/30 p-3 text-xs">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="font-medium">Memory cleanup preview <span className="font-normal text-muted-foreground">— nothing is deleted until you apply</span></div>
+                <div className="flex items-center gap-2">
+                  <button onClick={applyCleanup} disabled={cleanupBusy || (cleanup.prune.total + cleanup.merge.drops === 0)} className="rounded bg-red-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-red-700 disabled:opacity-50">{cleanupBusy ? 'applying…' : `Apply — remove ${cleanup.prune.total + cleanup.merge.drops}`}</button>
+                  <button onClick={() => setCleanup(null)} className="text-[11px] text-muted-foreground underline underline-offset-2">Cancel</button>
+                </div>
+              </div>
+              <div className="text-[11px] text-muted-foreground">Policy: prune never-recalled memories older than <strong>{cleanup.opts.pruneAfterDays}d</strong> below importance <strong>{cleanup.opts.keepImportance}</strong>; merge duplicates{cleanup.opts.dedupeThreshold != null ? ` (cosine ≥ ${cleanup.opts.dedupeThreshold})` : ' (exact-content)'}.</div>
+              <div className="mt-2 grid gap-3 md:grid-cols-2">
+                <div>
+                  <div className="mb-1 font-medium">Prune — {cleanup.prune.total} never-recalled</div>
+                  {cleanup.prune.total === 0 ? <div className="text-muted-foreground">nothing to prune</div> : (
+                    <ul className="space-y-0.5">
+                      {cleanup.prune.sample.map((m) => <li key={m.id} className="truncate text-muted-foreground"><span className="text-foreground">{m.agent}</span> · {m.ageDays}d · {m.snippet}</li>)}
+                      {cleanup.prune.total > cleanup.prune.sample.length && <li className="text-muted-foreground">+{cleanup.prune.total - cleanup.prune.sample.length} more…</li>}
+                    </ul>
+                  )}
+                </div>
+                <div>
+                  <div className="mb-1 font-medium">Merge — {cleanup.merge.groups} group{cleanup.merge.groups === 1 ? '' : 's'}, {cleanup.merge.drops} removed</div>
+                  {cleanup.merge.groups === 0 ? <div className="text-muted-foreground">no duplicates</div> : (
+                    <ul className="space-y-0.5">
+                      {cleanup.merge.sample.map((g, i) => <li key={i} className="truncate text-muted-foreground"><span className="text-foreground">{g.agent}</span> · −{g.drop} dup · {g.keepSnippet}</li>)}
+                      {cleanup.merge.groups > cleanup.merge.sample.length && <li className="text-muted-foreground">+{cleanup.merge.groups - cleanup.merge.sample.length} more group{cleanup.merge.groups - cleanup.merge.sample.length === 1 ? '' : 's'}…</li>}
+                    </ul>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
         </div>
       )}
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -275,6 +275,9 @@ export interface FrictionMap { rejections: RejectedCapability[]; pendingApproval
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
 export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations'
 export interface ImprovementTile { domain: ImprovementDomain; count: number; title: string; detail: string; actionLabel: string; href: string }
+export interface CleanupPruneItem { id: string; agent: string; snippet: string; ageDays: number; importance: number | null }
+export interface CleanupMergeGroup { agent: string; keepSnippet: string; drop: number }
+export interface MemoryCleanupPlan { opts: { pruneAfterDays: number; keepImportance: number; dedupeThreshold?: number }; prune: { total: number; sample: CleanupPruneItem[] }; merge: { groups: number; drops: number; sample: CleanupMergeGroup[] } }
 export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
 export interface MeasureIntervention { id: string; title: string; at: number; before: { n: number; rate: number | null }; after: { n: number; rate: number | null }; deltaPp: number | null; verdict: 'improved' | 'declined' | 'flat' | 'insufficient' }
 export interface Measurement {
@@ -1112,6 +1115,9 @@ export const api = {
   improveAgent: (agent: string) => call<{ ok: boolean; spawned: boolean; reason?: string; sessionId?: string; items?: number; slug?: string; error?: string }>('POST', '/api/insights/improve', { agent }),
   applyProposal: (agent: string) => call<{ ok: boolean; rev?: number; error?: string }>('POST', `/api/insights/proposal/${encodeURIComponent(agent)}/apply`),
   dismissProposal: (agent: string) => call<{ ok: boolean; error?: string }>('POST', `/api/insights/proposal/${encodeURIComponent(agent)}/dismiss`),
+  // Memory domain: preview exactly what a cleanup would prune + merge (no mutation), then apply the same plan.
+  memoryCleanupPreview: () => call<{ ok: boolean; plan?: MemoryCleanupPlan; error?: string }>('GET', '/api/insights/memory/cleanup'),
+  memoryCleanupApply: () => call<{ ok: boolean; pruned?: number; merged?: number; error?: string }>('POST', '/api/insights/memory/cleanup'),
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),


### PR DESCRIPTION
Second slice of improvement tiles v2. The Memory tile becomes generative — but deterministic (a query + cosine, no spawned agent, unlike the Agents CLAUDE.md rewrite).

## What it does
**Preview cleanup** shows exactly what a maintenance pass would **prune** (never-recalled aged memories) and **merge** (duplicates) — real totals + sample items, per agent — **without deleting anything**. The owner reviews, then **Apply** runs the same plan, or **Cancel** discards it. The review-gated counterpart to the *blind* scheduled `maintain` in Settings → Memory (which deletes with no preview).

## Design
`src/edge/memory-cleanup.ts` reads the local `memories` table (the SQL readers' source of truth — same as Dreaming/consolidation) and reuses the existing `planConsolidation`, mirroring `maintain`'s prune + merge SQL so **preview and apply agree exactly**. Policy comes from the saved Settings → Memory maintenance config, else safe defaults (30d / importance 0.5). Audited `memory.maintained` (`via: 'insights-cleanup'`).

Route: `GET|POST /api/insights/memory/cleanup` (owner/admin).

- typecheck (server + web) clean · governance 68/68

Skills domain follows next.