### PR TITLE
feat(sessions): "Operations" menu with in-place Reload (v0.223.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.223.0] — 2026-07-16
+### Added
+- **"Operations" menu on every session terminal.** A new dropdown pinned top-right of the live terminal,
+  next to Files, gathers the session-lifecycle actions in one place: **Reload**, **Fork**, **Stop**,
+  **Delete**, and **Transfer** (hand the run-as to a teammate). **Reload** is new — it restarts the agent
+  process IN PLACE (kill the pane, then `claude --resume` the same session id) so a newly-connected MCP
+  server is picked up; MCP servers only spawn at claude launch, so a running session otherwise can't see
+  one added mid-run. The conversation is preserved and, unlike Stop, no "stopped" episode is written, so
+  the real end-of-run episode still fires. New `POST /api/sessions/:id/reload` → `TerminalManager.reloadSession`
+  (gated only for resumable claude-code sessions); the console remounts the terminal to re-attach and
+  resurrect via attach.sh. **Fork** moves here from the terminal tab-strip hover controls (still available
+  on the session cards/rows).
+
 ## [0.222.1] — 2026-07-16
 ### Fixed
 - **Session trail: `task_dispatch` no longer mis-reads as "deleted".** The `task.dispatched` audit event

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.222.1",
+  "version": "0.223.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.222.1",
+      "version": "0.223.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.222.1",
+  "version": "0.223.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2573,6 +2573,18 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     tm.allowResume(id);
     return sendJson(res, 200, { ok: true });
   }
