### PR TITLE
feat(insights): improvement tiles v2 — Goals unstick (v0.181.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.180.0] — 2026-07-14
+## [0.181.0] — 2026-07-14
+### Added
+- **Insights improvement tiles v2 — Goals domain ("unstick").** The Goals tile expands the actual stuck
+  goals in place (active, no progress in 7+ days), each with a **plan** action that spawns the existing
+  governed **strategist** (`Strategist.plan` — reused wholesale, no new spawn or apply surface) to file the
+  next tasks under the goal for a human to review + dispatch. The stuck-goal list is surfaced in the
+  `/api/insights` + `/api/dreaming` payloads (`stuckGoals`); planning reuses `POST /api/goals/:id/plan`.
 ### Added
 - **Insights improvement tiles v2 — KB domain ("preview tidy").** The KB tile gains a **Preview tidy**
   action: a deterministic preview of exactly which DEAD pages (never read, 30d+ old) would be archived —

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.180.0",
+  "version": "0.181.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.180.0",
+      "version": "0.181.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.180.0",
+  "version": "0.181.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -138,6 +138,16 @@ function pendingProposals(os: AgentOS): string[] {
     .filter((id) => !!os.agents.get(id));
 }
 
+/** Active goals with no progress (no goal_event) in 7+ days — the Insights Goals tile's "plan"-able list.
+ *  Matches the tile's stuck-count query; each can be nudged with the existing strategist plan route. */
+function stuckGoals(os: AgentOS, now = Date.now()): Array<{ id: string; title: string; days: number }> {
+  const cutoff = now - 7 * 86_400_000;
+  return os.db
+    .prepare("SELECT g.id, g.title, COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) AS last FROM goals g WHERE g.tenant = ? AND g.status = 'active' AND COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) < ? ORDER BY last")
+    .all<{ id: string; title: string; last: number }>(os.tenant, cutoff)
+    .map((g) => ({ id: g.id, title: g.title, days: Math.floor((now - g.last) / 86_400_000) }));
+}
+
 /** Read the agent's current on-disk snapshot (manifest fields + CLAUDE.md), to record as the "before". */
 function readAgentSnapshot(ag: AgentManifest): AgentConfigSnapshot {
   const file = ag.dir ? path.join(ag.dir, 'CLAUDE.md') : '';
@@ -2420,6 +2430,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       measurement: measureLearning(os), // "Is it working?" — success-rate trend + per-intervention before/after (G1)
       insights: dreamInsights, improvements: buildImprovements(os, dreamInsights), // scorecard + friction + improvement tiles
       proposals: pendingProposals(os), // agents with a drafted-CLAUDE.md proposal awaiting Apply/Dismiss
+      stuckGoals: stuckGoals(os), // active goals with no progress in 7+ days — plan-able from the Goals tile
       digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
     });
   }
