### PR TITLE
feat(library): share a deliverable with the team and the web (v0.208.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.208.0] — 2026-07-16
+### Added
+- **Share a Library deliverable with the team and the web.** An artifact was previously visible only to
+  its producer (plus owner/admin) and reachable only behind the console login. The detail panel now has a
+  Share section (owner/admin, or the member whose session produced it) with two independent toggles:
+  - **Shared with workspace** — flips tenant-wide visibility; every member then sees the deliverable in
+    their Library (on top of the existing provenance rule).
+  - **Public link** — mints an unguessable, revocable `/shared/<token>` URL served **before** the member
+    gate, so anyone with the link can view/download it with no login (the same secret-in-URL model as
+    inbound `/hooks`). Toggling it off revokes the link. The URL is copy-to-clipboard (insecure-context
+    fallback for the plain-HTTP tailnet).
+  New `artifacts.shared_team`/`share_token` columns (unique partial index on the token), store methods
+  `setTeamShared`/`setPublic`/`getByToken`, `POST /api/artifacts/:id/share`, and the public
+  `GET /shared/:token` route. The public route is hardened: HTML/SVG is served under
+  `Content-Security-Policy: sandbox` (opaque origin — a shared page's scripts can't read cookies or call
+  same-origin `/api`) plus `X-Content-Type-Options: nosniff`, mirroring the console's iframe sandbox. The
+  byte-range/streaming logic is shared with the authenticated raw route. Every share change and public
+  view is audited (`artifact.shared`, `artifact.share.viewed`).
+
 ## [0.207.2] — 2026-07-15
 ### Fixed
 - **Bundled `agent-os.service` no longer hangs every interactive session on a fresh hardened box.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.207.2",
+  "version": "0.208.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.207.2",
+      "version": "0.208.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.207.2",
+  "version": "0.208.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -532,6 +532,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, out.status, out.body);
   }
 
+  // ── public artifact share (PUBLIC — authenticated by the artifact's own unguessable token) ──────
+  // An owner/admin/producer mints a login-free link to ONE published deliverable; anyone with the URL
+  // views/downloads it. Sits BEFORE the member gate like /hooks, and is authenticated the same way — by
+  // an unguessable secret in the URL rather than a cookie. Host-scoped to this tenant (the registry has
+  // already routed us into the right runtime), so a token only resolves within its own tenant's gallery.
+  // Serves bytes inline; `?file=` selects a sibling (future multi-file `kind:'site'`).
+  const sharedMatch = p.match(/^\/shared\/([A-Za-z0-9_-]+)$/);
+  if (method === 'GET' && sharedMatch) {
+    const a = os.artifacts.getByToken(sharedMatch[1]);
+    if (!a) return end(res, 404);
+    const resolved = os.artifacts.readPath(a.id, url.searchParams.get('file') || undefined);
+    if (!resolved) return end(res, 404);
+    // Audit only the primary (non-range) fetch — media scrubbing fires many range requests for one view.
+    if (!req.headers['range']) os.audit.append({ ts: Date.now(), runId: a.sessionId, tenant: os.tenant, principal: 'public', type: 'artifact.share.viewed', data: { id: a.id, file: resolved.filename } });
+    return streamArtifactFile(req, res, resolved, { sandbox: true });
+  }
+
   // ── Composio ingress (PUBLIC — verified by the Composio webhook signing secret) ───────────────
   // Composio Webhook Triggers V2 POST app events (Slack message/DM, …) here. Verify the Svix-style
   // signature, parse the event, and fire matching `composio` automations → governed agent sessions.
