### PR TITLE
feat(sessions): add "Activity" shortcut to the per-session Operations menu (v0.224.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.224.0] — 2026-07-16
+### Added
+- **"Activity" shortcut in the per-session Operations menu.** The session activity trail side panel
+  (objects the run opened + their live status, v0.221.0) was only reachable from the Sessions list rows.
+  Added it as the top item of the terminal-view **Operations** dropdown (`OperationsMenu`), so while
+  you're watching a live run you can open the trail in one click. Threaded a new `onActivity` callback
+  through `SessionOps` to `setInspect`, opening the same `SessionActivity` panel.
+
 ## [0.223.0] — 2026-07-16
 ### Added
 - **"Operations" menu on every session terminal.** A new dropdown pinned top-right of the live terminal,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.223.0",
+  "version": "0.224.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.223.0",
+      "version": "0.224.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.223.0",
+  "version": "0.224.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2382,6 +2382,7 @@ type SessionOps = {
   onStop: (id: string) => void
   onDelete: (id: string, tmux: string) => void
   onTransfer: (id: string, toMemberId: string) => void
+  onActivity: (s: Session) => void
 }
 
 /** The per-session "Operations" dropdown pinned top-right of the live terminal, next to Files. One menu
@@ -2393,7 +2394,7 @@ type SessionOps = {
  *  - Stop / Delete — halt or remove the session.
  *  Each item mirrors the gating of its tab-strip/card counterpart. */
 function OperationsMenu({ session, ops, onReload }: { session: Session; ops: SessionOps; onReload: () => void }) {
-  const { members, me, onOpen, onStop, onDelete, onTransfer } = ops
+  const { members, me, onOpen, onStop, onDelete, onTransfer, onActivity } = ops
   const canTransfer = me.role === 'owner' || me.role === 'admin' || session.runAs === me.id
   const transferTargets = canTransfer ? members.filter((m) => m.id !== session.runAs) : []
   return (
@@ -2402,13 +2403,22 @@ function OperationsMenu({ session, ops, onReload }: { session: Session; ops: Ses
         render={
           <button
             className="flex items-center gap-1 rounded bg-neutral-800/90 px-2 py-1 text-xs text-neutral-200 shadow hover:bg-neutral-700"
-            title="session operations — reload, transfer, fork, stop, delete"
+            title="session operations — activity, reload, transfer, fork, stop, delete"
           >
             <Wrench className="h-3.5 w-3.5" /> Operations
           </button>
         }
       />
       <DropdownMenuContent align="end" className="min-w-[15rem]">
+        {/* Activity — open the trail side panel (objects this session opened + their live status). */}
+        <DropdownMenuItem className="gap-2 text-xs" onClick={() => onActivity(session)}>
+          <Activity className="mt-0.5 h-3.5 w-3.5 shrink-0 text-sky-500" />
+          <span className="flex flex-col">
+            <span>Activity</span>
+            <span className="text-[10px] text-muted-foreground">what this session opened · objects &amp; live status</span>
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
         {session.resumable && (
           <DropdownMenuItem className="gap-2 text-xs" onClick={onReload}>
             <RefreshCw className="mt-0.5 h-3.5 w-3.5 shrink-0 text-emerald-500" />
@@ -2772,7 +2782,7 @@ function SessionsPage({
           </div>
         </div>
         <TerminalFrame key={selected.tmux} session={sessions.find((s) => s.tmux === selected.tmux)} tmux={selected.tmux} onActivity={onActivity}
-          ops={{ members, me, onOpen, onStop, onDelete, onTransfer }} />
+          ops={{ members, me, onOpen, onStop, onDelete, onTransfer, onActivity: setInspect }} />
       </div>
     )
   }


### PR DESCRIPTION
Builds on the new per-session **Operations** dropdown (#371) and the session activity trail (#368).

The activity trail side panel — the objects a run opened (tasks, secrets, policy proposals, KB pages, skills) with their **live status** — was only reachable from the Sessions *list* rows. This adds it as the **top item of the terminal-view Operations menu**, so while you're watching a live run you can open the trail in one click.

**Change:** threads a new `onActivity` callback through `SessionOps` → `OperationsMenu`, wired to `setInspect` (the same state that drives the `SessionActivity` panel).

Web-only; `cd web && npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fS9mHadnGxa2VKhEKn7a7