### PR TITLE
fix(sessions): Operations→Activity works in the terminal-tabs view (v0.225.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.225.1] — 2026-07-16
+### Fixed
+- **Operations → Activity now works in the terminal-tabs view.** The v0.224.0 Activity shortcut set the
+  panel state via `setInspect`, but `SessionsPage` early-returns the terminal-tabs view before the
+  `{inspect && <SessionActivity>}` render, which lived only in the session-list branch — so opening a
+  session's terminal and choosing Operations → Activity did nothing. Mount the `SessionActivity` panel in
+  the terminal-view branch too, so the shortcut opens the trail from both views.
+
 ## [0.225.0] — 2026-07-16
 ### Fixed
 - **Delegation loop closes itself: the caller is woken when the delegate finishes.** Two gaps meant an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.225.0",
+  "version": "0.225.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.225.0",
+      "version": "0.225.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.225.0",
+  "version": "0.225.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2783,6 +2783,9 @@ function SessionsPage({
         </div>
         <TerminalFrame key={selected.tmux} session={sessions.find((s) => s.tmux === selected.tmux)} tmux={selected.tmux} onActivity={onActivity}
           ops={{ members, me, onOpen, onStop, onDelete, onTransfer, onActivity: setInspect }} />
+        {/* Activity side panel — mounted here too so the Operations→Activity shortcut works from the
+            terminal-tabs view, not just the list view (this branch early-returns before the list's copy). */}
+        {inspect && <SessionActivity session={inspect} onClose={() => setInspect(null)} />}
       </div>
     )
   }


### PR DESCRIPTION
Follow-up to #373. The Activity shortcut in the per-session Operations menu did nothing when opened from a session's **terminal-tabs view** — only the list view worked.

**Cause:** `SessionsPage` early-returns the terminal-tabs JSX before reaching the `{inspect && <SessionActivity>}` render, which only lived in the session-list branch. `setInspect` fired but nothing was mounted to show the panel.

**Fix:** mount `<SessionActivity>` in the terminal-view branch too, so Operations → Activity opens the trail from both views.

Web-only; `cd web && npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fS9mHadnGxa2VKhEKn7a7