### PR TITLE
fix(memory): mirror recall reinforcement + surface automem error bodies (v0.229.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.229.1] — 2026-07-20
+### Fixed
+- **Memory recall reinforcement was invisible under an external backend — every mirrored memory read
+  as never-recalled forever.** All three production tenants run the `automem` backend, so recall is
+  served by automem while the OS's SQL-level machinery (prune, Dreaming, the consolidation gardener,
+  the Memory-hub "never recalled" count) reads the local `memories` **mirror** table. But
+  `MirroredMemoryProvider.recall` delegated straight to the backend and never bumped the mirror's
+  `recall_count`/`last_recalled_at` — so fleet-wide the mirror showed **100% of memories as
+  never-recalled** (235/235, 692/692, 144/144; avg recall 0). Two consequences: the Memory-hub health
+  metric was meaningless, and `maintain()`'s prune (`DELETE … WHERE recall_count = 0 AND importance <
+  keep`) would delete memories recalled hundreds of times in the real store. Recall now reinforces the
+  mirror for the returned ids (same gate as the SQLite provider — a real query with results, not a
+  blank recency listing), via a new public `SqliteMemoryProvider.reinforce(ids)`. Best-effort: a mirror
+  failure never fails a recall.
+- **`automem` request failures swallowed the response body, making the recurring `→ 400` opaque.** The
+  fleet logged 140+ `episode.error` events of the bare form `automem POST /memory → 400` with no clue
+  *why* automem rejected the write. The thrown error now appends a snippet of the response body (where a
+  4xx validation reject spells out the reason), so the store-failure/`episode.error` audit becomes
+  diagnosable.
+
 ## [0.229.0] — 2026-07-20
 ### Added
 - **Agent review requests now DM the owner/admin tier, not just the Inbox.** When an agent files a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.229.0",
+  "version": "0.229.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.229.0",
+      "version": "0.229.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.229.0",
+  "version": "0.229.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/automem-provider.ts
+++ b/src/memory/automem-provider.ts
@@ -227,7 +227,12 @@ export class AutomemMemoryProvider implements MemoryProvider {
         body: body ? JSON.stringify(body) : undefined,
         signal: ctrl.signal,
       });
-      if (!res.ok) throw new Error(`automem ${method} ${pathName} → ${res.status}`);
+      if (!res.ok) {
+        // Include a snippet of the response body: a 4xx (esp. a 400 validation reject) carries the
+        // reason there, and it's the only breadcrumb the `episode.error`/store-failure audit gets.
+        const detail = await res.text().catch(() => '');
+        throw new Error(`automem ${method} ${pathName} → ${res.status}${detail ? ` ${detail.slice(0, 200)}` : ''}`);
+      }
       return await res.json();
     } finally {
       clearTimeout(timer);

--- a/src/memory/mirror.ts
+++ b/src/memory/mirror.ts
@@ -34,9 +34,21 @@ export class MirroredMemoryProvider implements MemoryProvider {
     return rec;
   }
 
-  /** Recall is the backend's job — the reason to run a non-SQLite store at all. */
-  recall(q: RecallQuery): Promise<MemoryRecord[]> {
-    return this.backend.recall(q);
+  /**
+   * Recall is the backend's job — the reason to run a non-SQLite store at all. But the reinforcement
+   * signal (recall_count/last_recalled_at) lands only in the external store, while the OS's SQL-level
+   * machinery — prune, Dreaming, consolidation, the Memory-hub counts — reads the local mirror table.
+   * So we mirror the usage bump too: reinforce the returned ids in the mirror (same gate as the sqlite
+   * provider — a real query with results, not a blank recency listing). Without this the mirror shows
+   * EVERY memory as never-recalled forever, and `maintain()`'s prune (`WHERE recall_count = 0`) could
+   * delete memories recalled hundreds of times in the backend. Best-effort: never fail a recall.
+   */
+  async recall(q: RecallQuery): Promise<MemoryRecord[]> {
+    const out = await this.backend.recall(q);
+    if (q.query && out.length) {
+      try { this.mirror.reinforce(out.map((r) => r.id)); } catch { /* mirror is best-effort */ }
+    }
+    return out;
   }
 
   async update(input: UpdateInput): Promise<MemoryRecord | null> {

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -162,13 +162,22 @@ export class SqliteMemoryProvider implements MemoryProvider {
     const out = recs.slice(0, limit);
     // Usage tracking for maintenance: count a memory as "used" when an actual query surfaces it (not a
     // blank recency listing), so prune can safely target the never-recalled.
-    if (q.query && out.length) {
-      const ids = out.map((r) => r.id);
-      this.db
-        .prepare(`UPDATE memories SET recall_count = recall_count + 1, last_recalled_at = ? WHERE id IN (${ids.map(() => '?').join(',')})`)
-        .run(Date.now(), ...ids);
-    }
+    if (q.query && out.length) this.reinforce(out.map((r) => r.id));
     return out;
+  }
+
+  /**
+   * Bump `recall_count`/`last_recalled_at` for a set of ids — the usage signal prune relies on. Called
+   * internally by `recall`, and PUBLICLY by MirroredMemoryProvider when a non-SQLite backend served the
+   * recall: without this the mirror table (which Dreaming, consolidation, prune, and the Memory-hub
+   * counts all read directly) would show every memory as never-recalled forever, so prune could delete
+   * rows recalled hundreds of times in the real backend. No-op on an empty list.
+   */
+  reinforce(ids: string[]): void {
+    if (!ids.length) return;
+    this.db
+      .prepare(`UPDATE memories SET recall_count = recall_count + 1, last_recalled_at = ? WHERE id IN (${ids.map(() => '?').join(',')})`)
+      .run(Date.now(), ...ids);
   }
 
   async maintain(opts: MemoryMaintenance): Promise<MemoryMaintenanceResult> {


### PR DESCRIPTION
## Fleet-insights run — 2026-07-20

Mined 639 agent sessions across all three production tenants (instapods 127, instawp 444, expresstech 68, 30-day window). Two well-evidenced, cross-tenant, low-risk fixes shipped; the rest is surfaced below.

### 🔴 Shipped 1 — Memory recall reinforcement was invisible under an external backend
**Evidence (all three tenants):** `memoryHealth` reported **100% of memories never-recalled** — instapods 235/235, instawp 692/692, expresstech 144/144, avg recall 0. All three run the `automem` backend (confirmed from `settings.memory_config`), so every tenant is wrapped by `MirroredMemoryProvider`.

**Root cause:** `MirroredMemoryProvider.recall` delegated straight to the backend and never bumped the local mirror table's `recall_count`/`last_recalled_at`. But the OS's SQL-level machinery — `maintain()` prune, Dreaming, the consolidation gardener, and the Memory-hub "never recalled" count — all read the mirror table directly. So the reinforcement signal only ever landed in automem, and the mirror showed every memory as never-recalled forever.

**Impact:** (1) the Memory-hub health metric was meaningless; (2) `maintain()`'s prune (`DELETE … WHERE recall_count = 0 AND importance < keep`) would delete memories recalled hundreds of times in the real store — silent data loss whenever prune is enabled.

**Fix:** recall reinforces the mirror for the returned ids, gated exactly like the SQLite provider (a real query with results, not a blank recency listing), via a new public `SqliteMemoryProvider.reinforce(ids)`. Best-effort — a mirror failure never fails a recall.

### 🟠 Shipped 2 — `automem` request failures swallowed the response body
**Evidence:** 140+ `episode.error` audit events on instawp of the bare form `automem POST /memory → 400`, plus ~18 each on instapods/expresstech — no clue *why* automem rejected the write.

**Fix:** the thrown error now appends a snippet of the response body (a 4xx validation reject spells out the reason there), so the store-failure/`episode.error` audit becomes diagnosable. Pure observability; no behavior change on the success path.

### Verification
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ (untouched) · `npm run test:governance` → **68/68** ✓
- In-process mirror test: a recalled row is reinforced (recall_count 0→1, `last_recalled_at` set) while an unrelated row and a blank-query recency listing stay at 0.

### Proposed, not implemented (needs a human / a repro)
- **The automem 400 itself** (140 on instawp) — a payload/schema reject that likely means episodes aren't persisting to the external store. Can't reproduce blind against the three different automem deployments; Shipped-2 makes the next occurrence self-explain the cause. Recommend re-checking `episode.error` after this lands.
- **Discord reconnect churn** — `discord.connect.failed`: instapods 100 (`fetch failed`), expresstech 208 (`500 Internal Server Error`). The socket appears to retry a mis-provisioned/flapping Discord bot indefinitely, spamming audit. Wants a give-up/backoff cap in `discord-socket.ts` — deferred as it changes live-socket behavior and can't be validated from here.
- **58 pending (unanswered) `ask` questions** across tenants (13/32/13). Out-of-band notification already exists; this reads as a human-response gap, not a code bug.
- **`scheduler.deferred` volume** — instawp 9,476, expresstech 3,043. Likely the pile-up guard perpetually deferring an always-alive session; worth checking for a stuck automation, but the guard is behaving as designed.

> Bundles + transcripts contained customer data and were kept in the session scratchpad — never committed; this PR reasons over aggregates only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)