### PR TITLE
Link the GitHub "not installed" warning to the install page (v0.184.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.184.0] — 2026-07-14
+### Changed
+- **The "authorized but not installed" GitHub warning now links straight to the install page.** The amber
+  banner on the per-member GitHub card (Connections → Mine / Profile) that appears when a member has
+  authorized but the App isn't installed anywhere used to just say "install the App (Connections → Creds)" —
+  now **"install the App ↗"** is a real link to `github.com/apps/<slug>/installations/new`. For Apps
+  configured by hand (no slug from the one-click manifest flow), the slug is **resolved on demand** from
+  `GET /app` (new `appMetadata` + `GithubIdentity.ensureAppSlug`, self-healed when `/api/github/me` is
+  viewed) so the link works regardless of how the App was set up; if the slug still can't be resolved it
+  falls back to the previous text. (`src/connectors/github.ts`, `src/edge/github-identity.ts`,
+  `src/server.ts`, `web/src/connectors.tsx`, `web/src/lib/api.ts`; `scripts/github-per-member-test.cjs` now 74/74.)
+
 ## [0.183.1] — 2026-07-14
 ### Fixed
 - **Flag the System machinery agents as built-in.** The code-provisioned System agents spawned by the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.183.0",
+  "version": "0.184.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.183.0",
+      "version": "0.184.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.183.1",
+  "version": "0.184.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/github-per-member-test.cjs
+++ b/scripts/github-per-member-test.cjs
@@ -55,6 +55,7 @@ global.fetch = async (urlIn, opts = {}) => {
   }
   if (/\/user\/installations\/\d+\/repositories/.test(url)) return json({ total_count: 5, repositories: [] });
   // Company-bot minter: list App installations, then mint an installation (bot) token.