@@ -4347,56 +4364,30 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   //    artifacts from sessions they spawned (or an automation they created). Unlike the raw file
   //    browser this exposes only curated, published deliverables — never the whole data home.
   if (method === 'GET' && p === '/api/artifacts') {
-    const visible = os.artifacts.list().filter((a) => tm.canViewSpawn(a.source ?? null, me));
-    return sendJson(res, 200, { artifacts: visible, enabled: os.artifacts.enabled });
+    // A member sees an artifact if it's from a session they own (provenance) OR it's shared with the
+    // whole tenant. The public share TOKEN is a credential, not display data — surface it (and the
+    // resolved link) only to whoever may manage sharing (owner/admin/producer); everyone else gets a
+    // plain `public` boolean so the UI can badge it without leaking the URL.
+    const visible = os.artifacts.list().filter((a) => tm.canViewSpawn(a.source ?? null, me) || a.sharedTeam);
+    const shaped = visible.map((a) => {
+      const mine = isAdmin(me) || a.source === me.id;
+      return {
+        ...a,
+        public: !!a.shareToken,
+        shareToken: mine ? a.shareToken : undefined,
+        shareUrl: mine && a.shareToken ? sharedLinkFor(req, a.shareToken) : undefined,
+      };
+    });
+    return sendJson(res, 200, { artifacts: shaped, enabled: os.artifacts.enabled });
   }
   const artRawMatch = p.match(/^\/api\/artifacts\/([\w-]+)\/raw$/);
   if (method === 'GET' && artRawMatch) {
     const a = os.artifacts.get(artRawMatch[1]);
     if (!a) return sendJson(res, 404, { error: 'not found' });
-    if (!tm.canViewSpawn(a.source ?? null, me)) return sendJson(res, 403, { error: 'forbidden' });
+    if (!tm.canViewSpawn(a.source ?? null, me) && !a.sharedTeam) return sendJson(res, 403, { error: 'forbidden' });
     const resolved = os.artifacts.readPath(a.id, url.searchParams.get('file') || undefined);
     if (!resolved) return sendJson(res, 404, { error: 'file not found' });
-    let total: number;
-    try { total = fs.statSync(resolved.absPath).size; } catch { return sendJson(res, 404, { error: 'file not found' }); }
-    const disposition = `inline; filename="${resolved.filename.replace(/"/g, '')}"`;
-    // Honour byte-range requests — <video>/<audio> scrubbing (and Safari playback at all) depends on
-    // 206 Partial Content responses, and it keeps large downloads resumable.
-    const range = req.headers['range'];
-    const m = typeof range === 'string' ? range.match(/^bytes=(\d*)-(\d*)$/) : null;
-    if (m && (m[1] || m[2]) && total > 0) {
-      let start = m[1] ? parseInt(m[1], 10) : NaN;
-      let end = m[2] ? parseInt(m[2], 10) : NaN;
-      if (Number.isNaN(start)) { start = total - end; end = total - 1; }   // suffix range: bytes=-N
-      else if (Number.isNaN(end)) end = total - 1;                          // open range:   bytes=N-
-      if (start > end || start < 0 || start >= total) {
-        res.writeHead(416, { 'content-range': `bytes */${total}` });
-        res.end();
-        return;
-      }
-      end = Math.min(end, total - 1);
-      const stream = fs.createReadStream(resolved.absPath, { start, end });
-      stream.on('error', () => { if (!res.headersSent) sendJson(res, 500, { error: 'read failed' }); else res.end(); });
-      res.writeHead(206, {
-        'content-type': resolved.mime,
-        'content-disposition': disposition,
-        'content-range': `bytes ${start}-${end}/${total}`,
-        'accept-ranges': 'bytes',
-        'content-length': end - start + 1,
-      });
-      stream.pipe(res);
-      return;
-    }
-    const stream = fs.createReadStream(resolved.absPath);
-    stream.on('error', () => { if (!res.headersSent) sendJson(res, 500, { error: 'read failed' }); else res.end(); });
-    res.writeHead(200, {
-      'content-type': resolved.mime,
-      'content-disposition': disposition,
-      'accept-ranges': 'bytes',
-      'content-length': total,
-    });
-    stream.pipe(res);
-    return;
+    return streamArtifactFile(req, res, resolved);
   }
   const artMatch = p.match(/^\/api\/artifacts\/([\w-]+)$/);
   // Move an artifact into a folder ('' = root). Same gate as delete: owner/admin, or the member whose
@@ -4420,6 +4411,22 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.artifacts.remove(a.id);
     os.audit.append({ ts: Date.now(), runId: a.sessionId, tenant: os.tenant, principal: me.email, type: 'artifact.deleted', data: { id: a.id, filename: a.filename } });
     return sendJson(res, 200, { ok: true });
