### PR TITLE
feat(console): session status dot shows blocked/headless, not just live (v0.234.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.235.0] — 2026-07-20
+### Changed
+- **The session status dot now reflects the state that needs you, not just "live vs not".** The little
+  dot on every session row (`statusDot` in `web/src/App.tsx`) used to have four colours — emerald=live,
+  amber=stopped, red=crashed, muted=done — so a run sitting on a pending approval or `ask` looked
+  identical to one happily working. It now surfaces the two derived flags the server already computes
+  (`Session.blocked`/`headless`) with a priority-ordered mapping: **blocked wins** and shows an
+  amber **pulsing** dot (the only animated one — the state you must act on); a live run is emerald,
+  **filled** for your own interactive session and a **hollow ring** for an unattended (headless) run, so
+  "the fleet is doing this on its own" reads differently from "I'm driving this" without spending a
+  second colour; stopped/crashed/done are unchanged. `statusLabel` reads "waiting" for a blocked run so
+  the word next to the dot never contradicts it. Purely presentational — no data model or API change.
+
 ## [0.234.0] — 2026-07-20
 ### Added
 - **An agent can spawn fleet teammates as native in-process sub-agents.** A parent agent's manifest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.234.0",
+  "version": "0.235.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.234.0",
+      "version": "0.235.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.234.0",
+  "version": "0.235.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -45,16 +45,28 @@ const canApprove = (role: Role, level: 'head' | 'owner'): boolean =>
  *  for the green dot: an interactive session that reported `done` but keeps an attachable pane is live. */
 const isLive = (s: Session): boolean => Boolean(s.alive) || s.status === 'running'
 
-/** Status dot colour for a session: live=emerald, done=muted, stopped=amber, crashed=red. */
+/** Status dot for a session — the at-a-glance lifecycle signal, priority-ordered so the state that
+ *  most needs a human wins:
+ *   • blocked  → amber, PULSING  — live but waiting on you (a pending `ask` or approval gate). The one
+ *                                  you must act on, so it's the only animated dot.
+ *   • live     → emerald         — working. FILLED for your own interactive run; a HOLLOW ring for an
+ *                                  unattended (headless) run, so "the fleet is doing this on its own"
+ *                                  reads differently from "I'm driving this" without a second colour.
+ *   • stopped  → amber (static)  — halted by a human/reaper.
+ *   • crashed  → red             — pane died with no end signal.
+ *   • done     → muted           — finished cleanly (and any unknown legacy value). */
 const statusDot = (s: Session): string =>
-  isLive(s) ? 'bg-emerald-500'
+  s.blocked ? 'bg-amber-400 animate-pulse'
+    : isLive(s) ? (s.headless ? 'border border-emerald-500' : 'bg-emerald-500')
     : s.status === 'stopped' ? 'bg-amber-500'
     : s.status === 'crashed' ? 'bg-red-500'
     : 'bg-muted-foreground/40' // done (and any unknown legacy value)
 
-/** The status word shown next to the dot. A live pane whose stored status is a terminal state (a
- *  `done` interactive session still running) reads "live" so the label never contradicts a green dot. */
-const statusLabel = (s: Session): string => (isLive(s) && s.status !== 'running' ? 'live' : s.status)
+/** The status word shown next to the dot. `blocked` reads "waiting" (it needs a human); a live pane
+ *  whose stored status is a terminal state (a `done` interactive session still running) reads "live"
+ *  so the label never contradicts the dot. */
+const statusLabel = (s: Session): string =>
+  s.blocked ? 'waiting' : isLive(s) && s.status !== 'running' ? 'live' : s.status
 
 /** The RESULT word: what the agent said came of the run, falling back to how the process ended. `done`
  *  only means "the process exited" — it's the outcome that says whether the work landed, so once a run


### PR DESCRIPTION
## What

The little status dot on every session row used to have four colours — 🟢 live / 🟠 stopped / 🔴 crashed / ⚪ done — keyed only off `isLive`. So a run **sitting on a pending approval or `ask`** looked identical to one happily working, and an **unattended fleet run** looked identical to your own interactive session. Both of those are states you want to spot at a glance.

The server already computes `Session.blocked` and `Session.headless`; the dot just ignored them. Now `statusDot` (`web/src/App.tsx`) priority-orders them:

| dot | state | meaning |
|---|---|---|
| 🟡 amber **pulsing** | `blocked` | live but waiting on you (pending `ask`/approval) — the only animated dot, the one to act on. Wins over everything. |
| 🟢 emerald **filled** | live, interactive | your own run, working |
| 🟢 emerald **hollow ring** | live, headless | an unattended/fleet run, working — reads differently from "I'm driving this" without a second colour |
| 🟠 amber | stopped | unchanged |
| 🔴 red | crashed | unchanged |
| ⚪ muted | done | unchanged |

`statusLabel` now reads **"waiting"** for a blocked run so the word next to the dot never contradicts it.

## Why

Blocked ("needs a human") is the single most important state to surface and it was invisible; headless-vs-interactive was only shown via a separate badge. This puts both into the one indicator that's on every row.

## Scope

Purely presentational — no data model, API, or server change. Same `statusDot(s)` helper feeds every existing render site (sidebar nav, session list, table, status pill), so all of them get it at once.

## Test

- `cd web && npm run build` ✓ — compiles; the new classes (`animate-pulse`, `bg-amber-400`, `border-emerald-500`) are all present in the emitted bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)