### PR TITLE
feat(library): edit text/markdown deliverables in place (v0.214.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.214.0] — 2026-07-16
+### Added
+- **Edit a text/Markdown deliverable in place in the Library.** A published artifact used to be a
+  read-only snapshot; now owner/admin — or the member whose session produced it — can fix a typo or
+  update a Markdown report without republishing. An **Edit** (pencil) button in the detail panel opens
+  an inline editor (Save/Cancel); it overwrites the snapshot's file in place, so its id-dir/filename are
+  unchanged and every existing link (Library deep-link, public `/shared/<token>`) keeps resolving. New
+  `ArtifactStore.writeContent` (text-only guard — binaries are refused so a write can't corrupt them),
+  `PUT /api/artifacts/:id/content` (same gate as move/delete/share), audited `artifact.edited`.
+
 ## [0.213.0] — 2026-07-16
 ### Changed
 - **"Open" on a Library deliverable renders markdown instead of showing raw source.** The Open button

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.213.0",
+  "version": "0.214.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.213.0",
+      "version": "0.214.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.213.0",
+  "version": "0.214.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4481,6 +4481,21 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.audit.append({ ts: Date.now(), runId: a.sessionId, tenant: os.tenant, principal: me.email, type: 'artifact.shared', data: { id: a.id, team: updated.sharedTeam, public: !!updated.shareToken } });
     return sendJson(res, 200, { ok: true, artifact: { ...updated, public: !!updated.shareToken, shareUrl: updated.shareToken ? sharedLinkFor(req, updated.shareToken) : undefined } });
   }
+  // Edit a TEXT/markdown deliverable's content in place — human curation of a published artifact. Same
+  // gate as move/delete/share (owner/admin, or the producing member). The store refuses non-text mimes.
+  // Auto-apply + audited (`artifact.edited`); the snapshot id-dir/filename are unchanged so links persist.
+  const artContentMatch = p.match(/^\/api\/artifacts\/([\w-]+)\/content$/);
+  if (method === 'PUT' && artContentMatch) {
+    const a = os.artifacts.get(artContentMatch[1]);
+    if (!a) return sendJson(res, 404, { error: 'not found' });
+    if (!isAdmin(me) && a.source !== me.id) return sendJson(res, 403, { error: 'forbidden' });
+    const b = await readBody(req);
+    if (typeof b.content !== 'string') return sendJson(res, 400, { error: 'content (string) required' });
+    const r = os.artifacts.writeContent(a.id, b.content);
+    if (!r.ok) return sendJson(res, 400, { error: r.error });
+    os.audit.append({ ts: Date.now(), runId: a.sessionId, tenant: os.tenant, principal: me.email, type: 'artifact.edited', data: { id: a.id, filename: a.filename, bytes: r.artifact.bytes, was: a.bytes } });
+    return sendJson(res, 200, { ok: true, artifact: r.artifact });
+  }
 
   // ── policy (the risk ruleset). Read: owner/admin. Edit: OWNER only — it governs what needs
   //    approval, so an admin must not be able to downgrade a red rule to bypass owner sign-off. ──

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -234,6 +234,25 @@ export class ArtifactStore {
     return { absPath: abs, mime: mimeOf(abs), filename: path.basename(abs) };
   }
 