+  }
+  // Share an artifact beyond its producer — same gate as move/delete (owner/admin, or the producing
+  // member). `team` toggles whole-tenant Library visibility; `public` mints/revokes the login-free
+  // `/shared/<token>` link. Either field is optional; only the ones present are applied. Auto-apply +
+  // audited (`artifact.shared`). Returns the updated artifact incl. the resolved public link (if any).
+  const artShareMatch = p.match(/^\/api\/artifacts\/([\w-]+)\/share$/);
+  if (method === 'POST' && artShareMatch) {
+    const a = os.artifacts.get(artShareMatch[1]);
+    if (!a) return sendJson(res, 404, { error: 'not found' });
+    if (!isAdmin(me) && a.source !== me.id) return sendJson(res, 403, { error: 'forbidden' });
+    const b = await readBody(req);
+    if (typeof b.team === 'boolean') os.artifacts.setTeamShared(a.id, b.team);
+    if (typeof b.public === 'boolean') os.artifacts.setPublic(a.id, b.public);
+    const updated = os.artifacts.get(a.id)!;
+    os.audit.append({ ts: Date.now(), runId: a.sessionId, tenant: os.tenant, principal: me.email, type: 'artifact.shared', data: { id: a.id, team: updated.sharedTeam, public: !!updated.shareToken } });
+    return sendJson(res, 200, { ok: true, artifact: { ...updated, public: !!updated.shareToken, shareUrl: updated.shareToken ? sharedLinkFor(req, updated.shareToken) : undefined } });
   }
 
   // ── policy (the risk ruleset). Read: owner/admin. Edit: OWNER only — it governs what needs
@@ -4978,6 +4985,74 @@ function hookUrlFor(req: http.IncomingMessage, id: string, secret: string): stri
   const proto = String(req.headers['x-forwarded-proto'] || 'http').split(',')[0];
   const host = req.headers.host || '127.0.0.1';
   return `${proto}://${host}/hooks/${id}?key=${secret}`;
+}
+
+/** The public login-free URL for an artifact's share token — same host/proto derivation as invite links. */
+function sharedLinkFor(req: http.IncomingMessage, token: string): string {
+  const proto = String(req.headers['x-forwarded-proto'] || 'http').split(',')[0];
+  const host = req.headers.host || '127.0.0.1';
+  return `${proto}://${host}/shared/${token}`;
+}
+
+/**
+ * Stream an artifact file to the response with inline disposition and byte-range support. Shared by the
+ * authenticated console raw route and the public `/shared/<token>` route — <video>/<audio> scrubbing
+ * (and Safari playback at all) depends on 206 Partial Content, and it keeps large downloads resumable.
+ */
+function streamArtifactFile(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  resolved: { absPath: string; mime: string; filename: string },
+  opts: { sandbox?: boolean } = {},
+): void {
+  let total: number;
+  try { total = fs.statSync(resolved.absPath).size; } catch { return sendJson(res, 404, { error: 'file not found' }); }
+  const disposition = `inline; filename="${resolved.filename.replace(/"/g, '')}"`;
+  // Public-share hardening: the file is served as a TOP-LEVEL document on the app's own origin, so an
+  // HTML/SVG artifact would otherwise run script with real same-origin privileges (cookies, /api). The
+  // console dodges this by rendering HTML in an iframe sandboxed WITHOUT allow-same-origin; we reproduce
+  // that for the public route with `Content-Security-Policy: sandbox` (an opaque origin — scripts run but
+  // can't read cookies or call same-origin APIs), plus nosniff so a mislabeled file can't be sniffed into
+  // executable HTML. Rendering of images/pdf/video/markdown/text is unaffected.
+  const extra: Record<string, string> = opts.sandbox
+    ? { 'content-security-policy': 'sandbox allow-scripts allow-popups allow-forms allow-downloads', 'x-content-type-options': 'nosniff' }
+    : {};
+  const range = req.headers['range'];
+  const m = typeof range === 'string' ? range.match(/^bytes=(\d*)-(\d*)$/) : null;
+  if (m && (m[1] || m[2]) && total > 0) {
+    let start = m[1] ? parseInt(m[1], 10) : NaN;
+    let end = m[2] ? parseInt(m[2], 10) : NaN;
+    if (Number.isNaN(start)) { start = total - end; end = total - 1; }   // suffix range: bytes=-N
+    else if (Number.isNaN(end)) end = total - 1;                          // open range:   bytes=N-
+    if (start > end || start < 0 || start >= total) {
+      res.writeHead(416, { 'content-range': `bytes */${total}` });
+      res.end();
+      return;
+    }
+    end = Math.min(end, total - 1);
+    const stream = fs.createReadStream(resolved.absPath, { start, end });
+    stream.on('error', () => { if (!res.headersSent) sendJson(res, 500, { error: 'read failed' }); else res.end(); });
+    res.writeHead(206, {
+      'content-type': resolved.mime,
+      'content-disposition': disposition,
+      'content-range': `bytes ${start}-${end}/${total}`,
+      'accept-ranges': 'bytes',
+      'content-length': end - start + 1,
+      ...extra,
+    });
+    stream.pipe(res);
+    return;
+  }
+  const stream = fs.createReadStream(resolved.absPath);
+  stream.on('error', () => { if (!res.headersSent) sendJson(res, 500, { error: 'read failed' }); else res.end(); });
+  res.writeHead(200, {
+    'content-type': resolved.mime,
+    'content-disposition': disposition,
+    'accept-ranges': 'bytes',
+    'content-length': total,
+    ...extra,
+  });
+  stream.pipe(res);
 }
 
 // ── auth helpers ─────────────────────────────────────────────────────────────

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -11,7 +11,7 @@
  * small generated website — `kind:'site'`) is just MORE files in the same dir, served through the
  * same raw route via its `?file=` seam. No migration, no new storage shape.
  */
