### PR TITLE
feat(insights): improvement tiles v2 — KB preview tidy (v0.180.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.179.0] — 2026-07-14
+## [0.180.0] — 2026-07-14
+### Added
+- **Insights improvement tiles v2 — KB domain ("preview tidy").** The KB tile gains a **Preview tidy**
+  action: a deterministic preview of exactly which DEAD pages (never read, 30d+ old) would be archived —
+  real counts + sample — **without removing anything**, so an owner eyeballs them before applying. **Apply**
+  archives them via `kb.remove`, which is soft: the `kb_revisions` history survives, so an archived page is
+  recoverable via revert. Long-unread-but-once-read (STALE) pages are surfaced for MANUAL review (linked,
+  never auto-archived) — a once-useful reference shouldn't vanish on a timer. Deterministic, no LLM (like
+  Memory cleanup). `src/edge/kb-tidy.ts`; route `GET|POST /api/insights/kb/tidy`; audited `kb.tidied`.
 ### Added
 - **Insights improvement tiles v2 — Skills domain ("draft a skill").** Completes the first v2 batch
   (Agents · Memory · Skills). The Skills tile gains a **Draft a skill** action that spawns a governed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.179.0",
+  "version": "0.180.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.179.0",
+      "version": "0.180.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.179.0",
+  "version": "0.180.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/kb-tidy.ts
+++ b/src/edge/kb-tidy.ts
@@ -1,0 +1,68 @@
+/**
+ * KB improvement tile — **"generate the fix" for the knowledge base** (KB domain of Insights v2).
+ *
+ * The tile detects clutter (never-read aged pages + long-unread pages); this turns it into a REVIEWABLE
+ * archive: a deterministic **preview** of exactly which DEAD pages (never read, aged past a floor) would be
+ * archived, so an owner eyeballs them before removal — then **applies** it. Removal is soft: `kb.remove`
+ * deletes the live page + its file but the `kb_revisions` history survives, so an archived page is
+ * recoverable via revert — the same reversibility posture as the other v2 fixes.
+ *
+ * Conservative on purpose. Only NEVER-read pages are archivable; pages that were read but have gone stale
+ * are surfaced for MANUAL review (linked, not deleted) — a once-useful reference shouldn't vanish on a
+ * timer. Pure over `kb_pages`; no LLM (like Memory cleanup, unlike the Agents/Skills spawns).
+ */
+import type { AgentOS } from '../kernel';
+
+const DAY = 86_400_000;
+const DEAD_AFTER_DAYS = 30;  // never-read AND older than this → archivable clutter
+const STALE_AFTER_DAYS = 90; // was read, but not since this → surface for review (never auto-archived)
+const SAMPLE = 8;
+
+export interface KbTidyItem { id: string; section: string; slug: string; title: string; ageDays: number; lastReadDays: number | null }
+export interface KbTidyPlan {
+  deadAfterDays: number;
+  staleAfterDays: number;
+  dead: { total: number; sample: KbTidyItem[] };   // archivable now (never read)
+  stale: { total: number; sample: KbTidyItem[] };   // review-only (read once, long ago)
+}
+
+interface Row { id: string; section: string; slug: string; title: string; created_at: number; read_count: number; last_read_at: number | null }
+
+function toItem(r: Row, now: number): KbTidyItem {
+  return {
+    id: r.id, section: r.section, slug: r.slug, title: r.title || `${r.section}/${r.slug}`,
+    ageDays: Math.floor((now - r.created_at) / DAY),
+    lastReadDays: r.last_read_at ? Math.floor((now - r.last_read_at) / DAY) : null,
+  };
+}
+
+/** Compute the archivable (dead) + review (stale) page lists WITHOUT mutating anything (the review artifact). */
+export function planKbTidy(os: AgentOS, now = Date.now()): KbTidyPlan {
+  const db = os.db;
+  const deadRows = db
+    .prepare('SELECT id, section, slug, title, created_at, read_count, last_read_at FROM kb_pages WHERE tenant = ? AND read_count = 0 AND created_at < ? ORDER BY created_at')
+    .all<Row>(os.tenant, now - DEAD_AFTER_DAYS * DAY);
+  const staleRows = db
+    .prepare('SELECT id, section, slug, title, created_at, read_count, last_read_at FROM kb_pages WHERE tenant = ? AND last_read_at IS NOT NULL AND last_read_at < ? ORDER BY last_read_at')
+    .all<Row>(os.tenant, now - STALE_AFTER_DAYS * DAY);
+  return {
+    deadAfterDays: DEAD_AFTER_DAYS,
+    staleAfterDays: STALE_AFTER_DAYS,
+    dead: { total: deadRows.length, sample: deadRows.slice(0, SAMPLE).map((r) => toItem(r, now)) },
+    stale: { total: staleRows.length, sample: staleRows.slice(0, SAMPLE).map((r) => toItem(r, now)) },
+  };
+}
+
+/** Archive the DEAD (never-read, aged) pages — soft remove (history survives, revertable). Audited. */
+export function applyKbTidy(os: AgentOS, by = 'system', now = Date.now()): { archived: number } {
+  const db = os.db;
+  const rows = db
+    .prepare('SELECT id, section, slug FROM kb_pages WHERE tenant = ? AND read_count = 0 AND created_at < ?')
+    .all<{ id: string; section: string; slug: string }>(os.tenant, now - DEAD_AFTER_DAYS * DAY);
+  let archived = 0;
+  for (const r of rows) if (os.kb.remove(r.id)) archived++;
+  if (archived) {
+    os.audit.append({ ts: now, runId: '-', tenant: os.tenant, principal: by, type: 'kb.tidied', data: { archived, via: 'insights-tidy', deadAfterDays: DEAD_AFTER_DAYS } });
+  }
+  return { archived };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,6 +30,7 @@ import { Diagnosis } from './edge/diagnosis';
 import { Improver, proposalSlug } from './edge/improver';
 import { planMemoryCleanup, applyMemoryCleanup, cleanupOpts } from './edge/memory-cleanup';
 import { SkillScout } from './edge/skill-scout';
+import { planKbTidy, applyKbTidy } from './edge/kb-tidy';
 import { Strategist } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -2492,6 +2493,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     if (method === 'GET') return sendJson(res, 200, { ok: true, plan: planMemoryCleanup(os) });
     const r = applyMemoryCleanup(os, cleanupOpts(os), me.email);
+    return sendJson(res, 200, { ok: true, ...r });
+  }
+  // KB domain "generate the fix": PREVIEW which dead (never-read, aged) pages would be archived (no
+  // mutation), then POST archives them — soft remove, history survives + revertable. Review-gated tidy.
+  if (p === '/api/insights/kb/tidy' && (method === 'GET' || method === 'POST')) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (method === 'GET') return sendJson(res, 200, { ok: true, plan: planKbTidy(os) });
+    const r = applyKbTidy(os, me.email);
     return sendJson(res, 200, { ok: true, ...r });
   }
   // Skills domain "generate the fix": spawn the skill-scout to mine recent successful fleet runs for a

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -8304,6 +8304,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [proposals, setProposals] = useState<string[]>([])
   const [cleanup, setCleanup] = useState<MemoryCleanupPlan | null>(null)
   const [cleanupBusy, setCleanupBusy] = useState(false)
