### PR TITLE
fix(agents): share dialog footer no longer bleeds outside the rounded card (v0.243.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.243.4] — 2026-07-20
+### Fixed
+- **Share-agent dialog footer no longer bleeds outside the rounded card.** The footer (the "Runnable
+  by …" summary + Done button) used shadcn `DialogFooter`'s default `-mx-4 -mb-4` negative margins,
+  which assume the dialog body has `p-4` padding to absorb them — but the Share dialog sets `p-0` on
+  `DialogContent` (its header/body/footer own their padding), so the bar hung ~16px past the popup's
+  left/right/bottom edges as a detached-looking strip. Neutralised with `mx-0 mb-0` so it sits flush
+  inside the rounded container.
+
 ## [0.243.3] — 2026-07-20
 ### Fixed
 - **Self-learning "recurring topics" no longer surfaces conversational filler or people's names.** Live

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.243.3",
+  "version": "0.243.4",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1922,7 +1922,7 @@ function ShareAgentDialog({ agent, open, onOpenChange }: { agent: AgentInfo; ope
           </div>
         )}
 
-        <DialogFooter className="flex-row items-center justify-between border-t bg-muted/40">
+        <DialogFooter className="mx-0 mb-0 flex-row items-center justify-between border-t bg-muted/40">
           <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
             {err ? <span className="text-destructive">{err}</span> : <><Users className="h-3.5 w-3.5" />{summary}</>}
           </span>


### PR DESCRIPTION
## Problem

The Agents-page **Share dialog** footer (the "Runnable by …" summary + **Done** button) rendered as a detached-looking bar hanging ~16px past the popup's left/right/bottom edges.

## Cause

`DialogContent` is set to `p-0` (the dialog's header/body/footer each own their padding), but shadcn's `DialogFooter` carries default `-mx-4 -mb-4` negative margins that assume a `p-4` body to absorb them. With `p-0`, nothing absorbed them, so the footer bled outside the rounded card.

## Fix

One line — add `mx-0 mb-0` to the footer's className to neutralise the negative margins so it sits flush inside the rounded container. Verified with a before/after screenshot against an ephemeral instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVfxDWBcQLbAqJPshB4Ha2