### PR TITLE
feat(sessions): Quick Shortcuts — out-of-band session summary + canned prompts (v0.208.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.209.0] — 2026-07-16
+### Added
+- **Quick Shortcuts on every terminal session** — a `⚡ Shortcuts` menu in the terminal chrome with:
+  - **Summarize this session** — an *out-of-band* summary. Reads the run's already-written transcript
+    and summarizes it in a throwaway `claude -p`, shown in a modal. The target session's own context is
+    never touched, so asking "what's this run doing?" doesn't pollute the agent. Degrades to a
+    deterministic transcript summary if the summarizer can't run (`POST /api/sessions/:id/summarize`).
+  - **Check now** / **Update yourself** — built-in canned prompts typed straight into the live session.
+  - **Personal shortcuts** — members save their own label+prompt canned prompts (Profile → *My
+    shortcuts*, or inline from the menu). Stored per member in `member_prefs`
+    (`GET`/`PUT /api/me/shortcuts`), capped/sanitized.
+  - Firing a shortcut injects text into the live pane exactly as if the attached human typed it
+    (`POST /api/sessions/:id/inject`, `TerminalManager.injectToSession`) — same trust as attaching and
+    typing, and every resulting effect is still mediated by the PreToolUse gate. Audited
+    `session.inject` / `session.summarized`.
+
 ## [0.208.2] — 2026-07-16
 ### Fixed
 - **Agent-emitted console deep-links now use the tenant's real FQDN, not `127.0.0.1:<port>`.** Links an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.208.1",
