### PR TITLE
docs(deploy): nginx backslash gotcha — blank terminal / /terminal/ws 403 (v0.227.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.227.4] — 2026-07-20
+### Documentation
+- **Deploy runbook: the "blank browser terminal / `/terminal/ws → 403`" nginx gotcha.** Documented a
+  config artifact that hit insta-ai — a literal backslash before every `$variable` in `proxy_set_header`
+  (a leaked shell-heredoc escape, e.g. `Host \$host;`) makes nginx send `Host: \example.com` and a bogus
+  non-empty `Upgrade: \` on every request. The Node app tolerates it so the console loads, but
+  ttyd/libwebsockets 403s the WebSocket handshake — so only the browser terminal breaks (blank), while
+  sessions otherwise spawn fine. Added diagnosis (tcpdump the nginx→ttyd hop) and the one-line fix
+  (`sed -i 's/\\$/$/g'` + reload) to `README.md` and `CLAUDE.md`.
+
 ## [0.227.3] — 2026-07-17
 ### Fixed
 - **Cron automations now honor `run_as` — personal Composio/connectors are injected.** The scheduler

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -437,6 +437,22 @@ in `src/types.ts` and `TeamStore.canRun()`.
   `map $http_upgrade $connection_upgrade { default upgrade; "" close; }` + `proxy_set_header Connection
   $connection_upgrade;` so plain requests get `Connection: close`. Symptom is deceptive: `curl` straight
   to `127.0.0.1:3010` (and a raw `nc` HTTP/1.1 request) both return 200, only the nginx hop 502s.
+- **nginx gotcha that bit insta-ai again (2026-07-16) — a literal backslash before every `$variable`.**
+  If the site config was generated through a shell heredoc/`sed` that escaped the `$` and the backslash
+  leaked onto disk (`proxy_set_header Host \$host;`, `Upgrade \$http_upgrade;`, …), nginx emits the value
+  **with a leading backslash** — `Host: \aos.ai.instawp.io` — and a bogus non-empty `Upgrade: \` on EVERY
+  request (empty `$http_upgrade` still yields `\`). The Node app tolerates the malformed `Host` so the
+  console loads normally, but **ttyd/libwebsockets strictly validates it and 403s the WebSocket
+  handshake**, so ONLY the browser terminal breaks: it renders **blank** and the access log shows
+  `GET /terminal/ws → 403`, while sessions otherwise spawn fine (live tmux pane, working API — a spawn
+  bug that isn't one). Nail it by tcpdumping the nginx→ttyd hop
+  (`tcpdump -i lo -A 'tcp port 3011'`): healthy shows `Host: aos.ai.instawp.io`, broken shows
+  `Host: \aos.ai.instawp.io` — the header-value backslash is the only diff (direct `curl` to ttyd with a
+  clean Host = 200, through nginx = 403). Fix = strip them: `sudo sed -i 's/\\$/$/g' <site.conf>` (leaves
+  a legit no-backslash `$connection_upgrade` from the conf.d map untouched), `nginx -t`, `reload`. Verify
+  `/terminal/`+cookie → 200, no-cookie → 401, WS handshake (`Upgrade` + `Sec-WebSocket-Protocol: tty`) →
+  101. Was isolated to insta-ai (that one config was hand-written differently); jump-server + expresstech
+  configs were clean.
 - **Hardened-unit gotcha — `ReadWritePaths=` dirs must pre-exist.** Under `ProtectHome=read-only` the
   unit fails to start with `status=226/NAMESPACE` (`Failed to set up mount namespacing: <path>: No such
   file or directory`) if any carve-out path is missing. On a fresh box `~/.config`/`~/.cache`/`~/.claude`

--- a/README.md
+++ b/README.md
@@ -97,6 +97,20 @@ between the platforms is entirely in how the process supervisor treats that surv
   > proxy_set_header   Connection $connection_upgrade;   # NOT a bare "upgrade"
   > ```
 
+  > **nginx gotcha — no literal backslash before `$variable` in `proxy_set_header`.** If the config was
+  > generated through a shell heredoc/`sed` that escaped the `$` (`\$host`, `\$http_upgrade`, …) and the
+  > backslash leaked onto disk, nginx emits the value *with a leading backslash* — `Host: \example.com`,
+  > and a bogus non-empty `Upgrade: \` on **every** request (empty `$http_upgrade` still yields `\`). The
+  > Node app tolerates the malformed `Host`, so the console loads fine — but ttyd/libwebsockets strictly
+  > validates it and returns **403** on the WebSocket handshake, so **only the browser terminal breaks**:
+  > it renders blank and the access log shows `GET /terminal/ws → 403` while sessions otherwise spawn
+  > normally (a live tmux pane, working API). Diagnose by tcpdumping the nginx→ttyd hop
+  > (`tcpdump -i lo -A 'tcp port <ttyd-port>'`) — a healthy request shows `Host: example.com`, the broken
+  > one `Host: \example.com`. Fix: strip the backslashes — `sed -i 's/\\$/$/g' <site.conf>` (leaves a
+  > legit no-backslash `$connection_upgrade` untouched), `nginx -t`, `systemctl reload nginx`. Verify:
+  > `/terminal/`+cookie → 200, no-cookie → 401, and the WS handshake (`Upgrade` +
+  > `Sec-WebSocket-Protocol: tty`) → 101.
+
   > **systemd gotcha — every `ReadWritePaths=` dir must already exist.** Under `ProtectHome=read-only`
   > the unit carves out writable paths (the data home, the checkout, `~/.claude`, …); if any listed path
   > is missing on disk the service refuses to start with `status=226/NAMESPACE`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.227.3",
+  "version": "0.227.4",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
## What

Documents an nginx config gotcha that took down the browser terminal on the **insta-ai** tenant, and its one-line fix.

**Root cause:** the site config had a literal backslash before every `$variable` in `proxy_set_header` (a shell-heredoc escape that leaked onto disk — `Host \$host;`, `Upgrade \$http_upgrade;`, …). nginx then emits the value *with a leading backslash* (`Host: \aos.ai.instawp.io`) and a bogus non-empty `Upgrade: \` on **every** request. The Node app tolerates the malformed `Host` so the console loads normally — but **ttyd/libwebsockets strictly validates it and 403s the WebSocket handshake**, so *only the browser terminal breaks* (renders blank; access log shows `GET /terminal/ws → 403`) while sessions otherwise spawn fine.

**Diagnosis:** tcpdump the nginx→ttyd hop — healthy `Host: aos.ai.instawp.io`, broken `Host: \aos.ai.instawp.io`.
**Fix:** `sudo sed -i 's/\\$/$/g' <site.conf>` (leaves the legit no-backslash `$connection_upgrade` untouched) + `nginx -t` + reload. Live config already fixed on the box.

## Scope

Docs only — new gotcha blockquote in `README.md`, matching entry in `CLAUDE.md`'s production-deploy gotchas, CHANGELOG + patch bump to v0.227.4. Verified isolated to insta-ai; jump-server + expresstech nginx configs were checked and are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)