### PR TITLE
docs(CLAUDE.md): correct the memory-mcp tool count (57 + 11)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,8 +205,9 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 49 always-on tools
-  + 2 chat-only. Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 57 always-on tools
+  + 11 conditional (chat-reply / egress / media, each exposed only when its env flag is set; full list
+  in `docs/agent-mcp-tools.md`). Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). Episodic self-query (the run-history companion to semantic memory):
   `session_history` lists the agent's OWN past sessions (id/title/status/rating, own-scoped, "have I done
   this before?") and `session_open` reopens any one — the friendly transcript timeline (`readConversation`)


### PR DESCRIPTION
Follow-up to #364. The `memory-mcp.ts` line in CLAUDE.md said "49 always-on tools + 2 chat-only" — stale on both numbers. Corrected to **57 always-on + 11 conditional** (chat-reply / egress / media, each exposed only when its env flag is set), matching the freshly-reconciled `docs/agent-mcp-tools.md` table, and added a pointer to that doc.

Docs-only — no code change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)