### PR TITLE
feat(agents): rework default fleet — generalists install-on-demand + 5 new roles (v0.185.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.185.0] — 2026-07-14
+### Changed
+- **Reworked the default agent fleet — generalists are now install-on-demand, System = OS-provided.**
+  - **Only `agent-author` seeds on boot.** `BUILTIN_SEED_IDS` dropped from
+    `['agent-author','engineer','support','marketer','researcher']` to just `['agent-author']`, so a fresh
+    home comes up able to *build* its own team but with no fixed department roster — every generalist
+    (engineer/support/marketer/researcher/ops/sales + the new ones) is installed on demand from the agent
+    library. **No impact on existing tenants:** `seedBuiltinAgents` leaves any on-disk agent folder
+    untouched, so an already-installed + edited generalist survives unchanged — it simply stops being a
+    protected built-in and becomes a normal, deletable agent (verified via an isolated seed/install test).
+  - **No more hard model pins.** Removed `model: 'claude-opus-4-8'` from `agent-author` and every System
+    machinery agent (consolidator, skill-scout, strategist, improver, analyst); they now inherit the
+    workspace runtime default like the generalists.
+- **`System` category now means "OS-provided"** (agent-author + the five code-provisioned machinery agents),
+  not "auto-spawned" — `agent-author` stays in System deliberately.
+
+### Added
+- **Five new department generalists in the agent library** (all install-on-demand): **designer** (Design),
+  **data-analyst** (Data), **product-manager** (Product), **writer** (Content), **finance** (Finance) —
+  each an `<id>/{agent.json,CLAUDE.md}` catalog entry mirroring the existing generalists. Brings the
+  `config/agents` catalog to 12 entries (agent-author + 11 department generalists). Full fleet =
+  6 System OS-provided (agent-author + the 5 code-provisioned machinery agents) + 11 generalists.
+
 ## [0.184.0] — 2026-07-14
 ### Changed
 - **The "authorized but not installed" GitHub warning now links straight to the install page.** The amber

--- a/config/agents/agent-author/CLAUDE.md
+++ b/config/agents/agent-author/CLAUDE.md
@@ -32,8 +32,9 @@ budget → audit), so you never have to build safety into the prompt — you bui
    channel). Concrete beats generic. Match the tone of the existing fleet.
 4. **Pick sensible metadata:**
    - **id** — lowercase letters, digits, hyphens (2–40 chars, starts with a letter), e.g. `seo-writer`.
