### PR TITLE
feat(secrets): secret_request — agent asks a human to PROVIDE a credential, no session paste (v0.184.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,23 @@ new version heading in the same commit.
 
 ## [0.186.0] — 2026-07-14
 ### Added
-- **`secret_request` — an agent asks a human to PROVIDE a credential, without a paste into the session.**
-  The inverse of `secret_put`: when an agent needs a password/API key/token it does not already have, it
-  now `secret_request`s the KEY (with a reason) instead of prompting the human to paste the raw value into
-  chat — where it would persist in the transcript. The request carries only the key + reason (never a
-  value), posts a `secret.request` card to owner/admins (Inbox + a new **Settings → Secrets → Agent
-  requests** review section), and short-circuits `exists` if the agent can already resolve the key or
-  `duplicate` on an open request. A human fulfils it by typing the value into a password field
-  (`POST /api/secrets/requests/:id/fulfill`): it is sealed straight into the vault under the requesting
-  agent's principal (default — only that agent can `secret_get` it — or tenant-wide `*`) and can be
-  injected into that agent's shell at launch (reusing `secret_assignments`). The value never touches the
-  transcript, the card, or the audit trail; audited `secret.requested` / `secret.request.fulfilled` /
+- **`secret_request` — an agent asks a human about a credential KEY, without a paste into the session.**
+  When an agent needs a password/API key/token, it now `secret_request`s the KEY (with a reason) rather
+  than a human pasting the raw value into chat — where it would persist in the transcript. The request
+  carries only the key + reason (never a value) and **auto-detects two modes** so the agent doesn't have
+  to know which case it's in:
+  - **provide** (the inverse of `secret_put`) — the vault doesn't have the key: a human types the value
+    into a password field (`POST …/fulfill`), sealed into the vault under the requesting agent's principal
+    (default — only that agent can `secret_get` it — or tenant-wide `*`).
+  - **access** — the key already EXISTS but is scoped away from the agent (owned by another agent or a
+    person): a human **grants** access and the existing sealed value is re-scoped to the agent
+    server-side — no value is re-typed or shown. Grant is agent-scoped (not widened to everyone).
+
+  Either mode can also inject the value into the agent's shell at launch (reusing `secret_assignments`),
+  short-circuits `exists` if the agent can already resolve the key or `duplicate` on an open request, and
+  posts a `secret.request` card to owner/admins (Inbox + a new **Settings → Secrets → Agent requests**
+  review section). The value never touches the transcript, the card, or the audit trail; audited
+  `secret.requested` (with `mode`) / `secret.request.fulfilled` / `secret.request.granted` /
   `secret.request.dismissed` by key only. New MCP tool `secret_request`, loopback
   `POST /api/agent/secret/request`, admin routes `GET /api/secrets/requests` +
   `POST /api/secrets/requests/:id/{fulfill,dismiss}`, and `TerminalManager.requestSecret` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.184.0] — 2026-07-14
