### PR TITLE
docs(trust-seed): correct the --dangerously-skip-permissions trust-dialog claim

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -462,10 +462,17 @@ in `src/types.ts` and `TeamStore.canRun()`.
   seeding `hasTrustDialogAccepted` into **`~/.claude.json`** — a file in the HOME ROOT, written via
   atomic temp-file + rename, so it needs the home **directory** writable, not just `~/.claude`. With
   `ProtectHome=read-only` + `ReadWritePaths=…/.claude` (the sub-dir only), that write fails and is
-  swallowed by the seeder's `|| true`, so trust is never recorded and every **interactive** run parks
-  forever on "Do you trust the files in this folder?" (headless dodges it via
-  `--dangerously-skip-permissions`). **Deceptive symptom:** the session row is `running` and the tmux
-  pane is alive, `capture-pane` shows the trust prompt. **Fix:** make the service user's home writable
+  swallowed by the seeder's `|| true`, so trust is never recorded and every run — **interactive AND
+  unattended alike** — parks forever on "Do you trust the files in this folder?". (Correction, verified
+  2026-07-20: `--dangerously-skip-permissions` does NOT dodge this — it suppresses per-tool permission
+  PROMPTS, not the folder-trust dialog; only the `~/.claude.json` pre-seed does. The pre-attachable
+  `claude -p` headless lane sidestepped it because print-mode never shows the dialog, but the current
+  UNATTENDED lane is an attachable interactive TUI, so a failed seed hangs it exactly like interactive.
+  Same seed also silently misses when the home is a **symlink** — macOS `os.tmpdir()` returns
+  `/var/folders/…`, a link to `/private/var/…`: Claude opens the workspace by its REAL path, so the trust
+  key must be seeded under the real path (`realpathSync` the home) or the dialog still fires. This bites
+  in-process test harnesses on scratch homes; prod homes are real paths.) **Deceptive symptom:** the
+  session row is `running` and the tmux pane is alive, `capture-pane` shows the trust prompt. **Fix:** make the service user's home writable
   (`ReadWritePaths=/home/<svc>`) and re-lock persistence vectors (`ReadOnlyPaths=/home/<svc>/.ssh`),
   keeping `ProtectSystem=strict`. The bundled `agent-os.service` now ships this pattern.
 

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -155,10 +155,16 @@ cat > .claude/aos-settings.json <<JSON
 JSON
 
 # Pre-accept the workspace-TRUST dialog for this agent folder. Freshly-created agent folders have
-# never been trusted, so an INTERACTIVE claude would open with "Do you trust the files in this
-# folder?" (headless already dodges it via --dangerously-skip-permissions). Trust is stored
-# per-directory in ~/.claude.json under projects["<dir>"].hasTrustDialogAccepted; seed it so the
-# dialog never fires. Keyed off the REAL $HOME of whatever user/lane runs this (local or uid-isolated).
+# never been trusted, so claude would open with "Do you trust the files in this folder?" — and BOTH
+# lanes need this seed to dodge it. (--dangerously-skip-permissions does NOT dodge the trust dialog;
+# it only suppresses per-tool permission PROMPTS. The pre-attachable `claude -p` headless lane
+# sidestepped the dialog because print-mode never shows it, but the current UNATTENDED lane is an
+# attachable interactive TUI, so a missing seed hangs it exactly like interactive — verified 2026-07-20.)
+# Trust is stored per-directory in ~/.claude.json under projects["<dir>"].hasTrustDialogAccepted; seed
+# it so the dialog never fires. The key MUST be the path claude actually opens: if $AGENT_DIR is a
+# symlink (e.g. a macOS scratch home under /var → /private/var), claude resolves it to the real path,
+# so seed under the realpath or the dialog still fires. Keyed off the REAL $HOME of whatever user/lane
+# runs this (local or uid-isolated).
 # Idempotent (only writes on first launch of each agent), atomic (temp+rename), and never fatal —
 # a failure here must not block the session. NOTE: this only bypasses the one-time TRUST gate; the
 # PreToolUse gate hook + deny rules above still govern every effect, so security posture is unchanged.


### PR DESCRIPTION
## What

Corrects a stale claim in the trust-seed docs, in two places (`CLAUDE.md` + `terminal/claude-launch.sh`): that the headless lane "dodges" Claude Code's folder-trust dialog via `--dangerously-skip-permissions`.

## Why

`--dangerously-skip-permissions` suppresses per-tool permission **prompts** — it does **not** dismiss the folder-**trust** dialog. The `~/.claude.json` pre-seed is what dodges trust, and **both** lanes now depend on it:

- The pre-attachable `claude -p` headless lane sidestepped the dialog only because print-mode never shows it.
- The current **UNATTENDED** lane is an attachable interactive TUI, so a failed/missing seed hangs it exactly like an interactive run.

Also documents a symlink pitfall found while verifying headless gate governance end-to-end: a home behind a symlink (macOS `/var` → `/private/var`) makes the seed key not match the real path Claude opens, so the trust dialog fires even when the seed write succeeds — `realpathSync` the home. Bites in-process test harnesses on scratch homes; prod homes are real paths.

## Verification

Confirmed via a real headless agent-os session: the UNATTENDED run parked on the trust dialog (`gate.attempt=0`) until the seed path matched the resolved workspace path; after the fix, the gate correctly **denied** destructive Bash and raised an **approval card** for risky Bash.

Comment-only; no runtime change (no build/restart needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)