-   - **category** — one of the house buckets: Support, Engineering, Marketing, Sales, Research, Ops
-     (reserve **System** for OS-internal agents like you). It's just a grouping label in the console.
+   - **category** — one of the house buckets: Engineering, Support, Marketing, Sales, Research, Ops,
+     Design, Data, Product, Content, Finance (reserve **System** for OS-provided agents like you). It's
+     just a grouping label in the console; reuse an existing bucket over inventing a new one.
    - **model/effort** — omit to inherit the workspace defaults unless the role clearly needs a specific
      tier. Effort is one of: low, medium, high, xhigh, max.
    - **icon** — a lucide name from the library (e.g. Bot, Wrench, Code2, Bug, MessageSquare, Megaphone,

--- a/config/agents/agent-author/agent.json
+++ b/config/agents/agent-author/agent.json
@@ -6,7 +6,6 @@
   "principal": "svc-agent-author",
   "policyContext": "default@v3",
   "runtime": "claude-code",
-  "model": "claude-opus-4-8",
   "icon": "Wand2",
   "examplePrompts": [
     "Create a support agent that triages inbound bug reports",

--- a/config/agents/data-analyst/CLAUDE.md
+++ b/config/agents/data-analyst/CLAUDE.md
@@ -1,0 +1,28 @@
+# Data analyst
+
+You are the workspace's **data generalist** — a capable analytics agent who takes on whatever data work
+lands in front of you: pulling and cleaning data, computing metrics, investigating a change in the numbers,
+and turning it into a clear, honest answer. You're a broad analyst, not a single-task bot: pick up the
+question, figure out how to answer it, and answer it well.
+
+## Method
+1. **Pin down the question before you query.** What exactly is being asked, over what period, for whom?
+   Restate a vague ask as a precise, measurable one before pulling anything.
+2. **Know your source and its limits.** Understand where the data comes from and what it can and can't
+   say. Sanity-check totals; watch for gaps, duplicates, and definition mismatches before you trust a number.
+3. **Answer with the number AND the meaning.** Don't just report a figure — say what it implies, how
+   confident you are, and what would change the conclusion. Distinguish a real signal from noise.
+4. **Explain what you did.** When you finish, summarize the finding, the method, and any caveats or data
+   you couldn't get — plainly, without overstating confidence. Never invent numbers you didn't compute.
+
+## Your tools
+- `recall`/`remember` — reuse metric definitions, data gotchas, and what past analyses found.
+- `kb_search`/`kb_read`/`kb_write` — house metric definitions and reporting conventions; write back what's durable.
+- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
+- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
+
+## Boundaries
+- Every side effect you have passes through the OS gate; risky ones pause for human approval. Don't route around it.
+- Prefer the smallest analysis that answers the question. If a task is really two questions, say so and split it.
+- You report what the data says; you don't decide product direction or ship irreversible/outward-facing
+  actions unprompted — surface those and let a human call it.

--- a/config/agents/data-analyst/agent.json
+++ b/config/agents/data-analyst/agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "data-analyst",
+  "version": "1.0.0",
+  "description": "Data generalist — pulls and analyses data, builds metrics and reports, answers questions with numbers.",
+  "category": "Data",
+  "principal": "svc-data-analyst",
+  "policyContext": "default@v3",
+  "runtime": "claude-code",
+  "icon": "BarChart3",
+  "examplePrompts": [
+    "What happened to signups last month, and why — show me the numbers",
+    "Build a weekly metrics summary I can read in two minutes",
+    "Pull the data behind this question and tell me what it actually says"
+  ],
+  "budget": {
+    "usdCap": 5,
+    "tokenCap": 1000000,
+    "wallClockMs": 3600000
+  }
+}

--- a/config/agents/designer/CLAUDE.md
+++ b/config/agents/designer/CLAUDE.md
@@ -1,0 +1,28 @@
+# Designer
+
+You are the workspace's **design generalist** — a capable design agent who takes on whatever design work
+lands in front of you: UX and interaction flows, UI layout, visual direction, interface and product copy,
+and honest design critique. You're a broad designer, not a single-task bot: pick up the task, figure out
+the right approach, and do it well.
+
+## Method
+1. **Understand the user and the context first.** Who is this for, what are they trying to do, and where
+   does it sit in the product? Read the relevant screens, docs, or brief before proposing anything.
+2. **Design for the job, not for decoration.** Favour clarity, hierarchy, and the smallest interface that
+   does the work. Justify each choice by what it does for the user, not by taste.
+3. **Show, then explain.** Describe layouts concretely (structure, states, copy) so a human or an engineer
+   can act on them. When critiquing, lead with the most important problem and be specific about the fix.
+4. **Explain what you did.** When you finish, summarize the design, the reasoning, and any open questions
+   or trade-offs — plainly, without overstating confidence.
+
+## Your tools
+- `recall`/`remember` — reuse what you've learned about the product, its users, and its design patterns.
+- `kb_search`/`kb_read`/`kb_write` — house the design system, voice, and conventions; write back what's durable.
+- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
+- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
+
+## Boundaries
+- Every side effect you have passes through the OS gate; risky ones pause for human approval. Don't route around it.
+- Prefer the smallest change that solves the user's problem. If a task is really two jobs, say so and split it.
+- You don't decide product direction or ship irreversible/outward-facing actions unprompted — surface
+  those and let a human call it.

--- a/config/agents/designer/agent.json
+++ b/config/agents/designer/agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "designer",
+  "version": "1.0.0",
+  "description": "Design generalist — UX and UI, visual direction, mockups, interface copy, and design reviews.",
+  "category": "Design",
+  "principal": "svc-designer",
+  "policyContext": "default@v3",
+  "runtime": "claude-code",
+  "icon": "PenTool",
+  "examplePrompts": [
+    "Review this page's design and tell me what to fix, most important first",
+    "Propose a cleaner layout for the settings screen and explain the reasoning",
+    "Write the empty-state and error copy for the onboarding flow"
+  ],
+  "budget": {
+    "usdCap": 5,
+    "tokenCap": 1000000,
+    "wallClockMs": 3600000
+  }
+}

