### PR TITLE
feat(sessions): close silent session-lifecycle gaps — Discord continuity, ownerless-crash escalation, chat-mirror on crash/no-report end (v0.200.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.200.0] — 2026-07-14
+### Added
+- **Discord thread continuity — parity with Slack.** A follow-up message inside a Discord thread already
+  bound to a session now *continues that conversation* (resumes the same agent + transcript) instead of
+  firing a brand-new run. Before this, every message in a Discord thread re-triggered a fresh,
+  duplicate-and-competing session; only Slack had continuity. The Discord message parser now surfaces
+  plain (non-@mention) guild messages — flagged `mentioned:false` — so a thread reply like "ok, now do X"
+  reaches the dispatcher, which routes it to the bound session via the new
+  `Automations.continueDiscordThread` / `TerminalManager.sessionForDiscordThread` (line-for-line analogues
+  of the proven Slack path); a non-mention message that isn't a live-thread continuation is dropped, so
+  ordinary channel chatter never spawns a run. The `/agent` router also spawns Discord chat sessions
+  **resident** (warm) now, matching Slack, so follow-ups deliver into the live pane. (`src/connectors/discord.ts`,
+  `src/edge/discord-socket.ts`, `src/edge/automations.ts`, `src/terminal.ts`)
+
+### Fixed
+- **Unattended-run crashes are no longer silent.** A crash of a session with *no human owner* (a pure
+  `automation:`/`task:` run — e.g. a nightly cron agent that dies at 3am) used to notify **nobody**: its
+  crash card was addressed to `sessionOwner`, which resolves to empty, so it was invisible in every
+  member's inbox and DM'd no one. `notifySessionEvent` now treats a **crash as an always-on failure
+  signal**: the owner is DM'd regardless of their opt-in `dm` preference, and an ownerless run **escalates
+  to the `admins` tier** — so an unattended crash always reaches a person. Routine `waiting`/`completed`
+  beats stay opt-in owner-only (no flood). (`src/tenant-registry.ts`)
+- **Chat-triggered runs no longer leave their thread hanging on crash or no-report completion.** The
+  Slack/Discord chat-mirror only fired on an explicit agent `report`. A chat-spawned run that **crashed**,
+  or that **exited cleanly without calling `report`**, posted its outcome to the console inbox but never
+  back to the originating chat thread — the human who pinged it saw silence. Both end paths now mirror a
+  finish/crash line into the bound thread (no-op for non-chat runs). (`src/terminal.ts`)
+
 ## [0.199.0] — 2026-07-14
 ### Added
 - **Apps — background dispatch (apps trigger agents).** A hosted app can now hand work to an agent in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.199.0",
