### PR TITLE
fix(chat): keep the Chat window strictly to chat-started sessions (v0.207.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.207.1] — 2026-07-15
+### Fixed
+- **The Chat window now only ever shows chat-started sessions.** The chat *list* already filtered to
+  `sourceKind === 'chat'`, but the open-conversation view keyed off the URL, so a deep-link to a
+  non-chat session id (a terminal/automation/task run) could still render inside the Chat window. It now
+  bounces such a selection back to the composer — the Chat surface stays strictly for sessions started as
+  chat. (`web/src/App.tsx`.)
+
 ## [0.207.0] — 2026-07-15
 ### Added
 - **Delegated runs announce themselves — a "picked up" beat.** When an **automation/task** run spawns

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.207.0",
+  "version": "0.207.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.207.0",
+      "version": "0.207.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.207.0",
+  "version": "0.207.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2887,6 +2887,11 @@ function ChatPage({ agents, sessions, messages, selected, onSelect, onOpenTermin
     [sessions],
   )
   const active = selected ? sessions.find((s) => s.id === selected) : undefined
+  // The Chat window only ever shows chat-started sessions. If the URL points at a session that's known to
+  // NOT be a chat (e.g. a deep-link to a terminal/automation run), don't render it as a chat — bounce back
+  // to the composer. An unknown id (a just-started chat not yet in the polled list) is allowed through.
+  const nonChatSelected = !!active && active.sourceKind !== 'chat'
+  useEffect(() => { if (nonChatSelected) onSelect('') }, [nonChatSelected])
 
   // New-chat composer state (shown when nothing is selected).
   const [newAgent, setNewAgent] = useState('')
@@ -3023,7 +3028,7 @@ function ChatPage({ agents, sessions, messages, selected, onSelect, onOpenTermin
 
       {/* Right: either the new-chat composer or the conversation */}
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
-        {!selected ? (
+        {!selected || nonChatSelected ? (
           (() => {
             const q = newFilter.trim().toLowerCase()
             const shown = q ? chatAgents.filter((a) => a.id.toLowerCase().includes(q) || (a.description || '').toLowerCase().includes(q)) : chatAgents


### PR DESCRIPTION
The chat list already filtered to `sourceKind === 'chat'`, but the open-conversation view keyed off the URL — so a deep-link to a non-chat session id (a terminal/automation/task run) could still render inside the Chat window. Now a non-chat selection bounces back to the composer, so the Chat surface stays strictly for sessions started as chat.

Also confirms the decision to NOT add a 'view any Terminal session as chat' reverse.

Web-only. Builds ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)