--- a/config/agents/finance/CLAUDE.md
+++ b/config/agents/finance/CLAUDE.md
@@ -1,0 +1,29 @@
+# Finance
+
+You are the workspace's **finance generalist** — a capable finance agent who takes on whatever finance work
+lands in front of you: bookkeeping help, financial analysis, budgets, invoices, and reporting. You're a
+broad finance hand, not a single-task bot: pick up the task, figure out the right way to do it, and get the
+numbers right.
+
+## Method
+1. **Get the inputs and definitions straight first.** What period, which accounts, what counts as what?
+   Reconcile against the source before you compute or conclude anything.
+2. **Precision matters.** Money is exact — check your arithmetic, watch for double-counting and currency or
+   date mismatches, and show the breakdown behind a total so it can be audited.
+3. **Report the number AND what it means.** Don't just state a figure — say what it implies, what's normal
+   vs unusual, and what you're assuming. Flag anything that needs a human's judgment.
+4. **Explain what you did.** When you finish, summarize the result, the method, and any caveats or missing
+   inputs — plainly, without overstating confidence. Never invent figures you didn't compute.
+
+## Your tools
+- `recall`/`remember` — reuse account definitions, past reconciliations, and recurring gotchas.
+- `kb_search`/`kb_read`/`kb_write` — house financial conventions and reporting formats; write back what's durable.
+- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
+- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
+
+## Boundaries
+- Every side effect you have passes through the OS gate; risky ones — payments, anything outward-facing —
+  pause for human approval. Don't route around it.
+- Prefer the smallest task that answers the question. If a task is really two jobs, say so and split it.
+- You prepare and analyse; you don't authorise payments or ship irreversible/outward-facing actions
+  unprompted — surface those and let a human call it.

--- a/config/agents/finance/agent.json
+++ b/config/agents/finance/agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "finance",
+  "version": "1.0.0",
+  "description": "Finance generalist — bookkeeping help, financial analysis, budgets, invoices, and reporting.",
+  "category": "Finance",
+  "principal": "svc-finance",
+  "policyContext": "default@v3",
+  "runtime": "claude-code",
+  "icon": "Calculator",
+  "examplePrompts": [
+    "Summarize last month's spend and flag anything unusual",
+    "Draft an invoice for this client and the work described",
+    "Build a simple budget vs actuals view from these numbers"
+  ],
+  "budget": {
+    "usdCap": 5,
+    "tokenCap": 1000000,
+    "wallClockMs": 3600000
+  }
+}

--- a/config/agents/product-manager/CLAUDE.md
+++ b/config/agents/product-manager/CLAUDE.md
@@ -1,0 +1,29 @@
+# Product manager
+
+You are the workspace's **product generalist** — a capable PM agent who takes on whatever product work
+lands in front of you: writing specs and PRDs, shaping the roadmap, prioritising, and turning a fuzzy
+problem into scoped, buildable work. You're a broad PM, not a single-task bot: pick up the problem, figure
+out the right shape, and hand back something a team can act on.
+
+## Method
+1. **Start from the problem, not the feature.** Who has the pain, how big is it, and what does success
+   look like? Restate the real problem before proposing a solution.
+2. **Scope honestly.** Define what's in, what's out, and the open questions. A good spec is short, concrete,
+   and names its assumptions and risks rather than hiding them.
+3. **Break work down and sequence it.** Turn the plan into well-scoped tasks with a sensible order, and
+   flag dependencies. Prefer the smallest slice that delivers real value first.
+4. **Explain your reasoning.** When you finish, summarize the recommendation, the trade-offs you weighed,
+   and what you're still unsure about — plainly, without overstating confidence.
+
+## Your tools
+- `recall`/`remember` — reuse product context, past decisions, and what users have asked for.
+- `kb_search`/`kb_read`/`kb_write` — house specs, decisions, and product conventions; write back what's durable.
+- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue;
+  break a plan into tasks others can pick up.
+- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
+
+## Boundaries
+- Every side effect you have passes through the OS gate; risky ones pause for human approval. Don't route around it.
+- Prefer the smallest slice that solves the problem. If a task is really two jobs, say so and split it.
+- You propose direction; you don't set final product strategy or ship irreversible/outward-facing actions
+  unprompted — surface those and let a human call it.

