### PR TITLE
fix(agents): deny native AskUserQuestion — it hangs unattended runs (v0.193.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.195.1] — 2026-07-14
+### Fixed
+- **Agents can no longer hang a run on the native `AskUserQuestion` picker.** Claude's built-in
+  `AskUserQuestion` tool renders an interactive multiple-choice prompt in the terminal TUI and blocks the
+  turn until someone presses Enter at the keyboard — but an Agent OS run has no human at the terminal
+  (chat/automation/task/Slack runs are unattended). So an agent that reached for it (e.g. asked to "ask a
+  question") would **hang forever**: no turn output, nothing in the Inbox, a stuck pane — and in the new
+  Chat surface it looked like the question tool "wasn't rendering." The launcher now **denies
+  `AskUserQuestion`** (`terminal/claude-launch.sh`; deny rules apply even under
+  `--dangerously-skip-permissions`), and the operating notes steer agents to **`ask_human`** (governed →
+  Inbox card + DM, blocks for the reply) or plain prose — both work in every surface, including Chat.
+  This was a latent bug for all unattended runs, surfaced by the Chat work. (`terminal/claude-launch.sh`,
+  `src/terminal.ts`.)
+
 ## [0.195.0] — 2026-07-14
 ### Fixed
 - **Plain-text links in the terminal are now clickable — no scheme needed, and OSC-8 markdown links work

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.195.0",
+  "version": "0.195.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.195.0",
+      "version": "0.195.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.195.0",
+  "version": "0.195.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -78,7 +78,9 @@ into this prompt — you must reach for it:
 ## Talking to the human — use the Inbox, not just the terminal
 Your terminal output may not be read. The operator lives in the Inbox:
 - \`ask\` when you're blocked on a judgement only the human can make — it waits for their reply. Prefer
-  asking over guessing on anything risky or ambiguous.
+  asking over guessing on anything risky or ambiguous. This is the ONLY way to ask a person here: there
+  is no human at your terminal, so a native multiple-choice/interactive prompt just hangs unanswered —
+  always use \`ask\` (or plain text if you're in a chat), never an interactive picker.
 - \`report\` exactly once when you finish, with the outcome and a one-line summary, so the result is
   visible without anyone reading the terminal. If the task taught you something durable, pass it in
   \`lessons\` — it's saved to your memory as a note to your future self.

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -71,7 +71,13 @@ STATUSLINE="$(dirname "$HOOK")/statusline.js"
 # under it and a deny would block the agent reading its OWN files — so we deny only crown-jewel
 # paths that never overlap the agent folder.
 H="${HOME#/}"
-DENYS="\"Read(//$H/.ssh/**)\", \"Read(//$H/.aws/**)\", \"Read(//$H/.gnupg/**)\", \"Read(//$H/.claude/**)\""
+# Deny the native AskUserQuestion tool: it renders a multiple-choice picker in the TUI and BLOCKS the
+# turn until someone presses Enter at the keyboard — but an Agent OS run has no human at the terminal
+# (chat/automation/task/Slack runs are unattended; even an attached session interacts via the console).
+# So it hangs the run forever and never reaches the Inbox. Denied here, the agent asks via `ask_human`
+# (governed → Inbox card + DM, blocks for the answer) or in plain prose — both work everywhere. (deny
+# rules apply even under --dangerously-skip-permissions.)
+DENYS="\"AskUserQuestion\", \"Read(//$H/.ssh/**)\", \"Read(//$H/.aws/**)\", \"Read(//$H/.gnupg/**)\", \"Read(//$H/.claude/**)\""
 DATA_HOME="$(cd "$AGENT_DIR/../.." 2>/dev/null && pwd)"
 if [ -n "$DATA_HOME" ]; then
   DH="${DATA_HOME#/}"


### PR DESCRIPTION
## Root cause (diagnosed live on instapods)
Asked to "ask a test question," the engineer agent called Claude's **native `AskUserQuestion`** tool, which renders an interactive multiple-choice picker **in the terminal TUI**:
```
❯ 1. Option A   2. Option B   3. Type something.   4. Chat about this
   Enter to select · ↑/↓ to navigate · Esc to cancel
```
An Agent OS run has **no human at the terminal** (chat/automation/task/Slack are unattended). So the turn blocks forever waiting for a keypress: no assistant output (→ nothing in `/conversation`), and the native tool **never touches the Inbox** (→ nothing for the chat's question card to render). It looked like the "ask tool wasn't rendering"; really the agent picked a TUI-only tool incompatible with a governed/remote session. Confirmed by capturing the live pane stuck on the picker — and stuck panes were piling up.

## Fix
- **Deny `AskUserQuestion`** in `terminal/claude-launch.sh` (added to `permissions.deny`; deny rules apply even under `--dangerously-skip-permissions`, unlike `allow`).
- **Steer agents to `ask_human`** in the operating notes — the governed equivalent that posts an Inbox card + DM, blocks for the reply, and renders as an answerable card in Chat. Plain-text questions also work (a normal chat bubble).

This is a **latent bug for every unattended run**, not just Chat — any automation/task/Slack agent that reached for `AskUserQuestion` would hang identically. Surfaced by the Chat work.

## Verified
- `npm run typecheck` + build ✓ · `npm run test:governance` → 68/68 ✓ · deny JSON shape validated
- **Live smoke on instapods to follow after merge**: start "ask a test question" and confirm the agent asks via `ask_human`/prose (renders + answerable) instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)