+  if (url === 'https://api.github.com/app') return json({ slug: 'agent-os-instapods', name: 'Agent OS', html_url: 'https://github.com/apps/agent-os-instapods' });
   if (url === 'https://api.github.com/app/installations') return json([{ id: 555, account: { login: 'InstaWP' }, repository_selection: 'all' }]);
   if (/\/app\/installations\/\d+\/access_tokens$/.test(url)) {
     botMintCount++;
@@ -326,6 +327,16 @@ async function main() {
   tm.injectGithubBaseline(be3, 'coder', 'sessB3');
   tm.injectMemberGithub(be3, 'coder', ownerId, 'sessB3');
   assert(be3.GH_TOKEN === 'gho_member', 'connected member token overrides the bot baseline (attribution)');
+
+  // installUrl self-heal: authorized-but-not-installed + bot creds present → /me resolves the App slug
+  // from GET /app so the warning links to the real install page (no manifest slug needed).
+  osx.settings.setGithubAppSlug('', 'owner@test');
+  gid2.save(ownerId, { token: 'gho_ni', login: 'octocat', connectedAt: Date.now() });
+  installState = 'none';
+  const meNI2 = await (await call('GET', '/api/github/me')).json();
+  assert(meNI2.install && meNI2.install.installed === false && (meNI2.installUrl || '').includes('/apps/agent-os-instapods/installations/new'),
+    '/me self-heals the App slug → a real install link when authorized-but-not-installed');
+  installState = 'installed';
   gid2.clear(ownerId);
   // Removing the private key drops the cached bot token + resolved installation.
   gid2.setPrivateKey('', 'owner@test');

--- a/src/connectors/github.ts
+++ b/src/connectors/github.ts
@@ -189,6 +189,28 @@ export async function githubUser(token: string): Promise<{ login: string; id: nu
 }
 
 /**
+ * The App's own metadata (`GET /app`, App-JWT authed) — chiefly its `slug`, which we need to build the
+ * `github.com/apps/<slug>/installations/new` install link for Apps that were configured by hand (so no
+ * slug came from the manifest flow). Cheap + idempotent; resolve once and cache in settings.
+ */
+export async function appMetadata(appId: string | number, privateKeyPem: string): Promise<{ slug: string; name: string; htmlUrl: string } | { error: string }> {
+  let jwt: string;
+  try {
+    jwt = appJwt(appId, privateKeyPem);
+  } catch (e) {
+    return { error: `could not sign App JWT (check the private key): ${e instanceof Error ? e.message : e}` };
+  }
+  try {
+    const res = await fetch(`${GH_API}/app`, { headers: { ...BASE_HEADERS, authorization: `Bearer ${jwt}` } });
+    if (!res.ok) return { error: `GET /app → ${res.status}` };
+    const j = (await res.json().catch(() => ({}))) as any;
+    return { slug: String(j?.slug ?? ''), name: String(j?.name ?? ''), htmlUrl: String(j?.html_url ?? '') };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'GET /app failed' };
+  }
+}
+
+/**
  * Whether a connected user token can actually *act* — i.e. the App is installed somewhere the token
  * reaches, not merely OAuth-authorized. This is the distinction that bit us in practice: a member can
  * "Connect" (authorize) and get a token with **zero installations**, which looks connected but can't

--- a/src/edge/github-identity.ts
+++ b/src/edge/github-identity.ts
@@ -11,7 +11,7 @@
  * Constructed on demand from the pieces the caller already holds (`os.secrets`, `os.settings`,
  * `os.tenant`) — no kernel wiring, so the blast radius stays small.
  */
-import { authorizeUrl, exchangeUserCode, refreshUserToken, githubUser, UserToken, listInstallations, mintInstallationToken } from '../connectors/github';
+import { authorizeUrl, exchangeUserCode, refreshUserToken, githubUser, UserToken, listInstallations, mintInstallationToken, appMetadata } from '../connectors/github';
 
 /** The vault key (per-member principal) holding the JSON token blob. */
 const USER_BLOB_KEY = 'github_user';
@@ -80,6 +80,24 @@ export class GithubIdentity {
   /** The created App's slug (manifest flow) → the "Install on your repos" link. */
   appSlug(): string {
     return this.os.settings.githubAppSlug();
+  }
+  /** The GitHub install page for this App, or '' if the slug isn't known yet. */
+  installUrl(): string {
+    const slug = this.appSlug();
+    return slug ? `https://github.com/apps/${slug}/installations/new` : '';
+  }
+  /**
+   * Resolve + cache the App slug from `GET /app` when we have the App credentials but no slug yet — so an
+   * App configured by hand (no slug from the manifest flow) still gets an "Install the App" link. One-shot:
+   * returns immediately once the slug is known; needs the bot creds (App id + private key).
+   */
+  async ensureAppSlug(by?: string): Promise<string> {
+    const existing = this.appSlug();
+    if (existing || !this.botConfigured()) return existing;
+    const meta = await appMetadata(this.appId(), this.privateKey());
+    if ('error' in meta || !meta.slug) return '';
+    this.os.settings.setGithubAppSlug(meta.slug, by);
+    return meta.slug;
   }
   /** Persist a freshly-created App's credentials in one shot (the manifest-conversion result). */
   saveApp(app: { clientId: string; clientSecret: string; slug: string }, by?: string): void {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3251,7 +3251,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       const st = await userInstallationStatus(blob.token).catch(() => null);
       if (st && !('error' in st)) install = st;
     }
-    return sendJson(res, 200, { configured: gh.configured(), connected: !!blob, login: blob?.login, expiresAt: blob?.expiresAt, install });
+    // Self-heal the install link: a hand-configured App has no slug from the manifest flow, so resolve it
+    // once (from GET /app) when we can, so the "Install the App" prompt is a real link, not just text.
+    if (blob && install && !install.installed && gh.botConfigured() && !gh.appSlug()) {
+      await gh.ensureAppSlug(me.email).catch(() => { /* best-effort; the text guidance still shows */ });
+    }
+    return sendJson(res, 200, { configured: gh.configured(), connected: !!blob, login: blob?.login, expiresAt: blob?.expiresAt, install, installUrl: gh.installUrl() });
   }
   if (method === 'GET' && p === '/api/github/connect') {
     const gh = new GithubIdentity(os);

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -549,7 +549,11 @@ export function GithubMineCard() {
       {/* Authorized but NOT installed — the trap: looks connected, but the App can't touch any repo. */}
       {st?.connected && st.install && !st.install.installed && (
         <p className="mt-2 rounded-md border border-amber-500/40 bg-amber-500/10 p-2 text-[11px] text-amber-700 dark:text-amber-400">
-          ⚠ You’re authorized, but the App isn’t <strong>installed</strong> on any repositories yet — so pushes will still fail. Authorizing and installing are separate steps: an owner needs to <strong>install the App</strong> on your org’s repos (Connections → Creds → Install the App). Until then, agents fall back to any configured token.
+          ⚠ You’re authorized, but the App isn’t <strong>installed</strong> on any repositories yet — so pushes will still fail. Authorizing and installing are separate steps: an owner needs to{' '}
+          {st.installUrl
+            ? <a href={st.installUrl} target="_blank" rel="noreferrer" className="font-medium underline hover:no-underline">install the App ↗</a>
+            : <strong>install the App</strong>}{' '}
+          on your org’s repos{st.installUrl ? '' : ' (Connections → Creds → Install the App)'}. Until then, agents fall back to any configured token.
         </p>
       )}
       {!st?.configured && !st?.connected && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -852,6 +852,8 @@ export interface GithubMe {
   /** Real App-installation status for the connected token — undefined when not connected or the check
    *  couldn't run. `installed:false` means authorized-but-not-installed (connected yet can't touch a repo). */
   install?: { installed: boolean; count: number; accounts: string[]; repos: number }
+  /** GitHub install page for the App (`…/apps/<slug>/installations/new`), or '' if the slug isn't known. */
+  installUrl?: string
   error?: string
 }
 


### PR DESCRIPTION
The amber **"You're authorized, but the App isn't installed"** banner on the per-member GitHub card (Connections → Mine / Profile) used to just *say* "install the App (Connections → Creds)". Now **"install the App ↗"** is a real link straight to `github.com/apps/<slug>/installations/new`.

For Apps configured **by hand** (which have no slug from the one-click manifest flow — e.g. instawp), the slug is resolved on demand from `GET /app` (`appMetadata` + `GithubIdentity.ensureAppSlug`, self-healed when `/api/github/me` is viewed), so the link works regardless of how the App was set up. If the slug still can't be resolved it falls back to the previous plain text.

- `src/connectors/github.ts` — `appMetadata` (`GET /app`)
- `src/edge/github-identity.ts` — `ensureAppSlug` + `installUrl`
- `src/server.ts` — `/api/github/me` self-heals the slug + returns `installUrl`
- `web/` — the banner links `installUrl` when present

Tests: `scripts/github-per-member-test.cjs` **74/74** (adds the self-heal → install-link case); typecheck, both builds, governance (68/68) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)