### PR TITLE
feat(sessions): tier-2 session insights — tuning, human-wait latency, deliverables (v0.236.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.236.0] — 2026-07-20
+### Added
+- **Tier-2 session insights — runtime tuning, human-wait latency, and deliverables on every row.**
+  Extends the result/duration/activity columns (0.232.0) with four more signals, all derived from
+  data the OS already records and stamped once when a run goes terminal (live rows re-derived per
+  poll). **model · effort** — the runtime tuning the run launched with (from its `session.tuning`
+  audit event), a muted pill leading the activity cluster, so "what ran this, how hard" reads next to
+  cost now that both lanes are per-task overridable. **Blocked-on-human time** — a ⏳ chip totalling
+  how long the run sat waiting on a person: approval gates (paired `approval.requested`→`resolved`
+  audit spans, since the approvals table keeps no resolved timestamp) plus `ask` questions; the
+  governed-OS latency nothing else surfaced, and a big value next to a small engaged time is a run
+  that mostly waited on people. **Artifacts published** — a 📎 chip counting the Library deliverables
+  the run produced. The stamp guard now retires a row only when both tiers are present, so rows
+  stamped by the 0.232.0 build re-stamp once to backfill the new columns rather than being skipped.
+
 ## [0.235.0] — 2026-07-20
 ### Changed
 - **The session status dot now reflects the state that needs you, not just "live vs not".** The little

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.235.0",
+  "version": "0.236.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.235.0",
+      "version": "0.236.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.235.0",
+  "version": "0.236.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -858,6 +858,20 @@ function migrate(db: Db): void {
   addColumn(db, 'term_sessions', 'gov_approvals', 'INTEGER');  // approval.requested — human gates hit
   addColumn(db, 'term_sessions', 'gov_denied', 'INTEGER');     // policy denials + rejected approvals
   addColumn(db, 'term_sessions', 'gov_errors', 'INTEGER');     // episode/session errors
+
+  // Session insights, tier 2 — the run's context + its human-latency cost. Same stamping discipline as
+  // the tier-1 columns above (once at terminal, live rows re-derived per poll).
+  //  · model/effort — the runtime tuning the run launched with (from its `session.tuning` audit event),
+  //    so "which model / how hard did it think" reads next to cost now that both are per-task overridable.
+  //    NULL = the run left that lane on the workspace default (nothing to show).
+  //  · blocked_ms — total time the run sat BLOCKED on a human: approval gates (paired
+  //    `approval.requested`→`approval.resolved` audit spans) + `ask` questions (`answered_at - created_at`).
+  //    The governed-OS latency nothing else surfaces. `gov_approvals IS NULL` still marks "not stamped".
+  //  · artifacts — how many deliverables the run published (rows in `artifacts` for this session).
+  addColumn(db, 'term_sessions', 'model', 'TEXT');             // e.g. claude-opus-4-8
+  addColumn(db, 'term_sessions', 'effort', 'TEXT');            // low | medium | high | …
+  addColumn(db, 'term_sessions', 'blocked_ms', 'INTEGER');     // total human-wait (approvals + questions)
+  addColumn(db, 'term_sessions', 'artifacts', 'INTEGER');      // deliverables published by the run
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -257,6 +257,17 @@ export interface Session {
    *  `errors` = session/episode errors. Live rows carry the running tally; terminal rows the stamped
    *  final one. Definitions mirror `episodeSalience`, which grades the same signals for memory. */
   insights?: { actions: number; approvals: number; denied: number; errors: number };
+  /** The runtime tuning the run launched with — the model id and reasoning effort (`session.tuning`).
+   *  Undefined for whichever lane the run left on the workspace default. Surfaced now that both are
+   *  per-task overridable, so "what ran this, how hard" reads next to what it cost. */
+  model?: string;
+  effort?: string;
+  /** Total milliseconds the run sat BLOCKED on a human — approval gates plus `ask` questions. The
+   *  governed-OS latency no other field captures; a big number next to a small `activeMs` is a run that
+   *  mostly waited on people. Undefined until stamped; 0 when it never blocked. */
+  blockedMs?: number;
+  /** How many deliverables the run published to the Library (`artifacts` rows). Undefined until stamped. */
+  artifacts?: number;
 }
 
 export interface FeedMessage {
@@ -334,6 +345,10 @@ interface SessionRow {
   gov_approvals: number | null;
   gov_denied: number | null;
   gov_errors: number | null;
+  model: string | null;
+  effort: string | null;
+  blocked_ms: number | null;
+  artifacts: number | null;
 }
 interface MessageRow {
   id: string;
@@ -653,8 +668,9 @@ export class TerminalManager {
   }
 
   /**
-   * Stamp each row's OUTCOME (the agent's own verdict) and GOVERNANCE FINGERPRINT (what the run did
-   * through the gate) — the two things the sessions list can't say from `status` alone.
+   * Stamp each row's OUTCOME (the agent's own verdict), GOVERNANCE FINGERPRINT (what the run did
+   * through the gate), and CONTEXT (runtime tuning, human-wait latency, deliverables) — the things the
+   * sessions list can't say from `status` alone.
    *
    * Both derive from the run's audit stream, an indexed point lookup per row (`idx_audit_run`). A
    * TERMINAL run's stream is complete, so it's computed once and persisted; a LIVE run is recomputed
@@ -672,7 +688,10 @@ export class TerminalManager {
   private stampInsights(rows: SessionRow[]): void {
     for (const r of rows) {
       const live = r.status === 'running';
-      if (!live && r.gov_approvals != null) continue; // already stamped, and it can no longer change
+      // Fully stamped = both tiers present (`artifacts` is the tier-2 marker, like `gov_approvals` for
+      // tier-1). A row stamped by an older build carries the gov_* set but NULL tier-2 columns, so it
+      // re-stamps once to fill them, then this guard retires it. Terminal state can no longer change.
+      if (!live && r.gov_approvals != null && r.artifacts != null) continue;
 
       const counts = this.db.prepare(`SELECT
           SUM(type = 'gate.decision') AS actions,
@@ -701,16 +720,58 @@ export class TerminalManager {
         } catch { /* malformed audit payload — fall back to 'unknown' */ }
       }
 