+  "version": "0.209.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.208.1",
+      "version": "0.209.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.208.2",
+  "version": "0.209.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/summarize.ts
+++ b/src/edge/summarize.ts
@@ -1,0 +1,110 @@
+// Out-of-band session summary.
+//
+// "Ask about the session without polluting it": we summarize a run by reading its ALREADY-WRITTEN
+// claude transcript (via `readConversation`) and handing that text to a FRESH, throwaway `claude -p`
+// process. Nothing is typed into the target session — its own claude never sees this request, so its
+// context/transcript is untouched. The summary is shown to the human in a modal; it is not persisted.
+//
+// If the `claude` CLI can't be run (not on PATH, times out, errors), we degrade to a deterministic
+// summary computed straight from the transcript — the feature still returns something useful offline.
+
+import { execFile } from 'child_process';
+import * as os from 'os';
+import * as path from 'path';
+import { Conversation, ChatTurn } from './conversation';
+
+type Activity = Extract<ChatTurn, { kind: 'activity' }>;
+
+/** How many chars of transcript we feed the summarizer (keep the tail — the recent work matters most). */
+const TRANSCRIPT_CAP = 16000;
+
+export interface SessionSummary {
+  summary: string;
+  /** 'ai' = summarized by a throwaway claude; 'fallback' = deterministic (claude unavailable/failed). */
+  via: 'ai' | 'fallback';
+  /** false when the run hasn't written a transcript yet (nothing to summarize). */
+  found: boolean;
+}
+
+/** Flatten the friendly timeline into a compact plain-text script for the summarizer. */
+function renderTranscript(convo: Conversation): string {
+  const lines: string[] = [];
+  for (const t of convo.turns) {
+    if (t.kind === 'user') lines.push(`HUMAN: ${t.text}`);
+    else if (t.kind === 'assistant') lines.push(`AGENT: ${t.text}`);
+    else lines.push(`· ${t.label}${t.detail ? ` — ${t.detail}` : ''}${t.status === 'error' ? ' [failed]' : ''}`);
+  }
+  let text = lines.join('\n');
+  if (text.length > TRANSCRIPT_CAP) text = '…(earlier activity truncated)\n' + text.slice(text.length - TRANSCRIPT_CAP);
+  return text;
+}
+
+/** A no-LLM summary from the transcript's shape — the reliable floor when claude can't be reached. */
+function fallbackSummary(convo: Conversation): string {
+  const humans = convo.turns.filter((t) => t.kind === 'user').length;
+  const replies = convo.turns.filter((t) => t.kind === 'assistant');
+  const acts = convo.turns.filter((t): t is Activity => t.kind === 'activity');
+  const errors = acts.filter((a) => a.status === 'error').length;
+  const byLabel = new Map<string, number>();
+  for (const a of acts) byLabel.set(a.label, (byLabel.get(a.label) ?? 0) + 1);
+  const top = [...byLabel.entries()].sort((a, b) => b[1] - a[1]).slice(0, 6);
+  const last = replies.length ? replies[replies.length - 1].text : '';
+  const parts: string[] = [];
+  parts.push(`${humans} message${humans === 1 ? '' : 's'} from the human, ${replies.length} agent repl${replies.length === 1 ? 'y' : 'ies'}, ${acts.length} action${acts.length === 1 ? '' : 's'}${errors ? ` (${errors} failed)` : ''}.`);
+  if (top.length) parts.push('Most-used actions: ' + top.map(([l, n]) => `${l} ×${n}`).join(', ') + '.');
+  if (last) parts.push('Latest agent message:\n' + (last.length > 600 ? last.slice(0, 600) + '…' : last));
+  return parts.join('\n\n');
+}
+
+const INSTRUCTION = [
+  "You are summarizing an autonomous agent's work session for a teammate who wasn't watching it.",
+  'The session transcript is piped in below — the human\'s messages, the agent\'s replies, and a "·" activity log of the tools it used.',
+  'Write a tight summary the teammate can read in ~20 seconds:',
+  '- First line: the current status — what this session is doing and whether it is done, still working, waiting on something, or stuck.',
+  '- Then 3–6 short bullets: the key actions taken, decisions made, and any concrete results.',
+  '- Finally, call out anything that needs a human: questions asked, approvals, errors, or blockers. Omit this line if there are none.',
+  'Only use facts present in the transcript — do not invent details. Output plain text, no preamble, no markdown headers.',
+].join('\n');
+
+/** Run a fresh, throwaway `claude -p`, piping the transcript on stdin. Resolves its stdout. */
+function runClaude(instruction: string, transcript: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const home = os.homedir();
+    // Mirror claude-launch.sh: the CLI is often under ~/.local/bin and a hardened service ships a
+    // minimal PATH, so prepend it. Run in a neutral cwd (no agent .claude/settings.json or MCP config
+    // to pick up) — this is a pure text-in/text-out call with no tools.
+    const env = { ...process.env, PATH: `${path.join(home, '.local', 'bin')}:${process.env.PATH ?? ''}` };
+    const args = ['-p', instruction];
+    const model = process.env.AOS_SUMMARY_MODEL;
+    if (model) args.push('--model', model);
+    const child = execFile(
+      'claude',
+      args,
+      { env, cwd: os.tmpdir(), timeout: 90_000, maxBuffer: 8 * 1024 * 1024 },
+      (err, stdout) => {
+        if (err) return reject(err);
+        resolve(String(stdout || ''));
+      },
+    );
+    child.stdin?.on('error', () => {}); // a claude that exits early would EPIPE the write — ignore
+    child.stdin?.end(`TRANSCRIPT:\n${transcript}\n`);
+  });
+}
+
+/**
+ * Summarize a session's conversation out-of-band. Never touches the target session. Returns a
+ * deterministic fallback (never throws) if the transcript is empty or the summarizer can't run.
+ */
+export async function summarizeConversation(convo: Conversation): Promise<SessionSummary> {
+  if (!convo.found || convo.turns.length === 0) {
+    return { summary: 'This session has not produced a transcript yet — nothing to summarize.', via: 'fallback', found: false };
+  }
+  const transcript = renderTranscript(convo);
+  try {
+    const out = (await runClaude(INSTRUCTION, transcript)).trim();
+    if (out) return { summary: out, via: 'ai', found: true };
+  } catch {
+    // fall through to the deterministic summary
+  }
+  return { summary: fallbackSummary(convo), via: 'fallback', found: true };
+}

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -9,7 +9,7 @@
  */
 import { randomBytes } from 'crypto';
 import { Db } from '../state/db';
-import { AgentAccess, Member, MemberIdentity, IdentityProvider, Role, ApprovalLevel, canApprove, NotificationPrefs, sanitizeNotificationPrefs, sanitizeNavPins } from '../types';
+import { AgentAccess, Member, MemberIdentity, IdentityProvider, Role, ApprovalLevel, canApprove, NotificationPrefs, sanitizeNotificationPrefs, sanitizeNavPins, PromptShortcut, sanitizePromptShortcuts } from '../types';
 
 const INVITE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // magic links valid for 7 days
 const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000; // login cookie valid for 30 days
