### PR TITLE
feat(sessions): agents link every PR back to their session by default (v0.212.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.212.0] — 2026-07-16
+### Added
+- **Agents link every PR back to their session by default.** A new `AOS_SESSION_URL` env var carries a
+  human-facing console deep-link to the run (`<publicOrigin>/#/sessions/aos-<id>`), injected into every
+  session's shell and persisted in the resurrect env. The OS operating notes now instruct agents to drop
+  that link into any pull request (or similar external deliverable) they raise, so a reviewer can trace
+  the change back to the audited run that produced it (`src/terminal.ts`).
+
 ## [0.211.0] — 2026-07-16
 ### Added
 - **Open a deliverable full-screen in a new tab.** The Library detail panel gains an **Open** button

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.211.0",
+  "version": "0.212.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.211.0",
+      "version": "0.212.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.211.0",
+  "version": "0.212.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -88,6 +88,13 @@ Your terminal output may not be read. The operator lives in the Inbox:
 - \`publish\` real deliverables (a document, PDF, image, chart) to the Library — not scratch
   files.
 
+## Opening a pull request — always link back to this session
+When you raise a pull request (or any similar external deliverable that carries a description), add a
+link back to this Agent OS session so a reviewer can trace the change to the audited run that produced
+it. The link is in the \`AOS_SESSION_URL\` environment variable — read it with \`echo "$AOS_SESSION_URL"\`
+(or \`printenv AOS_SESSION_URL\`) and drop it into the PR body, e.g. a line like
+\`Agent OS session: <AOS_SESSION_URL>\`. Print it as a plain URL (links aren't clickable here).
+
 ## You are one agent in a fleet — don't work alone
 Other agents run in this workspace and you share state with them. You are a node, not a silo:
 - **Tasks** (\`task_*\`) are the shared work queue and the hand-off path. If work belongs to a specialist
@@ -1555,6 +1562,10 @@ export class TerminalManager {
       // AOS_URL above is the loopback base the tools call the API on — never show it to a human. Falls
       // back to the loopback base when no public origin is configured (dev/demo), so a link still forms.
       AOS_PUBLIC_URL: this.publicOrigin || this.baseUrl,
+      // A human-facing deep-link back to THIS session's console page (the tmux is `aos-<id>`, which is the
+      // sessions route's detail segment). Handed to agents so a PR/report/artifact can point a reviewer at
+      // the run that produced it — the traceability spine from an external artifact back into the audited OS.
+      AOS_SESSION_URL: `${this.publicOrigin || this.baseUrl}/#/sessions/aos-${id}`,
       AOS_TENANT: this.os.tenant, // routes loopback agent calls to THIS tenant's runtime (multi-tenant)
       SESSION: id,
       AGENT: agent,


### PR DESCRIPTION
## What

Makes agents include a link back to their Agent OS session in every pull request they raise, by default.

- **New `AOS_SESSION_URL` env var** — a human-facing console deep-link to the run (`<publicOrigin>/#/sessions/aos-<id>`, since the tmux name is `aos-<id>` and that's the sessions route's detail segment). Injected into every session's shell env via `sessionEnv()` and persisted in the resurrect env (`writeEnvFile`), so resumed interactive runs keep it too.
- **Default operating-notes instruction** — `AGENT_OS_OPERATING_NOTES` now tells agents that when they open a PR (or similar external deliverable that carries a description), they should read `$AOS_SESSION_URL` and drop it into the body (e.g. `Agent OS session: <url>`), printed as a plain URL since links aren't clickable in the terminal.

## Why

A PR opened by an agent had no trail back into the audited run that produced it. This closes the traceability loop: a reviewer on GitHub can click straight through to the session — its transcript, approvals, and audit — that generated the change.

## Testing

- `npm run typecheck` / `npm run build` — clean
- `npm run test:governance` — 68/68 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)