-import { randomUUID } from 'crypto';
+import { randomBytes, randomUUID } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Db } from './db';
@@ -31,6 +31,10 @@ export interface Artifact {
   bytes: number;
   /** USD this artifact cost to generate (image/video); undefined for published (non-generated) files. */
   costUsd?: number;
+  /** Shared with the whole tenant — every member sees it in the Library, on top of the provenance rule. */
+  sharedTeam: boolean;
+  /** When set, the artifact has a public login-free link (`/shared/<token>`). undefined = not public. */
+  shareToken?: string;
   createdAt: number;
 }
 
@@ -48,6 +52,8 @@ interface ArtifactRow {
   mime: string;
   bytes: number;
   cost_usd: number | null;
+  shared_team: number;
+  share_token: string | null;
   created_at: number;
 }
 
@@ -108,6 +114,8 @@ export class ArtifactStore {
       mime: mimeOf(filename),
       bytes: st.size,
       cost_usd: null, // published files aren't generated → no cost
+      shared_team: 0, // published private to its producer until explicitly shared
+      share_token: null,
       created_at: Date.now(),
     };
     this.insertRow(row);
@@ -118,12 +126,13 @@ export class ArtifactStore {
   private insertRow(row: ArtifactRow): void {
     this.db
       .prepare(
-        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, cost_usd, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, cost_usd, shared_team, share_token, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         row.id, row.session_id, row.agent, row.source, row.kind, row.title, row.description,
-        row.folder, row.filename, row.rel_path, row.mime, row.bytes, row.cost_usd, row.created_at,
+        row.folder, row.filename, row.rel_path, row.mime, row.bytes, row.cost_usd,
+        row.shared_team, row.share_token, row.created_at,
       );
   }
 
@@ -166,6 +175,8 @@ export class ArtifactStore {
       mime: mimeOf(filename),
       bytes: input.bytes.length,
       cost_usd: typeof input.costUsd === 'number' ? input.costUsd : null,
+      shared_team: 0,
+      share_token: null,
       created_at: Date.now(),
     };
     this.insertRow(row);
@@ -215,6 +226,33 @@ export class ArtifactStore {
     return { absPath: abs, mime: mimeOf(abs), filename: path.basename(abs) };
   }
 
+  /** Share (or unshare) an artifact with the whole tenant — every member then sees it in the Library. */
+  setTeamShared(id: string, shared: boolean): boolean {
+    const info = this.db.prepare('UPDATE artifacts SET shared_team = ? WHERE id = ?').run(shared ? 1 : 0, id);
+    return info.changes > 0;
+  }
+
+  /**
+   * Toggle the public login-free link. Turning it ON mints a crypto-random token (reusing the existing
+   * one if already public, so the URL is stable across re-toggles); OFF clears it (revokes the link).
+   * Returns the resulting token (null when off / artifact missing). The token is the sole credential the
+   * public `/shared/<token>` route trusts, so it must be unguessable — `randomBytes`, not `Math.random`.
+   */
+  setPublic(id: string, on: boolean): string | null {
+    const a = this.get(id);
+    if (!a) return null;
+    const token = on ? a.shareToken ?? randomBytes(18).toString('base64url') : null;
+    this.db.prepare('UPDATE artifacts SET share_token = ? WHERE id = ?').run(token, id);
+    return token;
+  }
+
+  /** Resolve an artifact by its public share token (the `/shared/<token>` lookup). undefined if none. */
+  getByToken(token: string): Artifact | undefined {
+    if (!token) return undefined;
+    const r = this.db.prepare('SELECT * FROM artifacts WHERE share_token = ?').get<ArtifactRow>(token);
+    return r ? toArtifact(r) : undefined;
+  }
+
   /** Move an artifact into a folder (metadata only — the on-disk id-dir never moves). '' = root. */
   move(id: string, folder: string): boolean {
     const info = this.db.prepare('UPDATE artifacts SET folder = ? WHERE id = ?').run(normFolder(folder), id);
@@ -246,6 +284,8 @@ function toArtifact(r: ArtifactRow): Artifact {
     mime: r.mime,
     bytes: r.bytes,
     costUsd: r.cost_usd ?? undefined,
+    sharedTeam: r.shared_team === 1,
+    shareToken: r.share_token ?? undefined,
     createdAt: r.created_at,
   };
 }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -788,6 +788,16 @@ function migrate(db: Db): void {
   // Generated-media cost: the USD a generated artifact (image/video) cost to produce, so the gallery
   // can show what each deliverable spent. NULL for published (non-generated) artifacts. Nullable REAL.
   addColumn(db, 'artifacts', 'cost_usd', 'REAL');
+
+  // Sharing an artifact beyond its producer. `shared_team` (0/1) makes it visible to EVERY member of
+  // the tenant in the Library (on top of the provenance rule); `share_token`, when set, mints a public,
+  // login-free link — `/shared/<token>`, served before the member gate — that anyone with the URL can
+  // view/download. Both default off: an artifact stays scoped to its producer (canViewSpawn) until an
+  // owner/admin/producer explicitly shares it. The unique partial index makes the token an O(1) lookup
+  // key for the public route (and guarantees no two artifacts collide on a token).
+  addColumn(db, 'artifacts', 'shared_team', 'INTEGER NOT NULL DEFAULT 0');
+  addColumn(db, 'artifacts', 'share_token', 'TEXT');
+  db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_share_token ON artifacts(share_token) WHERE share_token IS NOT NULL');
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4466,6 +4466,12 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
     load()
   }
 
+  const share = async (a: Artifact, patch: { team?: boolean; public?: boolean }) => {
+    const r = await api.shareArtifact(a.id, patch)
+    if (r.error || !r.ok) { setHint('⚠ ' + (r.error ?? 'share failed')); return }
+    load()
+  }
+
   return (
     <div className="space-y-3">
       <p className="max-w-3xl text-sm text-muted-foreground">
@@ -4533,6 +4539,8 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
                       <span>· {fmtSize(selected.bytes)}</span>
                       {selected.costUsd != null && <span>· <span title="Generation cost">{fmtCost(selected.costUsd)}</span></span>}
                       <span>· session <span className="font-mono">{selected.sessionId}</span></span>
+                      {selected.sharedTeam && <Badge variant="outline" className="gap-1 px-1.5 py-0 text-[10px] font-normal"><Users className="h-3 w-3" />Workspace</Badge>}
+                      {selected.public && <Badge variant="outline" className="gap-1 px-1.5 py-0 text-[10px] font-normal"><Globe className="h-3 w-3" />Public</Badge>}
                     </div>
                   </div>
                   <div className="flex shrink-0 gap-2">
@@ -4545,6 +4553,19 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
                     )}
                   </div>
                 </div>