+### Added
+- **`secret_request` — an agent asks a human to PROVIDE a credential, without a paste into the session.**
+  The inverse of `secret_put`: when an agent needs a password/API key/token it does not already have, it
+  now `secret_request`s the KEY (with a reason) instead of prompting the human to paste the raw value into
+  chat — where it would persist in the transcript. The request carries only the key + reason (never a
+  value), posts a `secret.request` card to owner/admins (Inbox + a new **Settings → Secrets → Agent
+  requests** review section), and short-circuits `exists` if the agent can already resolve the key or
+  `duplicate` on an open request. A human fulfils it by typing the value into a password field
+  (`POST /api/secrets/requests/:id/fulfill`): it is sealed straight into the vault under the requesting
+  agent's principal (default — only that agent can `secret_get` it — or tenant-wide `*`) and can be
+  injected into that agent's shell at launch (reusing `secret_assignments`). The value never touches the
+  transcript, the card, or the audit trail; audited `secret.requested` / `secret.request.fulfilled` /
+  `secret.request.dismissed` by key only. New MCP tool `secret_request`, loopback
+  `POST /api/agent/secret/request`, admin routes `GET /api/secrets/requests` +
+  `POST /api/secrets/requests/:id/{fulfill,dismiss}`, and `TerminalManager.requestSecret` /
+  `secretRequestCard` / `setSecretRequestStatus` / `openSecretRequests`.
+
 ## [0.183.1] — 2026-07-14
 ### Fixed
 - **Flag the System machinery agents as built-in.** The code-provisioned System agents spawned by the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 45 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 46 always-on tools
   + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). KB: `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`. Operator/inbox:
   `ask`/`check_inbox`/`report`/`update`/`notify`/`publish`/`library_list` (session cards are
@@ -235,9 +235,16 @@ Key modules:
   SYNCHRONOUS — the caller BLOCKS until the delegate finishes and resumes with its result, each poll kicking
   the same guarded dispatch so waiting drives the work (and retries a crashed run). An agent `task_create` now
   also dispatches an `autoDispatch` hand-off immediately (parity with the console) instead of waiting for the tick. Secrets
-  (shared credential handoff): `secret_put`/`secret_get`/`secret_list` — an agent stores a password/key
+  (shared credential handoff): `secret_put`/`secret_get`/`secret_list`/`secret_request` — an agent stores a password/key
   tenant-wide under a KEY (approval-gated `secret.put`; value kept out of audit/approval-card/policy args,
-  encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. (Complementary,
+  encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. `secret_request`
+  is the inverse for a credential the agent does NOT have: it ASKS a human to PROVIDE the value (carries
+  only the key + reason, never a value) instead of prompting them to paste the secret into the session
+  transcript — posts a `secret.request` card to owner/admins (Inbox + **Settings → Secrets → Agent
+  requests**); the human types the value into a password field → `POST /api/secrets/requests/:id/fulfill`
+  seals it into the vault under the requesting agent's principal (default; or tenant-wide `*`) and can
+  inject it into that agent's shell; short-circuits `exists`/`duplicate`, audited `secret.requested`/
+  `secret.request.fulfilled`/`secret.request.dismissed` (never the value). (Complementary,
   admin-side: **Settings → Secrets** can *assign* a stored secret to agents — `PUT /api/secrets/agents`,
   the `secret_assignments` table — so it's injected into each assigned agent's shell at launch, the
   central-grant inverse of manifest `shellSecrets`. Injection only, not a `secret_get` grant.) GitHub

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,13 +238,15 @@ Key modules:
   (shared credential handoff): `secret_put`/`secret_get`/`secret_list`/`secret_request` — an agent stores a password/key
   tenant-wide under a KEY (approval-gated `secret.put`; value kept out of audit/approval-card/policy args,
   encrypted at rest), hands the key NAME to another agent, who `secret_get`s it read-once. `secret_request`
-  is the inverse for a credential the agent does NOT have: it ASKS a human to PROVIDE the value (carries
-  only the key + reason, never a value) instead of prompting them to paste the secret into the session
-  transcript — posts a `secret.request` card to owner/admins (Inbox + **Settings → Secrets → Agent
-  requests**); the human types the value into a password field → `POST /api/secrets/requests/:id/fulfill`
-  seals it into the vault under the requesting agent's principal (default; or tenant-wide `*`) and can
-  inject it into that agent's shell; short-circuits `exists`/`duplicate`, audited `secret.requested`/
-  `secret.request.fulfilled`/`secret.request.dismissed` (never the value). (Complementary,
+  is the ASK counterpart for a credential the agent needs — it carries only the key + reason, never a
+  value, so nothing lands in the session transcript, and **auto-detects two modes**: `provide` (the key
+  isn't in the vault → a human types the value into a password field, sealed under the agent's principal
+  or tenant-wide `*`) and `access` (the key EXISTS but is scoped away from the agent → a human GRANTS it;
+  the server re-scopes the existing sealed value to the agent, no re-type, agent-scoped not widened). Posts
+  a `secret.request` card to owner/admins (Inbox + **Settings → Secrets → Agent requests**); resolved via
+  `POST /api/secrets/requests/:id/fulfill` (either mode can also inject into the agent's shell);
+  short-circuits `exists`/`duplicate`, audited `secret.requested` (+`mode`) / `secret.request.fulfilled` /
+  `secret.request.granted` / `secret.request.dismissed` (never the value). (Complementary,
   admin-side: **Settings → Secrets** can *assign* a stored secret to agents — `PUT /api/secrets/agents`,
   the `secret_assignments` table — so it's injected into each assigned agent's shell at launch, the
   central-grant inverse of manifest `shellSecrets`. Injection only, not a `secret_get` grant.) GitHub

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -55,7 +55,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `secret_put` | `POST /api/agent/secret/put` | `TerminalManager.putSecret` | W | shared-scope (`*`) vault write; **approval-gated** (policy `secret.put`, blocks until decided); value NEVER in audit/approval-card/policy args; audited `secret.put` (key only); `updated_by=agent:<id>` |
 | `secret_get` | `POST /api/agent/secret/get` | `TerminalManager.getSecret` | R | returns plaintext to caller; allow+audit (a policy `deny`/`ask` on `secret.get` refuses — reads never hang); audited `secret.get` (key + found, never value) |
 | `secret_list` | `GET /api/agent/secret/list` | `TerminalManager.listSecrets` | R | shared (`*`) secret KEYS + metadata only, never values |
-| `secret_request` | `POST /api/agent/secret/request` | `TerminalManager.requestSecret` + messages | W | the inverse of `secret_put`: an agent that does NOT have a credential **asks a human to provide it**, so the raw value is typed into a secure form instead of pasted into the transcript. Carries only the KEY + reason, never a value. Short-circuits `exists` if the agent can already `getSync` the key, `duplicate` on an open request for the same key+agent (dedup via `json_extract`), else posts a `secret.request` card to owner/admins; audited `secret.requested`. Human fulfils via `POST /api/secrets/requests/:id/fulfill` (owner/admin; seals the value under the requesting agent's principal by default — or tenant-wide `*` — and optionally `setAssignedAgents` to inject it into that agent's shell at launch; VALUE never audited, only key/principal/injected) or dismisses via `POST /api/secrets/requests/:id/dismiss`. Delivery: `secret_get` immediately, or the injected shell env var on the agent's next session |
+| `secret_request` | `POST /api/agent/secret/request` | `TerminalManager.requestSecret` + messages | W | an agent **asks a human about a credential KEY** — carrying only the KEY + reason, never a value, so nothing sensitive hits the transcript. **Auto-detects `mode`:** `provide` (key not in vault → human types the value; the inverse of `secret_put`) or `access` (key EXISTS but scoped away → human grants; the server re-scopes the existing sealed value to the agent, no re-type). Short-circuits `exists` if the agent can already `getSync` the key, `duplicate` on an open request for the same key+agent (dedup via `json_extract`), else posts a `secret.request` card to owner/admins; audited `secret.requested` (+`mode`). Human resolves via `POST /api/secrets/requests/:id/fulfill` (owner/admin): **provide** seals a typed value under the agent's principal (default; or `*`); **access** copies the existing value to the agent's principal (`grantRead`, default on) — agent-scoped, not widened. Both can `setAssignedAgents` to inject into the agent's shell at launch; VALUE never audited (only key/principal/mode/injected). Dismiss via `…/dismiss`. Delivery: `secret_get` immediately, or the injected shell env var next session |
 | `github_refresh` | `POST /api/agent/github/refresh` | `GithubIdentity.forceRefresh` | W | recover a live run whose injected `GH_TOKEN` (the run-as member's ~8h user token) went bad mid-flight. FORCES a refresh now (unlike the launch-time `ensureFresh`, which only fires within the expiry skew) via the stored `ghr_` refresh token, and RETURNS the fresh token so the agent can `export GH_TOKEN=…` (env can't be mutated from outside the process; the git credential helper + `gh` read `$GH_TOKEN` at call time). The token is the run's OWN identity, already injected at launch — no new exposure. Run-as-scoped: resolves the member from the session (`no_member` for company/bot runs). Typed non-ok statuses tell the agent to STOP retrying and have the human re-link GitHub: `not_connected`/`no_refresh_token`/`not_configured`/`failed`. Audited `github.token.refreshed` / `github.token.refresh_failed` (`via:'agent'`, never the token) |
 | `slack_reply` | `POST /api/agent/slack/reply` | SlackSocket | W | only when `SLACK_REPLY=1` (chat-triggered) |
 | `discord_reply` | `POST /api/agent/discord/reply` | DiscordSocket | W | only when `DISCORD_REPLY=1` (chat-triggered) |
@@ -119,18 +119,27 @@ on their linked Slack/Discord (`TerminalManager.setMemberNotifier` → `notifyMe
 It is **one named recipient only** — there is deliberately no team-wide broadcast — and it's
 allow+audit (`member.notified`), no policy gate, same posture as `slack_send`.
 
-### `secret_request` — ask a human to provide a credential (no paste)
+### `secret_request` — ask a human about a credential KEY (no paste)
 
-The inverse of `secret_put`: when an agent needs a credential it does **not** already have, it
-`secret_request`s the KEY (with a reason) rather than asking the human to paste the value into chat —
-where it would land in the transcript. This posts a `secret.request` card to owner/admins (Inbox + a
-**Secrets → Agent requests** review section). The human types the value into a password field; it is
-sealed straight into the vault under the requesting agent's principal (default — only that agent can
-`secret_get` it) or tenant-wide `*`, and can optionally be injected into the agent's shell env at
-launch (reusing `secret_assignments`). The request itself never carries a value, so nothing sensitive
-touches the transcript, audit, or the card. It short-circuits `exists` if the agent can already resolve
-the key, and `duplicate` on an open request for the same key. Delivery to the agent: `secret_get` once
-fulfilled, or the shell env var on its next session if injected.
+When an agent needs a credential, it `secret_request`s the KEY (with a reason) rather than asking a
+human to paste the value into chat — where it would land in the transcript. The request never carries
+a value, so nothing sensitive touches the transcript, audit, or the card. It **auto-detects two modes**
+so the agent doesn't have to know which case it's in, and posts a `secret.request` card to owner/admins
+(Inbox + a **Secrets → Agent requests** review section):
+
+- **provide** — the vault doesn't have the key (the inverse of `secret_put`). The human types the value
+  into a password field; it is sealed under the requesting agent's principal (default — only that agent
+  can `secret_get` it) or tenant-wide `*`.
+- **access** — the key already **exists** in the vault but under a principal this agent can't read
+  (another agent, or a person). The human **grants** access: the server reads the existing sealed value
+  inside the process and writes a copy under the requesting agent's principal (`grantRead`, default on)
+  — the value is never re-typed or shown, and the grant is **agent-scoped**, not widened to everyone.
+
+Either mode can also inject the value into the agent's shell at launch (reusing `secret_assignments`).
+It short-circuits `exists` if the agent can already resolve the key, and `duplicate` on an open request
+for the same key. Delivery: `secret_get` once resolved, or the shell env var on its next session if
+injected. (Caveat, same as the rest of the vault's per-principal model: an access grant copies the
+value, so a later rotation of the source secret does not propagate to the granted copy.)
 
 ### `secret_put` / `secret_get` — the shared credential handoff
 

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -55,6 +55,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `secret_put` | `POST /api/agent/secret/put` | `TerminalManager.putSecret` | W | shared-scope (`*`) vault write; **approval-gated** (policy `secret.put`, blocks until decided); value NEVER in audit/approval-card/policy args; audited `secret.put` (key only); `updated_by=agent:<id>` |
 | `secret_get` | `POST /api/agent/secret/get` | `TerminalManager.getSecret` | R | returns plaintext to caller; allow+audit (a policy `deny`/`ask` on `secret.get` refuses — reads never hang); audited `secret.get` (key + found, never value) |
 | `secret_list` | `GET /api/agent/secret/list` | `TerminalManager.listSecrets` | R | shared (`*`) secret KEYS + metadata only, never values |
+| `secret_request` | `POST /api/agent/secret/request` | `TerminalManager.requestSecret` + messages | W | the inverse of `secret_put`: an agent that does NOT have a credential **asks a human to provide it**, so the raw value is typed into a secure form instead of pasted into the transcript. Carries only the KEY + reason, never a value. Short-circuits `exists` if the agent can already `getSync` the key, `duplicate` on an open request for the same key+agent (dedup via `json_extract`), else posts a `secret.request` card to owner/admins; audited `secret.requested`. Human fulfils via `POST /api/secrets/requests/:id/fulfill` (owner/admin; seals the value under the requesting agent's principal by default — or tenant-wide `*` — and optionally `setAssignedAgents` to inject it into that agent's shell at launch; VALUE never audited, only key/principal/injected) or dismisses via `POST /api/secrets/requests/:id/dismiss`. Delivery: `secret_get` immediately, or the injected shell env var on the agent's next session |
 | `github_refresh` | `POST /api/agent/github/refresh` | `GithubIdentity.forceRefresh` | W | recover a live run whose injected `GH_TOKEN` (the run-as member's ~8h user token) went bad mid-flight. FORCES a refresh now (unlike the launch-time `ensureFresh`, which only fires within the expiry skew) via the stored `ghr_` refresh token, and RETURNS the fresh token so the agent can `export GH_TOKEN=…` (env can't be mutated from outside the process; the git credential helper + `gh` read `$GH_TOKEN` at call time). The token is the run's OWN identity, already injected at launch — no new exposure. Run-as-scoped: resolves the member from the session (`no_member` for company/bot runs). Typed non-ok statuses tell the agent to STOP retrying and have the human re-link GitHub: `not_connected`/`no_refresh_token`/`not_configured`/`failed`. Audited `github.token.refreshed` / `github.token.refresh_failed` (`via:'agent'`, never the token) |
 | `slack_reply` | `POST /api/agent/slack/reply` | SlackSocket | W | only when `SLACK_REPLY=1` (chat-triggered) |
 | `discord_reply` | `POST /api/agent/discord/reply` | DiscordSocket | W | only when `DISCORD_REPLY=1` (chat-triggered) |
@@ -117,6 +118,19 @@ inbox card addressed to that one member (`member` audience → lands in their `m
 on their linked Slack/Discord (`TerminalManager.setMemberNotifier` → `notifyMember` in the registry).
 It is **one named recipient only** — there is deliberately no team-wide broadcast — and it's
 allow+audit (`member.notified`), no policy gate, same posture as `slack_send`.
+
+### `secret_request` — ask a human to provide a credential (no paste)
+
+The inverse of `secret_put`: when an agent needs a credential it does **not** already have, it
+`secret_request`s the KEY (with a reason) rather than asking the human to paste the value into chat —
+where it would land in the transcript. This posts a `secret.request` card to owner/admins (Inbox + a
+**Secrets → Agent requests** review section). The human types the value into a password field; it is
+sealed straight into the vault under the requesting agent's principal (default — only that agent can
+`secret_get` it) or tenant-wide `*`, and can optionally be injected into the agent's shell env at
+launch (reusing `secret_assignments`). The request itself never carries a value, so nothing sensitive
+touches the transcript, audit, or the card. It short-circuits `exists` if the agent can already resolve
+the key, and `duplicate` on an open request for the same key. Delivery to the agent: `secret_get` once
+fulfilled, or the shell env var on its next session if injected.
 
 ### `secret_put` / `secret_get` — the shared credential handoff
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.183.0",
+  "version": "0.184.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.183.0",
+      "version": "0.184.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.183.1",
+  "version": "0.184.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -1090,13 +1090,15 @@ const TOOLS = [
   {
     name: 'secret_request',
     description:
-      'Ask a human to PROVIDE a credential you need but do NOT have — an API key, password, token, or ' +
-      'connection string. Use this INSTEAD of asking the human to paste the secret to you in chat: the raw ' +
-      'value would end up in this transcript. This raises a request card an owner/admin fulfils by typing ' +
-      'the value into a secure form (encrypted at rest, never shown to you unless you secret_get it). You ' +
-      'pass only the KEY name you will fetch it by and why you need it — never a value. Once fulfilled, the ' +
-      'credential is in the vault: secret_get it by that key, or (if they chose to inject it) it is a shell ' +
-      'env var on your next session. First check secret_list — the team may already have it.',
+      'Ask a human about a credential KEY you need — an API key, password, token, or connection string. ' +
+      'Two cases, handled automatically: (1) if the vault does NOT have the key, an owner/admin PROVIDES ' +
+      'it by typing the value into a secure form — use this INSTEAD of asking them to paste the secret to ' +
+      'you in chat, where the raw value would end up in this transcript; (2) if the key already EXISTS in ' +
+      'the vault but you cannot read it (it belongs to another agent or person), an owner/admin GRANTS you ' +
+      'ACCESS and the existing value is re-scoped to you — no one re-types it. Either way you pass only the ' +
+      'KEY name and why you need it, never a value. Once resolved: secret_get it by that key, or (if they ' +
+      'inject it) it is a shell env var on your next session. First check secret_list — you may already ' +
+      'have access.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -2044,10 +2046,11 @@ async function secretRequest(args: Record<string, unknown>): Promise<string> {
     headers: H({ 'content-type': 'application/json' }),
     body: JSON.stringify({ session: SESSION, key, reasoning: args.reasoning != null ? String(args.reasoning) : undefined }),
   });
-  const d = (await res.json()) as { ok?: boolean; status?: string; error?: string };
+  const d = (await res.json()) as { ok?: boolean; status?: string; mode?: string; error?: string };
   if (!d.ok) return `Could not request the secret: ${d.error ?? 'unknown error'}`;
   if (d.status === 'exists') return `"${key}" is already in the vault and available to you — secret_get "${key}".`;
   if (d.status === 'duplicate') return `A request for "${key}" is already awaiting review.`;
+  if (d.mode === 'access') return `Requested ACCESS to "${key}" — it's already in the vault but scoped away from you. An owner/admin will grant you access (the existing value is re-scoped to you; no one re-types it). Once granted, secret_get "${key}", or it'll be a shell env var on your next session if they inject it.`;
   return `Requested "${key}" — an owner/admin will provide it into the vault (they type the value, you never see it pasted here). Once fulfilled, secret_get "${key}", or it'll be a shell env var on your next session if they inject it.`;
 }
 

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -1088,6 +1088,26 @@ const TOOLS = [
     inputSchema: { type: 'object', additionalProperties: false, properties: {} },
   },
   {
+    name: 'secret_request',
+    description:
+      'Ask a human to PROVIDE a credential you need but do NOT have — an API key, password, token, or ' +
+      'connection string. Use this INSTEAD of asking the human to paste the secret to you in chat: the raw ' +
+      'value would end up in this transcript. This raises a request card an owner/admin fulfils by typing ' +
+      'the value into a secure form (encrypted at rest, never shown to you unless you secret_get it). You ' +
+      'pass only the KEY name you will fetch it by and why you need it — never a value. Once fulfilled, the ' +
+      'credential is in the vault: secret_get it by that key, or (if they chose to inject it) it is a shell ' +
+      'env var on your next session. First check secret_list — the team may already have it.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        key: { type: 'string', description: 'The handle you will fetch the credential by — a letter/underscore then letters, digits or underscores, e.g. "STRIPE_API_KEY", "PROD_DB_URL".' },
+        reasoning: { type: 'string', description: 'One line for the human: what this credential is and why you need it (helps them fulfil it quickly).' },
+      },
+      required: ['key'],
+    },
+  },
+  {
     name: 'github_refresh',
     description:
       'Refresh YOUR GitHub token when git/gh suddenly fails with "Bad credentials" or a 401. Your ' +
@@ -2016,6 +2036,21 @@ async function secretList(): Promise<string> {
     rows.map((s) => `• ${s.key}${s.updatedBy ? ` — set by ${s.updatedBy}` : ''}`).join('\n');
 }
 
+async function secretRequest(args: Record<string, unknown>): Promise<string> {
+  const key = String(args.key ?? '').trim();
+  if (!key) return 'secret_request needs the key name of the credential you need, e.g. secret_request({ key: "STRIPE_API_KEY" }).';
+  const res = await fetch(AOS_URL + '/api/agent/secret/request', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({ session: SESSION, key, reasoning: args.reasoning != null ? String(args.reasoning) : undefined }),
+  });
+  const d = (await res.json()) as { ok?: boolean; status?: string; error?: string };
+  if (!d.ok) return `Could not request the secret: ${d.error ?? 'unknown error'}`;
+  if (d.status === 'exists') return `"${key}" is already in the vault and available to you — secret_get "${key}".`;
+  if (d.status === 'duplicate') return `A request for "${key}" is already awaiting review.`;
+  return `Requested "${key}" — an owner/admin will provide it into the vault (they type the value, you never see it pasted here). Once fulfilled, secret_get "${key}", or it'll be a shell env var on your next session if they inject it.`;
+}
+
 // ── Per-member GitHub token refresh: recover a live run whose ~8h GH_TOKEN went bad mid-flight ──────
 async function githubRefresh(): Promise<string> {
   const res = await fetch(AOS_URL + '/api/agent/github/refresh', {
@@ -2323,6 +2358,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'secret_put' ? await secretPut(args)
         : name === 'secret_get' ? await secretGet(args)
         : name === 'secret_list' ? await secretList()
+        : name === 'secret_request' ? await secretRequest(args)
         : name === 'github_refresh' ? await githubRefresh()
         : `unknown tool: ${name}`;
       send({ jsonrpc: '2.0', id, result: { content: [{ type: 'text', text }] } });

--- a/src/server.ts
+++ b/src/server.ts
@@ -4234,16 +4234,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'secret.assigned', data: { secretPrincipal: principal, key, agents } });
     return sendJson(res, 200, { ok: true, agents });
   }
-  // List open agent secret-requests for the Secrets settings review section (owner/admin). These are
-  // agents that ran `secret_request` — asking a human to PROVIDE a credential, without a value in play.
+  // List open agent secret-requests for the Secrets settings review section (owner/admin). Each is an
+  // agent that ran `secret_request`, tagged `mode`: 'provide' (the key isn't in the vault — a human must
+  // enter a value) or 'access' (the key exists but the agent can't read it — a human grants access).
   if (method === 'GET' && p === '/api/secrets/requests') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     return sendJson(res, 200, { requests: tm.openSecretRequests() });
   }
-  // Fulfill an agent's secret.request card (owner/admin): the human types the value into a secure form
-  // (it arrives here, never touches the session transcript), we seal it into the vault under the chosen
-  // principal, optionally inject it into the requesting agent's shell at launch, and mark the card done.
-  // The VALUE is never audited — only the key + who/where.
+  // Fulfill an agent's secret.request card (owner/admin). Two paths keyed by the card's `mode`:
+  //  • provide — the human types the value into a secure form (it arrives here, never touching the
+  //    session transcript); we seal it into the vault under the chosen principal.
+  //  • access — the key already exists under a principal the agent can't read; NO value is typed. We
+  //    re-scope the existing sealed value to the requesting agent server-side (read it via the vault,
+  //    write a copy under the agent's principal) so it can secret_get — the value is never returned.
+  // Either path optionally injects it into the agent's shell at launch. The VALUE is never audited.
   const secretReqFulfill = p.match(/^\/api\/secrets\/requests\/([\w.-]+)\/fulfill$/);
   if (method === 'POST' && secretReqFulfill) {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
@@ -4251,11 +4255,28 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!card) return sendJson(res, 404, { error: 'no such secret request' });
     if (card.status !== 'open') return sendJson(res, 409, { error: 'this request was already resolved' });
     const b = await readBody(req);
