### PR TITLE
feat(chat): Open in Terminal — hand a chat session off to the raw TUI (v0.206.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.206.0] — 2026-07-15
+### Added
+- **"Open in Terminal" from a Chat session.** A chat conversation can now be handed off to the raw
+  Terminal in one click — for when a technical teammate needs to watch or steer the run hands-on. Since a
+  chat session is headless per-turn (no live pane between turns), the take-over is two-mode: if a turn is
+  mid-flight it **claims the live pane**; if the chat is idle it **resurrects it as an interactive resident
+  session that resumes the same transcript** (no seed prompt — drops you straight into a steerable claude),
+  writes the launch env so ttyd can attach, and marks it claimed/sticky. Then the console opens the
+  terminal on it. New `TerminalManager.takeoverToTerminal` + `POST /api/sessions/:id/takeover-terminal`;
+  the launcher's resident-resume now omits an empty seed (`${TASK:+…}`) so a no-prompt resume lands in the
+  interactive TUI. Same session, same governance — just the raw view. (`src/terminal.ts`, `src/server.ts`,
+  `terminal/claude-launch.sh`, `web/src/App.tsx`, `web/src/lib/api.ts`.)
+
 ## [0.205.0] — 2026-07-14
 ### Added
 - **Apps — custom domains (point `my.tool.com` at any app).** A published app can bind one or more

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.205.0",
+  "version": "0.206.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.205.0",
+      "version": "0.206.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.205.0",
+  "version": "0.206.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2187,6 +2187,17 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (r === 'error') return sendJson(res, 409, { error: 'this session could not accept the message' });
     return sendJson(res, 200, { status: 'sent' });
   }