+                {(me.role === 'owner' || me.role === 'admin' || selected.source === me.id) && (
+                  <div className="space-y-2 rounded-md border bg-muted/30 p-2.5 text-xs">
+                    <label className="flex cursor-pointer items-start gap-2">
+                      <input type="checkbox" className="mt-0.5" checked={!!selected.sharedTeam} onChange={(e) => share(selected, { team: e.target.checked })} />
+                      <span className="inline-flex items-center gap-1.5"><Users className="h-3.5 w-3.5" />Shared with workspace<span className="text-muted-foreground">— everyone on the team sees it in the Library</span></span>
+                    </label>
+                    <label className="flex cursor-pointer items-start gap-2">
+                      <input type="checkbox" className="mt-0.5" checked={!!selected.public} onChange={(e) => share(selected, { public: e.target.checked })} />
+                      <span className="inline-flex items-center gap-1.5"><Globe className="h-3.5 w-3.5" />Public link<span className="text-muted-foreground">— anyone with the URL can view, no login required</span></span>
+                    </label>
+                    {selected.shareUrl && <CopyLink link={selected.shareUrl} />}
+                  </div>
+                )}
                 <ArtifactBody a={selected} />
               </CardContent>
             </Card>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -263,6 +263,14 @@ export interface Artifact {
   bytes: number
   /** USD this artifact cost to generate (image/video); absent for published (non-generated) files. */
   costUsd?: number
+  /** Shared with the whole tenant — every member sees it in the Library. */
+  sharedTeam?: boolean
+  /** Whether a public login-free link exists (safe boolean, surfaced to every viewer). */
+  public?: boolean
+  /** The public share token — only returned to whoever may manage sharing (owner/admin/producer). */
+  shareToken?: string
+  /** The resolved public URL (`/shared/<token>`) — present only when `shareToken` is. */
+  shareUrl?: string
   createdAt: number
 }
 
@@ -1346,6 +1354,8 @@ export const api = {
   artifacts: () => call<{ artifacts: Artifact[]; enabled: boolean }>('GET', '/api/artifacts'),
   deleteArtifact: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/artifacts/' + id),
   moveArtifact: (id: string, folder: string) => call<{ ok: boolean; artifact?: Artifact; error?: string }>('PATCH', '/api/artifacts/' + id, { folder }),
+  /** Share an artifact with the tenant (`team`) and/or mint/revoke its public link (`public`). */
+  shareArtifact: (id: string, body: { team?: boolean; public?: boolean }) => call<{ ok: boolean; artifact?: Artifact; error?: string }>('POST', `/api/artifacts/${id}/share`, body),
   /** Direct URL to an artifact's bytes (for <img>/<iframe>/download). `file` selects a sibling (sites). */
   artifactRawUrl: (id: string, file?: string) => `/api/artifacts/${id}/raw${file ? `?file=${encodeURIComponent(file)}` : ''}`,
 


### PR DESCRIPTION
## What

Adds the ability to **share a Library artifact with the team and with the web** — the two capabilities that didn't exist before. Previously an artifact was visible only to its producer (plus owner/admin) and reachable only behind the console login.

The Library detail panel now has a **Share** section, shown to owner/admin or the member whose session produced the deliverable, with two independent toggles:

- **Shared with workspace** — flips tenant-wide visibility; every member then sees it in their Library (on top of the existing provenance rule).
- **Public link** — mints an unguessable, revocable `/shared/<token>` URL served **before** the member gate, so anyone with the link views/downloads it with no login (same secret-in-URL model as inbound `/hooks`). Toggling off revokes it. Copy-to-clipboard with the insecure-context fallback for the plain-HTTP tailnet.

## How

- **DB** (`src/state/db.ts`): `artifacts.shared_team` (0/1) + `share_token` (nullable) via `addColumn`, plus a unique **partial** index on the token for O(1) public lookup.
- **Store** (`src/state/artifacts.ts`): `setTeamShared`, `setPublic` (mints/reuses/revokes a `randomBytes` token), `getByToken`; `Artifact` gains `sharedTeam`/`shareToken`.
- **Server** (`src/server.ts`):
  - `/api/artifacts` list filter → `canViewSpawn || sharedTeam`; the token/link are surfaced only to whoever may manage sharing, everyone else gets a plain `public` boolean.
  - raw route gate extended with `|| sharedTeam`.
  - `POST /api/artifacts/:id/share` (owner/admin/producer gate, mirrors move/delete).
  - public `GET /shared/:token` before the member gate.
  - byte-range/streaming extracted into a shared `streamArtifactFile` helper.
- **Hardening**: the public route serves HTML/SVG under `Content-Security-Policy: sandbox` (opaque origin — a shared page's scripts can't read cookies or call same-origin `/api`, mirroring the console's iframe sandbox) + `X-Content-Type-Options: nosniff`.
- **Web** (`web/src/App.tsx`, `lib/api.ts`): Share toggles + `CopyLink`, Workspace/Public badges, `shareArtifact` client method.
- **Audit**: `artifact.shared`, `artifact.share.viewed`.

## Verification

End-to-end in an isolated `AGENT_OS_HOME`: share toggles persist, token mint is idempotent + revocable, `/shared/<token>` serves bytes + 206 ranges + CSP/nosniff headers, bad/revoked token → 404, and the authenticated raw route still → 401 without login. `npm run typecheck` + `cd web && npm run build` + `npm run test:governance` (68/68) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMSbnPEbqSVPGLasTKENp