### PR TITLE
fix(sessions): reap done-orphan panes of both lanes (v0.206.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.206.1] — 2026-07-15
+### Fixed
+- **Interactive sessions that `report` done no longer leak their pane forever.** A `headless=0`
+  (member/chat) run ends by calling `report`, which flips its row to `status='done'` while its interactive
+  TUI pane is still live. `markTurnIdle` bails on non-headless runs and the idle-interactive reaper (sweep 3)
+  only touches `running` rows, so the `done`+`headless=0` combination was caught by **no** reaper branch —
+  its `claude` process (~350 MB RSS) lingered indefinitely. Over days these piled up until a box's RAM/CPU
+  was exhausted (observed on the instawp tenant: 19 orphaned tmux/`claude` processes, some 5 days old, swap
+  full, load avg 100). The done-orphan backstop (reaper sweep 2) is now **lane-agnostic** — it reaps a live
+  `done` pane of *either* lane on sight, keeping the existing "human attached / blocked on a person" guards
+  so an actively-watched pane is never killed. The unattended idle-straggler rule stays `headless=1`-only.
+  (`src/terminal.ts`.)
+
 ## [0.206.0] — 2026-07-15
 ### Added
 - **"Open in Terminal" from a Chat session.** A chat conversation can now be handed off to the raw

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.206.0",
+  "version": "0.206.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.206.0",
+      "version": "0.206.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.206.0",
+  "version": "0.206.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1359,13 +1359,17 @@ export class TerminalManager {
       } catch { /* one bad row must not stop the sweep */ }
     }
 
-    // (2) unattended backstop — the safety net for markTurnIdle. Two ways an unattended run leaks a live pane:
-    //   (a) DONE ORPHAN — it ended via `report`, which flips the row to 'done' before the Stop beacon lands, so
-    //       markTurnIdle used to bail. Its pane must die regardless of idle time; a done run should hold no TUI.
-    //       (markTurnIdle now reaps these directly; this sweep also clears any that predate the fix or whose
-    //       Stop beacon never landed.) Only detectable when we can poll liveness (see below).
-    //   (b) IDLE STRAGGLER — still 'running' with a turn-end beacon seen (`last_activity` set) and idle past the
-    //       timeout: the classic case where the Stop beacon was lost or a human attached then detached.
+    // (2) DONE-ORPHAN + unattended-straggler backstop — the safety net for markTurnIdle. Two ways a run leaks
+    // a live pane:
+    //   (a) DONE ORPHAN — the run ended via `report`, which flips the row to 'done' while its interactive TUI
+    //       pane is still live; a done run should hold NO pane, ever, regardless of idle time. This bites BOTH
+    //       lanes: an unattended run whose Stop beacon never landed, AND — the common one — an INTERACTIVE
+    //       (`headless=0`) member/chat run, for which markTurnIdle bails (non-headless) and the idle-interactive
+    //       sweep (3) only touches 'running' rows, so a report-ended one is caught by neither. So we sweep
+    //       done-orphans of EITHER lane here. Only detectable when we can poll liveness (see below).
+    //   (b) IDLE STRAGGLER — an UNATTENDED (`headless=1`) run still 'running' with a turn-end beacon seen
+    //       (`last_activity` set) and idle past the timeout: the classic lost-Stop-beacon / attach-then-detach
+    //       case. (Interactive stragglers are sweep (3)'s job, on the longer interactive timeout.)
     // `aliveNames()` returns the live tmux set, or NULL when the backend can't report liveness (the Linux
     // LauncherSessionBackend always; a transient local poll failure). When we CAN poll, gate on true pane
     // liveness so a cleanly-reaped row is never re-killed / re-audited on a later tick (a `done` row keeps its
@@ -1373,7 +1377,7 @@ export class TerminalManager {
     // back to the classic time-based rule for RUNNING rows only (never blind-sweep a 'done' row, or we'd
     // re-teardown it every tick with no way to know its pane already died).
     const alive = this.backend.aliveNames();
-    const unattended = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, last_activity FROM term_sessions WHERE headless = 1 AND resident = 0 AND claimed_by IS NULL AND status IN ('running','done')")
+    const unattended = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, last_activity FROM term_sessions WHERE resident = 0 AND claimed_by IS NULL AND (status = 'done' OR (headless = 1 AND status = 'running'))")
       .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; last_activity: number | null }>();
     for (const r of unattended) {
       try {


### PR DESCRIPTION
## Problem

The instawp tenant exhausted RAM/CPU (14/15 GB used, swap full, load avg 100). Investigation found **30 tmux sessions / 23 `claude` processes** alive but only **11** were `running` in the DB. The other **19 were zombies**: DB row already `done` (some finished **5 days ago**), pane + `claude` process (~350 MB RSS each) never killed.

## Root cause

**17 of the 19 zombies were `headless=0` + `status='done'`** — a combination reaped by no branch of `reapIdleSessions`:

- **markTurnIdle** (Stop-hook fast path that reaps done-orphans) returns early for any non-headless run.
- **Reaper sweep 2** (unattended done-orphan backstop) filtered `headless = 1`.
- **Reaper sweep 3** (idle-interactive) filtered `status = 'running'`.

An interactive (member/chat) run ends by calling `report`, which flips its row to `status='done'` **without killing the pane**. From then on nothing reaps it — the `claude` process lingers forever. It's the dominant usage pattern (101 historical `headless=0`+`done` rows), so they pile up over days until OOM/manual kill.

Confirmed present in deployed v0.200.0 **and** `main` (v0.206.0).

## Fix

Make the done-orphan backstop (sweep 2) **lane-agnostic**: reap a live `done` pane of *either* lane on sight, keeping the existing `hasClient → skip` (human watching) and `hasPendingHumanBlock → skip` guards. The unattended idle-straggler rule stays `headless=1`-only. One-line WHERE change: `headless = 1 AND … status IN ('running','done')` → `resident = 0 AND claimed_by IS NULL AND (status = 'done' OR (headless = 1 AND status = 'running'))`.

## Remediation already done on the box

Killed the 19 `done`, unattended zombies live: tmux 30→11, free RAM 296 MB→4.0 GB, load 100→9.

## Test

- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run test:governance` → 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)