+  // Take a chat session over into the Terminal: make it a live, attachable interactive TUI (claim the
+  // live pane, or resurrect an idle chat as an interactive resident resume). The client then opens the
+  // terminal on aos-<id>.
+  const takeoverMatch = p.match(/^\/api\/sessions\/([\w-]+)\/takeover-terminal$/);
+  if (method === 'POST' && takeoverMatch) {
+    const id = takeoverMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to take over this session' });
+    const out = tm.takeoverToTerminal(id, me.email);
+    return sendJson(res, out.ok ? 200 : 409, out);
+  }
   // Session activity: "which agent-os primitives did this run use?" — the session's audit stream,
   // classified into a chronological timeline + a grouped count summary. Same visibility as the terminal
   // (canViewSession), so a member sees the activity of the runs they can attach to, not just admins.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1289,6 +1289,41 @@ export class TerminalManager {
   }
 
   /**
+   * Take a native-console CHAT session over into the Terminal. A chat session is headless per-turn (no
+   * persisted launch env, and between turns its pane is gone), so unlike {@link claimSession} we can't
+   * always just attach. Two cases:
+   *  - a turn is still running → `claimSession` the live pane (zero disruption, attach to the stream);
+   *  - idle/dead → resurrect it as an interactive RESIDENT TUI that resumes the SAME transcript with no
+   *    seed prompt (drops the human straight into a steerable claude), writes the launch env (so ttyd can
+   *    attach + later reattach), and marks it claimed/sticky so the reapers leave it alone.
+   * The caller then opens the terminal on `aos-<id>`. Returns an error only for an unknown / non-resumable
+   * / non-claude-code session.
+   */
+  takeoverToTerminal(sessionId: string, by: string): { ok: boolean; error?: string } {
+    const row = this.db.prepare('SELECT agent, secret, claude_session_id, run_as, spawned_by FROM term_sessions WHERE id = ?')
+      .get<{ agent: string; secret: string | null; claude_session_id: string | null; run_as: string | null; spawned_by: string | null }>(sessionId);
+    if (!row) return { ok: false, error: 'unknown session' };
+    const manifest = this.os.agents.get(row.agent);
+    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be taken over' };
+    if (!row.claude_session_id) return { ok: false, error: 'this chat has no conversation to open yet' };
+    // A turn is still generating → attach to the live pane, no relaunch.
+    if (this.isAlive(sessionId)) return this.claimSession(sessionId, by);
+    // Idle/dead → resurrect as an interactive resident TUI (resumes the transcript, no seed prompt).
+    this.allowResume(sessionId);
+    this.db.prepare("UPDATE term_sessions SET status = 'running', headless = 0, resident = 1, claimed_by = ?, claimed_at = ?, last_activity = ?, updated_at = ? WHERE id = ?")
+      .run(by, Date.now(), Date.now(), Date.now(), sessionId);
+    const hasSlack = !!this.db.prepare('SELECT 1 FROM slack_threads WHERE session_id = ?').get(sessionId);
+    const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
+    this.audit(sessionId, by, 'session.claimed', { agent: row.agent, via: 'chat-takeover' });
+    this.launchClaudeCode({
+      id: sessionId, agent: row.agent, task: '', secret: row.secret ?? randomBytes(24).toString('hex'),
+      actingMember: row.run_as ?? undefined, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord,
+      headless: false, resident: true, resume: true, claudeSessionId: row.claude_session_id,
+    });
+    return { ok: true };
+  }
+
+  /**
    * Idle reaper (run from the process-wide 60s sweep in server.ts). Two jobs, one pass; never throws:
    *
    *  1. RESIDENT (warm chat) sessions whose last turn is older than the configured timeout

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -236,8 +236,8 @@ if [ "${RESIDENT:-}" = "1" ] || [ "${UNATTENDED:-}" = "1" ]; then
   echo
   if [ "${RESUME:-}" = "1" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
     notify_resumed
-    claude --resume "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" "$TASK" \
-      || claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" "$TASK"
+    claude --resume "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" ${TASK:+"$TASK"} \
+      || claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" ${TASK:+"$TASK"}
   elif [ -n "${CLAUDE_SESSION_ID:-}" ]; then
     claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" "$TASK"
   else

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1237,7 +1237,7 @@ function Console({ me }: { me: Member }) {
           {route === 'sessions' && <SessionsPage me={me} members={members} sessions={sessions} waiting={waiting} selected={selected} hiddenTabs={hiddenTabs} onOpen={openTerminal} onCloseTab={closeTab} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onRate={rateSession} onRename={renameSession} onTransfer={transferSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
           {route === 'overview' && me.role === 'owner' && <OverviewPage me={me} sessions={sessions} messages={messages} members={members} agents={state?.agents ?? []} maturity={maturity} onOpen={openTerminal} nav={nav} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} members={members} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} onOpenGoal={(id) => nav('goals', id)} />}
-          {route === 'chat' && <ChatPage agents={state?.agents ?? []} sessions={sessions} messages={messages} selected={detail} onSelect={(id) => nav('chat', id)} />}
+          {route === 'chat' && <ChatPage agents={state?.agents ?? []} sessions={sessions} messages={messages} selected={detail} onSelect={(id) => nav('chat', id)} onOpenTerminal={openTerminal} />}
           {route === 'connectors' && <ConnectionsPage me={me} tab={detail} onTab={(t) => nav('connectors', t)} />}
           {route === 'team' && <TeamPage me={me} onProfileChange={refreshState} />}
           {route === 'profile' && <ProfilePage me={state?.me ?? me} prefs={prefs} onSavePrefs={savePrefs} onProfileChange={refreshState} />}
@@ -2863,12 +2863,13 @@ function ChatBubble({ turn, agentIcon }: { turn: Extract<ChatTurn, { kind: 'user
   )
 }
 
-function ChatPage({ agents, sessions, messages, selected, onSelect }: {
+function ChatPage({ agents, sessions, messages, selected, onSelect, onOpenTerminal }: {
   agents: AgentInfo[]
   sessions: Session[]
   messages: Msg[]
   selected: string
   onSelect: (id: string) => void
+  onOpenTerminal: (tmux: string, title?: string) => void
 }) {
   // Chattable agents = claude-code runtime the member is allowed to run. Chat sessions = ones this
   // surface (or the chat router) spawned, newest first.
@@ -2974,6 +2975,17 @@ function ChatPage({ agents, sessions, messages, selected, onSelect }: {
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); fn() }
   }
 
+  // Hand this conversation off to the Terminal: make it a live, attachable interactive session (claim the
+  // live pane or resurrect an idle chat as an interactive resume), then open the terminal on it.
+  const takeover = async () => {
+    if (!selected || busy) return
+    setBusy(true); setErr('')
+    const r = await api.takeoverToTerminal(selected)
+    setBusy(false)
+    if (r.error) { setErr(r.error); return }
+    onOpenTerminal('aos-' + selected, activeAgent?.id || active?.agent)
+  }
+
   return (
     <div className="flex h-full min-h-0 gap-4">
       {/* Left rail: your chats + a new-chat button */}
