### PR TITLE
feat(system): native-dependency check + one-shot install (tmux/ttyd/claude/git) (v0.210.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.210.0] — 2026-07-16
+### Added
+- **Native-dependency check + one-shot install.** A fresh box needs a few native commands Agent OS shells
+  out to (`tmux` backs every session pane, `ttyd` serves the in-browser terminal, `claude` is the agent
+  runtime, `git` powers self-update) — previously undocumented beyond a prose line in CLAUDE.md, and the
+  classic "why won't a session start?" gap.
+  - **Settings → System → Native dependencies** — a new panel (`GET /api/deps`) showing each tool's
+    present/missing state, version, and purpose. When something's missing it surfaces the exact install
+    command (copyable) and the `npm run install-deps` shortcut; the owner gets an **Install now** button
+    (`POST /api/deps/install`, owner-gated, audited `system.deps.installed`) that runs the box's package
+    manager (brew on macOS; apt/dnf/yum/pacman/zypper on Linux) and re-checks, streaming each step's log.
+  - **`npm run install-deps`** (and `npm run check-deps`) — a zero-dependency bootstrap shell script
+    (`scripts/install-deps.sh`) that works on a fresh checkout *before* `npm run build`, portable to
+    bash 3.2 + BSD userland. Detects the package manager and installs the still-missing tools.
+  - **`agent-os deps` / `agent-os install-deps`** — the same check/install from the built CLI, for a box
+    where the server is already running.
+  Deps installed another way (`claude`, via npm) are never auto-installed — their manual hint is shown
+  instead. New module `src/edge/deps.ts` (`checkDeps`/`installDeps`), modeled on the self-update path.
+
 ## [0.209.0] — 2026-07-16
 ### Added
 - **Quick Shortcuts on every terminal session** — a `⚡ Shortcuts` menu in the terminal chrome with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.209.0",
+  "version": "0.210.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.209.0",
+      "version": "0.210.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.209.0",
+  "version": "0.210.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -23,6 +23,8 @@
     "serve": "node dist/cli.js serve",
     "start": "node dist/cli.js serve",
     "demo": "node dist/cli.js demo",
+    "install-deps": "bash scripts/install-deps.sh",
+    "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
     "test:governance": "node scripts/governance-conformance.cjs",

--- a/scripts/install-deps.sh
+++ b/scripts/install-deps.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Install (or check) the native commands Agent OS needs to run agent sessions.
+#
+# This is the ZERO-DEPENDENCY bootstrap shortcut: it works on a fresh checkout BEFORE `npm run build`
+# (nothing here needs dist/), so it's the first thing to run on a new box. `npm run install-deps` maps
+# to it. Once the server is built and running, the same check is available in the console under
+# Settings → System, and from the built CLI (`agent-os deps` / `agent-os install-deps`).
+#
+# Native deps (matches src/edge/deps.ts):
+#   tmux   — backs every agent session (persistent panes)          [required, pkg]
+#   ttyd   — serves the in-browser terminal                        [required, pkg]
+#   claude — the agent runtime each session launches               [required, npm i -g @anthropic-ai/claude-code]
+#   git    — powers self-update                                    [optional, pkg]
+#
+# Portable to bash 3.2 + BSD userland (the macOS default) as well as Linux — see CLAUDE.md. Pass
+# `--check` to only report status (no install, exit 1 if a required dep is missing).
+set -u
+
+CHECK_ONLY=0
+[ "${1:-}" = "--check" ] && CHECK_ONLY=1
+
+# ── resolve the package manager (first present wins; brew preferred on macOS) ──
+MANAGER=""
+if [ "$(uname -s)" = "Darwin" ]; then
+  command -v brew >/dev/null 2>&1 && MANAGER="brew"
+else
+  for m in apt-get dnf yum pacman zypper brew; do
+    if command -v "$m" >/dev/null 2>&1; then MANAGER="$m"; break; fi
+  done
+fi
+
+# The install command for a given package manager + package list ($1 = pkgs).
+install_cmd() {
+  case "$MANAGER" in
+    brew)    echo "brew install $1" ;;
+    apt-get) echo "sudo apt-get update && sudo apt-get install -y $1" ;;
+    dnf)     echo "sudo dnf install -y $1" ;;
+    yum)     echo "sudo yum install -y $1" ;;
+    pacman)  echo "sudo pacman -S --noconfirm $1" ;;
+    zypper)  echo "sudo zypper install -y $1" ;;
+    *)       echo "" ;;
+  esac
+}
+
+# ── check each dep; collect the missing package-manager-installable ones ──
+MISSING_PKGS=""
+MISSING_REQUIRED=0
+
+check_one() { # bin  label  required(0/1)  pkg(or "")  hint(or "")  versionArg(default --version)
+  local bin="$1" label="$2" required="$3" pkg="$4" hint="$5" varg="${6:---version}"
+  if command -v "$bin" >/dev/null 2>&1; then
+    local ver
+    ver="$("$bin" "$varg" 2>&1 | head -n1)"
+    printf "  \342\234\223 %-12s %s\n" "$label" "$ver"
+  else
+    if [ "$required" = "1" ]; then MISSING_REQUIRED=1; fi
+    if [ -n "$pkg" ] && [ -n "$MANAGER" ]; then
+      MISSING_PKGS="$MISSING_PKGS $pkg"
+      printf "  \342\234\227 %-12s missing\n" "$label"
+    else
+      printf "  \342\234\227 %-12s missing \342\200\224 %s\n" "$label" "${hint:-install manually}"
+    fi
+  fi
+}
+
+echo "Native dependencies:"
+check_one tmux   "tmux"        1 "tmux" "" "-V"
+check_one ttyd   "ttyd"        1 "ttyd" ""
+check_one claude "Claude Code" 1 ""     "npm install -g @anthropic-ai/claude-code"
+check_one git    "git"         0 "git"  ""
+echo ""
+
+# Trim leading whitespace from the accumulated package list.
+MISSING_PKGS="$(echo "$MISSING_PKGS" | sed 's/^ *//')"
+
+if [ -z "$MISSING_PKGS" ]; then
+  if [ "$MISSING_REQUIRED" = "1" ]; then
+    echo "Some required dependencies are missing and can't be installed automatically — see the hints above."
+    exit 1
+  fi
+  echo "All required dependencies are installed."
+  exit 0
+fi
+
+CMD="$(install_cmd "$MISSING_PKGS")"
+
+if [ "$CHECK_ONLY" = "1" ] || [ -z "$MANAGER" ]; then
+  if [ -z "$MANAGER" ]; then
+    echo "No supported package manager found (brew/apt/dnf/yum/pacman/zypper)."
+    echo "Install the missing tools by hand:$MISSING_PKGS"
+  else
+    echo "Missing:$MISSING_PKGS"
+    echo "Install with:"
+    echo "  $CMD"
+  fi
+  [ "$MISSING_REQUIRED" = "1" ] && exit 1
+  exit 0
+fi
+
+echo "Installing:$MISSING_PKGS"
+echo "  $CMD"
+echo ""
+sh -c "$CMD"
+STATUS=$?
+
+echo ""
+if [ "$STATUS" = "0" ]; then
+  echo "Done. Re-run 'npm run install-deps -- --check' to verify."
+else
+  echo "Install failed (exit $STATUS) — run the command above by hand to see why."
+fi
+exit "$STATUS"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { TenantStore } from './state/control';
 import { reconcileTenant } from './governance/policy-reconcile';
 import { Role } from './types';
 import { VERSION } from './version';
+import { checkDeps, installDeps, type DepsReport } from './edge/deps';
 
 // `node:sqlite` is stable enough to depend on but still emits an ExperimentalWarning on first
 // use. Swallow just that one line so the console output stays clean; surface every other warning.
@@ -56,6 +57,12 @@ async function main(): Promise<void> {
     case 'policy':
       policy(rest);
       break;
+    case 'deps':
+      deps(false);
+      break;
+    case 'install-deps':
+      deps(true);
+      break;
     case 'demo':
       await import('./demo');
       break;
@@ -79,6 +86,31 @@ async function main(): Promise<void> {
       usage();
       if (cmd && !['help', '--help', '-h'].includes(cmd)) process.exitCode = 1;
   }
+}
+
+/** Check (and optionally install) the native tools a running instance shells out to. No server needed. */
+function deps(install: boolean): void {
+  const print = (r: DepsReport): void => {
+    for (const d of r.deps) {
+      const mark = d.installed ? '✓' : d.required ? '✗' : '·';
+      const tail = d.installed ? (d.version || d.path || '') : (d.pkg ? '(missing)' : `(missing — ${d.hint || 'install manually'})`);
+      console.log(`  ${mark} ${d.label.padEnd(12)} ${tail}`);
+    }
+    console.log(r.ok ? '\nAll required dependencies are installed.' : '\nSome required dependencies are missing.');
+    if (!r.ok && r.installCommand) console.log(`Install them with:\n  ${r.installCommand}`);
+    else if (!r.ok) console.log('No supported package manager found — install the missing tools by hand (see hints above).');
+  };
+
+  if (!install) { const r = checkDeps(); print(r); process.exitCode = r.ok ? 0 : 1; return; }
+
+  const pre = checkDeps();
+  if (pre.ok && !pre.installable.length) { console.log('All required dependencies are already installed.'); return; }
+  console.log('Installing missing dependencies…\n');
+  const result = installDeps();
+  for (const s of result.steps) console.log(`${s.ok ? '✓' : '✗'} ${s.cmd}${s.out ? `\n${s.out}` : ''}`);
+  console.log('');
+  print(result.report);
+  process.exitCode = result.ok ? 0 : 1;
 }
 
 /** Team management from the box (box access ≈ owner) — the secure recovery path for login. */
@@ -284,6 +316,8 @@ function usage(): void {
   invite <email> [role] mint a magic-link to invite a teammate (role: admin | member)
   login-link <email>    print a fresh login link for an existing member (recovery)
   members               list workspace members and their roles
+  deps                   check the native tools sessions need (tmux/ttyd/claude/git)
+  install-deps           install the missing native tools via the box's package manager
   tenant <sub>          multi-tenant admin: list | create <slug> --owner <email> | remove <slug>
   policy reconcile      align agents' policyContext to the enforced ruleset (--tenant <slug> | --all; --yes to apply)
   demo                  run the scripted governance demo in the terminal

--- a/src/edge/deps.ts
+++ b/src/edge/deps.ts
@@ -1,0 +1,199 @@
+/**
+ * System dependencies — the native commands Agent OS needs on the box to run agent sessions.
+ *
+ * The Node process itself is zero-dependency, but a live instance shells out to a couple of native
+ * tools that aren't Node built-ins: `tmux` (backs every persistent agent pane) and `ttyd` (serves the
+ * in-browser terminal). `claude` (the agent runtime each session launches) and `git` (the self-update
+ * path) round out the set. On a fresh box these are the classic "why won't a session start?" gaps, so
+ * we make them checkable from Settings → System and installable via one shortcut.
+ *
+ * `checkDeps()` probes each binary (present? which path? what version?) — pure inspection, safe for any
+ * member to read. `installDeps()` resolves the box's package manager (brew on macOS; apt/dnf/yum/pacman
+ * on Linux) and installs the still-missing package-manager-installable deps, returning each step's log —
+ * owner-gated at the route, same posture as the self-update apply. Deps with no package (i.e. `claude`,
+ * installed via npm) are never auto-installed; we surface their manual hint instead.
+ */
+import { spawnSync } from 'child_process';
+
+export interface Dep {
+  /** The binary as invoked on PATH. */
+  bin: string;
+  /** Human label for the UI. */
+  label: string;
+  /** Why Agent OS needs it. */
+  purpose: string;
+  /** A hard requirement (agent sessions won't run without it) vs. recommended. */
+  required: boolean;
+  /** Package name for the system package manager (brew/apt/…); omit for deps installed another way. */
+  pkg?: string;
+  /** Manual install hint, shown when there's no `pkg` (e.g. `claude` via npm) or the box has no manager. */
+  hint?: string;
+  /** Flag that prints the version — defaults to `--version`; tmux only understands `-V`. */
+  versionArg?: string;
+}
+
+/** The native tools a running instance shells out to. Order = display order. */
+export const REQUIRED_DEPS: Dep[] = [
+  {
+    bin: 'tmux',
+    label: 'tmux',
+    purpose: 'Backs every agent session — each run lives in a persistent tmux pane.',
+    required: true,
+    pkg: 'tmux',
+    versionArg: '-V',
+  },
+  {
+    bin: 'ttyd',
+    label: 'ttyd',
+    purpose: 'Serves the in-browser terminal used to watch and take over a live session.',
+    required: true,
+    pkg: 'ttyd',
+  },
+  {
+    bin: 'claude',
+    label: 'Claude Code',
+    purpose: 'The agent runtime each claude-code session launches.',
+    required: true,
+    hint: 'npm install -g @anthropic-ai/claude-code',
+  },
+  {
+    bin: 'git',
+    label: 'git',
+    purpose: 'Powers self-update (fetch → fast-forward pull → rebuild) from Settings → System.',
+    required: false,
+    pkg: 'git',
+  },
+];
+
+export interface DepStatus extends Dep {
+  installed: boolean;
+  /** Resolved absolute path on PATH, when installed. */
+  path?: string;
+  /** First line of `<bin> --version`, best-effort (some tools print to stderr / don't support it). */
+  version?: string;
+}
+
+export interface DepsReport {
+  deps: DepStatus[];
+  /** True when every `required` dep is present — sessions can run. */
+  ok: boolean;
+  /** Missing deps that a package manager could install (drives the "Install now" button). */
+  installable: string[];
+  /** The resolved package manager for this box, or null when none is available (→ manual hints only). */
+  manager: PackageManager | null;
+  /** The one-line shell command that installs the currently-missing installable deps, or null when
+   *  nothing's missing / no manager. Shown copyable in the UI as the fallback to the button. */
+  installCommand: string | null;
+  /** The zero-dependency bootstrap shortcut (works before `npm run build`). Always shown as a hint. */
+  shortcut: string;
+  platform: string;
+}
+
+/** Resolve a binary's absolute path via `command -v` (portable across sh); '' when not found. */
+function whichBin(bin: string): string {
+  const r = spawnSync('sh', ['-c', `command -v ${bin} 2>/dev/null`], { encoding: 'utf8', timeout: 5000 });
+  return (r.stdout || '').trim().split('\n')[0] || '';
+}
+
+/** Best-effort version string — first line of `<bin> <versionArg>` (stdout or stderr); undefined if none. */
+function binVersion(bin: string, versionArg = '--version'): string | undefined {
+  const r = spawnSync(bin, [versionArg], { encoding: 'utf8', timeout: 5000 });
+  const out = `${r.stdout || ''}${r.stderr || ''}`.trim().split('\n')[0].trim();
+  return out || undefined;
+}
+
+/** Probe every dependency: present? where? what version? Pure inspection — no side effects. */
+export function checkDeps(): DepsReport {
+  const deps: DepStatus[] = REQUIRED_DEPS.map((d) => {
+    const path = whichBin(d.bin);
+    return { ...d, installed: !!path, path: path || undefined, version: path ? binVersion(d.bin, d.versionArg) : undefined };
+  });
+  const ok = deps.every((d) => !d.required || d.installed);
+  const manager = resolveManager();
+  // A missing dep is "installable" only if it names a package AND we have a manager to install it with.
+  const installable = deps.filter((d) => !d.installed && d.pkg && manager).map((d) => d.bin);
+  const pkgs = deps.filter((d) => installable.includes(d.bin)).map((d) => d.pkg!) as string[];
+  return {
+    deps,
+    ok,
+    installable,
+    manager,
+    installCommand: manager && pkgs.length ? installCommandFor(manager, pkgs) : null,
+    shortcut: 'npm run install-deps',
+    platform: process.platform,
+  };
+}
+
+export type PackageManager = 'brew' | 'apt-get' | 'dnf' | 'yum' | 'pacman' | 'zypper';
+
+/** Detect the box's package manager (first present wins; brew preferred on macOS). */
+export function resolveManager(): PackageManager | null {
+  const order: PackageManager[] = process.platform === 'darwin'
+    ? ['brew']
+    : ['apt-get', 'dnf', 'yum', 'pacman', 'zypper', 'brew'];
+  for (const m of order) if (whichBin(m)) return m;
+  return null;
+}
+
+/** The full install command for a manager + package list. Linux managers need root; brew must NOT. */
+export function installCommandFor(manager: PackageManager, pkgs: string[]): string {
+  const list = pkgs.join(' ');
+  switch (manager) {
+    case 'brew': return `brew install ${list}`;
+    case 'apt-get': return `sudo apt-get update && sudo apt-get install -y ${list}`;
+    case 'dnf': return `sudo dnf install -y ${list}`;
+    case 'yum': return `sudo yum install -y ${list}`;
+    case 'pacman': return `sudo pacman -S --noconfirm ${list}`;
+    case 'zypper': return `sudo zypper install -y ${list}`;
+  }
+}
+
+export interface InstallStep { cmd: string; ok: boolean; out: string }
+export interface InstallResult {
+  ok: boolean;
+  steps: InstallStep[];
+  /** The dependency report after the install attempt, so the UI can refresh in one round-trip. */
+  report: DepsReport;
+  error?: string;
+}
+
+/**
+ * Install the currently-missing, package-manager-installable deps and re-check. Owner-gated at the route.
+ * We run the resolved manager directly (not via `sh -c`) so a hung network can't wedge a shell; brew is
+ * invoked without sudo (it refuses to run as root), the Linux managers with it.
+ */
+export function installDeps(): InstallResult {
+  const before = checkDeps();
+  if (before.ok && !before.installable.length)
+    return { ok: true, steps: [], report: before, error: undefined };
+  const manager = before.manager;
+  if (!manager)
+    return { ok: false, steps: [], report: before, error: 'no supported package manager found (brew/apt/dnf/yum/pacman/zypper) — install the missing tools by hand' };
+  const pkgs = before.deps.filter((d) => before.installable.includes(d.bin)).map((d) => d.pkg!);
+  if (!pkgs.length)
+    return { ok: false, steps: [], report: before, error: 'nothing installable is missing (remaining gaps need a manual install — see each dependency\'s hint)' };
+
+  const steps: InstallStep[] = [];
+  const run = (label: string, cmd: string, args: string[]): boolean => {
+    const r = spawnSync(cmd, args, { encoding: 'utf8', timeout: 10 * 60_000, maxBuffer: 16 * 1024 * 1024 });
+    const out = `${r.stdout || ''}${r.stderr || ''}`.trim();
+    steps.push({ cmd: label, ok: r.status === 0, out: out.slice(-4000) });
+    return r.status === 0;
+  };
+
+  let ok = true;
+  if (manager === 'brew') {
+    ok = run(`brew install ${pkgs.join(' ')}`, 'brew', ['install', ...pkgs]);
+  } else if (manager === 'apt-get') {
+    // apt needs its index fresh before an install can resolve the packages.
+    run('sudo apt-get update', 'sudo', ['apt-get', 'update']);
+    ok = run(`sudo apt-get install -y ${pkgs.join(' ')}`, 'sudo', ['apt-get', 'install', '-y', ...pkgs]);
+  } else if (manager === 'dnf' || manager === 'yum' || manager === 'zypper') {
+    ok = run(`sudo ${manager} install -y ${pkgs.join(' ')}`, 'sudo', [manager, 'install', '-y', ...pkgs]);
+  } else if (manager === 'pacman') {
+    ok = run(`sudo pacman -S --noconfirm ${pkgs.join(' ')}`, 'sudo', ['pacman', '-S', '--noconfirm', ...pkgs]);
+  }
+
+  const report = checkDeps();
+  return { ok: ok && report.ok, steps, report, error: ok ? undefined : 'one or more install steps failed — see the logs' };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ import { planKbTidy, applyKbTidy } from './edge/kb-tidy';
 import { Strategist, STRATEGIST_ID } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
+import { checkDeps, installDeps } from './edge/deps';
 import { CATALOG, redact } from './connectors/connectors';
 import { GithubIdentity } from './edge/github-identity';
 import { convertAppManifest, userInstallationStatus } from './connectors/github';
@@ -3524,6 +3525,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/system') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     return sendJson(res, 200, await systemMetrics(tm));
+  }
+  // ── native system dependencies (tmux/ttyd/claude/git) — "is the box set up to run sessions?" ──
+  if (method === 'GET' && p === '/api/deps') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, checkDeps());
+  }
+  // Install the still-missing, package-manager-installable deps (brew/apt/…). Owner-gated (it runs a
+  // privileged system install), same posture as the self-update apply below.
+  if (method === 'POST' && p === '/api/deps/install') {
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
+    const result = installDeps();
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'system.deps.installed', data: { ok: result.ok, steps: result.steps.map((s) => ({ cmd: s.cmd, ok: s.ok })) } });
+    return sendJson(res, 200, result);
   }
   // ── stop every running session (softer sibling of the kill switch; leaves the gate open) ──
   if (method === 'POST' && p === '/api/sessions/stop-all') {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type ChatTurn } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -10218,6 +10218,7 @@ function SystemSettings({ state, me }: { state: StateResp | null; me: Member }) 
   return (
     <div className="space-y-4">
       <SoftwarePanel me={me} />
+      <NativeDepsPanel me={me} />
       <HostResourcesPanel />
       <StopAllPanel />
       <Card>
@@ -10252,6 +10253,146 @@ function SystemSettings({ state, me }: { state: StateResp | null; me: Member }) 
           />
         </CardContent>
       </Card>
+    </div>
+  )
+}
+
+/**
+ * Settings → System → Native dependencies — is this box set up to run agent sessions? Probes the native
+ * commands Agent OS shells out to (tmux/ttyd/claude/git) via `GET /api/deps`. When something's missing it
+ * shows the exact install command (copyable) + the `npm run install-deps` shortcut, and — for the owner —
+ * an "Install now" button that runs the box's package manager (`POST /api/deps/install`) and re-checks.
+ */
+function NativeDepsPanel({ me }: { me: Member }) {
+  const [report, setReport] = useState<DepsReport | null>(null)
+  const [err, setErr] = useState('')
+  const [installing, setInstalling] = useState(false)
+  const [result, setResult] = useState<DepsInstallResult | null>(null)
+  const [copied, setCopied] = useState('')
+
+  const load = () => api.deps().then((r) => { setErr(''); setReport(r) }).catch(() => setErr('Could not read dependency status.'))
+  useEffect(() => { load() }, [])
+
+  const copy = async (text: string) => { if (await copyText(text)) { setCopied(text); setTimeout(() => setCopied(''), 1500) } }
+
+  const install = async () => {
+    setInstalling(true); setResult(null); setErr('')
+    const r = await api.installDeps().catch(() => null)
+    setInstalling(false)
+    if (!r) return setErr('Install request failed.')
+    setResult(r); setReport(r.report)
+  }
+
+  const isOwner = me.role === 'owner'
+  const missingRequired = report ? report.deps.filter((d) => d.required && !d.installed) : []
+
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm font-semibold"><Boxes className="h-4 w-4" /> Native dependencies</div>
+          <div className="flex items-center gap-2">
+            <Button size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-xs" disabled={installing} onClick={load}>
+              <RefreshCw className="h-3.5 w-3.5" /> Re-check
+            </Button>
+            {isOwner && report && report.installable.length > 0 && (
+              <Button size="sm" variant="outline" className="h-7 gap-1.5 px-2 text-xs" disabled={installing} onClick={install}>
+                <Download className={`h-3.5 w-3.5 ${installing ? 'animate-pulse' : ''}`} /> {installing ? 'Installing…' : 'Install now'}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <p className="text-sm text-muted-foreground">
+          The native commands Agent OS shells out to on this box. Sessions won't start until the required ones are present.
+        </p>
+
+        {err && <p className="text-sm text-red-600">{err}</p>}
+        {!report ? (
+          <p className="text-sm text-muted-foreground">Checking…</p>
+        ) : (
+          <>
+            {report.ok
+              ? <div className="flex items-center gap-1.5 text-xs text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> All required dependencies are installed.</div>
+              : <div className="flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20">
+                  <AlertTriangle className="h-3.5 w-3.5 shrink-0" /> {missingRequired.length} required {missingRequired.length === 1 ? 'dependency is' : 'dependencies are'} missing — agent sessions can't run.
+                </div>}
+
+            <dl className="divide-y rounded-md border">
+              {report.deps.map((d) => <DepRow key={d.bin} d={d} />)}
+            </dl>
+
+            {(report.installCommand || !report.ok) && (
+              <div className="space-y-2 rounded-md border bg-muted/40 p-3">
+                <p className="text-xs font-medium text-muted-foreground">Install the missing tools</p>
+                {report.installCommand ? (
+                  <CmdLine text={report.installCommand} copied={copied} onCopy={copy} />
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    No supported package manager found on this box{report.platform ? ` (${report.platform})` : ''} — install the missing tools by hand using each row's hint.
+                  </p>
+                )}
+                <p className="text-xs text-muted-foreground">Or, from the repo checkout, run the shortcut:</p>
+                <CmdLine text={report.shortcut} copied={copied} onCopy={copy} />
+              </div>
+            )}
+
+            {result && (
+              <div className="space-y-1.5">
+                <p className={`text-xs font-medium ${result.ok ? 'text-emerald-600' : 'text-amber-600'}`}>
+                  {result.ok ? 'Installed — all required dependencies are present.' : (result.error || 'Install finished with problems.')}
+                </p>
+                {result.steps.length > 0 && (
+                  <div className="max-h-48 space-y-1.5 overflow-auto rounded-md border bg-muted/40 p-2">
+                    {result.steps.map((s, i) => (
+                      <div key={i}>
+                        <div className="flex items-center gap-1.5 text-[11px] font-medium">
+                          {s.ok ? <CheckCircle2 className="h-3 w-3 text-emerald-600" /> : <XCircle className="h-3 w-3 text-red-600" />}
+                          <span className="font-mono">{s.cmd}</span>
+                        </div>
+                        {s.out && <pre className="mt-0.5 whitespace-pre-wrap break-all pl-4 text-[10px] leading-snug text-muted-foreground">{s.out}</pre>}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+/** One dependency row: label + purpose + present/missing badge (with version/path when installed). */
+function DepRow({ d }: { d: DepStatus }) {
+  return (
+    <div className="flex items-start gap-3 px-3 py-2">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-sm font-medium">{d.label}</span>
+          {!d.required && <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">optional</span>}
+        </div>
+        <p className="text-xs text-muted-foreground">{d.purpose}</p>
+        {d.installed
+          ? (d.version || d.path) && <p className="truncate font-mono text-[10px] text-muted-foreground" title={d.path}>{d.version || d.path}</p>
+          : d.hint && <p className="font-mono text-[10px] text-muted-foreground">install: {d.hint}</p>}
+      </div>
+      {d.installed
+        ? <span className="flex shrink-0 items-center gap-1 text-xs text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> installed</span>
+        : <span className={`flex shrink-0 items-center gap-1 text-xs ${d.required ? 'text-red-600' : 'text-amber-600'}`}><XCircle className="h-3.5 w-3.5" /> missing</span>}
+    </div>
+  )
+}
+
+/** A copyable one-line shell command. */
+function CmdLine({ text, copied, onCopy }: { text: string; copied: string; onCopy: (t: string) => void }) {
+  return (
+    <div className="flex items-center gap-2">
+      <code className="min-w-0 flex-1 overflow-x-auto whitespace-nowrap rounded bg-background px-2 py-1.5 font-mono text-xs">{text}</code>
+      <Button size="sm" variant="ghost" className="h-7 shrink-0 gap-1 px-2 text-xs" onClick={() => onCopy(text)}>
+        {copied === text ? <><Check className="h-3.5 w-3.5" /> Copied</> : <><Copy className="h-3.5 w-3.5" /> Copy</>}
+      </Button>
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -145,6 +145,42 @@ export interface SystemMetrics {
   sessions: { available: boolean; totalRss: number; sessions: { id: string; agent: string; title: string; rss: number }[] }
   error?: string
 }
+/** One native command Agent OS shells out to (GET /api/deps). */
+export interface DepStatus {
+  bin: string
+  label: string
+  purpose: string
+  required: boolean
+  /** Package name for the box's package manager; absent when installed another way (e.g. claude via npm). */
+  pkg?: string
+  /** Manual install hint, when there's no `pkg` or no package manager on the box. */
+  hint?: string
+  installed: boolean
+  path?: string
+  version?: string
+}
+/** Native-dependency report for Settings → System (GET /api/deps). */
+export interface DepsReport {
+  deps: DepStatus[]
+  /** True when every required dep is present — sessions can run. */
+  ok: boolean
+  /** Missing deps a package manager could install (drives the "Install now" button). */
+  installable: string[]
+  /** Resolved package manager, or null when the box has none (→ manual hints only). */
+  manager: 'brew' | 'apt-get' | 'dnf' | 'yum' | 'pacman' | 'zypper' | null
+  /** One-line command that installs the missing installable deps, or null when nothing's missing. */
+  installCommand: string | null
+  /** Zero-dependency bootstrap shortcut (works before a build). */
+  shortcut: string
+  platform: string
+}
+/** Result of POST /api/deps/install — per-step logs plus the re-checked report. */
+export interface DepsInstallResult {
+  ok: boolean
+  steps: { cmd: string; ok: boolean; out: string }[]
+  report: DepsReport
+  error?: string
+}
 export interface Session {
   id: string
   agent: string
@@ -1052,6 +1088,10 @@ export const api = {
   stopAllSessions: () => call<{ ok: boolean; halted?: number; error?: string }>('POST', '/api/sessions/stop-all'),
   /** Host resource snapshot for Settings → System (RAM / CPU / uptime). */
   system: () => call<SystemMetrics>('GET', '/api/system'),
+  /** Native-dependency check for Settings → System (tmux/ttyd/claude/git present?). */
+  deps: () => call<DepsReport>('GET', '/api/deps'),
+  /** Install the missing package-manager-installable deps (owner-only). Returns step logs + fresh report. */
+  installDeps: () => call<DepsInstallResult>('POST', '/api/deps/install'),
   rateSession: (id: string, rating: 'up' | 'down' | null) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/rate`, { rating }),
   /** Give a session a human-chosen display title (overrides the auto/AI-generated one). */
   renameSession: (id: string, title: string) => call<{ ok: boolean; error?: string; title?: string }>('POST', `/api/sessions/${id}/rename`, { title }),


### PR DESCRIPTION
## What

Adds a **native-dependency check + one-shot install** for the native commands Agent OS shells out to on the box — the classic "why won't a session start?" gap on a fresh machine:

| dep | why | install |
|-----|-----|---------|
| `tmux` | backs every agent session (persistent panes) | pkg |
| `ttyd` | serves the in-browser terminal | pkg |
| `claude` | the agent runtime each session launches | `npm i -g @anthropic-ai/claude-code` |
| `git` | powers self-update | pkg (optional) |

## Surfaces

- **Settings → System → Native dependencies** — new panel (`GET /api/deps`) showing each tool's present/missing state, version, and purpose. When missing: the exact install command (copyable) + the `npm run install-deps` shortcut, and — for the owner — an **Install now** button (`POST /api/deps/install`, owner-gated, audited `system.deps.installed`) that runs the box's package manager (brew / apt / dnf / yum / pacman / zypper) and re-checks, streaming each step's log.
- **`npm run install-deps`** (+ `npm run check-deps`) — the shortcut. A zero-dependency bootstrap shell script (`scripts/install-deps.sh`) that works on a fresh checkout **before** `npm run build`, portable to bash 3.2 + BSD userland (per CLAUDE.md).
- **`agent-os deps` / `agent-os install-deps`** — the same check/install from the built CLI.

Deps installed another way (`claude`, via npm) are never auto-installed — their manual hint is shown instead. New module `src/edge/deps.ts` (`checkDeps`/`installDeps`), modeled on the self-update path (`src/edge/updater.ts`).

## Verification

- `npm run typecheck` ✓, `cd web && npm run build` ✓, `npm run test:governance` → 68/68 ✓
- In-process authed smoke test: unauth `GET /api/deps` → 401; authed → 200 with correct report (`manager=brew`, all deps ✓); `POST /api/deps/install` → 200 no-op ok.
- Missing-dep path (stripped PATH): `installable=[tmux,ttyd]`, `installCommand="brew install tmux ttyd"`, `claude` correctly excluded from installable (no pkg) and shows its npm hint. Shell script `--check` matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fS9mHadnGxa2VKhEKn7a7