+      // Runtime tuning the run launched with (set once at launch — present even while live).
+      const tuning = this.db
+        .prepare("SELECT data FROM audit_events WHERE run_id = ? AND type = 'session.tuning' ORDER BY ts DESC LIMIT 1")
+        .get<{ data: string }>(r.id);
+      let model: string | null = null;
+      let effort: string | null = null;
+      if (tuning) {
+        try {
+          const d = JSON.parse(tuning.data) as { model?: string; effort?: string };
+          model = d.model ?? null;
+          effort = d.effort ?? null;
+        } catch { /* malformed — leave both null */ }
+      }
+
+      // Human-wait: `ask` questions (own table carries the answered timestamp) + approval gates (no
+      // resolved_at column, so pair the audit spans by approvalId). Only closed waits count — a still-
+      // pending block hasn't cost a measurable duration yet, and this run is terminal by here anyway.
+      const qWait = this.db
+        .prepare('SELECT COALESCE(SUM(answered_at - created_at), 0) AS ms FROM questions WHERE run_id = ? AND answered_at IS NOT NULL')
+        .get<{ ms: number }>(r.id)?.ms ?? 0;
+      const apEvents = this.db
+        .prepare("SELECT ts, type, data FROM audit_events WHERE run_id = ? AND type IN ('approval.requested', 'approval.resolved') ORDER BY ts ASC")
+        .all<{ ts: number; type: string; data: string }>(r.id);
+      const requestedAt = new Map<string, number>();
+      let apWait = 0;
+      for (const e of apEvents) {
+        let id: string | undefined;
+        try { id = (JSON.parse(e.data) as { approvalId?: string }).approvalId; } catch { /* skip */ }
+        if (!id) continue;
+        if (e.type === 'approval.requested') requestedAt.set(id, e.ts);
+        else { const t0 = requestedAt.get(id); if (t0 != null) { apWait += Math.max(0, e.ts - t0); requestedAt.delete(id); } }
+      }
+      const blockedMs = qWait + apWait;
+
+      const artifacts = this.db
+        .prepare('SELECT COUNT(*) AS n FROM artifacts WHERE session_id = ?')
+        .get<{ n: number }>(r.id)?.n ?? 0;
+
       r.gov_actions = actions;
       r.gov_approvals = approvals;
       r.gov_denied = denied;
       r.gov_errors = errors;
       r.outcome = outcome;
       r.report_summary = summary;
+      r.model = model;
+      r.effort = effort;
+      r.blocked_ms = blockedMs;
+      r.artifacts = artifacts;
       if (live) continue; // still moving — surface it, but don't freeze it onto the row
       this.db
-        .prepare('UPDATE term_sessions SET gov_actions = ?, gov_approvals = ?, gov_denied = ?, gov_errors = ?, outcome = ?, report_summary = ? WHERE id = ?')
-        .run(actions, approvals, denied, errors, outcome, summary, r.id);
+        .prepare('UPDATE term_sessions SET gov_actions = ?, gov_approvals = ?, gov_denied = ?, gov_errors = ?, outcome = ?, report_summary = ?, model = ?, effort = ?, blocked_ms = ?, artifacts = ? WHERE id = ?')
+        .run(actions, approvals, denied, errors, outcome, summary, model, effort, blockedMs, artifacts, r.id);
     }
   }
 
@@ -4378,7 +4439,7 @@ function buildAskAgentPrompt(id: string, callerAgent: string, question: string, 
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined, costUsd: r.cost_usd ?? undefined, tokens: r.cost_usd != null ? { input: r.input_tokens ?? 0, output: r.output_tokens ?? 0, cacheRead: r.cache_read_tokens ?? 0, cacheWrite: r.cache_write_tokens ?? 0 } : undefined, outcome: r.outcome ?? undefined, summary: r.report_summary ?? undefined, activeMs: r.active_ms ?? undefined, turns: r.turns ?? undefined, toolCalls: r.tool_calls ?? undefined, insights: r.gov_approvals != null ? { actions: r.gov_actions ?? 0, approvals: r.gov_approvals, denied: r.gov_denied ?? 0, errors: r.gov_errors ?? 0 } : undefined };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined, costUsd: r.cost_usd ?? undefined, tokens: r.cost_usd != null ? { input: r.input_tokens ?? 0, output: r.output_tokens ?? 0, cacheRead: r.cache_read_tokens ?? 0, cacheWrite: r.cache_write_tokens ?? 0 } : undefined, outcome: r.outcome ?? undefined, summary: r.report_summary ?? undefined, activeMs: r.active_ms ?? undefined, turns: r.turns ?? undefined, toolCalls: r.tool_calls ?? undefined, insights: r.gov_approvals != null ? { actions: r.gov_actions ?? 0, approvals: r.gov_approvals, denied: r.gov_denied ?? 0, errors: r.gov_errors ?? 0 } : undefined, model: r.model ?? undefined, effort: r.effort ?? undefined, blockedMs: r.blocked_ms ?? undefined, artifacts: r.artifacts ?? undefined };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -105,20 +105,37 @@ const formatDuration = (ms?: number): string => {
   return `${Math.floor(m / 60)}h ${m % 60}m`
 }
 