+  const [kbTidy, setKbTidy] = useState<KbTidyPlan | null>(null)
   const [alertsOn, setAlertsOn] = useState(true)
   const toggleAlerts = async (on: boolean) => { setAlertsOn(on); await api.setInsightAlerts(on) }
   const [busy, setBusy] = useState(false)
@@ -8364,6 +8365,16 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
     setCleanupBusy(true); const r = await api.draftSkill(); setCleanupBusy(false)
     setDxHint(r.error ? `⚠ ${r.error}` : r.spawned ? `Mining ${r.items ?? ''} recent runs for a reusable pattern… if the scout finds one it'll appear as a proposal on the Skills page to review & publish.` : (r.reason ?? 'no candidate'))
     setTimeout(() => setDxHint(''), 8000)
+  }
+  const previewKbTidy = async () => {
+    setCleanupBusy(true); const r = await api.kbTidyPreview(); setCleanupBusy(false)
+    if (r.error || !r.plan) return setDxHint(`⚠ ${r.error ?? 'could not build a plan'}`)
+    setKbTidy(r.plan)
+  }
+  const applyKbTidy = async () => {
+    setCleanupBusy(true); const r = await api.kbTidyApply(); setCleanupBusy(false); setKbTidy(null)
+    setDxHint(r.error ? `⚠ ${r.error}` : `Archived ${r.archived ?? 0} dead page${r.archived === 1 ? '' : 's'} — recoverable from page history.`)
+    setTimeout(() => setDxHint(''), 6000); refresh()
   }
   const previewCleanup = async () => {
     setCleanupBusy(true); const r = await api.memoryCleanupPreview(); setCleanupBusy(false)
@@ -8446,6 +8457,13 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                   <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview cleanup →'}</div>
                 </button>
               )
