### PR TITLE
fix(links): agents emit FQDN console deep-links, not 127.0.0.1:<port> (v0.208.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.208.2] — 2026-07-16
+### Fixed
+- **Agent-emitted console deep-links now use the tenant's real FQDN, not `127.0.0.1:<port>`.** Links an
+  agent handed to a human (e.g. a `publish` "View it: …" Library link) were built from `AOS_URL`, which
+  is the **loopback** base the OS-owned MCP tools call the API on — correct for requests, unusable for a
+  human. The launcher now also exports `AOS_PUBLIC_URL` (the tenant's `consoleOrigin` —
+  `AGENT_OS_PUBLIC_URL`/config `publicUrl`/subdomain), and `memory-mcp`'s `consoleLink` prefers it,
+  falling back to the loopback base only in dev/demo where no public origin is configured. Out-of-band
+  notifier links (already built server-side from `consoleOrigin`) were unaffected; this closes the same
+  gap for anything the agent itself prints.
+
 ## [0.208.1] — 2026-07-16
 ### Changed
 - **Connections → Creds → GitHub: OAuth creds now sit above the company-bot creds.** The per-member OAuth

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.208.1",
+  "version": "0.208.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -12,11 +12,16 @@
  * transport), and uses the global `fetch`. Spawned by claude with AOS_URL/SESSION/AGENT in env.
  */
 const AOS_URL = (process.env.AOS_URL || 'http://127.0.0.1:3010').replace(/\/$/, '');
-// Absolute console deep-links agents can hand to a human. Being absolute (AOS_URL is the deployment's
-// real public origin) they're clickable in the browser terminal (xterm WebLinks) and autolink in the
-// console's markdown/inbox renderers. Mirrors the web app's hash routes (#/kb/<section>/<slug>, etc.).
+// The base for absolute console deep-links agents hand to a human. Prefer AOS_PUBLIC_URL — the tenant's
+// REAL external origin (its Tailscale/FQDN, from AGENT_OS_PUBLIC_URL/config publicUrl via consoleOrigin,
+// exported by the launcher). AOS_URL is the LOOPBACK base (http://127.0.0.1:<port>) the tools call the
+// API on; correct for requests, but NOT a URL a human can open — quoting it gives out `127.0.0.1:<port>`
+// links. Fall back to AOS_URL only when no public origin is configured (dev/demo). Absolute links are
+// clickable in the browser terminal (xterm WebLinks) and autolink in the console's markdown/inbox
+// renderers. Mirrors the web app's hash routes (#/kb/<section>/<slug>, etc.).
+const PUBLIC_URL = (process.env.AOS_PUBLIC_URL || AOS_URL).replace(/\/$/, '');
 const consoleLink = (route: string, detail?: string): string =>
-  `${AOS_URL}/#/${route}${detail ? '/' + detail.split('/').map(encodeURIComponent).join('/') : ''}`;
+  `${PUBLIC_URL}/#/${route}${detail ? '/' + detail.split('/').map(encodeURIComponent).join('/') : ''}`;
 const kbLink = (section: string, slug: string): string => consoleLink('kb', `${section}/${slug}`);
 const SESSION = process.env.SESSION || '';
 const AGENT = process.env.AGENT || '';

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1551,6 +1551,10 @@ export class TerminalManager {
   private sessionEnv(id: string, agent: string, task: string, secret: string): Record<string, string> {
     const env: Record<string, string> = {
       AOS_URL: this.baseUrl,
+      // The tenant's REAL external origin (FQDN/Tailscale), for human-facing deep-links agents emit.
+      // AOS_URL above is the loopback base the tools call the API on — never show it to a human. Falls
+      // back to the loopback base when no public origin is configured (dev/demo), so a link still forms.
+      AOS_PUBLIC_URL: this.publicOrigin || this.baseUrl,
       AOS_TENANT: this.os.tenant, // routes loopback agent calls to THIS tenant's runtime (multi-tenant)
       SESSION: id,
       AGENT: agent,
@@ -1845,7 +1849,8 @@ export class TerminalManager {
       // `slack_send`/`slack_dm` (and Discord equivalents) whenever the workspace has that platform
       // configured — any session can message a channel/person, not just chat-triggered ones.
       env: {
-        AOS_URL: this.baseUrl, AOS_TENANT: this.os.tenant, SESSION: sessionId, AGENT: agent, AOS_SECRET: secret,
+        AOS_URL: this.baseUrl, AOS_PUBLIC_URL: this.publicOrigin || this.baseUrl,
+        AOS_TENANT: this.os.tenant, SESSION: sessionId, AGENT: agent, AOS_SECRET: secret,
         ...(slackReply ? { SLACK_REPLY: '1' } : {}),
         ...(discordReply ? { DISCORD_REPLY: '1' } : {}),
         // ASK_ANSWER: '1' exposes the `answer` tool — only on an ask_agent delegate, so it can return its


### PR DESCRIPTION
## Why

Agents were handing humans links like `http://127.0.0.1:3012/#/artifacts/59f9c77d` (e.g. the `publish` "View it: …" Library link) instead of the tenant's real FQDN.

**Root cause:** the OS-owned MCP tools (`src/memory/memory-mcp.ts`) build human-facing console deep-links via `consoleLink()`, which used **`AOS_URL`** — the **loopback** base (`http://127.0.0.1:<port>`) the tools call the API on. Correct for requests, but not a URL a human can open. The tenant's real public origin (`TerminalManager.publicOrigin` = `consoleOrigin`, from `AGENT_OS_PUBLIC_URL`/config `publicUrl`/subdomain) already existed but was only used for chat-mirror DM links — never exported to the agent, so it had no way to emit an FQDN link and fell back to loopback.

Out-of-band notifier links (approval/task DMs, digests) were unaffected — they're built server-side from `consoleOrigin`. This closes the same gap for anything the **agent itself** prints.

## What

- Launcher exports `AOS_PUBLIC_URL` (= `this.publicOrigin || this.baseUrl`) alongside `AOS_URL`, at both agent-env sites in `src/terminal.ts`.
- `memory-mcp`'s `consoleLink` builds from a new `PUBLIC_URL = AOS_PUBLIC_URL || AOS_URL`, falling back to the loopback base only in dev/demo where no public origin is configured. API calls (`fetch` to `/api/*`) still use `AOS_URL`.

## Verification

- `npm run typecheck`, `npm run build`, `npm run test:governance` (68/68) all pass.
- Logic check with the instawp env (`AOS_URL=http://127.0.0.1:3012`, `AOS_PUBLIC_URL=https://aos.agents.instawp.net`): API base stays `127.0.0.1:3012`; the View link resolves to `https://aos.agents.instawp.net/#/artifacts/59f9c77d`.

Deployment note: the instawp box already sets `AGENT_OS_PUBLIC_URL=https://aos.agents.instawp.net`, so `consoleOrigin` was already correct — the only missing piece was plumbing it to the agent. A deployment with no public URL configured still falls back to `localhost:<port>` from `consoleOrigin`; set `AGENT_OS_PUBLIC_URL` there to get true FQDNs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)