@@ -2428,7 +2439,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/insights') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const ins = buildInsights(os);
-    return sendJson(res, 200, { insights: ins, improvements: buildImprovements(os, ins), measurement: measureLearning(os), proposals: pendingProposals(os) });
+    return sendJson(res, 200, { insights: ins, improvements: buildImprovements(os, ins), measurement: measureLearning(os), proposals: pendingProposals(os), stuckGoals: stuckGoals(os) });
   }
   // Root-cause diagnosis: spawn the analyst to work out WHY a struggling agent keeps failing, into a KB page.
   if (method === 'POST' && p === '/api/insights/diagnose') {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -8305,6 +8305,8 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [cleanup, setCleanup] = useState<MemoryCleanupPlan | null>(null)
   const [cleanupBusy, setCleanupBusy] = useState(false)
   const [kbTidy, setKbTidy] = useState<KbTidyPlan | null>(null)
+  const [stuckGoals, setStuckGoals] = useState<StuckGoal[]>([])
+  const [goalsOpen, setGoalsOpen] = useState(false)
   const [alertsOn, setAlertsOn] = useState(true)
   const toggleAlerts = async (on: boolean) => { setAlertsOn(on); await api.setInsightAlerts(on) }
   const [busy, setBusy] = useState(false)
@@ -8315,7 +8317,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [preview, setPreview] = useState<DigestModel | null>(null)
 
   const refresh = () => {
-    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setImprovements(r.improvements ?? []); setProposals(r.proposals ?? []); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setImprovements(r.improvements ?? []); setProposals(r.proposals ?? []); setStuckGoals(r.stuckGoals ?? []); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
     api.digestToday().then((r) => { if (!r.error) setPreview(r) }).catch(() => {})
   }
   const saveDigest = async (patch: Partial<DigestConfig>) => {
@@ -8360,6 +8362,11 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const dismissProposal = async (agent: string) => {
     setDxBusy(agent); await api.dismissProposal(agent); setDxBusy('')
     setDxHint(`Dismissed the draft for ${agent}.`); setTimeout(() => setDxHint(''), 4000); refresh()
+  }
+  const planStuckGoal = async (id: string, title: string) => {
+    setDxBusy(id); const r = await api.planGoal(id); setDxBusy('')
+    setDxHint(r.error ? `⚠ ${r.error}` : `Planning "${title}"… the strategist will file next tasks under the goal (review + dispatch them on the Goals page).`)
+    setTimeout(() => setDxHint(''), 7000)
   }
   const draftSkill = async () => {
     setCleanupBusy(true); const r = await api.draftSkill(); setCleanupBusy(false)
@@ -8464,6 +8471,13 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                   <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview tidy →'}</div>
                 </button>
               )
+              // Goals tile: expand the stuck goals in place, each with a "plan" that spawns the strategist.
+              if (t.domain === 'goals' && t.count > 0) return (
+                <button key={t.domain} onClick={() => setGoalsOpen((v) => !v)} className={`${cls}`}>
+                  {inner}
+                  <div className="mt-2 text-[11px] font-medium text-primary">{goalsOpen ? 'Hide stuck goals' : 'Unstick →'}</div>
+                </button>
+              )
               // Skills tile is generative too: mine fleet patterns for a NEW skill, and (if any) review the queue.
               if (t.domain === 'skills') return (
                 <div key={t.domain} className={cls}>
@@ -8544,6 +8558,20 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                   <div className="mt-1 text-[10px] text-muted-foreground">Stale pages were useful once — refresh or archive them by hand in <a href="#/kb" className="underline">Knowledge</a>.</div>
                 </div>
               </div>
+            </div>
+          )}
+          {goalsOpen && stuckGoals.length > 0 && (
+            <div className="mt-3 rounded-lg border bg-muted/30 p-3 text-xs">
+              <div className="mb-2 font-medium">Stuck goals <span className="font-normal text-muted-foreground">— plan spawns the strategist to file next tasks (you review + dispatch)</span></div>
+              <ul className="space-y-1">
+                {stuckGoals.map((g) => (
+                  <li key={g.id} className="flex items-baseline gap-2 border-b py-1 last:border-0">
+                    <a href={`#/goals/${g.id}`} className="flex-1 truncate font-medium underline-offset-2 hover:underline">{g.title}</a>
+                    <span className="shrink-0 text-muted-foreground">{g.days}d idle</span>
+                    <button onClick={() => planStuckGoal(g.id, g.title)} disabled={dxBusy === g.id} className="shrink-0 text-primary underline underline-offset-2 disabled:opacity-50">{dxBusy === g.id ? 'planning…' : 'plan'}</button>
+                  </li>
+                ))}
+              </ul>
             </div>
           )}
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -280,6 +280,7 @@ export interface CleanupMergeGroup { agent: string; keepSnippet: string; drop: n
 export interface MemoryCleanupPlan { opts: { pruneAfterDays: number; keepImportance: number; dedupeThreshold?: number }; prune: { total: number; sample: CleanupPruneItem[] }; merge: { groups: number; drops: number; sample: CleanupMergeGroup[] } }
 export interface KbTidyItem { id: string; section: string; slug: string; title: string; ageDays: number; lastReadDays: number | null }
 export interface KbTidyPlan { deadAfterDays: number; staleAfterDays: number; dead: { total: number; sample: KbTidyItem[] }; stale: { total: number; sample: KbTidyItem[] } }
+export interface StuckGoal { id: string; title: string; days: number }
 export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
 export interface MeasureIntervention { id: string; title: string; at: number; before: { n: number; rate: number | null }; after: { n: number; rate: number | null }; deltaPp: number | null; verdict: 'improved' | 'declined' | 'flat' | 'insufficient' }
 export interface Measurement {
@@ -1097,7 +1098,7 @@ export const api = {
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
   planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; improvements?: ImprovementTile[]; proposals?: string[]; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; improvements?: ImprovementTile[]; proposals?: string[]; stuckGoals?: StuckGoal[]; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),


### PR DESCRIPTION
Fifth v2 domain — Goals. Reuses the existing governed **strategist** wholesale (no new spawn/apply surface).

## What it does
The Goals tile now expands the actual **stuck goals** in place (active, no progress in 7+ days), each with a **plan** action that spawns the existing `Strategist.plan` — a governed headless agent that files the next tasks under the goal for a human to review + dispatch. Tasks are the reviewable unit (Kanban), so nothing runs unattended.

Zero new backend routes: the stuck-goal list is surfaced in `/api/insights` + `/api/dreaming` (`stuckGoals`), and planning reuses the existing `POST /api/goals/:id/plan`.

- typecheck (server + web) clean · governance 68/68

Automations is the last v2 domain.