+              // KB tile is generative: preview which dead pages would be archived (soft, revertable).
+              if (t.domain === 'kb' && t.count > 0) return (
+                <button key={t.domain} onClick={previewKbTidy} disabled={cleanupBusy} className={`${cls} disabled:opacity-50`}>
+                  {inner}
+                  <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview tidy →'}</div>
+                </button>
+              )
               // Skills tile is generative too: mine fleet patterns for a NEW skill, and (if any) review the queue.
               if (t.domain === 'skills') return (
                 <div key={t.domain} className={cls}>
@@ -8492,6 +8510,38 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                       {cleanup.merge.groups > cleanup.merge.sample.length && <li className="text-muted-foreground">+{cleanup.merge.groups - cleanup.merge.sample.length} more group{cleanup.merge.groups - cleanup.merge.sample.length === 1 ? '' : 's'}…</li>}
                     </ul>
                   )}
+                </div>
+              </div>
+            </div>
+          )}
+          {kbTidy && (
+            <div className="mt-3 rounded-lg border bg-muted/30 p-3 text-xs">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="font-medium">KB tidy preview <span className="font-normal text-muted-foreground">— archiving is soft (recoverable from page history)</span></div>
+                <div className="flex items-center gap-2">
+                  <button onClick={applyKbTidy} disabled={cleanupBusy || kbTidy.dead.total === 0} className="rounded bg-red-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-red-700 disabled:opacity-50">{cleanupBusy ? 'archiving…' : `Archive ${kbTidy.dead.total} dead`}</button>
+                  <button onClick={() => setKbTidy(null)} className="text-[11px] text-muted-foreground underline underline-offset-2">Cancel</button>
+                </div>
+              </div>
+              <div className="mt-2 grid gap-3 md:grid-cols-2">
+                <div>
+                  <div className="mb-1 font-medium">Archive — {kbTidy.dead.total} dead <span className="font-normal text-muted-foreground">(never read, {kbTidy.deadAfterDays}d+ old)</span></div>
+                  {kbTidy.dead.total === 0 ? <div className="text-muted-foreground">nothing dead to archive</div> : (
+                    <ul className="space-y-0.5">
+                      {kbTidy.dead.sample.map((pg) => <li key={pg.id} className="truncate text-muted-foreground"><span className="text-foreground">{pg.section}/{pg.slug}</span> · {pg.ageDays}d</li>)}
+                      {kbTidy.dead.total > kbTidy.dead.sample.length && <li className="text-muted-foreground">+{kbTidy.dead.total - kbTidy.dead.sample.length} more…</li>}
+                    </ul>
+                  )}
+                </div>
+                <div>
+                  <div className="mb-1 font-medium">Review — {kbTidy.stale.total} stale <span className="font-normal text-muted-foreground">(unread {kbTidy.staleAfterDays}d+)</span></div>
+                  {kbTidy.stale.total === 0 ? <div className="text-muted-foreground">nothing stale</div> : (
+                    <ul className="space-y-0.5">
+                      {kbTidy.stale.sample.map((pg) => <li key={pg.id} className="truncate text-muted-foreground"><a href="#/kb" className="text-foreground underline underline-offset-2">{pg.section}/{pg.slug}</a> · last read {pg.lastReadDays}d ago</li>)}
+                      {kbTidy.stale.total > kbTidy.stale.sample.length && <li className="text-muted-foreground">+{kbTidy.stale.total - kbTidy.stale.sample.length} more…</li>}
+                    </ul>
+                  )}
+                  <div className="mt-1 text-[10px] text-muted-foreground">Stale pages were useful once — refresh or archive them by hand in <a href="#/kb" className="underline">Knowledge</a>.</div>
                 </div>
               </div>
             </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -278,6 +278,8 @@ export interface ImprovementTile { domain: ImprovementDomain; count: number; tit
 export interface CleanupPruneItem { id: string; agent: string; snippet: string; ageDays: number; importance: number | null }
 export interface CleanupMergeGroup { agent: string; keepSnippet: string; drop: number }
 export interface MemoryCleanupPlan { opts: { pruneAfterDays: number; keepImportance: number; dedupeThreshold?: number }; prune: { total: number; sample: CleanupPruneItem[] }; merge: { groups: number; drops: number; sample: CleanupMergeGroup[] } }
+export interface KbTidyItem { id: string; section: string; slug: string; title: string; ageDays: number; lastReadDays: number | null }
+export interface KbTidyPlan { deadAfterDays: number; staleAfterDays: number; dead: { total: number; sample: KbTidyItem[] }; stale: { total: number; sample: KbTidyItem[] } }
 export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
 export interface MeasureIntervention { id: string; title: string; at: number; before: { n: number; rate: number | null }; after: { n: number; rate: number | null }; deltaPp: number | null; verdict: 'improved' | 'declined' | 'flat' | 'insufficient' }
 export interface Measurement {
@@ -1120,6 +1122,9 @@ export const api = {
   memoryCleanupApply: () => call<{ ok: boolean; pruned?: number; merged?: number; error?: string }>('POST', '/api/insights/memory/cleanup'),
   // Skills domain: spawn the scout to mine fleet runs for a recurring pattern and draft a skill (proposal-gated).
   draftSkill: () => call<{ ok: boolean; spawned: boolean; reason?: string; sessionId?: string; items?: number; error?: string }>('POST', '/api/insights/skills/draft'),
+  // KB domain: preview which dead pages would be archived (no mutation), then apply (soft remove, revertable).
+  kbTidyPreview: () => call<{ ok: boolean; plan?: KbTidyPlan; error?: string }>('GET', '/api/insights/kb/tidy'),
+  kbTidyApply: () => call<{ ok: boolean; archived?: number; error?: string }>('POST', '/api/insights/kb/tidy'),
 
   createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),


### PR DESCRIPTION
Fourth v2 domain — KB. Deterministic (like Memory), reuses `kb.remove` (soft, revertable via `kb_revisions`).

## What it does
**Preview tidy** shows exactly which DEAD pages (never read, 30d+ old) would be archived — real counts + sample — **without removing anything**. The owner reviews, then **Apply** archives them.

Archiving is **soft**: `kb.remove` drops the live page + file but `kb_revisions` history survives, so an archived page is recoverable via revert — same reversibility posture as the other v2 fixes.

**Conservative:** only NEVER-read pages are archivable. Pages that were read but have gone stale are surfaced for **manual review** (linked, not deleted) — a once-useful reference shouldn't vanish on a timer.

Route: `GET|POST /api/insights/kb/tidy` (owner/admin); audited `kb.tidied`.

- typecheck (server + web) clean · governance 68/68

Goals + Automations follow.