+  // Reload a session: restart its agent process in place (kill the pane, keep the transcript) so a
+  // newly-connected MCP server is picked up — MCP servers spawn at claude launch, so a running session
+  // can't see one added mid-run. The frontend remounts the terminal right after, and attach.sh
+  // resurrects via `claude --resume <same id>`. Same per-member gate as stop/resume.
+  const reloadMatch = p.match(/^\/api\/sessions\/([\w-]+)\/reload$/);
+  if (method === 'POST' && reloadMatch) {
+    const id = reloadMatch[1];
+    if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
+    const r = tm.reloadSession(id, me.email);
+    return sendJson(res, r.ok ? 200 : 400, r);
+  }
   // Permanently delete a session (kill tmux + cascade messages/questions/files) — same gate.
   const sessMatch = p.match(/^\/api\/sessions\/([\w-]+)$/);
   if (method === 'DELETE' && sessMatch) {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3626,6 +3626,42 @@ export class TerminalManager {
   }
 
   /**
+   * Restart a resumable session's agent process IN PLACE, keeping its conversation. Kills the live pane
+   * and leaves the session resurrectable (no stop-marker) so the next terminal (re)attach relaunches it
+   * via `claude --resume <same claude id>` — the way to pick up a newly-connected MCP server (MCP servers
+   * spawn at claude launch, so a running session can't see one added mid-run). Unlike `stopSession` this
+   * writes NO 'stopped' episode and drops no resume-block, so the run stays whole: the real end-of-run
+   * episode still fires later, and the resurrected pane continues the SAME transcript. The pane dies for
+   * < 1s while the frontend remounts the terminal; status flips to 'stopped' meanwhile only to keep the
+   * crash-detector (a gone tmux on a 'running' row) from mislabelling the restart. Pending questions/
+   * approvals are cancelled — the process is going away and can't answer them. Only a claude-code session
+   * with a persisted launch env (resurrectable) can be reloaded. Caller applies the per-member gate.
+   */
+  reloadSession(sessionId: string, by: string): { ok: boolean; error?: string } {
+    const r = this.db.prepare('SELECT agent, tmux, status, spawned_by, run_as FROM term_sessions WHERE id = ?').get<{ agent: string; tmux: string; status: string; spawned_by: string | null; run_as: string | null }>(sessionId);
+    if (!r) return { ok: false, error: 'unknown session' };
+    // Reload only works for a resurrectable session — one whose persisted launch env attach.sh can
+    // `claude --resume` from. A headless run (no env) has nothing to restart into.
+    if (!this.os.paths || !fs.existsSync(path.join(this.os.paths.connectors, `session-${sessionId}.env`))) {
+      return { ok: false, error: 'this session cannot be reloaded (no resumable conversation)' };
+    }
+    const space = this.spaceFor(r.run_as ?? r.spawned_by);
+    this.captureTranscript(sessionId, space, r.tmux);
+    this.backend.kill(space, r.tmux);
+    // Park it 'stopped' so the lazy crash-detector (running row + gone tmux → crashed) doesn't fire in the
+    // sub-second window before the terminal reattaches and the resume launcher flips it back to 'running'.
+    if (r.status === 'running') this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
+    this.clearNotifications(sessionId);
+    this.cancelPendingQuestions(sessionId, by);
+    this.cancelPendingApprovals(sessionId, by);
+    // Deliberate restart — the OPPOSITE of stopSession: clear any stale stop-marker so attach.sh
+    // resurrects (`claude --resume`) the moment the terminal reconnects.
+    this.allowResume(sessionId);
+    this.audit(sessionId, by, 'session.reloaded', { tmux: r.tmux });
+    return { ok: true };
+  }
+
+  /**
    * A human verdict on a finished run — 'up' (did what I wanted) / 'down' (didn't) / null (clear it).
    * The ground-truth signal that feeds the agent maturity score above self-report + task result. One
    * verdict per session (latest wins); the caller must be allowed to see the session (checked upstream).
@@ -3972,7 +4008,7 @@ function shSingleQuote(v: string): string {
  *  the paired/duplicate signals (gate.attempt pairs gate.decision; approval.resolved/auto_approved pair
  *  approval.requested) so the audit-summary counts each governed action once, not two or three times. */
 const EPISODE_NOISE = new Set([
-  'session.created', 'session.ended', 'session.reported', 'session.resumed', 'session.stopped',
+  'session.created', 'session.ended', 'session.reported', 'session.resumed', 'session.reloaded', 'session.stopped',
   'session.error', 'session.tuning', 'session.progress', 'session.notified', 'session.attachment',
   'skills.materialized', 'skills.reloaded', 'skills.error', 'connector.minted', 'connector.mint.failed',
   'connector.secret.unresolved', 'shell.secret.injected', 'shell.secret.unresolved',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2007,7 +2007,7 @@ function QuickShortcuts({ session, attachable }: { session: Session; attachable:
 /** The live terminal pane. It asks the server for the attach URL — the shared /terminal/?arg=…
  *  (uid-isolation off) or a per-member /terminal/<space>/?arg=… (on) — and derives the ttyd WebSocket
  *  endpoint from it, which our first-party <Xterm> speaks directly (no iframe). */
-function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux: string; onActivity?: (sid: string) => void }) {
+function TerminalFrame({ session, tmux, onActivity, ops }: { session?: Session; tmux: string; onActivity?: (sid: string) => void; ops?: SessionOps }) {
   const [wsUrl, setWsUrl] = useState('')
   const [err, setErr] = useState('')
   const [transcript, setTranscript] = useState<string | null>(null)
@@ -2041,6 +2041,16 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
     if (!r.ok) { setErr(r.error || 'could not take over this run'); return }
     // Claimed — the live pane keeps streaming; just hide the button and (re)attach to it cleanly.
     setTranscript(null); setOverrideAttach(true); setNonce((n) => n + 1)
+  }
+  // "Reload" (Operations menu): restart the agent process in place — the server kills the pane and leaves
+  // the session resurrectable, then bumping `nonce` remounts the terminal so it re-attaches and attach.sh
+  // relaunches via `claude --resume` (same session id), picking up any newly-connected MCP server. Returns
+  // the API result so the ImageDropZone chrome can toast success/failure.
+  const reload = async (): Promise<{ ok: boolean; error?: string }> => {
+    if (!session?.id) return { ok: false, error: 'no session' }
+    const r = await api.reloadSession(session.id)
+    if (r.ok) { setTranscript(null); setNonce((n) => n + 1) }
+    return r
   }
   useEffect(() => {
     let alive = true
@@ -2084,7 +2094,7 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
       )}
       <ImageDropZone session={session} attachable={Boolean(session) && (isLive(session!) || overrideAttach)}
         onActivity={onActivity && session?.id ? () => onActivity(session.id) : undefined}
-        fontSize={fontSize} setFontSize={setFontSize}>
+        fontSize={fontSize} setFontSize={setFontSize} ops={ops} onReload={reload}>
         <Xterm key={nonce} wsUrl={wsUrl} fontSize={fontSize} copyOnSelect />
       </ImageDropZone>
     </div>
@@ -2097,9 +2107,13 @@ function TerminalFrame({ session, tmux, onActivity }: { session?: Session; tmux:
  *  (file paste). Each uploads the bytes; the server saves them in the agent's folder and types the path
  *  into the running claude. Now that the terminal is same-document (no iframe), drops/pastes over it
  *  bubble to our window handlers directly — no cross-document interception needed. */
-function ImageDropZone({ session, attachable, children, onActivity, fontSize, setFontSize }: {
+function ImageDropZone({ session, attachable, children, onActivity, fontSize, setFontSize, ops, onReload }: {
   session?: Session; attachable?: boolean; children: ReactNode; onActivity?: () => void
   fontSize: number; setFontSize: (f: number | ((s: number) => number)) => void
+  /** Lifecycle callbacks for the top-right "Operations" menu (absent → the menu is hidden). */
+  ops?: SessionOps
+  /** Reload the agent process in place; resolves with the API result so we can toast it. */
+  onReload?: () => Promise<{ ok: boolean; error?: string }>
 }) {
   const [drag, setDrag] = useState(false)
   const [help, setHelp] = useState(false)
@@ -2222,6 +2236,18 @@ function ImageDropZone({ session, attachable, children, onActivity, fontSize, se
             <FolderTree className="h-3.5 w-3.5" /> Files
           </a>
         )}
+        {/* Operations — the session-lifecycle menu (reload / transfer / fork / stop / delete) */}
+        {session?.id && ops && onReload && (
+          <OperationsMenu
+            session={session}
+            ops={ops}
+            onReload={async () => {
+              setToast({ kind: 'busy', text: 'reloading agent…' })
+              const r = await onReload()
+              setToast(r.ok ? { kind: 'ok', text: 'agent reloaded — MCP is reconnecting' } : { kind: 'err', text: r.error || 'reload failed' })
+            }}
+          />
+        )}
         {/* 📎 attach button — opens a file picker (any file type); always works regardless of focus */}
         <label
           className="flex cursor-pointer items-center gap-1 rounded bg-neutral-800/90 px-2 py-1 text-xs text-neutral-200 shadow hover:bg-neutral-700"
@@ -2342,6 +2368,95 @@ function TransferMenu({ session, members, me, onTransfer, variant }: {
             <span className="truncate">{m.name}</span>
           </DropdownMenuItem>
         ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/** The lifecycle callbacks the terminal-view "Operations" menu needs — threaded from SessionsPage down
+ *  through TerminalFrame → ImageDropZone so the menu can act on the open session. */
+type SessionOps = {
+  members: Member[]
+  me: Member
+  onOpen: (tmux: string, title: string) => void
+  onStop: (id: string) => void
+  onDelete: (id: string, tmux: string) => void
+  onTransfer: (id: string, toMemberId: string) => void
+}
+
+/** The per-session "Operations" dropdown pinned top-right of the live terminal, next to Files. One menu
+ *  for the session-lifecycle actions that were otherwise scattered across the tab strip / cards:
+ *  - Reload — restart the agent process IN PLACE (kill + `claude --resume`, same session id), the way to
+ *    pick up a newly-connected MCP server (they only spawn at claude launch). Resumable sessions only.
+ *  - Transfer — hand the run-as to another member (owner/admin or the current owner; the "share" action).
+ *  - Fork — branch a new session that inherits this conversation.
+ *  - Stop / Delete — halt or remove the session.
+ *  Each item mirrors the gating of its tab-strip/card counterpart. */
+function OperationsMenu({ session, ops, onReload }: { session: Session; ops: SessionOps; onReload: () => void }) {
+  const { members, me, onOpen, onStop, onDelete, onTransfer } = ops
+  const canTransfer = me.role === 'owner' || me.role === 'admin' || session.runAs === me.id
+  const transferTargets = canTransfer ? members.filter((m) => m.id !== session.runAs) : []
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            className="flex items-center gap-1 rounded bg-neutral-800/90 px-2 py-1 text-xs text-neutral-200 shadow hover:bg-neutral-700"
+            title="session operations — reload, transfer, fork, stop, delete"
+          >
+            <Wrench className="h-3.5 w-3.5" /> Operations
+          </button>
+        }
+      />
+      <DropdownMenuContent align="end" className="min-w-[15rem]">
+        {session.resumable && (
+          <DropdownMenuItem className="gap-2 text-xs" onClick={onReload}>
+            <RefreshCw className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
+            <span className="flex flex-col">
+              <span>Reload</span>
+              <span className="text-[10px] text-muted-foreground">restart the agent · picks up new MCP connections</span>
+            </span>
+          </DropdownMenuItem>
+        )}
+        {canFork(session) && (
+          <DropdownMenuItem className="gap-2 text-xs" onClick={() => forkAndOpen(session, onOpen)}>
+            <GitBranch className="mt-0.5 h-3.5 w-3.5 shrink-0 text-violet-500" />
+            <span className="flex flex-col">
+              <span>Fork</span>
+              <span className="text-[10px] text-muted-foreground">branch a new session from this conversation</span>
+            </span>
+          </DropdownMenuItem>
+        )}
+        {isLive(session) && (
+          <DropdownMenuItem className="gap-2 text-xs" onClick={() => onStop(session.id)}>
+            <Square className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-500" />
+            <span className="flex flex-col">
+              <span>Stop</span>
+              <span className="text-[10px] text-muted-foreground">halt this session's shell</span>
+            </span>
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem variant="destructive" className="gap-2 text-xs" onClick={() => onDelete(session.id, session.tmux)}>
+          <Trash2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <span className="flex flex-col">
+            <span>Delete</span>
+            <span className="text-[10px] text-muted-foreground opacity-80">remove the session + its messages/files</span>
+          </span>
+        </DropdownMenuItem>
+        {transferTargets.length > 0 && (
+          <>
+            <DropdownMenuSeparator />
+            <div className="px-2 py-1 text-[11px] text-muted-foreground">Transfer to…</div>
+            <div className="max-h-48 overflow-y-auto">
+              {transferTargets.map((m) => (
+                <DropdownMenuItem key={m.id} className="gap-2 text-xs" onClick={() => onTransfer(session.id, m.id)}>
+                  <MemberAvatar member={m} className="h-4 w-4 text-[9px]" />
+                  <span className="truncate">{m.name}</span>
+                </DropdownMenuItem>
+              ))}
+            </div>
+          </>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   )
@@ -2594,11 +2709,7 @@ function SessionsPage({
               <Terminal className="h-3 w-3" />
             </button>
           )}
-          {canFork(s) && (
-            <button className="rounded p-0.5 text-violet-400 hover:bg-neutral-600 hover:text-violet-300" onClick={() => forkAndOpen(s, onOpen)} title="fork — branch a new session that inherits this conversation (the original is left untouched)">
-              <GitBranch className="h-3 w-3" />
-            </button>
-          )}
+          {/* Fork moved to the terminal-view "Operations" menu (top-right, next to Files). */}
           {isLive(s) && (
             <button className="rounded p-0.5 text-amber-400 hover:bg-neutral-600 hover:text-amber-300" onClick={() => onStop(s.id)} title="stop — kill this session's shell">
               <Square className="h-3 w-3" />
@@ -2660,7 +2771,8 @@ function SessionsPage({
             )}
           </div>
         </div>
-        <TerminalFrame key={selected.tmux} session={sessions.find((s) => s.tmux === selected.tmux)} tmux={selected.tmux} onActivity={onActivity} />
+        <TerminalFrame key={selected.tmux} session={sessions.find((s) => s.tmux === selected.tmux)} tmux={selected.tmux} onActivity={onActivity}
+          ops={{ members, me, onOpen, onStop, onDelete, onTransfer }} />
       </div>
     )
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1125,6 +1125,9 @@ export const api = {
   messages: (scope: 'mine' | 'all' = 'mine') => call<Msg[]>('GET', `/api/messages${scope === 'all' ? '?scope=all' : ''}`),
   run: (agent: string, task: string) => call<{ id: string; tmux: string; error?: string }>('POST', '/api/sessions', { agent, task }),
   stopSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/stop`),
+  /** Restart a session's agent process in place (keeps the transcript, resumes the same claude id) so a
+   *  newly-connected MCP server is picked up. The terminal must remount right after to re-attach. */
+  reloadSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/reload`),
   /** Halt every running session tenant-wide (owner/admin). Softer sibling of the kill switch. */
   stopAllSessions: () => call<{ ok: boolean; halted?: number; error?: string }>('POST', '/api/sessions/stop-all'),
   /** Host resource snapshot for Settings → System (RAM / CPU / uptime). */


### PR DESCRIPTION
## What

Adds an **Operations** dropdown pinned top-right of every session's live terminal, next to **Files**. It gathers the session-lifecycle actions into one menu:

- **Reload** *(new)* — restart the agent process in place (kill the pane, then `claude --resume` the same session id) so a **newly-connected MCP server is picked up**. MCP servers only spawn at claude launch, so a running session otherwise can't see one added mid-run.
- **Transfer** — hand the run-as to another teammate (the "share" action; reuses the existing transfer flow).
- **Fork** — branch a new session from this conversation (**moved here** from the terminal tab-strip hover controls; still available on the session cards/rows).
- **Stop** / **Delete**.

## Why Reload is safe

`reloadSession` is a lighter sibling of `stopSession`: it kills the pane and leaves the session resurrectable (no stop-marker), but writes **no `stopped` episode** and cancels only the now-unanswerable pending questions/approvals. So the run stays whole — the conversation is preserved via `claude --resume` and the real end-of-run episode still fires later. The session is parked `stopped` for the sub-second window before re-attach so the crash-detector (gone tmux on a `running` row) doesn't mislabel the restart. Gated to resumable claude-code sessions (headless runs have no launch env to resume).

## Changes

- `src/terminal.ts` — `TerminalManager.reloadSession`; `session.reloaded` added to `EPISODE_NOISE`.
- `src/server.ts` — `POST /api/sessions/:id/reload` (same per-member gate as stop/resume).
- `web/src/App.tsx` — `OperationsMenu` component threaded through `TerminalFrame` → `ImageDropZone`; terminal remounts (nonce bump) after reload to re-attach and resurrect. Fork removed from the tab-strip hover controls.
- `web/src/lib/api.ts` — `api.reloadSession`.

## Verification

- `npm run typecheck`, `npm run build`, `cd web && npm run build` — all clean.
- `npm run test:governance` — 68/68 passed.
- Isolated in-process harness against a real `TerminalManager`: unknown session → `unknown session`; a row with no persisted env → `cannot be reloaded`, and the guard returns **before** touching the pane (status unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)