### PR TITLE
GitHub Creds: OAuth creds above the optional bot creds (v0.208.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.208.1] — 2026-07-16
+### Changed
+- **Connections → Creds → GitHub: OAuth creds now sit above the company-bot creds.** The per-member OAuth
+  **Client ID / secret** (the essential setup that drives Connect GitHub) is shown first; the optional
+  **company-bot** App ID / private key (the safety-net baseline) moved below it — reflecting that the bot is
+  an add-on, not the primary credential. Card ordering only. (`web/src/App.tsx`)
+
 ## [0.208.0] — 2026-07-16
 ### Added
 - **Share a Library deliverable with the team and the web.** An artifact was previously visible only to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.208.0",
+  "version": "0.208.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.208.0",
+      "version": "0.208.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.208.0",
+  "version": "0.208.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11643,8 +11643,50 @@ function IntegrationsSettings({ me }: { me: Member }) {
             </div>
           )}
 
-          {/* Company-bot baseline: App ID + private key → a shared installation token every session can
-              push with, so per-agent PATs can be retired. Optional but recommended once the App is installed. */}
+          {/* Per-member OAuth creds (client id + secret) — the ESSENTIAL setup (drives Connect GitHub).
+              Shown first; the optional company-bot creds sit below it. */}
+          <details className="rounded-md border" open={!github.configured}>
+            <summary className="cursor-pointer select-none px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground">
+              {github.configured ? 'Replace credentials manually' : 'Or paste credentials manually (GitHub App or OAuth App)'}
+            </summary>
+            <div className="space-y-3 border-t p-3">
+              <p className="text-[11px] text-muted-foreground">
+                Set the app's <strong>Authorization callback URL</strong> to this server's <code className="text-[11px]">/api/github/callback</code>.
+              </p>
+              <Field label="Client ID">
+                <Input
+                  value={ghId}
+                  onChange={(e) => setGhId(e.target.value.trim())}
+                  placeholder={github.clientId ? 'saved — type a new id to replace' : 'Iv1.… / a GitHub App or OAuth App client id'}
+                  className="font-mono text-xs"
+                />
+              </Field>
+              <Field label="Client secret">
+                <Input
+                  type="password"
+                  value={ghSecret}
+                  onChange={(e) => setGhSecret(e.target.value)}
+                  placeholder={github.clientSecret ? '•••• (saved) — type a new secret to replace' : 'the App client secret'}
+                  className="font-mono text-xs"
+                />
+              </Field>
+              <div className="flex items-center gap-2">
+                <Button
+                  size="sm"
+                  onClick={() => save({ ...(ghId.trim() ? { githubClientId: ghId.trim() } : {}), ...(ghSecret.trim() ? { githubClientSecret: ghSecret.trim() } : {}) }, 'saved')}
+                  disabled={busy || (!ghId.trim() && !ghSecret.trim())}
+                >
+                  Save GitHub App
+                </Button>
+                {(github.clientId || github.clientSecret) && (
+                  <Button variant="ghost" onClick={() => save({ githubClientId: '', githubClientSecret: '' }, 'removed')} disabled={busy}>Remove</Button>
+                )}
+              </div>
+            </div>
+          </details>
+
+          {/* Company-bot baseline (App ID + private key) — the OPTIONAL safety net: a shared installation
+              token so unconnected members + automation can still push. Sits below the essential OAuth creds. */}
           <details className="rounded-md border" open={github.configured && !github.botReady}>
             <summary className="cursor-pointer select-none px-3 py-2 text-xs font-medium hover:bg-muted/40">
               <span className="text-foreground">Company-bot token</span>{' '}
@@ -11689,47 +11731,6 @@ function IntegrationsSettings({ me }: { me: Member }) {
               {github.appId && github.privateKey && !github.botReady && (
                 <p className="text-[11px] text-destructive">⚠ Credentials saved but a bot token couldn't be minted — check the App ID matches the key and the App is installed on at least one account.</p>
               )}
-            </div>
-          </details>
-
-          {/* Manual / OAuth-App creds — the fallback. Collapsed once an App is configured. */}
-          <details className="rounded-md border" open={!github.configured}>
-            <summary className="cursor-pointer select-none px-3 py-2 text-xs font-medium text-muted-foreground hover:text-foreground">
-              {github.configured ? 'Replace credentials manually' : 'Or paste credentials manually (GitHub App or OAuth App)'}
-            </summary>
-            <div className="space-y-3 border-t p-3">
-              <p className="text-[11px] text-muted-foreground">
-                Set the app's <strong>Authorization callback URL</strong> to this server's <code className="text-[11px]">/api/github/callback</code>.
-              </p>
-              <Field label="Client ID">
-                <Input
-                  value={ghId}
-                  onChange={(e) => setGhId(e.target.value.trim())}
-                  placeholder={github.clientId ? 'saved — type a new id to replace' : 'Iv1.… / a GitHub App or OAuth App client id'}
-                  className="font-mono text-xs"
-                />
-              </Field>
-              <Field label="Client secret">
-                <Input
-                  type="password"
-                  value={ghSecret}
-                  onChange={(e) => setGhSecret(e.target.value)}
-                  placeholder={github.clientSecret ? '•••• (saved) — type a new secret to replace' : 'the App client secret'}
-                  className="font-mono text-xs"
-                />
-              </Field>
-              <div className="flex items-center gap-2">
-                <Button
-                  size="sm"
-                  onClick={() => save({ ...(ghId.trim() ? { githubClientId: ghId.trim() } : {}), ...(ghSecret.trim() ? { githubClientSecret: ghSecret.trim() } : {}) }, 'saved')}
-                  disabled={busy || (!ghId.trim() && !ghSecret.trim())}
-                >
-                  Save GitHub App
-                </Button>
-                {(github.clientId || github.clientSecret) && (
-                  <Button variant="ghost" onClick={() => save({ githubClientId: '', githubClientSecret: '' }, 'removed')} disabled={busy}>Remove</Button>
-                )}
-              </div>
             </div>
           </details>
         </CardContent>


### PR DESCRIPTION
Card reorder only. In Connections → Creds → GitHub, the per-member **OAuth Client ID / secret** (the essential setup that drives Connect GitHub) now sits above the optional **company-bot** App ID / private key (the safety-net baseline) — reflecting that the bot is an add-on, not the primary credential. `web/src/App.tsx` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)