### PR TITLE
fix(agents): flag System machinery agents built-in (v0.183.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.183.1] — 2026-07-14
+### Fixed
+- **Flag the System machinery agents as built-in.** The code-provisioned System agents spawned by the
+  edge loops — `skill-scout`, `strategist`, `improver`, `analyst` — were missing from `BUILT_IN_AGENT_IDS`,
+  so (unlike `consolidator` and the seeded generalists) they showed in the console *without* the "built-in"
+  badge and were **deletable** — letting an admin remove OS infrastructure a learning/goals loop depends on.
+  Added all four to the set so the whole System fleet is consistently flagged + delete-protected. No change
+  to `BUILTIN_SEED_IDS` (they're code-provisioned on first use, not boot-seeded from `config/agents/`);
+  their manifests already carry `category: 'System'`.
+
 ## [0.183.0] — 2026-07-14
 ### Added
 - **`github_refresh` agent tool — recover a live run whose GitHub token expired mid-flight.** An agent's

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.183.0",
+  "version": "0.183.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,12 +26,12 @@ import { Digest } from './edge/digest';
 import { measureLearning } from './edge/measurement';
 import { buildInsights } from './edge/insights';
 import { buildImprovements } from './edge/improvements';
-import { Diagnosis } from './edge/diagnosis';
-import { Improver, proposalSlug } from './edge/improver';
+import { Diagnosis, ANALYST_ID } from './edge/diagnosis';
+import { Improver, proposalSlug, IMPROVER_ID } from './edge/improver';
 import { planMemoryCleanup, applyMemoryCleanup, cleanupOpts } from './edge/memory-cleanup';
-import { SkillScout } from './edge/skill-scout';
+import { SkillScout, SCOUT_ID } from './edge/skill-scout';
 import { planKbTidy, applyKbTidy } from './edge/kb-tidy';
-import { Strategist } from './edge/strategist';
+import { Strategist, STRATEGIST_ID } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
 import { CATALOG, redact } from './connectors/connectors';
@@ -109,12 +109,17 @@ const CONSOLE_HTML = path.resolve(__dirname, '../public/console.html');
 const LANDING_HTML = path.resolve(__dirname, '../public/landing.html');
 const WEB_DIST = path.resolve(__dirname, '../web/dist');
 
-/** The agents Agent OS ships with, code-provisioned into every home on boot (the department
- *  generalists + the agent-author + the consolidator). We flag these by id rather than by disk
- *  location because they materialise UNDER the user's agents home, so the `deletable` path check
- *  can't tell them apart from a hand-authored agent — and homes provisioned before this flag existed
- *  carry no marker in their on-disk manifests. */
-const BUILT_IN_AGENT_IDS = new Set<string>([...BUILTIN_SEED_IDS, CONSOLIDATOR_ID]);
+/** The agents Agent OS ships with: the boot-seeded fleet (department generalists + agent-author) plus
+ *  the code-provisioned System machinery spawned by the edge loops (consolidator, skill-scout,
+ *  strategist, improver, analyst). We flag these by id rather than by disk location because they
+ *  materialise UNDER the user's agents home, so the `deletable` path check can't tell them apart from a
+ *  hand-authored agent — and homes provisioned before this flag existed carry no marker in their on-disk
+ *  manifests. The flag drives the console "built-in" badge + delete protection (a System agent is OS
+ *  infrastructure a loop depends on, not a user teammate). */
+const BUILT_IN_AGENT_IDS = new Set<string>([
+  ...BUILTIN_SEED_IDS, CONSOLIDATOR_ID,
+  SCOUT_ID, STRATEGIST_ID, IMPROVER_ID, ANALYST_ID,
+]);
 
 /** The full editable state of an agent, from its manifest + on-disk CLAUDE.md — the unit revisions snapshot. */
 function manifestToSnapshot(ag: AgentManifest, claudeMd: string): AgentConfigSnapshot {


### PR DESCRIPTION
## What

The code-provisioned **System machinery** agents spawned by the edge loops — `skill-scout`, `strategist`, `improver`, `analyst` — were missing from `BUILT_IN_AGENT_IDS` in `src/server.ts`. So unlike `consolidator` and the boot-seeded generalists, they rendered in the console **without** the "built-in" badge and were **deletable** — letting an admin remove OS infrastructure that a learning/goals loop depends on.

## Change

- Add `SCOUT_ID`, `STRATEGIST_ID`, `IMPROVER_ID`, `ANALYST_ID` to `BUILT_IN_AGENT_IDS` (import the constants, already exported from their `src/edge/*` modules).
- Refresh the stale doc comment on the set.
- `BUILTIN_SEED_IDS` **unchanged** — these are provisioned on first use by the edge loops, not boot-seeded from `config/agents/`.
- Their manifests already carry `category: 'System'` — no manifest change needed.

## Verify

`npm run typecheck` + `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)