+    const inject = b.inject === true || b.inject === 'true';
+    if (card.mode === 'access') {
+      // Grant access to an EXISTING vault secret: find where it lives (any principal but this agent),
+      // resolve its current value inside the process, and copy it under the agent's own principal.
+      const src = os.secrets.list(os.tenant).find((s) => s.key === card.key && s.principal !== card.agent);
+      if (!src) return sendJson(res, 404, { error: `"${card.key}" is no longer in the vault to grant` });
+      const val = os.secrets.getSync(os.tenant, src.principal, card.key);
+      if (val === undefined) return sendJson(res, 404, { error: `could not resolve "${card.key}" to grant` });
+      const grantRead = b.grantRead !== false && b.grantRead !== 'false'; // default: enable secret_get
+      if (grantRead) os.secrets.set(os.tenant, card.key, val, { principal: card.agent, updatedBy: me.email });
+      // Inject reads the owner's value at launch — use the agent's fresh copy if we made one, else the source.
+      if (inject) os.secrets.setAssignedAgents(os.tenant, grantRead ? card.agent : src.principal, card.key, [card.agent]);
+      if (!grantRead && !inject) return sendJson(res, 400, { error: 'grant read access, inject into the shell, or both' });
+      tm.setSecretRequestStatus(secretReqFulfill[1], 'fulfilled');
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'secret.request.granted', data: { key: card.key, from: src.principal, grantedTo: card.agent, read: grantRead, injected: inject } });
+      return sendJson(res, 200, { ok: true, granted: true, injected: inject });
+    }
+    // provide mode: a human-entered value seals into the vault.
     const value = b.value != null ? String(b.value) : '';
     if (!value) return sendJson(res, 400, { error: 'value is required' });
     // Default scope: the requesting agent's own principal (only it can secret_get). `*` = tenant-wide.
     const principal = b.principal ? String(b.principal).trim() : card.agent;
-    const inject = b.inject === true || b.inject === 'true';
     os.secrets.set(os.tenant, card.key, value, { principal, updatedBy: me.email });
     if (inject) os.secrets.setAssignedAgents(os.tenant, principal, card.key, [card.agent]);
     tm.setSecretRequestStatus(secretReqFulfill[1], 'fulfilled');

--- a/src/server.ts
+++ b/src/server.ts
@@ -654,6 +654,21 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     return sendJson(res, 200, { secrets: tm.listSecrets() });
   }
+  // agent ASKS a human to PROVIDE a credential it lacks (`secret_request`) — the inverse of secret/put:
+  // it carries only the KEY + reason, never a value, so the raw secret is typed into a secure form
+  // instead of pasted into the transcript. Posts an owner/admin 'secret.request' card; a human fulfills
+  // it via POST /api/secrets/requests/:id/fulfill. Pre-auth loopback, session-secret gated.
+  if (method === 'POST' && p === '/api/agent/secret/request') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const key = String(b.key || '').trim();
+    if (!ENV_NAME.test(key) || key.length > 64) return sendJson(res, 400, { error: 'key must be a letter/underscore then letters, digits or underscores, ≤64 chars (e.g. STRIPE_API_KEY)' });
+    const out = tm.requestSecret(session, agent, key, b.reasoning != null ? String(b.reasoning) : undefined);
+    return sendJson(res, out.ok ? 200 : 400, out);
+  }
 
   // ── Per-member GitHub token refresh, agent-facing (loopback, session-scoped) ──────────────────────
   // An agent's injected GH_TOKEN is the run-as member's user-to-server token (~8h life). It's refreshed
@@ -4213,6 +4228,45 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.secrets.setAssignedAgents(os.tenant, principal, key, agents);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'secret.assigned', data: { secretPrincipal: principal, key, agents } });
     return sendJson(res, 200, { ok: true, agents });
