### PR TITLE
feat(chat): ask_human choices → buttons; Chat nav pinnable+Beta; new-chat layout (v0.196.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.196.2] — 2026-07-14
+### Added
+- **`ask_human` can offer one-click choices.** The tool takes an optional `options` list (up to 8); the
+  question then renders as **clickable buttons** in the human's Inbox and in Chat, and their reply is the
+  option they pick (they can still type a different answer). This is the governed, works-everywhere
+  answer to Claude's native multiple-choice picker (which is denied — it hangs unattended runs, v0.195.1):
+  same delightful UX, real tool result, no native-tool interception. (`src/memory/memory-mcp.ts`,
+  `src/server.ts` `/api/ask`, `src/terminal.ts` `askQuestion` → message `args.options`, `web/src/App.tsx`
+  Chat + Inbox question cards.) Also folds the siteboon/claudecodeui (Agent SDK `canUseTool` +
+  interactive-tool bridge) findings into `docs/sdk-chat-runtime-plan.md`.
+### Changed
+- **Chat is now a pinnable nav item, hidden by default, tagged Beta.** Moved out of the hardwired sidebar
+  into the pin-customizable nav (not in the default pin set) — it lives under **Manage** until a member
+  pins it to Main, so the console isn't cluttered for people who don't use it — and carries a small
+  **Beta** badge. (`web/src/App.tsx`.)
+- **New-chat screen no longer buries the message box.** With many agents the composer was pushed off the
+  bottom of the screen. The agent list now scrolls in a capped area while the heading and the message box
+  stay fixed and visible, plus a filter box appears when there are more than six agents. (`web/src/App.tsx`.)
+
 ## [0.196.1] — 2026-07-14
 ### Fixed
 - **Sessions filters now survive leaving the page and coming back.** The sessions list's filters

--- a/docs/sdk-chat-runtime-plan.md
+++ b/docs/sdk-chat-runtime-plan.md
@@ -87,3 +87,35 @@ Chat page ──SSE── /api/chat/stream ──▶ SdkChatRuntime (new)
 v1 (hardened, transcript-driven) stays shippable and is the fallback. v2 swaps the **driver** and
 **display source** under the same Chat page and the same gateway; the page, the approval cards, and the
 session model are largely reused.
+
+## Reference implementation — siteboon/claudecodeui (now "CloudCLI")
+
+The closest open prior art, and worth reading before building (AGPL-3.0 — **study the pattern, don't
+fork/embed the code**; the network-copyleft clause would reach our hosted multi-tenant service). It
+rebranded to CloudCLI and **rewrote itself onto the Agent SDK** (`query()` + `canUseTool`) — independent
+validation of this plan. Concrete lessons to carry over:
+
+- **The bridge shape (server):** one `canUseTool(toolName, input, ctx)` choke point that short-circuits
+  against allow/deny lists, else mints a `requestId`, pushes a `permission_request` frame to the browser,
+  and `await`s a `pendingApprovals` promise resolved by the browser's response — returning SDK-native
+  `{ behavior: 'allow', updatedInput }` or `{ behavior: 'deny', message }`. This is exactly our
+  gateway→approval suspend/resume, expressed as an SDK callback. (`server/claude-sdk.js`.)
+- **Interactive tools resolved through the SAME callback:** `AskUserQuestion` / `ExitPlanMode` are kept in
+  a `TOOLS_REQUIRING_INTERACTION` set and answered by returning an **edited `updatedInput`** (the chosen
+  answers) with an **indefinite (no-timeout) wait**, rendered as clickable option buttons. So the native
+  multiple-choice picker becomes a web multiple-choice instead of a hang.
+- **The caveat that matters most for us:** in `auto`/`bypassPermissions` permission modes the SDK
+  **skips `canUseTool` entirely** — interactive tools must instead be caught by a **PreToolUse hook**
+  (which runs before the mode check). **Agent OS already has that gate hook**, so we are actually better
+  positioned than a pure-SDK app: our existing PreToolUse choke point can bridge interactive tools even
+  under skip-permissions.
+- **Reconnect resilience:** replay pending permission requests (by sequence number) on WS reconnect so an
+  in-flight approval survives a page refresh — adopt for the SSE/WS layer.
+
+### Stepping stone already shipped (v1.5)
+
+Rather than intercept Claude's native `AskUserQuestion` (denied fleet-wide — it hangs unattended runs;
+see CHANGELOG v0.195.1), Agent OS's own **`ask_human` now takes an optional `options[]`** that renders as
+one-click buttons in the Inbox and Chat (the human's reply is the option they pick). This delivers the
+multiple-choice UX through a governed tool with a real result — no native-tool interception, no hook
+hackery — and is the pattern the SDK runtime will generalize via `canUseTool`/`updatedInput`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.196.1",
+  "version": "0.196.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.196.1",
+      "version": "0.196.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.196.1",
+  "version": "0.196.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -445,6 +445,7 @@ const TOOLS = [
       properties: {
         question: { type: 'string', description: 'A specific, self-contained question.' },
         to: { type: 'string', description: 'Optional. A teammate to ask instead of the operator — their name or email (e.g. "Alex Rivera" or "alex@acme.com"). Omit to ask the human who owns this run.' },
+        options: { type: 'array', items: { type: 'string' }, description: 'Optional. A short list of choices for a multiple-choice question — they render as one-click buttons in the human\'s Inbox/Chat, and their reply is the option they pick. Use this instead of a native picker when the answer is one of a few known choices (e.g. ["Ship it", "Hold", "Let me look first"]); omit for an open question.' },
       },
       required: ['question'],
     },
@@ -1157,10 +1158,14 @@ async function ask(args: Record<string, unknown>): Promise<string> {
   const question = String(args.question ?? '').trim();
   if (!question) return 'No question provided.';
   const to = args.to ? String(args.to).trim() : undefined;
+  // Optional multiple-choice: a short list of string choices → one-click buttons in the human's card.
+  const options = Array.isArray(args.options)
+    ? args.options.map((o) => String(o).trim()).filter(Boolean).slice(0, 8)
+    : undefined;
   const res = await fetch(AOS_URL + '/api/ask', {
     method: 'POST',
     headers: H({ 'content-type': 'application/json' }),
-    body: JSON.stringify({ session: SESSION, agent: AGENT, question, to: to || undefined }),
+    body: JSON.stringify({ session: SESSION, agent: AGENT, question, to: to || undefined, options: options?.length ? options : undefined }),
   });
   const posted = (await res.json()) as { id?: string; error?: string; to?: string };
   if (posted.error) return `Could not ask: ${posted.error}`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -883,7 +883,10 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const question = String(b.question || '').trim();
     if (!question) return sendJson(res, 400, { error: 'question is required' });
     const to = b.to ? String(b.to).trim() : undefined;
-    const out = tm.askQuestion(session, agent, question, to);
+    const options = Array.isArray(b.options)
+      ? (b.options as unknown[]).map((o) => String(o).trim()).filter(Boolean).slice(0, 8)
+      : undefined;
+    const out = tm.askQuestion(session, agent, question, to, options?.length ? options : undefined);
     return sendJson(res, out.error ? 400 : 200, out);
   }
   const askMatch = p.match(/^\/api\/ask\/([\w-]+)$/);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2192,7 +2192,7 @@ export class TerminalManager {
    * "ask a teammate for info / a confirmation" channel — and both the inbox card and the DM target them,
    * and {@link canViewQuestion} grants them the answer. Returns `{ error }` when `to` matches no member.
    */
-  askQuestion(sessionId: string, agent: string, prompt: string, to?: string): { id?: string; error?: string; to?: string } {
+  askQuestion(sessionId: string, agent: string, prompt: string, to?: string, options?: string[]): { id?: string; error?: string; to?: string } {
     let target: Member | undefined;
     if (to && to.trim()) {
       target = this.resolveMember(to);
@@ -2205,7 +2205,9 @@ export class TerminalManager {
     // Card audience: the addressed teammate when `to` is set, else the session operator.
     const audienceKind = target ? 'member' : 'sessionOwner';
     const audienceId = target ? target.id : sessionId;
-    this.addMessage({ type: 'question', sessionId, agent, title: `Question — ${agent}`, body: prompt, status: 'pending', questionId: id, audienceKind, audienceId });
+    // Multiple-choice options (if any) ride along in the message args → the card renders one-click buttons.
+    const cleanOptions = options?.map((o) => o.trim()).filter(Boolean).slice(0, 8);
+    this.addMessage({ type: 'question', sessionId, agent, title: `Question — ${agent}`, body: prompt, status: 'pending', questionId: id, audienceKind, audienceId, ...(cleanOptions?.length ? { args: { options: cleanOptions } } : {}) });
     this.audit(sessionId, agent, 'question.asked', { questionId: id, prompt, ...(target ? { to: target.id } : {}) });
     // Out-of-band ping (like approvals): DM the person the run acts for — or the addressed teammate — so a
     // blocking `ask` doesn't sit unseen in the console. And if the run was triggered from chat, mirror the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -706,9 +706,10 @@ function UpdateNotice() {
  *  this list; Sessions is the middle switcher; Feedback is an external link. `route` drives active
  *  state; `adminOnly` hides the item entirely from members who can't view that page (so they can't pin
  *  what they can't see). Order here is the canonical order items render in, whether in Main or Manage. */
-type NavKey = 'goals' | 'tasks' | 'artifacts' | 'automations' | 'kb' | 'memory' | 'insights' | 'skills' | 'connectors' | 'team' | 'files' | 'audit' | 'settings' | 'docs'
-interface NavMeta { key: NavKey; route: Route; label: string; icon: ReactNode; adminOnly?: boolean }
+type NavKey = 'chat' | 'goals' | 'tasks' | 'artifacts' | 'automations' | 'kb' | 'memory' | 'insights' | 'skills' | 'connectors' | 'team' | 'files' | 'audit' | 'settings' | 'docs'
+interface NavMeta { key: NavKey; route: Route; label: string; icon: ReactNode; adminOnly?: boolean; beta?: boolean }
 const PINNABLE_NAV: NavMeta[] = [
+  { key: 'chat',        route: 'chat',        label: 'Chat',        icon: <MessageSquare className="h-4 w-4" />, beta: true },
   { key: 'goals',       route: 'goals',       label: 'Goals',       icon: <Target className="h-4 w-4" /> },
   { key: 'tasks',       route: 'tasks',       label: 'Tasks',       icon: <ListChecks className="h-4 w-4" /> },
   { key: 'artifacts',   route: 'artifacts',   label: 'Library',     icon: <Package className="h-4 w-4" /> },
@@ -1072,7 +1073,6 @@ function Console({ me }: { me: Member }) {
             {me.role === 'owner' && <Button render={<a href={navHref('overview')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'overview' ? 'text-primary' : 'text-muted-foreground'}`} title="Overview" onClick={onNavClick(() => nav('overview'))}><LayoutGrid className="h-4 w-4" /></Button>}
             <Button render={<a href={navHref('inbox')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'inbox' ? 'text-primary' : 'text-muted-foreground'}`} title="Inbox" onClick={onNavClick(() => nav('inbox'))}><InboxIcon className="h-4 w-4" /></Button>
             <Button render={<a href={navHref('agents')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'agents' || route === 'agent' ? 'text-primary' : 'text-muted-foreground'}`} title="Agents" onClick={onNavClick(() => nav('agents'))}><Bot className="h-4 w-4" /></Button>
-            <Button render={<a href={navHref('chat')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'chat' ? 'text-primary' : 'text-muted-foreground'}`} title="Chat" onClick={onNavClick(() => nav('chat'))}><MessageSquare className="h-4 w-4" /></Button>
             {pinnedNav.map((n) => (
               <Button key={n.key} render={<a href={navHref(n.route)} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === n.route ? 'text-primary' : 'text-muted-foreground'}`} title={n.label} onClick={onNavClick(() => nav(n.route))}>{n.icon}</Button>
             ))}
@@ -1099,9 +1099,8 @@ function Console({ me }: { me: Member }) {
             {me.role === 'owner' && <NavItem icon={<LayoutGrid className="h-4 w-4" />} label="Overview" active={route === 'overview'} href={navHref('overview')} onClick={() => nav('overview')} />}
             <NavItem icon={<InboxIcon className="h-4 w-4" />} label="Inbox" active={route === 'inbox'} badge={pendingApprovals || undefined} href={navHref('inbox')} onClick={() => nav('inbox')} />
             <NavItem icon={<Bot className="h-4 w-4" />} label="Agents" active={route === 'agents' || route === 'agent'} href={navHref('agents')} onClick={() => nav('agents')} />
-            <NavItem icon={<MessageSquare className="h-4 w-4" />} label="Chat" active={route === 'chat'} href={navHref('chat')} onClick={() => nav('chat')} />
             {pinnedNav.map((n) => (
-              <NavItem key={n.key} icon={n.icon} label={n.label} active={route === n.route} href={navHref(n.route)} onClick={() => nav(n.route)} pinned onTogglePin={() => togglePin(n.key)} />
+              <NavItem key={n.key} icon={n.icon} label={n.label} beta={n.beta} active={route === n.route} href={navHref(n.route)} onClick={() => nav(n.route)} pinned onTogglePin={() => togglePin(n.key)} />
             ))}
           </nav>
         </div>
@@ -1157,7 +1156,7 @@ function Console({ me }: { me: Member }) {
           {manageOpen && (
             <nav className="mb-1 space-y-1">
               {manageNav.map((n) => (
-                <NavItem key={n.key} icon={n.icon} label={n.label} active={route === n.route} href={navHref(n.route)} onClick={() => nav(n.route)} pinned={false} onTogglePin={() => togglePin(n.key)} />
+                <NavItem key={n.key} icon={n.icon} label={n.label} beta={n.beta} active={route === n.route} href={navHref(n.route)} onClick={() => nav(n.route)} pinned={false} onTogglePin={() => togglePin(n.key)} />
               ))}
               <a
                 href={FEEDBACK_URL}
@@ -1430,7 +1429,7 @@ function NotificationsBell({ items, unread, onOpen, onMarkAllRead, onOpenSetting
 /** A sidebar nav row. When `onTogglePin` is provided the row grows a hover-only pin button on the
  *  right — `pinned` items show "unpin" (send down to Manage), unpinned ones show "pin" (promote to
  *  Main). The button lives above the anchor and swallows the click so toggling never navigates. */
-function NavItem({ icon, label, active, badge, href, onClick, pinned, onTogglePin }: { icon: ReactNode; label: string; active: boolean; badge?: number; href: string; onClick: () => void; pinned?: boolean; onTogglePin?: () => void }) {
+function NavItem({ icon, label, active, badge, beta, href, onClick, pinned, onTogglePin }: { icon: ReactNode; label: string; active: boolean; badge?: number; beta?: boolean; href: string; onClick: () => void; pinned?: boolean; onTogglePin?: () => void }) {
   return (
     <div className="group relative">
       <a
@@ -1440,6 +1439,7 @@ function NavItem({ icon, label, active, badge, href, onClick, pinned, onTogglePi
       >
         {icon}
         <span className="flex-1 text-left">{label}</span>
+        {beta ? <span className="rounded bg-primary/10 px-1.5 py-0 text-[9px] font-semibold uppercase tracking-wide text-primary group-hover:invisible">Beta</span> : null}
         {badge ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{badge}</Badge> : null}
       </a>
       {onTogglePin && (
@@ -2867,6 +2867,7 @@ function ChatPage({ agents, sessions, messages, selected, onSelect }: {
 
   // New-chat composer state (shown when nothing is selected).
   const [newAgent, setNewAgent] = useState('')
+  const [newFilter, setNewFilter] = useState('')
   const [draft, setDraft] = useState('')
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState('')
@@ -2989,39 +2990,57 @@ function ChatPage({ agents, sessions, messages, selected, onSelect }: {
       {/* Right: either the new-chat composer or the conversation */}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         {!selected ? (
-          <div className="mx-auto flex w-full max-w-xl flex-1 flex-col justify-center gap-4">
-            <div>
-              <h2 className="text-lg font-semibold">Start a conversation</h2>
-              <p className="text-sm text-muted-foreground">Pick a teammate and tell them what you need. They work under the same approvals and guardrails as everyone else.</p>
-            </div>
-            <div className="grid grid-cols-2 gap-2">
-              {chatAgents.map((a) => (
-                <button
-                  key={a.id}
-                  onClick={() => setNewAgent(a.id)}
-                  className={`flex items-start gap-2 rounded-lg border p-2.5 text-left hover:border-primary ${(newAgent || chatAgents[0]?.id) === a.id ? 'border-primary bg-primary/5' : ''}`}
-                >
-                  <AgentIcon icon={a.icon} className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0">
-                    <span className="block truncate text-sm font-medium capitalize">{a.id}</span>
-                    <span className="block truncate text-xs text-muted-foreground">{a.description}</span>
-                  </span>
-                </button>
-              ))}
-            </div>
-            <div className="flex items-end gap-2">
-              <Textarea
-                value={draft}
-                onChange={(e) => setDraft(e.target.value)}
-                onKeyDown={(e) => onKey(e, startChat)}
-                placeholder={`Message ${newAgent || chatAgents[0]?.id || 'an agent'}…`}
-                className="max-h-40 min-h-[44px] resize-none text-sm"
-                rows={2}
-              />
-              <Button size="icon" disabled={busy || !draft.trim()} onClick={startChat}><Send className="h-4 w-4" /></Button>
-            </div>
-            {err && <p className="text-xs text-destructive">{err}</p>}
-          </div>
+          (() => {
+            const q = newFilter.trim().toLowerCase()
+            const shown = q ? chatAgents.filter((a) => a.id.toLowerCase().includes(q) || (a.description || '').toLowerCase().includes(q)) : chatAgents
+            const chosen = newAgent || chatAgents[0]?.id
+            return (
+              <div className="mx-auto flex h-full min-h-0 w-full max-w-xl flex-col gap-3 py-2">
+                <div className="shrink-0">
+                  <h2 className="text-lg font-semibold">Start a conversation</h2>
+                  <p className="text-sm text-muted-foreground">Pick a teammate and tell them what you need. They work under the same approvals and guardrails as everyone else.</p>
+                </div>
+                {chatAgents.length > 6 && (
+                  <Input value={newFilter} onChange={(e) => setNewFilter(e.target.value)} placeholder="Filter agents…" className="h-8 shrink-0 text-sm" />
+                )}
+                {/* The agent list scrolls; the heading and the composer stay put, so the message box is
+                    always visible no matter how many agents there are. */}
+                <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+                  <div className="grid grid-cols-2 gap-2">
+                    {shown.map((a) => (
+                      <button
+                        key={a.id}
+                        onClick={() => setNewAgent(a.id)}
+                        className={`flex items-start gap-2 rounded-lg border p-2.5 text-left hover:border-primary ${chosen === a.id ? 'border-primary bg-primary/5' : ''}`}
+                      >
+                        <AgentIcon icon={a.icon} className="mt-0.5 h-5 w-5 shrink-0 text-muted-foreground" />
+                        <span className="min-w-0">
+                          <span className="block truncate text-sm font-medium capitalize">{a.id}</span>
+                          <span className="block truncate text-xs text-muted-foreground">{a.description}</span>
+                        </span>
+                      </button>
+                    ))}
+                    {shown.length === 0 && <p className="col-span-2 px-1 py-2 text-xs text-muted-foreground">No agents match “{newFilter}”.</p>}
+                  </div>
+                </div>
+                <div className="shrink-0">
+                  <div className="mb-1 text-xs text-muted-foreground">Chatting with <span className="font-medium capitalize text-foreground">{chosen || 'an agent'}</span></div>
+                  <div className="flex items-end gap-2">
+                    <Textarea
+                      value={draft}
+                      onChange={(e) => setDraft(e.target.value)}
+                      onKeyDown={(e) => onKey(e, startChat)}
+                      placeholder={`Message ${chosen || 'an agent'}…`}
+                      className="max-h-40 min-h-[44px] resize-none text-sm"
+                      rows={2}
+                    />
+                    <Button size="icon" disabled={busy || !draft.trim()} onClick={startChat}><Send className="h-4 w-4" /></Button>
+                  </div>
+                  {err && <p className="mt-1 text-xs text-destructive">{err}</p>}
+                </div>
+              </div>
+            )
+          })()
         ) : (
           <>
             {/* Header */}
@@ -3098,8 +3117,10 @@ function ChatPage({ agents, sessions, messages, selected, onSelect }: {
 /** Inline reply box for an agent's question, inside the chat thread. */
 function QuestionReply({ m }: { m: Msg }) {
   const [answer, setAnswer] = useState('')
-  const [sent, setSent] = useState(false)
-  if (sent) return <div className="text-sm text-muted-foreground">Answer sent.</div>
+  const [sent, setSent] = useState('')
+  const options = (m.args as { options?: string[] } | undefined)?.options?.filter(Boolean) ?? []
+  const submit = (text: string) => { if (text.trim() && m.questionId) { api.answerQuestion(m.questionId, text.trim()); setSent(text.trim()) } }
+  if (sent) return <div className="text-sm text-muted-foreground">You answered: <span className="font-medium text-foreground">{sent}</span></div>
   return (
     <>
       <div className="flex items-start gap-2">
@@ -3109,10 +3130,18 @@ function QuestionReply({ m }: { m: Msg }) {
           <div className="whitespace-pre-wrap text-muted-foreground">{m.body || m.title}</div>
         </div>
       </div>
-      <div className="mt-2 flex items-end gap-2">
-        <Input value={answer} onChange={(e) => setAnswer(e.target.value)} placeholder="Your answer…" className="h-8 text-sm" onKeyDown={(e) => { if (e.key === 'Enter' && answer.trim() && m.questionId) { api.answerQuestion(m.questionId, answer.trim()); setSent(true) } }} />
-        <Button size="sm" disabled={!answer.trim()} onClick={() => { if (m.questionId) { api.answerQuestion(m.questionId, answer.trim()); setSent(true) } }}>Reply</Button>
-      </div>
+      {options.length > 0 ? (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {options.map((o, i) => (
+            <Button key={i} size="sm" variant="outline" onClick={() => submit(o)}>{o}</Button>
+          ))}
+        </div>
+      ) : (
+        <div className="mt-2 flex items-end gap-2">
+          <Input value={answer} onChange={(e) => setAnswer(e.target.value)} placeholder="Your answer…" className="h-8 text-sm" onKeyDown={(e) => { if (e.key === 'Enter') submit(answer) }} />
+          <Button size="sm" disabled={!answer.trim()} onClick={() => submit(answer)}>Reply</Button>
+        </div>
+      )}
     </>
   )
 }
@@ -3315,7 +3344,9 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
   }
 
   // ── Question (pending) ──
-  const send = async () => { if (!answer.trim()) return; setBusy(true); const r = await api.answerQuestion(m.questionId!, answer.trim()); if (r.error) setBusy(false) }
+  const qOptions = (m.args as { options?: string[] } | undefined)?.options?.filter(Boolean) ?? []
+  const answerWith = async (text: string) => { if (!text.trim()) return; setBusy(true); const r = await api.answerQuestion(m.questionId!, text.trim()); if (r.error) setBusy(false) }
+  const send = () => answerWith(answer)
   // Dismiss without answering: cancels the question so it leaves "Needs you" (and unblocks a live agent's `ask`).
   const dismissQ = async () => { setBusy(true); const r = await api.cancelQuestion(m.questionId!); if (r.error) { setBusy(false); alert(r.error) } }
   return (
@@ -3329,8 +3360,15 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
         <a href={navHref('sessions', 'aos-' + m.sessionId)} className="shrink-0 pt-0.5 text-[11px] text-muted-foreground underline hover:text-foreground" onClick={onNavClick(open)}>open</a>
         {time}
       </div>
+      {qOptions.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {qOptions.map((o, i) => (
+            <Button key={i} size="sm" variant="outline" className="h-8 text-xs" disabled={busy} onClick={() => answerWith(o)}>{o}</Button>
+          ))}
+        </div>
+      )}
       <div className="mt-2 flex gap-1.5">
-        <Input value={answer} onChange={(e) => setAnswer(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && send()} placeholder="Type your answer — the agent is waiting…" className="h-8 text-sm" />
+        <Input value={answer} onChange={(e) => setAnswer(e.target.value)} onKeyDown={(e) => e.key === 'Enter' && send()} placeholder={qOptions.length > 0 ? '…or type a different answer' : 'Type your answer — the agent is waiting…'} className="h-8 text-sm" />
         <Button size="sm" className="h-8 px-2.5 text-xs" disabled={busy || !answer.trim()} onClick={send}><Send className="mr-1 h-3.5 w-3.5" />Reply</Button>
         <Button size="sm" variant="ghost" className="h-8 px-2 text-xs text-muted-foreground" disabled={busy} onClick={dismissQ} title="Dismiss without answering — the agent stops waiting on this">Dismiss</Button>
       </div>


### PR DESCRIPTION
A "Chat surface v1.1" batch: the delightful multiple-choice path, plus the three UX asks.

## `ask_human` can offer one-click choices
The tool takes an optional **`options[]`** (≤8). The question then renders as **clickable buttons** in the human's Inbox and in Chat; their reply is the option they pick (they can still type a different answer). This is the governed, works-everywhere answer to Claude's native multiple-choice picker (which stays denied — it hangs unattended runs, v0.195.1): same UX, a real tool result, no native-tool interception, no hook hackery. Options ride the question message's `args.options`; both question cards render the buttons.

Also folds the **siteboon/claudecodeui** findings (Agent SDK `canUseTool` + interactive-tool bridge, and the "`auto`/`bypass` modes skip `canUseTool` → use a PreToolUse hook" caveat that favors agent-os's existing gate hook) into `docs/sdk-chat-runtime-plan.md`, and notes this `ask_human`-options work as the v1.5 stepping stone.

## UX asks
- **Chat nav is now pinnable + hidden by default, tagged Beta.** Moved out of the hardwired sidebar into the pin-customizable nav (not in the default pin set) — it lives under **Manage** until a member pins it to Main — and carries a small **Beta** badge.
- **New-chat no longer buries the message box.** With many agents the composer got pushed off-screen; the agent list now scrolls in a capped area while the heading + message box stay fixed, and a filter box appears past 6 agents.

## Verified
- `npm run typecheck` + server/web builds ✓ · `npm run test:governance` → 68/68 ✓
- In-process test: `askQuestion(...options)` round-trips `args.options` through `listMessages` (with-options → 3 buttons; no-options → free-text) ✓
- Bundle contains the Beta badge, filter box, and fixed composer ✓
- **Live smoke on instapods after merge**: drive an agent to `ask_human` with options and confirm buttons render + answering works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)