### PR TITLE
feat(inbox): approval round-trip — approve/deny from the Slack/Discord DM (v0.232.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.233.0] — 2026-07-20
+### Added
+- **Approve or reject a gated action straight from the Slack/Discord DM — the approval round-trip.**
+  Until now the approval ping was one-way: the DM told approvers to open the web Inbox to decide.
+  Approvals now close the loop the way `ask` questions already did. When an approval is raised,
+  `notifyApprovers` (`src/tenant-registry.ts`) binds it to each approver's DM channel in a new
+  `approval_dms` table (the twin of `question_dms`), and the DM now reads *"Reply 'approve' or 'deny' to
+  decide."* An inbound DM reply is matched back to the newest still-pending approval bound to that sender
+  by `TerminalManager.decideApprovalFromChat` (`src/terminal.ts`): it reads the reply as an approve/deny
+  intent (`parseApprovalIntent` — first-token/emoji match, conservative — ambiguous text prompts for a
+  clear yes/no instead of guessing on a governance decision), **re-checks the replier can still clear that
+  level** (`canApprove`, defense in depth), and settles the same gate the console resolves — attributed to
+  their member email, audited `approval.decided.viaDm`. The Slack/Discord socket DM handlers check this
+  before the question path; unknown senders fall through to chat unchanged. Purely additive — the console
+  approve/reject flow is untouched. Multi-approver safe (the binding is keyed per approver) and races with
+  the console cleanly (`resolve` no-ops once decided).
+
 ## [0.232.0] — 2026-07-20
 ### Added
 - **Session insights in the sessions list — result, engaged duration, and an activity fingerprint.**

--- a/docs/inbox-plan.md
+++ b/docs/inbox-plan.md
@@ -166,6 +166,21 @@ for oversight (`GET /api/messages?scope=all`, gated by `inboxScope`). (3) The **
 agent loops in ONE named teammate (inbox card addressed to them + DM) when a run concerns someone other
 than its owner. Console: an **My activity / All** toggle on the Inbox (owner/admin only).
 
+### 4.12 Approvals could be pinged but not *decided* over chat — ✅ SHIPPED (v0.232.0)
+The approval DM (§4.1's twin) was one-way: it told approvers to open the web Inbox to approve/reject —
+only agent `ask` questions could be answered by replying to the DM (`answerQuestionFromChat` +
+`question_dms`). **Fixed:** the symmetric approval path. `notifyApprovers` binds each approval to every
+approver's DM channel in a new `approval_dms` table (keyed per approver, so a multi-approver broadcast
+is unambiguous), and the DM now reads *"Reply 'approve' or 'deny' to decide."* An inbound Slack/Discord
+DM reply is matched to the newest still-pending bound approval by `TerminalManager.decideApprovalFromChat`,
+which reads the reply as an intent (`parseApprovalIntent` — conservative first-token/emoji match;
+ambiguous text prompts for a clear yes/no rather than guessing), **re-checks `canApprove(role, level)`**
+(defense in depth — a role downgrade since the DM yields `forbidden`), and settles the same gate the
+console does — audited `approval.decided.viaDm`. Checked before the question path in both sockets;
+unknown senders fall through to chat. Races the console cleanly (`resolve` no-ops once decided). Note:
+only a **DM** reply decides — a reply in a mirrored *thread* still routes to `continueThread` (typed into
+the live agent), matching the question path.
+
 ### 4.9 Agent can't be *pushed* an answer — ⏳ LATER
 An agent only learns its question was answered by polling `ask` or remembering to `check_inbox`. No push,
 no "N new replies since last check" cursor. Partially mitigated by `check_inbox`. **Plan:** an inbox
@@ -223,6 +238,7 @@ always-rule for owner sign-off (mirrors `skill_propose`).
 | **1** | Question DMs · chat loop · per-member read/dismiss | ✅ v0.39.0 |
 | **Always approve** | Learn a policy `allow` from an approval card (§4.4/§5) | ✅ v0.40.0 |
 | **Recipient routing** | Global `Audience`/`resolveRecipients` + explicit-audience cards + Tasks→Inbox (§4.10) | ✅ v0.63.1/v0.64.0 |
+| **Approval round-trip** | Approve/reject a gated action by replying to the Slack/Discord DM (§4.12) | ✅ v0.232.0 |
 | **2** | Server-side `ask` timeout/expiry · stale-item reminders + escalation | ⏳ |
 | **3** | `since`-cursor + SSE push · feed filter/search/grouping · optimistic UI | ⏳ |
 | **later** | Push answers to the agent · inbox cursor | ⏳ |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.232.0",
+  "version": "0.233.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.232.0",
+      "version": "0.233.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.232.0",
+  "version": "0.233.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -785,6 +785,17 @@ export class Automations {
     return this.tm.answerQuestionFromChat(provider, externalId, text);
   }
 
+  /**
+   * Inbound DM that might be resolving a pending approval: if the sender has a still-pending approval we
+   * DM'd them, read the reply as an approve/deny and settle the gate. The approval-side twin of
+   * {@link answerQuestionFromChat}. `null` → nothing bound (fall through to the question/chat router);
+   * `unclear`/`forbidden` → bound but the socket should nudge instead of falling through. The socket posts
+   * the ack. See {@link TerminalManager.decideApprovalFromChat}.
+   */
+  decideApprovalFromChat(provider: 'slack' | 'discord', externalId: string, text: string) {
+    return this.tm.decideApprovalFromChat(provider, externalId, text);
+  }
+
   /** Strip a leading `/agent` router prefix (only when it names a known agent) and any `<@…>` mention
    *  tokens from a follow-up before it's typed into a live claude — so a re-mention doesn't land as a
    *  slash command. Returns the cleaned message (never undefined). */

