### PR TITLE
fix(console): live notifications survive a backgrounded tab, no reload needed (v0.227.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.227.7] — 2026-07-20
+### Fixed
+- **Live notifications went stale in an already-open tab — the inbox only updated after a page reload,
+  and the tab-title 🔔 badge / per-session "waiting" bells stopped lighting up.** The whole console's
+  live feed rides one 1.5s `setInterval` that refills sessions + messages; everything (tab badge,
+  waiting bells, sidebar counts) derives from those. Two flaws froze it: (1) the two fetches ran
+  sequentially and unguarded, so a single transient failure of the first (`api.sessions()`) blocked
+  the message refresh; and (2) browsers throttle/freeze `setInterval` in a backgrounded tab — exactly
+  when the tab badge matters most. The poll now runs both fetches independently (`Promise.allSettled`,
+  ignoring non-array error payloads so a blip can't clobber good state) and re-polls immediately on
+  tab `focus`/`visibilitychange`, so switching back to the console shows current state at once.
+
 ## [0.227.6] — 2026-07-20
 ### Fixed
 - **Collapsed sidebar hid the "Update available" pill too.** The self-update notice only rendered in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.227.6",
+  "version": "0.227.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.227.6",
+      "version": "0.227.7",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.227.6",
+  "version": "0.227.7",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -886,13 +886,37 @@ function Console({ me }: { me: Member }) {
   }, [])
 
   useEffect(() => {
+    let alive = true
+    // Live feed for the whole console: sessions + the inbox. Both the tab-title 🔔 badge and every
+    // per-session "waiting" bell derive purely from these two arrays, so this poll is the ONLY thing
+    // keeping them fresh — there's no SSE/socket fallback. Guardrails:
+    //  • run the two fetches in parallel and independently (allSettled) — a transient failure of one
+    //    must never block the other. A sequential `await sessions(); await messages()` froze the whole
+    //    feed for the rest of the session if the first call ever rejected (a 401/5xx blip through the
+    //    tailscale/nginx hop), which read as "notifications only show after a page reload".
+    //  • ignore a non-array payload — an error tick returns `{error}`, not a list; don't clobber good
+    //    state with garbage.
     const poll = async () => {
-      setSessions(await api.sessions())
-      setMessages(await api.messages())
+      const [s, m] = await Promise.allSettled([api.sessions(), api.messages()])
+      if (!alive) return
+      if (s.status === 'fulfilled' && Array.isArray(s.value)) setSessions(s.value)
+      if (m.status === 'fulfilled' && Array.isArray(m.value)) setMessages(m.value)
     }
     poll()
     const t = setInterval(poll, 1500)
-    return () => clearInterval(t)
+    // Browsers throttle (and eventually freeze) setInterval in a backgrounded tab — exactly when the
+    // tab-title badge / waiting bells matter most, since you're looking at another tab. Re-poll the
+    // instant the tab regains visibility or focus so coming back to the console shows current state
+    // immediately, instead of waiting on a throttled tick (or needing a reload).
+    const wake = () => { if (document.visibilityState === 'visible') poll() }
+    document.addEventListener('visibilitychange', wake)
+    window.addEventListener('focus', wake)
+    return () => {
+      alive = false
+      clearInterval(t)
+      document.removeEventListener('visibilitychange', wake)
+      window.removeEventListener('focus', wake)
+    }
   }, [])
 
   // Browser-tab badge: a 🔔 + the bell's unread count (waiting + completions + crashes + approvals +


### PR DESCRIPTION
## Problem
Notifications weren't updating live in an already-open console tab:
- The **inbox** only showed new notifications after a full page reload.
- The **tab-title 🔔 badge** and per-session **"waiting" bells** stopped lighting up.

## Root cause
The entire console live feed rides a single 1.5s `setInterval` (`App.tsx`) that refills `sessions` + `messages`; the tab badge, waiting bells, and sidebar counts are all pure derivations of those two arrays. Two flaws froze it:

1. **Sequential, unguarded fetches** — `setSessions(await api.sessions()); setMessages(await api.messages())`. If the first call ever rejected (a 401/5xx blip through the tailscale/nginx hop; `call()` doesn't check `res.ok`), the message refresh never ran that tick.
2. **Background-tab throttling** — browsers throttle and eventually freeze `setInterval` in a backgrounded tab, which is exactly when the tab-title badge is supposed to nag you.

## Fix
- Poll runs both fetches **independently** via `Promise.allSettled`, and ignores non-array payloads so an error tick can't clobber good state.
- Re-poll **immediately** on `focus` / `visibilitychange`, so returning to the console shows current state at once instead of waiting on a throttled tick (or needing a reload).

No server change; no new dependency. Web build + `test:governance` (68/68) pass.