@@ -105,6 +105,20 @@ export class TeamStore {
   setNavPins(memberId: string, pins: unknown): string[] {
     const clean = sanitizeNavPins(pins) ?? [];
     this.writeRawPrefs(memberId, { ...this.rawPrefs(memberId), navPins: clean });
+    return clean;
+  }
+
+  /** This member's saved prompt shortcuts (the Quick Shortcuts strip in the terminal). Personal, stored
+   *  alongside the rest of their prefs; empty list when never set. */
+  promptShortcuts(memberId: string): PromptShortcut[] {
+    return sanitizePromptShortcuts(this.rawPrefs(memberId).promptShortcuts);
+  }
+
+  /** Persist this member's prompt shortcuts (sanitized + capped), preserving sibling prefs in the same
+   *  blob. Returns the resolved list. */
+  setPromptShortcuts(memberId: string, shortcuts: unknown): PromptShortcut[] {
+    const clean = sanitizePromptShortcuts(shortcuts);
+    this.writeRawPrefs(memberId, { ...this.rawPrefs(memberId), promptShortcuts: clean });
     return clean;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { evaluate } from './observability/evaluation';
 import { TerminalManager, AGENT_OS_OPERATING_NOTES } from './terminal';
 import { classifyActivity, clipText, ActivityCategory, ActivityEffect } from './state/session-activity';
 import { readConversation } from './edge/conversation';
+import { summarizeConversation } from './edge/summarize';
 import { Automation, Automations, nextCronRun, derivedConcurrencyCap, chatTitle } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
@@ -2306,6 +2307,36 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const r = tm.attachFile(id, me.email, data, String(b.ext || 'bin'), b.name ? String(b.name) : undefined);
     return sendJson(res, r.ok ? 200 : 400, r);
   }
+  // Quick Shortcuts — type text into a LIVE session's pane as if the attached human typed it (e.g.
+  // "Check now", a saved prompt). Same trust as attaching + typing, so the gate at canViewSession, not a
+  // policy check; every effect the resulting turn triggers is still mediated by the gate hook. Body:
+  // { text, submit? } (submit defaults true — the shortcut runs immediately).
+  const injectMatch = p.match(/^\/api\/sessions\/([\w-]+)\/inject$/);
+  if (method === 'POST' && injectMatch) {
+    const id = injectMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to send to this session' });
+    const b = await readBody(req);
+    const text = String(b.text || '');
+    if (!text.trim()) return sendJson(res, 400, { error: 'text is required' });
+    const submit = b.submit === undefined ? true : Boolean(b.submit);
+    const r = tm.injectToSession(id, text, submit, me.email);
+    return sendJson(res, r.ok ? 200 : 409, r);
+  }
+  // Out-of-band session summary — reads the run's existing transcript and summarizes it in a THROWAWAY
+  // claude, so the target session's own context is never touched (no pollution). Same visibility gate as
+  // the terminal/transcript. Returns { summary, via, found }; never blocks the session.
+  const summarizeMatch = p.match(/^\/api\/sessions\/([\w-]+)\/summarize$/);
+  if (method === 'POST' && summarizeMatch) {
+    const id = summarizeMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to view this session' });
+    const claudeId = tm.sessionClaudeId(id);
+    const convo = claudeId ? readConversation(claudeId) : { turns: [], found: false };
+    const out = await summarizeConversation(convo);
+    os.audit.append({ ts: Date.now(), runId: id, tenant: os.tenant, principal: me.email, type: 'session.summarized', data: { via: out.via, found: out.found } });
+    return sendJson(res, 200, out);
+  }
   // Stop a running session (kill its tmux, keep the row). Per-member: only the session's owner, or
   // an owner/admin — agents are shared, so canRun would let a peer stop another member's session.
   const stopMatch = p.match(/^\/api\/sessions\/([\w-]+)\/stop$/);
@@ -2415,6 +2446,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const context = os.team.setMemberContext(me.id, (b as { context?: unknown }).context);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'member.context.set', data: { chars: context.length } });
     return sendJson(res, 200, { context });
+  }
+  // This member's Quick Shortcuts — saved canned prompts they fire into a live terminal session with one
+  // click. Personal, self-service (no role gate); the payload is `{ shortcuts: PromptShortcut[] }`.
+  if (method === 'GET' && p === '/api/me/shortcuts') return sendJson(res, 200, { shortcuts: os.team.promptShortcuts(me.id) });
+  if (method === 'PUT' && p === '/api/me/shortcuts') {
+    const b = await readBody(req);
+    return sendJson(res, 200, { shortcuts: os.team.setPromptShortcuts(me.id, (b as { shortcuts?: unknown }).shortcuts) });
   }
   // This member's pinned sidebar nav (which secondary items sit up in Main). Per person, not admin-gated
   // — everyone customizes their own. The initial value ships on /api/auth/me; this saves changes.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1954,6 +1954,30 @@ export class TerminalManager {
     this.addMessage({ type: 'update', sessionId, agent: s.agent, title: `Task Update (${s.agent})`, body, status: 'open', audienceKind: 'sessionOwner', audienceId: sessionId });
   }
 
