### PR TITLE
feat(insights): improvement tiles v2 — Skills draft-a-skill (v0.179.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.178.0] — 2026-07-14
+## [0.179.0] — 2026-07-14
+### Added
+- **Insights improvement tiles v2 — Skills domain ("draft a skill").** Completes the first v2 batch
+  (Agents · Memory · Skills). The Skills tile gains a **Draft a skill** action that spawns a governed
+  headless **skill-scout** (`src/edge/skill-scout.ts`, same shape as the analyst / improver) which mines a
+  slice of the fleet's recent SUCCESSFUL runs, finds a recurring multi-step procedure the fleet keeps doing
+  by hand (checking `skill_find` so it never duplicates an existing skill), and drafts ONE reusable skill
+  via `skill_propose` — landing on the **existing** proposed-skill review queue (published from the Skills
+  page), so there's no new apply surface. It's told to draft nothing rather than force a weak skill. The
+  tile keeps a **Review N →** link to the queue alongside. Route `POST /api/insights/skills/draft`; audited
+  `insights.skill.scout`.
 ### Added
 - **Insights improvement tiles v2 — Memory domain ("preview cleanup").** The Memory tile is now generative:
   a **Preview cleanup** action shows exactly what a maintenance pass would prune (never-recalled aged

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.178.0",
+  "version": "0.179.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.178.0",
+      "version": "0.179.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.178.0",
+  "version": "0.179.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/skill-scout.ts
+++ b/src/edge/skill-scout.ts
@@ -1,0 +1,132 @@
+/**
+ * Skills improvement tile — **"generate the fix" for the skills library** (Skills domain of Insights v2).
+ *
+ * The other tiles surface what already exists (proposed skills awaiting publish); this one is generative:
+ * it spawns a governed headless **skill-scout** that reads a slice of the fleet's recent SUCCESSFUL runs,
+ * finds a RECURRING multi-step procedure the fleet keeps doing by hand (ideally across agents), checks it
+ * isn't already a skill, and drafts ONE reusable skill via `skill_propose`. That lands on the EXISTING
+ * proposed-skill rail — an owner reviews + publishes it from the Skills page — so there is no new apply
+ * surface; the scout only adds to the review queue the Skills tile already counts.
+ *
+ * Same governed-spawn shape as the analyst / improver / consolidation gardener (a real claude-code session
+ * through every gate + audit, no in-process LLM). On-demand: it costs a run, and an owner asks for it.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { AgentOS } from '../kernel';
+import type { TerminalManager } from '../terminal';
+import type { AgentManifest } from '../types';
+
+export const SCOUT_ID = 'skill-scout';
+const WINDOW_MS = 21 * 24 * 3_600_000; // recent enough to reflect how the fleet works now
+const MAX_ITEMS = 45;                   // token-bounded sample of successful runs
+const MIN_ITEMS = 8;                    // below this there isn't enough signal to spot a repeated pattern
+
+export interface ScoutResult { spawned: boolean; reason?: string; sessionId?: string; items?: number }
+
+interface EpRow { agent_id: string; content: string; metadata: string; created_at: number }
+
+export class SkillScout {
+  constructor(private readonly os: AgentOS, private readonly tm: TerminalManager) {}
+
+  /** Spawn the scout to mine recent fleet work for a recurring pattern and draft a skill (proposal-gated). */
+  async draft(by: string): Promise<ScoutResult> {
+    const db = this.os.db;
+    const since = Date.now() - WINDOW_MS;
+    const rows = db
+      .prepare("SELECT agent_id, content, metadata, created_at FROM memories WHERE created_at > ? AND tags LIKE '%\"episode\"%' ORDER BY created_at DESC LIMIT 300")
+      .all<EpRow>(since);
+    // Successful runs only — a skill codifies what WORKS, and we want the repeatable happy path.
+    const wins = rows.filter((r) => {
+      let o = '';
+      try { o = String((JSON.parse(r.metadata || '{}') as { outcome?: unknown }).outcome ?? ''); } catch { /* ignore */ }
+      return o === 'success';
+    }).slice(0, MAX_ITEMS);
+
+    if (wins.length < MIN_ITEMS) {
+      return { spawned: false, reason: `only ${wins.length} recent successful runs (need ${MIN_ITEMS} to spot a repeated pattern)`, items: wins.length };
+    }
+
+    this.ensureAgent();
+    wins.reverse();
+    const task = this.buildTask(wins);
+    const session = this.tm.createSession(SCOUT_ID, `Mine ${wins.length} fleet runs for a reusable skill`, task, by, true /* headless */, undefined, undefined, by /* run-as the requester */);
+    this.os.audit.append({ ts: Date.now(), runId: session.id, tenant: this.os.tenant, principal: by, type: 'insights.skill.scout', data: { items: wins.length, sessionId: session.id } });
+    return { spawned: true, sessionId: session.id, items: wins.length };
+  }
+
+  private buildTask(rows: EpRow[]): string {
+    const items = rows.map((r, i) => `--- [${i + 1}] ${r.agent_id} ---\n${firstLines(r.content, 6)}`);
+    return [
+      `You are the fleet **skill-scout**. Below are recent SUCCESSFUL runs from across the fleet (end-of-run`,
+      `recaps). Your job: find ONE recurring, reusable **procedure** — a multi-step task the fleet keeps doing`,
+      `by hand, ideally by more than one agent or repeatedly by one — and draft it as a reusable skill so the`,
+      `whole fleet can follow the same playbook next time.`,
+      ``,
+      items.join('\n\n'),
+      ``,
+      `--- end of runs ---`,
+      ``,
+      `Steps:`,
+      `1. **First call \`skill_find\`** (no query) to see what's ALREADY in the library — do NOT propose`,
+      `   something that already exists or closely overlaps.`,
+      `2. Pick the single STRONGEST recurring pattern in the runs above — one that genuinely repeats and would`,
+      `   save real work as a playbook. If nothing recurs clearly enough, **do not force it**: \`report\` that`,
+      `   you found no strong candidate and stop. A weak/speculative skill is worse than none.`,
+      `3. If you found one, draft it with **\`skill_propose\`** — a clear name, a one-line description of WHEN`,
+      `   to use it, and a concise step-by-step body (the reusable method, not a recap of these runs). Set`,
+      `   \`rationale\` to which runs/agents show the pattern.`,
+      `4. **\`report\`** one line: the skill you proposed (or that you found no candidate). Note the owner`,
+      `   reviews + publishes proposals on the Skills page.`,
+    ].join('\n');
+  }
+
+  /** Provision the scout agent into the data home on first use (idempotent; mirrors the analyst). */
+  private ensureAgent(): void {
+    if (this.os.agents.get(SCOUT_ID)?.dir) return;
+    const base = this.os.paths?.userAgents ?? path.join(process.cwd(), 'data', 'agents');
+    const dir = path.join(base, SCOUT_ID);
+    fs.mkdirSync(dir, { recursive: true });
+    const manifestPath = path.join(dir, 'agent.json');
+    if (!fs.existsSync(manifestPath)) fs.writeFileSync(manifestPath, JSON.stringify(MANIFEST, null, 2));
+    if (!fs.existsSync(path.join(dir, 'CLAUDE.md'))) fs.writeFileSync(path.join(dir, 'CLAUDE.md'), CLAUDE_MD);
+    this.os.registerAgent({ ...MANIFEST, dir });
+  }
+}
+
+function firstLines(s: string, n: number): string {
+  return s.trim().split('\n').slice(0, n).join('\n').slice(0, 500);
+}
+
+const MANIFEST: AgentManifest = {
+  id: SCOUT_ID,
+  version: '1.0.0',
+  description: 'Fleet skill-scout — mines recurring successful patterns and drafts reusable skills (proposal-gated).',
+  category: 'System',
+  principal: 'svc-skill-scout',
+  policyContext: 'default@v3',
+  runtime: 'claude-code',
+  model: 'claude-opus-4-8',
+  budget: { usdCap: 1, tokenCap: 200_000, wallClockMs: 600_000 },
+};
+
+const CLAUDE_MD = `# Fleet skill-scout (procedural memory)
+
+You are Agent OS's **skill-scout**. You are handed a batch of the fleet's recent SUCCESSFUL runs and you
+look for a **repeated procedure** worth turning into a reusable skill — a playbook the whole fleet can
+follow so the same multi-step task isn't re-figured-out every time.
+
+## Method
+1. **See what already exists.** Call \`skill_find\` (no query) first. Never propose a skill that duplicates
+   or closely overlaps one already in the library.
+2. **Find the strongest pattern.** Read the runs and look for the same multi-step task recurring — ideally
+   across different agents, or repeatedly by one. You want a genuine, repeatable procedure, not a one-off.
+3. **Don't force it.** If nothing recurs clearly enough to be worth a playbook, \`report\` that you found no
+   strong candidate and stop. A speculative skill is noise; restraint is the right call.
+4. **Draft one skill** with \`skill_propose\`: a clear \`name\`, a one-line \`description\` of WHEN to reach
+   for it, and a \`body\` that is the concise, reusable step-by-step method (general — not a transcript of
+   the sample runs). Put the evidence (which runs/agents show the pattern) in \`rationale\`.
+5. **\`report\`** one line naming the skill you proposed (or that there was no candidate). It lands as a
+   proposal for an owner to review + publish on the Skills page — you never publish it yourself.
+
+You only read the batch in your task and propose at most one skill. Nothing you do needs anyone's connectors.`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,6 +29,7 @@ import { buildImprovements } from './edge/improvements';
 import { Diagnosis } from './edge/diagnosis';
 import { Improver, proposalSlug } from './edge/improver';
 import { planMemoryCleanup, applyMemoryCleanup, cleanupOpts } from './edge/memory-cleanup';
