### PR TITLE
feat(insights): improvement tiles v2 — Automations triage (v0.182.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.181.0] — 2026-07-14
+## [0.182.0] — 2026-07-14
+### Added
+- **Insights improvement tiles v2 — Automations domain ("triage").** Completes the v2 set (all six tiles
+  now actionable). The Automations tile expands the enabled automations needing attention in place — the
+  ones whose **last run errored** (shown WITH the extracted error text) and **cron gone idle** (14+ days
+  quiet, with days-since) — each with **run now** (idle) and **disable** (retire) actions. Deterministic,
+  no spawned agent: the fix is to see WHY and act. The list is surfaced in `/api/insights` +
+  `/api/dreaming` (`troubledAutomations`); actions reuse the existing `PATCH /api/automations/:id` +
+  `POST /api/automations/:id/run` routes.
 ### Added
 - **Insights improvement tiles v2 — Goals domain ("unstick").** The Goals tile expands the actual stuck
   goals in place (active, no progress in 7+ days), each with a **plan** action that spawns the existing

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.181.0",
+  "version": "0.182.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.181.0",
+      "version": "0.182.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.181.0",
+  "version": "0.182.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -148,6 +148,29 @@ function stuckGoals(os: AgentOS, now = Date.now()): Array<{ id: string; title: s
     .map((g) => ({ id: g.id, title: g.title, days: Math.floor((now - g.last) / 86_400_000) }));
 }
 
+/** Enabled automations that need attention — last run ERRORED (with the error text) or a cron gone IDLE
+ *  (14+ days quiet). Matches the tile's failing+idle count; each can be disabled with the existing
+ *  updateAutomation route. The fix here is deterministic: see WHY, then retire it — no spawned agent. */
+function troubledAutomations(os: AgentOS, now = Date.now()): Array<{ id: string; name: string; type: string; reason: 'errored' | 'idle'; detail: string }> {
+  const out: Array<{ id: string; name: string; type: string; reason: 'errored' | 'idle'; detail: string }> = [];
+  const errored = os.db
+    .prepare("SELECT a.id, a.name, a.type, (SELECT e.data FROM audit_events e WHERE e.run_id = a.last_session_id AND e.type = 'session.error' ORDER BY e.ts DESC LIMIT 1) AS err FROM automations a WHERE a.enabled = 1 AND a.last_session_id IS NOT NULL AND EXISTS (SELECT 1 FROM audit_events e WHERE e.run_id = a.last_session_id AND e.type = 'session.error')")
+    .all<{ id: string; name: string; type: string; err: string | null }>();
+  for (const a of errored) {
+    let msg = 'last run errored';
+    try { const d = JSON.parse(a.err || '{}') as { error?: unknown }; if (d.error) msg = String(d.error); } catch { /* keep default */ }
+    out.push({ id: a.id, name: a.name, type: a.type, reason: 'errored', detail: msg.replace(/\s+/g, ' ').slice(0, 160) });
+  }
+  const idle = os.db
+    .prepare("SELECT id, name, type, last_fired_at FROM automations WHERE enabled = 1 AND type = 'cron' AND (last_fired_at IS NULL OR last_fired_at < ?)")
+    .all<{ id: string; name: string; type: string; last_fired_at: number | null }>(now - 14 * 86_400_000);
+  for (const a of idle) {
+    const detail = a.last_fired_at ? `no run in ${Math.floor((now - a.last_fired_at) / 86_400_000)} days` : 'never fired';
+    out.push({ id: a.id, name: a.name, type: a.type, reason: 'idle', detail });
+  }
+  return out;
+}
+
 /** Read the agent's current on-disk snapshot (manifest fields + CLAUDE.md), to record as the "before". */
 function readAgentSnapshot(ag: AgentManifest): AgentConfigSnapshot {
   const file = ag.dir ? path.join(ag.dir, 'CLAUDE.md') : '';
@@ -2431,6 +2454,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       insights: dreamInsights, improvements: buildImprovements(os, dreamInsights), // scorecard + friction + improvement tiles
       proposals: pendingProposals(os), // agents with a drafted-CLAUDE.md proposal awaiting Apply/Dismiss
       stuckGoals: stuckGoals(os), // active goals with no progress in 7+ days — plan-able from the Goals tile
+      troubledAutomations: troubledAutomations(os), // errored/idle automations — triage from the Automations tile
       digest: { enabled: os.settings.digestEnabled(), channel: os.settings.digestChannel(), discordChannel: os.settings.digestDiscordChannel(), hour: os.settings.digestHour(), slackConfigured: os.settings.slackConfigured(), discordConfigured: os.settings.discordConfigured(), lastPostedAt: lastPosted?.t ?? undefined },
     });
   }
