### PR TITLE
feat(governance): re-nudge stale approvals/questions so blocked agents aren't abandoned (v0.240.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.242.0] — 2026-07-20
+### Added
+- **Stale human-in-the-loop prompts now get re-nudged once, so a missed ask doesn't strand an agent
+  forever.** Fleet-usage mining across all three tenants showed the biggest governance friction isn't a
+  bad rule — it's *abandonment*: agents that raise an approval gate or `ask` a question and are never
+  answered (instawp alone: 24 approvals + 32 questions sitting pending; every tenant had unanswered
+  questions). Only overdue **tasks** had a reminder sweep; approvals/questions had a single ask-time DM
+  and then silence. Now the scheduler tick runs `TerminalManager.escalateStalePrompts`: an approval or
+  question that has blocked a **still-running** session past a threshold (`AOS_STALE_PROMPT_MIN_MS`,
+  default 3h) gets its out-of-band DM fired a **second time** — through the *same* approval/question
+  notifiers, so the reminder re-binds the reply-to-decide/answer DM channel and reaches the same
+  audience. Fires **exactly once per item** (durable `escalated_at` marker on `approvals`/`questions`,
+  like the overdue-task guard, so a restart never re-alarms), skips prompts older than
+  `AOS_STALE_PROMPT_MAX_MS` (default 3 days — a long-abandoned gate is treated as dead, and the floor
+  stops the first sweep bursting on history) and prompts whose session already ended. Audited
+  `approval.escalated` / `question.escalated`. Wired in the tenant registry
+  (`Automations.setStalePromptSweeper`) reusing the existing notifier path.
+
 ## [0.241.0] — 2026-07-20
 ### Added
 - **Agents page now shows a per-agent "N Automations" shortcut.** When a claude-code agent has one or

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.241.0",
+  "version": "0.242.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.241.0",
+      "version": "0.242.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.241.0",
+  "version": "0.242.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -311,6 +311,11 @@ export class Automations {
   private overdueNotifier?: (task: Task) => void;
   setOverdueNotifier(fn: (task: Task) => void): void { this.overdueNotifier = fn; }
 
+  /** Best-effort sweep run each tick that re-nudges stale pending approvals/questions (wired in the
+   *  tenant registry to `TerminalManager.escalateStalePrompts`). Given the tick's `now` in epoch ms. */
+  private stalePromptSweeper?: (now: number) => void;
+  setStalePromptSweeper(fn: (now: number) => void): void { this.stalePromptSweeper = fn; }
+
   // ── CRUD ───────────────────────────────────────────────────────────────────────
   list(): Automation[] {
     return this.db.prepare('SELECT * FROM automations ORDER BY created_at').all<AutomationRow>().map(toAutomation);
@@ -932,6 +937,9 @@ export class Automations {
     this.sweepOverdue(now);
     this.sweepStuckGoals(now);
     this.sweepExpiredShares(now);
+    // Re-nudge stale human-in-the-loop prompts (approvals/questions blocking an agent) so a missed ask
+    // doesn't strand the run forever. Wrapped so a bad row can't take down the scheduler.
+    try { this.stalePromptSweeper?.(now.getTime()); } catch { /* best-effort, never kills the tick */ }
   }
 
   /**

--- a/src/governance/approvals.ts
+++ b/src/governance/approvals.ts
@@ -67,6 +67,27 @@ export class InMemoryApprovals implements Approvals {
       (r) => r.status === 'pending' && (!tenant || r.tenant === tenant),
     );
   }
+
+  private escalated = new Set<string>();
+
+  staleForEscalation(minAgeMs: number, maxAgeMs: number, now: number, tenant?: string): ApprovalRequest[] {
+    return [...this.items.values()]
+      .filter(
+        (r) =>
+          r.status === 'pending' &&
+          (!tenant || r.tenant === tenant) &&
+          !this.escalated.has(r.id) &&
+          now - r.createdAt >= minAgeMs &&
+          now - r.createdAt <= maxAgeMs,
+      )
+      .sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  markEscalated(id: string, _now: number): boolean {
+    if (this.escalated.has(id)) return false;
+    this.escalated.add(id);
+    return true;
+  }
 }
 
 interface ApprovalRow {
@@ -171,5 +192,25 @@ export class SqliteApprovals implements Approvals {
       ? this.db.prepare("SELECT * FROM approvals WHERE status = 'pending' AND tenant = ? ORDER BY created_at").all<ApprovalRow>(tenant)
       : this.db.prepare("SELECT * FROM approvals WHERE status = 'pending' ORDER BY created_at").all<ApprovalRow>();
     return rows.map(toRequest);
+  }
+
+  staleForEscalation(minAgeMs: number, maxAgeMs: number, now: number, tenant?: string): ApprovalRequest[] {
+    const maxCreated = now - minAgeMs; // created at/before this = old enough to nag
+    const minCreated = now - maxAgeMs; // created at/after this = recent enough to still care
+    const rows = tenant
+      ? this.db
+          .prepare("SELECT * FROM approvals WHERE status = 'pending' AND escalated_at IS NULL AND tenant = ? AND created_at <= ? AND created_at >= ? ORDER BY created_at")
+          .all<ApprovalRow>(tenant, maxCreated, minCreated)
+      : this.db
+          .prepare("SELECT * FROM approvals WHERE status = 'pending' AND escalated_at IS NULL AND created_at <= ? AND created_at >= ? ORDER BY created_at")
+          .all<ApprovalRow>(maxCreated, minCreated);
+    return rows.map(toRequest);
+  }
+
+  markEscalated(id: string, now: number): boolean {
+    // Only stamp a still-pending, not-yet-escalated row, so a race with a resolve/second-sweep can't
+    // double-fire the reminder. `changes` is >0 only when THIS call won the stamp.
+    const res = this.db.prepare("UPDATE approvals SET escalated_at = ? WHERE id = ? AND escalated_at IS NULL AND status = 'pending'").run(now, id);
+    return res.changes > 0;
   }
 }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -872,6 +872,13 @@ function migrate(db: Db): void {
   addColumn(db, 'term_sessions', 'effort', 'TEXT');            // low | medium | high | …
   addColumn(db, 'term_sessions', 'blocked_ms', 'INTEGER');     // total human-wait (approvals + questions)
   addColumn(db, 'term_sessions', 'artifacts', 'INTEGER');      // deliverables published by the run
+
+  // Stale-prompt escalation: a once-per-item marker so the scheduler's re-nudge sweep DMs the approver /
+  // operator EXACTLY ONCE when an approval or question has sat pending past the threshold, and never
+  // re-alarms across restarts (same discipline as `markOverdueNotified` on tasks). NULL = not yet
+  // re-nudged; a timestamp = we already sent the reminder. A resolved/answered row is skipped by status.
+  addColumn(db, 'approvals', 'escalated_at', 'INTEGER');       // when the stale-approval reminder fired
+  addColumn(db, 'questions', 'escalated_at', 'INTEGER');       // when the stale-question reminder fired
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -262,6 +262,11 @@ export class TenantRegistry {
     // Deadline notifications: when a task passes its due date, DM its owner (the human it runs as) once,
     // so a missed deadline surfaces off the board. Owner-less → owner/admins. Mirrors the question path.
     autos.setOverdueNotifier((task) => { void notifyTaskOverdue(os, slack, discord, consoleOrigin, task); });
+    // Stale-prompt escalation: each scheduler tick, re-nudge approvals/questions that have blocked an
+    // agent past the threshold — reusing the same approval/question notifiers wired above so the reminder
+    // re-binds the reply-to-decide DM. One reminder per item (durable marker); off the tenant registry
+    // because it needs the TerminalManager that owns the questions table + the approval notice path.
+    autos.setStalePromptSweeper((now) => { tm.escalateStalePrompts(now); });
     // Task lifecycle → Inbox: a create/assign/status change lands an audience-addressed inbox card for
     // the right human (assignee/owner) — routed via resolveRecipients — and DMs them. Fires for EVERY
     // mutation path (console, agent MCP, dispatcher) because the sink lives on the store, not the routes.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -41,6 +41,11 @@ const VIDEO_INCALL_POLL_MS = 10_000;       // …10s apart (~30s max block, with
 // (so `agentAskStatus` fails the caller out). A grace so a just-spawned run — whose tmux may not yet
 // register — isn't misjudged; the caller polls every 3s and real answers take far longer than this.
 const ASK_AGENT_GRACE_MS = 20_000;
+// Stale-prompt escalation window (see TerminalManager.escalateStalePrompts). A pending approval / `ask`
+// question older than MIN gets ONE reminder DM; the MAX floor keeps the first sweep from re-nudging
+// long-abandoned rows in a burst (and, past MAX, a still-pending prompt is treated as dead, not nagged).
+const STALE_PROMPT_MIN_MS = 3 * 60 * 60_000;   // 3h pending → re-nudge the approver/operator once
+const STALE_PROMPT_MAX_MS = 3 * 24 * 60 * 60_000; // ignore anything pending longer than 3 days
 import { LauncherClient } from './edge/launcher';
 import { parseSecretRef } from './edge/secrets';
 import { materializeSubagents } from './edge/subagents';
@@ -500,6 +505,49 @@ export class TerminalManager {
    *  a blocking `ask` pings the run-as member out-of-band instead of sitting unseen. */
   private questionNotifier?: (notice: QuestionNotice) => void;
   setQuestionNotifier(fn: (notice: QuestionNotice) => void): void { this.questionNotifier = fn; }
+
+  /**
+   * Re-nudge stale human-in-the-loop prompts: an approval or `ask` question that has sat pending past
+   * {@link STALE_PROMPT_MIN_MS} (and is younger than {@link STALE_PROMPT_MAX_MS}) gets its out-of-band
+   * DM fired a SECOND time — via the SAME {@link approvalNotifier}/{@link questionNotifier} the original
+   * ask used, so the reminder re-binds the reply-to-decide DM channel and reaches the same audience.
+   * Exactly once per item (a durable `escalated_at` marker, like the overdue-task sweep), so a restart
+   * never re-alarms and the max-age floor stops the first sweep from bursting on historically-abandoned
+   * rows. Only prompts whose session is still `running` are nudged — a dead run's orphaned gate is moot.
+   * Driven by the scheduler tick (see {@link Automations.setStalePromptSweeper}); best-effort, never throws.
+   */
+  escalateStalePrompts(now: number): void {
+    const min = Number(process.env.AOS_STALE_PROMPT_MIN_MS) || STALE_PROMPT_MIN_MS;
+    const max = Number(process.env.AOS_STALE_PROMPT_MAX_MS) || STALE_PROMPT_MAX_MS;
+    const isRunning = (runId: string): boolean =>
+      this.db.prepare("SELECT 1 FROM term_sessions WHERE id = ? AND status = 'running' LIMIT 1").get(runId) != null;
+    // Approvals — the store owns the age/marker query; we add the liveness filter + rebuild the notice
+    // (approval rows don't carry the agent name or riskClass, so derive both here).
+    for (const a of this.os.approvals.staleForEscalation(min, max, now, this.os.tenant)) {
+      if (!isRunning(a.runId)) continue;
+      if (!this.os.approvals.markEscalated(a.id, now)) continue;
+      const agent = this.db.prepare('SELECT agent FROM term_sessions WHERE id = ?').get<{ agent: string }>(a.runId)?.agent ?? 'agent';
+      try {
+        this.approvalNotifier?.({ approvalId: a.id, sessionId: a.runId, agent, capability: a.attempt.capabilityId, level: a.level, riskClass: riskClassForLevel(a.level), reason: a.reason });
+      } catch { /* notifications are advisory */ }
+      this.audit(a.runId, agent, 'approval.escalated', { approvalId: a.id, level: a.level, capability: a.attempt.capabilityId, ageMs: now - a.createdAt });
+    }
+    // Questions — this table lives here, so query it directly for the same window + one-time marker.
+    const minCreated = now - max, maxCreated = now - min;
+    const stale = this.db
+      .prepare("SELECT id, run_id, agent, prompt, audience_id, created_at FROM questions WHERE status = 'pending' AND escalated_at IS NULL AND created_at <= ? AND created_at >= ? ORDER BY created_at")
+      .all<{ id: string; run_id: string; agent: string; prompt: string; audience_id: string | null; created_at: number }>(maxCreated, minCreated);
+    for (const q of stale) {
+      if (!isRunning(q.run_id)) continue;
+      const marked = this.db.prepare("UPDATE questions SET escalated_at = ? WHERE id = ? AND escalated_at IS NULL AND status = 'pending'").run(now, q.id);
+      if (marked.changes === 0) continue;
+      try {
+        this.questionNotifier?.({ questionId: q.id, sessionId: q.run_id, agent: q.agent, prompt: q.prompt, to: q.audience_id ?? undefined });
+      } catch { /* notifications are advisory */ }
+      this.audit(q.run_id, q.agent, 'question.escalated', { questionId: q.id, ageMs: now - q.created_at });
+    }
+  }
+
   /** Optional sink that mirrors an inbox-worthy event (completion, question, approval) back to the
    *  Slack/Discord thread a chat-triggered session is bound to, so the human who pinged the agent in
    *  chat sees the outcome there instead of having to switch to the console. No-op for non-chat runs

--- a/src/types.ts
+++ b/src/types.ts
@@ -358,6 +358,13 @@ export interface Approvals {
    *  whether a pending request was actually cancelled. */
   cancel(id: string, by: string): boolean;
   pending(tenant?: string): ApprovalRequest[];
+  /** Pending approvals that have sat past the escalation threshold and haven't been re-nudged yet — the
+   *  source for the scheduler's stale-prompt reminder sweep. `minAgeMs`/`maxAgeMs` bound the window (older
+   *  than min so a fresh gate isn't nagged; younger than max so an ancient/abandoned one isn't re-alarmed
+   *  in a burst on the first sweep). Oldest first. */
+  staleForEscalation(minAgeMs: number, maxAgeMs: number, now: number, tenant?: string): ApprovalRequest[];
+  /** Stamp an approval's one-time escalation marker; true only the FIRST time, so the reminder fires once. */
+  markEscalated(id: string, now: number): boolean;
 }
 
 export interface Identity {


### PR DESCRIPTION
## Fleet-insights pass — governance/approvals/policy focus

Mined agent-session usage across **all three tenants** (instapods, instawp, expresstech, 30d) with a governance lens. The single dominant, cross-tenant friction was **not** a bad policy rule — it was **abandonment of human-in-the-loop prompts**:

| Signal | instapods | instawp | expresstech |
|---|---|---|---|
| Pending (unanswered) **questions** | 14 | 32 | 13 |
| Pending **approvals** | 5 | 34 | 4 |

Agents raise an approval gate or `ask` a question, the one ask-time Slack/Discord DM is missed, and the run is stranded — often literal duplicates ("Should we deploy now?" ×2) and finished-work sign-offs left hanging. Only overdue **tasks** had a reminder sweep (`sweepOverdue`); approvals and questions had **no** re-nudge.

## What shipped

`TerminalManager.escalateStalePrompts`, driven by the existing scheduler tick (`Automations.setStalePromptSweeper`, wired in the tenant registry):

- An approval / `ask` question that has blocked a **still-running** session past `AOS_STALE_PROMPT_MIN_MS` (**3h**) has its out-of-band DM fired a **second time** — through the *same* `approvalNotifier`/`questionNotifier`, so the reminder **re-binds the reply-to-decide/answer DM channel** and hits the same audience (no new notification surface).
- **Exactly once per item**: durable `escalated_at` marker on `approvals` + `questions` (same discipline as the overdue-task once-guard) → a restart never re-alarms.
- Skips prompts older than `AOS_STALE_PROMPT_MAX_MS` (**3 days**) so the first sweep can't burst on historically-abandoned rows, and skips prompts whose session already ended (a dead run's orphaned gate is moot).
- Audited `approval.escalated` / `question.escalated`.