+import { SkillScout } from './edge/skill-scout';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -2492,6 +2493,18 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (method === 'GET') return sendJson(res, 200, { ok: true, plan: planMemoryCleanup(os) });
     const r = applyMemoryCleanup(os, cleanupOpts(os), me.email);
     return sendJson(res, 200, { ok: true, ...r });
+  }
+  // Skills domain "generate the fix": spawn the skill-scout to mine recent successful fleet runs for a
+  // recurring procedure and draft it as a skill via skill_propose — lands on the existing proposed-skill
+  // review queue (published from the Skills page); no new apply surface.
+  if (method === 'POST' && p === '/api/insights/skills/draft') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    try {
+      const r = await new SkillScout(os, tm).draft(me.email);
+      return sendJson(res, r.spawned ? 200 : 400, { ok: r.spawned, ...r });
+    } catch (e) {
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
   }
   // Apply / dismiss a config recommendation (human-gated — nothing auto-applies).
   const recMatch = p.match(/^\/api\/dreaming\/recommendation\/([\w.-]+)\/(apply|dismiss)$/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8360,6 +8360,11 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
     setDxBusy(agent); await api.dismissProposal(agent); setDxBusy('')
     setDxHint(`Dismissed the draft for ${agent}.`); setTimeout(() => setDxHint(''), 4000); refresh()
   }
+  const draftSkill = async () => {
+    setCleanupBusy(true); const r = await api.draftSkill(); setCleanupBusy(false)
+    setDxHint(r.error ? `⚠ ${r.error}` : r.spawned ? `Mining ${r.items ?? ''} recent runs for a reusable pattern… if the scout finds one it'll appear as a proposal on the Skills page to review & publish.` : (r.reason ?? 'no candidate'))
+    setTimeout(() => setDxHint(''), 8000)
+  }
   const previewCleanup = async () => {
     setCleanupBusy(true); const r = await api.memoryCleanupPreview(); setCleanupBusy(false)
     if (r.error || !r.plan) return setDxHint(`⚠ ${r.error ?? 'could not build a plan'}`)
@@ -8440,6 +8445,16 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                   {inner}
                   <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview cleanup →'}</div>
                 </button>
+              )
+              // Skills tile is generative too: mine fleet patterns for a NEW skill, and (if any) review the queue.
+              if (t.domain === 'skills') return (
+                <div key={t.domain} className={cls}>
+                  {inner}
+                  <div className="mt-2 flex items-center gap-3 text-[11px] font-medium">
+                    <button onClick={draftSkill} disabled={cleanupBusy} className="text-primary underline underline-offset-2 disabled:opacity-50">{cleanupBusy ? 'mining…' : 'Draft a skill'}</button>
+                    {t.count > 0 && <a href={t.href} className="text-emerald-600 underline underline-offset-2">Review {t.count} →</a>}
+                  </div>
+                </div>
               )
               return (
                 <a key={t.domain} href={t.href} className={cls}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1118,6 +1118,8 @@ export const api = {
   // Memory domain: preview exactly what a cleanup would prune + merge (no mutation), then apply the same plan.
   memoryCleanupPreview: () => call<{ ok: boolean; plan?: MemoryCleanupPlan; error?: string }>('GET', '/api/insights/memory/cleanup'),
   memoryCleanupApply: () => call<{ ok: boolean; pruned?: number; merged?: number; error?: string }>('POST', '/api/insights/memory/cleanup'),
+  // Skills domain: spawn the scout to mine fleet runs for a recurring pattern and draft a skill (proposal-gated).
+  draftSkill: () => call<{ ok: boolean; spawned: boolean; reason?: string; sessionId?: string; items?: number; error?: string }>('POST', '/api/insights/skills/draft'),
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),


### PR DESCRIPTION
Third slice — completes the first v2 batch (**Agents · Memory · Skills**).

## What it does
The Skills tile gains a **Draft a skill** action that spawns a governed headless **skill-scout** (same shape as the analyst / improver — a real claude-code session through every gate + audit). It mines a slice of the fleet's recent SUCCESSFUL runs, finds a recurring multi-step procedure the fleet keeps doing by hand (calling `skill_find` first so it never duplicates an existing skill), and drafts ONE reusable skill via `skill_propose`.

That lands on the **existing** proposed-skill review queue — an owner publishes it from the Skills page — so there's **no new apply surface**; the scout just adds to the queue the tile already counts. The tile keeps a **Review N →** link alongside.

The scout is explicitly told to **draft nothing rather than force a weak skill** — restraint over noise.

Route: `POST /api/insights/skills/draft` (owner/admin); audited `insights.skill.scout`.

- typecheck (server + web) clean · governance 68/68