### PR TITLE
feat(sessions): result, engaged duration + activity fingerprint in the session list (v0.232.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.232.0] — 2026-07-20
+### Added
+- **Session insights in the sessions list — result, engaged duration, and an activity fingerprint.**
+  The list could only say a run was `done`, which means the process exited, not that the work landed.
+  Every row (and grid card) now carries: **Result** — the agent's own verdict from its end-of-session
+  `report` (`success`/`failure`/`partial`), with the summary as a tooltip and as the card's one-liner;
+  a finished run that never reported reads **"no report"**, since nobody closing the loop is itself a
+  finding. **Took** — ENGAGED time read from the transcript with idle gaps excluded, because wall-clock
+  is not a usable duration (an interactive session idles between turns, so a 7-minute run routinely
+  spans 13 hours of `updated_at - created_at`). **Activity** — tool calls, approvals needed, denials
+  and errors, with tool calls leading since governed actions only count the subset the gate mediates.
+  Both new columns are sortable. Timing and volume fall out of the same transcript walk that already
+  prices a run; outcome and the governance counts are indexed lookups on the audit stream. Everything
+  stamps once when a run goes terminal and is never recomputed — live rows re-tally each poll, and a
+  pruned transcript stamps zeros instead of being re-probed on every list call forever.
+
 ## [0.231.1] — 2026-07-20
 ### Removed
 - **Reverted the agent learning-`velocity` metric (0.231.0).** Reverted because it was shipped a step

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.231.1",
+  "version": "0.232.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.231.1",
+      "version": "0.232.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.231.1",
+  "version": "0.232.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/session-cost.ts
+++ b/src/edge/session-cost.ts
@@ -1,10 +1,15 @@
-// What a claude-code session cost, derived from its transcript.
+// What a claude-code session cost — and how long it actually worked — derived from its transcript.
 //
 // Claude Code writes per-message token `usage` (but no dollar figure) into the session JSONL that
 // `conversation.ts` already locates by the pinned `claude_session_id`. This module reads that same
 // file, sums the usage across every assistant turn, and multiplies by per-model sticker rates to get
 // a USD cost. It is READ-ONLY and best-effort — a missing/unreadable transcript yields `null`, so a
 // caller treats cost as simply "not known yet".
+//
+// The same single walk also yields the run's SHAPE — engaged time, turns, tool calls — because the
+// transcript is the only place that knows it. Wall-clock (`updated_at - created_at`) is not a usable
+// duration: an interactive session idles between turns, so a 6-minute run can span 48 hours. Engaged
+// time sums only the gaps a turn was plausibly in flight (see IDLE_GAP_MS).
 
 import * as fs from 'fs';
 import { findTranscript } from './conversation';
@@ -20,7 +25,22 @@ export interface SessionCost {
   cacheReadTokens: number;
   /** Cache-write input tokens (billed at 1.25× for 5-min, 2× for 1-hour ephemeral writes). */
   cacheWriteTokens: number;
+  /** ENGAGED milliseconds: the sum of gaps between consecutive transcript entries, counting only gaps
+   *  shorter than {@link IDLE_GAP_MS}. A long gap is a human who walked away (or an unattended run
+   *  parked on an approval), not work — so it's excluded rather than inflating the duration. */
+  activeMs: number;
+  /** Conversation turns — user messages that are real prompts, not the tool_result envelopes claude
+   *  code writes back as `user` lines. A one-shot headless run is 1; a long steered session is many. */
+  turns: number;
+  /** Tool calls the agent made (`tool_use` blocks). The honest "how much did it actually do" volume —
+   *  unlike the governed-action count, which only sees capabilities the gate mediates. */
+  toolCalls: number;
 }
+
+/** A gap longer than this between two transcript entries is idle time, not work. Five minutes is
+ *  comfortably longer than a slow turn (including a long tool run) and far shorter than a human
+ *  stepping away, so it splits the two without needing per-turn instrumentation. */
+const IDLE_GAP_MS = 5 * 60_000;
 
 // Per-model sticker pricing, USD per 1M tokens. Cache rates derive from the input rate — read = 0.1×,
 // 5-minute write = 1.25×, 1-hour write = 2× — per Anthropic's prompt-cache pricing. We deliberately do
@@ -58,6 +78,10 @@ export function readSessionCost(claudeSessionId: string): SessionCost | null {
   let outputTokens = 0;
   let cacheReadTokens = 0;
   let cacheWriteTokens = 0;
+  let activeMs = 0;
+  let turns = 0;
+  let toolCalls = 0;
+  let prevTs = 0;
 
   for (const line of raw.split('\n')) {
     if (!line.trim()) continue;
@@ -67,6 +91,25 @@ export function readSessionCost(claudeSessionId: string): SessionCost | null {
     } catch {
       continue;
     }
+
+    // ── shape: timing + volume, over BOTH roles (the assistant-only cost pass below is narrower) ──
+    if (o.type === 'assistant' || o.type === 'user') {
+      const ts = Date.parse(o.timestamp) || 0;
+      if (ts) {
+        if (prevTs) {
+          const gap = ts - prevTs;
+          if (gap > 0 && gap < IDLE_GAP_MS) activeMs += gap;
+        }
+        prevTs = ts;
+      }
+      const content = o.message?.content;
+      const blocks = Array.isArray(content) ? content : [];
+      // A `user` line carrying a tool_result is the transcript's plumbing, not a person's prompt.
+      const isToolResult = blocks.some((b: any) => b && b.type === 'tool_result');
+      if (o.type === 'user' && !isToolResult) turns++;
+      if (o.type === 'assistant') toolCalls += blocks.filter((b: any) => b && b.type === 'tool_use').length;
+    }
+
     // Only assistant messages carry request `usage`; each one is a distinct billed request, so summing
     // across all of them is the whole-session total (cached prefixes re-read each turn are real spend).
     if (o.type !== 'assistant') continue;
@@ -98,5 +141,5 @@ export function readSessionCost(claudeSessionId: string): SessionCost | null {
       1_000_000;
   }
 
-  return { costUsd, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens };
+  return { costUsd, inputTokens, outputTokens, cacheReadTokens, cacheWriteTokens, activeMs, turns, toolCalls };
 }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -821,6 +821,26 @@ function migrate(db: Db): void {
   // world-reachable forever. Set when the link is minted; the public route rejects an expired token
   // immediately and the scheduler sweep clears it from the row. NULL = no public link (nothing to expire).
   addColumn(db, 'artifacts', 'share_expires_at', 'INTEGER');
+
+  // Session insights — what a finished run actually did, so the sessions list can say more than
+  // "done" (which only means the process exited). All are stamped ONCE when the run reaches a terminal
+  // state and never recomputed; NULL = not yet stamped.
+  //  · outcome/report_summary — the agent's OWN verdict, from its end-of-session `report`
+  //    (`session.reported` audit event). 'unknown' when a run ended without reporting, which is itself
+  //    the signal that nobody closed the loop. Distinct from `status`.
+  //  · active_ms / turns / tool_calls — the run's shape, from the same transcript walk that prices it
+  //    (src/edge/session-cost.ts). `active_ms` is ENGAGED time, not wall-clock.
+  //  · gov_* — the governance fingerprint, counted off this run's audit stream. `gov_approvals IS NULL`
+  //    is the "not yet stamped" marker for all four (a run with no governed activity stamps zeros).
+  addColumn(db, 'term_sessions', 'outcome', 'TEXT');           // success | failure | partial | unknown | …
+  addColumn(db, 'term_sessions', 'report_summary', 'TEXT');    // the report's one-line summary
+  addColumn(db, 'term_sessions', 'active_ms', 'INTEGER');      // engaged time (idle gaps excluded)
+  addColumn(db, 'term_sessions', 'turns', 'INTEGER');          // real user prompts (not tool_results)
+  addColumn(db, 'term_sessions', 'tool_calls', 'INTEGER');     // tool_use blocks the agent issued
+  addColumn(db, 'term_sessions', 'gov_actions', 'INTEGER');    // gate.decision — governed effects
+  addColumn(db, 'term_sessions', 'gov_approvals', 'INTEGER');  // approval.requested — human gates hit
+  addColumn(db, 'term_sessions', 'gov_denied', 'INTEGER');     // policy denials + rejected approvals
+  addColumn(db, 'term_sessions', 'gov_errors', 'INTEGER');     // episode/session errors
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -235,6 +235,27 @@ export interface Session {
   /** Token breakdown behind `costUsd` (uncached input / output / cache-read / cache-write). Undefined
    *  until cost is computed. */
   tokens?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  /** What the AGENT said happened, from its end-of-session `report` — 'success' | 'failure' | 'partial'
+   *  | 'unknown' | … Orthogonal to `status`, which only says how the PROCESS ended: a `done` session can
+   *  carry a `failure` outcome, and an `unknown` outcome on a finished run means nobody closed the loop.
+   *  Undefined while the run is live or before it's been stamped. */
+  outcome?: string;
+  /** The report's one-line summary — the human-readable "what came of it" behind {@link outcome}. */
+  summary?: string;
+  /** ENGAGED milliseconds, from the transcript (idle gaps excluded) — the honest answer to "how long
+   *  did this take". Wall-clock (`updatedAt - createdAt`) is not: an interactive session idles between
+   *  turns, so it routinely spans hours or days of nothing. Undefined until stamped. */
+  activeMs?: number;
+  /** Real user prompts in the conversation (1 for a one-shot headless run, many for a steered one). */
+  turns?: number;
+  /** Tool calls the agent issued — the true activity volume, unlike `insights.actions` which counts
+   *  only the subset of effects the gate mediates. */
+  toolCalls?: number;
+  /** The governance fingerprint of the run, counted off its audit stream: `actions` = governed effects
+   *  (gate.decision), `approvals` = human gates hit, `denied` = policy denials + rejected approvals,
+   *  `errors` = session/episode errors. Live rows carry the running tally; terminal rows the stamped
+   *  final one. Definitions mirror `episodeSalience`, which grades the same signals for memory. */
+  insights?: { actions: number; approvals: number; denied: number; errors: number };
 }
 
 export interface FeedMessage {
@@ -303,6 +324,15 @@ interface SessionRow {
   output_tokens: number | null;
   cache_read_tokens: number | null;
   cache_write_tokens: number | null;
+  outcome: string | null;
+  report_summary: string | null;
+  active_ms: number | null;
+  turns: number | null;
+  tool_calls: number | null;
+  gov_actions: number | null;
+  gov_approvals: number | null;
+  gov_denied: number | null;
+  gov_errors: number | null;
 }
 interface MessageRow {
   id: string;
@@ -529,6 +559,9 @@ export class TerminalManager {
     // still-uncosted terminal rows here (bounded per call so a first load with a large history doesn't
     // stall parsing hundreds of transcripts — newest first, the rest catch up over subsequent polls).
     this.backfillCosts(visible);
+    // Outcome + governance counts: cheap indexed lookups off the audit stream (unlike cost, which parses
+    // a transcript), so this isn't budgeted — terminal rows are stamped once, live rows re-tallied.
+    this.stampInsights(visible);
     const resumable = this.resumableIds();
     // One query resolves the whole list's blocked-on-human state (a pending ask/approval), instead of a
     // per-row check — so the console gets an authoritative `blocked` without re-deriving it from the feed.
@@ -547,7 +580,8 @@ export class TerminalManager {
   }
 
   /**
-   * Compute + persist USD cost for terminal rows that don't have it yet. A run's transcript is complete
+   * Compute + persist USD cost — and the run's SHAPE (engaged time / turns / tool calls, which come out
+   * of the same walk) — for terminal rows that don't have it yet. A run's transcript is complete
    * once it reaches a terminal state (done/stopped/crashed), so we parse it once, store the result on the
    * row, and never re-read. Bounded per call (`MAX_COST_BACKFILL`) so the first list after a deploy with a
    * long history amortizes the parsing across polls instead of blocking on all of it at once. Rows are
@@ -558,9 +592,9 @@ export class TerminalManager {
     let budget = 20; // MAX_COST_BACKFILL — cap transcript parses per list call
     for (const r of rows) {
       if (budget <= 0) break;
-      if (r.cost_usd != null) continue;                 // already costed
-      if (r.status === 'running') continue;             // transcript still growing — cost at end
-      if (!r.claude_session_id) continue;               // non-claude run has no transcript to price
+      if (r.cost_usd != null && r.active_ms != null) continue; // already fully derived
+      if (r.status === 'running') continue;             // transcript still growing — derive at end
+      if (!r.claude_session_id) continue;               // non-claude run has no transcript to read
       budget--;
       let cost;
       try {
@@ -568,15 +602,92 @@ export class TerminalManager {
       } catch {
         continue;                                       // transcript unreadable — retry on a later poll
       }
-      if (!cost) continue;                              // no transcript yet
+      if (!cost) {
+        // No transcript. For an unpriced row that's "not written yet" — retry on a later poll. But a row
+        // that's ALREADY priced and lands here has had its transcript pruned since; we were only after
+        // its shape, so stamp zeros rather than re-probe a file that's never coming back (which would
+        // otherwise eat this budget on every poll forever and starve genuinely new rows).
+        if (r.cost_usd != null) {
+          this.db.prepare('UPDATE term_sessions SET active_ms = 0, turns = 0, tool_calls = 0 WHERE id = ?').run(r.id);
+          r.active_ms = 0;
+          r.turns = 0;
+          r.tool_calls = 0;
+        }
+        continue;
+      }
       this.db
-        .prepare('UPDATE term_sessions SET cost_usd = ?, input_tokens = ?, output_tokens = ?, cache_read_tokens = ?, cache_write_tokens = ? WHERE id = ?')
-        .run(cost.costUsd, cost.inputTokens, cost.outputTokens, cost.cacheReadTokens, cost.cacheWriteTokens, r.id);
+        .prepare('UPDATE term_sessions SET cost_usd = ?, input_tokens = ?, output_tokens = ?, cache_read_tokens = ?, cache_write_tokens = ?, active_ms = ?, turns = ?, tool_calls = ? WHERE id = ?')
+        .run(cost.costUsd, cost.inputTokens, cost.outputTokens, cost.cacheReadTokens, cost.cacheWriteTokens, cost.activeMs, cost.turns, cost.toolCalls, r.id);
       r.cost_usd = cost.costUsd;
       r.input_tokens = cost.inputTokens;
       r.output_tokens = cost.outputTokens;
       r.cache_read_tokens = cost.cacheReadTokens;
       r.cache_write_tokens = cost.cacheWriteTokens;
+      r.active_ms = cost.activeMs;
+      r.turns = cost.turns;
+      r.tool_calls = cost.toolCalls;
+    }
+  }
+
+  /**
+   * Stamp each row's OUTCOME (the agent's own verdict) and GOVERNANCE FINGERPRINT (what the run did
+   * through the gate) — the two things the sessions list can't say from `status` alone.
+   *
+   * Both derive from the run's audit stream, an indexed point lookup per row (`idx_audit_run`). A
+   * TERMINAL run's stream is complete, so it's computed once and persisted; a LIVE run is recomputed
+   * each call (its tally is still moving) and never written. Counting mirrors `episodeSalience`, which
+   * grades the same signals for memory — one vocabulary for "what happened in this run". The one
+   * deliberate divergence: `errors` counts only `session.error` (the run itself failing), not
+   * `episode.error`, which is the OS failing to WRITE the episode memory afterwards — housekeeping the
+   * agent had no part in, and which would otherwise brand a clean run as errored. Salience still weighs
+   * both, since an internal failure IS worth remembering; the list is about the run's own work.
+   *
+   * A finished run that never reported stamps `outcome = 'unknown'` rather than staying NULL, so it
+   * isn't re-derived on every poll forever — and so the list can show that nobody closed the loop.
+   * Mutates the rows in place, so the same response carries what it just computed.
+   */
+  private stampInsights(rows: SessionRow[]): void {
+    for (const r of rows) {
+      const live = r.status === 'running';
+      if (!live && r.gov_approvals != null) continue; // already stamped, and it can no longer change
+
+      const counts = this.db.prepare(`SELECT
+          SUM(type = 'gate.decision') AS actions,
+          SUM(type = 'approval.requested') AS approvals,
+          SUM(type = 'gate.decision' AND data LIKE '%"effect":"deny"%') AS gateDenied,
+          SUM(type = 'approval.resolved' AND data LIKE '%"approved":false%') AS rejected,
+          SUM(type = 'session.error') AS errors
+        FROM audit_events WHERE run_id = ?`)
+        .get<{ actions: number | null; approvals: number | null; gateDenied: number | null; rejected: number | null; errors: number | null }>(r.id);
+      const actions = counts?.actions ?? 0;
+      const approvals = counts?.approvals ?? 0;
+      const denied = (counts?.gateDenied ?? 0) + (counts?.rejected ?? 0);
+      const errors = counts?.errors ?? 0;
+
+      // The agent's own end-of-session verdict. Latest wins — a resumed run can report more than once.
+      const report = this.db
+        .prepare("SELECT data FROM audit_events WHERE run_id = ? AND type = 'session.reported' ORDER BY ts DESC LIMIT 1")
+        .get<{ data: string }>(r.id);
+      let outcome = live ? null : 'unknown';
+      let summary: string | null = null;
+      if (report) {
+        try {
+          const d = JSON.parse(report.data) as { outcome?: string; summary?: string };
+          if (d.outcome) outcome = d.outcome;
+          if (d.summary) summary = d.summary.trim() || null;
+        } catch { /* malformed audit payload — fall back to 'unknown' */ }
+      }
+
+      r.gov_actions = actions;
+      r.gov_approvals = approvals;
+      r.gov_denied = denied;
+      r.gov_errors = errors;
+      r.outcome = outcome;
+      r.report_summary = summary;
+      if (live) continue; // still moving — surface it, but don't freeze it onto the row
+      this.db
+        .prepare('UPDATE term_sessions SET gov_actions = ?, gov_approvals = ?, gov_denied = ?, gov_errors = ?, outcome = ?, report_summary = ? WHERE id = ?')
+        .run(actions, approvals, denied, errors, outcome, summary, r.id);
     }
   }
 
@@ -4171,7 +4282,7 @@ function buildAskAgentPrompt(id: string, callerAgent: string, question: string, 
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined, costUsd: r.cost_usd ?? undefined, tokens: r.cost_usd != null ? { input: r.input_tokens ?? 0, output: r.output_tokens ?? 0, cacheRead: r.cache_read_tokens ?? 0, cacheWrite: r.cache_write_tokens ?? 0 } : undefined };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined, costUsd: r.cost_usd ?? undefined, tokens: r.cost_usd != null ? { input: r.input_tokens ?? 0, output: r.output_tokens ?? 0, cacheRead: r.cache_read_tokens ?? 0, cacheWrite: r.cache_write_tokens ?? 0 } : undefined, outcome: r.outcome ?? undefined, summary: r.report_summary ?? undefined, activeMs: r.active_ms ?? undefined, turns: r.turns ?? undefined, toolCalls: r.tool_calls ?? undefined, insights: r.gov_approvals != null ? { actions: r.gov_actions ?? 0, approvals: r.gov_approvals, denied: r.gov_denied ?? 0, errors: r.gov_errors ?? 0 } : undefined };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,62 @@ const statusDot = (s: Session): string =>
  *  `done` interactive session still running) reads "live" so the label never contradicts a green dot. */
 const statusLabel = (s: Session): string => (isLive(s) && s.status !== 'running' ? 'live' : s.status)
 
+/** The RESULT word: what the agent said came of the run, falling back to how the process ended. `done`
+ *  only means "the process exited" — it's the outcome that says whether the work landed, so once a run
+ *  has reported its own verdict that's what the list shows. A finished run with no report reads
+ *  `no report`: nobody closed the loop, which is a finding, not a blank. */
+const resultLabel = (s: Session): string => {
+  if (isLive(s)) return statusLabel(s)
+  if (s.status === 'crashed' || s.status === 'stopped') return s.status
+  if (!s.outcome) return s.status              // not stamped yet — fall back to the process view
+  if (s.outcome === 'unknown') return 'no report'
+  return s.outcome
+}
+
+/** Colour for the result word — green only when the agent actually claims success, red on failure or a
+ *  crash, amber for partial/stopped, and dim for "it ended but said nothing". */
+const resultTone = (s: Session): string => {
+  if (isLive(s)) return 'text-emerald-600'
+  if (s.status === 'crashed') return 'text-red-600'
+  const o = s.outcome
+  if (o === 'success') return 'text-emerald-600'
+  if (o === 'failure' || o === 'error') return 'text-red-600'
+  if (o === 'partial' || s.status === 'stopped') return 'text-amber-600'
+  return 'text-muted-foreground'
+}
+
+/** Compact engaged duration — `45s` / `6m` / `1h 20m`. Undefined (still live, or not yet stamped)
+ *  renders as a dim placeholder, matching how cost reads before it's computed. */
+const formatDuration = (ms?: number): string => {
+  // 0 is the "transcript is gone, nothing to measure" stamp (see backfillCosts) — read it as unknown,
+  // not as an instantaneous run.
+  if (!ms) return '—'
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.round(s / 60)
+  if (m < 60) return `${m}m`
+  return `${Math.floor(m / 60)}h ${m % 60}m`
+}
+
+/** The run's activity fingerprint: how much it did, how often it needed a human, what got refused.
+ *  Tool calls lead because they're the volume that's always there — governed actions are only the
+ *  subset the gate mediates, so a real run can legitimately show 0. Zero-valued chips are dropped so
+ *  the common case stays quiet and an approval/denial actually catches the eye. */
+function SessionInsights({ s, className = '' }: { s: Session; className?: string }) {
+  const g = s.insights
+  const chips: Array<{ key: string; text: string; cls: string; title: string }> = []
+  if (s.toolCalls != null) chips.push({ key: 'tools', text: `${s.toolCalls}⚙`, cls: 'text-muted-foreground', title: `${s.toolCalls} tool calls${s.turns != null ? ` · ${s.turns} turn${s.turns === 1 ? '' : 's'}` : ''}` })
+  if (g?.approvals) chips.push({ key: 'appr', text: `${g.approvals}✋`, cls: 'text-sky-600', title: `${g.approvals} approval${g.approvals === 1 ? '' : 's'} needed a human` })
+  if (g?.denied) chips.push({ key: 'deny', text: `${g.denied}⛔`, cls: 'text-red-600', title: `${g.denied} action${g.denied === 1 ? '' : 's'} denied by policy or rejected` })
+  if (g?.errors) chips.push({ key: 'err', text: `${g.errors}⚠`, cls: 'text-amber-600', title: `${g.errors} error${g.errors === 1 ? '' : 's'}` })
+  if (!chips.length) return <span className={`text-xs text-muted-foreground/50 ${className}`}>—</span>
+  return (
+    <span className={`flex items-center gap-1.5 text-xs tabular-nums ${className}`}>
+      {chips.map((c) => <span key={c.key} className={c.cls} title={c.title}>{c.text}</span>)}
+    </span>
+  )
+}
+
 /** A stopped/ended/crashed interactive session that can be resurrected in place: re-opening its
  *  terminal runs `claude --resume` (via terminal/attach.sh), picking the conversation back up. Shown
  *  as a Resume affordance. Requires a persisted launch env (`resumable`) and no live pane — a live
@@ -150,9 +206,9 @@ const originMeta = (kind?: Session['sourceKind']) => ORIGIN_META[kind ?? 'system
 
 /** Sortable columns of the sessions list. `updated` is the default (most recently active first); it's
  *  the omitted value in the URL, so a clean `#/sessions` shows the freshest sessions on top. */
-type SessionSortKey = 'created' | 'title' | 'agent' | 'id' | 'startedBy' | 'status' | 'updated' | 'cost'
+type SessionSortKey = 'created' | 'title' | 'agent' | 'id' | 'startedBy' | 'status' | 'updated' | 'cost' | 'duration'
 type SortDir = 'asc' | 'desc'
-const SESSION_SORT_KEYS: SessionSortKey[] = ['created', 'title', 'agent', 'id', 'startedBy', 'status', 'updated', 'cost']
+const SESSION_SORT_KEYS: SessionSortKey[] = ['created', 'title', 'agent', 'id', 'startedBy', 'status', 'updated', 'cost', 'duration']
 const DEFAULT_SORT_KEY: SessionSortKey = 'updated'
 /** Status ordering for the Status-column sort: live → done → stopped → crashed. */
 const statusRank = (s: Session): number =>
@@ -168,6 +224,7 @@ const compareSessions = (a: Session, b: Session, key: SessionSortKey): number =>
     case 'status': return statusRank(a) - statusRank(b)
     case 'updated': return a.updatedAt - b.updatedAt
     case 'cost': return (a.costUsd ?? -1) - (b.costUsd ?? -1)
+    case 'duration': return (a.activeMs ?? -1) - (b.activeMs ?? -1)
   }
 }
 
@@ -3132,8 +3189,19 @@ function SessionsPage({
                   {waiting.has(s.id) && <WaitingBell className="h-3.5 w-3.5" />}
                 </div>
                 <div className="mt-1 flex items-center gap-1.5 truncate text-xs text-muted-foreground">
-                  <span className="truncate">{s.agent} · {statusLabel(s)} · <span className="font-mono">{s.id}</span></span>
+                  <span className="truncate"><span className={resultTone(s)}>{resultLabel(s)}</span> · {s.agent} · <span className="font-mono">{s.id}</span></span>
                   <ModeBadge headless={s.headless} />
+                </div>
+                {/* The agent's own one-line verdict — the card's "what came of it" line. Clamped to two
+                    lines so a long summary can't stretch the grid. Skipped when the title was DERIVED
+                    from this summary (titleFromSummary), which would otherwise print it twice. */}
+                {s.summary && !s.summary.startsWith(s.title.replace(/…$/, '').trim()) && (
+                  <div className="mt-1 line-clamp-2 text-xs text-muted-foreground/80" title={s.summary}>{s.summary}</div>
+                )}
+                <div className="mt-1 flex items-center gap-2 text-[11px] tabular-nums text-muted-foreground">
+                  {s.activeMs != null && <span title={`${formatDuration(s.activeMs)} of engaged work — idle gaps excluded`}>{formatDuration(s.activeMs)}</span>}
+                  <SessionInsights s={s} className="text-[11px]" />
+                  {s.costUsd != null && <span title="run cost">{formatCost(s.costUsd)}</span>}
                 </div>
                 <div className="mt-1 flex items-center justify-between gap-2">
                   <OriginBadge s={s} members={members} />
@@ -3187,12 +3255,14 @@ function SessionsPage({
               <span className="h-2 w-2 shrink-0" aria-hidden />
               {sortHead('title', 'Session', 'min-w-0 flex-1')}
               {sortHead('agent', 'Agent', 'hidden w-32 shrink-0 sm:flex')}
-              {sortHead('id', 'ID', 'hidden w-20 shrink-0 md:flex')}
-              {sortHead('startedBy', 'Started by', 'w-40 shrink-0')}
+              {sortHead('id', 'ID', 'hidden w-20 shrink-0 xl:flex')}
+              {sortHead('startedBy', 'Started by', 'w-32 shrink-0')}
               <span className="w-24 shrink-0">Mode</span>
               {sortHead('updated', 'Updated', 'w-20 shrink-0')}
+              {sortHead('duration', 'Took', 'hidden w-16 shrink-0 justify-end lg:flex')}
+              <span className="hidden w-20 shrink-0 xl:block">Activity</span>
               {sortHead('cost', 'Cost', 'hidden w-16 shrink-0 justify-end lg:flex')}
-              {sortHead('status', 'Status', 'w-16 shrink-0')}
+              {sortHead('status', 'Result', 'w-20 shrink-0')}
             </div>
             <span className="w-32 shrink-0" aria-hidden />
           </div>
@@ -3210,12 +3280,18 @@ function SessionsPage({
                 <span className="min-w-0 flex-1 truncate text-sm font-medium">{s.title}</span>
                 {waiting.has(s.id) && <WaitingBell className="h-3.5 w-3.5" />}
                 <span className="hidden w-32 shrink-0 truncate text-xs text-muted-foreground sm:block">{s.agent}</span>
-                <span className="hidden w-20 shrink-0 truncate font-mono text-xs text-muted-foreground md:block" title={s.id}>{s.id}</span>
-                <OriginBadge s={s} members={members} className="w-40 shrink-0" />
+                <span className="hidden w-20 shrink-0 truncate font-mono text-xs text-muted-foreground xl:block" title={s.id}>{s.id}</span>
+                <OriginBadge s={s} members={members} className="w-32 shrink-0" />
                 <span className="flex w-24 shrink-0 items-center"><ModeBadge headless={s.headless} /></span>
                 <span className="w-20 shrink-0 text-xs tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
+                {/* Engaged time, not wall-clock — the tooltip spells out the difference, which is often
+                    hours for an interactive session that sat idle between turns. */}
+                <span className="hidden w-16 shrink-0 justify-end text-right text-xs tabular-nums text-muted-foreground lg:block" title={s.activeMs != null ? `${formatDuration(s.activeMs)} of engaged work — idle gaps excluded (open ${timeAgo(s.createdAt)} ago)` : 'duration not yet computed'}>{formatDuration(s.activeMs)}</span>
+                <SessionInsights s={s} className="hidden w-20 shrink-0 xl:flex" />
                 <span className="hidden w-16 shrink-0 justify-end text-right text-xs tabular-nums text-muted-foreground lg:block" title={s.tokens ? `${(s.tokens.input + s.tokens.output + s.tokens.cacheRead + s.tokens.cacheWrite).toLocaleString()} tokens (in ${s.tokens.input.toLocaleString()} · out ${s.tokens.output.toLocaleString()} · cache-read ${s.tokens.cacheRead.toLocaleString()} · cache-write ${s.tokens.cacheWrite.toLocaleString()})` : 'cost not yet computed'}>{formatCost(s.costUsd)}</span>
-                <span className="w-16 shrink-0 text-xs text-muted-foreground">{statusLabel(s)}</span>
+                {/* Result = the agent's own verdict, falling back to the process status. The summary
+                    rides along as the tooltip so "what came of it" is one hover away. */}
+                <span className={`w-20 shrink-0 truncate text-xs ${resultTone(s)}`} title={s.summary ? `${statusLabel(s)} · ${s.summary}` : statusLabel(s)}>{resultLabel(s)}</span>
               </button>
               {/* Human verdict — finished runs only; stays visible once rated, faint-until-hover otherwise. */}
               <div className={`shrink-0 transition-opacity ${!isLive(s) ? (s.rating ? '' : 'opacity-40 group-hover:opacity-100') : 'invisible'}`}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -235,6 +235,23 @@ export interface Session {
   costUsd?: number
   /** Token breakdown behind `costUsd` (uncached input / output / cache-read / cache-write). */
   tokens?: { input: number; output: number; cacheRead: number; cacheWrite: number }
+  /** What the AGENT said happened, from its end-of-session `report` — 'success' | 'failure' | 'partial'
+   *  | 'unknown' | … Orthogonal to `status`, which only says how the process ended: a `done` run can
+   *  carry a `failure` outcome, and `unknown` on a finished run means nobody closed the loop. */
+  outcome?: string
+  /** The report's one-line summary — the "what came of it" behind `outcome`. */
+  summary?: string
+  /** ENGAGED milliseconds from the transcript, idle gaps excluded. The honest run duration — wall-clock
+   *  (`updatedAt - createdAt`) isn't, since an interactive session idles between turns for hours. */
+  activeMs?: number
+  /** Real user prompts in the conversation (1 for a one-shot headless run, many for a steered one). */
+  turns?: number
+  /** Tool calls the agent issued — the true activity volume (`insights.actions` counts only the subset
+   *  of effects the gate mediates, which is 0 for a run that never touched a governed capability). */
+  toolCalls?: number
+  /** Governance fingerprint: governed effects, human gates hit, denials, errors. Live rows carry the
+   *  running tally; terminal rows the final stamped one. */
+  insights?: { actions: number; approvals: number; denied: number; errors: number }
 }
 export interface AuditEvent {
   id: number


### PR DESCRIPTION
The sessions list could only say a run was `done` — which means the process exited, not that the work landed. Three insights now ride on every row and grid card.

**Result** — the agent's OWN verdict, from its end-of-session `report` (`success` / `failure` / `partial`), with the summary as a tooltip and as the card's one-liner. A finished run that never reported reads **"no report"**: nobody closed the loop, which is a finding, not a blank. Colour-coded (green only when the agent actually claims success).

**Took** — ENGAGED time from the transcript, idle gaps excluded. Wall-clock is not a usable duration: an interactive session idles between turns, so on live data a 7-minute run spans 13 hours of `updated_at - created_at`, and a stopped one showed 48h.

**Activity** — tool calls · approvals needed · denials · errors. Tool calls lead because governed actions only count the subset the gate mediates (legitimately 0 for many real runs). Zero-valued chips are dropped so an approval or denial actually catches the eye.

Both new columns are sortable.

### How it's computed
- Timing + volume fall out of the **same transcript walk that already prices a run** (`session-cost.ts`) — no new file reads.
- Outcome + governance counts are **indexed lookups** on the audit stream (`idx_audit_run`).
- Everything **stamps once** when a run goes terminal and is never recomputed; live rows re-tally each poll. A pruned transcript stamps zeros rather than being re-probed on every list call forever (measured: cold 127-row list converges over ~4 polls, then 8ms).

Counting mirrors `episodeSalience` with one deliberate divergence: `errors` counts only `session.error`, **not** `episode.error` — that's the OS failing to write the episode memory *afterwards*, housekeeping the agent had no part in, and it was branding clean runs as errored.

### Verification
- `npm run typecheck`, both builds, `npm run test:governance` → 68/68.
- Driven end-to-end against a **copy of the live instapods DB** in an isolated `AGENT_OS_HOME` (127 real sessions): stamping, the vanished-transcript guard, and convergence all confirmed; list + grid screenshotted in a headless browser as an owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PX3EPzxB13gehNcfsU3Hnk