Additive and low-risk: it only sends a reminder DM for an already-pending prompt; it never changes a policy decision, auto-resolves anything, or widens access.

## Verification

- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → **68/68** ✓ · `npm run demo` ✓
- End-to-end harness on an isolated scratch home: seeded old/fresh/ancient/dead approvals + questions → **only the old + running** prompts escalated, **once each**, second sweep idempotent, `approval.escalated`/`question.escalated` audited once. ✅

## Proposed, not implemented (surfaced for a human call)

These recurred but are policy-tuning or architectural — deliberately left un-shipped:

1. **Host-governance re-prompting** — `net.connect`/`ssh.exec` → *approve* because "host is not a granted connection" / "host could not be identified" drove **32** human interrupts on instapods (pod-troubleshooter/pod-migrator infra work). Security-sensitive; the "could not be identified" escalate-on-unknown is working as designed but noisy. Wants a granted-hosts UX, not a code hotfix.
2. **`file.write → ask` blanket rule load** — 52 approvals on instapods (pure blanket rule) vs instawp's smarter split (28 `outsideWorkdir` + 22 blanket). The bundled default could adopt instawp's *outsideWorkdir* refinement — but policy changes don't reach existing tenants (persisted overrides), so this only helps new ones.
3. **Connector/OAuth reconnect is fail-closed with no self-service** — expresstech's scheduled ClickUp radar **failed producing nothing** twice (Composio connection inactive → reconnect approval pending); peer-reviewer repeatedly blocked on "Connect GitHub (link expires ~10 min)". Wants a connection-health preflight and/or a durable reconnect path — architectural.

🤖 Generated with [Claude Code](https://claude.com/claude-code)