@@ -2439,7 +2463,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/insights') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const ins = buildInsights(os);
-    return sendJson(res, 200, { insights: ins, improvements: buildImprovements(os, ins), measurement: measureLearning(os), proposals: pendingProposals(os), stuckGoals: stuckGoals(os) });
+    return sendJson(res, 200, { insights: ins, improvements: buildImprovements(os, ins), measurement: measureLearning(os), proposals: pendingProposals(os), stuckGoals: stuckGoals(os), troubledAutomations: troubledAutomations(os) });
   }
   // Root-cause diagnosis: spawn the analyst to work out WHY a struggling agent keeps failing, into a KB page.
   if (method === 'POST' && p === '/api/insights/diagnose') {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -8307,6 +8307,8 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [kbTidy, setKbTidy] = useState<KbTidyPlan | null>(null)
   const [stuckGoals, setStuckGoals] = useState<StuckGoal[]>([])
   const [goalsOpen, setGoalsOpen] = useState(false)
+  const [troubledAutos, setTroubledAutos] = useState<TroubledAutomation[]>([])
+  const [autosOpen, setAutosOpen] = useState(false)
   const [alertsOn, setAlertsOn] = useState(true)
   const toggleAlerts = async (on: boolean) => { setAlertsOn(on); await api.setInsightAlerts(on) }
   const [busy, setBusy] = useState(false)
@@ -8317,7 +8319,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [preview, setPreview] = useState<DigestModel | null>(null)
 
   const refresh = () => {
-    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setImprovements(r.improvements ?? []); setProposals(r.proposals ?? []); setStuckGoals(r.stuckGoals ?? []); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
+    api.dreaming().then((r) => { if (r.error) return; setEveryHours(String(r.everyHours ?? 0)); setLast(r.lastDreamedAt); setApply(r.applyLearnings !== false); setGuidance(r.guidance ?? ''); setRecs(r.recommendations ?? []); setState(r.state ?? null); setMeasure(r.measurement ?? null); setInsights(r.insights ?? null); setImprovements(r.improvements ?? []); setProposals(r.proposals ?? []); setStuckGoals(r.stuckGoals ?? []); setTroubledAutos(r.troubledAutomations ?? []); setAlertsOn(r.alertsEnabled !== false); if (r.digest) setDigest(r.digest) }).catch(() => {})
     api.digestToday().then((r) => { if (!r.error) setPreview(r) }).catch(() => {})
   }
   const saveDigest = async (patch: Partial<DigestConfig>) => {
@@ -8362,6 +8364,16 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const dismissProposal = async (agent: string) => {
     setDxBusy(agent); await api.dismissProposal(agent); setDxBusy('')
     setDxHint(`Dismissed the draft for ${agent}.`); setTimeout(() => setDxHint(''), 4000); refresh()
+  }
+  const disableAuto = async (id: string, name: string) => {
+    setDxBusy(id); const r = await api.updateAutomation(id, { enabled: false }); setDxBusy('')
+    setDxHint(r.error ? `⚠ ${r.error}` : `Disabled "${name}" — re-enable it any time on the Automations page.`)
+    setTimeout(() => setDxHint(''), 5000); refresh()
+  }
+  const runAuto = async (id: string, name: string) => {
+    setDxBusy(id); const r = await api.runAutomation(id); setDxBusy('')
+    setDxHint(r.error ? `⚠ ${r.error}` : r.ok ? `Ran "${name}" now — check its result on the Automations page.` : (r.reason ?? 'could not run'))
+    setTimeout(() => setDxHint(''), 6000)
   }
   const planStuckGoal = async (id: string, title: string) => {
     setDxBusy(id); const r = await api.planGoal(id); setDxBusy('')
@@ -8478,6 +8490,13 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                   <div className="mt-2 text-[11px] font-medium text-primary">{goalsOpen ? 'Hide stuck goals' : 'Unstick →'}</div>
                 </button>
               )
+              // Automations tile: expand the errored/idle ones in place, each with its cause + disable/run.
+              if (t.domain === 'automations' && t.count > 0) return (
+                <button key={t.domain} onClick={() => setAutosOpen((v) => !v)} className={`${cls}`}>
+                  {inner}
+                  <div className="mt-2 text-[11px] font-medium text-primary">{autosOpen ? 'Hide' : 'Triage →'}</div>
+                </button>
+              )
               // Skills tile is generative too: mine fleet patterns for a NEW skill, and (if any) review the queue.
               if (t.domain === 'skills') return (
                 <div key={t.domain} className={cls}>
@@ -8569,6 +8588,22 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                     <a href={`#/goals/${g.id}`} className="flex-1 truncate font-medium underline-offset-2 hover:underline">{g.title}</a>
                     <span className="shrink-0 text-muted-foreground">{g.days}d idle</span>
                     <button onClick={() => planStuckGoal(g.id, g.title)} disabled={dxBusy === g.id} className="shrink-0 text-primary underline underline-offset-2 disabled:opacity-50">{dxBusy === g.id ? 'planning…' : 'plan'}</button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {autosOpen && troubledAutos.length > 0 && (
+            <div className="mt-3 rounded-lg border bg-muted/30 p-3 text-xs">
+              <div className="mb-2 font-medium">Automations needing attention <span className="font-normal text-muted-foreground">— see the cause, then re-run or disable</span></div>
+              <ul className="space-y-1.5">
+                {troubledAutos.map((a) => (
+                  <li key={a.id} className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 border-b py-1 last:border-0">
+                    <a href="#/automations" className="max-w-[12rem] truncate font-medium underline-offset-2 hover:underline">{a.name}</a>
+                    <span className={`shrink-0 rounded px-1 text-[10px] ${a.reason === 'errored' ? 'bg-red-100 text-red-700' : 'bg-amber-100 text-amber-700'}`}>{a.reason}</span>
+                    <span className="min-w-0 flex-1 truncate text-muted-foreground" title={a.detail}>{a.detail}</span>
+                    {a.reason === 'idle' && <button onClick={() => runAuto(a.id, a.name)} disabled={dxBusy === a.id} className="shrink-0 text-primary underline underline-offset-2 disabled:opacity-50">{dxBusy === a.id ? '…' : 'run now'}</button>}
+                    <button onClick={() => disableAuto(a.id, a.name)} disabled={dxBusy === a.id} className="shrink-0 text-muted-foreground underline underline-offset-2 disabled:opacity-50">disable</button>
                   </li>
                 ))}
               </ul>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -281,6 +281,7 @@ export interface MemoryCleanupPlan { opts: { pruneAfterDays: number; keepImporta
 export interface KbTidyItem { id: string; section: string; slug: string; title: string; ageDays: number; lastReadDays: number | null }
 export interface KbTidyPlan { deadAfterDays: number; staleAfterDays: number; dead: { total: number; sample: KbTidyItem[] }; stale: { total: number; sample: KbTidyItem[] } }
 export interface StuckGoal { id: string; title: string; days: number }
+export interface TroubledAutomation { id: string; name: string; type: string; reason: 'errored' | 'idle'; detail: string }
 export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
 export interface MeasureIntervention { id: string; title: string; at: number; before: { n: number; rate: number | null }; after: { n: number; rate: number | null }; deltaPp: number | null; verdict: 'improved' | 'declined' | 'flat' | 'insufficient' }
 export interface Measurement {
@@ -1098,7 +1099,7 @@ export const api = {
   commentGoal: (id: string, body: string) => call<{ ok: boolean; goal?: Goal; error?: string }>('POST', `/api/goals/${id}/comment`, { body }),
   deleteGoal: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/goals/${id}`),
   planGoal: (id: string) => call<{ ok: boolean; sessionId?: string; error?: string }>('POST', `/api/goals/${id}/plan`),
-  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; improvements?: ImprovementTile[]; proposals?: string[]; stuckGoals?: StuckGoal[]; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
+  dreaming: () => call<{ everyHours: number; lastDreamedAt?: number; applyLearnings?: boolean; guidance?: string; recommendations?: Recommendation[]; digest?: DigestConfig; state?: DreamingState; measurement?: Measurement; insights?: Insights; improvements?: ImprovementTile[]; proposals?: string[]; stuckGoals?: StuckGoal[]; troubledAutomations?: TroubledAutomation[]; alertsEnabled?: boolean; error?: string }>('GET', '/api/dreaming'),
   applyRecommendation: (id: string) => call<{ ok: boolean; applied?: unknown; error?: string }>('POST', `/api/dreaming/recommendation/${id}/apply`),
   dismissRecommendation: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/dreaming/recommendation/${id}/dismiss`),
   setDreaming: (everyHours: number) => call<{ ok: boolean; everyHours: number; error?: string }>('PUT', '/api/dreaming', { everyHours }),


### PR DESCRIPTION
Sixth and final v2 domain — **completes the set** (all six improvement tiles now actionable).

## What it does
The Automations tile expands the enabled automations needing attention in place:
- **errored** — last run failed, shown **with the extracted error text** (from the `session.error` audit event) so you see the actual cause,
- **idle** — a cron gone quiet 14+ days (with days-since).

Each row offers **run now** (idle) and **disable** (retire). Deterministic — the fix is to see WHY and act, no spawned agent.

Zero new routes: the list is surfaced in `/api/insights` + `/api/dreaming` (`troubledAutomations`); actions reuse `PATCH /api/automations/:id` + `POST /api/automations/:id/run`.

- typecheck (server + web) clean · governance 68/68