### PR TITLE
feat(agents): make the fleet always aware of Goals & Tasks primitives (v0.216.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.217.0] — 2026-07-16
+### Changed
+- **Agents are now always aware of the Goals & Tasks primitives**, not just when active goals happen to
+  be injected. The always-present operating notes gain a proper mental model — **Goal → Task → this
+  session** — with the full verb set: `task_list` to check work isn't already filed before starting (not
+  just for pulling shared work), `task_create` reframed from delegation-only to also parking/​tracking
+  your own multi-step work, `task_update` to close the loop, and a dedicated **Goals** bullet
+  (`goal_list`/`goal_get` to see direction, link work with `task_create({ goalId })`, `goal_propose` a
+  new direction for a human to approve). Previously the only mention of the goal verbs lived inside the
+  dynamic active-goals injection, so an agent with goal-injection off or an empty goal list had no idea
+  goals existed as a primitive. The live active-goals section is slimmed to pure data + a pointer (its
+  mechanics now live in the always-present note), so total prompt size stays roughly flat.
+
 ## [0.216.0] — 2026-07-16
 ### Changed
 - **Stripe-style prefixed entity ids across the board.** Every referenceable persisted entity now mints a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.216.0",
+  "version": "0.217.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.216.0",
+      "version": "0.217.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.216.0",
+  "version": "0.217.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -98,10 +98,18 @@ it. The link is in the \`AOS_SESSION_URL\` environment variable — read it with
 
 ## You are one agent in a fleet — don't work alone
 Other agents run in this workspace and you share state with them. You are a node, not a silo:
-- **Tasks** (\`task_*\`) are the shared work queue and the hand-off path. If work belongs to a specialist
-  agent or is too big for this run, \`task_create\` and assign it — an agent-assigned task spawns that
-  agent as a governed run under the same accountable human. Prefer delegating specialised work over
-  doing it poorly yourself; \`task_list\` / \`task_claim\` to pull shared work.
+- **Tasks** (\`task_*\`) are the shared, durable work queue — the unit of work between "something asked"
+  and "a session ran". Before non-trivial work, \`task_list\` to check it isn't already filed or in
+  flight (don't duplicate), and \`task_claim\` to take one. \`task_create\` to file work: hand it to a
+  specialist (\`assignee: "agent:<id>", autoDispatch: true\` spawns that agent as a governed run under the
+  same accountable human), park work too big for this run, or make your own multi-step work trackable —
+  then \`task_update\` to close the loop (\`done\`, or \`blocked\` with why). Prefer delegating specialised
+  work over doing it poorly yourself; an unassigned task just waits for someone to pick it up.
+- **Goals** (\`goal_*\`) are the strategic layer your work ladders up to — **Goal → Task → this session**.
+  Goals are human-owned *direction*: \`goal_list\` / \`goal_get\` to see what the fleet is working toward,
+  steer your work to advance one, and link tasks to it with \`task_create({ goalId })\` so progress rolls
+  up. You can't activate or edit a goal, but if you spot a direction worth making explicit, \`goal_propose\`
+  a draft for a human to approve.
 - **Knowledge Base** (\`kb_*\`) is the fleet's shared, living wiki. \`kb_search\` before assuming a fact
   isn't already written down; \`kb_write\` durable facts, runbooks, and conventions that help *other*
   agents and humans. (Memory is for facts only *you* reuse; the KB is for the whole fleet.)
@@ -1794,10 +1802,8 @@ export class TerminalManager {
       if (active.length) {
         goalsSection =
           '# Company goals — the direction your work serves\n\n' +
-          'These are the active goals the whole fleet is working toward. Keep them in mind when you pick ' +
-          'up or file work: prefer tasks that advance a goal, and link work to one where it fits ' +
-          '(`goal_list` shows them live). You can `goal_propose` a new goal for a human to approve — you ' +
-          'cannot activate or edit one yourself.\n\n' +
+          'The active goals the whole fleet is working toward right now (see the Goals & Tasks note above ' +
+          'for how to link work and propose new ones). Prefer work that advances one:\n\n' +
           active
             .map((g) => `- ${g.title}${g.target ? ` — target: ${g.target}` : ''}${g.body ? `\n  ${g.body.replace(/\s+/g, ' ').trim().slice(0, 200)}` : ''}`)
             .join('\n');


### PR DESCRIPTION
## What

Agents now carry a compact, **always-present** mental model of the Goals & Tasks primitives in their operating notes — instead of goal-awareness being an accident of the dynamic active-goals injection.

### Before
- The **only** mention of `goal_list` / `goal_get` / `goal_propose` lived inside `goalsSection`, which renders **only** when `injectGoals()` is on *and* there are active goals. An agent with goal-injection off, or an empty goal list, had zero idea Goals existed as a primitive.
- The **Tasks** bullet was framed as delegation-only ("hand off to a specialist / too big for this run"). It never told agents to `task_list` **before starting** (to avoid duplicating work in flight), to track their **own** multi-step work, or to close the loop.

### After (`AGENT_OS_OPERATING_NOTES`, always injected)
- **Tasks** bullet, expanded: search-first (`task_list` to check it isn't already filed/in-flight), `task_claim` to take one, `task_create` for hand-off **or** parking/tracking your own multi-step work, `task_update` to close (`done`/`blocked`).
- **Goals** bullet, new: the **Goal → Task → this session** ladder — `goal_list`/`goal_get` to see direction, link work with `task_create({ goalId })`, `goal_propose` a draft for a human to approve (agents can't activate/edit).
- The dynamic active-goals section is **slimmed to pure data + a pointer** (its mechanics now live in the always-present note), so total prompt size stays roughly flat — honoring the "brief enough not to eat the context window" constraint.

No new tools — the full `task_*` / `goal_*` MCP surface already existed; this closes the *awareness* gap.

## Testing
- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run test:governance` → 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)