+  /**
+   * Inject text into a LIVE session's pane exactly as if the attached human typed it (tmux send-keys),
+   * optionally submitting with Enter. Powers the console's Quick Shortcuts (e.g. "Check now", a saved
+   * prompt): a human affordance, not an agent effect, so it carries the SAME trust as attaching and
+   * typing — no policy gate here, but every effect the resulting turn triggers is still mediated by the
+   * PreToolUse gate hook. Newlines are flattened to a space so a stray return can't submit early; the
+   * separate Enter keypress (when `submit`) is the one authoritative submit. Refuses a dead/unknown
+   * session (there is no pane to type into).
+   */
+  injectToSession(sessionId: string, text: string, submit: boolean, by: string): { ok: boolean; error?: string } {
+    const row = this.db.prepare('SELECT tmux, status, run_as, spawned_by FROM term_sessions WHERE id = ?')
+      .get<{ tmux: string; status: string; run_as: string | null; spawned_by: string | null }>(sessionId);
+    if (!row) return { ok: false, error: 'unknown session' };
+    const body = (text || '').replace(/\r?\n+/g, ' ').trim();
+    if (!body) return { ok: false, error: 'nothing to send' };
+    if (row.status !== 'running' || !this.isAlive(sessionId)) return { ok: false, error: 'session is not live — open it first' };
+    const space = this.spaceFor(row.run_as ?? row.spawned_by);
+    const ok = this.backend.injectText(space, row.tmux, body, submit);
+    if (!ok) return { ok: false, error: 'could not deliver keystrokes to the terminal' };
+    this.db.prepare('UPDATE term_sessions SET last_activity = ?, updated_at = ? WHERE id = ?').run(Date.now(), Date.now(), sessionId);
+    this.audit(sessionId, this.sessionAgent(sessionId) ?? '', 'session.inject', { by, chars: body.length, submit });
+    return { ok: true };
+  }
+
   /** The gate. Same policy brain as the console — allow flows, ask → inbox approval (auto-cleared for
    *  an attended approver), never → deny. Args are enriched into facts first (the single classifier). */
   gate(sessionId: string, agent: string, capability: string, rawArgs: Record<string, unknown>, reasoning: string): GateResult {

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,45 @@ export function sanitizeNavPins(input: unknown): string[] | null {
 }
 
 /**
+ * A member-defined prompt shortcut — a named canned prompt they can fire into a live terminal session
+ * with one click (the console's Quick Shortcuts strip). Purely a personal convenience stored in
+ * `member_prefs`; the text is injected into the running claude exactly as if the human typed it, so
+ * every effect it triggers is still governed by the gate. `id` is a stable client-minted handle used
+ * only to key the list for edit/delete.
+ */
+export interface PromptShortcut {
+  id: string;
+  label: string;
+  prompt: string;
+}
+
+export const PROMPT_SHORTCUT_MAX = 20;
+export const PROMPT_SHORTCUT_LABEL_MAX = 40;
+export const PROMPT_SHORTCUT_PROMPT_MAX = 2000;
+
+/** Validate/normalize an untrusted shortcuts payload: drop anything malformed, trim + cap each field,
+ *  synthesize a stable id when one is missing, and bound the list length. A shortcut with an empty
+ *  label or empty prompt is dropped (both are required to be useful). */
+export function sanitizePromptShortcuts(input: unknown): PromptShortcut[] {
+  if (!Array.isArray(input)) return [];
+  const out: PromptShortcut[] = [];
+  const seen = new Set<string>();
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') continue;
+    const r = raw as Partial<PromptShortcut>;
+    const label = String(r.label ?? '').trim().slice(0, PROMPT_SHORTCUT_LABEL_MAX);
+    const prompt = String(r.prompt ?? '').trim().slice(0, PROMPT_SHORTCUT_PROMPT_MAX);
+    if (!label || !prompt) continue;
+    let id = String(r.id ?? '').trim().slice(0, 40);
+    if (!id || seen.has(id)) id = `s${out.length + 1}`;
+    seen.add(id);
+    out.push({ id, label, prompt });
+    if (out.length >= PROMPT_SHORTCUT_MAX) break;
+  }
+  return out;
+}
+
+/**
  * The external accounts a member is known by on other platforms — the join key that lets a chat
  * trigger (Slack/Discord) run AS the right person. One external id maps to at most one member
  * (enforced by the table's `(provider, external_id)` primary key), so run-as is never ambiguous.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,7 @@ import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
 import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type ChatTurn } from '@/lib/api'
-import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS } from '@/lib/api'
+import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
 import { docPages } from '@/docs'
@@ -1827,6 +1827,157 @@ function TerminalHelpModal({ open, onClose }: { open: boolean; onClose: () => vo
   )
 }
 
+/** A plain-text, out-of-band summary of a session — reads the run's transcript and summarizes it in a
+ *  throwaway claude, so the session's own context is never touched. Fetches on open; regenerate re-asks. */
+function SessionSummaryModal({ sessionId, open, onClose }: { sessionId: string; open: boolean; onClose: () => void }) {
+  const [loading, setLoading] = useState(false)
+  const [summary, setSummary] = useState('')
+  const [via, setVia] = useState<'ai' | 'fallback' | null>(null)
+  const [err, setErr] = useState('')
+  const load = async () => {
+    setLoading(true); setErr(''); setVia(null)
+    const r = await api.summarizeSession(sessionId)
+    setLoading(false)
+    if (r.error) { setErr(r.error); return }
+    setSummary(r.summary || ''); setVia(r.via ?? null)
+  }
+  useEffect(() => { if (open) void load() }, [open, sessionId]) // eslint-disable-line react-hooks/exhaustive-deps
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader><DialogTitle className="flex items-center gap-2"><Sparkles className="h-4 w-4" /> Session summary</DialogTitle></DialogHeader>
+        {loading ? (
+          <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground"><RefreshCw className="h-4 w-4 animate-spin" /> Reading the transcript and summarizing…</div>
+        ) : err ? (
+          <div className="py-6 text-sm text-red-500">⚠ {err}</div>
+        ) : (
+          <div className="max-h-[55vh] overflow-auto whitespace-pre-wrap text-sm leading-relaxed text-foreground">{summary || '(no summary)'}</div>
+        )}
+        <div className="flex items-center gap-3 border-t pt-3">
+          <Button size="sm" variant="outline" className="gap-1.5" onClick={() => void load()} disabled={loading}>
+            <RefreshCw className={'h-3.5 w-3.5' + (loading ? ' animate-spin' : '')} /> Regenerate
+          </Button>
+          {via === 'fallback' && !loading && <span className="text-[11px] text-muted-foreground">basic summary — the AI summarizer was unavailable</span>}
+          <span className="ml-auto text-[11px] text-muted-foreground">out-of-band · the session isn’t touched</span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+const mkShortcutId = () => Date.now().toString(36) + Math.random().toString(36).slice(2, 8)
+
+/** The built-in shortcuts every session gets, on top of the member's saved ones. */
+const BUILTIN_SHORTCUTS: { id: string; label: string; prompt: string; title: string }[] = [
+  { id: 'check', label: 'Check now', prompt: 'Check now', title: 'Nudge the agent to run its check now' },
+  { id: 'update', label: 'Update yourself', prompt: 'Update yourself', title: 'Ask the agent to review and update itself' },
+]
+
+/** The Quick Shortcuts control in the terminal chrome: a one-click "Summary" (out-of-band) plus canned
+ *  prompts that type straight into the live session (built-ins + the member's own saved shortcuts, added
+ *  inline or on the Profile page). Injection is gated on the pane being live/attachable. */
+function QuickShortcuts({ session, attachable }: { session: Session; attachable: boolean }) {
+  const [open, setOpen] = useState(false)
+  const [summaryOpen, setSummaryOpen] = useState(false)
+  const [custom, setCustom] = useState<PromptShortcut[]>([])
+  const [note, setNote] = useState<{ kind: 'ok' | 'err'; text: string } | null>(null)
+  const [adding, setAdding] = useState(false)
+  const [draftLabel, setDraftLabel] = useState('')
+  const [draftPrompt, setDraftPrompt] = useState('')
+  const [busy, setBusy] = useState(false)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  const loadCustom = () => api.promptShortcuts().then((r) => setCustom(r.shortcuts || [])).catch(() => {})
+  useEffect(() => { if (open) loadCustom() }, [open]) // eslint-disable-line react-hooks/exhaustive-deps
+  // Close the popover on an outside click.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent) => { if (wrapRef.current && !wrapRef.current.contains(e.target as Node)) setOpen(false) }
+    window.addEventListener('mousedown', onDown)
+    return () => window.removeEventListener('mousedown', onDown)
+  }, [open])
+  useEffect(() => { if (!note) return; const t = setTimeout(() => setNote(null), 3000); return () => clearTimeout(t) }, [note])
+
+  const fire = async (prompt: string) => {
+    if (!attachable) { setNote({ kind: 'err', text: 'open/attach the session first' }); return }
+    setBusy(true)
+    const r = await api.injectToSession(session.id, prompt)
+    setBusy(false)
+    if (r.ok) { setNote({ kind: 'ok', text: 'Sent ✓' }); setOpen(false) }
+    else setNote({ kind: 'err', text: r.error || 'could not send' })
+  }
+  const addShortcut = async () => {
+    const label = draftLabel.trim(); const prompt = draftPrompt.trim()
+    if (!label || !prompt) return
+    setBusy(true)
+    const next = [...custom, { id: mkShortcutId(), label, prompt }]
+    const r = await api.savePromptShortcuts(next)
+    setBusy(false)
+    setCustom(r.shortcuts || next); setDraftLabel(''); setDraftPrompt(''); setAdding(false)
+  }
+  const removeShortcut = async (id: string) => {
+    const next = custom.filter((s) => s.id !== id)
+    setCustom(next) // optimistic
+    const r = await api.savePromptShortcuts(next)
+    setCustom(r.shortcuts || next)
+  }
+
+  return (
+    <div ref={wrapRef} className="relative">
+      <button
+        className="flex items-center gap-1 rounded bg-neutral-800/90 px-2 py-1 text-xs text-neutral-200 shadow hover:bg-neutral-700"
+        title="Quick Shortcuts — summarize this run, or fire a canned prompt into it"
+        onClick={() => setOpen((o) => !o)}
+      ><Zap className="h-3.5 w-3.5" /> Shortcuts <ChevronDown className="h-3 w-3 opacity-70" /></button>
+      {note && (
+        <div className={`absolute left-0 top-full mt-1 whitespace-nowrap rounded px-2 py-1 text-[11px] shadow ${note.kind === 'ok' ? 'bg-emerald-700 text-emerald-50' : 'bg-red-700 text-red-50'}`}>{note.text}</div>
+      )}
+      {open && (
+        <div className="absolute left-0 top-full z-30 mt-1 w-64 rounded-md border border-neutral-700 bg-neutral-900 p-1.5 text-neutral-200 shadow-xl">
+          {/* Summary — out of band, always available */}
+          <button className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-neutral-800"
+            onClick={() => { setOpen(false); setSummaryOpen(true) }} title="Summarize the whole session in a modal — the session itself is not touched">
+            <Sparkles className="h-3.5 w-3.5 shrink-0 text-sky-400" /> <span className="flex-1">Summarize this session</span>
+          </button>
+          <div className="my-1 flex items-center gap-2 px-2 text-[10px] uppercase tracking-wider text-neutral-500">
+            <span>Send to session</span><div className="h-px flex-1 bg-neutral-800" />
+          </div>
+          {!attachable && <p className="px-2 pb-1 text-[10px] text-neutral-500">Open/attach the session to send a prompt.</p>}
+          {[...BUILTIN_SHORTCUTS, ...custom].map((s) => (
+            <div key={s.id} className="group flex items-center">
+              <button className="flex flex-1 items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-neutral-800 disabled:opacity-40"
+                onClick={() => void fire(s.prompt)} disabled={busy || !attachable} title={'title' in s ? (s as { title: string }).title : s.prompt}>
+                <Send className="h-3.5 w-3.5 shrink-0 text-neutral-400" /> <span className="flex-1 truncate">{s.label}</span>
+              </button>
+              {!('title' in s) && (
+                <button className="mr-1 rounded p-1 text-neutral-500 opacity-0 hover:bg-neutral-800 hover:text-red-400 group-hover:opacity-100"
+                  onClick={() => void removeShortcut(s.id)} title="remove this shortcut"><Trash2 className="h-3 w-3" /></button>
+              )}
+            </div>
+          ))}
+          {/* Add a personal shortcut inline (also editable on the Profile page) */}
+          {adding ? (
+            <div className="mt-1 space-y-1.5 border-t border-neutral-800 p-1.5">
+              <Input value={draftLabel} onChange={(e) => setDraftLabel(e.target.value)} placeholder="Label (e.g. Ship it)" maxLength={40}
+                className="h-7 border-neutral-700 bg-neutral-800 text-xs text-neutral-100 placeholder:text-neutral-500" />
+              <Textarea value={draftPrompt} onChange={(e) => setDraftPrompt(e.target.value)} placeholder="Prompt sent to the agent…" maxLength={2000}
+                className="min-h-[54px] border-neutral-700 bg-neutral-800 text-xs text-neutral-100 placeholder:text-neutral-500" />
+              <div className="flex items-center gap-2">
+                <Button size="sm" className="h-6 px-2 text-xs" onClick={() => void addShortcut()} disabled={busy || !draftLabel.trim() || !draftPrompt.trim()}>Save</Button>
+                <button className="text-[11px] text-neutral-400 hover:text-neutral-200" onClick={() => { setAdding(false); setDraftLabel(''); setDraftPrompt('') }}>Cancel</button>
+              </div>
+            </div>
+          ) : (
+            <button className="mt-1 flex w-full items-center gap-2 rounded border-t border-neutral-800 px-2 py-1.5 text-left text-[11px] text-neutral-400 hover:bg-neutral-800 hover:text-neutral-200"
+              onClick={() => setAdding(true)}><Plus className="h-3.5 w-3.5" /> Add a shortcut</button>
+          )}
+        </div>
+      )}
+      <SessionSummaryModal sessionId={session.id} open={summaryOpen} onClose={() => setSummaryOpen(false)} />
+    </div>
+  )
+}
+
 /** The live terminal pane. It asks the server for the attach URL — the shared /terminal/?arg=…
  *  (uid-isolation off) or a per-member /terminal/<space>/?arg=… (on) — and derives the ttyd WebSocket
  *  endpoint from it, which our first-party <Xterm> speaks directly (no iframe). */
