### PR TITLE
Record per-session cost; surface on sessions list & automation runs (v0.218.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.218.0] — 2026-07-16
+### Added
+- **Per-session cost tracking, surfaced on the sessions list and automation runs.** Every claude-code
+  session now records what it cost — computed from its transcript's per-request token `usage`
+  (input / output / cache-read / cache-write, each cache tier priced at its own 5-min vs 1-hour rate)
+  × per-model sticker rates (`src/edge/session-cost.ts`). Cost is derived once a run reaches a terminal
+  state, then cached on the `term_sessions` row (new `cost_usd` + token-breakdown columns) — filled
+  lazily on first read in `listSessions` (bounded per call so a long history doesn't stall the first
+  load) and persisted, so neither the sessions list nor automation-run history re-parses the transcript
+  each poll. The console shows a sortable **Cost** column on the sessions list (with a token-breakdown
+  tooltip) and the per-run cost in an automation's run history.
+
 ## [0.217.0] — 2026-07-16
 ### Changed
 - **Agents are now always aware of the Goals & Tasks primitives**, not just when active goals happen to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.217.0",
+  "version": "0.218.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.217.0",
+      "version": "0.218.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.217.0",
+  "version": "0.218.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/conversation.ts
+++ b/src/edge/conversation.ts
@@ -39,7 +39,7 @@ export interface Conversation {
 const claudeConfigDir = (): string => process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 
 /** Locate `<claudeSessionId>.jsonl` under any project dir. Filename is unique, so cwd escaping is irrelevant. */
-function findTranscript(claudeSessionId: string): string | undefined {
+export function findTranscript(claudeSessionId: string): string | undefined {
   const projects = path.join(claudeConfigDir(), 'projects');
   let dirs: string[];
   try {

--- a/src/edge/session-cost.ts
+++ b/src/edge/session-cost.ts
@@ -1,0 +1,102 @@
+// What a claude-code session cost, derived from its transcript.
+//
+// Claude Code writes per-message token `usage` (but no dollar figure) into the session JSONL that
+// `conversation.ts` already locates by the pinned `claude_session_id`. This module reads that same
+// file, sums the usage across every assistant turn, and multiplies by per-model sticker rates to get
+// a USD cost. It is READ-ONLY and best-effort — a missing/unreadable transcript yields `null`, so a
+// caller treats cost as simply "not known yet".
+
+import * as fs from 'fs';
+import { findTranscript } from './conversation';
+
+export interface SessionCost {
+  /** Total USD across every request in the transcript. */
+  costUsd: number;
+  /** Uncached input tokens (billed at the model's input rate). */
+  inputTokens: number;
+  /** Output tokens. */
+  outputTokens: number;
+  /** Cache-read input tokens (billed at ~0.1× input). */
+  cacheReadTokens: number;
+  /** Cache-write input tokens (billed at 1.25× for 5-min, 2× for 1-hour ephemeral writes). */
+  cacheWriteTokens: number;
+}
+
+// Per-model sticker pricing, USD per 1M tokens. Cache rates derive from the input rate — read = 0.1×,
+// 5-minute write = 1.25×, 1-hour write = 2× — per Anthropic's prompt-cache pricing. We deliberately do
+// NOT model Sonnet 5's introductory discount (it's date-bounded); the sticker rate keeps the recorded
+// number stable rather than silently shifting on a calendar boundary. An unknown model falls back to
+// Opus-tier so we never undercount a mystery run.
+interface Rate { input: number; output: number }
+const RATES: Array<[RegExp, Rate]> = [
+  [/opus/, { input: 5, output: 25 }],
+  [/fable|mythos/, { input: 10, output: 50 }],
+  [/sonnet/, { input: 3, output: 15 }],
+  [/haiku/, { input: 1, output: 5 }],
+];
+const FALLBACK: Rate = { input: 5, output: 25 };
+
+function rateFor(model: string): Rate {
+  for (const [re, r] of RATES) if (re.test(model)) return r;
+  return FALLBACK;
+}
+
+/** Sum the transcript's per-request usage into a USD cost + token breakdown. `null` when no transcript
+ *  file exists yet (the run hasn't written one) or it can't be read. */
+export function readSessionCost(claudeSessionId: string): SessionCost | null {
+  const file = findTranscript(claudeSessionId);
+  if (!file) return null;
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, 'utf8');
+  } catch {
+    return null;
+  }
+
+  let costUsd = 0;
+  let inputTokens = 0;
+  let outputTokens = 0;
+  let cacheReadTokens = 0;
+  let cacheWriteTokens = 0;
+
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    let o: any;
+    try {
+      o = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    // Only assistant messages carry request `usage`; each one is a distinct billed request, so summing
+    // across all of them is the whole-session total (cached prefixes re-read each turn are real spend).
+    if (o.type !== 'assistant') continue;
+    const u = o.message?.usage;
+    if (!u) continue;
+
+    const rate = rateFor(String(o.message?.model || ''));
+    const inp = u.input_tokens || 0;
+    const out = u.output_tokens || 0;
+    const cacheRead = u.cache_read_input_tokens || 0;
+    // Cache creation splits into 1-hour (2×) and 5-minute (1.25×) ephemeral write tiers. When the split
+    // isn't present, treat the flat `cache_creation_input_tokens` as a 5-minute write (the default TTL).
+    const cc = u.cache_creation || {};
+    const write1h = cc.ephemeral_1h_input_tokens || 0;
+    const write5mSplit = cc.ephemeral_5m_input_tokens || 0;
+    const split = write1h + write5mSplit;
+    const write5m = split ? write5mSplit : (u.cache_creation_input_tokens || 0);
+
+    inputTokens += inp;
+    outputTokens += out;
+    cacheReadTokens += cacheRead;
+    cacheWriteTokens += write1h + write5m;
+    costUsd +=
+      (inp * rate.input +
+        out * rate.output +
+        cacheRead * rate.input * 0.1 +
+        write5m * rate.input * 1.25 +
+        write1h * rate.input * 2.0) /
+      1_000_000;
+  }
+
+  return { costUsd, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens };
+}

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -763,6 +763,17 @@ function migrate(db: Db): void {
   addColumn(db, 'term_sessions', 'claimed_by', 'TEXT');    // member id who took it over (NULL = unclaimed)
   addColumn(db, 'term_sessions', 'claimed_at', 'INTEGER'); // when (epoch ms)
 
+  // What the run cost, computed from its claude transcript's per-request token `usage` × model rates
+  // (src/edge/session-cost.ts). Filled once the session reaches a terminal state — lazily on first read
+  // in listSessions, then persisted — so both the sessions list and automation-run history can surface
+  // spend without re-parsing the transcript each poll. NULL = not computed yet (still running, or no
+  // transcript). The token columns are the breakdown behind cost_usd.
+  addColumn(db, 'term_sessions', 'cost_usd', 'REAL');            // total USD (NULL = unknown/not yet computed)
+  addColumn(db, 'term_sessions', 'input_tokens', 'INTEGER');     // uncached input tokens
+  addColumn(db, 'term_sessions', 'output_tokens', 'INTEGER');    // output tokens
+  addColumn(db, 'term_sessions', 'cache_read_tokens', 'INTEGER'); // cache-read input tokens
+  addColumn(db, 'term_sessions', 'cache_write_tokens', 'INTEGER'); // cache-write input tokens
+
   // Profile picture: a small square `data:image/…;base64,…` URL. NULL → the UI shows the member's
   // initial. Members set their own from the Team page; owners/admins may set anyone's.
   addColumn(db, 'members', 'avatar', 'TEXT');

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -28,6 +28,7 @@ import { DEFAULT_IMAGE_COST_USD, resolveImageBackend, imageErrorInfo } from './e
 import { VendorError, retryableStatus, timedFetch, withRetry, vendorErrorInfo } from './edge/vendor-fetch';
 import { DEFAULT_VIDEO_COST_PER_SEC_USD, DEFAULT_VIDEO_DURATION_SEC, resolveVideoBackend, videoBackend, VideoBackend } from './edge/video-gen';
 import { understandMedia } from './edge/media-understand';
+import { readSessionCost } from './edge/session-cost';
 
 // Video render tuning: a submitted job renders async. The in-call path polls briefly for the fast case;
 // the tick poller finishes the rest, bounded by a TTL + a poll ceiling so a stuck render can't linger.
@@ -228,6 +229,12 @@ export interface Session {
   ratedBy?: string;
   ratedByLabel?: string;
   ratedAt?: number;
+  /** What the run cost in USD, from its transcript's per-request token usage × model rates. Undefined
+   *  while the run is live or before it's been computed (transcript not yet parsed / not written). */
+  costUsd?: number;
+  /** Token breakdown behind `costUsd` (uncached input / output / cache-read / cache-write). Undefined
+   *  until cost is computed. */
+  tokens?: { input: number; output: number; cacheRead: number; cacheWrite: number };
 }
 
 export interface FeedMessage {
@@ -291,6 +298,11 @@ interface SessionRow {
   rating: string | null;
   rated_by: string | null;
   rated_at: number | null;
+  cost_usd: number | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_tokens: number | null;
+  cache_write_tokens: number | null;
 }
 interface MessageRow {
   id: string;
@@ -491,6 +503,10 @@ export class TerminalManager {
       }
     }
     const visible = viewer ? rows.filter((r) => this.canViewRow(r.spawned_by, r.run_as, viewer)) : rows;
+    // Cost is derived from the transcript once a run is terminal, then cached on the row. Backfill any
+    // still-uncosted terminal rows here (bounded per call so a first load with a large history doesn't
+    // stall parsing hundreds of transcripts — newest first, the rest catch up over subsequent polls).
+    this.backfillCosts(visible);
     const resumable = this.resumableIds();
     // One query resolves the whole list's blocked-on-human state (a pending ask/approval), instead of a
     // per-row check — so the console gets an authoritative `blocked` without re-deriving it from the feed.
@@ -506,6 +522,40 @@ export class TerminalManager {
       runAsLabel: this.runAsLabel(r.run_as),
       ratedByLabel: this.runAsLabel(r.rated_by),
     }));
+  }
+
+  /**
+   * Compute + persist USD cost for terminal rows that don't have it yet. A run's transcript is complete
+   * once it reaches a terminal state (done/stopped/crashed), so we parse it once, store the result on the
+   * row, and never re-read. Bounded per call (`MAX_COST_BACKFILL`) so the first list after a deploy with a
+   * long history amortizes the parsing across polls instead of blocking on all of it at once. Rows are
+   * newest-first (listSessions' ORDER BY), so recent sessions get costed first. Mutates the passed rows so
+   * the same listSessions response already carries the cost it just computed.
+   */
+  private backfillCosts(rows: SessionRow[]): void {
+    let budget = 20; // MAX_COST_BACKFILL — cap transcript parses per list call
+    for (const r of rows) {
+      if (budget <= 0) break;
+      if (r.cost_usd != null) continue;                 // already costed
+      if (r.status === 'running') continue;             // transcript still growing — cost at end
+      if (!r.claude_session_id) continue;               // non-claude run has no transcript to price
+      budget--;
+      let cost;
+      try {
+        cost = readSessionCost(r.claude_session_id);
+      } catch {
+        continue;                                       // transcript unreadable — retry on a later poll
+      }
+      if (!cost) continue;                              // no transcript yet
+      this.db
+        .prepare('UPDATE term_sessions SET cost_usd = ?, input_tokens = ?, output_tokens = ?, cache_read_tokens = ?, cache_write_tokens = ? WHERE id = ?')
+        .run(cost.costUsd, cost.inputTokens, cost.outputTokens, cost.cacheReadTokens, cost.cacheWriteTokens, r.id);
+      r.cost_usd = cost.costUsd;
+      r.input_tokens = cost.inputTokens;
+      r.output_tokens = cost.outputTokens;
+      r.cache_read_tokens = cost.cacheReadTokens;
+      r.cache_write_tokens = cost.cacheWriteTokens;
+    }
   }
 
   /**
@@ -4025,7 +4075,7 @@ function buildAskAgentPrompt(id: string, callerAgent: string, question: string, 
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined, costUsd: r.cost_usd ?? undefined, tokens: r.cost_usd != null ? { input: r.input_tokens ?? 0, output: r.output_tokens ?? 0, cacheRead: r.cache_read_tokens ?? 0, cacheWrite: r.cache_write_tokens ?? 0 } : undefined };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -150,9 +150,9 @@ const originMeta = (kind?: Session['sourceKind']) => ORIGIN_META[kind ?? 'system
 
 /** Sortable columns of the sessions list. `updated` is the default (most recently active first); it's
  *  the omitted value in the URL, so a clean `#/sessions` shows the freshest sessions on top. */
-type SessionSortKey = 'created' | 'title' | 'agent' | 'id' | 'startedBy' | 'status' | 'updated'
+type SessionSortKey = 'created' | 'title' | 'agent' | 'id' | 'startedBy' | 'status' | 'updated' | 'cost'
 type SortDir = 'asc' | 'desc'
-const SESSION_SORT_KEYS: SessionSortKey[] = ['created', 'title', 'agent', 'id', 'startedBy', 'status', 'updated']
+const SESSION_SORT_KEYS: SessionSortKey[] = ['created', 'title', 'agent', 'id', 'startedBy', 'status', 'updated', 'cost']
 const DEFAULT_SORT_KEY: SessionSortKey = 'updated'
 /** Status ordering for the Status-column sort: live → done → stopped → crashed. */
 const statusRank = (s: Session): number =>
@@ -167,7 +167,17 @@ const compareSessions = (a: Session, b: Session, key: SessionSortKey): number =>
     case 'startedBy': return (a.spawnedByLabel ?? '').localeCompare(b.spawnedByLabel ?? '')
     case 'status': return statusRank(a) - statusRank(b)
     case 'updated': return a.updatedAt - b.updatedAt
+    case 'cost': return (a.costUsd ?? -1) - (b.costUsd ?? -1)
   }
+}
+
+/** Format a session's USD cost for the list — a compact `$0.42` / `$12.30`, sub-cent as `<$0.01`, and a
+ *  dim placeholder while it's still live or not yet computed. */
+const formatCost = (usd?: number): string => {
+  if (usd == null) return '—'
+  if (usd === 0) return '$0'
+  if (usd < 0.01) return '<$0.01'
+  return usd < 100 ? `$${usd.toFixed(2)}` : `$${Math.round(usd).toLocaleString()}`
 }
 
 /** The sessions-list view state (filters + sort), held in the URL hash query so it survives a
@@ -2845,6 +2855,7 @@ function SessionsPage({
               {sortHead('startedBy', 'Started by', 'w-40 shrink-0')}
               <span className="w-24 shrink-0">Mode</span>
               {sortHead('updated', 'Updated', 'w-20 shrink-0')}
+              {sortHead('cost', 'Cost', 'hidden w-16 shrink-0 justify-end lg:flex')}
               {sortHead('status', 'Status', 'w-16 shrink-0')}
             </div>
             <span className="w-32 shrink-0" aria-hidden />
@@ -2867,6 +2878,7 @@ function SessionsPage({
                 <OriginBadge s={s} members={members} className="w-40 shrink-0" />
                 <span className="flex w-24 shrink-0 items-center"><ModeBadge headless={s.headless} /></span>
                 <span className="w-20 shrink-0 text-xs tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
+                <span className="hidden w-16 shrink-0 justify-end text-right text-xs tabular-nums text-muted-foreground lg:block" title={s.tokens ? `${(s.tokens.input + s.tokens.output + s.tokens.cacheRead + s.tokens.cacheWrite).toLocaleString()} tokens (in ${s.tokens.input.toLocaleString()} · out ${s.tokens.output.toLocaleString()} · cache-read ${s.tokens.cacheRead.toLocaleString()} · cache-write ${s.tokens.cacheWrite.toLocaleString()})` : 'cost not yet computed'}>{formatCost(s.costUsd)}</span>
                 <span className="w-16 shrink-0 text-xs text-muted-foreground">{statusLabel(s)}</span>
               </button>
               {/* Human verdict — finished runs only; stays visible once rated, faint-until-hover otherwise. */}
@@ -7709,6 +7721,7 @@ function AutomationRuns({ id, onOpen }: { id: string; onOpen: (tmux: string, tit
               <Clock className="h-3 w-3 shrink-0 text-muted-foreground/50" />
               <span className="shrink-0 text-muted-foreground">{new Date(s.createdAt).toLocaleString()}</span>
               {s.spawnedByLabel && <span className="ml-auto min-w-0 truncate text-muted-foreground/60">{s.spawnedByLabel}</span>}
+              {s.costUsd != null && <span className={`${s.spawnedByLabel ? 'pl-2' : 'ml-auto'} shrink-0 tabular-nums text-muted-foreground`} title="run cost">{formatCost(s.costUsd)}</span>}
             </button>
           ))}
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -230,6 +230,11 @@ export interface Session {
   ratedBy?: string
   ratedByLabel?: string
   ratedAt?: number
+  /** What the run cost in USD, from its transcript's token usage × model rates. Undefined while the run
+   *  is still live or before it's been computed. */
+  costUsd?: number
+  /** Token breakdown behind `costUsd` (uncached input / output / cache-read / cache-write). */
+  tokens?: { input: number; output: number; cacheRead: number; cacheWrite: number }
 }
 export interface AuditEvent {
   id: number


### PR DESCRIPTION
## What

Every claude-code session now records **what it cost**, and that cost is surfaced on the **sessions list** and in an automation's **run history**.

## How it works

- **`src/edge/session-cost.ts` (new)** — reads the session's claude transcript (located by the pinned `claude_session_id`, reusing `conversation.ts`'s `findTranscript`), sums the per-request token `usage` across every assistant turn, and multiplies by per-model sticker rates. Cache tokens are priced correctly: reads at 0.1× input, and cache writes split into 5-minute (1.25×) vs 1-hour (2×) ephemeral tiers using the transcript's `cache_creation` breakdown. Unknown models fall back to Opus-tier so nothing is undercounted. Read-only + best-effort — a missing/unreadable transcript yields `null`.
- **DB** — `term_sessions` gains `cost_usd` (REAL) plus a token breakdown (`input_tokens` / `output_tokens` / `cache_read_tokens` / `cache_write_tokens`), all nullable.
- **`TerminalManager`** — a run's transcript is complete once it's terminal, so cost is derived **lazily on first read in `listSessions`** (`backfillCosts`, bounded to 20 transcript parses per call so a long history amortizes across polls instead of stalling the first load) and **persisted** on the row. `toSession` surfaces `costUsd` + `tokens`. Automation runs go through `listRunsFor` → `listSessions`, so they inherit the cost with no extra wiring.
- **Console** — a sortable **Cost** column on the sessions list (compact `$0.42`, `<$0.01`, `—` while live/uncomputed; token-breakdown tooltip), and per-run cost in the automation run-history rows.

## Verification

- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` (68/68) all green.
- `readSessionCost` cross-checked against a real 58-request Opus 4.8 transcript: **\$5.64** = input \$0.11 + output \$1.18 + cache-read \$1.61 + cache-write \$2.74 (1-hour tier), matching a hand calculation.
- Migration + backfill `UPDATE` + `SELECT *` round-trip verified on an isolated DB (new columns present, cost persists and reads back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fS9mHadnGxa2VKhEKn7a7