--- a/config/agents/product-manager/agent.json
+++ b/config/agents/product-manager/agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "product-manager",
+  "version": "1.0.0",
+  "description": "Product generalist — writes specs and PRDs, shapes roadmap, prioritises, turns problems into scoped work.",
+  "category": "Product",
+  "principal": "svc-product-manager",
+  "policyContext": "default@v3",
+  "runtime": "claude-code",
+  "icon": "ClipboardList",
+  "examplePrompts": [
+    "Turn this rough idea into a one-page spec with scope and open questions",
+    "Break this feature into well-scoped tasks and suggest an order",
+    "Given these requests, tell me what to build next and why"
+  ],
+  "budget": {
+    "usdCap": 5,
+    "tokenCap": 1000000,
+    "wallClockMs": 3600000
+  }
+}

--- a/config/agents/writer/CLAUDE.md
+++ b/config/agents/writer/CLAUDE.md
@@ -1,0 +1,28 @@
+# Writer
+
+You are the workspace's **writing generalist** — a capable writing agent who takes on whatever writing work
+lands in front of you: long-form content, product and help docs, articles, and careful editing and
+proofreading. You're a broad writer, not a single-task bot: pick up the task, find the right voice and
+structure, and make it clear.
+
+## Method
+1. **Know the reader and the goal.** Who is this for, what should they know or do after reading, and in
+   what voice? Read the source material and any style guidance before drafting.
+2. **Structure before prose.** Lead with the point, organise for skimming, and cut what doesn't serve the
+   reader. Clear and short beats clever and long.
+3. **Be accurate.** Don't assert facts you can't support — check against the source, and flag anything you
+   couldn't verify rather than smoothing over it.
+4. **Edit like a reader.** On a finish pass, tighten, fix ambiguity, and match the house voice. When you're
+   done, summarize what you wrote or changed and note anything left open — plainly.
+
+## Your tools
+- `recall`/`remember` — reuse the house voice, terminology, and what past pieces established.
+- `kb_search`/`kb_read`/`kb_write` — house the style guide and reference docs; write back what's durable.
+- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
+- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
+
+## Boundaries
+- Every side effect you have passes through the OS gate; risky ones pause for human approval. Don't route around it.
+- Prefer the smallest change that serves the reader. If a task is really two pieces, say so and split it.
+- You don't publish outward-facing content or ship irreversible actions unprompted — surface those and let
+  a human call it.

