### PR TITLE
feat(sessions): session observability — timely crash detection, first-class blocked state, delegated-run started beat (v0.207.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.207.0] — 2026-07-15
+### Added
+- **Delegated runs announce themselves — a "picked up" beat.** When an **automation/task** run spawns
+  (its owner isn't watching the console), it now fires a `started` lifecycle event → an **opt-in DM** to
+  the run's owner (🚀, gated on their `dm` pref; no inbox card, so the feed stays agent-authored). Before,
+  a human learned nothing about a delegated run until it finished, asked, or crashed. Deliberately scoped:
+  console-spawned runs (the operator is right there) and chat runs (their thread already gets an "on it"
+  ack) skip it, so it's a signal, not noise. (`src/terminal.ts`, `src/tenant-registry.ts`)
+- **"Blocked" is a first-class session state.** `GET /api/sessions` now returns a server-authoritative
+  **`blocked`** flag per live run (a pending `ask` question or approval gate), instead of the console
+  re-deriving "waiting on you" from the message feed in three different places. New **"Blocked" filter**
+  on the Sessions list; the per-session waiting bell and the Overview blocked-count now read the one
+  authoritative field (the bell unions it with the old notification-card signal, so a governed block that
+  wrote no card still lights up). (`src/terminal.ts`, `web/src/lib/api.ts`, `web/src/App.tsx`)
+
+### Fixed
+- **Crashes surface on the timer, not just on page load.** Crash detection (a `running` row whose tmux
+  pane vanished with no end signal) ran only *lazily* — when someone read the sessions list — so an
+  unattended run that OOM'd with no console open stayed `running` in the DB, and its crash card + (now
+  always-on) owner/admin notification didn't fire until the next UI poll. The detection now also runs on
+  the process-wide 60s sweep (`sweepCrashed`, sharing the sweep's single liveness poll), so a crash and
+  its alert land promptly regardless of who's watching. Detection logic is factored into one `markCrashed`
+  path shared by the lazy read and the timer. (`src/terminal.ts`)
+
 ## [0.206.1] — 2026-07-15
 ### Fixed
 - **Interactive sessions that `report` done no longer leak their pane forever.** A `headless=0`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.206.1",
+  "version": "0.207.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.206.1",
+      "version": "0.207.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.206.1",
+  "version": "0.207.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/session-observ-test.cjs
+++ b/scripts/session-observ-test.cjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/* Session-observability test: (1) timer-driven crash detection in reapIdleSessions (sweepCrashed),
+ * (2) the server-authoritative `blocked` field on listSessions, (3) the 'started' lifecycle event for
+ * delegated (automation/task) runs. Isolated home; backend stubbed so no real tmux is needed. */
+const fs = require('fs'); const os = require('os'); const path = require('path');
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-observ-test-'));
+process.env.AGENT_OS_HOME = HOME; process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+const aos = loadAgentOS();
+const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+
+let aliveSet = new Set();
+tm.backend.aliveNames = () => aliveSet;
+tm.backend.kill = () => {};
+tm.backend.hasClient = () => false;
+tm.backend.spawn = () => {};        // createSession mock-runtime path
+tm.backend.capturePane = () => null; // captureTranscript / residentTurnState no-op
+const events = [];
+tm.setSessionEventNotifier((n) => events.push(n));
+aos.settings.setInteractiveIdleTimeoutHours(0); // disable sweep-3 so it can't interfere with the crash test
+
+let n = 0;
+const mkSession = (o) => {
+  const id = 'ts_' + (++n);
+  const cols = { id, agent: 'website-bot', title: 't', task: 'x', tmux: 'aos-' + id, status: 'running',
+    headless: 0, resident: 0, claimed_by: null, last_activity: null, run_as: 'm_alice', spawned_by: 'm_alice',
+    claude_session_id: null, created_at: Date.now(), updated_at: Date.now(), ...o };
+  aos.db.prepare("INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,resident,claimed_by,last_activity,run_as,spawned_by,claude_session_id,created_at,updated_at) VALUES (@id,@agent,@title,@task,@tmux,@status,@headless,@resident,@claimed_by,@last_activity,@run_as,@spawned_by,@claude_session_id,@created_at,@updated_at)").run(cols);
+  return id;
+};
+const statusOf = (id) => aos.db.prepare("SELECT status s FROM term_sessions WHERE id=?").get(id).s;
+const addQuestion = (runId, status) => aos.db.prepare("INSERT INTO questions (id,run_id,tenant,agent,prompt,status,created_at) VALUES (?,?,?,?,?,?,?)").run('q_'+runId, runId, aos.tenant, 'website-bot', 'ok?', status, Date.now());
+
+console.log('\n\x1b[1m1) timer-driven crash detection (sweepCrashed via reapIdleSessions)\x1b[0m');
+const dead = mkSession({ tmux: 'aos-DEAD', created_at: Date.now() - 60_000 }); // pane gone, past 10s grace → crash
+const liveOk = mkSession({ tmux: 'aos-LIVE' });                                 // pane alive → keep
+const fresh = mkSession({ tmux: 'aos-FRESH', created_at: Date.now() - 2_000 }); // pane gone but within grace → keep
+aliveSet = new Set(['aos-LIVE']);
+tm.reapIdleSessions();
+assert(statusOf(dead) === 'crashed', 'running row w/ vanished pane (past grace) → crashed on the timer', statusOf(dead));
+assert(statusOf(liveOk) === 'running', 'running row w/ live pane → left running');
+assert(statusOf(fresh) === 'running', 'vanished pane within 10s grace → left running (no false crash)');
+assert(events.some((e) => e.kind === 'crashed' && e.sessionId === dead), 'crash fired a "crashed" session-event (drives the always-on DM)');
+assert(!events.some((e) => e.kind === 'crashed' && e.sessionId === liveOk), 'live row did not fire a crash event');
+
+console.log('\n\x1b[1m2) server-authoritative `blocked` field (listSessions)\x1b[0m');
+const bQ = mkSession({ tmux: 'aos-BQ' });   addQuestion(bQ, 'pending');   // running + pending ask → blocked
+const bNone = mkSession({ tmux: 'aos-BN' });                              // running, nothing → not blocked
+const bAns = mkSession({ tmux: 'aos-BA' });  addQuestion(bAns, 'answered'); // answered question → not blocked
+const bDone = mkSession({ tmux: 'aos-BD', status: 'done' }); addQuestion(bDone, 'pending'); // pending but not running → not blocked (running-gate)
+aliveSet = new Set(['aos-BQ', 'aos-BN', 'aos-BA', 'aos-BD', 'aos-LIVE']); // keep them alive so listSessions won't crash them
+const list = tm.listSessions();
+const byId = Object.fromEntries(list.map((s) => [s.id, s]));
+assert(byId[bQ].blocked === true, 'running + pending question → blocked:true');
+assert(byId[bNone].blocked === false, 'running + no block → blocked:false');
+assert(byId[bAns].blocked === false, 'answered question → blocked:false');
+assert(byId[bDone].blocked === false, 'pending question on a DONE run → blocked:false (running-gate)');
+
+console.log('\n\x1b[1m3) `started` lifecycle event — delegated runs only\x1b[0m');
+const before = events.length;
+const sAuto = tm.createSession('teambot', 'A', 'nightly digest', 'automation:cron1', true);
+const sTask = tm.createSession('teambot', 'B', 'do work', 'task:t1', true);
+const sConsole = tm.createSession('teambot', 'C', 'manual run', 'm_alice', false);
+const sChat = tm.createSession('teambot', 'D', 'chat run', 'chat:teambot', false);
+const started = events.slice(before).filter((e) => e.kind === 'started').map((e) => e.sessionId);
+assert(started.includes(sAuto.id), 'automation: run fired a "started" event');
+assert(started.includes(sTask.id), 'task: run fired a "started" event');
+assert(!started.includes(sConsole.id), 'console (member) run did NOT fire "started" (operator is present)');
+assert(!started.includes(sChat.id), 'chat run did NOT fire "started" (thread already acks)');
+
+console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}SESSION OBSERV: ${pass}/${pass + fail} passed\x1b[0m`);
+try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
+process.exit(fail === 0 ? 0 : 1);

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -530,7 +530,7 @@ export async function notifySessionEvent(os: AgentOS, slack: Pick<SlackSocket, '
     ? (owner.length ? owner : resolveRecipients(os, { kind: 'admins' }))
     : owner.filter((m) => os.team.notificationPrefs(m.id).dm);
   if (!targets.length) return;
-  const icon = notice.kind === 'waiting' ? '🔔' : notice.kind === 'crashed' ? '💥' : '✅';
+  const icon = notice.kind === 'waiting' ? '🔔' : notice.kind === 'crashed' ? '💥' : notice.kind === 'started' ? '🚀' : '✅';
   const url = consolePage(consoleOrigin, 'sessions');
   const text = (p: ChatPlatform) => `${icon} ${notice.title}\n${notice.message}\nOpen it in the ${chatLink(p, url, 'Agent OS console')}.`;
   const dms = await deliverDM(slack, discord, os, targets, text);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -188,6 +188,12 @@ export interface Session {
   /** The member id who "took over" (claimed) this unattended run to watch/steer it — set makes the
    *  session sticky (never auto-reaped at turn-end). Undefined = nobody has claimed it. */
   claimedBy?: string;
+  /** True when the run is BLOCKED on a human right now — a pending `ask` question or a pending approval
+   *  gate whose turn can't end until someone answers. The one authoritative "needs you" state, resolved
+   *  server-side (a pending question OR approval for this run) so the console doesn't re-derive it from the
+   *  message feed. Only meaningful for a live run (`status === 'running'`). Drives the "blocked" list
+   *  filter and the sidebar/overview "waiting on you" treatment. */
+  blocked?: boolean;
   /** The member id this session ACTS AS (run_as) — distinct from `spawnedBy` provenance. A task- or
    *  chat-triggered run is spawned by `task:`/`automation:` but runs as (and is owned by) a member,
    *  so the console keys "my sessions" off this too. */
@@ -342,16 +348,16 @@ export interface MemberNotice {
   important: boolean;
 }
 
-/** What the session-event notifier sink receives when one of a member's own sessions changes state —
- *  it started waiting on them, finished, or crashed. The registry DMs the run's owner (its `run_as`,
- *  else the console member who spawned it) on Slack/Discord IF that member opted into `dm` notifications.
- *  The inbox card is written inline regardless; this is only the out-of-band push, gated on preference so
- *  it doesn't flood. Approvals/questions have their own (always-on) notifiers — this covers the newer
- *  complete/waiting/crashed events the console added a bell for. */
+/** What the session-event notifier sink receives when one of a member's own sessions changes state — it
+ *  began (a delegated/unattended run), started waiting on them, finished, or crashed. The registry DMs the
+ *  run's owner (its `run_as`, else the console member who spawned it) on Slack/Discord IF that member opted
+ *  into `dm` notifications (except `crashed`, an always-on failure signal that also escalates to admins).
+ *  Most kinds also write an inbox card inline; `started` is DM-only (no card — the feed stays agent-
+ *  authored, not a lifecycle log). Approvals/questions have their own (always-on) notifiers. */
 export interface SessionEventNotice {
   sessionId: string;
   agent: string;
-  kind: 'waiting' | 'completed' | 'crashed';
+  kind: 'started' | 'waiting' | 'completed' | 'crashed';
   title: string;
   message: string;
 }
@@ -465,40 +471,18 @@ export class TerminalManager {
     if (alive) {
       const cutoff = Date.now() - 10_000;
       for (const r of rows) {
-        if (r.status === 'running' && !alive.has(r.tmux) && r.created_at < cutoff) {
-          const crashedAt = Date.now();
-          this.db.prepare("UPDATE term_sessions SET status = 'crashed', updated_at = ? WHERE id = ?").run(crashedAt, r.id);
-          r.status = 'crashed';
-          r.updated_at = crashedAt; // keep the in-memory row in sync so this same response isn't stale
-          // A crash fires no end signal (no `report`/`markEnded`/`stopSession`), so this sweep is the
-          // only place to capture what the run did before it died. Outcome 'crashed'; idempotent, so
-          // repeated polls won't write twice; skipped if the session did no real work.
-          this.writeEpisode(r.id, r.agent, 'crashed');
-          // A crashed agent can't answer or act — retire its open questions + approvals like a clean stop.
-          this.cancelPendingQuestions(r.id, 'system');
-          this.cancelPendingApprovals(r.id, 'system');
-          // Surface the crash to the owner: a 'completed' card (outcome 'crashed') is the only feed entry a
-          // crash produces, since it fires no clean end signal. Guarded on hasCompleted so a run that had
-          // already reported before its pane died isn't double-carded; the status flip makes it once-only.
-          if (!this.hasCompleted(r.id)) {
-            const title = `Crashed — ${r.agent}`;
-            const body = 'The session ended unexpectedly (the process died).';
-            this.addMessage({ type: 'completed', sessionId: r.id, agent: r.agent, title, body, status: 'open', outcome: 'crashed', audienceKind: 'sessionOwner', audienceId: r.id });
-            this.fireSessionEvent(r.id, r.agent, 'crashed', title, body);
-            // Close the chat loop: a crash fires no `report` (the only other mirror point), so a chat-
-            // triggered run that DIED would otherwise leave its Slack/Discord thread hanging forever. Tell
-            // the thread it broke. No-op for non-chat runs (no bound thread).
-            const inboxLink = consolePage(this.publicOrigin, 'inbox');
-            try { this.chatMirror?.(r.id, (p) => `💥 ${r.agent} crashed — the session ended unexpectedly.\n${chatLink(p, inboxLink, 'Open in Agent OS')}`); } catch { /* advisory */ }
-          }
-        }
+        if (r.status === 'running' && !alive.has(r.tmux) && r.created_at < cutoff) this.markCrashed(r);
       }
     }
     const visible = viewer ? rows.filter((r) => this.canViewRow(r.spawned_by, r.run_as, viewer)) : rows;
     const resumable = this.resumableIds();
+    // One query resolves the whole list's blocked-on-human state (a pending ask/approval), instead of a
+    // per-row check — so the console gets an authoritative `blocked` without re-deriving it from the feed.
+    const blocked = this.blockedSessionIds();
     return visible.map((r) => ({
       ...toSession(r),
       alive: alive ? alive.has(r.tmux) : undefined,
+      blocked: r.status === 'running' && blocked.has(r.id),
       resumable: resumable.has(r.id),
       forkable: !!r.claude_session_id && this.os.agents.get(r.agent)?.runtime === 'claude-code',
       spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as),
@@ -506,6 +490,64 @@ export class TerminalManager {
       runAsLabel: this.runAsLabel(r.run_as),
       ratedByLabel: this.runAsLabel(r.rated_by),
     }));
+  }
+
+  /**
+   * Flip a `running` row whose tmux pane vanished with no end signal (kill/OOM/reboot) to `crashed`, and
+   * surface it: capture the pre-death episode, retire its open questions/approvals (a dead agent can't
+   * answer), and — once only, guarded by `hasCompleted` + the status flip — post the owner crash card, the
+   * always-on crash notification, and the chat-thread mirror. Mutates the passed row so an in-flight
+   * `listSessions` response reflects the new status the same tick. Shared by the lazy read-time detection
+   * (`listSessions`) and the periodic timer sweep (`sweepCrashed`) so a crash surfaces even with no console
+   * open. Idempotent — a second call after the status flip is a cheap no-op.
+   */
+  private markCrashed(r: SessionRow): void {
+    const crashedAt = Date.now();
+    this.db.prepare("UPDATE term_sessions SET status = 'crashed', updated_at = ? WHERE id = ?").run(crashedAt, r.id);
+    r.status = 'crashed';
+    r.updated_at = crashedAt;
+    this.writeEpisode(r.id, r.agent, 'crashed');
+    this.cancelPendingQuestions(r.id, 'system');
+    this.cancelPendingApprovals(r.id, 'system');
+    if (!this.hasCompleted(r.id)) {
+      const title = `Crashed — ${r.agent}`;
+      const body = 'The session ended unexpectedly (the process died).';
+      this.addMessage({ type: 'completed', sessionId: r.id, agent: r.agent, title, body, status: 'open', outcome: 'crashed', audienceKind: 'sessionOwner', audienceId: r.id });
+      this.fireSessionEvent(r.id, r.agent, 'crashed', title, body);
+      // Close the chat loop: a crash fires no `report` (the only other mirror point), so a chat-triggered
+      // run that DIED would otherwise leave its Slack/Discord thread hanging forever. No-op for non-chat runs.
+      const inboxLink = consolePage(this.publicOrigin, 'inbox');
+      try { this.chatMirror?.(r.id, (p) => `💥 ${r.agent} crashed — the session ended unexpectedly.\n${chatLink(p, inboxLink, 'Open in Agent OS')}`); } catch { /* advisory */ }
+    }
+  }
+
+  /**
+   * Timer-driven crash detection — the same rule `listSessions` applies lazily on read, but run on the
+   * process-wide 60s sweep so a crash (and its always-on owner/admin DM) surfaces even when nobody has the
+   * console open (before this, an unattended run that OOM'd at 3am stayed `running` in the DB until the next
+   * UI poll, delaying the crash notification indefinitely). A `running` row whose pane is gone past the 10s
+   * grace died with no end signal → `markCrashed`. No-op when liveness can't be polled (launcher backend /
+   * transient failure) so a tmux hiccup can't false-crash the fleet.
+   */
+  private sweepCrashed(alive: Set<string> | null): void {
+    if (!alive) return;
+    const cutoff = Date.now() - 10_000;
+    const rows = this.db.prepare("SELECT * FROM term_sessions WHERE status = 'running'").all<SessionRow>();
+    for (const r of rows) {
+      if (!alive.has(r.tmux) && r.created_at < cutoff) {
+        try { this.markCrashed(r); } catch { /* one bad row must not stop the sweep */ }
+      }
+    }
+  }
+
+  /** The set of session ids BLOCKED on a human right now — a pending `ask` question or a pending approval
+   *  gate. One batched pass over the questions table + the tenant's pending approvals, for `listSessions`
+   *  to stamp `blocked` per row without an N+1 of {@link hasPendingHumanBlock}. */
+  private blockedSessionIds(): Set<string> {
+    const ids = new Set<string>();
+    for (const q of this.db.prepare("SELECT DISTINCT run_id FROM questions WHERE status = 'pending'").all<{ run_id: string }>()) ids.add(q.run_id);
+    for (const a of this.os.approvals.pending(this.os.tenant)) ids.add(a.runId);
+    return ids;
   }
 
   /**
@@ -1001,6 +1043,15 @@ export class TerminalManager {
     // a member), the trail shows what fired it AND whose identity it used.
     this.audit(id, agent, 'session.created', { tmux, task, runtime, dir: manifest?.dir, headless, resident, spawnedBy: spawnedBy ?? null, runAs: actingMember ?? null });
 
+    // "Picked up" beat for a DELEGATED, unattended run (automation/task provenance): its owner isn't
+    // watching the console, so without this they learn nothing until it finishes, asks, or crashes. Fire a
+    // `started` lifecycle event → an opt-in DM to the run's owner (gated on their `dm` pref; no inbox card,
+    // to keep the feed agent-authored). Deliberately scoped: a console-spawned run (the operator is right
+    // there) and a chat run (its thread already gets an "on it" ack) skip this, so it's a signal, not noise.
+    if (spawnedBy && (spawnedBy.startsWith('automation:') || spawnedBy.startsWith('task:'))) {
+      this.fireSessionEvent(id, agent, 'started', `Started — ${agent}`, task || 'A delegated run began.');
+    }
+
     if (runtime === 'claude-code' && manifest?.dir) {
       this.launchClaudeCode({ id, agent, task, secret, actingMember, spawnedBy, hasSlack: !!slack?.channel, hasDiscord: !!discord?.channel, headless, resident, resume: !!resumeClaudeId, claudeSessionId });
     } else {
@@ -1341,6 +1392,12 @@ export class TerminalManager {
   reapIdleSessions(): void {
     const timeoutMin = this.os.settings.chatIdleTimeoutMinutes();
     const cutoff = timeoutMin > 0 ? Date.now() - timeoutMin * 60_000 : Date.now() + 1; // 0 → reap all now
+    // One liveness poll for the whole sweep (crash detection + the unattended backstop both need it).
+    const alive = this.backend.aliveNames();
+
+    // (0) crash detection on the timer — flip any running row whose pane vanished with no end signal to
+    // `crashed` and fire its (always-on) notification NOW, instead of waiting for the next console poll.
+    this.sweepCrashed(alive);
 
     // (1) resident warm-chat idle reap — unchanged behavior.
     const residents = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent FROM term_sessions WHERE resident = 1 AND status = 'running' AND COALESCE(last_activity, created_at) < ?")
@@ -1375,8 +1432,8 @@ export class TerminalManager {
     // liveness so a cleanly-reaped row is never re-killed / re-audited on a later tick (a `done` row keeps its
     // status forever once torn down) — this is what lets us sweep 'done' orphans safely. When we CAN'T, fall
     // back to the classic time-based rule for RUNNING rows only (never blind-sweep a 'done' row, or we'd
-    // re-teardown it every tick with no way to know its pane already died).
-    const alive = this.backend.aliveNames();
+    // re-teardown it every tick with no way to know its pane already died). Uses the single `alive` poll
+    // taken at the top of the sweep.
     const unattended = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, last_activity FROM term_sessions WHERE resident = 0 AND claimed_by IS NULL AND (status = 'done' OR (headless = 1 AND status = 'running'))")
       .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; last_activity: number | null }>();
     for (const r of unattended) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -106,16 +106,20 @@ const sessionSource = (s: Session): SessionSource => {
 }
 
 /** Session-list status filter. `live` matches any session with a live pane (regardless of stored
- *  status); the terminal states match only when NOT live, so a live pane reporting `done` reads as
- *  Live, never Done — the same rule `statusLabel` uses for the dot. */
-type SessionStatusFilter = 'all' | 'live' | 'done' | 'stopped' | 'crashed'
+ *  status); `blocked` narrows to live runs waiting on a human (a pending ask/approval); the terminal
+ *  states match only when NOT live, so a live pane reporting `done` reads as Live, never Done — the same
+ *  rule `statusLabel` uses for the dot. */
+type SessionStatusFilter = 'all' | 'live' | 'blocked' | 'done' | 'stopped' | 'crashed'
 const matchesStatus = (s: Session, f: SessionStatusFilter): boolean =>
-  f === 'all' ? true : f === 'live' ? isLive(s) : !isLive(s) && s.status === f
+  f === 'all' ? true
+    : f === 'live' ? isLive(s)
+      : f === 'blocked' ? isLive(s) && Boolean(s.blocked)
+        : !isLive(s) && s.status === f
 
 // Filter labels — shared by the dropdown options AND the collapsed trigger (base-ui's SelectValue
 // renders the raw value unless given a formatter, so the two must read from one source).
 const SESSION_STATUS_LABELS: Record<SessionStatusFilter, string> =
-  { all: 'All statuses', live: 'Live', done: 'Done', stopped: 'Stopped', crashed: 'Crashed' }
+  { all: 'All statuses', live: 'Live', blocked: 'Blocked', done: 'Done', stopped: 'Stopped', crashed: 'Crashed' }
 const SESSION_SOURCE_LABELS: Record<'all' | SessionSource, string> =
   { all: 'All sources', member: 'Member', automation: 'Automation', task: 'Task', chat: 'Chat' }
 
@@ -1017,8 +1021,12 @@ function Console({ me }: { me: Member }) {
   }
 
   const pendingApprovals = messages.filter(isActionRequired).length
-  // Sessions where Claude is blocked waiting on the human — drives the per-session bell everywhere.
+  // Sessions where Claude is blocked waiting on the human — drives the per-session bell everywhere. Union
+  // of two signals: an open 'notification' card (the agent said so / a permission-prompt Notification) and
+  // the server-authoritative `s.blocked` (a pending governed ask/approval), so the bell shows even when a
+  // block produced no card.
   const waiting = new Set(messages.filter((m) => m.type === 'notification' && m.status === 'open').map((m) => m.sessionId))
+  for (const s of sessions) if (s.blocked) waiting.add(s.id)
   // The sidebar "All" badge counts genuinely LIVE runs — a session actively RUNNING with a live pane —
   // mirroring the server's canonical aliveSessionCount. `isLive` is deliberately broader (an interactive
   // session that reported `done` but keeps an attachable pane reads live so its dot stays green +
@@ -1235,7 +1243,7 @@ function Console({ me }: { me: Member }) {
           {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onDuplicate={duplicateAgent} onRescan={rescanAgents} onImport={importAgent} onRefresh={refreshState} />}
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); nav('agents', id) }} />}
           {route === 'sessions' && <SessionsPage me={me} members={members} sessions={sessions} waiting={waiting} selected={selected} hiddenTabs={hiddenTabs} onOpen={openTerminal} onCloseTab={closeTab} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onRate={rateSession} onRename={renameSession} onTransfer={transferSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
-          {route === 'overview' && me.role === 'owner' && <OverviewPage me={me} sessions={sessions} messages={messages} members={members} agents={state?.agents ?? []} maturity={maturity} onOpen={openTerminal} nav={nav} />}
+          {route === 'overview' && me.role === 'owner' && <OverviewPage me={me} sessions={sessions} members={members} agents={state?.agents ?? []} maturity={maturity} onOpen={openTerminal} nav={nav} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} members={members} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} onOpenGoal={(id) => nav('goals', id)} />}
           {route === 'chat' && <ChatPage agents={state?.agents ?? []} sessions={sessions} messages={messages} selected={detail} onSelect={(id) => nav('chat', id)} onOpenTerminal={openTerminal} />}
           {route === 'connectors' && <ConnectionsPage me={me} tab={detail} onTab={(t) => nav('connectors', t)} />}
@@ -5722,12 +5730,13 @@ const fromDateInput = (v: string): number | null => (v ? new Date(v + 'T00:00:00
 /** Owner-only home. What the fleet is doing right now (live sessions + who's accountable for each) and
  *  which agents are earning trust. Pure-props: it reads the sessions/messages the Console already polls
  *  and the fleet maturity map, so it live-updates on the 1.5s tick with no fetch of its own. */
-function OverviewPage({ me, sessions, messages, members, agents, maturity, onOpen, nav }: {
-  me: Member; sessions: Session[]; messages: Msg[]; members: Member[]; agents: AgentInfo[]
+function OverviewPage({ me, sessions, members, agents, maturity, onOpen, nav }: {
+  me: Member; sessions: Session[]; members: Member[]; agents: AgentInfo[]
   maturity: Record<string, AgentStats>; onOpen: (tmux: string, title: string) => void; nav: (r: Route, detail?: string) => void
 }) {
-  // A run is "blocked" when it has a pending approval/question waiting on a human (keyed by session id).
-  const blockedRuns = useMemo(() => new Set(messages.filter(isActionRequired).map((m) => m.sessionId)), [messages])
+  // A run is "blocked" when it's waiting on a human (a pending ask/approval). Read straight off the
+  // server-authoritative `s.blocked` flag now, rather than re-deriving it from the message feed.
+  const blockedRuns = useMemo(() => new Set(sessions.filter((s) => s.blocked).map((s) => s.id)), [sessions])
   const live = useMemo(() => sessions.filter(isLive).sort((a, b) => a.createdAt - b.createdAt), [sessions])
   const t0 = useMemo(() => { const d = new Date(); d.setHours(0, 0, 0, 0); return d.getTime() }, [])
   const doneToday = sessions.filter((s) => s.status === 'done' && s.updatedAt >= t0).length

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -169,6 +169,10 @@ export interface Session {
   /** The member id who "took over" (claimed) this unattended run — set means it's sticky (won't be
    *  auto-closed at turn-end) and the Take-over affordance is hidden. Undefined = unclaimed. */
   claimedBy?: string
+  /** True when a LIVE run is blocked on a human right now — a pending `ask` question or approval gate.
+   *  Server-authoritative (the console no longer re-derives "waiting on you" from the message feed).
+   *  Drives the "Blocked" list filter, the per-session waiting bell, and the Overview blocked count. */
+  blocked?: boolean
   /** The member id this session runs AS (run_as). A task/chat-triggered run is spawnedBy `task:`/
    *  `automation:` but runs as a member — the sidebar keys "my sessions" off this too. */
   runAs?: string


### PR DESCRIPTION
## Why

Follow-up to the v0.200.0 session-lifecycle notification fixes. That work made crashes and ownerless runs *notify* the right person; this closes the three **observability** gaps the audit flagged next — so the notifications fire promptly and the console reads block-state from one authoritative place.

## What changed

### 1. Crashes surface on the timer, not just on page load (fix)
Crash detection — a `running` row whose tmux pane vanished with no end signal — ran **lazily**, only when someone read the sessions list. So an unattended run that OOM'd with no console open stayed `running` in the DB, and its crash card + (now always-on) owner/admin DM didn't fire until the next UI poll. Detection now **also runs on the process-wide 60s sweep** (`sweepCrashed`, reusing the sweep's single liveness poll). The per-row logic is factored into one `markCrashed` path shared by the lazy read and the timer, so behavior can't drift between them.

### 2. `blocked` is a first-class session state (enhancement)
`GET /api/sessions` now returns a **server-authoritative `blocked`** flag per live run (a pending `ask` question or approval gate), computed once per list via a batched query — instead of the console re-deriving "waiting on you" from the message feed in **three** different spots. New **"Blocked" filter** on the Sessions list; the sidebar waiting-bell and the Overview blocked-count now read the one field (the bell **unions** it with the legacy notification-card signal, so a governed block that wrote no card still lights up).

### 3. Delegated runs announce themselves — a "picked up" beat (feature)
An **automation/task** run (whose owner isn't at the console) now fires a `started` lifecycle event → an **opt-in DM** to the run's owner (🚀, gated on their `dm` pref; **no inbox card**, to keep the feed agent-authored). Deliberately scoped: console-spawned runs (operator present) and chat runs (thread already acks) skip it.

## Testing
- `npm run build` (server + web) clean
- `npm run test:governance` → **68/68**
- New `scripts/session-observ-test.cjs` → **13/13** (crash-on-timer incl. the 10s grace + false-crash guard; the `blocked` field incl. the running-gate + answered-question cases; `started` fires for automation/task and NOT for console/chat). Isolated `AGENT_OS_HOME`, backend stubbed — no live data touched.

## Files
`src/terminal.ts` · `src/tenant-registry.ts` · `web/src/lib/api.ts` · `web/src/App.tsx` · `scripts/session-observ-test.cjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)