+  }
+  // List open agent secret-requests for the Secrets settings review section (owner/admin). These are
+  // agents that ran `secret_request` — asking a human to PROVIDE a credential, without a value in play.
+  if (method === 'GET' && p === '/api/secrets/requests') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { requests: tm.openSecretRequests() });
+  }
+  // Fulfill an agent's secret.request card (owner/admin): the human types the value into a secure form
+  // (it arrives here, never touches the session transcript), we seal it into the vault under the chosen
+  // principal, optionally inject it into the requesting agent's shell at launch, and mark the card done.
+  // The VALUE is never audited — only the key + who/where.
+  const secretReqFulfill = p.match(/^\/api\/secrets\/requests\/([\w.-]+)\/fulfill$/);
+  if (method === 'POST' && secretReqFulfill) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const card = tm.secretRequestCard(secretReqFulfill[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such secret request' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this request was already resolved' });
+    const b = await readBody(req);
+    const value = b.value != null ? String(b.value) : '';
+    if (!value) return sendJson(res, 400, { error: 'value is required' });
+    // Default scope: the requesting agent's own principal (only it can secret_get). `*` = tenant-wide.
+    const principal = b.principal ? String(b.principal).trim() : card.agent;
+    const inject = b.inject === true || b.inject === 'true';
+    os.secrets.set(os.tenant, card.key, value, { principal, updatedBy: me.email });
+    if (inject) os.secrets.setAssignedAgents(os.tenant, principal, card.key, [card.agent]);
+    tm.setSecretRequestStatus(secretReqFulfill[1], 'fulfilled');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'secret.request.fulfilled', data: { key: card.key, secretPrincipal: principal, requestedBy: card.agent, injected: inject } });
+    return sendJson(res, 200, { ok: true, injected: inject });
+  }
+  // Dismiss an agent's secret.request card (owner/admin) without providing — marks it resolved.
+  const secretReqReject = p.match(/^\/api\/secrets\/requests\/([\w.-]+)\/dismiss$/);
+  if (method === 'POST' && secretReqReject) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const card = tm.secretRequestCard(secretReqReject[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such secret request' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this request was already resolved' });
+    tm.setSecretRequestStatus(secretReqReject[1], 'rejected');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'secret.request.dismissed', data: { key: card.key, requestedBy: card.agent } });
+    return sendJson(res, 200, { ok: true });
   }
 
   // ── approvals (shared with the console) ──────────────────────────────────────

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -207,7 +207,7 @@ export interface Session {
 
 export interface FeedMessage {
   id: string;
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'host.proposed';
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed';
   sessionId: string;
   agent: string;
   title: string;
@@ -2541,6 +2541,66 @@ export class TerminalManager {
         let a: Record<string, unknown> = {};
         try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate corrupt payload */ }
         return { id: r.id, skill: String(a.skill ?? ''), source: String(a.source ?? 'catalog'), agent: r.agent, rationale: a.rationale ? String(a.rationale) : undefined, createdAt: r.created_at };
+      });
+  }
+
+  /**
+   * Agent asks a human to PROVIDE a credential it needs (the `secret_request` tool) — the inverse of
+   * {@link putSecret}. Where `secret_put` is an agent handing a value it already HAS to the vault,
+   * `secret_request` is an agent that does NOT have the value asking a human to enter it, so the raw
+   * secret is typed into a secure form (encrypted at rest) instead of being pasted into the session
+   * transcript. It never carries a value — only the KEY it wants and why. Short-circuits if the agent
+   * can already resolve that key (it doesn't need to ask) or an identical request is already open, else
+   * posts an owner/admin-addressed 'secret.request' card and audits `secret.requested`. A human fulfills
+   * it via POST /api/secrets/requests/:id/fulfill (which stores the value + optionally injects it). */
+  requestSecret(sessionId: string, agent: string, key: string, reasoning?: string): { ok: boolean; status?: 'requested' | 'exists' | 'duplicate'; error?: string } {
+    const k = (key || '').trim();
+    if (!k) return { ok: false, error: 'a secret key is required' };
+    // Already resolvable for this agent (its own principal or the shared `*`) → no need to ask a human.
+    if (this.os.secrets.getSync(this.os.tenant, agent, k) !== undefined) return { ok: true, status: 'exists' };
+    // Dedupe against an already-open request for the same key from the same agent.
+    const open = this.db
+      .prepare(`SELECT 1 FROM messages WHERE type = 'secret.request' AND status = 'open' AND agent = ? AND json_extract(args, '$.key') = ?`)
+      .get(agent, k);
+    if (open) return { ok: true, status: 'duplicate' };
+    this.addMessage({
+      type: 'secret.request', sessionId, agent,
+      title: `Secret requested — ${k}`,
+      body: (reasoning?.trim() || `${agent} needs the credential "${k}" to continue.`).trim(),
+      status: 'open',
+      args: { key: k, ...(reasoning ? { reasoning } : {}) },
+      // Providing a credential is an owner/admin act — address the request card to the admin tier.
+      audienceKind: 'admins',
+    });
+    this.audit(sessionId, agent, 'secret.requested', { key: k, reasoning });
+    return { ok: true, status: 'requested' };
+  }
+
+  /** Read a 'secret.request' card's payload (for the fulfill/dismiss routes). undefined if not one. */
+  secretRequestCard(id: string): { key: string; agent: string; reasoning?: string; status: string } | undefined {
+    const row = this.db
+      .prepare(`SELECT agent, args, status FROM messages WHERE id = ? AND type = 'secret.request'`)
+      .get<{ agent: string; args: string | null; status: string }>(id);
+    if (!row) return undefined;
+    let a: Record<string, unknown> = {};
+    try { a = row.args ? JSON.parse(row.args) : {}; } catch { /* tolerate a corrupt payload */ }
+    return { key: String(a.key ?? ''), agent: row.agent, reasoning: a.reasoning ? String(a.reasoning) : undefined, status: row.status };
+  }
+
+  /** Mark a 'secret.request' card resolved once a human fulfilled (provided) or dismissed it. */
+  setSecretRequestStatus(id: string, status: 'fulfilled' | 'rejected'): void {
+    this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'secret.request'`).run(status, id);
+  }
+
+  /** Open (unresolved) secret.request cards — the Secrets settings page's agent-request review section. */
+  openSecretRequests(): { id: string; key: string; agent: string; reasoning?: string; createdAt: number }[] {
+    return this.db
+      .prepare(`SELECT id, agent, args, created_at FROM messages WHERE type = 'secret.request' AND status = 'open' ORDER BY created_at DESC`)
+      .all<{ id: string; agent: string; args: string | null; created_at: number }>()
+      .map((r) => {
+        let a: Record<string, unknown> = {};
+        try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate corrupt payload */ }
+        return { id: r.id, key: String(a.key ?? ''), agent: r.agent, reasoning: a.reasoning ? String(a.reasoning) : undefined, createdAt: r.created_at };
       });
   }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2545,62 +2545,74 @@ export class TerminalManager {
   }
 
   /**
-   * Agent asks a human to PROVIDE a credential it needs (the `secret_request` tool) — the inverse of
-   * {@link putSecret}. Where `secret_put` is an agent handing a value it already HAS to the vault,
-   * `secret_request` is an agent that does NOT have the value asking a human to enter it, so the raw
-   * secret is typed into a secure form (encrypted at rest) instead of being pasted into the session
-   * transcript. It never carries a value — only the KEY it wants and why. Short-circuits if the agent
-   * can already resolve that key (it doesn't need to ask) or an identical request is already open, else
-   * posts an owner/admin-addressed 'secret.request' card and audits `secret.requested`. A human fulfills
-   * it via POST /api/secrets/requests/:id/fulfill (which stores the value + optionally injects it). */
-  requestSecret(sessionId: string, agent: string, key: string, reasoning?: string): { ok: boolean; status?: 'requested' | 'exists' | 'duplicate'; error?: string } {
+   * Agent asks a human about a credential KEY it needs (the `secret_request` tool). Auto-detects two
+   * modes so the agent doesn't have to know which case it's in:
+   *   • **provide** — the key isn't in the vault at all: a human types the value into a secure form
+   *     (encrypted at rest) instead of the agent asking them to paste the raw secret into the session
+   *     transcript. The inverse of {@link putSecret} (which is an agent handing over a value it HAS).
+   *   • **access** — the key already EXISTS in the vault but under a principal this agent can't read
+   *     (another agent / a member / a non-shared scope): a human GRANTS access, and the server re-scopes
+   *     the existing sealed value to this agent — no value is ever re-typed or exposed.
+   * Either way it never carries a value — only the KEY and why. Short-circuits if the agent can already
+   * resolve the key (it has access) or an identical request is already open, else posts an owner/admin
+   * 'secret.request' card tagged with the detected `mode` and audits `secret.requested`. A human resolves
+   * it via POST /api/secrets/requests/:id/fulfill. */
+  requestSecret(sessionId: string, agent: string, key: string, reasoning?: string): { ok: boolean; status?: 'requested' | 'exists' | 'duplicate'; mode?: 'provide' | 'access'; error?: string } {
     const k = (key || '').trim();
     if (!k) return { ok: false, error: 'a secret key is required' };
     // Already resolvable for this agent (its own principal or the shared `*`) → no need to ask a human.
     if (this.os.secrets.getSync(this.os.tenant, agent, k) !== undefined) return { ok: true, status: 'exists' };
+    // Detect mode: does the key exist ANYWHERE in the vault (a principal this agent just can't read)?
+    // If so this is an access-grant request; otherwise the vault has nothing and a human must provide it.
+    const inVault = this.os.secrets.list(this.os.tenant).some((s) => s.key === k);
+    const mode: 'provide' | 'access' = inVault ? 'access' : 'provide';
     // Dedupe against an already-open request for the same key from the same agent.
     const open = this.db
       .prepare(`SELECT 1 FROM messages WHERE type = 'secret.request' AND status = 'open' AND agent = ? AND json_extract(args, '$.key') = ?`)
       .get(agent, k);
-    if (open) return { ok: true, status: 'duplicate' };
+    if (open) return { ok: true, status: 'duplicate', mode };
+    const defaultBody = mode === 'access'
+      ? `${agent} is requesting access to the existing credential "${k}".`
+      : `${agent} needs the credential "${k}" to continue.`;
     this.addMessage({
       type: 'secret.request', sessionId, agent,
-      title: `Secret requested — ${k}`,
-      body: (reasoning?.trim() || `${agent} needs the credential "${k}" to continue.`).trim(),
+      title: mode === 'access' ? `Secret access requested — ${k}` : `Secret requested — ${k}`,
+      body: (reasoning?.trim() || defaultBody).trim(),
       status: 'open',
-      args: { key: k, ...(reasoning ? { reasoning } : {}) },
-      // Providing a credential is an owner/admin act — address the request card to the admin tier.
+      args: { key: k, mode, ...(reasoning ? { reasoning } : {}) },
+      // Providing/granting a credential is an owner/admin act — address the card to the admin tier.
       audienceKind: 'admins',
     });
-    this.audit(sessionId, agent, 'secret.requested', { key: k, reasoning });
-    return { ok: true, status: 'requested' };
+    this.audit(sessionId, agent, 'secret.requested', { key: k, mode, reasoning });
+    return { ok: true, status: 'requested', mode };
   }
 
-  /** Read a 'secret.request' card's payload (for the fulfill/dismiss routes). undefined if not one. */
-  secretRequestCard(id: string): { key: string; agent: string; reasoning?: string; status: string } | undefined {
+  /** Read a 'secret.request' card's payload (for the fulfill/dismiss routes). undefined if not one.
+   *  `mode` is 'access' (grant an existing key) or 'provide' (a human enters a new value). */
+  secretRequestCard(id: string): { key: string; agent: string; mode: 'provide' | 'access'; reasoning?: string; status: string } | undefined {
     const row = this.db
       .prepare(`SELECT agent, args, status FROM messages WHERE id = ? AND type = 'secret.request'`)
       .get<{ agent: string; args: string | null; status: string }>(id);
     if (!row) return undefined;
     let a: Record<string, unknown> = {};
     try { a = row.args ? JSON.parse(row.args) : {}; } catch { /* tolerate a corrupt payload */ }
-    return { key: String(a.key ?? ''), agent: row.agent, reasoning: a.reasoning ? String(a.reasoning) : undefined, status: row.status };
+    return { key: String(a.key ?? ''), agent: row.agent, mode: a.mode === 'access' ? 'access' : 'provide', reasoning: a.reasoning ? String(a.reasoning) : undefined, status: row.status };
   }
 
-  /** Mark a 'secret.request' card resolved once a human fulfilled (provided) or dismissed it. */
+  /** Mark a 'secret.request' card resolved once a human fulfilled (provided/granted) or dismissed it. */
   setSecretRequestStatus(id: string, status: 'fulfilled' | 'rejected'): void {
     this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'secret.request'`).run(status, id);
   }
 
   /** Open (unresolved) secret.request cards — the Secrets settings page's agent-request review section. */
-  openSecretRequests(): { id: string; key: string; agent: string; reasoning?: string; createdAt: number }[] {
+  openSecretRequests(): { id: string; key: string; agent: string; mode: 'provide' | 'access'; reasoning?: string; createdAt: number }[] {
     return this.db
       .prepare(`SELECT id, agent, args, created_at FROM messages WHERE type = 'secret.request' AND status = 'open' ORDER BY created_at DESC`)
       .all<{ id: string; agent: string; args: string | null; created_at: number }>()
       .map((r) => {
         let a: Record<string, unknown> = {};
         try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate corrupt payload */ }
-        return { id: r.id, key: String(a.key ?? ''), agent: r.agent, reasoning: a.reasoning ? String(a.reasoning) : undefined, createdAt: r.created_at };
+        return { id: r.id, key: String(a.key ?? ''), agent: r.agent, mode: a.mode === 'access' ? 'access' : 'provide', reasoning: a.reasoning ? String(a.reasoning) : undefined, createdAt: r.created_at };
       });
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3041,9 +3041,10 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
     badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">{resolved || 'review in Skills'}</Badge>
   } else if (m.type === 'secret.request') {
     Icon = KeyRound; iconCls = 'text-amber-600'; highlight = m.status === 'open'
-    const resolved = m.status === 'fulfilled' ? 'provided' : m.status === 'rejected' ? 'dismissed' : ''
-    verb = 'requested a secret'; detail = m.body
-    badge = <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">{resolved || 'provide in Secrets'}</Badge>
+    const isAccess = (m.args as { mode?: string } | undefined)?.mode === 'access'
+    const resolved = m.status === 'fulfilled' ? (isAccess ? 'granted' : 'provided') : m.status === 'rejected' ? 'dismissed' : ''
+    verb = isAccess ? 'requested secret access' : 'requested a secret'; detail = m.body
+    badge = <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">{resolved || (isAccess ? 'grant in Secrets' : 'provide in Secrets')}</Badge>
   } else if (m.type === 'update') {
     Icon = Activity; iconCls = 'text-muted-foreground'
     detail = m.body
@@ -8049,20 +8050,26 @@ function AgentSkillRequestCard({ r, onChanged }: { r: SkillRequest; onChanged: (
   )
 }
 
-/** A single agent secret-request awaiting a human (via `secret_request`). The human types the value into
- *  a password field — it is sealed straight into the vault (default: scoped to the requesting agent, or
- *  tenant-wide), optionally injected into that agent's shell — and never returned or shown to the agent. */
+/** A single agent secret-request awaiting a human (via `secret_request`). Two modes:
+ *  • provide — the key isn't in the vault: type the value into a password field; it is sealed straight
+ *    into the vault (scoped to the requesting agent, or tenant-wide), optionally injected into its shell.
+ *  • access — the key exists but the agent can't read it: GRANT access; the existing value is re-scoped
+ *    to the agent server-side (no value typed or shown), optionally injected into its shell. */
 function AgentSecretRequestCard({ r, agents, onChanged }: { r: SecretRequest; agents: AgentInfo[]; onChanged: () => void }) {
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const [value, setValue] = useState('')
   const [tenantWide, setTenantWide] = useState(false)
   const [inject, setInject] = useState(true)
+  const [grantRead, setGrantRead] = useState(true)
   const knownAgent = agents.some((a) => a.id === r.agent)
-  const provide = async () => {
-    if (!value) return
+  const isAccess = r.mode === 'access'
+  const submit = async () => {
+    if (isAccess ? (!grantRead && !(inject && knownAgent)) : !value) return
     setBusy(true); setHint('')
-    const res = await api.fulfillSecretRequest(r.id, value, { principal: tenantWide ? '*' : r.agent, inject: inject && knownAgent })
+    const res = isAccess
+      ? await api.fulfillSecretRequest(r.id, { grantRead, inject: inject && knownAgent })
+      : await api.fulfillSecretRequest(r.id, { value, principal: tenantWide ? '*' : r.agent, inject: inject && knownAgent })
     setBusy(false)
     if (!res.ok || res.error) return setHint('⚠ ' + (res.error || 'failed'))
     setValue(''); onChanged()
@@ -8081,7 +8088,7 @@ function AgentSecretRequestCard({ r, agents, onChanged }: { r: SecretRequest; ag
           <div className="min-w-0">
             <div className="flex flex-wrap items-center gap-1.5">
               <span className="font-mono text-sm font-medium">{r.key}</span>
-              <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">requested</Badge>
+              <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">{isAccess ? 'access requested' : 'requested'}</Badge>
             </div>
             <div className="mt-1 text-[11px] text-muted-foreground">
               by <span className="font-mono">{r.agent}</span>{r.createdAt ? ` · ${timeAgo(r.createdAt)}` : ''}
@@ -8090,18 +8097,27 @@ function AgentSecretRequestCard({ r, agents, onChanged }: { r: SecretRequest; ag
           </div>
           <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" title="dismiss" disabled={busy} onClick={dismiss}><Trash2 className="h-3.5 w-3.5" /></Button>
         </div>
-        <Input type="password" value={value} disabled={busy} placeholder={`paste the value for ${r.key}`}
-          onChange={(e) => setValue(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') provide() }} />
+        {isAccess
+          ? <p className="text-[11px] text-muted-foreground"><span className="font-mono">{r.key}</span> is already in the vault. Granting re-scopes its existing value to <span className="font-mono">{r.agent}</span> — the value is never re-typed or shown.</p>
+          : <Input type="password" value={value} disabled={busy} placeholder={`paste the value for ${r.key}`}
+              onChange={(e) => setValue(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') submit() }} />}
         <div className="flex flex-wrap items-center gap-3">
-          <label className="flex items-center gap-1 text-[11px] text-muted-foreground" title={`store under the requesting agent (${r.agent}) only, or tenant-wide so any agent can secret_get it`}>
-            <input type="checkbox" checked={tenantWide} disabled={busy} onChange={(e) => setTenantWide(e.target.checked)} />
-            tenant-wide
-          </label>
+          {isAccess
+            ? <label className="flex items-center gap-1 text-[11px] text-muted-foreground" title={`let ${r.agent} secret_get ${r.key} (copies the current value under its principal)`}>
+                <input type="checkbox" checked={grantRead} disabled={busy} onChange={(e) => setGrantRead(e.target.checked)} />
+                allow secret_get
+              </label>
+            : <label className="flex items-center gap-1 text-[11px] text-muted-foreground" title={`store under the requesting agent (${r.agent}) only, or tenant-wide so any agent can secret_get it`}>
+                <input type="checkbox" checked={tenantWide} disabled={busy} onChange={(e) => setTenantWide(e.target.checked)} />
+                tenant-wide
+              </label>}
           <label className="flex items-center gap-1 text-[11px] text-muted-foreground" title={knownAgent ? `also inject ${r.key} into ${r.agent}'s shell env at launch` : `${r.agent} is not a current agent — it can still secret_get the value`}>
             <input type="checkbox" checked={inject} disabled={busy || !knownAgent} onChange={(e) => setInject(e.target.checked)} />
             inject into {r.agent}'s shell
           </label>
-          <Button size="sm" className="ml-auto" disabled={busy || !value} onClick={provide}><Check className="mr-1 h-3.5 w-3.5" />Provide</Button>
+          <Button size="sm" className="ml-auto" disabled={busy || (isAccess ? (!grantRead && !(inject && knownAgent)) : !value)} onClick={submit}>
+            <Check className="mr-1 h-3.5 w-3.5" />{isAccess ? 'Grant' : 'Provide'}
+          </Button>
         </div>
         {hint && <div className="text-xs text-destructive">{hint}</div>}
       </CardContent>
@@ -9550,8 +9566,9 @@ function SecretsSettings({ me, agents }: { me: Member; agents: AgentInfo[] }) {
               <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">{requests.length}</Badge>
             </div>
             <p className="text-[11px] text-muted-foreground">
-              An agent asked (via <span className="font-mono">secret_request</span>) for a credential it needs. Provide the value here —
-              it is <strong>sealed straight into the vault</strong>, never shown to the agent or pasted into its session.
+              An agent asked (via <span className="font-mono">secret_request</span>) for a credential. If the vault doesn't have it,
+              <strong> provide</strong> the value here — sealed straight into the vault, never shown to the agent or pasted into its session.
+              If it already exists but is scoped away from the agent, <strong>grant</strong> access — the existing value is re-scoped, never re-typed.
             </p>
             {requests.map((r) => <AgentSecretRequestCard key={r.id} r={r} agents={agents} onChanged={onRequestResolved} />)}
           </CardContent>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent } from 'react'
-import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, FileCode, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Lightbulb, Moon, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink, Paperclip } from 'lucide-react'
+import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, FileCode, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Lightbulb, Moon, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink, Paperclip, KeyRound } from 'lucide-react'
 import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, Pin, PinOff, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type DirListing, type FileEntry, type FileContent, type Artifact, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -3039,6 +3039,11 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
     const resolved = m.status === 'approved' ? 'installed' : m.status === 'rejected' ? 'dismissed' : ''
     verb = 'requested a skill'; detail = m.body
     badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">{resolved || 'review in Skills'}</Badge>
+  } else if (m.type === 'secret.request') {
+    Icon = KeyRound; iconCls = 'text-amber-600'; highlight = m.status === 'open'
+    const resolved = m.status === 'fulfilled' ? 'provided' : m.status === 'rejected' ? 'dismissed' : ''
+    verb = 'requested a secret'; detail = m.body
+    badge = <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">{resolved || 'provide in Secrets'}</Badge>
   } else if (m.type === 'update') {
     Icon = Activity; iconCls = 'text-muted-foreground'
     detail = m.body
@@ -8044,6 +8049,66 @@ function AgentSkillRequestCard({ r, onChanged }: { r: SkillRequest; onChanged: (
   )
 }
 
+/** A single agent secret-request awaiting a human (via `secret_request`). The human types the value into
+ *  a password field — it is sealed straight into the vault (default: scoped to the requesting agent, or
+ *  tenant-wide), optionally injected into that agent's shell — and never returned or shown to the agent. */
+function AgentSecretRequestCard({ r, agents, onChanged }: { r: SecretRequest; agents: AgentInfo[]; onChanged: () => void }) {
+  const [busy, setBusy] = useState(false)
+  const [hint, setHint] = useState('')
+  const [value, setValue] = useState('')
+  const [tenantWide, setTenantWide] = useState(false)
+  const [inject, setInject] = useState(true)
+  const knownAgent = agents.some((a) => a.id === r.agent)
+  const provide = async () => {
+    if (!value) return
+    setBusy(true); setHint('')
+    const res = await api.fulfillSecretRequest(r.id, value, { principal: tenantWide ? '*' : r.agent, inject: inject && knownAgent })
+    setBusy(false)
+    if (!res.ok || res.error) return setHint('⚠ ' + (res.error || 'failed'))
+    setValue(''); onChanged()
+  }
+  const dismiss = async () => {
+    setBusy(true); setHint('')
+    const res = await api.dismissSecretRequest(r.id)
+    setBusy(false)
+    if (!res.ok || res.error) return setHint('⚠ ' + (res.error || 'failed'))
+    onChanged()
+  }
+  return (
+    <Card className="border-amber-200">
+      <CardContent className="space-y-2 p-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-1.5">
+              <span className="font-mono text-sm font-medium">{r.key}</span>
+              <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">requested</Badge>
+            </div>
+            <div className="mt-1 text-[11px] text-muted-foreground">
+              by <span className="font-mono">{r.agent}</span>{r.createdAt ? ` · ${timeAgo(r.createdAt)}` : ''}
+              {r.reasoning ? <> · <span className="italic">“{r.reasoning}”</span></> : null}
+            </div>
+          </div>
+          <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" title="dismiss" disabled={busy} onClick={dismiss}><Trash2 className="h-3.5 w-3.5" /></Button>
+        </div>
+        <Input type="password" value={value} disabled={busy} placeholder={`paste the value for ${r.key}`}
+          onChange={(e) => setValue(e.target.value)} onKeyDown={(e) => { if (e.key === 'Enter') provide() }} />
+        <div className="flex flex-wrap items-center gap-3">
+          <label className="flex items-center gap-1 text-[11px] text-muted-foreground" title={`store under the requesting agent (${r.agent}) only, or tenant-wide so any agent can secret_get it`}>
+            <input type="checkbox" checked={tenantWide} disabled={busy} onChange={(e) => setTenantWide(e.target.checked)} />
+            tenant-wide
+          </label>
+          <label className="flex items-center gap-1 text-[11px] text-muted-foreground" title={knownAgent ? `also inject ${r.key} into ${r.agent}'s shell env at launch` : `${r.agent} is not a current agent — it can still secret_get the value`}>
+            <input type="checkbox" checked={inject} disabled={busy || !knownAgent} onChange={(e) => setInject(e.target.checked)} />
+            inject into {r.agent}'s shell
+          </label>
+          <Button size="sm" className="ml-auto" disabled={busy || !value} onClick={provide}><Check className="mr-1 h-3.5 w-3.5" />Provide</Button>
+        </div>
+        {hint && <div className="text-xs text-destructive">{hint}</div>}
+      </CardContent>
+    </Card>
+  )
+}
+
 function ProposedSkillCard({ s, onChanged }: { s: SkillSummary; onChanged: () => void }) {
   const [reviewing, setReviewing] = useState(false)
   const [content, setContent] = useState('')
@@ -9442,10 +9507,13 @@ function SecretsSettings({ me, agents }: { me: Member; agents: AgentInfo[] }) {
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const [openRow, setOpenRow] = useState<string | null>(null)
+  const [requests, setRequests] = useState<SecretRequest[]>([])
   const canEdit = me.role === 'owner' || me.role === 'admin'
 
   const refresh = () => api.secrets().then((r) => { if (!r.error) setSecrets(r.secrets); setLoading(false) }).catch(() => setLoading(false))
-  useEffect(() => { refresh() }, [])
+  const loadRequests = () => api.secretRequests().then((r) => setRequests(r.requests ?? [])).catch(() => setRequests([]))
+  useEffect(() => { refresh(); if (canEdit) loadRequests() }, [])
+  const onRequestResolved = () => { loadRequests(); refresh() }
 
   const toggleAgent = async (s: SecretMeta, agentId: string) => {
     const cur = s.agents ?? []
@@ -9473,6 +9541,22 @@ function SecretsSettings({ me, agents }: { me: Member; agents: AgentInfo[] }) {
 
   return (
     <div className="space-y-4">
+      {canEdit && requests.length > 0 && (
+        <Card className="border-amber-200">
+          <CardContent className="space-y-2.5 p-4">
+            <div className="flex items-center gap-2">
+              <KeyRound className="h-4 w-4 text-amber-600" />
+              <h3 className="text-sm font-medium">Agent requests</h3>
+              <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">{requests.length}</Badge>
+            </div>
+            <p className="text-[11px] text-muted-foreground">
+              An agent asked (via <span className="font-mono">secret_request</span>) for a credential it needs. Provide the value here —
+              it is <strong>sealed straight into the vault</strong>, never shown to the agent or pasted into its session.
+            </p>
+            {requests.map((r) => <AgentSecretRequestCard key={r.id} r={r} agents={agents} onChanged={onRequestResolved} />)}
+          </CardContent>
+        </Card>
+      )}
       <Card>
         <CardContent className="space-y-3 p-4">
           <p className="text-sm text-muted-foreground">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -782,8 +782,9 @@ export interface SkillshResp { query: string; hits: SkillshHit[]; error?: string
 export interface SkillRequest { id: string; skill: string; source: string; agent: string; rationale?: string; createdAt: number }
 export interface SkillRequestsResp { requests: SkillRequest[]; error?: string }
 
-/** An agent's `secret_request` awaiting a human to provide the credential value (no value in play here). */
-export interface SecretRequest { id: string; key: string; agent: string; reasoning?: string; createdAt: number }
+/** An agent's `secret_request` awaiting a human. `mode`: 'provide' (enter a new value) or 'access'
+ *  (grant the agent an existing vault key — no value typed). No secret value is ever in play here. */
+export interface SecretRequest { id: string; key: string; agent: string; mode: 'provide' | 'access'; reasoning?: string; createdAt: number }
 export interface SecretRequestsResp { requests: SecretRequest[]; error?: string }
 
 export interface CompanySettings {
@@ -1167,8 +1168,10 @@ export const api = {
   deleteSecret: (key: string, principal?: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/secrets', { key, principal }),
   setSecretAgents: (principal: string, key: string, agents: string[]) => call<{ ok: boolean; agents?: string[]; error?: string }>('PUT', '/api/secrets/agents', { principal, key, agents }),
   secretRequests: () => call<SecretRequestsResp>('GET', '/api/secrets/requests'),
-  fulfillSecretRequest: (id: string, value: string, opts?: { principal?: string; inject?: boolean }) =>
-    call<{ ok: boolean; injected?: boolean; error?: string }>('POST', '/api/secrets/requests/' + encodeURIComponent(id) + '/fulfill', { value, principal: opts?.principal, inject: opts?.inject }),
+  // provide mode: pass the typed `value` (+ optional principal). access (grant) mode: omit `value`,
+  // pass `grantRead` (enable secret_get) and/or `inject`. `inject` applies to both modes.
+  fulfillSecretRequest: (id: string, opts: { value?: string; principal?: string; inject?: boolean; grantRead?: boolean }) =>
+    call<{ ok: boolean; injected?: boolean; granted?: boolean; error?: string }>('POST', '/api/secrets/requests/' + encodeURIComponent(id) + '/fulfill', opts),
   dismissSecretRequest: (id: string) =>
     call<{ ok: boolean; error?: string }>('POST', '/api/secrets/requests/' + encodeURIComponent(id) + '/dismiss'),
   killSwitch: () => call<{ engaged: boolean; reason?: string; updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/kill-switch'),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -466,12 +466,12 @@ export interface AddGoalReq {
 
 export interface Msg {
   id: string
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'host.proposed'
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed'
   sessionId: string
   agent: string
   title: string
   body: string
-  status: 'open' | 'pending' | 'approved' | 'rejected' | 'answered' | 'cancelled'
+  status: 'open' | 'pending' | 'approved' | 'rejected' | 'answered' | 'cancelled' | 'fulfilled'
   approvalId?: string
   capability?: string
   args?: unknown
@@ -781,6 +781,10 @@ export interface SkillshResp { query: string; hits: SkillshHit[]; error?: string
 /** An agent's pending request to have a catalog skill installed (via `skill_request`). */
 export interface SkillRequest { id: string; skill: string; source: string; agent: string; rationale?: string; createdAt: number }
 export interface SkillRequestsResp { requests: SkillRequest[]; error?: string }
+
+/** An agent's `secret_request` awaiting a human to provide the credential value (no value in play here). */
+export interface SecretRequest { id: string; key: string; agent: string; reasoning?: string; createdAt: number }
+export interface SecretRequestsResp { requests: SecretRequest[]; error?: string }
 
 export interface CompanySettings {
   companyMd: string
@@ -1160,6 +1164,11 @@ export const api = {
   setSecret: (key: string, value: string, principal?: string) => call<{ ok: boolean; error?: string }>('POST', '/api/secrets', { key, value, principal }),
   deleteSecret: (key: string, principal?: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/secrets', { key, principal }),
   setSecretAgents: (principal: string, key: string, agents: string[]) => call<{ ok: boolean; agents?: string[]; error?: string }>('PUT', '/api/secrets/agents', { principal, key, agents }),
+  secretRequests: () => call<SecretRequestsResp>('GET', '/api/secrets/requests'),
+  fulfillSecretRequest: (id: string, value: string, opts?: { principal?: string; inject?: boolean }) =>
+    call<{ ok: boolean; injected?: boolean; error?: string }>('POST', '/api/secrets/requests/' + encodeURIComponent(id) + '/fulfill', { value, principal: opts?.principal, inject: opts?.inject }),
+  dismissSecretRequest: (id: string) =>
+    call<{ ok: boolean; error?: string }>('POST', '/api/secrets/requests/' + encodeURIComponent(id) + '/dismiss'),
   killSwitch: () => call<{ engaged: boolean; reason?: string; updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/kill-switch'),
   setKillSwitch: (engaged: boolean, reason?: string, haltSessions?: boolean) => call<{ ok: boolean; engaged: boolean; reason?: string; halted?: number; updatedBy?: string; error?: string }>('POST', '/api/settings/kill-switch', { engaged, reason, haltSessions }),
 


### PR DESCRIPTION
## What

Adds **`secret_request`** — the inverse of `secret_put`. When an agent needs a credential it does **not** already have (an API key, password, token, connection string), it now asks a human to *provide* it, instead of the human pasting the raw secret into the chat — where it would persist in the session transcript, and often the audit.

## Flow

1. Agent calls `secret_request({ key, reasoning })` — carries only the KEY name it'll fetch by and why. Never a value.
   - Short-circuits `exists` if the agent can already `secret_get` the key, `duplicate` on an open request for the same key+agent.
2. Posts a `secret.request` card to owner/admins — visible in the **Inbox** and a new **Settings → Secrets → Agent requests** review section.
3. A human fulfils it by typing the value into a **password field** (`POST /api/secrets/requests/:id/fulfill`):
   - Sealed straight into the vault under the requesting agent's principal by default (only that agent can `secret_get` it), or tenant-wide `*`.
   - Optional **inject into the agent's shell** at launch (reuses `secret_assignments`) — best for a plain CLI like `gh`/`psql`.
4. Delivery: `secret_get` once fulfilled, or the shell env var on the agent's next session if injected.

The value **never** touches the transcript, the request card, or the audit trail. Audited `secret.requested` / `secret.request.fulfilled` / `secret.request.dismissed` — by key/principal/injected only, never the value.

## Surface

- **MCP tool** `secret_request` (`src/memory/memory-mcp.ts`) — +1 always-on tool.
- **Loopback** `POST /api/agent/secret/request` (`src/server.ts`).
- **Admin routes** `GET /api/secrets/requests`, `POST /api/secrets/requests/:id/fulfill`, `POST /api/secrets/requests/:id/dismiss`.
- **`TerminalManager`** `requestSecret` / `secretRequestCard` / `setSecretRequestStatus` / `openSecretRequests` (`src/terminal.ts`).
- **Web** `secret.request` inbox card + `AgentSecretRequestCard` fulfil form on the Secrets settings page (`web/src/App.tsx`, `web/src/lib/api.ts`).
- Docs: `docs/agent-mcp-tools.md`, `CLAUDE.md`.

Mirrors the existing `skill_request` pattern end to end.

## Validation

- `npm run typecheck` + `npm run build` + `cd web && npm run build` — clean.
- `npm run test:governance` — **68/68**.
- Isolated in-process test of the request → fulfil → `secret_get` round-trip (scratch `AGENT_OS_HOME`): **12/12**, covering principal scoping (agent-scoped hidden from other agents; tenant-wide shared), dedup, `exists`/`duplicate` short-circuits, and card lifecycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)