@@ -2031,6 +2182,7 @@ function ImageDropZone({ session, attachable, children, onActivity, fontSize, se
           title="How to use the terminal — shortcuts & quirks"
           onClick={() => setHelp(true)}
         ><HelpCircle className="h-3.5 w-3.5" /> Help</button>
+        {session?.id && <QuickShortcuts session={session} attachable={Boolean(attachable)} />}
       </div>
       <TerminalHelpModal open={help} onClose={() => setHelp(false)} />
       {/* top-right session toolbar: browse the agent's folder + attach a file */}
@@ -4965,6 +5117,50 @@ function IdentityEditor({ member, identities, onChange }: { member: Member; iden
  *  Their avatar/name, the free-text "context" injected into every session run as them, notification
  *  preferences (moved off the bell), and their chat handles (run-as join keys). Managing OTHER people
  *  (roles, invites, access) stays on the Team page. */
+/** Manage this member's Quick Shortcuts (saved canned prompts). Used on the Profile page; the same
+ *  shortcuts also appear in every terminal's Quick Shortcuts strip. Adds, edits (label + prompt), and
+ *  removes; each change persists the full list. */
+function PromptShortcutsEditor() {
+  const [shortcuts, setShortcuts] = useState<PromptShortcut[]>([])
+  const [loaded, setLoaded] = useState(false)
+  const [label, setLabel] = useState('')
+  const [prompt, setPrompt] = useState('')
+  const [busy, setBusy] = useState(false)
+  useEffect(() => { api.promptShortcuts().then((r) => { setShortcuts(r.shortcuts || []); setLoaded(true) }).catch(() => setLoaded(true)) }, [])
+  const persist = async (next: PromptShortcut[]) => {
+    setShortcuts(next); setBusy(true)
+    try { const r = await api.savePromptShortcuts(next); setShortcuts(r.shortcuts || next) } finally { setBusy(false) }
+  }
+  const add = async () => {
+    const l = label.trim(); const p = prompt.trim()
+    if (!l || !p) return
+    await persist([...shortcuts, { id: mkShortcutId(), label: l, prompt: p }])
+    setLabel(''); setPrompt('')
+  }
+  const edit = (id: string, patch: Partial<PromptShortcut>) => setShortcuts((cur) => cur.map((s) => (s.id === id ? { ...s, ...patch } : s)))
+  return (
+    <div className="space-y-3">
+      <div className="space-y-2">
+        {loaded && shortcuts.length === 0 && <p className="text-xs text-muted-foreground">No shortcuts yet — add one below.</p>}
+        {shortcuts.map((s) => (
+          <div key={s.id} className="flex items-start gap-2 rounded-md border p-2">
+            <div className="flex-1 space-y-1.5">
+              <Input value={s.label} onChange={(e) => edit(s.id, { label: e.target.value })} onBlur={() => persist(shortcuts)} maxLength={40} placeholder="Label" className="h-7 text-xs" />
+              <Textarea value={s.prompt} onChange={(e) => edit(s.id, { prompt: e.target.value })} onBlur={() => persist(shortcuts)} maxLength={2000} className="min-h-[52px] font-mono text-xs" />
+            </div>
+            <Button size="icon" variant="ghost" className="h-7 w-7 shrink-0 text-muted-foreground hover:text-red-500" onClick={() => void persist(shortcuts.filter((x) => x.id !== s.id))} disabled={busy} title="remove"><Trash2 className="h-4 w-4" /></Button>
+          </div>
+        ))}
+      </div>
+      <div className="space-y-1.5 rounded-md border border-dashed p-2">
+        <Input value={label} onChange={(e) => setLabel(e.target.value)} maxLength={40} placeholder="New shortcut label (e.g. Ship it)" className="h-7 text-xs" />
+        <Textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} maxLength={2000} placeholder="Prompt sent to the agent when you click this shortcut…" className="min-h-[52px] font-mono text-xs" />
+        <Button size="sm" className="gap-1.5" onClick={() => void add()} disabled={busy || !label.trim() || !prompt.trim()}><Plus className="h-3.5 w-3.5" /> Add shortcut</Button>
+      </div>
+    </div>
+  )
+}
+
 function ProfilePage({ me, prefs, onSavePrefs, onProfileChange }: {
   me: Member
   prefs: NotificationPrefs
@@ -5025,6 +5221,17 @@ function ProfilePage({ me, prefs, onSavePrefs, onProfileChange }: {
           {ctxSaved && <span className="text-xs text-emerald-600">Saved</span>}
           <span className="ml-auto text-[11px] text-muted-foreground">{context.length.toLocaleString()}/8,000</span>
         </div>
+      </section>
+
+      {/* Quick Shortcuts — saved canned prompts for the terminal's Quick Shortcuts strip */}
+      <section className="space-y-2">
+        <div className="text-[11px] uppercase tracking-wider text-muted-foreground">My shortcuts</div>
+        <p className="text-sm text-muted-foreground">
+          Canned prompts you can fire into a live terminal session with one click, from the
+          <strong> Shortcuts</strong> menu on any terminal. Each is typed into the running agent exactly as
+          if you’d typed it — every effect is still governed.
+        </p>
+        <PromptShortcutsEditor />
       </section>
 
       {/* Notifications (moved off the bell) */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -13,6 +13,12 @@ export interface Member {
    *  `[]` → the member explicitly pinned nothing. */
   navPins?: string[] | null
 }
+/** A member-defined canned prompt fired into a live session from the Quick Shortcuts strip. */
+export interface PromptShortcut {
+  id: string
+  label: string
+  prompt: string
+}
 export type IdentityProvider = 'slack' | 'discord' | 'email' | 'github'
 export const IDENTITY_PROVIDERS: IdentityProvider[] = ['slack', 'discord', 'email', 'github']
 export interface MemberIdentity {
@@ -1100,6 +1106,17 @@ export const api = {
   saveMyContext: (context: string) => call<{ context: string }>('PUT', '/api/me/context', { context }),
   /** Persist this member's pinned sidebar nav (the keys promoted to Main). Returns the resolved list. */
   saveNavPins: (pinned: string[]) => call<{ pinned: string[] }>('PUT', '/api/me/nav', { pinned }),
+  /** This member's saved Quick Shortcuts (canned prompts for a live terminal session). */
+  promptShortcuts: () => call<{ shortcuts: PromptShortcut[] }>('GET', '/api/me/shortcuts'),
+  savePromptShortcuts: (shortcuts: PromptShortcut[]) => call<{ shortcuts: PromptShortcut[] }>('PUT', '/api/me/shortcuts', { shortcuts }),
+  /** Type text into a LIVE session's pane as if the attached human typed it (Quick Shortcuts). `submit`
+   *  defaults true (fire immediately). 409 = the session isn't live to type into. */
+  injectToSession: (id: string, text: string, submit = true) =>
+    call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/inject`, { text, submit }),
+  /** Out-of-band summary of a session: reads its transcript and summarizes it in a throwaway claude —
+   *  the target session is never touched. `via` = 'ai' | 'fallback'. */
+  summarizeSession: (id: string) =>
+    call<{ summary: string; via: 'ai' | 'fallback'; found: boolean; error?: string }>('POST', `/api/sessions/${id}/summarize`),
 
   team: () => call<TeamResp>('GET', '/api/team'),
   audit: (f: { session?: string; type?: string; principal?: string; limit?: number } = {}) => {


### PR DESCRIPTION
## What

A **⚡ Shortcuts** menu on every terminal session, with three things:

### 1. Summarize this session — *out of band, no pollution*
Reads the run's already-written claude transcript and summarizes it in a **throwaway `claude -p`** process, shown in a modal. The target session's own claude never sees the request, so its context/transcript is untouched. Degrades to a deterministic transcript summary (action counts, last message, errors) if the summarizer can't run.
- `POST /api/sessions/:id/summarize` → `src/edge/summarize.ts`

### 2. Built-in prompts fired into the live session
- **Check now** — sends the literal `Check now`
- **Update yourself** — sends `Update yourself`

### 3. Personal prompt shortcuts (saved per member)
Members save their own `label` + `prompt` shortcuts, managed on **Profile → My shortcuts** or added inline from the menu. Stored per member in `member_prefs`, sanitized + capped.
- `GET`/`PUT /api/me/shortcuts`

## How injection stays governed
Firing a shortcut types text into the live pane **exactly as if the attached human typed it** (`TerminalManager.injectToSession` → tmux send-keys). That's the same trust as attaching and typing: no policy gate on the keystroke itself, but every effect the resulting turn triggers is still mediated by the PreToolUse gate hook. Injection is gated on the pane being live/attachable. Audited `session.inject` / `session.summarized`.

## Testing
- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` (68/68) — all green.
- Isolated in-process smoke test (scratch `AGENT_OS_HOME`): sanitizer caps/dedupe/trim, `member_prefs` round-trip preserving sibling prefs, summarizer fallback + live `claude -p` path.
- HTTP smoke test on an ephemeral server: unauth `/api/me/shortcuts` → 401, authed GET/PUT round-trip + sanitize, `inject`/`summarize` on unknown session → 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)