### PR TITLE
fix(sessions): stop the done-orphan reaper from killing a member's headed session (v0.242.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.242.1] — 2026-07-20
+### Fixed
+- **A member's own interactive ("headed") console session no longer gets killed out from under them
+  when its agent calls `report`.** Many fleet agents end a run by calling the `report` tool, which flips
+  the session row to `done` mid-turn. The 60-second idle sweep's **done-orphan** backstop (`reapIdleSessions`
+  sweep 2) then treated *any* unclaimed non-resident `done` row as an orphaned pane and reaped it on sight —
+  including a member-spawned interactive session the human was actively using. Result: you'd open a headed
+  session, the agent would finish and `report`, and within a minute the live TUI was torn down
+  (`session.reaped reason=done-orphan`) even though nobody had walked away. The done-orphan reap is now
+  scoped to genuinely **unattended-lane** runs (chat/automation/task/ask provenance — a colon in
+  `spawned_by`); a member's own interactive session (bare member-id `spawned_by`, `headless=0`) is left to
+  the **idle-interactive janitor** (sweep 3) instead, which now also reclaims a member's `done` session but
+  only after the long idle timeout (Settings → default 48h) and with its `done` outcome preserved. So a
+  headed session stays live for follow-ups and is only reclaimed once truly idle.
+
 ## [0.242.0] — 2026-07-20
 ### Added
 - **Stale human-in-the-loop prompts now get re-nudged once, so a missed ask doesn't strand an agent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.242.0",
+  "version": "0.242.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.242.0",
+      "version": "0.242.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.242.0",
+  "version": "0.242.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1764,12 +1764,15 @@ export class TerminalManager {
 
     // (2) DONE-ORPHAN + unattended-straggler backstop — the safety net for markTurnIdle. Two ways a run leaks
     // a live pane:
-    //   (a) DONE ORPHAN — the run ended via `report`, which flips the row to 'done' while its interactive TUI
-    //       pane is still live; a done run should hold NO pane, ever, regardless of idle time. This bites BOTH
-    //       lanes: an unattended run whose Stop beacon never landed, AND — the common one — an INTERACTIVE
-    //       (`headless=0`) member/chat run, for which markTurnIdle bails (non-headless) and the idle-interactive
-    //       sweep (3) only touches 'running' rows, so a report-ended one is caught by neither. So we sweep
-    //       done-orphans of EITHER lane here. Only detectable when we can poll liveness (see below).
+    //   (a) DONE ORPHAN — an UNATTENDED (chat/automation/task/ask) run that ended via `report`, which flips
+    //       the row to 'done' while its interactive TUI pane is still live; such a run has no human owning its
+    //       lifecycle, so a done row should hold NO pane — reap on sight. This catches an unattended run whose
+    //       Stop beacon never landed. **Excluded here: a MEMBER's own console session** (`headless=0`,
+    //       `spawned_by` = a bare member id, no `chat:`/`automation:`/`task:`/`ask:` colon). The human opened
+    //       that TUI and owns its lifecycle — calling `report` is a status signal, not "kill my terminal" — so
+    //       reaping it seconds later yanks a live pane out from under an active user ("my headed session got
+    //       killed on its own"). The idle-interactive janitor (sweep 3) reclaims it on the long timeout instead.
+    //       Only detectable when we can poll liveness (see below).
     //   (b) IDLE STRAGGLER — an UNATTENDED (`headless=1`) run still 'running' with a turn-end beacon seen
     //       (`last_activity` set) and idle past the timeout: the classic lost-Stop-beacon / attach-then-detach
     //       case. (Interactive stragglers are sweep (3)'s job, on the longer interactive timeout.)
