### PR TITLE
fix(console): standardize browser-tab titles (v0.196.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.196.3] — 2026-07-14
+### Changed
+- **Standardized browser-tab titles across the whole console.** The tab title now leads with the current
+  page — `<page> · <tenant> · Agent OS` (e.g. `Tasks · instapods · Agent OS`) — instead of just
+  `<tenant> · Agent OS`, so pinned/duplicated tabs are distinguishable at a glance. An open session or
+  agent-detail page uses its own name (`<session title>` / `Agent · <id>`), and the unread-notification
+  `🔔 (N)` prefix is preserved. Page names now come from one `ROUTE_TITLES` map that also drives the
+  header `<h1>`, so the tab and the on-screen heading can never drift. (`web/src/App.tsx`.)
+
 ## [0.196.2] — 2026-07-14
 ### Added
 - **`ask_human` can offer one-click choices.** The tool takes an optional `options` list (up to 8); the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.196.2",
+  "version": "0.196.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.196.2",
+      "version": "0.196.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.196.2",
+  "version": "0.196.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,15 @@ const TERM_FONT_MIN = 8, TERM_FONT_MAX = 40
 type Route = 'overview' | 'inbox' | 'chat' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'goals' | 'tasks' | 'memory' | 'insights' | 'kb' | 'skills' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent' | 'docs' | 'profile'
 // The full set of pages, used by the hash router to validate the URL on load. Keep in sync with Route.
 const ROUTES: Route[] = ['overview', 'inbox', 'chat', 'sessions', 'agents', 'new-agent', 'connectors', 'team', 'automations', 'goals', 'tasks', 'memory', 'insights', 'kb', 'skills', 'files', 'artifacts', 'settings', 'audit', 'agent', 'docs', 'profile']
+// The single source of truth for a page's human name — used for the header <h1> AND the browser-tab
+// title, so both always agree. The `agent` detail page appends the agent id at the call site.
+const ROUTE_TITLES: Record<Route, string> = {
+  overview: 'Overview', inbox: 'Inbox', chat: 'Chat', sessions: 'Sessions', agents: 'Agents',
+  'new-agent': 'New agent', agent: 'Agent', connectors: 'Connections', team: 'Team',
+  automations: 'Automations', goals: 'Goals', tasks: 'Tasks', memory: 'Memory', insights: 'Insights',
+  kb: 'Knowledge Base', skills: 'Skills', files: 'Files', artifacts: 'Library', audit: 'Audit log',
+  settings: 'Company settings', docs: 'Docs', profile: 'Profile',
+}
 type Selected = { tmux: string; title: string } | null
 
 /** Mirror of the server rule: owner approves anything, admin approves head-level only. */
@@ -825,9 +834,12 @@ function Console({ me }: { me: Member }) {
   const notifyItems = useMemo(() => buildNotifyItems(messages, prefs), [messages, prefs])
   const notifyUnread = notifyItems.filter((x) => x.unread).length
   useEffect(() => {
-    const base = `${state?.tenantName || state?.tenant ? `${state.tenantName || state.tenant} · ` : ''}Agent OS`
+    const brand = `${state?.tenantName || state?.tenant ? `${state.tenantName || state.tenant} · ` : ''}Agent OS`
+    // Lead with the current page (or the open session/agent) so the tab says "<page> · <tenant> · Agent OS".
+    const page = selected ? selected.title : route === 'agent' && editAgent ? `Agent · ${editAgent}` : ROUTE_TITLES[route]
+    const base = page ? `${page} · ${brand}` : brand
     document.title = notifyUnread > 0 ? `🔔 (${notifyUnread}) ${base}` : base
-  }, [notifyUnread, state?.tenantName, state?.tenant])
+  }, [notifyUnread, state?.tenantName, state?.tenant, route, editAgent, selected])
 
   // Toast pop-ins: watch the unread notification set and surface a toast for any item that's newly
   // appeared since the last poll (seeded on first load so the backlog stays quiet). Respects the
@@ -1211,7 +1223,7 @@ function Console({ me }: { me: Member }) {
           ) : (
             <div className="flex items-center gap-3">
               <h1 className="max-w-[60vw] truncate text-lg font-semibold">
-                {route === 'overview' ? 'Overview' : route === 'inbox' ? 'Inbox' : route === 'chat' ? 'Chat' : route === 'sessions' ? 'Sessions' : route === 'connectors' ? 'Connections' : route === 'team' ? 'Team' : route === 'automations' ? 'Automations' : route === 'goals' ? 'Goals' : route === 'tasks' ? 'Tasks' : route === 'memory' ? 'Memory' : route === 'insights' ? 'Insights' : route === 'kb' ? 'Knowledge Base' : route === 'skills' ? 'Skills' : route === 'files' ? 'Files' : route === 'artifacts' ? 'Library' : route === 'audit' ? 'Audit log' : route === 'settings' ? 'Company settings' : route === 'docs' ? 'Docs' : route === 'new-agent' ? 'New agent' : route === 'agent' ? `Agent · ${editAgent}` : route === 'profile' ? 'Profile' : 'Agents'}
+                {route === 'agent' ? `Agent · ${editAgent}` : ROUTE_TITLES[route]}
               </h1>
             </div>
           )}


### PR DESCRIPTION
## What

Standardizes browser-tab titles across the whole console. The tab now leads with the current page:

`<page> · <tenant> · Agent OS`  — e.g. `Tasks · instapods · Agent OS`

Previously the tab was just `<tenant> · Agent OS` for every page, so pinned/duplicated tabs were indistinguishable.

## Details

- Introduced a single `ROUTE_TITLES: Record<Route, string>` map as the source of truth for page names.
- It now drives **both** the header `<h1>` (replacing a long inline ternary) and the `document.title` effect, so the tab and the on-screen heading can never drift.
- An open session uses its session title; the agent-detail page uses `Agent · <id>`.
- The unread-notification `🔔 (N)` prefix is preserved.

## Verify

`cd web && npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)