### PR TITLE
feat(agents): spawn fleet teammates as native in-process sub-agents (v0.232.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.234.0] — 2026-07-20
+### Added
+- **An agent can spawn fleet teammates as native in-process sub-agents.** A parent agent's manifest
+  gains `usableSubagents: string[]` — an opt-in list of OTHER fleet agent ids it may invoke through
+  Claude Code's built-in `Agent`/Task tool. At launch each named teammate's manifest + persona (its
+  `CLAUDE.md`) is materialised into the parent's `.claude/agents/<id>.md` (`src/edge/subagents.ts`,
+  mirroring how the skills library syncs into `.claude/skills` — idempotent, refreshes only our managed
+  files via an `.aos-managed.json` index, preserves hand-authored ones). The running claude can then
+  delegate a slice of its OWN turn to a teammate in-process (sub-second, no separate governed session) —
+  the lightweight counterpart to `task_dispatch`, which stays the path for delegating to a *separately
+  accountable* citizen. **The gateway invariant holds:** a native sub-agent runs in the parent's
+  process, so the PreToolUse gate hook fires for its tool calls too — every effect is still classified/
+  approved/budgeted/audited, under the parent session's principal + budget. Claude Code tags the hook
+  input with `agent_type`/`agent_id`; `terminal/gate-hook.sh` forwards them (via a U+001F field
+  separator — a tab would collapse the empty fields of a normal top-level call) and `gate()` stamps
+  `gate.attempt`/`gate.decision` with `subagent`/`subagentId`, so the audit trail attributes a governed
+  effect to which sub-agent produced it. The sub-agent's toolset is capped to a conservative allow-list
+  (`SUBAGENT_DEFAULT_TOOLS`: read/search + gated Bash/Edit/Write + memory recall) — never proactive
+  egress, the vault, `publish`, or the operator/inbox surface. Settable from the owner/admin agent
+  config route (`GET`/`PUT /api/agents/:id/config`, `sanitizeUsableSubagents`); a self-editing agent
+  cannot widen its own reach. See `docs/subagents-plan.md`.
+
 ## [0.233.0] — 2026-07-20
 ### Added
 - **Approve or reject a gated action straight from the Slack/Discord DM — the approval round-trip.**

--- a/docs/subagents-plan.md
+++ b/docs/subagents-plan.md
@@ -1,0 +1,77 @@
+# Fleet agents as native sub-agents
+
+**Status:** shipped v0.232.0 (materialisation + gate attribution + config route). UI opt-in editor: TODO.
+
+## The idea
+
+Claude Code already has a native, in-process sub-agent runtime: the built-in `Agent`/Task tool spawns
+a child defined by a `.claude/agents/<name>.md` file (frontmatter + persona), runs it to completion,
+and returns its result inline — sub-second, no separate process. Each Agent OS session *is* a
+claude-code process, so we let a running agent spawn **one of our own fleet teammates** as such a
+sub-agent: the parent opts in via `usableSubagents`, and at launch we render each named teammate into
+its `.claude/agents/<id>.md`.
+
+This is the lightweight sibling of task delegation:
+
+| | Native sub-agent (`usableSubagents`) | `task_dispatch` / `task_wait` |
+|---|---|---|
+| Runtime | in-process, sub-second, ephemeral | a new governed tmux session |
+| Identity / budget / audit | **rolls up to the parent** run | a **distinct principal**, separately accountable |
+| Console | invisible (a sub-run of the parent) | first-class session + Kanban card |
+| Use it for | "help me finish *my* turn" | "hand off to an accountable teammate" |
+
+Two intents, two tools. Neither replaces the other.
+
+## Why the invariant still holds
+
+Agent OS's one invariant: *every effect an agent has on the world passes the mediated gateway.* A
+native sub-agent runs **in the same process** as the parent session, so the **PreToolUse gate hook
+fires for the sub-agent's tool calls too** (confirmed against the Claude Code hooks docs). Every
+sub-agent effect is therefore still classified / approved / budgeted / audited — there is no ungoverned
+path. What changes is only *topology and attribution*:
+
+- The sub-agent acts under the **parent session's principal, run-as identity, and budget** — it is not
+  a separate citizen. So the real guardrails on "how much can a session amplify itself" are the two
+  knobs below, not a separate governance context.
+- Claude Code tags the PreToolUse hook input with `agent_type` + `agent_id` (present *only* for
+  sub-agent calls). `terminal/gate-hook.sh` forwards them to `POST /api/gate`, and `TerminalManager.gate`
+  stamps `gate.attempt` / `gate.decision` with `subagent` / `subagentId` — so the audit trail shows
+  *which* sub-agent produced a governed effect, even though it rolls up to the parent run.
+
+## The two guardrails
+
+1. **`usableSubagents` allow-list** (per parent manifest). Empty/undefined ⇒ the agent spawns no fleet
+   sub-agents. Self-references, unknown ids, and non-`claude-code` teammates are ignored at
+   materialisation time. Owner/admin-only to set (the agent config route); a self-editing agent can't
+   widen its own reach.
+2. **Capped toolset** (`SUBAGENT_DEFAULT_TOOLS` in `src/edge/subagents.ts`), written into each
+   sub-agent's `tools:` frontmatter: read/search + gated `Bash`/`Edit`/`Write` + memory *recall*.
+   Deliberately **excludes** proactive egress (`slack_send`/`discord_send`), the secrets tools,
+   `publish`, and the `ask`/`report` operator surface — a delegate has no business reaching those under
+   the parent's identity.
+
+## Implementation
+
+- `src/types.ts` — `usableSubagents?: string[]` on `AgentManifest`; `sanitizeUsableSubagents()`.
+- `src/edge/subagents.ts` — `materializeSubagents(claudeDir, parent, fleet)` renders each allowed
+  teammate to `.claude/agents/<id>.md` (persona = the teammate's `CLAUDE.md`). Idempotent: tracks its
+  own files in `.aos-managed.json`, deletes deselected ones, and never touches hand-authored `*.md`.
+  Mirrors the skills-materialisation pattern.
+- `src/terminal.ts` — `launchClaudeCode` calls `materializeSubagents` right after `materializeSkills`;
+  `gate()` takes an optional `subagent` and threads it into the two audit events.
+- `terminal/gate-hook.sh` — extracts `agent_type`/`agent_id` (U+001F-separated, so the empty fields of
+  a top-level call don't collapse) and forwards them as `subagentType`/`subagentId`.
+- `src/server.ts` — `/api/gate` reads those; the agent config route (`GET`/`PUT /api/agents/:id/config`)
+  reads/writes `usableSubagents`.
+
+## Follow-ups
+
+- **Console editor.** The config route round-trips `usableSubagents`, but the agent settings UI has no
+  picker yet — today you set it by editing `agent.json` (or via `PUT /api/agents/:id/config`). Add a
+  multi-select of fleet teammates.
+- **Per-parent tool scoping.** One global default toolset today. A parent (or a per-delegate entry)
+  could narrow it further.
+- **Nesting visibility.** `agent_id` is captured in audit but the console doesn't yet render a sub-run
+  tree. A "N sub-agent calls" badge on the session view would make the topology legible.
+- **A live-refresh path** (à la `refreshAgentSkills`) so toggling `usableSubagents` reaches a resident
+  interactive session without a relaunch. Headless runs pick it up next launch already.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.233.0",
+  "version": "0.234.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.233.0",
+      "version": "0.234.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.233.0",
+  "version": "0.234.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/subagents.ts
+++ b/src/edge/subagents.ts
@@ -1,0 +1,149 @@
+/**
+ * Fleet-agent-as-sub-agent materialisation.
+ *
+ * Claude Code has a native, in-process sub-agent runtime: the built-in `Agent`/Task tool spawns a
+ * child defined by a `.claude/agents/<name>.md` file (frontmatter + persona), runs it to completion,
+ * and returns its result inline — sub-second, no separate process. Agent OS piggybacks on it: when a
+ * parent agent's manifest opts in via `usableSubagents`, we render EACH named fleet teammate into the
+ * parent's `<dir>/.claude/agents/<id>.md` at launch, exactly like the skills library is synced into
+ * `.claude/skills`. The running claude can then delegate a slice of its OWN turn to a teammate persona
+ * without filing a task or spawning a governed session — the lightweight counterpart to `task_dispatch`.
+ *
+ * The invariant survives because a native sub-agent runs IN THE SAME PROCESS as the parent session:
+ * the PreToolUse gate hook fires for the sub-agent's tool calls too (Claude Code passes `agent_type`/
+ * `agent_id` on the hook input), so every effect is still classified/approved/budgeted/audited — under
+ * THIS session's principal + budget, tagged with which sub-agent produced it. The only real guardrails
+ * on "how big can a session amplify itself" are therefore (a) the `usableSubagents` allow-list and
+ * (b) the capped toolset below — deliberately excluding proactive egress (`slack_send`/`discord_send`),
+ * the secrets tools, `publish`, and the operator/inbox surface. A sub-agent is a worker for the current
+ * turn, not an independent citizen. See docs/subagents-plan.md.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { AgentManifest } from '../types';
+
+/**
+ * The toolset a materialised fleet sub-agent is allowed to use, written verbatim into the `tools:`
+ * frontmatter (a Claude Code allow-list; anything not listed is unavailable to the child). Chosen to
+ * be a genuinely useful worker whose risky actions are STILL gated — Bash/Edit/Write pass the gate
+ * hook — while withholding the amplifying tools a delegate has no business reaching under the parent's
+ * identity: proactive egress, the vault, `publish`, `ask`/`report`, agent/policy self-mutation. The
+ * OS-owned memory RECALL tools are included so the child has read context; writes/forget are not.
+ */
+export const SUBAGENT_DEFAULT_TOOLS: readonly string[] = [
+  'Read',
+  'Glob',
+  'Grep',
+  'Bash',
+  'Edit',
+  'Write',
+  'mcp__agentos__recall',
+  'mcp__agentos__kb_search',
+  'mcp__agentos__kb_read',
+];
+
+/** Marker file listing the `.md` files we manage, so a re-sync refreshes ONLY ours and leaves any
+ *  hand-authored per-agent sub-agents in `.claude/agents/` untouched (mirrors skills' `.aos-managed`). */
+const INDEX = '.aos-managed.json';
+
+/** Escape a value for a single-line YAML frontmatter scalar (description can contain colons/quotes). */
+function yamlScalar(s: string): string {
+  const clean = s.replace(/\s+/g, ' ').trim();
+  return `"${clean.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+/** Render one fleet manifest as a Claude Code sub-agent definition (frontmatter + persona body). */
+export function renderSubagentMd(delegate: AgentManifest, tools: readonly string[]): string {
+  const persona = readPersona(delegate);
+  const lines = [
+    '---',
+    `name: ${delegate.id}`,
+    `description: ${yamlScalar(delegate.description || `The ${delegate.id} agent.`)}`,
+    `tools: ${tools.join(', ')}`,
+  ];
+  if (delegate.model) lines.push(`model: ${delegate.model}`);
+  lines.push('---', '');
+  lines.push(
+    `You are the **${delegate.id}** agent, invoked as a sub-agent to handle a focused slice of a`,
+    `teammate's task. Do the work, then return your result — it becomes the caller's tool result, not a`,
+    `message to a human. ${delegate.description || ''}`.trim(),
+    '',
+  );
+  if (persona) {
+    lines.push('---', '', '# Your operating instructions', '', persona.trim(), '');
+  }
+  return lines.join('\n');
+}
+
+/** The delegate's own CLAUDE.md is its persona/system prompt when launched normally; embed it so the
+ *  sub-agent adopts the same behaviour. Best-effort — a missing/oversized file just yields no body. */
+function readPersona(delegate: AgentManifest): string {
+  if (!delegate.dir) return '';
+  try {
+    const p = path.join(delegate.dir, 'CLAUDE.md');
+    const stat = fs.statSync(p);
+    if (stat.size > 64 * 1024) return ''; // don't inline a runaway file
+    return fs.readFileSync(p, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+/**
+ * Sync the parent agent's `usableSubagents` into `<claudeDir>/agents/*.md`. Returns the delegate ids
+ * actually written. Idempotent and safe to call every launch:
+ *  - the `.claude/agents` dir is always ensured (Claude only watches a dir that existed at startup);
+ *  - files we previously managed but no longer should (removed from the list / gone from the fleet)
+ *    are deleted, tracked via the `.aos-managed.json` index;
+ *  - hand-authored `.md` files not in our index are never touched;
+ *  - a self-reference, an unknown id, or a non-claude-code teammate is skipped.
+ * Best-effort by contract: the caller wraps this so a failure never blocks a session launch.
+ */
+export function materializeSubagents(
+  claudeDir: string,
+  parent: AgentManifest,
+  fleet: Map<string, AgentManifest>,
+  tools: readonly string[] = SUBAGENT_DEFAULT_TOOLS,
+): string[] {
+  const agentsDir = path.join(claudeDir, 'agents');
+  fs.mkdirSync(agentsDir, { recursive: true });
+
+  const wanted = (parent.usableSubagents ?? [])
+    .map((id) => fleet.get(id))
+    .filter((m): m is AgentManifest => !!m && m.id !== parent.id && m.runtime === 'claude-code');
+
+  // Remove files we managed last time but shouldn't now (deselected or vanished from the fleet).
+  const prev = readIndex(agentsDir);
+  const nextNames = new Set(wanted.map((m) => `${m.id}.md`));
+  for (const stale of prev) {
+    if (!nextNames.has(stale)) {
+      try { fs.rmSync(path.join(agentsDir, stale), { force: true }); } catch { /* best-effort */ }
+    }
+  }
+
+  const written: string[] = [];
+  for (const delegate of wanted) {
+    try {
+      fs.writeFileSync(path.join(agentsDir, `${delegate.id}.md`), renderSubagentMd(delegate, tools));
+      written.push(delegate.id);
+    } catch { /* skip a single unwritable delegate, keep the rest */ }
+  }
+  writeIndex(agentsDir, written.map((id) => `${id}.md`));
+  return written;
+}
+
+function readIndex(agentsDir: string): string[] {
+  try {
+    const raw = JSON.parse(fs.readFileSync(path.join(agentsDir, INDEX), 'utf8'));
+    return Array.isArray(raw) ? raw.filter((x) => typeof x === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeIndex(agentsDir: string, names: string[]): void {
+  try {
+    if (names.length) fs.writeFileSync(path.join(agentsDir, INDEX), JSON.stringify(names));
+    else fs.rmSync(path.join(agentsDir, INDEX), { force: true });
+  } catch { /* best-effort */ }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,7 +47,7 @@ import { JsonPolicyEngine, PolicyDocument, applyProposal, validatePolicyDocument
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
 import { parseBundle } from './governance/bundle-import';
-import { AgentManifest, AppManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, isValidAppSlug, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeAppDomains, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, TaskStatus, GoalStatus } from './types';
+import { AgentManifest, AppManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, isValidAppSlug, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeAppDomains, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, sanitizeUsableSubagents, TaskStatus, GoalStatus } from './types';
 import { AgentConfigSnapshot } from './state/agent-revisions';
 import { computeAgentStats, computeAgentStat } from './state/agent-stats';
 
@@ -582,12 +582,17 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const sessionId = String(b.sessionId || '');
     if (!tm.hasSession(sessionId)) return sendJson(res, 404, { error: 'unknown session' });
     if (!sessionSecretOk(sessionId)) return sendJson(res, 403, { error: 'bad session secret' });
+    // A native Claude Code sub-agent's tool call carries `agent_type`/`agent_id` on the PreToolUse hook
+    // input (the gate hook forwards them). Present ⇒ this governed effect came from a sub-agent of the
+    // session; thread it into the audit trail. Absent for a normal top-level tool call.
+    const subagent = b.subagentType ? { type: String(b.subagentType), id: b.subagentId ? String(b.subagentId) : undefined } : undefined;
     const result = tm.gate(
       sessionId,
       String(b.agent || ''),
       String(b.capability || ''),
       (b.args && typeof b.args === 'object') ? b.args : {},
       String(b.reasoning || ''),
+      subagent,
     );
     return sendJson(res, 200, result);
   }
@@ -3518,7 +3523,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!ag?.dir) return sendJson(res, 404, { error: 'agent not found or has no folder' });
     if (ag.runtime !== 'claude-code') return sendJson(res, 400, { error: 'runtime tuning applies to claude-code agents only' });
     if (method === 'GET') {
-      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, netMode: ag.netMode ?? 'open', category: ag.category, icon: ag.icon });
+      return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, usableSubagents: ag.usableSubagents ?? [], netMode: ag.netMode ?? 'open', category: ag.category, icon: ag.icon });
     }
     const b = await readBody(req);
     const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
@@ -3530,6 +3535,10 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // everything else.
     const prompts = 'examplePrompts' in b ? sanitizeExamplePrompts(b.examplePrompts) : ag.examplePrompts;
     const shellSecrets = 'shellSecrets' in b ? sanitizeShellSecrets(b.shellSecrets) : ag.shellSecrets;
+    // Which fleet teammates this agent may spawn as native sub-agents. Amplification-sensitive but not a
+    // governance bypass (every sub-agent effect is still gated), so it rides the owner/admin config route
+    // like shellSecrets. A self-editing agent can't reach here to widen its own reach.
+    const usableSubagents = 'usableSubagents' in b ? sanitizeUsableSubagents(b.usableSubagents) : ag.usableSubagents;
     // netMode is governance-sensitive (only owner/admin reach this route; a self-editing agent CANNOT
     // change it). 'allowlist' locks the agent to its granted hosts; anything else → 'open'. Undefined
     // ('open') is left off the manifest to keep it clean.
@@ -3537,7 +3546,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
     const icon = 'icon' in b ? sanitizeIcon(b.icon) : ag.icon;
     const description = 'description' in b ? String(b.description ?? '').trim() : ag.description;
-    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, netMode: netMode === 'open' ? undefined : netMode, category, icon };
+    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, examplePrompts: prompts, shellSecrets, usableSubagents, netMode: netMode === 'open' ? undefined : netMode, category, icon };
     const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     os.registerAgent(next);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,7 +15,7 @@ import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { containedPath, mimeOf } from './state/artifacts';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
-import { ActionAttempt, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
+import { ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval } from './governance/enricher';
 import { hostGovernanceDecision, stricterDecision } from './governance/host-match';
 import { Audience, approvalAudience, resolveRecipients } from './governance/recipients';
@@ -43,6 +43,7 @@ const VIDEO_INCALL_POLL_MS = 10_000;       // …10s apart (~30s max block, with
 const ASK_AGENT_GRACE_MS = 20_000;
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
+import { materializeSubagents } from './edge/subagents';
 import { GithubIdentity } from './edge/github-identity';
 import { LauncherSessionBackend, LocalSessionBackend, SessionBackend, SpawnErrorSink } from './edge/session-backend';
 
@@ -1365,6 +1366,7 @@ export class TerminalManager {
     const mcpJson = this.buildMcpConfigJson(o.id, o.agent, o.actingMember, o.secret, o.hasSlack, o.hasDiscord, askAnswer);
     const companyMd = this.buildCompanyMd(o.agent, o.actingMember);
     this.materializeSkills(o.id, o.agent, manifest.dir);
+    this.materializeSubagents(o.id, o.agent, manifest);
     // Unattended (automation/cron/task) runs are now an attachable interactive TUI, not `claude -p` — so a
     // human can take one over mid-run by simply attaching (no kill, no resume). The launcher's UNATTENDED
     // lane runs interactive + `--dangerously-skip-permissions` (the gate hook still governs every effect),
@@ -2162,6 +2164,21 @@ export class TerminalManager {
   }
 
   /**
+   * Sync the agent's opted-in `usableSubagents` fleet teammates into `<dir>/.claude/agents/*.md` so the
+   * launched claude can spawn them as native in-process sub-agents (the `Agent`/Task tool). The gate
+   * hook still governs every effect a sub-agent has (tagged with its `agent_type`); this just exposes
+   * the teammate personas. Best-effort — a failure must never block a session launch.
+   */
+  private materializeSubagents(sessionId: string, agent: string, manifest: AgentManifest): void {
+    try {
+      const names = materializeSubagents(path.join(manifest.dir!, '.claude'), manifest, this.os.agents);
+      if (names.length) this.audit(sessionId, agent, 'subagents.materialized', { count: names.length, subagents: names });
+    } catch (e) {
+      this.audit(sessionId, agent, 'subagents.error', { error: String(e) });
+    }
+  }
+
+  /**
    * Phase 3 same-session skill delivery. After a skill is installed for `agent` (an approved
    * `skill_request`), push it into that agent's LIVE interactive sessions instead of waiting for their
    * next launch: re-materialise the library into the agent's watched `.claude/skills` (so the new skill
@@ -2230,7 +2247,12 @@ export class TerminalManager {
 
   /** The gate. Same policy brain as the console — allow flows, ask → inbox approval (auto-cleared for
    *  an attended approver), never → deny. Args are enriched into facts first (the single classifier). */
-  gate(sessionId: string, agent: string, capability: string, rawArgs: Record<string, unknown>, reasoning: string): GateResult {
+  gate(sessionId: string, agent: string, capability: string, rawArgs: Record<string, unknown>, reasoning: string, subagent?: { type?: string; id?: string }): GateResult {
+    // A native Claude Code sub-agent (the `Agent`/Task tool) runs IN this session's process, so its
+    // tool calls arrive here under the SAME session/principal/budget — Claude Code just tags the hook
+    // input with `agent_type`/`agent_id`. Carry that through into the audit trail so a governed effect
+    // is attributable to which sub-agent produced it, without inventing a separate governed session.
+    const sub = subagent?.type ? { subagent: subagent.type, subagentId: subagent.id } : undefined;
     // Workspace emergency stop — deny every action before classifying anything.
     if (this.os.settings.killSwitch().engaged) {
       this.audit(sessionId, agent, 'gate.killswitch', { capability });
@@ -2283,8 +2305,8 @@ export class TerminalManager {
     if (hostGrants && (capability === 'net.connect' || capability === 'ssh.exec')) {
       decision = stricterDecision(decision, hostGovernanceDecision(capability, args));
     }
-    this.audit(sessionId, agent, 'gate.attempt', { capability, args, reasoning });
-    this.audit(sessionId, agent, 'gate.decision', { capability, decision });
+    this.audit(sessionId, agent, 'gate.attempt', { capability, args, reasoning, ...sub });
+    this.audit(sessionId, agent, 'gate.decision', { capability, decision, ...sub });
 
     if (decision.effect === 'allow') return { decision: 'allow' };
     if (decision.effect === 'deny') return { decision: 'deny' };
@@ -4243,7 +4265,8 @@ function shSingleQuote(v: string): string {
 const EPISODE_NOISE = new Set([
   'session.created', 'session.ended', 'session.reported', 'session.resumed', 'session.reloaded', 'session.stopped',
   'session.error', 'session.tuning', 'session.progress', 'session.notified', 'session.attachment',
-  'skills.materialized', 'skills.reloaded', 'skills.error', 'connector.minted', 'connector.mint.failed',
+  'skills.materialized', 'skills.reloaded', 'skills.error', 'subagents.materialized', 'subagents.error',
+  'connector.minted', 'connector.mint.failed',
   'connector.secret.unresolved', 'shell.secret.injected', 'shell.secret.unresolved',
   'gate.attempt', 'gate.killswitch', 'approval.resolved',
   'approval.auto_approved', 'episode.stored', 'episode.error',

--- a/src/types.ts
+++ b/src/types.ts
@@ -956,6 +956,16 @@ export interface AgentManifest extends RuntimeTuning {
    *  shell.exec; only internal-looking or explicitly-listed hosts are governed. `'allowlist'` (lockdown):
    *  ANY detected egress to a host not in this agent's grants pauses/denies. Undefined → 'open'. */
   netMode?: 'open' | 'allowlist';
+  /** Opt-in list of OTHER fleet agent ids this agent may spawn as **native Claude Code sub-agents**
+   *  (the built-in `Agent`/Task tool). At launch each named agent's manifest + persona (its CLAUDE.md)
+   *  is materialised into this agent's `.claude/agents/<id>.md`, so the running claude can delegate a
+   *  slice of its OWN turn to a teammate in-process (sub-second, no separate governed session) — the
+   *  lightweight counterpart to `task_dispatch`. Every effect the sub-agent has still passes the
+   *  PreToolUse gate hook (attributed to THIS session's principal + budget, tagged with the sub-agent's
+   *  `agent_type`), and the sub-agent's toolset is capped to {@link SUBAGENT_DEFAULT_TOOLS} — never the
+   *  egress/secret tools. Undefined/empty → this agent spawns no fleet sub-agents. Self-references and
+   *  non-claude-code / unknown ids are ignored. See docs/subagents-plan.md. */
+  usableSubagents?: string[];
   /** The agent's visual icon. Either a built-in library id (a lucide icon name like `"Bot"`) or a raw
    *  custom `<svg>…</svg>` markup string the user uploaded. Undefined → the console falls back to a
    *  default glyph. Purely cosmetic. Rendered in an `<img>` so inline SVG can't execute scripts. */
@@ -1142,6 +1152,29 @@ export function sanitizeShellSecrets(input: unknown): string[] | undefined {
     seen.add(k);
     out.push(k);
     if (out.length >= 32) break;
+  }
+  return out.length ? out : undefined;
+}
+
+/** Normalize a `usableSubagents` payload (API body or config file): coerce to an array of well-formed
+ *  agent ids (the fleet-teammate ids this agent may spawn as native sub-agents), dedupe order-preserving,
+ *  cap the list at 16. Existence / claude-code / self-reference filtering happens at materialisation time
+ *  against the live fleet, so this only enforces the id SHAPE. Undefined when empty → no manifest key. */
+export function sanitizeUsableSubagents(input: unknown): string[] | undefined {
+  const raw = Array.isArray(input)
+    ? input
+    : typeof input === 'string'
+      ? input.split(/[\s,]+/) // accept a comma/space/newline-separated string from a UI field too
+      : [];
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const x of raw) {
+    if (typeof x !== 'string') continue;
+    const id = x.trim().toLowerCase();
+    if (!/^[a-z][a-z0-9-]{1,39}$/.test(id) || seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+    if (out.length >= 16) break;
   }
   return out.length ? out : undefined;
 }

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -36,7 +36,13 @@ emit() {
 # the FULL tool_input to the server, which enriches it into facts (case-insensitive, argument-aware —
 # it sees the SQL inside db_query/execute_php, the dollar amount, the delete count) and classifies.
 # Tab-separated so the JSON input survives `read` on one line (JSON.stringify escapes tabs/newlines).
-IFS=$'\t' read -r TOOL INPUT <<<"$(printf '%s' "$EVENT" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const e=JSON.parse(d||"{}");process.stdout.write((e.tool_name||"")+"\t"+JSON.stringify(e.tool_input||{}))})')"
+# `agent_type`/`agent_id` are present ONLY when this tool call comes from a native sub-agent (the
+# Agent/Task tool). We forward them so the server can attribute the governed effect to which sub-agent
+# produced it. The fields are separated by U+001F (unit separator), NOT a tab: a tab is IFS-whitespace,
+# so `read` would COLLAPSE the empty agent_type/agent_id fields of a normal top-level call and shove the
+# JSON into the wrong variable. U+001F is non-whitespace (no collapsing, empty fields preserved) and can
+# never appear literally in INPUT because JSON.stringify escapes all control chars < 0x20.
+IFS=$'\x1f' read -r TOOL SUBTYPE SUBID INPUT <<<"$(printf '%s' "$EVENT" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const e=JSON.parse(d||"{}");const S="\x1f";process.stdout.write([e.tool_name||"",e.agent_type||"",e.agent_id||"",JSON.stringify(e.tool_input||{})].join(S))})')"
 
 # The OS-owned tools (memory recall/remember, ask/report, policy preview) are internal and never
 # touch the outside world, so they bypass the gate entirely.
@@ -58,7 +64,7 @@ case "$TOOL" in
   *) exit 0 ;;  # any other built-in tool (Read/Glob/Grep/…) isn't a world side effect → allow
 esac
 
-payload=$(node -e 'const[s,a,cap,t,inp]=process.argv.slice(1);let input={};try{input=JSON.parse(inp||"{}")}catch(e){};console.log(JSON.stringify({sessionId:s,agent:a,capability:cap,args:{tool:t,input},reasoning:"claude PreToolUse: "+t}))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$INPUT")
+payload=$(node -e 'const[s,a,cap,t,inp,st,si]=process.argv.slice(1);let input={};try{input=JSON.parse(inp||"{}")}catch(e){};const o={sessionId:s,agent:a,capability:cap,args:{tool:t,input},reasoning:"claude PreToolUse: "+t};if(st){o.subagentType=st;if(si)o.subagentId=si;}console.log(JSON.stringify(o))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$INPUT" "$SUBTYPE" "$SUBID")
 
 # FAIL-CLOSED classify. Retry the gate until it returns a usable decision; a transient failure (server
 # restart, network blip, the documented stale-server 401/404 window) must NEVER fall through to "allow".


### PR DESCRIPTION
## What

Lets a running agent spawn **another fleet agent as a native Claude Code sub-agent** (the built-in `Agent`/Task tool) — sub-second, in-process, no separate governed session. The lightweight counterpart to `task_dispatch` (which stays the path for delegating to a *separately accountable* citizen).

A parent agent opts in via a new manifest field `usableSubagents: string[]`. At launch each named teammate's manifest + persona (its `CLAUDE.md`) is materialised into the parent's `.claude/agents/<id>.md` — mirroring how the skills library syncs into `.claude/skills`.

## Why the gateway invariant still holds

A native sub-agent runs **in the parent session's process**, so the PreToolUse gate hook fires for its tool calls too — every effect is still classified / approved / budgeted / audited, under the parent's principal + budget. Claude Code tags the hook input with `agent_type`/`agent_id` (present only for sub-agent calls); `terminal/gate-hook.sh` forwards them and `gate()` stamps `gate.attempt`/`gate.decision` with `subagent`/`subagentId`, so audit attributes a governed effect to which sub-agent produced it.

## Guardrails

1. **`usableSubagents` allow-list** — empty ⇒ no fleet sub-agents. Self/unknown/non-claude-code ids ignored. Owner/admin-only to set (`GET`/`PUT /api/agents/:id/config`); the self-edit path never reads it, so an agent can't widen its own reach.
2. **Capped toolset** (`SUBAGENT_DEFAULT_TOOLS`) written into each sub-agent's `tools:` frontmatter: read/search + gated Bash/Edit/Write + memory recall. Excludes egress (`slack_send`/`discord_send`), the vault, `publish`, and the operator/inbox surface.

## Notable fix

The gate hook forwards the new fields via a **U+001F** separator, not a tab: a tab is IFS-whitespace, so `read` would collapse the empty `agent_type`/`agent_id` fields of a normal top-level call and mis-parse the JSON into the wrong variable. Verified both paths (top-level + sub-agent, incl. a piped command) build correct payloads.

## Deploy note

Touches server/store code + an agent-facing hook + the gate hook → needs `npm run build` **+ server restart** to take effect on the live tenant, and sessions must relaunch to pick up the new `.claude/agents` materialisation. Not deployed by this PR.

## Test
- `npm run typecheck` clean
- `npm run test:governance` → 68/68
- Isolated materializer test: filters mock/self/unknown, embeds persona, refreshes on reselect, removes deselected, preserves hand-authored files
- Isolated gate-hook parse test: subagent / top-level / subtype-without-id all correct

See `docs/subagents-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVfxDWBcQLbAqJPshB4Ha2