### PR TITLE
chore(control): remove dead randomId helper (v0.219.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.219.1] — 2026-07-16
+### Removed
+- **Dead `randomId` helper in the control plane.** `src/state/control.ts` exported a legacy
+  `randomId(prefix)` id generator that had zero callers since the prefixed-id migration
+  (`src/id.ts` / `newId`) took over entity id minting. Removed it and its now-unused `randomBytes`
+  import — no behavior change.
+
 ## [0.219.0] — 2026-07-16
 ### Added
 - **Episodic self-query — an agent can read its own history of past sessions, and reopen any one.** Two

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.219.0",
+  "version": "0.219.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/state/control.ts
+++ b/src/state/control.ts
@@ -6,7 +6,6 @@
  *
  * A tenant's `slug` becomes its subdomain (`<slug>.<baseDomain>`), so slugs are DNS-label-safe.
  */
-import { randomBytes } from 'crypto';
 import { DatabaseSync } from 'node:sqlite';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -101,9 +100,4 @@ export class TenantStore {
 
 function toRecord(r: TenantRow): TenantRecord {
   return { slug: r.slug, displayName: r.display_name, ownerEmail: r.owner_email, status: r.status, createdAt: r.created_at };
-}
-
-/** A short opaque id helper (kept here so callers don't reach for crypto directly). */
-export function randomId(prefix = ''): string {
-  return prefix + randomBytes(8).toString('hex');
 }


### PR DESCRIPTION
Removes the legacy `randomId(prefix)` helper from `src/state/control.ts`. It has had **zero callers** since the prefixed-id migration (`src/id.ts` / `newId`) took over entity id minting, so it was dead code. Also drops its now-unused `randomBytes` import.

No behavior change. Follow-up to the id-migration sweep — this was the last non-secret raw-id spot left (the only other `randomUUID` is in `src/core/run.ts`, intentionally kept since core may import only from `types.ts`).

- typecheck ✓
- build ✓
- governance conformance 68/68 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMSbnPEbqSVPGLasTKENp