### PR TITLE
fix(inbox): insight-alert cards deep-link to their page, not a dead session (v0.227.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.227.8] — 2026-07-20
+### Fixed
+- **Insight-alert cards in the Inbox had no useful action — clicking "Open" landed on a dead session
+  terminal.** The intelligence layer posts proactive alerts (a struggling agent, a capability that keeps
+  getting rejected, approvals piling up) as session-less `notification` cards keyed `insight:<key>`. The
+  console's `ActionItem` renderer treated every `notification` as "Claude is waiting in a session" and
+  hardcoded its button to `#/sessions/aos-insight:<key>` — a tmux name no session ever has, so the
+  session lookup returned null and the user got an empty/dead terminal. Alerts now carry a real in-app
+  target (`args.route`/`args.detail`): success-drop / struggling-agent / crashing-agent → **Insights**,
+  a rejected capability → **Settings › Policy**, pending approvals → **Inbox**. The card renders a
+  lightbulb "insight" style with a **View <page>** button that deep-links there (both the Inbox card and
+  the notification-bell/toast click path), and legacy cards with no route fall back to the Insights page.
+
 ## [0.227.7] — 2026-07-20
 ### Fixed
 - **Live notifications went stale in an already-open tab — the inbox only updated after a page reload,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.227.7",
+  "version": "0.227.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.227.7",
+      "version": "0.227.8",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.227.7",
+  "version": "0.227.8",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/alerts.ts
+++ b/src/edge/alerts.ts
@@ -14,7 +14,17 @@ import { measureLearning } from './measurement';
 
 const COOLDOWN_MS = 3 * 24 * 3_600_000; // don't re-alert the same key within 3 days
 
-export interface InsightAlert { key: string; severity: 'high' | 'medium'; title: string; body: string }
+export interface InsightAlert {
+  key: string;
+  severity: 'high' | 'medium';
+  title: string;
+  body: string;
+  /** Where the card's action should take the human — an in-app route (+ optional sub-detail) rather than
+   *  a session. Insight cards back NO session, so without this the console links "Open" to a phantom
+   *  `insight:<key>` session id → a dead terminal. */
+  route: string;
+  detail?: string;
+}
 
 /** Detect the conditions worth a human's attention right now (pure — no dedup, no side effects). */
 export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
@@ -29,6 +39,7 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
       severity: 'high',
       title: `Fleet success rate dropped ${Math.abs(m.deltaPp)} points`,
       body: `Success fell to ${m.recent.rate}% this week (${m.recent.n} runs) from ${m.prior.rate}% the week before. Check the Insights page for which agents regressed.`,
+      route: 'insights',
     });
   }
 
@@ -42,6 +53,7 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
         severity: 'high',
         title: `${a.agent} is failing (${a.rate}% success)`,
         body: `${a.agent} succeeded on only ${a.rate}% of ${a.runs} work runs in the last ${ins.windowDays} days (${a.failed} failed). Open Insights and "Diagnose" it to see the root cause.`,
+        route: 'insights',
       });
     }
     // Crashing = the process/pane keeps dying (infra: too heavy / OOM / timeout) — a different fix than
@@ -52,6 +64,7 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
         severity: 'high',
         title: `${a.agent}'s runs keep crashing`,
         body: `${a.crashed} of ${a.agent}'s runs crashed in the last ${ins.windowDays} days — the process died mid-run (usually too-heavy work, OOM, or a timeout), not a task failure. Scope its tasks smaller, or give it more headroom.`,
+        route: 'insights',
       });
     }
   }
@@ -64,6 +77,8 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
         severity: 'medium',
         title: `"${r.capability}" keeps getting rejected`,
         body: `${r.count} approvals for \`${r.capability}\` were rejected. If it should never run, deny it outright in Policy; if it's fine, auto-allow it — either way agents stop wasting runs asking.`,
+        route: 'settings',
+        detail: 'policy',
       });
     }
   }
@@ -76,6 +91,7 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
       severity: 'medium',
       title: `${ins.friction.pendingApprovals} approvals waiting on a human`,
       body: `${ins.friction.pendingApprovals} approvals are pending (oldest ${oldestH}h). Agents are blocked until someone resolves them — see the Inbox.`,
+      route: 'inbox',
     });
   }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2424,11 +2424,15 @@ export class TerminalManager {
 
   /** Post a proactive **insight alert** to the admins' Inbox — a session-less `notification` card the
    *  intelligence layer raises when something warrants attention (a struggling agent, recurring rejections).
-   *  Keyed by `insight:<key>` so it's a stable, de-dupable row. */
-  postInsightAlert(input: { key: string; title: string; body: string; severity: string }): void {
+   *  Keyed by `insight:<key>` so it's a stable, de-dupable row. `args.route`/`args.detail` deep-link the
+   *  card to the page that acts on it (Insights / Policy / Inbox) — the card backs NO session, so without
+   *  a route the console would link "Open" to the phantom `insight:<key>` session id and land on a dead
+   *  terminal. */
+  postInsightAlert(input: { key: string; title: string; body: string; severity: string; route: string; detail?: string }): void {
     this.addMessage({
       type: 'notification', sessionId: `insight:${input.key}`, agent: 'insights', title: input.title,
-      body: input.body, status: 'open', args: { key: input.key, severity: input.severity },
+      body: input.body, status: 'open',
+      args: { key: input.key, severity: input.severity, route: input.route, detail: input.detail },
       audienceKind: 'admins',
     });
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -569,6 +569,19 @@ function onNavClick(go: () => void) {
   }
 }
 
+/** An **insight-alert** card (posted by the intelligence layer via `postInsightAlert`) backs NO session —
+ *  its `sessionId` is the sentinel `insight:<key>`. So it must deep-link to the page that acts on it
+ *  (Insights / Policy / Inbox) via `args.route`/`args.detail`, never to `#/sessions/aos-insight:<key>`,
+ *  which resolves to no session and lands on a dead terminal. Returns the target, or null for an ordinary
+ *  session-backed notification. Legacy cards (predating the routed args) fall back to the Insights page. */
+function insightTarget(m: Msg): { route: Route; detail?: string; label: string } | null {
+  if (m.type !== 'notification' || !m.sessionId?.startsWith('insight:')) return null
+  const a = (m.args ?? {}) as { route?: string; detail?: string }
+  const route = (ROUTES as string[]).includes(a.route ?? '') ? (a.route as Route) : 'insights'
+  const label = a.detail === 'policy' ? 'Policy' : ROUTE_TITLES[route] ?? 'Insights'
+  return { route, detail: a.detail, label }
+}
+
 export default function App() {
   // undefined = checking, null = not logged in (show Login), Member = authed.
   const [me, setMe] = useState<Member | null | undefined>(undefined)
@@ -1101,6 +1114,9 @@ function Console({ me }: { me: Member }) {
       setMessages((ms) => ms.map((x) => (x.id === m.id ? { ...x, read: true } : x)))
       void api.markRead(m.id)
     }
+    // A proactive insight alert backs no session — route it to the page that acts on it, not a terminal.
+    const ins = insightTarget(m)
+    if (ins) { nav(ins.route, ins.detail); return }
     const kind = notifyKindOf(m)
     const sess = sessions.find((s) => s.id === m.sessionId)
     if ((kind === 'waiting' || kind === 'completed' || kind === 'crashed') && sess) openTerminal(sess.tmux)
@@ -3902,18 +3918,22 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
   const open = () => onOpen('aos-' + m.sessionId, m.agent + ' · ' + m.sessionId)
   const time = <span className="shrink-0 pt-0.5 text-[11px] tabular-nums text-muted-foreground">{timeAgo(m.createdAt)}</span>
 
-  // ── Notification (Claude is waiting on you — permission prompt / idle input) ──
+  // ── Notification — either "Claude is waiting on you" (session-backed) or a proactive insight alert
+  //    (session-less; deep-links to the page that acts on it, never to a phantom session terminal). ──
   if (m.type === 'notification') {
+    const ins = insightTarget(m)
     return (
       <div className="flex items-start gap-2.5 rounded-lg border border-indigo-300 bg-indigo-50/40 px-3 py-2.5">
-        <Bell className="mt-0.5 h-4 w-4 shrink-0 text-indigo-600" />
+        {ins ? <Lightbulb className="mt-0.5 h-4 w-4 shrink-0 text-indigo-600" /> : <Bell className="mt-0.5 h-4 w-4 shrink-0 text-indigo-600" />}
         <div className="min-w-0 flex-1">
-          <MsgHeading m={m}><span className="shrink-0 text-indigo-600">· waiting for you</span></MsgHeading>
+          <MsgHeading m={m}><span className="shrink-0 text-indigo-600">{ins ? '· insight' : '· waiting for you'}</span></MsgHeading>
           <div className="mt-1 whitespace-pre-line break-words text-xs text-muted-foreground"><InlineLinks text={m.body} /></div>
         </div>
         {time}
         <div className="flex shrink-0 gap-1">
-          <Button render={<a href={navHref('sessions', 'aos-' + m.sessionId)} />} size="sm" className="h-7 px-2.5 text-xs" onClick={onNavClick(open)}>Open</Button>
+          {ins
+            ? <Button render={<a href={navHref(ins.route, ins.detail)} />} size="sm" className="h-7 px-2.5 text-xs">View {ins.label}</Button>
+            : <Button render={<a href={navHref('sessions', 'aos-' + m.sessionId)} />} size="sm" className="h-7 px-2.5 text-xs" onClick={onNavClick(open)}>Open</Button>}
           <Button size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => onDismiss(m.id)}>Dismiss</Button>
         </div>
       </div>


### PR DESCRIPTION
## Problem
Notifications posted to the Inbox by **Insights** (the proactive intelligence layer) had no useful action — clicking **Open** took you to a **dead session terminal**.

## Root cause
Insight alerts (`postInsightAlert`) are *session-less* `notification` cards keyed with the sentinel `session_id = insight:<key>`. The console's `ActionItem` renderer treats every `notification` as "Claude is waiting in a session" and hardcodes its button to `#/sessions/aos-insight:<key>`. No session ever has that tmux name, so the session lookup returns `null` → an empty/dead terminal. The alert bodies said things like "Check the Insights page" / "deny it in Policy", but the card offered no link there.

## Fix
Give each alert a real in-app target and honor it in the console:

- **`src/edge/alerts.ts`** — `InsightAlert` gains `route` (+ optional `detail`): fleet success-drop / struggling-agent / crashing-agent → `insights`; a rejected capability → `settings`/`policy`; pending approvals → `inbox`.
- **`src/terminal.ts`** — `postInsightAlert` threads `route`/`detail` into the card's `args`.
- **`web/src/App.tsx`** — new `insightTarget(m)` helper detects an `insight:` card and resolves its `{route, detail, label}` (legacy cards with no route fall back to **Insights**). `ActionItem` renders these with a lightbulb "· insight" style and a **View <page>** button that deep-links to the right page instead of a session; the notification-bell/toast click path (`openNotification`) routes them the same way.

## Verification
- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 68/68 ✓
- Runtime: exercised `postInsightAlert` against a scratch DB — cards now persist `args` incl. `route`/`detail` (`{"key":"friction:shell.exec","severity":"medium","route":"settings","detail":"policy"}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)