### PR TITLE
docs(PILLARS): correct the MCP tool count (22 → 57 + 11)

### DIFF
--- a/docs/PILLARS.md
+++ b/docs/PILLARS.md
@@ -108,11 +108,10 @@ governance events.
 - **task (started)** — now carries **provenance** (`source`): manual vs `automation:<id>`.
 - **update** — agent progress notes.
 
-The OS-owned MCP server (`agentos`) carries 22 always-on tools (memory `recall`/`remember`/`revise`/
-`forget`; KB `kb_search`/`kb_read`/`kb_write`/`kb_history`/`kb_revert`; operator/inbox `ask`/`check_inbox`/
-`report`/`update`/`publish`/`library_list`; `schedule`/`unschedule`; `directory_lookup`; `list_capabilities`/
-`policy_check`) + chat-only `slack_reply`/`discord_reply`, materialised into every claude-code session.
-Canonical matrix: `docs/agent-mcp-tools.md`. Read/unread **and** dismiss are **per-member, server-backed**
+The OS-owned MCP server (`agentos`) carries 57 always-on tools + 11 conditional (chat-reply / egress /
+media, each exposed only when its env flag is set), spanning memory, KB, tasks, goals, the operator/inbox,
+skills, secrets, scheduling, agent self-editing, and app-building — materialised into every claude-code
+session. Canonical, per-tool matrix (routes + stores + governance notes): `docs/agent-mcp-tools.md`. Read/unread **and** dismiss are **per-member, server-backed**
 (a `message_state(message_id, member_id, read_at, dismissed_at)` join keyed to the viewer) — one admin
 dismissing no longer hides a row for everyone, and unread syncs across a member's devices. Plus an
 action-required count badge.


### PR DESCRIPTION
Follow-up to #364 / #366 — the last stale MCP tool count I found by grepping the codebase.

`docs/PILLARS.md` claimed the `agentos` server carries **"22 always-on tools"** with a hand-enumerated list that had rotted (no tasks, goals, agents, apps, secrets, skills, hosts, or media tools). Corrected to **57 always-on + 11 conditional** and swapped the per-tool enumeration for a plane-level summary — so it won't re-rot each time a tool is added — keeping `docs/agent-mcp-tools.md` as the canonical per-tool matrix.

Grep swept the whole tree: the only other numeric tool counts are `CHANGELOG.md` (historical release records — correctly left untouched) and `agent-capabilities-plan.md` ("1 tool" = a phase's file footprint, not a total). Both already-current: `docs/agent-mcp-tools.md` and `CLAUDE.md`.

Docs-only — no code change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)