### PR TITLE
fix(web): widen Quick Shortcuts session-summary modal (v0.211.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.212.0",
+  "version": "0.211.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.212.0",
+      "version": "0.211.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.212.0",
+  "version": "0.211.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1844,7 +1844,7 @@ function SessionSummaryModal({ sessionId, open, onClose }: { sessionId: string; 
   useEffect(() => { if (open) void load() }, [open, sessionId]) // eslint-disable-line react-hooks/exhaustive-deps
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) onClose() }}>
-      <DialogContent className="max-w-lg">
+      <DialogContent className="max-w-2xl">
         <DialogHeader><DialogTitle className="flex items-center gap-2"><Sparkles className="h-4 w-4" /> Session summary</DialogTitle></DialogHeader>
         {loading ? (
           <div className="flex items-center gap-2 py-8 text-sm text-muted-foreground"><RefreshCw className="h-4 w-4 animate-spin" /> Reading the transcript and summarizing…</div>


### PR DESCRIPTION
Widens the **Session summary** modal (Quick Shortcuts → Summarize) from `max-w-lg` (512px) to `max-w-2xl` (672px) so the summary prose has a comfortable line length. CSS-class change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)