@@ -3060,10 +3072,13 @@ function ChatPage({ agents, sessions, messages, selected, onSelect }: {
             {/* Header */}
             <div className="mb-2 flex items-center gap-2 border-b pb-2">
               <AgentIcon icon={activeAgent?.icon} className="h-5 w-5 shrink-0 text-muted-foreground" />
-              <div className="min-w-0">
+              <div className="min-w-0 flex-1">
                 <div className="truncate text-sm font-medium">{active?.title || activeAgent?.id || active?.agent}</div>
                 <div className="text-[11px] capitalize text-muted-foreground">{activeAgent?.id || active?.agent}{working ? ' · working…' : ''}</div>
               </div>
+              <Button size="sm" variant="ghost" className="h-7 shrink-0 gap-1.5 text-xs text-muted-foreground" onClick={takeover} disabled={busy} title="Open this conversation in the Terminal — a live session you can type into and steer">
+                <TerminalSquare className="h-3.5 w-3.5" /> Open in Terminal
+              </Button>
             </div>
 
             {/* Timeline */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1062,6 +1062,9 @@ export const api = {
    *  turn is still generating (keep the draft, resend shortly). */
   reply: (id: string, message: string) =>
     call<{ status?: 'sent' | 'busy'; error?: string }>('POST', `/api/sessions/${id}/reply`, { message }),
+  /** Take a chat session over into the Terminal — makes it a live attachable interactive TUI; the caller
+   *  then opens the terminal on it. */
+  takeoverToTerminal: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/takeover-terminal`),
   /** Upload a pasted/dropped/picked file (ANY type) into a live session; the server saves it in the
    *  agent's folder and types the path into the running claude. `dataB64` is base64 (no data: prefix);
    *  `ext` e.g. 'pdf'; `name` is the original filename, preserved when given. */


### PR DESCRIPTION
Adds the **"Open in Terminal"** bridge on a Chat session — for when a technical teammate needs to watch or steer a run hands-on, without leaving the governed session model.

## Why it's two-mode
A chat session is **headless per-turn** (no live pane between turns, no persisted launch env), so it can't always just be attached like an automation run:
- **Mid-turn** → `claimSession` the **live pane** (zero disruption, attach to the stream).
- **Idle/dead** → resurrect it as an **interactive resident** session that **resumes the same transcript with no seed prompt** (drops you into a steerable claude), writes the launch env so ttyd can attach + later reattach, and marks it claimed/sticky so reapers leave it alone.

Then the console opens the terminal on `aos-<id>`. Same session, same gateway/governance — just the raw view.

## Changes
- `TerminalManager.takeoverToTerminal(id, by)` — the two-mode logic.
- `POST /api/sessions/:id/takeover-terminal` (canView-gated).
- `terminal/claude-launch.sh`: resident-resume now omits an empty seed (`${TASK:+"$TASK"}`) so a no-prompt resume lands in the interactive TUI instead of passing a stray empty arg.
- Chat header gets an **"Open in Terminal"** button (`web/src/App.tsx`, `web/src/lib/api.ts`).

## Verified
- `npm run typecheck` + server/web builds ✓ · `npm run test:governance` → 68/68 ✓
- **Live smoke on instapods after merge**: take over both a mid-turn chat and an idle chat, confirm each opens as a live, typeable terminal session that kept the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)