@@ -1780,10 +1783,16 @@ export class TerminalManager {
     // back to the classic time-based rule for RUNNING rows only (never blind-sweep a 'done' row, or we'd
     // re-teardown it every tick with no way to know its pane already died). Uses the single `alive` poll
     // taken at the top of the sweep.
-    const unattended = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, last_activity FROM term_sessions WHERE resident = 0 AND claimed_by IS NULL AND (status = 'done' OR (headless = 1 AND status = 'running'))")
-      .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; last_activity: number | null }>();
+    const unattended = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, headless, last_activity FROM term_sessions WHERE resident = 0 AND claimed_by IS NULL AND (status = 'done' OR (headless = 1 AND status = 'running'))")
+      .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; headless: number; last_activity: number | null }>();
     for (const r of unattended) {
       try {
+        // A MEMBER's own interactive console session is never a done-orphan: the human owns its lifecycle,
+        // so its agent calling `report` (which flips the row to 'done') must not cost it its live pane. Its
+        // spawn provenance is a bare member id (no colon), unlike chat:/automation:/task:/ask: runs. Leave it
+        // to the idle-interactive janitor (sweep 3); reaping it here yanks the TUI out from under an active
+        // user seconds after the agent reports. Unattended-lane done runs fall through and are reaped below.
+        if (r.status === 'done' && !r.headless && r.spawned_by && !r.spawned_by.includes(':')) continue;
         if (alive) {
           if (!alive.has(r.tmux)) continue;                          // pane already gone — nothing to reap
           // a 'running' straggler is only idle-reaped once it has seen a turn-end beacon AND gone quiet past the
@@ -1800,31 +1809,37 @@ export class TerminalManager {
       } catch { /* one bad row must not stop the sweep */ }
     }
 
-    // (3) idle INTERACTIVE (member) sessions. A member's own attachable session holds a `claude` process
-    // too, but — unlike a resident chat (sweep 1) or an unattended run (turn-end / sweep 2) — nothing ever
-    // reaps it. A forgotten, detached one lingers for DAYS, wasting RAM and (now that the cap is on)
-    // permanently hogging a concurrency-cap slot so scheduled work starves. Reap one idle past the
-    // configurable timeout (Settings, default 48 h) with NO client attached and no pending human block; it
-    // stays Resumable (a deliberate console re-open clears `blockResume`), so this is a janitor, not a
-    // guillotine. Skip claimed take-overs — a human owns that lifecycle. `0` disables. Uses
-    // COALESCE(last_activity, created_at): a member session rarely stamps last_activity, so age is the
-    // fallback clock. Runs regardless of `aliveNames()` (kill is harmless on an already-dead pane).
+    // (3) idle INTERACTIVE (member) sessions — running OR done. A member's own attachable session holds a
+    // `claude` process too, but — unlike a resident chat (sweep 1) or an unattended run (turn-end / sweep 2) —
+    // nothing else reaps it. It's the ONLY reaper for a member's `done` session now that sweep 2 leaves those
+    // to the human (a report-ended member run keeps its live TUI so a follow-up still works). A forgotten,
+    // detached one lingers for DAYS, wasting RAM and (now that the cap is on) permanently hogging a
+    // concurrency-cap slot so scheduled work starves. Reap one idle past the configurable timeout (Settings,
+    // default 48 h) with NO client attached and no pending human block; it stays Resumable (a deliberate
+    // console re-open clears `blockResume`), so this is a janitor, not a guillotine. Skip claimed take-overs —
+    // a human owns that lifecycle. `0` disables. Uses COALESCE(last_activity, created_at): a member session
+    // rarely stamps last_activity, so age is the fallback clock.
     const idleHours = this.os.settings.interactiveIdleTimeoutHours();
     if (idleHours > 0) {
       const idleCutoff = Date.now() - idleHours * 3600_000;
-      const stale = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent FROM term_sessions WHERE headless = 0 AND resident = 0 AND claimed_by IS NULL AND status = 'running' AND COALESCE(last_activity, created_at) < ?")
-        .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string }>(idleCutoff);
+      const stale = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status FROM term_sessions WHERE headless = 0 AND resident = 0 AND claimed_by IS NULL AND status IN ('running','done') AND COALESCE(last_activity, created_at) < ?")
+        .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string }>(idleCutoff);
       for (const r of stale) {
         try {
+          // A reaped 'running' row flips to 'stopped' and drops out of the query next tick; a 'done' row keeps
+          // its status (below), so skip one whose pane is already gone to avoid re-killing / re-auditing it
+          // every tick. Only applies when we can poll liveness (local backend); null → fall through as before.
+          if (r.status === 'done' && alive && !alive.has(r.tmux)) continue;
           const space = this.spaceFor(r.run_as ?? r.spawned_by);
           if (this.backend.hasClient(space, r.tmux) === true) continue; // someone's attached — it's in use
           if (this.hasPendingHumanBlock(r.id)) continue;               // blocked on a person — leave it
           this.backend.kill(space, r.tmux);
-          this.db.prepare("UPDATE term_sessions SET status = 'stopped', updated_at = ? WHERE id = ?").run(Date.now(), r.id);
+          // Preserve a completed session's outcome — only a still-running one becomes 'stopped'.
+          this.db.prepare("UPDATE term_sessions SET status = ?, updated_at = ? WHERE id = ?").run(r.status === 'done' ? 'done' : 'stopped', Date.now(), r.id);
           this.cancelPendingQuestions(r.id, 'system');
           this.cancelPendingApprovals(r.id, 'system');
-          this.blockResume(r.id); // stay stopped against a ttyd auto-reconnect; a deliberate Resume clears it
-          this.audit(r.id, r.agent, 'session.reaped', { reason: 'idle-interactive', idleHours });
+          this.blockResume(r.id); // stay reaped against a ttyd auto-reconnect; a deliberate Resume clears it
+          this.audit(r.id, r.agent, 'session.reaped', { reason: 'idle-interactive', idleHours, status: r.status });
         } catch { /* one bad row must not stop the sweep */ }
       }
     }


