### PR TITLE
fix(console): show the update-available pill on the collapsed sidebar (v0.227.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.227.6] — 2026-07-20
+### Fixed
+- **Collapsed sidebar hid the "Update available" pill too.** The self-update notice only rendered in
+  the expanded sidebar, so a collapsed rail gave no sign the box was behind origin. The rail now shows
+  an amber download icon (with a pip) at its foot when an update is available, opening the same
+  update-and-restart dialog.
+
 ## [0.229.1] — 2026-07-20
 ### Fixed
 - **Memory recall reinforcement was invisible under an external backend — every mirrored memory read

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.229.1",
+  "version": "0.227.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.229.1",
+      "version": "0.227.6",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.229.1",
+  "version": "0.227.6",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -648,7 +648,7 @@ function RailDot({ tone = 'bg-primary', title }: { tone?: string; title: string 
  * preview and, for the owner, an "Update & restart" button that pulls + rebuilds + bounces the box;
  * the panel then waits for `/health` to report the new version and reloads the console.
  */
-function UpdateNotice() {
+function UpdateNotice({ compact = false }: { compact?: boolean } = {}) {
   const [status, setStatus] = useState<UpdateStatus | null>(null)
   const [open, setOpen] = useState(false)
   const [applying, setApplying] = useState(false)
@@ -685,14 +685,31 @@ function UpdateNotice() {
 
   return (
     <>
-      <button
-        onClick={() => setOpen(true)}
-        className="mt-1.5 flex w-full items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-left text-[11px] font-medium text-amber-700 ring-1 ring-amber-200 hover:bg-amber-100 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20"
-        title={`Update available: v${status.latest} (${status.behind} commit${status.behind === 1 ? '' : 's'} behind)`}
-      >
-        <Download className="h-3 w-3 shrink-0" />
-        <span className="truncate">Update available · v{status.latest}</span>
-      </button>
+      {compact ? (
+        // Collapsed-rail trigger: the pill has no room, so an amber icon button with a pulsing pip
+        // carries the same "update available" signal and opens the same dialog.
+        <span className="relative">
+          <Button
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8 text-amber-600 dark:text-amber-400"
+            onClick={() => setOpen(true)}
+            title={`Update available: v${status.latest} (${status.behind} commit${status.behind === 1 ? '' : 's'} behind)`}
+          >
+            <Download className="h-4 w-4" />
+          </Button>
+          <RailDot tone="bg-amber-500" title={`Update available · v${status.latest}`} />
+        </span>
+      ) : (
+        <button
+          onClick={() => setOpen(true)}
+          className="mt-1.5 flex w-full items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1 text-left text-[11px] font-medium text-amber-700 ring-1 ring-amber-200 hover:bg-amber-100 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20"
+          title={`Update available: v${status.latest} (${status.behind} commit${status.behind === 1 ? '' : 's'} behind)`}
+        >
+          <Download className="h-3 w-3 shrink-0" />
+          <span className="truncate">Update available · v{status.latest}</span>
+        </button>
+      )}
 
       {open && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={() => !applying && !restarting && setOpen(false)}>
@@ -1164,6 +1181,8 @@ function Console({ me }: { me: Member }) {
                 : <RailBadge count={runningSessions} tone="bg-emerald-500 text-white" title={`${runningSessions} session${runningSessions === 1 ? '' : 's'} running`} />}
             </span>
           </nav>
+          {/* Pinned to the bottom of the rail (renders nothing unless the checkout is behind origin). */}
+          <div className="mt-auto"><UpdateNotice compact /></div>
         </aside>
       )}
       <aside className={`${sidebarCollapsed ? 'hidden' : 'flex'} w-72 shrink-0 flex-col border-r bg-background`}>


### PR DESCRIPTION
Follow-up to #381. The self-update `UpdateNotice` only rendered its pill in the expanded sidebar, so once collapsed the rail gave no sign the box was behind origin.

Added a `compact` variant of `UpdateNotice`: an amber download icon with a `RailDot` pip, pinned to the foot of the collapsed rail (`mt-auto`), opening the exact same update-and-restart dialog. Renders nothing unless the checkout is behind origin, same as the pill.

Validated: `tsc -b` + `vite build` clean, `npm run test:governance` 68/68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01787qeWRiADDLy4aPzYRREQ