### PR TITLE
fix(sessions): persist list filters across navigation (v0.195.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.196.1] — 2026-07-14
+### Fixed
+- **Sessions filters now survive leaving the page and coming back.** The sessions list's filters
+  (status / agent / source / mode / owner / search / My-All / sort) were mirrored only to the URL hash
+  query — a refresh or deep-link restored them, but clicking the sidebar's **Sessions** link routes to a
+  bare `#/sessions` with no query, so every filter snapped back to its default. They're now also mirrored
+  to `localStorage` (`aos_sessions_filters`) on every change and seeded from there when the URL carries no
+  query, so the last-used filter is restored when you navigate away and return. (`web/src/App.tsx`.)
+
 ## [0.196.0] — 2026-07-14
 ### Added
 - **Apps — hosting core (first slice).** The foundation for hosting small server-side apps (a mini-CRM,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.196.0",
+  "version": "0.196.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.196.0",
+      "version": "0.196.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.196.0",
+  "version": "0.196.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -158,7 +158,15 @@ const compareSessions = (a: Session, b: Session, key: SessionSortKey): number =>
 }
 
 /** The sessions-list view state (filters + sort), held in the URL hash query so it survives a
- *  refresh / deep-link. */
+ *  refresh / deep-link, AND mirrored to localStorage so it survives navigating away and back via the
+ *  sidebar's "Sessions" link (which routes to a bare `#/sessions` with no query). */
+const SESSIONS_FILTER_KEY = 'aos_sessions_filters'
+/** The query string to seed the sessions filters from: prefer an explicit URL query (a refresh /
+ *  deep-link / same-route nav preserves it), else the last-used filters saved in localStorage. */
+const seedSessionFilterQuery = (urlQuery: string): string => {
+  if (urlQuery) return urlQuery
+  try { return localStorage.getItem(SESSIONS_FILTER_KEY) ?? '' } catch { return '' }
+}
 interface SessionFilters { q: string; status: SessionStatusFilter; agent: string; source: 'all' | SessionSource; mode: SessionModeFilter; owner: string; mine: boolean; sortKey: SessionSortKey; sortDir: SortDir }
 const parseSessionFilters = (qs: string): SessionFilters => {
   const p = new URLSearchParams(qs)
@@ -2226,8 +2234,11 @@ function SessionsPage({
 
   // Filters (client-side over the already-fetched list). Search spans title/agent/id/task/starter;
   // status/agent/source/owner narrow by dimension. All default to "show everything". Seeded ONCE from
-  // the URL hash query (so a refresh / deep-link restores them) and mirrored back on every change.
-  const seed = useRef(parseSessionFilters(urlQuery)).current
+  // the URL hash query (so a refresh / deep-link restores them) — or, when the URL carries none (e.g.
+  // arriving via the sidebar's bare `#/sessions` link), from the last-used filters in localStorage —
+  // and mirrored back to both on every change.
+  const seedQs = useRef(seedSessionFilterQuery(urlQuery)).current
+  const seed = useRef(parseSessionFilters(seedQs)).current
   const [query, setQuery] = useState(seed.q)
   const [statusFilter, setStatusFilter] = useState<SessionStatusFilter>(seed.status)
   const [agentFilter, setAgentFilter] = useState(seed.agent)
@@ -2241,7 +2252,7 @@ function SessionsPage({
   // automation-fired run they're entitled to, and the toggle is hidden for them anyway). An explicit
   // `?mine=` in the URL wins over the default, so a deliberate choice survives a refresh / deep-link.
   const isFleetViewer = me.role === 'owner' || me.role === 'admin'
-  const seedMineParam = useRef(new URLSearchParams(urlQuery).get('mine')).current
+  const seedMineParam = useRef(new URLSearchParams(seedQs).get('mine')).current
   const [mine, setMine] = useState(seedMineParam === null ? isFleetViewer : seedMineParam === '1')
   const [sortKey, setSortKey] = useState<SessionSortKey>(seed.sortKey)
   const [sortDir, setSortDir] = useState<SortDir>(seed.sortDir)
@@ -2249,6 +2260,9 @@ function SessionsPage({
     const params = sessionFiltersToParams({ q: query, status: statusFilter, agent: agentFilter, source: sourceFilter, mode: modeFilter, owner: ownerFilter, mine, sortKey, sortDir })
     if (mine !== isFleetViewer) params.mine = mine ? '1' : '0' // only persist a deviation from the per-viewer default
     onFiltersChange(params)
+    // Also mirror to localStorage so the choice survives leaving the page and returning via the bare
+    // `#/sessions` sidebar link (which carries no query). Empty = defaults, which seeds cleanly next time.
+    try { localStorage.setItem(SESSIONS_FILTER_KEY, new URLSearchParams(params).toString()) } catch { /* storage unavailable */ }
     // onFiltersChange is a stable replaceState wrapper; depending on the filter/sort values only is intentional.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query, statusFilter, agentFilter, sourceFilter, modeFilter, ownerFilter, mine, sortKey, sortDir])


### PR DESCRIPTION
## What

The sessions list's filters (status / agent / source / mode / owner / search / My-All toggle / sort) were mirrored only to the URL hash query. A refresh or deep-link restored them, but the sidebar's **Sessions** link routes to a bare `#/sessions` with **no** query — so every filter snapped back to its default when you navigated away and clicked back in.

## Change

`web/src/App.tsx`:
- New `SESSIONS_FILTER_KEY` (`aos_sessions_filters`) + `seedSessionFilterQuery(urlQuery)` helper: prefer an explicit URL query, else fall back to the last-used filters saved in localStorage.
- `SessionsPage` seeds `seed` / `seedMineParam` / the `mine` toggle through that helper.
- The existing mirror effect (URL replaceState on every filter change) now also writes the same param bag to localStorage. Empty/default = empty string, so a cleared view seeds cleanly next time. Storage access is try/caught for blocked-storage contexts.

Net: choose a filter → navigate away → click **Sessions** → the filter is restored.

Web-only change (served off disk from `web/dist`); no server restart needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)