### PR TITLE
fix(web): closing a tab no longer opens a teammate's session (v0.213.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.214.1] — 2026-07-16
+### Fixed
+- **Closing a session tab no longer jumps to a teammate's session.** When you closed the open tab (or
+  stopped the session you were viewing), the fallback that picks the "next" tab scanned the *entire*
+  fleet list — which, for an owner/admin, includes every member's sessions — so it could open an
+  unowned session that flickers until you click one of your own tabs. Both fallbacks (`closeTab` and
+  `stopSession` in `web/src/App.tsx`) now scope the pick to sessions that are mine (spawned by or run
+  as me), mirroring the "mine"-scoped sidebar/strip.
+
 ## [0.214.0] — 2026-07-16
 ### Added
 - **Edit a text/Markdown deliverable in place in the Library.** A published artifact used to be a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.214.0",
+  "version": "0.214.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.214.0",
+      "version": "0.214.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.214.0",
+  "version": "0.214.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -927,6 +927,8 @@ function Console({ me }: { me: Member }) {
     setMessages((ms) => ms.filter((m) => !toClear.some((c) => c.id === m.id)))
     toClear.forEach((m) => { void api.dismissMessage(m.id) })
   }
+  // A session belongs to me if I spawned it or it runs as me — the same rule that scopes the sidebar/strip.
+  const isMine = (s: Session) => s.spawnedBy === me.id || s.runAs === me.id
   const openTerminal = (tmux: string, _title?: string) => {
     // The tmux lands in the URL (`#/sessions/<tmux>`); `selected` is derived from it above.
     nav('sessions', tmux)
@@ -940,7 +942,9 @@ function Console({ me }: { me: Member }) {
   const closeTab = (tmux: string) => {
     const n = new Set(hiddenTabs); n.add(tmux); persistHiddenTabs(n)
     if (selected?.tmux === tmux) {
-      const next = sessions.find((s) => isLive(s) && s.tmux !== tmux && !n.has(s.tmux))
+      // Only fall back to a tab that is actually MINE — the switcher strip is "mine"-scoped, so for an
+      // owner/admin `sessions` is the whole fleet and an unscoped pick would jump to a teammate's session.
+      const next = sessions.find((s) => isLive(s) && isMine(s) && s.tmux !== tmux && !n.has(s.tmux))
       if (next) nav('sessions', next.tmux)
       else nav('sessions')
     }
@@ -955,7 +959,8 @@ function Console({ me }: { me: Member }) {
     // If you stopped the session you're currently viewing, don't sit on a dead terminal:
     // hop to the next open session, or fall back to the all-sessions list when none remain.
     if (stopped && selected?.tmux === stopped.tmux) {
-      const next = fresh.find((s) => isLive(s) && s.tmux !== stopped.tmux && !hiddenTabs.has(s.tmux))
+      // Same scoping as closeTab: never hop to a teammate's session (the fleet-wide list an owner sees).
+      const next = fresh.find((s) => isLive(s) && isMine(s) && s.tmux !== stopped.tmux && !hiddenTabs.has(s.tmux))
       if (next) nav('sessions', next.tmux)
       else nav('sessions')
     }


### PR DESCRIPTION
## The bug
Closing a session tab — especially right after **stopping** the session you're viewing — would open a *different* session belonging to some other team member. It flickered in the viewport and cleared as soon as you clicked one of your own tabs.

## Cause
Both fallbacks that pick the "next" tab (`closeTab` and `stopSession` in `web/src/App.tsx`) scanned the **entire** `sessions` list for the next live, non-hidden tab. For an owner/admin, `/api/sessions` returns the whole fleet, so the pick could land on a teammate's session — one that isn't even in your "mine"-scoped sidebar/strip, hence the flicker-then-vanish.

## Fix
Add an `isMine(s)` helper (`spawnedBy === me.id || runAs === me.id`) — the same rule that already scopes the sidebar (`mySessions`) and the terminal strip — and apply it to both fallbacks. Now closing/stopping only ever hops to another of *your* sessions, else drops to the All-sessions list.

Frontend-only; the Node server serves `web/dist` off disk so no restart is needed on deploy.

## Verification
- `cd web && npm run build` ✓
- `npm run typecheck` ✓
- `npm run test:governance` → 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fS9mHadnGxa2VKhEKn7a7