--- a/src/edge/discord-socket.ts
+++ b/src/edge/discord-socket.ts
@@ -212,6 +212,24 @@ export class DiscordSocket {
     // (and the `/agent` router prefix) starts clean. `<@!id>` is the legacy nickname-mention form.
     const text = (ev.text || '').replace(new RegExp(`^\\s*<@!?${this.botUserId}>\\s*`), '').trim();
 
+    // Inline approve/deny: a DM reply from someone with a pending approval we sent them resolves the gate
+    // directly (no trip to the web Inbox) — the approval-side twin of the question path below. Only for
+    // DMs (where the approval ping was sent). Checked first: while an approval is pending, a "yes"/"no"
+    // in this DM is a decision, not chat. `null` → nothing bound, fall through to the question/chat router.
+    if (ev.eventType === 'direct_message') {
+      const decided = this.autos.decideApprovalFromChat('discord', ev.user, text);
+      if (decided) {
+        if (decided.status === 'decided') {
+          void this.dmUser(ev.user, decided.approved ? `✅ Approved — \`${decided.capability}\` will proceed.` : `🚫 Rejected — \`${decided.capability}\` was blocked.`);
+        } else if (decided.status === 'unclear') {
+          void this.dmUser(ev.user, `I couldn't tell if that's a yes or no — reply **approve** or **deny** to decide the pending request.`);
+        } else {
+          void this.dmUser(ev.user, `You're no longer able to approve that request.`);
+        }
+        return;
+      }
+    }
+
     // Inline answer: a DM reply from someone with a pending `ask_human` question answers it directly (no
     // trip to the web Inbox). Only for DMs — that's where the question was sent. If nothing pending is
     // bound to this sender, fall through to the normal chat router (an ordinary DM is just a chat).

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -193,6 +193,24 @@ export class SlackSocket {
     const isDm = ev.channelType === 'im' || ev.channelType === 'mpim';
     if (ev.eventType !== 'app_mention' && !isDm) return;
 
+    // Inline approve/deny: a DM reply from someone with a pending approval we sent them resolves the gate
+    // directly (no trip to the web Inbox) — the approval-side twin of the question path below. Only for
+    // DMs (where the approval ping was sent). Checked first: while an approval is pending, a "yes"/"no"
+    // in this DM is a decision, not chat. `null` → nothing bound, fall through to the question/chat router.
+    if (isDm) {
+      const decided = this.autos.decideApprovalFromChat('slack', ev.user, text);
+      if (decided) {
+        if (decided.status === 'decided') {
+          void this.dmUser(ev.user, decided.approved ? `✅ Approved — \`${decided.capability}\` will proceed.` : `🚫 Rejected — \`${decided.capability}\` was blocked.`);
+        } else if (decided.status === 'unclear') {
+          void this.dmUser(ev.user, `I couldn't tell if that's a yes or no — reply *approve* or *deny* to decide the pending request.`);
+        } else {
+          void this.dmUser(ev.user, `You're no longer able to approve that request.`);
+        }
+        return;
+      }
+    }
+
     // Inline answer: a DM reply from someone with a pending `ask_human` question answers it directly (no
     // trip to the web Inbox). Only for DMs — that's where the question was sent. If nothing pending is
     // bound to this sender, fall through to the normal chat router (an ordinary DM is just a chat).

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -248,6 +248,23 @@ function migrate(db: Db): void {
     );
     CREATE INDEX IF NOT EXISTS idx_question_dms_lookup ON question_dms (provider, external_id, created_at);
 
+    -- The approval-side twin of question_dms: binds an approval card to the Slack/Discord DM we sent
+    -- whoever can approve it, so a human can APPROVE/REJECT by REPLYING in that DM (not just via the web
+    -- Inbox). Written when the approval is DM'd (one row per approver × provider); read on an inbound DM:
+    -- the sender's external id → the newest still-pending bound approval, whose reply text (approve/deny)
+    -- resolves the gate. Keyed (approval_id, provider, external_id) so several approvers can each be bound;
+    -- an approval drops out of the match once it's no longer pending (join on approvals.status), no cleanup.
+    CREATE TABLE IF NOT EXISTS approval_dms (
+      approval_id TEXT NOT NULL,
+      tenant      TEXT NOT NULL,
+      provider    TEXT NOT NULL,          -- 'slack' | 'discord'
+      external_id TEXT NOT NULL,          -- the approver's Slack/Discord user id (the DM sender on reply)
+      member_id   TEXT,                   -- the member we DM'd (for the resolved-by attribution)
+      created_at  INTEGER NOT NULL,
+      PRIMARY KEY (approval_id, provider, external_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_approval_dms_lookup ON approval_dms (provider, external_id, created_at);
+
     -- The deliverables gallery: artifacts agents explicitly publish (a PDF/Markdown/image now;
     -- a multi-file site/app later). Each row is a snapshot copied into <home>/artifacts/<id>/.
     -- Carries full provenance (session + agent + source) — the SAME shape as the messages table, so

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -247,7 +247,7 @@ export class TenantRegistry {
     void discord.start();
     // Chat approval notifications (M5): when a risky action lands an approval card, DM whoever can
     // approve it — via their linked Slack/Discord account (identity map). Best-effort, off the hot path.
-    tm.setApprovalNotifier((notice) => { void notifyApprovers(os, slack, discord, consoleOrigin, notice); });
+    tm.setApprovalNotifier((notice) => { void notifyApprovers(os, tm, slack, discord, consoleOrigin, notice); });
     // Question notifications: when an agent asks the human a question, DM the person the run acts for so
     // a blocking `ask` doesn't sit unseen until it times out — the question-side twin of the above.
     tm.setQuestionNotifier((notice) => { void notifyQuestionAsked(os, tm, slack, discord, consoleOrigin, notice); });
@@ -366,19 +366,28 @@ export async function notifyLoginLink(os: AgentOS, slack: Pick<SlackSocket, 'dmU
  * (`canApprove(role, level)`); `deliverDM` reaches them via the identity map. Off the gate's hot path
  * (the caller fires-and-forgets). Audited once.
  */
-export async function notifyApprovers(os: AgentOS, slack: Pick<SlackSocket, 'dmUser' | 'userIdForEmail'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: ApprovalNotice): Promise<void> {
+export async function notifyApprovers(os: AgentOS, tm: Pick<TerminalManager, 'bindApprovalDm'>, slack: Pick<SlackSocket, 'dmUser' | 'userIdForEmail'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: ApprovalNotice): Promise<void> {
   // Route to the SAME audience the inbox card uses (approvalAudience): the session owner alone when they
   // can clear this level (an admin self-approving their own run), else the full approver tier — so we
   // stop DMing every admin about every other admin's self-approvable session.
   const approvers = resolveRecipients(os, approvalAudience(os, notice.sessionId, notice.level));
   if (!approvers.length) return;
+  // Bind the approval to each approver's DM channel so they can resolve it by REPLYING "approve"/"deny"
+  // to the DM — the reply is matched back to this approval on inbound (TerminalManager.decideApprovalFromChat).
+  for (const a of approvers) {
+    const ids = os.team.externalIdsFor(a.id);
+    const slackId = ids.find((i) => i.provider === 'slack')?.externalId;
+    const discordId = ids.find((i) => i.provider === 'discord')?.externalId;
+    if (slackId) tm.bindApprovalDm(notice.approvalId, 'slack', slackId, a.id);
+    if (discordId) tm.bindApprovalDm(notice.approvalId, 'discord', discordId, a.id);
+  }
   // Plain text + backticks render fine in both Slack mrkdwn and Discord markdown (no */** ambiguity).
   const dot = notice.riskClass === 'red' ? '🔴' : '🟡';
   const inbox = consolePage(consoleOrigin, 'inbox');
   const text = (p: ChatPlatform) =>
     `${dot} ${notice.riskClass.toUpperCase()} approval needed — \`${notice.capability}\` (${notice.level}) requested by agent ${notice.agent}.` +
     (notice.reason ? `\nwhy: ${notice.reason}` : '') +
-    `\nOpen the ${chatLink(p, inbox, 'Agent OS Inbox')} to approve or reject.`;
+    `\n*Reply "approve" or "deny"* to decide, or open the ${chatLink(p, inbox, 'Agent OS Inbox')}.`;
   const dms = await deliverDM(slack, discord, os, approvers, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'approval.notified', data: { capability: notice.capability, level: notice.level, approvers: approvers.length, dms } });
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -373,12 +373,34 @@ interface MessageRow {
 
 /** What the approval-notifier sink receives when a risky action lands an approval card. */
 export interface ApprovalNotice {
+  /** The pending approval's id — the notifier binds it to the DM(s) it sends so a reply (approve/deny)
+   *  can resolve the gate, the approval-side twin of {@link QuestionNotice.questionId}. */
+  approvalId: string;
   sessionId: string;
   agent: string;
   capability: string;
   level: ApprovalLevel;
   riskClass: 'yellow' | 'red';
   reason?: string;
+}
+
+/**
+ * Read a Slack/Discord DM reply as an approve / deny decision for a pending approval. Deliberately
+ * conservative: matches on the FIRST token (so "approve", "yes go ahead", "👍" ⇒ approve; "deny",
+ * "no", "reject it", "👎" ⇒ deny) or a whole-message emoji, and returns `null` for anything ambiguous
+ * so the caller prompts for a clear yes/no rather than guessing wrong on a governance decision.
+ */
+export function parseApprovalIntent(text: string): 'approve' | 'deny' | null {
+  const t = (text || '').trim().toLowerCase().replace(/[.!,]+$/, '');
+  if (!t) return null;
+  const first = t.split(/\s+/)[0];
+  const APPROVE = new Set(['approve', 'approved', 'approves', 'yes', 'y', 'yeah', 'yep', 'yup', 'ok', 'okay', 'k', 'sure', 'go', 'allow', 'allowed', 'lgtm', 'accept', 'accepted', '👍', '✅', '👌']);
+  const DENY = new Set(['deny', 'denied', 'reject', 'rejected', 'no', 'n', 'nope', 'nah', 'block', 'blocked', 'stop', 'decline', 'declined', '👎', '❌', '🚫']);
+  if (APPROVE.has(t) || APPROVE.has(first)) return 'approve';
+  if (DENY.has(t) || DENY.has(first)) return 'deny';
+  if (/[👍✅👌]/u.test(t)) return 'approve';
+  if (/[👎❌🚫]/u.test(t)) return 'deny';
+  return null;
 }
 
 /** What the question-notifier sink receives when an agent asks the human a question — so an out-of-band
@@ -2302,7 +2324,7 @@ export class TerminalManager {
     });
     this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability });
     // Out-of-band ping (Slack/Discord DM to whoever can approve) — best-effort, never blocks the gate.
-    try { this.approvalNotifier?.({ sessionId, agent, capability, level: decision.level, riskClass: decision.riskClass, reason: decision.reason }); } catch { /* notifications are advisory */ }
+    try { this.approvalNotifier?.({ approvalId: req.id, sessionId, agent, capability, level: decision.level, riskClass: decision.riskClass, reason: decision.reason }); } catch { /* notifications are advisory */ }
     // If the run was triggered from chat, surface the gate in that thread too (the approver DM reaches
     // the approver; this reaches everyone watching the thread). No-op for non-chat runs.
     const dot = decision.riskClass === 'red' ? '🔴' : '🟡';
@@ -2372,7 +2394,7 @@ export class TerminalManager {
           audienceId: audienceIdOf(aud),
         });
         this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability: 'secret.put' });
-        try { this.approvalNotifier?.({ sessionId, agent, capability: 'secret.put', level: decision.level, riskClass: decision.riskClass, reason: decision.reason }); } catch { /* advisory */ }
+        try { this.approvalNotifier?.({ approvalId: req.id, sessionId, agent, capability: 'secret.put', level: decision.level, riskClass: decision.riskClass, reason: decision.reason }); } catch { /* advisory */ }
         const approved = await settle;
         this.audit(sessionId, agent, 'approval.resolved', { approvalId: req.id, approved });
         if (!approved) return { status: 'denied', detail: `approval rejected (${decision.level})` };
@@ -2680,6 +2702,57 @@ export class TerminalManager {
   /** The session id a question belongs to (for audit attribution on the DM-answer path). */
   private questionRunId(questionId: string): string | undefined {
     return this.db.prepare('SELECT run_id FROM questions WHERE id = ?').get<{ run_id: string }>(questionId)?.run_id;
+  }
+
+  /** Bind a pending approval to a Slack/Discord DM recipient, so a reply in that DM can resolve it — the
+   *  approval-side twin of {@link bindQuestionDm}. Called by the approval notifier once per approver ×
+   *  provider it DM'd. Keyed on (approval, provider, external_id) so several approvers can each be bound. */
+  bindApprovalDm(approvalId: string, provider: 'slack' | 'discord', externalId: string, memberId?: string): void {
+    if (!approvalId || !externalId) return;
+    this.db
+      .prepare('INSERT OR REPLACE INTO approval_dms (approval_id, tenant, provider, external_id, member_id, created_at) VALUES (?, ?, ?, ?, ?, ?)')
+      .run(approvalId, this.os.tenant, provider, externalId, memberId ?? null, Date.now());
+  }
+
+  /**
+   * Resolve a pending approval from an inbound Slack/Discord DM reply — the approval-side twin of
+   * {@link answerQuestionFromChat}. Matches the sender to the newest still-pending approval we DM'd them,
+   * reads their reply as an approve/deny intent, re-checks they may clear that level (`canApprove`), and
+   * settles the gate (attributed to their member email — same as the web route). Returns:
+   *  - `null`               — nothing pending is bound to this sender ⇒ the caller falls through to the
+   *                           question/chat router (an ordinary DM is just a chat).
+   *  - `{ status:'unclear' }`   — a pending approval IS bound but the reply isn't a clear yes/no ⇒ the
+   *                           caller asks them to reply "approve"/"deny" (does NOT fall through — we know
+   *                           they're mid-approval, so treating it as fresh chat would be wrong).
+   *  - `{ status:'forbidden' }` — bound, but the sender can no longer approve this level (role changed).
+   *  - `{ status:'decided', … }` — the gate was settled; `approved` + `capability` for the ack.
+   */
+  decideApprovalFromChat(provider: 'slack' | 'discord', externalId: string, text: string):
+    | { status: 'decided'; approved: boolean; capability: string }
+    | { status: 'unclear' }
+    | { status: 'forbidden' }
+    | null {
+    if (!externalId) return null;
+    const row = this.db
+      .prepare(
+        `SELECT ad.approval_id AS aid, a.run_id AS runId, a.capability AS capability, a.level AS level
+           FROM approval_dms ad JOIN approvals a ON a.id = ad.approval_id
+          WHERE ad.provider = ? AND ad.external_id = ? AND a.status = 'pending'
+          ORDER BY ad.created_at DESC LIMIT 1`,
+      )
+      .get<{ aid: string; runId: string; capability: string; level: ApprovalLevel }>(provider, externalId);
+    if (!row) return null;
+    // A pending approval is bound to this sender — read their reply as a decision.
+    const intent = parseApprovalIntent(text);
+    if (!intent) return { status: 'unclear' };
+    // Defense in depth: the binding implies they were in the approver audience, but re-check they may
+    // still clear this level before settling (mirrors the web route's canApprove gate).
+    const member = this.os.team.memberByExternalId(provider, externalId);
+    if (!member || !this.os.team.canApprove(member, row.level)) return { status: 'forbidden' };
+    const approved = intent === 'approve';
+    this.os.approvals.resolve(row.aid, approved, member.email); // no-op if already decided (console race)
+    this.audit(row.runId, member.email, 'approval.decided.viaDm', { approvalId: row.aid, approved, provider });
+    return { status: 'decided', approved, capability: row.capability };
   }
 
   /**


### PR DESCRIPTION
## What

Closes the approval loop over chat. Until now the approval DM was a one-way ping (\"open the web Inbox to approve/reject\"); only agent \`ask\` questions could be resolved by replying to the DM. This makes approvals symmetric.

- **New \`approval_dms\` table** (twin of \`question_dms\`) — binds each raised approval to every approver's Slack/Discord DM channel, keyed per approver so a multi-approver broadcast is unambiguous.
- **\`notifyApprovers\`** now writes those bindings and the DM reads *\"Reply 'approve' or 'deny' to decide.\"*
- **\`TerminalManager.decideApprovalFromChat\`** matches an inbound DM reply to the newest still-pending bound approval, reads it via **\`parseApprovalIntent\`** (conservative first-token/emoji match — ambiguous text prompts for a clear yes/no rather than guessing on a governance decision), **re-checks \`canApprove(role, level)\`** (defense in depth), and settles the same gate the console does. Audited \`approval.decided.viaDm\`.
- **Both sockets** check approvals before the question path; unknown senders fall through to chat unchanged.

## Design notes

- Purely additive — the console approve/reject flow is untouched.
- Races the console cleanly: \`approvals.resolve\` no-ops once decided.
- Only a **DM** reply decides; a reply in a mirrored *thread* still routes to \`continueThread\` (typed into the live agent), matching the question path.

## Testing

- \`npm run typecheck\` ✓, \`npm run test:governance\` → 68/68 ✓
- Isolated in-process end-to-end harness (fresh scratch home): parser 18/18; approve/deny/unclear/forbidden/null branches, both providers, both levels, and console-race no-op all verified against the real \`approvals\` + \`approval_dms\` stores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)