-/** The run's activity fingerprint: how much it did, how often it needed a human, what got refused.
- *  Tool calls lead because they're the volume that's always there — governed actions are only the
- *  subset the gate mediates, so a real run can legitimately show 0. Zero-valued chips are dropped so
- *  the common case stays quiet and an approval/denial actually catches the eye. */
+/** Friendly model name — strip the `claude-` prefix and the trailing version so `claude-opus-4-8`
+ *  reads `opus`. Unknown ids fall back to the id minus the prefix. */
+const modelShort = (model?: string): string => {
+  if (!model) return ''
+  const m = model.replace(/^claude-/, '')
+  const fam = m.match(/^(opus|sonnet|haiku|fable|mythos)/)
+  return fam ? fam[1] : m
+}
+/** The run's launch tuning as one compact label, e.g. `opus·high` / `opus` / `high`. Empty when the
+ *  run left both lanes on the workspace default (nothing to show). */
+const tuningLabel = (s: Session): string => [modelShort(s.model), s.effort].filter(Boolean).join('·')
+
+/** The run's fingerprint: what it launched with, how much it did, how often it needed a human, what got
+ *  refused, and what it left behind. The tuning tag leads (context), then tool calls (the volume that's
+ *  always there — governed actions only count the gate-mediated subset, legitimately 0 for many runs),
+ *  then the friction/output chips. Zero-valued chips are dropped so the common case stays quiet and an
+ *  approval/denial/artifact actually catches the eye. */
 function SessionInsights({ s, className = '' }: { s: Session; className?: string }) {
   const g = s.insights
+  const tuning = tuningLabel(s)
   const chips: Array<{ key: string; text: string; cls: string; title: string }> = []
   if (s.toolCalls != null) chips.push({ key: 'tools', text: `${s.toolCalls}⚙`, cls: 'text-muted-foreground', title: `${s.toolCalls} tool calls${s.turns != null ? ` · ${s.turns} turn${s.turns === 1 ? '' : 's'}` : ''}` })
-  if (g?.approvals) chips.push({ key: 'appr', text: `${g.approvals}✋`, cls: 'text-sky-600', title: `${g.approvals} approval${g.approvals === 1 ? '' : 's'} needed a human` })
+  if (g?.approvals) chips.push({ key: 'appr', text: `${g.approvals}✋`, cls: 'text-sky-600', title: `${g.approvals} approval${g.approvals === 1 ? '' : 's'} needed a human${s.blockedMs ? ` · waited ${formatDuration(s.blockedMs)} on people` : ''}` })
+  if (s.blockedMs != null && s.blockedMs >= 1000) chips.push({ key: 'blk', text: `${formatDuration(s.blockedMs)}⏳`, cls: 'text-amber-600', title: `blocked ${formatDuration(s.blockedMs)} waiting on a human (approvals + questions)` })
   if (g?.denied) chips.push({ key: 'deny', text: `${g.denied}⛔`, cls: 'text-red-600', title: `${g.denied} action${g.denied === 1 ? '' : 's'} denied by policy or rejected` })
   if (g?.errors) chips.push({ key: 'err', text: `${g.errors}⚠`, cls: 'text-amber-600', title: `${g.errors} error${g.errors === 1 ? '' : 's'}` })
-  if (!chips.length) return <span className={`text-xs text-muted-foreground/50 ${className}`}>—</span>
+  if (s.artifacts) chips.push({ key: 'art', text: `${s.artifacts}📎`, cls: 'text-violet-600', title: `${s.artifacts} deliverable${s.artifacts === 1 ? '' : 's'} published to the Library` })
+  if (!tuning && !chips.length) return <span className={`text-xs text-muted-foreground/50 ${className}`}>—</span>
   return (
     <span className={`flex items-center gap-1.5 text-xs tabular-nums ${className}`}>
+      {tuning && <span className="rounded bg-muted px-1 text-[10px] font-medium not-italic text-muted-foreground" title={`ran on ${s.model ?? 'default model'}${s.effort ? ` at ${s.effort} effort` : ''}`}>{tuning}</span>}
       {chips.map((c) => <span key={c.key} className={c.cls} title={c.title}>{c.text}</span>)}
     </span>
   )
@@ -3272,7 +3289,7 @@ function SessionsPage({
               <span className="w-24 shrink-0">Mode</span>
               {sortHead('updated', 'Updated', 'w-20 shrink-0')}
               {sortHead('duration', 'Took', 'hidden w-16 shrink-0 justify-end lg:flex')}
-              <span className="hidden w-20 shrink-0 xl:block">Activity</span>
+              <span className="hidden w-36 shrink-0 xl:block">Activity</span>
               {sortHead('cost', 'Cost', 'hidden w-16 shrink-0 justify-end lg:flex')}
               {sortHead('status', 'Result', 'w-20 shrink-0')}
             </div>
@@ -3299,7 +3316,7 @@ function SessionsPage({
                 {/* Engaged time, not wall-clock — the tooltip spells out the difference, which is often
                     hours for an interactive session that sat idle between turns. */}
                 <span className="hidden w-16 shrink-0 justify-end text-right text-xs tabular-nums text-muted-foreground lg:block" title={s.activeMs != null ? `${formatDuration(s.activeMs)} of engaged work — idle gaps excluded (open ${timeAgo(s.createdAt)} ago)` : 'duration not yet computed'}>{formatDuration(s.activeMs)}</span>
-                <SessionInsights s={s} className="hidden w-20 shrink-0 xl:flex" />
+                <SessionInsights s={s} className="hidden w-36 shrink-0 overflow-hidden xl:flex" />
                 <span className="hidden w-16 shrink-0 justify-end text-right text-xs tabular-nums text-muted-foreground lg:block" title={s.tokens ? `${(s.tokens.input + s.tokens.output + s.tokens.cacheRead + s.tokens.cacheWrite).toLocaleString()} tokens (in ${s.tokens.input.toLocaleString()} · out ${s.tokens.output.toLocaleString()} · cache-read ${s.tokens.cacheRead.toLocaleString()} · cache-write ${s.tokens.cacheWrite.toLocaleString()})` : 'cost not yet computed'}>{formatCost(s.costUsd)}</span>
                 {/* Result = the agent's own verdict, falling back to the process status. The summary
                     rides along as the tooltip so "what came of it" is one hover away. */}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -252,6 +252,17 @@ export interface Session {
   /** Governance fingerprint: governed effects, human gates hit, denials, errors. Live rows carry the
    *  running tally; terminal rows the final stamped one. */
   insights?: { actions: number; approvals: number; denied: number; errors: number }
+  /** Runtime tuning the run launched with — model id + reasoning effort (`session.tuning`). Undefined
+   *  for whichever lane took the workspace default. Shown next to cost now that both are per-task
+   *  overridable. */
+  model?: string
+  effort?: string
+  /** Total ms the run sat BLOCKED on a human — approval gates + `ask` questions. The governed-OS
+   *  latency nothing else surfaces; large next to a small `activeMs` = a run that mostly waited on
+   *  people. Undefined until stamped; 0 when it never blocked. */
+  blockedMs?: number
+  /** Deliverables the run published to the Library (`artifacts` rows). Undefined until stamped. */
+  artifacts?: number
 }
 export interface AuditEvent {
   id: number


### PR DESCRIPTION
Builds on the tier-1 result / engaged-duration / activity columns ([#391](https://github.com/vikasprogrammer/agent-os/pull/391)) with four more signals — all off sources the OS already records, stamped once when a run goes terminal, live rows re-derived per poll.

- **model · effort** — the runtime tuning the run launched with, from its `session.tuning` audit event. A muted pill leading the activity cluster, so "what ran this, how hard" reads next to cost now that both lanes are per-task overridable. Empty when the run took the workspace default (`opus·high`, `opus·medium`, or just `high` when the model was defaulted).
- **Blocked-on-human time** — a ⏳ chip totalling how long the run sat waiting on a person: approval gates (paired `approval.requested`→`approval.resolved` audit spans, since the `approvals` table keeps no resolved timestamp) + `ask` questions (`answered_at − created_at`). The governed-OS latency nothing else surfaced; a big value next to a small engaged time is a run that mostly waited on people.
- **Artifacts published** — a 📎 chip counting the Library deliverables the run produced.

### Backfill correctness
The stamp guard now retires a row only when **both** tiers are present (`artifacts` is the tier-2 marker, like `gov_approvals` for tier-1). A row stamped by the 0.232.0 build carries the gov_* set but NULL tier-2 columns, so it re-stamps **once** to fill them, then the guard retires it — instead of being skipped forever.

### Verification
Driven against a copy of the live instapods DB (127 rows) in an isolated `AGENT_OS_HOME`: tuning reads `opus·high` / `opus·medium`, blocked **21s** pairs with the run's **3 approvals**, artifact counts (5 / 3 / 2 / 1) match the `artifacts` table. List + grid screenshotted headless as owner. `npm run typecheck`, both builds, `npm run test:governance` → 68/68. Nothing touched live data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PX3EPzxB13gehNcfsU3Hnk