+  /**
+   * Overwrite a TEXT artifact's entry file in place with new content — human curation of a published
+   * deliverable (e.g. fixing a typo in a Markdown report). Refuses binaries (a write would corrupt them)
+   * and a missing data home. The snapshot's id-dir + filename are unchanged, so every existing link
+   * (Library, public `/shared/<token>`) keeps resolving; only the stored byte size is updated.
+   */
+  writeContent(id: string, content: string): PublishResult {
+    if (!this.dir) return { ok: false, error: 'no data home configured (artifacts disabled)' };
+    const a = this.get(id);
+    if (!a) return { ok: false, error: 'not found' };
+    if (!isTextEditable(a.mime)) return { ok: false, error: 'only text and markdown artifacts are editable' };
+    const abs = containedPath(path.join(this.dir, id), a.filename);
+    if (!abs) return { ok: false, error: 'file not found' };
+    const buf = Buffer.from(content, 'utf8');
+    fs.writeFileSync(abs, buf);
+    this.db.prepare('UPDATE artifacts SET bytes = ? WHERE id = ?').run(buf.length, id);
+    return { ok: true, artifact: { ...a, bytes: buf.length } };
+  }
+
   /** Share (or unshare) an artifact with the whole tenant — every member then sees it in the Library. */
   setTeamShared(id: string, shared: boolean): boolean {
     const info = this.db.prepare('UPDATE artifacts SET shared_team = ? WHERE id = ?').run(shared ? 1 : 0, id);
@@ -356,6 +375,12 @@ export function containedPath(root: string, rel: string): string | null {
     return null;
   }
   return within(real) ? real : null;
+}
+
+/** Whether an artifact's content may be edited in place — text-like mimes only, never a binary (an
+ *  overwrite would corrupt it). HTML counts (it's text); images/PDF/video do not. */
+export function isTextEditable(mime: string): boolean {
+  return mime.startsWith('text/') || mime === 'application/json';
 }
 
 /** Content-type by extension — self-contained so the store has no server dependency. Covers the

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4699,6 +4699,28 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
     load()
   }
 
+  // In-place editing of a text/markdown deliverable. `editing` holds the id being edited; the draft is
+  // seeded from the artifact's current bytes. Switching the selected artifact cancels any open edit.
+  const [editing, setEditing] = useState<string | null>(null)
+  const [draft, setDraft] = useState('')
+  const [saving, setSaving] = useState(false)
+  useEffect(() => { setEditing(null) }, [sel])
+  const startEdit = async (a: Artifact) => {
+    setHint('')
+    try {
+      const t = await fetch(api.artifactRawUrl(a.id)).then((r) => r.text())
+      setDraft(t); setEditing(a.id)
+    } catch { setHint('⚠ could not load file for editing') }
+  }
+  const saveEdit = async () => {
+    if (!editing) return
+    setSaving(true)
+    const r = await api.editArtifact(editing, draft)
+    setSaving(false)
+    if (r.error || !r.ok) { setHint('⚠ ' + (r.error ?? 'save failed')); return }
+    setEditing(null); load()
+  }
+
   return (
     <div className="space-y-3">
       <p className="max-w-3xl text-sm text-muted-foreground">
@@ -4777,6 +4799,9 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
                     <a href={api.artifactRawUrl(selected.id)} download={selected.filename}><Button size="sm" variant="secondary"><Download className="mr-1 h-4 w-4" />Download</Button></a>
                     {(me.role === 'owner' || me.role === 'admin' || selected.source === me.id) && (
                       <>
+                        {(isMarkdownArt(selected) || (isTextMime(selected.mime) && !isHtmlArt(selected))) && editing !== selected.id && (
+                          <Button size="sm" variant="ghost" onClick={() => startEdit(selected)} title="Edit content"><Pencil className="h-4 w-4" /></Button>
+                        )}
                         <Button size="sm" variant="ghost" onClick={() => move(selected)} title="Move to a folder"><FolderPlus className="h-4 w-4" /></Button>
                         <Button size="sm" variant="ghost" className="text-destructive" onClick={() => remove(selected.id)}><Trash2 className="h-4 w-4" /></Button>
                       </>
@@ -4799,7 +4824,18 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
                     )}
                   </div>
                 )}
-                <ArtifactBody a={selected} />
+                {editing === selected.id ? (
+                  <div className="space-y-2">
+                    <Textarea value={draft} onChange={(e) => setDraft(e.target.value)} spellCheck={false} className="h-[60vh] w-full font-mono text-xs leading-relaxed" />
+                    <div className="flex items-center gap-2">
+                      <Button size="sm" disabled={saving} onClick={saveEdit}><Save className="mr-1 h-4 w-4" />{saving ? 'Saving…' : 'Save'}</Button>
+                      <Button size="sm" variant="ghost" onClick={() => setEditing(null)}>Cancel</Button>
+                      <span className="text-[11px] text-muted-foreground">Editing <span className="font-mono">{selected.filename}</span> — overwrites the published file (existing links keep working).</span>
+                    </div>
+                  </div>
+                ) : (
+                  <ArtifactBody a={selected} />
+                )}
               </CardContent>
             </Card>
           ) : (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1415,6 +1415,8 @@ export const api = {
   moveArtifact: (id: string, folder: string) => call<{ ok: boolean; artifact?: Artifact; error?: string }>('PATCH', '/api/artifacts/' + id, { folder }),
   /** Share an artifact with the tenant (`team`) and/or mint/revoke its public link (`public`). */
   shareArtifact: (id: string, body: { team?: boolean; public?: boolean }) => call<{ ok: boolean; artifact?: Artifact; error?: string }>('POST', `/api/artifacts/${id}/share`, body),
+  /** Overwrite a text/markdown artifact's content in place (owner/admin or producer). */
+  editArtifact: (id: string, content: string) => call<{ ok: boolean; artifact?: Artifact; error?: string }>('PUT', `/api/artifacts/${id}/content`, { content }),
   /** Direct URL to an artifact's bytes (for <img>/<iframe>/download). `file` selects a sibling (sites). */
   artifactRawUrl: (id: string, file?: string) => `/api/artifacts/${id}/raw${file ? `?file=${encodeURIComponent(file)}` : ''}`,
 


### PR DESCRIPTION
## What

Make published **text/Markdown deliverables editable** in the Library. Previously an artifact was a read-only snapshot; now owner/admin — or the member whose session produced it — can fix a typo or update a Markdown report without republishing.

## How

- **Edit** (pencil) button in the Library detail panel opens an inline editor (Save/Cancel), seeded with the artifact's current content.
- Backend `ArtifactStore.writeContent` overwrites the snapshot's entry file **in place** — id-dir and filename are unchanged, so every existing link (Library deep-link, public `/shared/<token>`) keeps resolving; only the stored byte size updates. **Text-only guard**: binaries (image/PDF/video) are refused so a write can't corrupt them.
- `PUT /api/artifacts/:id/content` — same gate as move/delete/share (owner/admin or producer), audited `artifact.edited`.

## Verification

Store + HTTP + real-browser (Playwright): `writeContent` overwrites markdown and refuses a PNG and a missing id; `PUT` is 401 without login; and in-browser the pencil opens an editor seeded with current content, **Save** persists to disk and re-renders the preview, editor closes. `typecheck` + `web build` + `test:governance` (68/68) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMSbnPEbqSVPGLasTKENp