### PR TITLE
feat(ids): Stripe-style prefixed entity ids across the board (v0.216.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.216.0] — 2026-07-16
+### Changed
+- **Stripe-style prefixed entity ids across the board.** Every referenceable persisted entity now mints a
+  namespaced, self-describing id via a single source of truth — the new `src/id.ts` (`newId('session')` →
+  `ses_a1b2c3…`, 64 bits of entropy vs the old 8-char `randomUUID().slice(0,8)`). Prefixes: `ses_`
+  (sessions), `tsk_`/`tev_`/`tatt_` (tasks/events/attachments), `goal_`/`gev_` (goals/events), `msg_`
+  (inbox), `qst_` (ask-human questions), `ask_` (agent-asks), `apr_` (approvals), `art_` (artifacts),
+  `vid_` (video jobs), `mem_` (memories), `kbp_`/`kbr_` (KB pages/revisions), `arev_`/`prev_`
+  (agent/policy revisions); `m_` (members) and `au_` (automations) keep their existing prefixes, now
+  routed through the same helper. Rollout is **forward-only** — pre-existing bare-hex ids stay valid and
+  keep working; nothing parses an id prefix (the new `parseId`/`isId` helpers are introspection-only, not
+  a gate). Deliberately left unprefixed: bearer secrets (auth-session sid, invite/webhook/session
+  secrets, artifact share token), the `claudeSessionId` UUID (`claude --session-id` format), numeric
+  `audit_events.id`, and human slugs (`connectors.id`, `tenants.slug`). The core governance `Run`
+  (`src/core/run.ts`) keeps its raw UUID to preserve the "core imports only from `types.ts`" invariant.
+
 ## [0.215.0] — 2026-07-16
 ### Changed
 - **Re-publishing a deliverable now updates it in place instead of creating a duplicate.** `publish` is

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.215.0",
+      "version": "0.216.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.215.0",
+  "version": "0.216.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -8,7 +8,8 @@
  * (`TriggerRef` in types.ts); the **Orchestrator** (core/orchestrator.ts) remains the internal run
  * engine. Zero-dependency cron: a minimal 5-field parser below (minute hour dom month dow).
  */
-import { randomBytes, randomUUID } from 'crypto';
+import { randomBytes } from 'crypto';
+import { newId } from '../id';
 import * as os from 'os';
 import * as path from 'path';
 import { Strategist } from './strategist';
@@ -342,7 +343,7 @@ export class Automations {
       throw new Error('type must be cron, webhook, composio, slack, or discord');
     }
     const a: Automation = {
-      id: 'au_' + randomUUID().slice(0, 8),
+      id: newId('automation'),
       agentId: input.agentId,
       name: input.name.trim(),
       type: input.type,
@@ -386,7 +387,7 @@ export class Automations {
       throw new Error(`too many pending scheduled tasks (max ${SCHEDULE_MAX_PENDING}) — cancel one first`);
     }
     const a: Automation = {
-      id: 'au_' + randomUUID().slice(0, 8),
+      id: newId('automation'),
       agentId: input.agentId,
       name: input.name.trim() || 'Scheduled task',
       type: 'once',

--- a/src/governance/approvals.ts
+++ b/src/governance/approvals.ts
@@ -6,7 +6,7 @@
  * in-memory with an optional auto-resolver so the demo can simulate a human.
  */
 import { ApprovalRequest, Approvals } from '../types';
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import { Db } from '../state/db';
 
 export class InMemoryApprovals implements Approvals {
@@ -23,7 +23,7 @@ export class InMemoryApprovals implements Approvals {
     req: ApprovalRequest;
     decision: Promise<boolean>;
   } {
-    const req: ApprovalRequest = { ...input, id: randomUUID(), status: 'pending', createdAt: Date.now() };
+    const req: ApprovalRequest = { ...input, id: newId('approval'), status: 'pending', createdAt: Date.now() };
     this.items.set(req.id, req);
 
     let resolveFn!: (approved: boolean) => void;
@@ -116,7 +116,7 @@ export class SqliteApprovals implements Approvals {
     req: ApprovalRequest;
     decision: Promise<boolean>;
   } {
-    const req: ApprovalRequest = { ...input, id: randomUUID(), status: 'pending', createdAt: Date.now() };
+    const req: ApprovalRequest = { ...input, id: newId('approval'), status: 'pending', createdAt: Date.now() };
     this.db
       .prepare('INSERT INTO approvals (id, run_id, tenant, level, capability, args, reasoning, reason, status, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
       .run(req.id, req.runId, req.tenant, req.level, req.attempt.capabilityId, JSON.stringify(req.attempt.args), req.attempt.reasoning ?? null, req.reason, 'pending', req.createdAt);

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -8,6 +8,7 @@
  * SQLite DB (see state/db.ts) so it survives restarts and stays isolated per data home.
  */
 import { randomBytes } from 'crypto';
+import { newId } from '../id';
 import { Db } from '../state/db';
 import { AgentAccess, Member, MemberIdentity, IdentityProvider, Role, ApprovalLevel, canApprove, NotificationPrefs, sanitizeNotificationPrefs, sanitizeNavPins, PromptShortcut, sanitizePromptShortcuts } from '../types';
 
@@ -391,7 +392,7 @@ export class TeamStore {
 
   // ── internals ────────────────────────────────────────────────────────────────
   private insertMember(email: string, name: string, role: Role, status: 'invited' | 'active'): Member {
-    const member: Member = { id: 'm_' + token().slice(0, 16), email: email.toLowerCase(), name, role, status, createdAt: Date.now() };
+    const member: Member = { id: newId('member'), email: email.toLowerCase(), name, role, status, createdAt: Date.now() };
     this.db
       .prepare('INSERT INTO members (id, email, name, role, status, created_at) VALUES (?, ?, ?, ?, ?, ?)')
       .run(member.id, member.email, member.name, member.role, member.status, member.createdAt);

--- a/src/id.ts
+++ b/src/id.ts
@@ -1,0 +1,85 @@
+// Stripe-style prefixed entity ids — one source of truth for the whole codebase.
+//
+// Every referenceable persisted entity gets an opaque, namespaced id of the form
+// `<prefix>_<hex>` (e.g. `ses_a1b2c3d4e5f60718`). The prefix makes an id
+// self-describing in logs, URLs, audit trails and API responses — you can tell a
+// session id from a task id at a glance, exactly like Stripe's `cus_`/`sub_`/`txn_`.
+//
+// Rollout is FORWARD-ONLY: new rows get prefixed ids; pre-existing bare-hex ids stay
+// valid. Nothing in the codebase parses or validates an id prefix, so old and new ids
+// coexist safely (see `parseId`/`isId` below — provided for optional, non-load-bearing
+// introspection, never as a gate).
+//
+// NOT every id lives here. Deliberately excluded because they are bearer secrets or
+// carry an externally-imposed format, not referenceable entity ids:
+//   - auth-session cookie sid, invite token, session/webhook secrets, artifact share
+//     token  → high-entropy secrets, must stay unguessable and unprefixed.
+//   - claudeSessionId                                → a raw UUID handed to `claude --session-id`.
+//   - audit_events.id                                → numeric AUTOINCREMENT.
+//   - connectors.id, tenants.slug, settings.key      → human-readable slugs / caller keys.
+
+import { randomBytes } from 'crypto';
+
+/**
+ * The prefix registry. Keys are logical entity names used at call sites; values are the
+ * wire prefix (without the trailing underscore). Keep this the ONLY place a prefix is
+ * spelled out — adding an entity means adding one line here.
+ */
+export const ID_PREFIX = {
+  member: 'm', // pre-existing prefix; kept as-is so historical `m_…` ids stay uniform
+  session: 'ses', // agent/terminal sessions (term_sessions)
+  message: 'msg', // inbox messages
+  question: 'qst', // ask-a-human questions
+  agentAsk: 'ask', // agent-to-agent asks
+  approval: 'apr', // governance approvals
+  automation: 'au', // pre-existing prefix; automations/triggers
+  artifact: 'art', // published artifacts
+  videoJob: 'vid', // video render jobs
+  memory: 'mem', // agent memories
+  kbPage: 'kbp', // knowledge-base pages
+  kbRevision: 'kbr', // knowledge-base revisions
+  task: 'tsk', // work-queue tasks
+  taskEvent: 'tev', // task event-log entries
+  taskAttachment: 'tatt', // task file attachments
+  goal: 'goal', // goals
+  goalEvent: 'gev', // goal event-log entries
+  agentRevision: 'arev', // agent self-edit revisions
+  policyRevision: 'prev', // policy revisions
+} as const;
+
+export type IdEntity = keyof typeof ID_PREFIX;
+
+/** 8 random bytes → 16 hex chars (64 bits). Comfortably collision-free per tenant. */
+const ENTROPY_BYTES = 8;
+
+/**
+ * Mint a fresh, namespaced id for `entity`, e.g. `newId('session')` → `ses_1f3a…`.
+ * This is the ONLY sanctioned way to generate an entity id.
+ */
+export function newId(entity: IdEntity): string {
+  return `${ID_PREFIX[entity]}_${randomBytes(ENTROPY_BYTES).toString('hex')}`;
+}
+
+/** Reverse-lookup: prefix string → logical entity name (or undefined). */
+const ENTITY_BY_PREFIX: Record<string, IdEntity> = Object.fromEntries(
+  (Object.entries(ID_PREFIX) as [IdEntity, string][]).map(([entity, prefix]) => [prefix, entity]),
+);
+
+/**
+ * Best-effort introspection — split a `<prefix>_<rest>` id. Returns null for bare/legacy
+ * ids (no known prefix). NON-LOAD-BEARING: never use this to authorize or route; ids are
+ * opaque and forward-only means many valid ids have no prefix.
+ */
+export function parseId(id: string): { entity: IdEntity; prefix: string; rest: string } | null {
+  const underscore = id.indexOf('_');
+  if (underscore <= 0) return null;
+  const prefix = id.slice(0, underscore);
+  const entity = ENTITY_BY_PREFIX[prefix];
+  if (!entity) return null;
+  return { entity, prefix, rest: id.slice(underscore + 1) };
+}
+
+/** True if `id` carries the prefix registered for `entity`. Introspection only — not a gate. */
+export function isId(id: string, entity: IdEntity): boolean {
+  return id.startsWith(`${ID_PREFIX[entity]}_`);
+}

--- a/src/memory/libsql-provider.ts
+++ b/src/memory/libsql-provider.ts
@@ -20,7 +20,7 @@
  * the core stays zero-dependency. If the backend is chosen without it installed, init throws with
  * an install hint.
  */
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import {
   DeleteInput, LibsqlMemoryConfig, MemoryMaintenance, MemoryMaintenanceResult, MemoryProvider,
   MemoryRanking, MemoryRecord, RecallQuery, StoreInput, UpdateInput,
@@ -111,7 +111,7 @@ export class LibsqlMemoryProvider implements MemoryProvider {
   async store(input: StoreInput): Promise<MemoryRecord> {
     await this.init();
     const rec: MemoryRecord = {
-      id: randomUUID(),
+      id: newId('memory'),
       tenant: input.tenant,
       agentId: input.agentId,
       content: input.content,

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -13,7 +13,7 @@
  *
  * Isolation: every query is scoped by (tenant, agent_id), so an agent only ever sees its own.
  */
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import { Db } from '../state/db';
 import {
   DeleteInput, MemoryMaintenance, MemoryMaintenanceResult, MemoryProvider, MemoryRanking,
@@ -51,7 +51,7 @@ export class SqliteMemoryProvider implements MemoryProvider {
 
   async store(input: StoreInput): Promise<MemoryRecord> {
     const rec: MemoryRecord = {
-      id: randomUUID(),
+      id: newId('memory'),
       tenant: input.tenant,
       agentId: input.agentId,
       content: input.content,

--- a/src/state/agent-revisions.ts
+++ b/src/state/agent-revisions.ts
@@ -10,7 +10,7 @@
  * This store is DB-only (a snapshot is pure structured state). The manifest itself still lives on disk
  * (`agent.json` + `CLAUDE.md`); the server writes those files and calls `commit` to record the version.
  */
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import { Db } from './db';
 import { Effort, PermissionMode } from '../types';
 
@@ -127,7 +127,7 @@ export class AgentRevisions {
         (id, tenant, agent_id, rev, description, category, icon, model, effort, permission_mode, example_prompts, shell_secrets, claude_md, summary, author, created_at)
         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`)
       .run(
-        randomUUID().slice(0, 8), tenant, agentId, rev,
+        newId('agentRevision'), tenant, agentId, rev,
         s.description, s.category ?? null, s.icon ?? null,
         s.model ?? null, s.effort ?? null, s.permissionMode ?? null,
         JSON.stringify(s.examplePrompts ?? []), JSON.stringify(s.shellSecrets ?? []), s.claudeMd,

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -11,7 +11,8 @@
  * small generated website — `kind:'site'`) is just MORE files in the same dir, served through the
  * same raw route via its `?file=` seam. No migration, no new storage shape.
  */
-import { randomBytes, randomUUID } from 'crypto';
+import { randomBytes } from 'crypto';
+import { newId } from '../id';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Db } from './db';
@@ -128,7 +129,7 @@ export class ArtifactStore {
       return { ok: true, updated: true, artifact: this.get(existing.id)! };
     }
 
-    const id = randomUUID().slice(0, 8);
+    const id = newId('artifact');
     const destDir = path.join(this.dir, id);
     fs.mkdirSync(destDir, { recursive: true });
     fs.copyFileSync(src, path.join(destDir, filename));
@@ -204,7 +205,7 @@ export class ArtifactStore {
   }): PublishResult {
     if (!this.dir) return { ok: false, error: 'no data home configured (artifacts disabled)' };
     const filename = path.basename(input.filename) || 'image.png';
-    const id = randomUUID().slice(0, 8);
+    const id = newId('artifact');
     const destDir = path.join(this.dir, id);
     fs.mkdirSync(destDir, { recursive: true });
     fs.writeFileSync(path.join(destDir, filename), input.bytes);

--- a/src/state/goals.ts
+++ b/src/state/goals.ts
@@ -12,7 +12,7 @@
  * DB-only, like TaskStore: a goal is structured state, not a document to co-author on disk, so there's
  * no `<home>/…` markdown mirror and the constructor is just `(db)`.
  */
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import { Db } from './db';
 import { Goal, GoalCreateInput, GoalEvent, GoalProgress, GoalQuery, GoalStatus, GoalUpdateInput, TaskStatus } from '../types';
 
@@ -53,7 +53,7 @@ export class GoalStore {
   /** Create a goal, log its opening `status` event, and (for a sub-goal) `link` it on the parent. */
   create(input: GoalCreateInput): Goal {
     const now = Date.now();
-    const id = randomUUID().slice(0, 8);
+    const id = newId('goal');
     const labels = input.labels ?? [];
     const status: GoalStatus = input.status && STATUSES.includes(input.status) ? input.status : 'active';
     this.db
@@ -203,7 +203,7 @@ export class GoalStore {
     for (const t of this.db.prepare('SELECT id FROM tasks WHERE goal_id = ?').all<{ id: string }>(id)) {
       this.db
         .prepare('INSERT INTO task_events (id, task_id, kind, body, author, session_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
-        .run(randomUUID().slice(0, 8), t.id, 'link', 'goal deleted — detached', 'system', null, Date.now());
+        .run(newId('goalEvent'), t.id, 'link', 'goal deleted — detached', 'system', null, Date.now());
     }
     this.db.prepare('UPDATE tasks SET goal_id = NULL WHERE goal_id = ?').run(id);
     return true;
@@ -245,7 +245,7 @@ export class GoalStore {
   private addEvent(goalId: string, kind: GoalEvent['kind'], body: string, author: string): void {
     this.db
       .prepare('INSERT INTO goal_events (id, goal_id, kind, body, author, created_at) VALUES (?, ?, ?, ?, ?, ?)')
-      .run(randomUUID().slice(0, 8), goalId, kind, body, author, Date.now());
+      .run(newId('goalEvent'), goalId, kind, body, author, Date.now());
   }
 }
 

--- a/src/state/kb.ts
+++ b/src/state/kb.ts
@@ -11,7 +11,7 @@
  * AND, when a data home exists, a `kb/<section>/<slug>.md` file on disk (human/git-friendly). The two
  * are written together on the single mutating path (`write`), so they never diverge.
  */
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Db } from './db';
@@ -50,7 +50,7 @@ export class KbStore {
     const existing = this.db
       .prepare('SELECT * FROM kb_pages WHERE tenant = ? AND section = ? AND slug = ?')
       .get<PageRow>(input.tenant, section, slug);
-    const id = existing?.id ?? randomUUID().slice(0, 8);
+    const id = existing?.id ?? newId('kbPage');
     const rev = existing ? existing.rev + 1 : 1;
     const title = (input.title ?? existing?.title ?? slug).trim() || slug;
     const tags = input.tags ?? (existing ? (JSON.parse(existing.tags) as string[]) : []);
@@ -69,7 +69,7 @@ export class KbStore {
     // Snapshot this version — the rollback + audit backbone.
     this.db
       .prepare('INSERT INTO kb_revisions (id, page_id, rev, title, tags, body, summary, author, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
-      .run(randomUUID().slice(0, 8), id, rev, title, JSON.stringify(tags), input.body, input.summary ?? null, input.author, now);
+      .run(newId('kbRevision'), id, rev, title, JSON.stringify(tags), input.body, input.summary ?? null, input.author, now);
     // Mirror to disk (best-effort; the column is the source of record for the API + FTS).
     const abs = this.contained(section, slug);
     if (abs) {

--- a/src/state/policy-revisions.ts
+++ b/src/state/policy-revisions.ts
@@ -9,7 +9,7 @@
  *
  * DB-only (a snapshot is pure structured state); the live document itself is the JSON override on disk.
  */
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import { Db } from './db';
 import { PolicyDocument } from '../governance/policy';
 
@@ -72,6 +72,6 @@ export class PolicyRevisions {
   private insert(tenant: string, rev: number, doc: PolicyDocument, summary: string, author: string, ts: number): void {
     this.db
       .prepare('INSERT INTO policy_revisions (id, tenant, rev, document, summary, author, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
-      .run(randomUUID().slice(0, 8), tenant, rev, JSON.stringify(doc), summary || null, author, ts);
+      .run(newId('policyRevision'), tenant, rev, JSON.stringify(doc), summary || null, author, ts);
   }
 }

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -16,7 +16,7 @@
  * there's no `<home>/…` markdown mirror and the constructor is just `(db)`. (Deliberate divergence from
  * the KB pattern — see docs/tasks-plan.md §Decision 2.)
  */
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import * as fs from 'fs';
 import * as path from 'path';
 import { Db } from './db';
@@ -78,7 +78,7 @@ export class TaskStore {
   /** Create a task, log its opening `status` event, and (for a sub-task) `link` it on the parent. */
   create(input: TaskCreateInput): Task {
     const now = Date.now();
-    const id = randomUUID().slice(0, 8);
+    const id = newId('task');
     const labels = input.labels ?? [];
     const priority = clampPriority(input.priority);
     const mode = input.mode === 'interactive' ? 'interactive' : 'headless';
@@ -446,7 +446,7 @@ export class TaskStore {
 
   /** Shared writer: copy bytes to disk, insert the row, log the `attach` event. */
   private writeAttachment(taskId: string, filename: string, bytes: Buffer, uploadedBy: string): AttachResult {
-    const id = randomUUID().slice(0, 8);
+    const id = newId('taskAttachment');
     const rel = path.join(taskId, `${id}-${filename}`);
     const dest = path.join(this.dir!, rel);
     try {
@@ -501,7 +501,7 @@ export class TaskStore {
   private addEvent(taskId: string, kind: TaskEvent['kind'], body: string, author: string, sessionId?: string): void {
     this.db
       .prepare('INSERT INTO task_events (id, task_id, kind, body, author, session_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)')
-      .run(randomUUID().slice(0, 8), taskId, kind, body, author, sessionId ?? null, Date.now());
+      .run(newId('taskEvent'), taskId, kind, body, author, sessionId ?? null, Date.now());
   }
 }
 

--- a/src/state/video-jobs.ts
+++ b/src/state/video-jobs.ts
@@ -10,7 +10,7 @@
  *
  * db-only (no on-disk mirror) — a job is transient control state, like TaskStore.
  */
-import { randomUUID } from 'crypto';
+import { newId } from '../id';
 import { Db } from './db';
 
 export type VideoJobStatus = 'rendering' | 'done' | 'failed' | 'expired';
@@ -69,7 +69,7 @@ export class VideoJobStore {
   }): VideoJob {
     const now = Date.now();
     const row: VideoJobRow = {
-      id: randomUUID().slice(0, 8),
+      id: newId('videoJob'),
       session_id: input.sessionId,
       agent: input.agent,
       source: input.source ?? null,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -10,6 +10,7 @@
 import { randomBytes, randomUUID, timingSafeEqual } from 'crypto';
 import * as fs from 'fs';
 import * as path from 'path';
+import { newId } from './id';
 import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { containedPath, mimeOf } from './state/artifacts';
@@ -1005,7 +1006,7 @@ export class TerminalManager {
    * normal attachable TUI that stays live until closed.
    */
   createSession(agent: string, title: string, task: string, spawnedBy?: string, headless = false, slack?: { channel: string; threadTs: string }, discord?: { channel: string; messageId: string }, runAs?: string, resumeClaudeId?: string, resident = false): Session {
-    const id = randomUUID().slice(0, 8);
+    const id = newId('session');
     const tmux = `aos-${id}`;
     // The claude conversation this run drives. A fresh run mints a new id (pinned via `--session-id`);
     // a thread follow-up passes the PRIOR run's id so the launcher `--resume`s the same transcript and
@@ -1085,7 +1086,7 @@ export class TerminalManager {
     if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be forked' };
     if (!src.claude_session_id) return { ok: false, error: 'this session has no conversation to fork yet' };
 
-    const id = randomUUID().slice(0, 8);
+    const id = newId('session');
     const tmux = `aos-${id}`;
     // The fork's OWN new conversation id (distinct from the parent's) — `--fork-session --session-id`
     // copies the parent history into it, leaving the parent's transcript intact.
@@ -2297,7 +2298,7 @@ export class TerminalManager {
     this.db
       .prepare('INSERT INTO messages (id, type, session_id, agent, title, body, status, approval_id, capability, args, level, source, question_id, outcome, audience_kind, audience_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
       .run(
-        randomUUID().slice(0, 8), m.type, m.sessionId, m.agent, m.title, m.body, m.status,
+        newId('message'), m.type, m.sessionId, m.agent, m.title, m.body, m.status,
         m.approvalId ?? null, m.capability ?? null, m.args !== undefined ? JSON.stringify(m.args) : null,
         m.level ?? null, m.source ?? null, m.questionId ?? null, m.outcome ?? null,
         m.audienceKind ?? null, m.audienceId ?? null, Date.now(),
@@ -2370,7 +2371,7 @@ export class TerminalManager {
       target = this.resolveMember(to);
       if (!target) return { error: `no teammate matches "${to}"` };
     }
-    const id = randomUUID().slice(0, 8);
+    const id = newId('question');
     this.db
       .prepare('INSERT INTO questions (id, run_id, tenant, agent, prompt, status, audience_id, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)')
       .run(id, sessionId, this.os.tenant, agent, prompt, 'pending', target?.id ?? null, Date.now());
@@ -2510,7 +2511,7 @@ export class TerminalManager {
     // Run-as passthrough: the delegate acts AS the caller's accountable human, so budget/approvals/identity
     // ladder to the same person the caller already answers to (mirrors task-owner passthrough).
     const runAs = this.db.prepare('SELECT run_as FROM term_sessions WHERE id = ?').get<{ run_as: string | null }>(callerSession)?.run_as ?? undefined;
-    const id = randomUUID().slice(0, 8);
+    const id = newId('agentAsk');
     this.db
       .prepare('INSERT INTO agent_asks (id, tenant, caller_run_id, caller_agent, target_agent, question, status, run_as, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)')
       .run(id, this.os.tenant, callerSession, callerAgent, target, question, 'pending', runAs ?? null, Date.now());


### PR DESCRIPTION
## What

Introduces a single, Stripe-style ID nomenclature for every persisted entity. Instead of scattered inline `randomUUID().slice(0, 8)` calls (bare 8-char hex, 32 bits, real collision surface), every id is now minted through one source of truth — **`src/id.ts`** — as `<prefix>_<hex>`, self-describing in logs, URLs, audit trails, and API responses.

```
newId('session') → ses_c97cb04a34cd33bf   (64 bits of entropy)
```

### Prefix registry
| Entity | Prefix | | Entity | Prefix |
|---|---|---|---|---|
| agent session | `ses_` | | approval | `apr_` |
| task / event / attachment | `tsk_` / `tev_` / `tatt_` | | automation | `au_` *(existing)* |
| goal / event | `goal_` / `gev_` | | artifact | `art_` |
| member | `m_` *(existing)* | | video job | `vid_` |
| inbox message | `msg_` | | memory | `mem_` |
| question (ask-human) | `qst_` | | KB page / revision | `kbp_` / `kbr_` |
| agent-ask | `ask_` | | agent / policy revision | `arev_` / `prev_` |

### Design decisions
- **Forward-only rollout.** New rows get prefixed ids; pre-existing bare-hex ids stay valid and keep working. This is how Stripe itself rolled out prefixes — zero data migration, no FK rewrites, no broken links. Nothing in the codebase parses or validates an id prefix, so old and new ids coexist safely. The new `parseId`/`isId` helpers are introspection-only, explicitly **not** load-bearing.
- **`m_` and `au_` kept** (already-prefixed entities), now routed through the same helper instead of ad-hoc string concatenation.
- **Deliberately left unprefixed** — bearer secrets (auth-session sid, invite/webhook/session secrets, artifact share token), the `claudeSessionId` (a raw UUID handed to `claude --session-id`), numeric `audit_events.id` (AUTOINCREMENT), and human slugs (`connectors.id`, `tenants.slug`).
- **Core stays pure.** `src/core/run.ts`'s abstract governance `Run` keeps its raw UUID to preserve the "core/kernel import contracts only from `src/types.ts`" invariant.

### Fixed inconsistencies
Two entities that used *full* UUIDs (`approvals`, `memories`) and the inconsistent generation across ~17 sites now all flow through `newId()`.

## Verification
- `npm run typecheck` ✓  ·  `npm run build` ✓
- `npm run test:governance` → **68/68 passed** ✓
- Real store round-trips in an isolated home: `tsk_…`, `goal_…`, `kbp_…`, `kbr_…` persist to SQLite and read back by id ✓
- `newId`/`parseId`/`isId` smoke-tested across all 19 entities; legacy bare ids `parseId → null` (no crash) ✓
- `npm run demo` (gateway + approvals path) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)