### PR TITLE
feat(chat): render Library deliverables inline in the chat window (v0.220.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.220.0] — 2026-07-16
+### Added
+- **Chat renders Library deliverables inline.** When an agent produces a Library artifact mid-conversation
+  — `publish` a report/file, `image_generate`/`image_edit` a picture, `video_generate` a clip — the plain-language
+  Chat window now shows it **inline** instead of a generic "Posted an update" line: an image thumbnail, a
+  video player, or a titled file tile, each deep-linking into the Library (`#/artifacts/<id>`). The transcript
+  parser (`src/edge/conversation.ts`) tags those activities with the artifact id(s) it finds in the tool
+  result (prefixed `art_…` ids), and the `/api/sessions/:id/conversation` route resolves them into
+  viewer-safe preview cards (`ChatArtifactRef`) — filtered by the same visibility gate as the Library, so a
+  card only shows a deliverable the viewer may already see. Also gave those tools distinct activity labels
+  ("Published to the Library", "Created an image", "Created a video") so the inline card reads naturally.
+
 ## [0.219.1] — 2026-07-16
 ### Removed
 - **Dead `randomId` helper in the control plane.** `src/state/control.ts` exported a legacy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.219.0",
+  "version": "0.220.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.219.0",
+      "version": "0.220.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.219.1",
+  "version": "0.220.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/conversation.ts
+++ b/src/edge/conversation.ts
@@ -15,6 +15,21 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
+/** A viewer-safe reference to a Library artifact an activity produced — enough for the chat UI to render
+ *  an inline preview card (thumbnail for images, a titled tile + open-in-Library link for everything else).
+ *  Resolved by the /conversation route from an activity's {@link ChatTurn} `artifactIds`; carries no
+ *  share token. `raw` is the bytes URL (`/api/artifacts/<id>/raw`) for an `<img>`/`<video>`. */
+export interface ChatArtifactRef {
+  id: string;
+  title: string;
+  kind: string;
+  mime: string;
+  filename: string;
+  isImage: boolean;
+  isVideo: boolean;
+  raw: string;
+}
+
 /** One entry in the human-readable timeline. */
 export type ChatTurn =
   | { kind: 'user'; text: string; ts: number }
@@ -27,6 +42,13 @@ export type ChatTurn =
       /** short human hint (a filename, a URL host, a query) — the UI may hide this behind a toggle */
       detail?: string;
       status: 'running' | 'ok' | 'error';
+      /** Library artifact id(s) this activity produced (publish / image_generate / video_generate / …),
+       *  parsed from the tool result. The /conversation route resolves these to rich {@link
+       *  ChatArtifactRef} cards the chat UI renders inline; unresolvable ids are dropped there. */
+      artifactIds?: string[];
+      /** Resolved, viewer-filtered artifact previews (populated by the /conversation route from
+       *  {@link ChatArtifactRef}); absent in the raw transcript parse. */
+      artifacts?: ChatArtifactRef[];
       ts: number;
     };
 
@@ -80,6 +102,13 @@ const host = (u: unknown): string | undefined => {
 const clip = (s: unknown, n = 80): string | undefined =>
   typeof s === 'string' && s ? (s.length > n ? s.slice(0, n) + '…' : s) : undefined;
 
+/** Strip the `mcp__<server>__` wrapper off an agent-os MCP tool name (`mcp__aos__publish` → `publish`);
+ *  a plain built-in name (`Bash`) passes through unchanged. */
+function bareName(name: string): string {
+  const mcp = name.match(/^mcp__[^_]*(?:_[^_]+)*__(.+)$/) || name.match(/^mcp__.+?__(.+)$/);
+  return mcp ? mcp[1] : name;
+}
+
 /** Map a tool_use block to a friendly label + short detail, tuned for a non-technical reader. */
 function friendlyTool(name: string, input: Record<string, unknown>): { label: string; detail?: string } {
   switch (name) {
@@ -107,18 +136,48 @@ function friendlyTool(name: string, input: Record<string, unknown>): { label: st
       return { label: 'Updated its plan' };
   }
   // agent-os MCP tools arrive as mcp__<server>__<tool>.
-  const mcp = name.match(/^mcp__[^_]*(?:_[^_]+)*__(.+)$/) || name.match(/^mcp__.+?__(.+)$/);
-  const bare = mcp ? mcp[1] : name;
+  const bare = bareName(name);
   if (/^slack_/.test(bare)) return { label: 'Sent a Slack message', detail: clip(input.text ?? input.message ?? input.channel) };
   if (/^discord_/.test(bare)) return { label: 'Sent a Discord message', detail: clip(input.content ?? input.message) };
   if (/^(remember|recall|revise|forget)$/.test(bare)) return { label: 'Used its memory' };
   if (/^kb_/.test(bare)) return { label: 'Used the knowledge base', detail: clip(input.query ?? input.slug ?? input.title) };
   if (/^task_/.test(bare)) return { label: 'Updated the task board', detail: clip(input.title) };
-  if (/^(report|update|notify|publish)$/.test(bare)) return { label: 'Posted an update' };
+  // Artifact-producing tools: keep a distinct label so the inline artifact card reads naturally under it.
+  if (bare === 'publish') return { label: 'Published to the Library', detail: clip(input.title ?? basename(input.path)) };
+  if (bare === 'image_generate') return { label: 'Created an image', detail: clip(input.prompt) };
+  if (bare === 'image_edit') return { label: 'Edited an image', detail: clip(input.prompt ?? input.operation) };
+  if (bare === 'video_generate') return { label: 'Created a video', detail: clip(input.prompt) };
+  if (/^(report|update|notify)$/.test(bare)) return { label: 'Posted an update' };
   if (bare === 'ask') return { label: 'Asked a question', detail: clip(input.question) };
   if (/^secret_/.test(bare)) return { label: 'Used a stored credential', detail: clip(input.key) };
   if (bare === 'directory_lookup') return { label: 'Looked someone up' };
   return { label: humanize(bare), detail: clip((input as any).query ?? (input as any).title) };
+}
+
+/** Bare (mcp-stripped) names of tools whose result yields Library artifact id(s) we render inline. */
+const ARTIFACT_TOOLS = new Set(['publish', 'image_generate', 'image_edit', 'video_generate']);
+
+/** Flatten a tool_result's `content` (string, or an array of `{type:'text',text}` blocks) to plain text. */
+function resultText(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((b) => (b && typeof b === 'object' && (b as any).type === 'text' ? String((b as any).text ?? '') : ''))
+      .join('\n');
+  }
+  return '';
+}
+
+/** Pull Library artifact ids out of a tool result. New ids are prefixed (`art_<hex>`); this deliberately
+ *  matches only the prefixed form (all publish/generate outputs mint prefixed ids), so we never mistake a
+ *  stray hex token for an id. De-duped, order preserved. */
+function extractArtifactIds(text: string): string[] {
+  const ids: string[] = [];
+  const seen = new Set<string>();
+  for (const m of text.matchAll(/\bart_[0-9a-f]+\b/g)) {
+    if (!seen.has(m[0])) { seen.add(m[0]); ids.push(m[0]); }
+  }
+  return ids;
 }
 
 /** Parse a claude transcript line's `message.content` into ordered turns; merge tool results by id. */
@@ -169,7 +228,15 @@ export function readConversation(claudeSessionId: string): Conversation {
         const idx = activityById.get(String(b.tool_use_id));
         if (idx != null) {
           const card = turns[idx];
-          if (card && card.kind === 'activity') card.status = b.is_error ? 'error' : 'ok';
+          if (card && card.kind === 'activity') {
+            card.status = b.is_error ? 'error' : 'ok';
+            // Artifact-producing tool that succeeded → capture the Library id(s) it returned, so the
+            // route can resolve them into inline preview cards.
+            if (!b.is_error && ARTIFACT_TOOLS.has(bareName(card.tool))) {
+              const ids = extractArtifactIds(resultText(b.content));
+              if (ids.length) card.artifactIds = ids;
+            }
+          }
         }
       }
       // thinking blocks are deliberately dropped — noise for a non-technical reader.

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
 import { TerminalManager, AGENT_OS_OPERATING_NOTES } from './terminal';
 import { classifyActivity, clipText, ActivityCategory, ActivityEffect } from './state/session-activity';
-import { readConversation } from './edge/conversation';
+import { readConversation, type ChatArtifactRef } from './edge/conversation';
 import { summarizeConversation } from './edge/summarize';
 import { Automation, Automations, nextCronRun, derivedConcurrencyCap, chatTitle } from './edge/automations';
 import { SlackSocket } from './edge/slack-socket';
@@ -2237,6 +2237,29 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to view this session' });
     const claudeId = tm.sessionClaudeId(id);
     const convo = claudeId ? readConversation(claudeId) : { turns: [], found: false };
+    // Resolve any artifact ids an activity produced (publish / image_generate / …) into viewer-safe
+    // preview cards the chat UI renders inline — dropping ids the viewer may not see or that no longer
+    // exist. The viewer already passed canViewSession, so their own run's deliverables resolve.
+    for (const t of convo.turns) {
+      if (t.kind !== 'activity' || !t.artifactIds?.length) continue;
+      const refs: ChatArtifactRef[] = [];
+      for (const aid of t.artifactIds) {
+        const a = os.artifacts.get(aid);
+        if (!a) continue;
+        if (!tm.canViewSpawn(a.source ?? null, me) && !a.sharedTeam) continue;
+        refs.push({
+          id: a.id,
+          title: a.title || a.filename,
+          kind: a.kind,
+          mime: a.mime,
+          filename: a.filename,
+          isImage: a.mime.startsWith('image/'),
+          isVideo: a.mime.startsWith('video/'),
+          raw: `/api/artifacts/${a.id}/raw`,
+        });
+      }
+      if (refs.length) t.artifacts = refs;
+    }
     return sendJson(res, 200, { agent, ...convo });
   }
   // Reply into a chat session (the human's next turn) as a clean, self-terminating headless resume run

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -3020,15 +3020,64 @@ function MsgHeading({ m, children }: { m: Msg; children?: ReactNode }) {
 // sends the human's turns via /reply (warm deliver, else transcript resume — the Slack-continuity path).
 // ─────────────────────────────────────────────────────────────────────────────────────────────────
 
-/** One friendly activity card ("Sent a Slack message" ✓). Terminal detail stays hidden by default. */
+/** An inline preview of a Library deliverable an agent just produced — a thumbnail for images, a player
+ *  for videos, a titled tile otherwise. The whole card deep-links into the Library (`#/artifacts/<id>`),
+ *  so a non-technical teammate sees the result right in the conversation and can open/download it. */
+function ArtifactCard({ a }: { a: ChatArtifactRef }) {
+  const href = navHref('artifacts', a.id)
+  if (a.isImage) {
+    return (
+      <a href={href} className="group block max-w-[16rem] overflow-hidden rounded-xl border bg-card transition hover:border-primary">
+        <img src={a.raw} alt={a.title} loading="lazy" className="max-h-44 w-full object-cover" />
+        <div className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs">
+          <ImageIcon className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate font-medium" title={a.title}>{a.title}</span>
+          <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground opacity-0 transition group-hover:opacity-100" />
+        </div>
+      </a>
+    )
+  }
+  if (a.isVideo) {
+    return (
+      <div className="max-w-[20rem] overflow-hidden rounded-xl border bg-card">
+        <video src={a.raw} controls preload="metadata" className="max-h-52 w-full bg-black" />
+        <a href={href} className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs hover:underline">
+          <Film className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 truncate font-medium" title={a.title}>{a.title}</span>
+          <ExternalLink className="h-3 w-3 shrink-0 text-muted-foreground" />
+        </a>
+      </div>
+    )
+  }
+  return (
+    <a href={href} className="group flex max-w-[20rem] items-center gap-2.5 rounded-xl border bg-card px-3 py-2 transition hover:border-primary">
+      <FileText className="h-5 w-5 shrink-0 text-muted-foreground" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-sm font-medium" title={a.title}>{a.title}</span>
+        <span className="block truncate text-[11px] text-muted-foreground">{a.filename}</span>
+      </span>
+      <ExternalLink className="h-3.5 w-3.5 shrink-0 text-muted-foreground opacity-0 transition group-hover:opacity-100" />
+    </a>
+  )
+}
+
+/** One friendly activity card ("Sent a Slack message" ✓). Terminal detail stays hidden by default. An
+ *  artifact-producing activity (publish / image_generate / …) shows its deliverable(s) inline beneath. */
 function ActivityCard({ turn }: { turn: Extract<ChatTurn, { kind: 'activity' }> }) {
   const dot =
     turn.status === 'error' ? 'bg-destructive' : turn.status === 'ok' ? 'bg-emerald-500' : 'bg-amber-400 animate-pulse'
   return (
-    <div className="flex items-center gap-2 pl-1 text-[12px] text-muted-foreground">
-      <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${dot}`} />
-      <span className="font-medium">{turn.label}</span>
-      {turn.detail && <span className="truncate font-mono text-[11px] opacity-70" title={turn.detail}>{turn.detail}</span>}
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2 pl-1 text-[12px] text-muted-foreground">
+        <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${dot}`} />
+        <span className="font-medium">{turn.label}</span>
+        {turn.detail && <span className="truncate font-mono text-[11px] opacity-70" title={turn.detail}>{turn.detail}</span>}
+      </div>
+      {turn.artifacts && turn.artifacts.length > 0 && (
+        <div className="flex flex-wrap gap-2 pl-3.5">
+          {turn.artifacts.map((a) => <ArtifactCard key={a.id} a={a} />)}
+        </div>
+      )}
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1042,11 +1042,24 @@ export interface PolicyProposalsResp { proposals: PolicyProposal[]; canApply?: b
 export interface PolicyRevision { id: string; rev: number; document: PolicyDocument; summary: string | null; author: string; createdAt: number }
 export interface PolicyRevisionsResp { revisions: PolicyRevision[]; canRevert?: boolean; error?: string }
 
+/** A viewer-safe Library artifact preview attached to a chat activity (mirrors src/edge/conversation.ts). */
+export interface ChatArtifactRef {
+  id: string
+  title: string
+  kind: string
+  mime: string
+  filename: string
+  isImage: boolean
+  isVideo: boolean
+  /** Bytes URL (`/api/artifacts/<id>/raw`) for an inline <img>/<video>. */
+  raw: string
+}
+
 /** One entry in the non-technical chat timeline (mirrors src/edge/conversation.ts). */
 export type ChatTurn =
   | { kind: 'user'; text: string; ts: number }
   | { kind: 'assistant'; text: string; ts: number }
-  | { kind: 'activity'; tool: string; label: string; detail?: string; status: 'running' | 'ok' | 'error'; ts: number }
+  | { kind: 'activity'; tool: string; label: string; detail?: string; status: 'running' | 'ok' | 'error'; artifactIds?: string[]; artifacts?: ChatArtifactRef[]; ts: number }
 export interface ConversationResp {
   agent?: string
   turns: ChatTurn[]


### PR DESCRIPTION
## What

Enhances the plain-language **Chat** window so that when an agent produces a Library deliverable mid-conversation, the result is rendered **inline** instead of a generic "Posted an update" activity line.

Covers every artifact-producing tool:
- **`publish`** → a titled file tile (or thumbnail/player if it's an image/video)
- **`image_generate` / `image_edit`** → an inline image thumbnail
- **`video_generate`** → an inline video player

Each card deep-links into the Library (`#/artifacts/<id>`), so a non-technical teammate sees the output right in the conversation and can open/download it.

## How

- **`src/edge/conversation.ts`** — the transcript parser now tags an artifact-producing activity with the artifact id(s) it finds in the tool result (matches prefixed `art_…` ids only, so a stray hex token is never mistaken for an id). Extracted a shared `bareName()` helper, added a `ChatArtifactRef` type, and gave those tools distinct friendly labels ("Published to the Library", "Created an image", "Edited an image", "Created a video").
- **`src/server.ts`** — `GET /api/sessions/:id/conversation` resolves each activity's `artifactIds` into viewer-safe `ChatArtifactRef` cards, **filtered by the same visibility gate as the Library** (`canViewSpawn || sharedTeam`) — a card only ever surfaces a deliverable the viewer may already see, and carries no share token.
- **`web/src/App.tsx`** — new `ArtifactCard` renders images (thumbnail), videos (`<video controls>`), and other files (titled tile) inline beneath the activity card; `web/src/lib/api.ts` mirrors the new turn/ref shape.

## Verification

- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → 68/68 ✓
- Unit-drove `readConversation` against a synthetic transcript (image_generate with string tool-result + two ids, publish with array tool-result + one id, slack_send with none) — labels + `artifactIds` extracted exactly as expected; non-artifact tools untouched.

Deploy note: touches `src/server.ts` + an MCP-visible schema-adjacent path, so making it live needs a build + server restart (the `/conversation` route change) and a fresh web build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)