### PR TITLE
feat(library): auto-expire public links (7d) + open in new tab + full-width md preview (v0.211.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.211.0] — 2026-07-16
+### Added
+- **Open a deliverable full-screen in a new tab.** The Library detail panel gains an **Open** button
+  next to Download — opens the artifact's raw URL in a new tab (`target="_blank"`), so a PDF/HTML/image
+  gets the whole viewport instead of the preview pane.
+### Changed
+- **Public Library links now auto-revoke after 7 days.** A protection so a shared link can't stay
+  world-reachable forever. Minting a public link stamps a 7-day expiry (`artifacts.share_expires_at`);
+  the public `/shared/<token>` route rejects an expired token immediately (404), and the scheduler tick
+  sweeps expired rows — clearing the token durably (audited `artifact.share.expired`). Re-toggling the
+  Public link renews the 7 days on the same URL. The detail panel shows when a link auto-revokes.
+- **Markdown preview fills the Library pane width.** The md/text preview was capped at `max-w-3xl`, so it
+  never widened with the pane (most visible after collapsing the sidebar); other artifact types are
+  already full-width. Markdown now matches (`web/src/App.tsx`).
+
 ## [0.210.0] — 2026-07-16
 ### Added
 - **Native-dependency check + one-shot install.** A fresh box needs a few native commands Agent OS shells

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.210.0",
+  "version": "0.211.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.210.0",
+      "version": "0.211.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.210.0",
+  "version": "0.211.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -884,6 +884,22 @@ export class Automations {
     }
     this.sweepOverdue(now);
     this.sweepStuckGoals(now);
+    this.sweepExpiredShares(now);
+  }
+
+  /**
+   * Auto-revoke public artifact links past their 7-day TTL — the "public forever" guard. The link
+   * already stops resolving at expiry (ArtifactStore.getByToken rejects it); this clears the token from
+   * the row so it's genuinely gone (and can be re-minted fresh). Wrapped so a bad row never kills the loop.
+   */
+  private sweepExpiredShares(now: Date): void {
+    try {
+      for (const id of this.os.artifacts.expirePublicShares(now.getTime())) {
+        this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'system', type: 'artifact.share.expired', data: { id } });
+      }
+    } catch {
+      // never let the share-expiry sweep take down the automation scheduler
+    }
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -4427,6 +4427,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         ...a,
         public: !!a.shareToken,
         shareToken: mine ? a.shareToken : undefined,
+        shareExpiresAt: mine ? a.shareExpiresAt : undefined,
         shareUrl: mine && a.shareToken ? sharedLinkFor(req, a.shareToken) : undefined,
       };
     });

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -16,6 +16,9 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Db } from './db';
 
+/** How long a public artifact link stays live before it auto-revokes (a "public forever" guard). */
+export const PUBLIC_SHARE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
 export interface Artifact {
   id: string;
   sessionId: string;
@@ -35,6 +38,8 @@ export interface Artifact {
   sharedTeam: boolean;
   /** When set, the artifact has a public login-free link (`/shared/<token>`). undefined = not public. */
   shareToken?: string;
+  /** Epoch ms when the public link auto-revokes (mint time + {@link PUBLIC_SHARE_TTL_MS}). */
+  shareExpiresAt?: number;
   createdAt: number;
 }
 
@@ -54,6 +59,7 @@ interface ArtifactRow {
   cost_usd: number | null;
   shared_team: number;
   share_token: string | null;
+  share_expires_at: number | null;
   created_at: number;
 }
 
@@ -116,6 +122,7 @@ export class ArtifactStore {
       cost_usd: null, // published files aren't generated → no cost
       shared_team: 0, // published private to its producer until explicitly shared
       share_token: null,
+      share_expires_at: null,
       created_at: Date.now(),
     };
     this.insertRow(row);
@@ -126,13 +133,13 @@ export class ArtifactStore {
   private insertRow(row: ArtifactRow): void {
     this.db
       .prepare(
-        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, cost_usd, shared_team, share_token, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO artifacts (id, session_id, agent, source, kind, title, description, folder, filename, rel_path, mime, bytes, cost_usd, shared_team, share_token, share_expires_at, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         row.id, row.session_id, row.agent, row.source, row.kind, row.title, row.description,
         row.folder, row.filename, row.rel_path, row.mime, row.bytes, row.cost_usd,
-        row.shared_team, row.share_token, row.created_at,
+        row.shared_team, row.share_token, row.share_expires_at, row.created_at,
       );
   }
 
@@ -177,6 +184,7 @@ export class ArtifactStore {
       cost_usd: typeof input.costUsd === 'number' ? input.costUsd : null,
       shared_team: 0,
       share_token: null,
+      share_expires_at: null,
       created_at: Date.now(),
     };
     this.insertRow(row);
@@ -234,23 +242,47 @@ export class ArtifactStore {
 
   /**
    * Toggle the public login-free link. Turning it ON mints a crypto-random token (reusing the existing
-   * one if already public, so the URL is stable across re-toggles); OFF clears it (revokes the link).
-   * Returns the resulting token (null when off / artifact missing). The token is the sole credential the
-   * public `/shared/<token>` route trusts, so it must be unguessable — `randomBytes`, not `Math.random`.
+   * one if already public, so the URL is stable across re-toggles) and (re)sets a fresh
+   * {@link PUBLIC_SHARE_TTL_MS} expiry — so re-sharing an expired/lapsing link renews its 7 days. OFF
+   * clears both (revokes the link). Returns the resulting token + expiry (nulls when off / missing). The
+   * token is the sole credential the public route trusts, so it must be unguessable — `randomBytes`.
    */
-  setPublic(id: string, on: boolean): string | null {
+  setPublic(id: string, on: boolean): { token: string | null; expiresAt: number | null } | null {
     const a = this.get(id);
     if (!a) return null;
-    const token = on ? a.shareToken ?? randomBytes(18).toString('base64url') : null;
-    this.db.prepare('UPDATE artifacts SET share_token = ? WHERE id = ?').run(token, id);
-    return token;
+    if (!on) {
+      this.db.prepare('UPDATE artifacts SET share_token = NULL, share_expires_at = NULL WHERE id = ?').run(id);
+      return { token: null, expiresAt: null };
+    }
+    const token = a.shareToken ?? randomBytes(18).toString('base64url');
+    const expiresAt = Date.now() + PUBLIC_SHARE_TTL_MS;
+    this.db.prepare('UPDATE artifacts SET share_token = ?, share_expires_at = ? WHERE id = ?').run(token, expiresAt, id);
+    return { token, expiresAt };
   }
 
-  /** Resolve an artifact by its public share token (the `/shared/<token>` lookup). undefined if none. */
+  /**
+   * Resolve an artifact by its public share token (the `/shared/<token>` lookup). Returns undefined if
+   * no such token OR the link has EXPIRED — so a lapsed link stops resolving the instant it expires, even
+   * before the scheduler sweep clears the row. undefined = serve a 404.
+   */
   getByToken(token: string): Artifact | undefined {
     if (!token) return undefined;
     const r = this.db.prepare('SELECT * FROM artifacts WHERE share_token = ?').get<ArtifactRow>(token);
-    return r ? toArtifact(r) : undefined;
+    if (!r) return undefined;
+    if (r.share_expires_at != null && r.share_expires_at < Date.now()) return undefined; // expired → gone
+    return toArtifact(r);
+  }
+
+  /**
+   * Auto-revoke public links past their expiry: clear the token + expiry from every lapsed row and return
+   * the affected ids (for the caller to audit). Called from the scheduler tick; the link already stops
+   * resolving at expiry (getByToken), this just makes the revocation durable so the token is truly gone.
+   */
+  expirePublicShares(now: number): string[] {
+    const where = 'share_token IS NOT NULL AND share_expires_at IS NOT NULL AND share_expires_at < ?';
+    const rows = this.db.prepare(`SELECT id FROM artifacts WHERE ${where}`).all<{ id: string }>(now);
+    if (rows.length) this.db.prepare(`UPDATE artifacts SET share_token = NULL, share_expires_at = NULL WHERE ${where}`).run(now);
+    return rows.map((r) => r.id);
   }
 
   /** Move an artifact into a folder (metadata only — the on-disk id-dir never moves). '' = root. */
@@ -286,6 +318,7 @@ function toArtifact(r: ArtifactRow): Artifact {
     costUsd: r.cost_usd ?? undefined,
     sharedTeam: r.shared_team === 1,
     shareToken: r.share_token ?? undefined,
+    shareExpiresAt: r.share_expires_at ?? undefined,
     createdAt: r.created_at,
   };
 }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -798,6 +798,10 @@ function migrate(db: Db): void {
   addColumn(db, 'artifacts', 'shared_team', 'INTEGER NOT NULL DEFAULT 0');
   addColumn(db, 'artifacts', 'share_token', 'TEXT');
   db.exec('CREATE UNIQUE INDEX IF NOT EXISTS idx_artifacts_share_token ON artifacts(share_token) WHERE share_token IS NOT NULL');
+  // Public-link expiry: a public share auto-revokes after a fixed TTL (7 days) so a link can't stay
+  // world-reachable forever. Set when the link is minted; the public route rejects an expired token
+  // immediately and the scheduler sweep clears it from the row. NULL = no public link (nothing to expire).
+  addColumn(db, 'artifacts', 'share_expires_at', 'INTEGER');
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4216,7 +4216,7 @@ function ArtifactBody({ a }: { a: Artifact }) {
   )
   if (wantsText) {
     if (text === null) return <div className="text-sm text-muted-foreground">Loading…</div>
-    if (isMarkdownArt(a)) return <div className="max-w-3xl text-sm"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{text}</ReactMarkdown></div>
+    if (isMarkdownArt(a)) return <div className="w-full text-sm"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{text}</ReactMarkdown></div>
     return <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-xs leading-relaxed">{text}</pre>
   }
   return (

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3746,6 +3746,12 @@ const fmtSize = (n: number): string =>
 /** Generated-media cost in USD — sub-cent amounts keep 4 decimals so a $0.0336 image doesn't read $0.03. */
 const fmtCost = (usd: number): string => (usd < 0.01 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`)
 
+/** A coarse "in N days"/"today"/"expired" for a future epoch-ms deadline (public-link expiry). */
+const fmtRelDays = (at: number): string => {
+  const d = Math.round((at - Date.now()) / 86_400_000)
+  return d < 0 ? 'expired' : d === 0 ? 'today' : d === 1 ? 'in 1 day' : `in ${d} days`
+}
+
 /** Browse + edit files in the instance's data home. The server confines every path to the
  *  home root; navigation (folders/breadcrumb) + a text editor, plus upload (button or drag-drop),
  *  download, new-folder and delete. */
@@ -4696,6 +4702,7 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
                     </div>
                   </div>
                   <div className="flex shrink-0 gap-2">
+                    <a href={api.artifactRawUrl(selected.id)} target="_blank" rel="noopener noreferrer"><Button size="sm" variant="secondary"><ExternalLink className="mr-1 h-4 w-4" />Open</Button></a>
                     <a href={api.artifactRawUrl(selected.id)} download={selected.filename}><Button size="sm" variant="secondary"><Download className="mr-1 h-4 w-4" />Download</Button></a>
                     {(me.role === 'owner' || me.role === 'admin' || selected.source === me.id) && (
                       <>
@@ -4716,6 +4723,9 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
                       <span className="inline-flex items-center gap-1.5"><Globe className="h-3.5 w-3.5" />Public link<span className="text-muted-foreground">— anyone with the URL can view, no login required</span></span>
                     </label>
                     {selected.shareUrl && <CopyLink link={selected.shareUrl} />}
+                    {selected.shareUrl && selected.shareExpiresAt && (
+                      <div className="flex items-center gap-1 text-[11px] text-muted-foreground"><Clock className="h-3 w-3" />Link auto-revokes {new Date(selected.shareExpiresAt).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })} ({fmtRelDays(selected.shareExpiresAt)}) — re-toggle to renew.</div>
+                    )}
                   </div>
                 )}
                 <ArtifactBody a={selected} />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -311,6 +311,8 @@ export interface Artifact {
   public?: boolean
   /** The public share token — only returned to whoever may manage sharing (owner/admin/producer). */
   shareToken?: string
+  /** Epoch ms when the public link auto-revokes (7 days after minting); present with `shareToken`. */
+  shareExpiresAt?: number
   /** The resolved public URL (`/shared/<token>`) — present only when `shareToken` is. */
   shareUrl?: string
   createdAt: number


### PR DESCRIPTION
## What

Three Library changes (follow-ups to the team/web sharing in #346):

1. **Public links auto-revoke after 7 days** — so a shared link can't stay world-reachable forever.
2. **Open in a new tab** — a full-screen view of a deliverable.
3. **Markdown preview fills the pane** — no longer capped at `max-w-3xl` (most visible after collapsing the sidebar).

## How

**Expiry**
- `artifacts.share_expires_at` column. `setPublic(id, true)` stamps `now + 7d` and reuses the token, so re-toggling Public **renews** the 7 days on the same URL.
- `getByToken` rejects an expired token → `/shared/<token>` 404s **immediately** at expiry, before any sweep.
- `expirePublicShares(now)` clears lapsed rows, wired into the scheduler `tick()` (`sweepExpiredShares`), audited `artifact.share.expired`, wrapped so a bad row can't kill the scheduler.
- Detail panel shows the auto-revoke date + "in N days".

**Open in new tab** — an **Open** button opens `artifactRawUrl` with `target="_blank"`, alongside Download. Pure frontend.

**Full-width markdown** — the md/text preview was wrapped in `max-w-3xl`; other types are already `w-full`. Made markdown match so it uses the pane's full width.

## Verification

End-to-end in an isolated home: expiry stamped at 7d, re-toggle renews with a stable token, expired token no longer resolves **pre-sweep** and the route 404s, the sweep clears token+expiry and is idempotent, a live link is untouched. `typecheck` + `web build` + `test:governance` (68/68) all green. Rebased onto `main` (past #348/#349).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMSbnPEbqSVPGLasTKENp