### PR TITLE
fix(console): collapsed sidebar surfaces approval/waiting/running counts (v0.227.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.227.5] — 2026-07-20
+### Fixed
+- **Collapsed sidebar showed no notifications.** The 48px rail dropped every signal the expanded
+  sidebar carries — pending approvals, live runs, "Claude is waiting on you" — so collapsing it hid
+  the fact that anything needed you. The rail's Inbox and Sessions icons now carry corner pips: an
+  amber count for items awaiting your decision (a plain dot when there's unread-but-nothing-to-decide),
+  and on Sessions an indigo count of your sessions blocked on you, falling back to the emerald
+  running-run count.
+
 ## [0.227.4] — 2026-07-20
 ### Documentation
 - **Deploy runbook: the "blank browser terminal / `/terminal/ws → 403`" nginx gotcha.** Documented a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.227.3",
+  "version": "0.227.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.227.3",
+      "version": "0.227.5",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.227.4",
+  "version": "0.227.5",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -620,6 +620,28 @@ function WaitingBell({ className = 'h-3.5 w-3.5', tone = 'text-indigo-600' }: { 
   )
 }
 
+/** Corner pip for the COLLAPSED sidebar rail. The expanded sidebar carries its signals as text
+ *  badges next to each label; at 48px wide there's no room for those, so the same counts ride the
+ *  icon itself — without this, collapsing the sidebar silently hides every pending approval, every
+ *  live run and every "Claude is waiting on you". `count === 0` renders nothing. */
+function RailBadge({ count, tone, title }: { count: number; tone: string; title: string }) {
+  if (!count) return null
+  return (
+    <span
+      title={title}
+      className={`pointer-events-none absolute -right-0.5 -top-0.5 flex h-4 min-w-[1rem] items-center justify-center rounded-full px-1 text-[9px] font-semibold leading-none ${tone}`}
+    >
+      {count > 99 ? '99+' : count}
+    </span>
+  )
+}
+
+/** A plain "there's something unread here" dot for the collapsed rail — used when a surface has news
+ *  but nothing that needs a decision, so it doesn't shout with a count. */
+function RailDot({ tone = 'bg-primary', title }: { tone?: string; title: string }) {
+  return <span title={title} className={`pointer-events-none absolute right-0.5 top-0.5 h-2 w-2 rounded-full ${tone}`} />
+}
+
 /**
  * Self-update notice — polls `/api/update` (a cached `git fetch` behind the scenes) and, when the
  * checkout is behind origin, shows a pill in the sidebar. Clicking opens a panel with the changelog
@@ -1079,6 +1101,10 @@ function Console({ me }: { me: Member }) {
   // Sidebar split: live sessions always show; the open one shows even if ended; the rest of the ended
   // ones hide behind the "N ended" toggle so a pile of past runs doesn't push live work off-screen.
   const navLive = mySessions.filter(isLive)
+  // Signals the collapsed rail surfaces (the expanded sidebar shows them per-row / per-label):
+  // how many of MY sessions are blocked on me, and whether the Inbox has anything unread at all.
+  const waitingMine = mySessions.filter((s) => waiting.has(s.id)).length
+  const unreadInbox = messages.filter((m) => !m.read).length
   const navEnded = mySessions.filter((s) => !isLive(s))
   const selectedEndedNav = navEnded.find((s) => s.tmux === selected?.tmux)
   const collapsibleNav = navEnded.filter((s) => s.tmux !== selected?.tmux)
@@ -1122,12 +1148,23 @@ function Console({ me }: { me: Member }) {
           <div className="mt-1 text-base" title={state?.tenantName || state?.tenant || 'Agent OS'}>⚙️</div>
           <nav className="mt-2 flex flex-col items-center gap-1">
             {me.role === 'owner' && <Button render={<a href={navHref('overview')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'overview' ? 'text-primary' : 'text-muted-foreground'}`} title="Overview" onClick={onNavClick(() => nav('overview'))}><LayoutGrid className="h-4 w-4" /></Button>}
-            <Button render={<a href={navHref('inbox')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'inbox' ? 'text-primary' : 'text-muted-foreground'}`} title="Inbox" onClick={onNavClick(() => nav('inbox'))}><InboxIcon className="h-4 w-4" /></Button>
+            <span className="relative">
+              <Button render={<a href={navHref('inbox')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'inbox' ? 'text-primary' : 'text-muted-foreground'}`} title={pendingApprovals ? `Inbox — ${pendingApprovals} needs you` : 'Inbox'} onClick={onNavClick(() => nav('inbox'))}><InboxIcon className="h-4 w-4" /></Button>
+              {pendingApprovals > 0
+                ? <RailBadge count={pendingApprovals} tone="bg-amber-500 text-white" title={`${pendingApprovals} item${pendingApprovals === 1 ? '' : 's'} need your decision`} />
+                : unreadInbox > 0 ? <RailDot title={`${unreadInbox} unread`} /> : null}
+            </span>
             <Button render={<a href={navHref('agents')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'agents' || route === 'agent' ? 'text-primary' : 'text-muted-foreground'}`} title="Agents" onClick={onNavClick(() => nav('agents'))}><Bot className="h-4 w-4" /></Button>
             {pinnedNav.map((n) => (
               <Button key={n.key} render={<a href={navHref(n.route)} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === n.route ? 'text-primary' : 'text-muted-foreground'}`} title={n.label} onClick={onNavClick(() => nav(n.route))}>{n.icon}</Button>
             ))}
-            <Button render={<a href={navHref('sessions')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'sessions' ? 'text-primary' : 'text-muted-foreground'}`} title="Sessions" onClick={onNavClick(() => nav('sessions'))}><TerminalSquare className="h-4 w-4" /></Button>
+            <span className="relative">
+              <Button render={<a href={navHref('sessions')} />} size="icon" variant="ghost" className={`h-8 w-8 ${route === 'sessions' ? 'text-primary' : 'text-muted-foreground'}`} title={waitingMine ? `Sessions — ${waitingMine} waiting on you` : runningSessions ? `Sessions — ${runningSessions} running` : 'Sessions'} onClick={onNavClick(() => nav('sessions'))}><TerminalSquare className="h-4 w-4" /></Button>
+              {/* A session blocked on the human outranks the live-run count — that's the one that needs you. */}
+              {waitingMine > 0
+                ? <RailBadge count={waitingMine} tone="bg-indigo-600 text-white" title={`${waitingMine} session${waitingMine === 1 ? '' : 's'} waiting for your input`} />
+                : <RailBadge count={runningSessions} tone="bg-emerald-500 text-white" title={`${runningSessions} session${runningSessions === 1 ? '' : 's'} running`} />}
+            </span>
           </nav>
         </aside>
       )}


### PR DESCRIPTION
The collapsed sidebar (48px rail) showed no notification count or visual indicator at all — every signal the expanded sidebar carries (Inbox approval badge, running-session count, per-session "Claude is waiting on you" bell) disappeared on collapse, so you could sit with pending approvals and never know.

The rail's icons now carry corner pips:
- **Inbox** — amber count of items needing a decision (`isActionRequired`); when there's nothing to decide but something unread, a plain dot instead.
- **Sessions** — indigo count of *my* sessions blocked on me (the `waiting` set), which outranks and falls back to the emerald live-run count (same number as the expanded "All" badge).

Tooltips spell the counts out ("Sessions — 2 waiting on you").

Validated: `tsc -b` + `vite build` clean, `npm run test:governance` 68/68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01787qeWRiADDLy4aPzYRREQ