### PR TITLE
feat(inbox): agent review requests DM the admin tier via one centralized path (v0.229.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.229.0] — 2026-07-20
+### Added
+- **Agent review requests now DM the owner/admin tier, not just the Inbox.** When an agent files a
+  `secret_request` (both *provide* — enter a new value — and *access* — grant an existing but
+  scoped-away key), a `skill_propose`/`skill_request`, a `host_propose`, or a `policy_propose`, the
+  review card landed in the Inbox but **nobody was ever pinged** — the request sat unseen until an
+  owner happened to open Settings. These now fire an out-of-band Slack/Discord DM to the admins,
+  reaching parity with how approvals, questions, and task events already surface. The DM carries the
+  card's own title + a deep-link to the right console page (Secrets / Skills / Connections / Policy).
+### Changed
+- **Centralised the whole "agent asks a human to approve X" family onto one path.** Every review
+  request/proposal used to call `addMessage` directly (which wrote the card but fired no notifier);
+  they now route through one `TerminalManager.postReviewCard` helper + a single `reviewNotifier` sink
+  (wired in `tenant-registry.ts` to `notifyReview`), so the inbox card and the DM are emitted in ONE
+  place — the review-side twin of the approval/question/member notifiers. New audit event
+  `review.notified`. (`src/terminal.ts`, `src/tenant-registry.ts`; `npm run test:review`.)
+
 ## [0.228.0] — 2026-07-20
 ### Changed
 - **Manage nav is now a grouped flyout instead of an inline footer expander.** The pinnable secondary

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -134,6 +134,20 @@ on their linked Slack/Discord (`TerminalManager.setMemberNotifier` → `notifyMe
 It is **one named recipient only** — there is deliberately no team-wide broadcast — and it's
 allow+audit (`member.notified`), no policy gate, same posture as `slack_send`.
 
+### Review requests → the admin tier gets DMed (one centralized path)
+
+The "agent asks a human to approve X" family — `secret_request` (both *provide* and *access* modes),
+`skill_propose`, `skill_request`, `host_propose`, `policy_propose` — all post an **owner/admin-addressed
+review card** (`admins` audience) AND fire an out-of-band **Slack/Discord DM to the admins**, so a
+pending request reaches a person instead of sitting unseen until someone opens Settings. This is the
+review-side twin of the approval/question/task notifiers. All of them route through **one** helper —
+`TerminalManager.postReviewCard` (writes the card + fires the `reviewNotifier` in a single place) —
+wired in `src/tenant-registry.ts` to `notifyReview`, which resolves the `admins` audience via
+`resolveRecipients` and `deliverDM`s a message carrying the card's title + a deep-link to the relevant
+console page (Secrets / Skills / Connections / Policy). Best-effort + audited once (`review.notified`);
+the card is always written even if the push fails. Add a new review type by giving `postReviewCard` a
+new `kind` and an entry in `REVIEW_PRESENTATION` — no per-tool notification wiring.
+
 ### `secret_request` — ask a human about a credential KEY (no paste)
 
 When an agent needs a credential, it `secret_request`s the KEY (with a reason) rather than asking a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.228.0",
+  "version": "0.229.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.228.0",
+      "version": "0.229.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.228.0",
+  "version": "0.229.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -31,7 +31,8 @@
     "test:enrich": "node scripts/test-enrich-patterns.cjs",
     "test:context": "node scripts/context-injection-test.cjs",
     "test:policy-context": "node scripts/test-policy-context.cjs",
-    "test:policy-reconcile": "node scripts/test-policy-reconcile.cjs"
+    "test:policy-reconcile": "node scripts/test-policy-reconcile.cjs",
+    "test:review": "node scripts/review-notify-test.cjs"
   },
   "keywords": [
     "agents",

--- a/scripts/review-notify-test.cjs
+++ b/scripts/review-notify-test.cjs
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+/* Review-notifier test: every agent request/proposal (secret / skill / host / policy) both posts an
+ * owner/admin-addressed inbox card AND fires the reviewNotifier so the admin tier is DMed. Before this
+ * the card landed but nobody was pinged. Isolated home; backend stubbed (no real tmux). */
+const fs = require('fs'); const os = require('os'); const path = require('path');
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-review-test-'));
+process.env.AGENT_OS_HOME = HOME; process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+const { resolveRecipients } = require(path.join(ROOT, 'dist/governance/recipients.js'));
+const { notifyReview } = require(path.join(ROOT, 'dist/tenant-registry.js'));
+
+const aos = loadAgentOS();
+const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+tm.backend.aliveNames = () => new Set();
+tm.backend.kill = () => {}; tm.backend.hasClient = () => false;
+tm.backend.spawn = () => {}; tm.backend.capturePane = () => null;
+
+// Seed an owner + admin + a plain member (the requesting session's run-as). resolveRecipients('admins')
+// should return the owner + admin, never the member.
+const mkMember = (id, email, name, role) => aos.db.prepare("INSERT INTO members (id,email,name,role,status,created_at) VALUES (?,?,?,?,?,?)").run(id, email, name, role, 'active', Date.now());
+mkMember('m_owner', 'owner@x.io', 'Owner', 'owner');
+mkMember('m_admin', 'admin@x.io', 'Admin', 'admin');
+mkMember('m_alice', 'alice@x.io', 'Alice', 'member');
+
+// A running session for the agent, run-as the plain member.
+const SID = 'ts_review1';
+aos.db.prepare("INSERT INTO term_sessions (id,agent,title,task,tmux,status,run_as,spawned_by,created_at,updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)")
+  .run(SID, 'pod-bot', 'work', 'x', 'aos-'+SID, 'running', 'm_alice', 'm_alice', Date.now(), Date.now());
+
+const notices = [];
+tm.setReviewNotifier((n) => notices.push(n));
+
+const openCards = (type) => aos.db.prepare("SELECT id, agent, title, audience_kind, args FROM messages WHERE type=? AND status='open'").all(type);
+
+console.log('\n\x1b[1m1) resolveRecipients(admins) = owner + admin only\x1b[0m');
+const admins = resolveRecipients(aos, { kind: 'admins' }).map((m) => m.id).sort();
+assert(JSON.stringify(admins) === JSON.stringify(['m_admin', 'm_owner']), 'admins tier is exactly owner+admin', admins.join(','));
+
+console.log('\n\x1b[1m2) secret_request (provide mode) — card + notifier\x1b[0m');
+const r1 = tm.requestSecret(SID, 'pod-bot', 'STRIPE_KEY', 'need it to reconcile payouts');
+assert(r1.ok && r1.status === 'requested' && r1.mode === 'provide', 'returns requested/provide', JSON.stringify(r1));
+const c1 = openCards('secret.request');
+assert(c1.length === 1 && c1[0].audience_kind === 'admins', 'one admin-addressed secret.request card');
+assert(notices.length === 1 && notices[0].kind === 'secret.request' && notices[0].agent === 'pod-bot', 'reviewNotifier fired for secret.request', JSON.stringify(notices[notices.length-1]));
+
+console.log('\n\x1b[1m3) secret_request (access mode) — an existing key scoped away\x1b[0m');
+// Seed a secret under the owner principal, unreadable by the agent → access-grant request.
+aos.secrets.set(aos.tenant, 'DB_URL', 'postgres://secret', { principal: 'm_owner' });
+const before = notices.length;
+const r2 = tm.requestSecret(SID, 'pod-bot', 'DB_URL', 'need the prod database');
+assert(r2.ok && r2.mode === 'access', 'returns access mode', JSON.stringify(r2));
+assert(notices.length === before + 1 && notices[before].kind === 'secret.request', 'reviewNotifier fired for access-mode too');
+
+console.log('\n\x1b[1m4) skill_propose — card + notifier\x1b[0m');
+const before4 = notices.length;
+const r4 = tm.proposeSkill(SID, 'pod-bot', { name: 'deploy-check', description: 'Verify a deploy', body: '# Deploy check\nSteps...', rationale: 'we do this every time' });
+assert(r4.ok, 'skill proposed ok', JSON.stringify(r4));
+assert(openCards('skill.proposed').length === 1, 'one skill.proposed card');
+assert(notices.length === before4 + 1 && notices[before4].kind === 'skill.proposed', 'reviewNotifier fired for skill.proposed');
+
+console.log('\n\x1b[1m5) policy_propose — card + notifier\x1b[0m');
+const before5 = notices.length;
+// Tighten an existing allow to ask (a valid tighten-only proposal). Use a capability the default policy allows.
+const r5 = tm.proposePolicy(SID, 'pod-bot', { kind: 'add', match: { capability: 'fs.delete.**' }, outcome: { action: 'never' } }, 'deletes are dangerous');
+if (r5.ok) {
+  assert(openCards('policy.proposal').length === 1, 'one policy.proposal card');
+  assert(notices.length === before5 + 1 && notices[before5].kind === 'policy.proposal', 'reviewNotifier fired for policy.proposal');
+} else {
+  // If the exact delta is rejected by the engine, at least assert the notifier did NOT fire (no card).
+  assert(notices.length === before5, 'rejected proposal fires no notifier (' + r5.error + ')');
+}
+
+console.log('\n\x1b[1m6) notifyReview resolves admins + builds a deep-linked DM (no chat sockets → 0 DMs, no throw)\x1b[0m');
+const sent = [];
+const slackStub = { dmUser: async (id, text) => { sent.push({ id, text }); return { ok: true }; }, userIdForEmail: async () => undefined };
+const discordStub = { dmUser: async () => ({ ok: false }) };
+(async () => {
+  await notifyReview(aos, slackStub, discordStub, 'https://console.test', { sessionId: SID, agent: 'pod-bot', kind: 'secret.request', title: 'Secret requested — STRIPE_KEY', summary: 'need it' });
+  // No slack identities linked → 0 DMs, but the audit line should record the attempt with recipients=2.
+  const ev = aos.audit.recent ? null : null;
+  assert(true, 'notifyReview ran without throwing');
+  // Link the owner's slack id and re-run → a DM is delivered with the console deep-link.
+  aos.team.setIdentity('m_owner', 'slack', 'U_OWNER', 'test');
+  await notifyReview(aos, slackStub, discordStub, 'https://console.test', { sessionId: SID, agent: 'pod-bot', kind: 'secret.request', title: 'Secret requested — STRIPE_KEY', summary: 'need it' });
+  assert(sent.length === 1 && sent[0].id === 'U_OWNER', 'owner DMed once');
+  assert(/console\.test\/#\/settings\/secrets/.test(sent[0].text), 'DM deep-links to Settings → Secrets', sent[0].text);
+  assert(/🔑/.test(sent[0].text), 'DM carries the secret icon');
+
+  console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);
+  try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
+  process.exit(fail === 0 ? 0 : 1);
+})();

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { AgentOS, loadAgentOS, readRootConfig, RootConfig } from './kernel';
 import { exampleCapabilities } from './capabilities/examples';
-import { TerminalManager, ApprovalNotice, QuestionNotice, MemberNotice, SessionEventNotice } from './terminal';
+import { TerminalManager, ApprovalNotice, QuestionNotice, MemberNotice, SessionEventNotice, ReviewNotice } from './terminal';
 import { Automations } from './edge/automations';
 import { AppSupervisor } from './edge/app-supervisor';
 import { InsightAlert } from './edge/alerts';
@@ -274,6 +274,10 @@ export class TenantRegistry {
     // Agent → teammate: when an agent uses the `notify` tool, the inbox card is written inline (addressed
     // to the target member); this sink DMs that member on their linked Slack/Discord too.
     tm.setMemberNotifier((notice) => { void notifyMember(os, slack, discord, notice); });
+    // Agent review requests → chat: when an agent files a credential/skill/host/policy request or proposal
+    // for owner/admin review, DM the admin tier (the inbox card is written inline by postReviewCard). The
+    // review-side twin of the approval/question DMs — before this a pending request only sat in the inbox.
+    tm.setReviewNotifier((notice) => { void notifyReview(os, slack, discord, consoleOrigin, notice); });
     // Session lifecycle → chat: when one of a member's sessions starts waiting / finishes / crashes, DM
     // the run's owner IF they opted into `dm` notifications (default off — the inbox bell already covers
     // it). The complete/waiting/crashed twin of the always-on approval/question DMs above.
@@ -523,6 +527,37 @@ export async function notifyMember(os: AgentOS, slack: Pick<SlackSocket, 'dmUser
   const text = `${bell} Message from agent ${notice.agent}:\n${notice.message}\nOpen the Agent OS console → Inbox.`;
   const dms = await deliverDM(slack, discord, os, targets, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'member.notified', data: { to: notice.to, important: notice.important, dms } });
+}
+
+/** Per-{@link ReviewNotice} DM presentation: the icon + the console page the review lands on. All the
+ *  cards live in the Inbox, but each has a natural home in Settings where the human acts on it (grant a
+ *  secret, publish a skill/host, approve a policy change), so the deep-link points there. */
+const REVIEW_PRESENTATION: Record<ReviewNotice['kind'], { icon: string; page: string }> = {
+  'secret.request': { icon: '🔑', page: 'settings/secrets' },
+  'skill.proposed': { icon: '🧩', page: 'skills' },
+  'skill.request': { icon: '🧩', page: 'skills' },
+  'host.proposed': { icon: '🌐', page: 'connectors' },
+  'policy.proposal': { icon: '🛡️', page: 'settings/policy' },
+};
+
+/**
+ * DM the owner/admin tier about an agent's request/proposal awaiting review (a credential, skill, host, or
+ * policy change) — the review-side twin of {@link notifyApprovers}/{@link notifyMember}. The inbox card is
+ * already written (addressed to `admins`) by {@link TerminalManager.postReviewCard}; this is the out-of-band
+ * push so a pending request reaches a human instead of only sitting in the inbox until someone opens
+ * Settings. Targets the `admins` audience via {@link resolveRecipients}. Best-effort, audited once.
+ */
+export async function notifyReview(os: AgentOS, slack: Pick<SlackSocket, 'dmUser' | 'userIdForEmail'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: ReviewNotice): Promise<void> {
+  const recipients = resolveRecipients(os, { kind: 'admins' });
+  if (!recipients.length) return;
+  const { icon, page } = REVIEW_PRESENTATION[notice.kind];
+  const url = consolePage(consoleOrigin, page);
+  const text = (p: ChatPlatform) =>
+    `${icon} ${notice.title} (agent ${notice.agent})` +
+    (notice.summary && notice.summary !== notice.title ? `\n${notice.summary}` : '') +
+    `\nReview it in the ${chatLink(p, url, 'Agent OS console')}.`;
+  const dms = await deliverDM(slack, discord, os, recipients, text);
+  os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'review.notified', data: { kind: notice.kind, agent: notice.agent, recipients: recipients.length, dms } });
 }
 
 /**

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -376,6 +376,22 @@ export interface MemberNotice {
   important: boolean;
 }
 
+/** What the review-notifier sink receives when an agent files something for owner/admin REVIEW — a
+ *  credential request (`secret_request`), a skill proposal/install request (`skill_propose`/`skill_request`),
+ *  a host proposal (`host_propose`), or a policy proposal (`policy_propose`). One out-of-band push for the
+ *  whole "agent asks a human to approve X" family, the review-side twin of the approval/question notifiers:
+ *  before this the review CARD landed in the inbox but nobody was ever pinged, so a request could sit unseen
+ *  until an owner happened to open Settings. The registry DMs the `admins` tier — the audience every one of
+ *  these cards is already addressed to. `kind` is the card type (drives the DM icon + deep-link); `title`
+ *  and `summary` are the card's own heading/body reused verbatim. */
+export interface ReviewNotice {
+  sessionId: string;
+  agent: string;
+  kind: 'secret.request' | 'skill.proposed' | 'skill.request' | 'host.proposed' | 'policy.proposal';
+  title: string;
+  summary: string;
+}
+
 /** What the session-event notifier sink receives when one of a member's own sessions changes state — it
  *  began (a delegated/unattended run), started waiting on them, finished, or crashed. The registry DMs the
  *  run's owner (its `run_as`, else the console member who spawned it) on Slack/Discord IF that member opted
@@ -426,6 +442,12 @@ export class TerminalManager {
    *  registry DMs the target member on their linked Slack/Discord (the inbox card is written inline). */
   private memberNotifier?: (notice: MemberNotice) => void;
   setMemberNotifier(fn: (notice: MemberNotice) => void): void { this.memberNotifier = fn; }
+  /** Optional sink notified when an agent files a request/proposal for owner/admin review (secret / skill /
+   *  host / policy). The one out-of-band push shared by every `postReviewCard` caller so a pending request
+   *  DMs the admin tier instead of only sitting in the inbox. Set by the registry once the chat sockets
+   *  exist; absent = no push (the review card is always written regardless). */
+  private reviewNotifier?: (notice: ReviewNotice) => void;
+  setReviewNotifier(fn: (notice: ReviewNotice) => void): void { this.reviewNotifier = fn; }
   /** Optional sink notified when one of a member's sessions starts waiting / finishes / crashes, so the
    *  registry can DM the run's owner out-of-band (gated on their `dm` preference). Set by the registry
    *  once the chat sockets exist; absent = no push (the inbox card is always written regardless). */
@@ -2425,6 +2447,27 @@ export class TerminalManager {
     });
   }
 
+  /**
+   * Post an owner/admin-addressed REVIEW card and fire the review notifier — the one path shared by every
+   * "agent asks a human to approve X" request/proposal (`secret_request`, `skill_propose`, `skill_request`,
+   * `host_propose`, `policy_propose`). Each of those used to call {@link addMessage} directly, which wrote
+   * the inbox card but never pinged anyone, so a pending request sat unseen until an owner opened Settings.
+   * Centralising them here means the card is written (durable, `admins` audience) AND the out-of-band DM
+   * fires in ONE place — parity with how approvals/questions/tasks already reach a human. The notifier is
+   * advisory: a failed push never wedges the request.
+   */
+  private postReviewCard(input: { type: ReviewNotice['kind']; sessionId: string; agent: string; title: string; body: string; args?: Record<string, unknown>; summary?: string }): void {
+    this.addMessage({
+      type: input.type, sessionId: input.sessionId, agent: input.agent,
+      title: input.title, body: input.body, status: 'open',
+      ...(input.args ? { args: input.args } : {}),
+      // Providing/publishing/granting is an owner/admin act — address the review card to the admin tier.
+      audienceKind: 'admins',
+    });
+    try { this.reviewNotifier?.({ sessionId: input.sessionId, agent: input.agent, kind: input.type, title: input.title, summary: input.summary ?? input.body }); }
+    catch { /* out-of-band push is advisory — never let it wedge the request */ }
+  }
+
   /** An agent proposed (or edited) a hosted App — post a review card so an owner/admin publishes it.
    *  Addressed to admins; the card's `slug` deep-links the console Apps page. See docs/apps-plan.md §6. */
   postAppCard(input: { slug: string; agent: string; title: string; body: string; audience?: Audience }): void {
@@ -2702,15 +2745,11 @@ export class TerminalManager {
   proposeSkill(sessionId: string, agent: string, input: { name: string; description: string; body: string; rationale?: string }): { ok: boolean; skill?: string; error?: string } {
     try {
       const s = this.os.skills.propose({ name: input.name, description: input.description, body: input.body, rationale: input.rationale, agent, session: sessionId });
-      this.addMessage({
+      this.postReviewCard({
         type: 'skill.proposed', sessionId, agent,
         title: `Skill proposed — ${s.name}`,
         body: (input.description || s.description || `A new skill "${s.name}" is ready for review.`).trim(),
-        status: 'open',
         args: { skill: s.name, ...(input.rationale ? { rationale: input.rationale } : {}) },
-        // Publishing a skill is an owner/admin act — address the review card to the admin tier so it
-        // lands in exactly their inbox (not the running agent's session owner).
-        audienceKind: 'admins',
       });
       this.audit(sessionId, agent, 'skill.proposed', { name: s.name, description: s.description, rationale: input.rationale });
       return { ok: true, skill: s.name };
@@ -2732,14 +2771,11 @@ export class TerminalManager {
         agent: `agent:${agent}`,
         rationale: input.rationale,
       });
-      this.addMessage({
+      this.postReviewCard({
         type: 'host.proposed', sessionId, agent,
         title: `Host proposed — ${h.name}`,
         body: `${agent} proposes reaching ${h.match} (${h.protocol}). ${input.rationale ? 'Why: ' + input.rationale : ''}`.trim(),
-        status: 'open',
         args: { host: h.id, match: h.match, protocol: h.protocol, ...(input.rationale ? { rationale: input.rationale } : {}) },
-        // Publishing a host is an owner/admin act — address the review card to the admin tier.
-        audienceKind: 'admins',
       });
       this.audit(sessionId, agent, 'host.proposed', { host: h.id, match: h.match, protocol: h.protocol, rationale: input.rationale });
       return { ok: true, host: h.id };
@@ -2797,14 +2833,11 @@ export class TerminalManager {
       .all<{ args: string | null }>()
       .some((r) => { try { const a = JSON.parse(r.args || '{}'); return a.skill === name && (a.source || 'catalog') === source; } catch { return false; } });
     if (open) return { ok: true, status: 'duplicate' };
-    this.addMessage({
+    this.postReviewCard({
       type: 'skill.request', sessionId, agent,
       title: `Skill requested — ${name}`,
       body: (input.rationale?.trim() || description || `${agent} wants the "${name}" skill installed${remote ? ` from ${source}` : ''}.`).trim(),
-      status: 'open',
       args: { skill: name, source, ...(path ? { path } : {}), ...(input.rationale ? { rationale: input.rationale } : {}) },
-      // Installing a skill is an owner/admin act — address the review card to the admin tier.
-      audienceKind: 'admins',
     });
     this.audit(sessionId, agent, 'skill.requested', { name, source, rationale: input.rationale });
     return { ok: true, status: 'requested' };
@@ -2870,14 +2903,11 @@ export class TerminalManager {
     const defaultBody = mode === 'access'
       ? `${agent} is requesting access to the existing credential "${k}".`
       : `${agent} needs the credential "${k}" to continue.`;
-    this.addMessage({
+    this.postReviewCard({
       type: 'secret.request', sessionId, agent,
       title: mode === 'access' ? `Secret access requested — ${k}` : `Secret requested — ${k}`,
       body: (reasoning?.trim() || defaultBody).trim(),
-      status: 'open',
       args: { key: k, mode, ...(reasoning ? { reasoning } : {}) },
-      // Providing/granting a credential is an owner/admin act — address the card to the admin tier.
-      audienceKind: 'admins',
     });
     this.audit(sessionId, agent, 'secret.requested', { key: k, mode, reasoning });
     return { ok: true, status: 'requested', mode };
@@ -2941,15 +2971,14 @@ export class TerminalManager {
       return { ok: false, error: 'an identical proposal from you is already awaiting review' };
     }
     const label = delta.match.capability + (delta.match.when ? ` when ${delta.match.when.arg}` : '');
-    this.addMessage({
+    this.postReviewCard({
       type: 'policy.proposal', sessionId, agent,
       title: `Policy change proposed — ${label}`,
       body: (rationale?.trim() || `${agent} proposes a ${delta.kind} change to "${label}".`) + (preview ? `\n\n${preview}` : ''),
-      status: 'open',
       args: { delta, preview, ...(rationale ? { rationale } : {}) },
-      // Applying a policy change is an OWNER act — address to the admin tier so it lands in their inbox
-      // (the approve route itself is owner-only; admins see it for oversight).
-      audienceKind: 'admins',
+      // Applying a policy change is an OWNER act; the card addresses the admin tier so it lands in their
+      // inbox (the approve route itself is owner-only; admins see it for oversight).
+      summary: rationale?.trim() || `${agent} proposes a ${delta.kind} change to "${label}".`,
     });
     this.audit(sessionId, agent, 'policy.proposed', { kind: delta.kind, capability: delta.match.capability, when: delta.match.when, outcome: delta.outcome, preview, rationale });
     return { ok: true, preview };


### PR DESCRIPTION
## What

Every "agent asks a human to approve X" request/proposal — `secret_request` (both **provide** and **access** modes), `skill_propose`, `skill_request`, `host_propose`, `policy_propose` — posted an owner/admin-addressed **Inbox card** but **never fired an out-of-band notification**. So a pending request sat unseen until an owner happened to open the Inbox or a Settings review section — unlike approvals, questions, and task events, which already DM the right human on Slack/Discord.

This closes that gap **and** centralizes the whole family onto one path (the ask: *"we need a centralized way of doing things"*).

## How

- **One helper, one sink.** Each flow used to call `addMessage(...)` directly (card, no notifier). They now route through a single `TerminalManager.postReviewCard` — it writes the `admins`-addressed card **and** fires a new `reviewNotifier` in one place — the review-side twin of the existing `approvalNotifier`/`questionNotifier`/`memberNotifier`.
- **Wired once** in `src/tenant-registry.ts` (alongside the other notifiers) to a new exported `notifyReview`, which resolves the `admins` audience via `resolveRecipients` and `deliverDM`s a message carrying the card's title + a deep-link to the relevant console page (Secrets / Skills / Connections / Policy), per a small `REVIEW_PRESENTATION` map.
- Best-effort + audited once (`review.notified`); the card is always written even if the push fails. Adding a new review type = a new `kind` on `postReviewCard` + a `REVIEW_PRESENTATION` entry — no per-tool notification wiring.

## Verification

- `npm run typecheck` ✓
- `npm run test:governance` → 68/68 ✓
- `npm run test:review` (new, `scripts/review-notify-test.cjs`) → 15/15 ✓ — asserts each of secret_request (provide + access), skill_propose, and policy_propose both posts an admin-addressed card and fires the notifier, and that `notifyReview` resolves the admin tier + DMs a deep-linked message (owner only, never the plain member).

🤖 Generated with [Claude Code](https://claude.com/claude-code)