### PR DESCRIPTION
## Problem

A member's own interactive ("headed") console session sometimes got **killed/completed on its own**, within ~60s of the agent finishing — e.g. `#/sessions/aos-ses_932da2183d89d8bc`.

### Root cause (traced from the audit trail)

Many fleet agents (like `newsletter-writer`) end a run by calling the `report` tool. `report()` flips the session row to **`done`** mid-turn while the interactive claude TUI is still live. The 60s idle sweep `reapIdleSessions` **sweep 2 (done-orphan backstop)** then matched it:

```
WHERE resident = 0 AND claimed_by IS NULL AND (status = 'done' OR (headless = 1 AND status = 'running'))
```

A member console session is `headless=0, resident=0, claimed_by=NULL` (never "claimed" — that's only for take-overs), so a `report`-ended one fell straight into the done-orphan branch and was reaped on sight (`session.reaped reason=done-orphan`) — killing the pane out from under an active user. Audit for the reported session:

```
15:33:09  session.reported   (agent called report → status=done)
15:34:46  session.ended
15:34:46  session.reaped   {"reason":"done-orphan"}
15:39:14  session.resumed  (human came back, had to re-open)
```

`hasClient` didn't save it: when the human isn't literally attached to the terminal pane at that tick (reading the report card, on the session list, tab backgrounded) it returns false.

## Fix

The done-orphan reap is meant to reclaim panes from **unattended-lane** runs (chat/automation/task/ask) whose Stop beacon never landed — those have no human owning their lifecycle. A member's own interactive session **does** have an owner. So:

- **Sweep 2** now skips a `done` row that is a member's own interactive session (`headless=0` + bare member-id `spawned_by`, i.e. no `chat:`/`automation:`/`task:`/`ask:` colon — the existing `ownsSession` convention). Unattended-lane done runs still reap on sight.
- **Sweep 3** (idle-interactive janitor) now also reclaims a member's `done` session, but only past the long idle timeout (Settings → Interactive idle, default **48h**), with the `done` outcome preserved and a liveness gate so a reclaimed pane isn't re-audited each tick.

Net: a headed session stays live for follow-ups and is only reclaimed once genuinely idle.

## Verification

In-process `reapIdleSessions` harness with a stub backend — all pass:
- fresh member done → pane **not** killed, stays `done`
- chat done → reaped
- automation done (headless) → reaped
- 100h-stale member done → reaped by janitor, status kept `done`

Plus `npm run typecheck`, `npm run build`, `npm run test:governance` (68/68).

🤖 Generated with [Claude Code](https://claude.com/claude-code)