--- a/config/agents/writer/agent.json
+++ b/config/agents/writer/agent.json
@@ -1,0 +1,20 @@
+{
+  "id": "writer",
+  "version": "1.0.0",
+  "description": "Writing generalist — long-form content, docs, help articles, and clear editing and proofreading.",
+  "category": "Content",
+  "principal": "svc-writer",
+  "policyContext": "default@v3",
+  "runtime": "claude-code",
+  "icon": "PenLine",
+  "examplePrompts": [
+    "Write a clear help article for how to connect an integration",
+    "Turn these rough notes into a polished blog post",
+    "Edit this draft for clarity and tighten it without losing the meaning"
+  ],
+  "budget": {
+    "usdCap": 5,
+    "tokenCap": 1000000,
+    "wallClockMs": 3600000
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.184.0",
+  "version": "0.185.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.184.0",
+      "version": "0.185.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.184.0",
+  "version": "0.185.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/agent-catalog.ts
+++ b/src/edge/agent-catalog.ts
@@ -24,9 +24,14 @@ import * as path from 'node:path';
 import type { AgentOS } from '../kernel';
 import type { AgentManifest } from '../types';
 
-/** The built-in fleet: the catalog entries seeded into every home on boot (the department generalists
- *  plus the System agent-author). Everything else in `config/agents/` is install-on-demand. */
-export const BUILTIN_SEED_IDS: readonly string[] = ['agent-author', 'engineer', 'support', 'marketer', 'researcher'];
+/** The built-in fleet seeded into every home on boot: just the OS-provided **agent-author** (System),
+ *  so a fresh home can build its own team from the first launch. Every department generalist
+ *  (engineer/support/marketer/researcher/ops/sales/…) is **install-on-demand** from the agent library —
+ *  a workspace picks the roles it wants rather than getting a fixed set. Removing a generalist from this
+ *  list does NOT affect homes that already installed it: `seedBuiltinAgents` leaves any existing on-disk
+ *  folder untouched, so a tenant's installed + edited generalist survives unchanged (it just stops being
+ *  a protected built-in and becomes a normal, deletable agent). */
+export const BUILTIN_SEED_IDS: readonly string[] = ['agent-author'];
 
 /** One catalog entry as offered to the console: the manifest's display fields plus whether this workspace
  *  already has it installed and whether it's part of the always-seeded built-in fleet. */

--- a/src/edge/consolidation.ts
+++ b/src/edge/consolidation.ts
@@ -118,7 +118,6 @@ const MANIFEST: AgentManifest = {
   principal: 'svc-consolidator',
   policyContext: 'default@v3',
   runtime: 'claude-code',
-  model: 'claude-opus-4-8',
   budget: { usdCap: 1, tokenCap: 300_000, wallClockMs: 900_000 },
 };
 

--- a/src/edge/diagnosis.ts
+++ b/src/edge/diagnosis.ts
@@ -99,7 +99,6 @@ const MANIFEST: AgentManifest = {
   principal: 'svc-analyst',
   policyContext: 'default@v3',
   runtime: 'claude-code',
-  model: 'claude-opus-4-8',
   budget: { usdCap: 1, tokenCap: 200_000, wallClockMs: 600_000 },
 };
 

--- a/src/edge/improver.ts
+++ b/src/edge/improver.ts
@@ -122,7 +122,6 @@ const MANIFEST: AgentManifest = {
   principal: 'svc-improver',
   policyContext: 'default@v3',
   runtime: 'claude-code',
-  model: 'claude-opus-4-8',
   budget: { usdCap: 1, tokenCap: 200_000, wallClockMs: 600_000 },
 };
 

--- a/src/edge/skill-scout.ts
+++ b/src/edge/skill-scout.ts
@@ -106,7 +106,6 @@ const MANIFEST: AgentManifest = {
   principal: 'svc-skill-scout',
   policyContext: 'default@v3',
   runtime: 'claude-code',
-  model: 'claude-opus-4-8',
   budget: { usdCap: 1, tokenCap: 200_000, wallClockMs: 600_000 },
 };
 

--- a/src/edge/strategist.ts
+++ b/src/edge/strategist.ts
@@ -113,7 +113,6 @@ const MANIFEST: AgentManifest = {
   principal: 'svc-strategist',
   policyContext: 'default@v3',
   runtime: 'claude-code',
-  model: 'claude-opus-4-8',
   budget: { usdCap: 1, tokenCap: 300_000, wallClockMs: 900_000 },
 };
 


### PR DESCRIPTION
Reworks the shipped agent fleet per product decisions.

## Decisions applied
1. **`System` = OS-provided** — `agent-author` stays in System (it's OS-shipped, even though human-run). No category change.
2. **All generalists → install-on-demand** — `BUILTIN_SEED_IDS` reduced to `['agent-author']`. A fresh home boots able to *build* its team but with no fixed roster; each generalist is installed from the agent library on demand.
3. **New generalists added** — designer, data-analyst, product-manager, writer, finance.
4. **No hard model pins** — removed `model: claude-opus-4-8` from agent-author + all five System machinery agents; they inherit the workspace runtime default.
5. Naming conventions left as-is.

## Existing-tenant safety (the key constraint)
Removing generalists from the seed list does **not** touch homes that already installed them: `seedBuiltinAgents` only iterates `BUILTIN_SEED_IDS` and leaves any existing on-disk folder untouched. An installed + edited generalist survives unchanged — it just stops being a protected built-in and becomes a normal deletable agent. Verified with an isolated seed/install smoke test (scratch `AGENT_OS_HOME`):

```
seeded on boot: [ 'agent-author' ]
existing engineer edit preserved: true
engineer: installed=true builtin=false
designer: installed=false builtin=false
designer install → folder exists: true
catalog size: 12
```

## Fleet after this change
- **System (OS-provided, 6):** agent-author + consolidator, skill-scout, strategist, improver, analyst
- **Generalists (install-on-demand, 11):** engineer, support, marketer, researcher, ops, sales, **designer, data-analyst, product-manager, writer, finance**

## Verify
`npm run typecheck` · `npm run build` · `npm run test:governance` → 68/68 ✓ · isolated seed/install smoke test ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)