### PR TITLE
fix(agents): count only standing automations in the "N Automations" shortcut (v0.243.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.243.2] — 2026-07-20
+### Fixed
+- **The Agents-page "N Automations" shortcut now counts only standing automations, not spent one-shots.**
+  A `once` automation that an agent scheduled and that has already fired (`lastFiredAt` set) is inert — it
+  lives in the collapsed "spent" section of the Automations page. The composer-header count was including
+  those, overstating the number; it now excludes them, matching what the filtered page actually shows.
+
 ## [0.243.1] — 2026-07-20
 ### Fixed
 - **A member's own interactive ("headed") console session no longer gets killed out from under them

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.243.1",
+  "version": "0.243.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.243.1",
+      "version": "0.243.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.243.1",
+  "version": "0.243.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1979,14 +1979,19 @@ function AgentsPage({
   }, [])
 
   // Per-agent automation counts — powers the "N Automations" shortcut in the composer header that
-  // jumps to the Automations page pre-filtered to this agent.
+  // jumps to the Automations page pre-filtered to this agent. Count only the standing automations, not
+  // spent one-shots (a `once` run scheduled by the agent that has already fired) — those live in the
+  // collapsed "spent" section of the Automations page, so counting them would overstate the shortcut.
   const [autoCounts, setAutoCounts] = useState<Record<string, number>>({})
   useEffect(() => {
     let ok = true
     api.automations().then((r) => {
       if (!ok) return
       const counts: Record<string, number> = {}
-      for (const a of r.automations ?? []) counts[a.agentId] = (counts[a.agentId] ?? 0) + 1
+      for (const a of r.automations ?? []) {
+        if (a.type === 'once' && a.lastFiredAt) continue // spent one-shot — never runs again
+        counts[a.agentId] = (counts[a.agentId] ?? 0) + 1
+      }
       setAutoCounts(counts)
     }).catch(() => {})
     return () => { ok = false }


### PR DESCRIPTION
## What

The Agents-page **⚡ N Automations** shortcut was counting **spent one-shots** — a `once` automation an agent scheduled that has already fired (`lastFiredAt` set). Those are inert and live in the collapsed "spent" section of the Automations page, so they overstated the count. Now excluded, so the header count matches what the filtered page prominently shows.

## How

One-line guard in the count reducer (`if (a.type === 'once' && a.lastFiredAt) continue`), mirroring the `isSpent` logic `AutomationsPage` already uses. **No change to the automation data model.**

## Test
- `cd web && npm run build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)