### PR TITLE
fix(governance): policy_propose response explains change propagation (v0.203.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.203.1] — 2026-07-14
+### Changed
+- **`policy_propose` success response now spells out propagation.** It tells the agent that an approved
+  policy change hot-reloads and applies LIVE to every running session at its next gated action — no
+  restart/respawn — contrasted with an MCP tool-schema change, which a live session only picks up on
+  respawn. Removes the ambiguity about when a tightened guardrail takes effect. (`src/memory/memory-mcp.ts`.)
+
 ## [0.203.0] — 2026-07-14
 ### Added
 - **Agents can propose governance-policy changes — owner-approved, tighten-only.** A new `policy_propose`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.203.0",
+  "version": "0.203.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.203.0",
+      "version": "0.203.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.203.0",
+  "version": "0.203.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -1627,7 +1627,7 @@ async function policyPropose(args: Record<string, unknown>): Promise<string> {
   });
   const d = (await res.json()) as { ok?: boolean; preview?: string; error?: string };
   return d.ok
-    ? `Policy change proposed${d.preview ? ` (${d.preview})` : ''} — it's in the owner's inbox for review. NOTHING changes until an owner approves it. Proposals may only tighten guardrails, never loosen them.`
+    ? `Policy change proposed${d.preview ? ` (${d.preview})` : ''} — it's in the owner's inbox for review. NOTHING changes until an owner approves it. Proposals may only tighten guardrails, never loosen them. Once approved, the change hot-reloads and applies LIVE to every running session at its next gated action — no restart or respawn needed (unlike an MCP tool-schema change, which a live session only picks up when it respawns).`
     : `Could not propose the policy change: ${d.error ?? 'unknown error'}`;
 }
 


### PR DESCRIPTION
Small copy fix following #337. The `policy_propose` success response now tells the agent how/when an approved change takes effect:

> Once approved, the change hot-reloads and applies **LIVE** to every running session at its next gated action — no restart or respawn needed (unlike an MCP tool-schema change, which a live session only picks up when it respawns).

This removes ambiguity about propagation and correctly distinguishes a **policy** change (live via `os.policy.update()`, the gate reads policy live) from an **MCP tool-schema** change (needs session respawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)