+  "version": "0.200.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.199.0",
+      "version": "0.200.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.199.0",
+  "version": "0.200.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/connectors/discord.ts
+++ b/src/connectors/discord.ts
@@ -143,15 +143,21 @@ export interface DiscordMessageEvent {
   text: string;
   /** Whether the author is a bot/webhook (caller should skip these to avoid loops). */
   fromBot: boolean;
+  /** True when this is an explicit trigger — a DM, or a guild message that @-mentioned the bot. A guild
+   *  message that did NOT mention us is still surfaced (for thread-continuity), but with `mentioned:false`
+   *  so the dispatcher only lets it CONTINUE a bound thread, never start a fresh run. */
+  mentioned: boolean;
   /** The full inner message object (capped when injected into a task template). */
   raw: any;
 }
 
 /**
- * Normalise a `MESSAGE_CREATE` payload into a routed message event, or null when it isn't one we act
- * on. We route exactly two cases — mirroring Slack's `app_mention` + DM `message`:
+ * Normalise a `MESSAGE_CREATE` payload into a routed message event (null only when it's unparseable).
+ * `mentioned` marks the two cases that start a FRESH run — mirroring Slack's `app_mention` + DM `message`:
  *   • a **DM** to the bot (no `guild_id`), or
  *   • a **guild** message that **@-mentions the bot** (`mentions[]` contains the bot's user id).
+ * A guild message that did NOT mention us is still returned (`mentioned:false`) so the dispatcher can use
+ * it for thread-continuity (a plain follow-up in a bound thread); it never fires a fresh run on its own.
  * Defensive: Discord's shapes vary, so every field is best-effort.
  */
 export function parseDiscordMessage(d: any, botUserId: string): DiscordMessageEvent | null {
@@ -162,9 +168,13 @@ export function parseDiscordMessage(d: any, botUserId: string): DiscordMessageEv
   const mentionsBot = Array.isArray(d.mentions) && botUserId
     ? d.mentions.some((m: any) => String(m?.id) === botUserId)
     : false;
-  if (!isDM && !mentionsBot) return null; // a guild message that didn't @ us — ignore
+  // We used to DROP every non-mention guild message here. Now we surface them too (flagged
+  // `mentioned:false`) so a plain follow-up inside a bound thread can CONTINUE that conversation —
+  // Discord parity with Slack's `message.channels` thread continuity. The dispatcher drops any
+  // non-mention message that isn't a live-thread continuation, so this never spams the /agent router.
   return {
     eventType: isDM ? 'direct_message' : 'mention',
+    mentioned: isDM || mentionsBot,
     channel: String(d.channel_id || ''),
     guildId,
     messageId: String(d.id || ''),

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -713,6 +713,35 @@ export class Automations {
   }
 
   /**
+   * Discord thread continuity — the exact analogue of {@link continueSlackThread}. A message inside a
+   * guild thread already bound to a session CONTINUES that conversation (deliver into the live claude, or
+   * revive the row) instead of hitting the `/agent` router with a fresh spawn. Keyed on the thread's
+   * channel id (the socket binds the session to the thread it branched at spawn). `none` → nothing
+   * resumable is bound → the caller falls through to a fresh spawn. The socket posts no ack; the agent's
+   * own `discord_reply` is the feedback.
+   */
+  continueDiscordThread(
+    event: { channel: string; actorLabel: string; text: string; raw: unknown },
+    runAsMember?: string,
+  ): { status: 'delivered' | 'revived' | 'none'; sessionId?: string } {
+    const bound = this.tm.sessionForDiscordThread(event.channel);
+    if (!bound || !bound.claudeSessionId) return { status: 'none' }; // unbound / unresumable → fresh spawn
+    const runAs = runAsMember ?? bound.runAs;
+    const msg = this.stripChatPrefix(event.text);
+    if (!msg) return { status: 'none' };
+    const emit = (mode: 'delivered' | 'revived') => this.os.audit.append({
+      ts: Date.now(), runId: bound.sessionId, tenant: this.os.tenant,
+      principal: runAs ? `member:${runAs}` : 'chat', type: 'chat.continued',
+      data: { mode, platform: 'discord', agent: bound.agent, session: bound.sessionId, channel: event.channel, runAs: runAs ?? null },
+    });
+    // Warm path: live resident session → deliver by typing into it.
+    if (this.tm.deliverToResident(bound.sessionId, msg)) { emit('delivered'); return { status: 'delivered', sessionId: bound.sessionId }; }
+    // Cold path: reaped/ended → revive the SAME row (resume transcript, seeded with the message).
+    if (this.tm.reviveResident(bound.sessionId, msg, runAs)) { emit('revived'); return { status: 'revived', sessionId: bound.sessionId }; }
+    return { status: 'none' };
+  }
+
+  /**
    * Inbound DM that might be answering a pending `ask_human` question: if the sender (`provider` + their
    * `externalId`) has a still-pending question we DM'd them, record the reply as its answer and return the
    * asking agent. `null` → nothing pending is bound to them, so the caller falls through to the normal chat
@@ -761,7 +790,7 @@ export class Automations {
     if (sessions.length === 0 && this.os.settings.chatRouterEnabled()) {
       const routed = this.routeChat(event.text);
       if (routed.agentId) {
-        const r = this.spawnChatAgent(routed.agentId, extra, { runAs: runAsMember, discord: { channel: event.channel, messageId: event.messageId }, title: chatTitle(event.text, routed.agentId) });
+        const r = this.spawnChatAgent(routed.agentId, extra, { runAs: runAsMember, discord: { channel: event.channel, messageId: event.messageId }, title: chatTitle(event.text, routed.agentId), resident: true });
         if (r.ok) sessions.push(r.sessionId);
       } else {
         reply = routed.help;

--- a/src/edge/discord-socket.ts
+++ b/src/edge/discord-socket.ts
@@ -228,6 +228,28 @@ export class DiscordSocket {
       }
     }
 
+    // Thread continuity: a message inside a guild thread already bound to a session continues THAT
+    // conversation (resume the same agent + transcript) instead of firing a fresh trigger — so a plain
+    // "ok, now do X" in the thread keeps talking to the agent rather than hitting the /agent router's help
+    // list. Guild-only (DMs have no threads); only the first @mention (nothing bound yet) falls through to
+    // a fresh spawn below. Mirrors slack-socket's continueSlackThread branch.
+    if (ev.guildId) {
+      const cont = this.autos.continueDiscordThread({ channel: ev.channel, actorLabel, text, raw: ev.raw }, runAsMember);
+      if (cont.status !== 'none') {
+        this.os.audit.append({
+          ts: Date.now(), runId: cont.sessionId ?? '-', tenant: this.os.tenant,
+          principal: runAsMember ? `member:${runAsMember}` : 'discord', type: 'trigger.discord',
+          data: { eventType: ev.eventType, channel: ev.channel, thread: true, continued: cont.status, runAs: runAsMember ?? null },
+        });
+        return;
+      }
+    }
+
+    // Not a thread continuation. A guild message that didn't @-mention us was surfaced only for the check
+    // above — drop it so ordinary channel chatter never spawns a run or spams the router (mirrors Slack's
+    // non-mention drop; the parser now lets these through solely for continuity). DMs always proceed.
+    if (!ev.mentioned) return;
+
     // Keep the whole exchange in ONE thread. For a guild @mention, branch a thread off the user's
     // message so the ack, the agent's replies, and everything after live together (not scattered as
     // channel replies). DMs have no threads → post back in the DM channel as before. If thread creation

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -469,14 +469,20 @@ export async function notifyMember(os: AgentOS, slack: Pick<SlackSocket, 'dmUser
 
 /**
  * DM the owner of a session that just changed state (started waiting / finished / crashed), on their
- * linked Slack/Discord — the lifecycle twin of {@link notifyMember}. Unlike approvals/questions this is
- * OPT-IN: only fires when the run's owner set their `dm` notification preference, since the inbox bell
- * already surfaces every one of these. Targets the `sessionOwner` audience only — a pure automation/task
- * run with no human owner pings nobody (there's no one whose bell it belongs to). Best-effort, audited.
+ * linked Slack/Discord — the lifecycle twin of {@link notifyMember}. Two tiers by kind:
+ * - **waiting / completed** are routine beats: OPT-IN and owner-only (fire only if the run's owner set
+ *   their `dm` pref), since the inbox bell already surfaces them and DMing every finish would flood.
+ * - **crashed** is a FAILURE signal, so it's always-on and escalates — like an unanswered question. The
+ *   owner hears it regardless of their `dm` pref, and a run with NO human owner (a pure automation/task)
+ *   falls back to the `admins` tier, so an unattended agent that dies at 3am still reaches a person
+ *   instead of failing silently (the largest silent class before this).
+ * Best-effort, audited.
  */
 export async function notifySessionEvent(os: AgentOS, slack: Pick<SlackSocket, 'dmUser'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: SessionEventNotice): Promise<void> {
-  const targets = resolveRecipients(os, { kind: 'sessionOwner', id: notice.sessionId })
-    .filter((m) => os.team.notificationPrefs(m.id).dm);
+  const owner = resolveRecipients(os, { kind: 'sessionOwner', id: notice.sessionId });
+  const targets = notice.kind === 'crashed'
+    ? (owner.length ? owner : resolveRecipients(os, { kind: 'admins' }))
+    : owner.filter((m) => os.team.notificationPrefs(m.id).dm);
   if (!targets.length) return;
   const icon = notice.kind === 'waiting' ? '🔔' : notice.kind === 'crashed' ? '💥' : '✅';
   const url = consolePage(consoleOrigin, 'sessions');

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -484,6 +484,11 @@ export class TerminalManager {
             const body = 'The session ended unexpectedly (the process died).';
             this.addMessage({ type: 'completed', sessionId: r.id, agent: r.agent, title, body, status: 'open', outcome: 'crashed', audienceKind: 'sessionOwner', audienceId: r.id });
             this.fireSessionEvent(r.id, r.agent, 'crashed', title, body);
+            // Close the chat loop: a crash fires no `report` (the only other mirror point), so a chat-
+            // triggered run that DIED would otherwise leave its Slack/Discord thread hanging forever. Tell
+            // the thread it broke. No-op for non-chat runs (no bound thread).
+            const inboxLink = consolePage(this.publicOrigin, 'inbox');
+            try { this.chatMirror?.(r.id, (p) => `💥 ${r.agent} crashed — the session ended unexpectedly.\n${chatLink(p, inboxLink, 'Open in Agent OS')}`); } catch { /* advisory */ }
           }
         }
       }
@@ -790,6 +795,25 @@ export class TerminalManager {
           ORDER BY t.created_at DESC LIMIT 1`,
       )
       .get<{ id: string; agent: string; runAs: string | null; claudeSessionId: string | null }>(channel, threadTs);
+    if (!row) return undefined;
+    return { sessionId: row.id, agent: row.agent, runAs: row.runAs ?? undefined, claudeSessionId: row.claudeSessionId ?? undefined };
+  }
+  /**
+   * The MOST RECENT session bound to a Discord channel — the thread-continuity twin of
+   * {@link sessionForSlackThread}. For a guild @mention the socket branches a real thread and binds the
+   * session to the THREAD's channel id, so a plain follow-up posted in that thread (which carries the
+   * thread's channel id) resumes the same agent + claude conversation. Undefined when nothing is bound
+   * (the first mention) or the newest run predates the claude-id column (unresumable → fresh spawn).
+   */
+  sessionForDiscordThread(channel: string): { sessionId: string; agent: string; runAs?: string; claudeSessionId?: string } | undefined {
+    const row = this.db
+      .prepare(
+        `SELECT t.id AS id, t.agent AS agent, t.run_as AS runAs, t.claude_session_id AS claudeSessionId
+           FROM discord_threads d JOIN term_sessions t ON t.id = d.session_id
+          WHERE d.channel = ?
+          ORDER BY t.created_at DESC LIMIT 1`,
+      )
+      .get<{ id: string; agent: string; runAs: string | null; claudeSessionId: string | null }>(channel);
     if (!row) return undefined;
     return { sessionId: row.id, agent: row.agent, runAs: row.runAs ?? undefined, claudeSessionId: row.claudeSessionId ?? undefined };
   }
@@ -3226,6 +3250,11 @@ export class TerminalManager {
       const body = 'The session ended.';
       this.addMessage({ type: 'completed', sessionId, agent: s.agent, title, body, status: 'open', outcome: 'ended', audienceKind: 'sessionOwner', audienceId: sessionId });
       this.fireSessionEvent(sessionId, s.agent, 'completed', title, body);
+      // Mirror the finish back to the chat thread the run came from: an agent that exits WITHOUT calling
+      // `report` (the only other mirror point) would otherwise leave its Slack/Discord thread waiting
+      // forever. No-op for non-chat runs (no bound thread).
+      const inboxLink = consolePage(this.publicOrigin, 'inbox');
+      try { this.chatMirror?.(sessionId, (p) => `☑️ ${s.agent} finished — the session ended.\n${chatLink(p, inboxLink, 'Open in Agent OS')}`); } catch { /* advisory */ }
     }
     this.audit(sessionId, s.agent, 'session.ended', {});
   }


### PR DESCRIPTION
## Why

A relook at the session lifecycle (initiation → progress → completion → who gets notified) surfaced three lifecycle events that reach **nobody** — silent failures in a system whose whole promise is governed, observable agent runs. This closes all three.

## What changed

### 1. Discord thread continuity — parity with Slack (new capability)
Before: every message in a Discord thread re-fired a **fresh, competing** session; only Slack had continuity. The Discord parser dropped every non-@mention guild message, so a plain thread reply ("ok, now do X") never even reached the dispatcher.

Now: the parser surfaces non-mention guild messages flagged `mentioned:false`; the dispatcher routes a thread reply to the bound session via new `Automations.continueDiscordThread` + `TerminalManager.sessionForDiscordThread` (line-for-line analogues of the proven Slack path). A non-mention message that isn't a live-thread continuation is dropped, so ordinary channel chatter never spawns a run. The `/agent` router now spawns Discord chat **resident** (warm), matching Slack.

### 2. Ownerless-run crashes are no longer silent (fix)
A crash of a run with no human owner (`automation:`/`task:` provenance, no `run_as` — e.g. a 3am cron agent) notified nobody: its card is `sessionOwner`-addressed, which resolves empty. `notifySessionEvent` now treats a **crash as an always-on failure signal** — owner DM'd regardless of `dm` pref, ownerless runs **escalate to `admins`**. Routine `waiting`/`completed` stay opt-in owner-only (no flood).

### 3. Chat-mirror on crash + no-report completion (fix)
The chat-mirror only fired on an explicit agent `report`. A chat-spawned run that **crashed** or **exited without `report`** posted to the console inbox but left the originating Slack/Discord thread hanging. Both end paths now mirror the outcome back to the thread (no-op for non-chat runs).

## Testing
- `npm run typecheck` + `npm run build` clean
- `npm run test:governance` → **68/68**
- Isolated in-process behavior script → **14/14** assertions (parser `mentioned` flag; crash-escalation tiers incl. always-on owner + ownerless→admins + opt-in completed; Discord thread binding lookup). Ran against a scratch `AGENT_OS_HOME`, no live data touched.

## Files
`src/connectors/discord.ts` · `src/edge/discord-socket.ts` · `src/edge/automations.ts` · `src/terminal.ts` · `src/tenant-registry.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)