### PR TITLE
fix(automations): cron branch honors run_as so personal Composio is injected (v0.227.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.227.3] — 2026-07-17
+### Fixed
+- **Cron automations now honor `run_as` — personal Composio/connectors are injected.** The scheduler
+  `tick()` cron branch fired with `this.fire(a, { guard: true })`, dropping the automation's `run_as`, so
+  every cron spawn ran with `actingMember = undefined` and saw only the shared company Composio. A daily
+  cron for a member's personal ClickUp therefore couldn't reach it and raised an owner-gated RED
+  `connector.connect` on the company account. The cron branch now passes `runAs: a.runAs` (mirroring the
+  `once` branch), so a cron session binds that member's identity and their personal connectors are minted —
+  no connect prompt. The `run_as` column on a cron row was previously dead.
+### Added
+- **"Run as" selector on the automation editor.** The create/edit form (and `POST`/`PATCH
+  /api/automations`) now expose a Run-as member picker, persisted to `automations.run_as`, so a cron/webhook/
+  event automation can be bound to a member from the console — the reason `run_as` was silently always empty.
+
 ## [0.227.2] — 2026-07-17
 ### Fixed
 - **`agent-browser` cleanup now handles agents that relocate the socket dir (follow-up to 0.227.1).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.227.2",
+  "version": "0.227.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.227.2",
+      "version": "0.227.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.227.2",
+  "version": "0.227.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -221,6 +221,9 @@ export interface AddAutomationInput {
   filter?: string;
   task: string;
   createdBy?: string;
+  /** Member id the fired session should act as — so a cron/webhook/etc. spawn binds THAT member's
+   *  connectors/Composio (e.g. their personal ClickUp) instead of the company-only fallback. */
+  runAs?: string;
 }
 
 export type FireResult =
@@ -355,10 +358,11 @@ export class Automations {
       enabled: true,
       createdBy: input.createdBy,
       createdAt: Date.now(),
+      runAs: input.runAs?.trim() || undefined,
     };
     this.db
-      .prepare('INSERT INTO automations (id, agent_id, name, type, mode, schedule, secret, filter, task, enabled, created_by, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
-      .run(a.id, a.agentId, a.name, a.type, a.mode, a.schedule ?? null, a.secret ?? null, a.filter ?? null, a.task, 1, a.createdBy ?? null, a.createdAt);
+      .prepare('INSERT INTO automations (id, agent_id, name, type, mode, schedule, secret, filter, task, enabled, created_by, created_at, run_as) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
+      .run(a.id, a.agentId, a.name, a.type, a.mode, a.schedule ?? null, a.secret ?? null, a.filter ?? null, a.task, 1, a.createdBy ?? null, a.createdAt, a.runAs ?? null);
     return a;
   }
 
@@ -467,7 +471,7 @@ export class Automations {
     return { ok: true, sessionId: s.id, tmux: s.tmux };
   }
 
-  update(id: string, patch: { name?: string; mode?: ExecMode; schedule?: string; filter?: string; task?: string; enabled?: boolean }): Automation | undefined {
+  update(id: string, patch: { name?: string; mode?: ExecMode; schedule?: string; filter?: string; task?: string; enabled?: boolean; runAs?: string | null }): Automation | undefined {
     const a = this.get(id);
     if (!a) return undefined;
     if (patch.schedule !== undefined && a.type === 'cron') parseCron(patch.schedule);
@@ -481,8 +485,10 @@ export class Automations {
         : a.type === 'composio'
           ? patch.filter.trim().toUpperCase()
           : patch.filter.trim();
+    // `runAs`: undefined = leave as-is; a member id sets it; null/'' clears it (back to company identity).
+    const nextRunAs = patch.runAs === undefined ? a.runAs ?? null : (patch.runAs || '').trim() || null;
     this.db
-      .prepare('UPDATE automations SET name = ?, mode = ?, schedule = ?, filter = ?, task = ?, enabled = ? WHERE id = ?')
+      .prepare('UPDATE automations SET name = ?, mode = ?, schedule = ?, filter = ?, task = ?, enabled = ?, run_as = ? WHERE id = ?')
       .run(
         patch.name?.trim() || a.name,
         patch.mode ?? a.mode,
@@ -490,6 +496,7 @@ export class Automations {
         nextFilter,
         patch.task ?? a.task,
         (patch.enabled ?? a.enabled) ? 1 : 0,
+        nextRunAs,
         id,
       );
     return this.get(id);
@@ -898,7 +905,9 @@ export class Automations {
       if (due == null) continue;                                                   // nothing due within the window
       if (a.lastFiredAt && Math.floor(a.lastFiredAt / 60_000) >= Math.floor(due / 60_000)) continue; // that occurrence already ran
       if (overCap()) { deferred++; continue; } // over cap → not stamped; retried next tick until the window closes
-      const r = this.fire(a, { guard: true });
+      // Bind the automation's run-as member (like the `once` branch) so a cron spawn acts under that
+      // identity — its personal Composio/connectors are injected instead of the company-only fallback.
+      const r = this.fire(a, { guard: true, runAs: a.runAs });
       if (r.ok) running++;
     }
     // Tasks share the same budget — dispatch only up to the remaining headroom (Infinity when uncapped).

--- a/src/server.ts
+++ b/src/server.ts
@@ -2136,6 +2136,10 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const b = await readBody(req);
     try {
       const type = b.type === 'webhook' ? 'webhook' : b.type === 'composio' ? 'composio' : b.type === 'slack' ? 'slack' : b.type === 'discord' ? 'discord' : 'cron';
+      // Optional "Run as": the fired session acts as this member so its connectors/Composio (e.g. their
+      // personal ClickUp) are injected. Validate it's a real member; '' clears it (company identity).
+      const runAs = b.runAs ? String(b.runAs) : '';
+      if (runAs && !os.team.getMember(runAs)) return sendJson(res, 400, { error: 'unknown run-as member' });
       const created = autos.add({
         agentId: String(b.agentId || ''),
         name: String(b.name || ''),
@@ -2145,6 +2149,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         filter: b.filter !== undefined ? String(b.filter) : undefined,
         task: String(b.task || ''),
         createdBy: me.id,
+        runAs: runAs || undefined,
       });
       return sendJson(res, 200, automationView(created, req, true));
     } catch (e) {
@@ -2187,6 +2192,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return sendJson(res, ok ? 200 : 404, { ok });
     }
     const b = await readBody(req);
+    // "Run as" edit: undefined leaves it, a member id sets it (validated), '' clears it to company identity.
+    let runAs: string | null | undefined;
+    if (b.runAs !== undefined) {
+      const id = String(b.runAs || '');
+      if (id && !os.team.getMember(id)) return sendJson(res, 400, { error: 'unknown run-as member' });
+      runAs = id || null;
+    }
     try {
       const updated = autos.update(autoMatch[1], {
         name: b.name !== undefined ? String(b.name) : undefined,
@@ -2195,6 +2207,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         filter: b.filter !== undefined ? String(b.filter) : undefined,
         task: b.task !== undefined ? String(b.task) : undefined,
         enabled: b.enabled !== undefined ? !!b.enabled : undefined,
+        runAs,
       });
       return sendJson(res, updated ? 200 : 404, updated ? automationView(updated, req, true) : { error: 'not found' });
     } catch (e) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7682,16 +7682,19 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
   const [scheduleCustom, setScheduleCustom] = useState(false)
   const [filter, setFilter] = useState('')
   const [task, setTask] = useState('')
+  const [runAs, setRunAs] = useState('') // member id the fired session acts as ('' = company identity)
+  const [members, setMembers] = useState<Member[]>([])
 
   const isAdmin = me.role === 'owner' || me.role === 'admin'
   const load = () => api.automations().then((r) => setItems(r.automations ?? []))
   useEffect(() => { load() }, [])
+  useEffect(() => { api.team().then((r) => setMembers(r.members ?? [])).catch(() => {}) }, [])
   useEffect(() => { if (!agentId && agents[0]) setAgentId(agents[0].id) }, [agents, agentId])
   // The form mounts at the top of the section, but Edit buttons live on cards further down — scroll the
   // form into view when it opens (or when switching which automation is being edited) so it isn't missed.
   useEffect(() => { if (showForm) formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' }) }, [showForm, editId])
 
-  const resetForm = () => { setName(''); setTask(''); setFilter(''); setType('cron'); setMode('headless'); setSchedule('*/30 * * * *'); setScheduleCustom(false); setEditId(null) }
+  const resetForm = () => { setName(''); setTask(''); setFilter(''); setType('cron'); setMode('headless'); setSchedule('*/30 * * * *'); setScheduleCustom(false); setRunAs(''); setEditId(null) }
   const startCreate = () => { resetForm(); setShowForm(true); setHint('') }
   const startEdit = (a: Automation) => {
     if (a.type === 'once') return // one-shot deferred runs aren't editable from the console
@@ -7701,6 +7704,7 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
     setType(a.type)
     setMode(a.mode)
     setFilter(a.filter ?? '')
+    setRunAs(a.runAs ?? '')
     if (a.type === 'cron') {
       const preset = CRON_PRESETS.some((p) => p.value === a.schedule)
       setScheduleCustom(!preset)
@@ -7714,10 +7718,10 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
     setHint('')
     if (editId) {
       // agentId + type are immutable on edit; everything else is patchable. filter only for event triggers.
-      const r = await api.updateAutomation(editId, { name, mode, schedule: type === 'cron' ? schedule : undefined, filter: type === 'composio' || type === 'slack' || type === 'discord' ? filter : undefined, task })
+      const r = await api.updateAutomation(editId, { name, mode, schedule: type === 'cron' ? schedule : undefined, filter: type === 'composio' || type === 'slack' || type === 'discord' ? filter : undefined, task, runAs })
       if (r.error) return setHint('⚠ ' + r.error)
     } else {
-      const r = await api.addAutomation({ name, agentId, type, mode, schedule: type === 'cron' ? schedule : undefined, filter: type === 'composio' || type === 'slack' || type === 'discord' ? filter : undefined, task })
+      const r = await api.addAutomation({ name, agentId, type, mode, schedule: type === 'cron' ? schedule : undefined, filter: type === 'composio' || type === 'slack' || type === 'discord' ? filter : undefined, task, runAs: runAs || undefined })
       if (r.error) return setHint('⚠ ' + r.error)
     }
     closeForm()
@@ -7869,6 +7873,17 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav }: { me: Member; ag
                     <Input value={filter} onChange={(e) => setFilter(e.target.value)} className="font-mono" placeholder="SLACK_DIRECT_MESSAGE_RECEIVED  (blank = any)" />
                   </Field>
                 )}
+                <Field label="Run as" help="The fired session acts as this member, so their personal connectors (e.g. their own ClickUp / Composio apps) are injected instead of the shared company account. Company identity = the company Composio only.">
+                  <Select value={runAs || '__company'} onValueChange={(v) => setRunAs(v && v !== '__company' ? v : '')}>
+                    <SelectTrigger><SelectValue /></SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__company">Company identity (no member)</SelectItem>
+                      {members.map((m) => (
+                        <SelectItem key={m.id} value={m.id}>{m.name || m.email}</SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
               </div>
               <Field label="Task">
                 <Textarea value={task} onChange={(e) => setTask(e.target.value)} className="min-h-[64px]" placeholder="What should the agent do each time this fires? (Webhook payloads are appended automatically.)" />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -628,6 +628,9 @@ export interface Automation {
   nextRunAt?: number
   /** Ready-to-paste webhook URL — present for admins on webhook automations only. */
   hookUrl?: string
+  /** Member id the fired session acts as — binds THAT member's connectors/Composio (e.g. personal
+   *  ClickUp) instead of the company fallback. Empty/absent = company identity. */
+  runAs?: string
 }
 export interface AddAutomationReq {
   agentId: string
@@ -637,6 +640,7 @@ export interface AddAutomationReq {
   schedule?: string
   filter?: string
   task: string
+  runAs?: string
 }
 
 export type Transport = 'stdio' | 'http' | 'sse'
@@ -1224,7 +1228,7 @@ export const api = {
 
   automations: () => call<{ automations: Automation[] }>('GET', '/api/automations'),
   addAutomation: (a: AddAutomationReq) => call<Automation & { error?: string }>('POST', '/api/automations', a),
-  updateAutomation: (id: string, patch: Partial<Pick<Automation, 'name' | 'mode' | 'schedule' | 'filter' | 'task' | 'enabled'>>) =>
+  updateAutomation: (id: string, patch: Partial<Pick<Automation, 'name' | 'mode' | 'schedule' | 'filter' | 'task' | 'enabled' | 'runAs'>>) =>
     call<Automation & { error?: string }>('PATCH', '/api/automations/' + id, patch),
   deleteAutomation: (id: string) => call<{ ok: boolean }>('DELETE', '/api/automations/' + id),
   /** Fire an automation once now. `mode` overrides its saved default for this run only (headless =


### PR DESCRIPTION
Releasing a fix authored by **@varun (varun@expresstech.io)** that was committed directly on the expresstech box and never pushed — surfaced while deploying the browser-leak fix there. Cherry-picked onto `main` (via `git am`, author preserved), version reconciled `0.226.0 → 0.227.3`.

## What it fixes
The scheduler `tick()` **cron branch** fired with `this.fire(a, { guard: true })`, **dropping the automation's `run_as`** — so every cron spawn ran with `actingMember = undefined` and saw only the shared company Composio. A daily cron for a member's **personal ClickUp** couldn't reach it and raised an owner-gated RED `connector.connect` on the company account. The cron branch now passes `runAs: a.runAs` (mirroring the `once` branch), so the session binds that member's identity and their personal connectors are minted — no connect prompt.

Also adds the **"Run as" selector to the automation editor** (create/edit form + `POST`/`PATCH /api/automations`), persisted to `automations.run_as` — the reason `run_as` was silently always empty.

## Verification
- `npm run build` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → **68/68** ✓ · typecheck ✓
- Applied cleanly onto main; only version/CHANGELOG needed reconciliation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)