### PR TITLE
feat(automations): agents can propose a new automation for human approval (v0.245.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.245.0] — 2026-07-20
+### Added
+- **Agents can now PROPOSE a new automation for a human to approve — a fourth propose lane.** Alongside
+  `skill_propose`/`policy_propose`/`host_propose`, a new agent tool **`automation_propose`** lets an agent
+  that notices recurring work (a daily report, a periodic audit, a reaction to an inbound event) suggest a
+  scheduled/triggered automation instead of only running when asked. It's a **draft**: nothing is created
+  and nothing can ever fire until an owner/admin approves it — the spec rides in an `automation.proposed`
+  review card (mirrors the policy-proposal pattern; no DB migration), and only on approve does
+  `Automations.add` create + enable it (cron validity checked at approve time). Same 10-deep queue cap +
+  identical-spec dedupe as the other lanes. Owner/admin approve/reject at **Automations → "Proposed by
+  agents"** (`GET /api/automations/proposals`, `POST …/:id/approve|reject`), with an inbox review card + DM.
+  Audited `automation.proposed` / `automation.proposal.approved` / `automation.proposal.rejected`.
+
 ## [0.244.0] — 2026-07-20
 ### Added
 - **Stale self-learning guidance is no longer served (or injected) as if current.** When the reflect

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.244.0",
+  "version": "0.245.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.244.0",
+      "version": "0.245.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.244.0",
+  "version": "0.245.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -625,6 +625,34 @@ const TOOLS = [
     },
   },
   {
+    name: 'automation_propose',
+    description:
+      'Propose a new AUTOMATION for a human to approve — a recurring/triggered job that spawns an agent ' +
+      'session unattended. Use this when you notice work that SHOULD run on a schedule or a trigger rather ' +
+      'than only when someone remembers to ask (a daily report, a periodic audit, a reaction to an inbound ' +
+      'event). Your proposal is a DRAFT: nothing is created and NOTHING will ever fire until an owner/admin ' +
+      'approves it (an inbox card notifies them) — so you cannot silently schedule yourself. Give a short ' +
+      '`name`, the `task` (the prompt the spawned session receives), and the trigger: for `type:"cron"` ' +
+      '(the default) a 5-field `schedule` (e.g. "0 9 * * 1-5" = 9am weekdays); for webhook/composio/slack/' +
+      'discord an optional `filter`. `agentId` defaults to you (the proposing agent). Always include a ' +
+      '`rationale` — the approver reads it to decide.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        name: { type: 'string', description: 'A short human label for the automation (e.g. "Daily marketing briefing").' },
+        task: { type: 'string', description: 'The task template — the prompt the spawned session runs each time it fires.' },
+        type: { type: 'string', enum: ['cron', 'webhook', 'composio', 'slack', 'discord'], description: 'Trigger type. Default: cron (time-based).' },
+        schedule: { type: 'string', description: 'For type:"cron" — a 5-field cron expression (min hour dom mon dow), e.g. "0 9 * * 1-5".' },
+        filter: { type: 'string', description: 'For event triggers — composio trigger slug, or slack/discord event type or channel id ("" = any).' },
+        agentId: { type: 'string', description: 'Which agent the automation runs. Defaults to you (the proposing agent).' },
+        mode: { type: 'string', enum: ['headless', 'interactive'], description: 'headless (unattended, default for event triggers) or interactive.' },
+        rationale: { type: 'string', description: 'Why this automation is worth running — the approver reads this to decide.' },
+      },
+      required: ['name', 'task'],
+    },
+  },
+  {
     name: 'skill_find',
     description:
       'Discover installable SKILLS — the reusable playbooks packaged for this workspace. Returns your ' +
@@ -1676,6 +1704,29 @@ async function policyPropose(args: Record<string, unknown>): Promise<string> {
   return d.ok
     ? `Policy change proposed${d.preview ? ` (${d.preview})` : ''} — it's in the owner's inbox for review. NOTHING changes until an owner approves it. Proposals may only tighten guardrails, never loosen them. Once approved, the change hot-reloads and applies LIVE to every running session at its next gated action — no restart or respawn needed (unlike an MCP tool-schema change, which a live session only picks up when it respawns).`
     : `Could not propose the policy change: ${d.error ?? 'unknown error'}`;
+}
+
+async function automationPropose(args: Record<string, unknown>): Promise<string> {
+  const name = String(args.name ?? '').trim();
+  const task = String(args.task ?? '').trim();
+  if (!name || !task) return 'automation_propose needs a name and a task (the prompt the automation runs).';
+  const res = await fetch(AOS_URL + '/api/agent/automation/propose', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({
+      session: SESSION, agent: AGENT, name, task,
+      type: args.type ? String(args.type) : undefined,
+      schedule: args.schedule ? String(args.schedule) : undefined,
+      filter: args.filter ? String(args.filter) : undefined,
+      agentId: args.agentId ? String(args.agentId) : undefined,
+      mode: args.mode ? String(args.mode) : undefined,
+      rationale: args.rationale ? String(args.rationale) : undefined,
+    }),
+  });
+  const d = (await res.json()) as { ok?: boolean; preview?: string; error?: string };
+  return d.ok
+    ? `Automation proposed${d.preview ? ` (${d.preview})` : ''} — it's a DRAFT in the owner/admin inbox for review. It is NOT created and will never fire until a human approves it.`
+    : `Could not propose the automation: ${d.error ?? 'unknown error'}`;
 }
 
 async function hostPropose(args: Record<string, unknown>): Promise<string> {
@@ -2733,6 +2784,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'publish' ? await publish(args)
         : name === 'skill_propose' ? await skillPropose(args)
         : name === 'policy_propose' ? await policyPropose(args)
+        : name === 'automation_propose' ? await automationPropose(args)
         : name === 'host_propose' ? await hostPropose(args)
         : name === 'skill_find' ? await skillFind(args)
         : name === 'skill_request' ? await skillRequest(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -15,7 +15,7 @@ import { TenantRegistry, TenantRuntime, notifyLoginLink, notifyInsightAlert } fr
 import { pendingAlerts } from './edge/alerts';
 import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
-import { TerminalManager, AGENT_OS_OPERATING_NOTES } from './terminal';
+import { TerminalManager, AGENT_OS_OPERATING_NOTES, type ProposedAutomation } from './terminal';
 import { classifyActivity, clipText, ActivityCategory, ActivityEffect, ActivityTarget } from './state/session-activity';
 import { readConversation, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from './edge/conversation';
 import { summarizeConversation } from './edge/summarize';
@@ -697,6 +697,28 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       : undefined;
     const delta = { kind: kind as never, match: { capability, ...(when ? { when } : {}) }, ...(outcome ? { outcome } : {}) };
     const out = tm.proposePolicy(session, agent, delta, b.rationale != null ? String(b.rationale) : undefined);
+    return sendJson(res, out.ok ? 200 : 400, out);
+  }
+
+  // Agent proposes a NEW automation for a human to approve — the automations twin of policy/propose.
+  // Nothing is created until an owner/admin approves (POST /api/automations/proposals/:id/approve); the
+  // spec lives in the review card. Pre-auth loopback, session-secret gated.
+  if (method === 'POST' && p === '/api/agent/automation/propose') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const spec = {
+      agentId: b.agentId != null ? String(b.agentId) : '',
+      name: String(b.name || ''),
+      type: (['cron', 'webhook', 'composio', 'slack', 'discord'].includes(String(b.type)) ? String(b.type) : 'cron') as ProposedAutomation['type'],
+      schedule: b.schedule != null ? String(b.schedule) : undefined,
+      filter: b.filter != null ? String(b.filter) : undefined,
+      task: String(b.task || ''),
+      mode: (b.mode === 'headless' || b.mode === 'interactive' ? b.mode : undefined) as ProposedAutomation['mode'],
+    };
+    const out = tm.proposeAutomation(session, agent, spec, b.rationale != null ? String(b.rationale) : undefined);
     return sendJson(res, out.ok ? 200 : 400, out);
   }
 
@@ -2170,6 +2192,42 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     } catch (e) {
       return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
     }
+  }
+  // Agent-proposed automations awaiting human sign-off (the automations twin of /api/policy/proposals).
+  if (method === 'GET' && p === '/api/automations/proposals') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { proposals: tm.openAutomationProposals() });
+  }
+  const autoPropApprove = p.match(/^\/api\/automations\/proposals\/([\w.-]+)\/approve$/);
+  if (method === 'POST' && autoPropApprove) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required — creating an automation is an admin act' });
+    const card = tm.automationProposalCard(autoPropApprove[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such automation proposal' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this proposal was already resolved' });
+    try {
+      const created = autos.add({
+        agentId: card.spec.agentId, name: card.spec.name, type: card.spec.type,
+        mode: card.spec.mode, schedule: card.spec.schedule, filter: card.spec.filter,
+        task: card.spec.task, createdBy: me.id,
+      });
+      tm.setAutomationProposalStatus(autoPropApprove[1], 'approved');
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'automation.proposal.approved', data: { by: me.email, agent: card.agent, id: created.id, name: created.name, type: created.type } });
+      return sendJson(res, 200, { ok: true, automation: automationView(created, req, true) });
+    } catch (e) {
+      // A bad cron / unknown agent surfaces to the human here (validated by `add`); the proposal stays open.
+      return sendJson(res, 400, { error: e instanceof Error ? e.message : String(e) });
+    }
+  }
+  const autoPropReject = p.match(/^\/api\/automations\/proposals\/([\w.-]+)\/reject$/);
+  if (method === 'POST' && autoPropReject) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const card = tm.automationProposalCard(autoPropReject[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such automation proposal' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this proposal was already resolved' });
+    const b = await readBody(req);
+    tm.setAutomationProposalStatus(autoPropReject[1], 'rejected');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'automation.proposal.rejected', data: { by: me.email, agent: card.agent, name: card.spec.name, note: b.note ? String(b.note) : undefined } });
+    return sendJson(res, 200, { ok: true });
   }
   const autoRun = p.match(/^\/api\/automations\/([\w-]+)\/run$/);
   if (method === 'POST' && autoRun) {

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -552,6 +552,7 @@ const REVIEW_PRESENTATION: Record<ReviewNotice['kind'], { icon: string; page: st
   'skill.request': { icon: '🧩', page: 'skills' },
   'host.proposed': { icon: '🌐', page: 'connectors' },
   'policy.proposal': { icon: '🛡️', page: 'settings/policy' },
+  'automation.proposed': { icon: '⚡', page: 'automations' },
 };
 
 /**

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -278,7 +278,7 @@ export interface Session {
 
 export interface FeedMessage {
   id: string;
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'app.proposed' | 'policy.proposal';
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'app.proposed' | 'policy.proposal' | 'automation.proposed';
   sessionId: string;
   agent: string;
   title: string;
@@ -461,9 +461,22 @@ export interface MemberNotice {
 export interface ReviewNotice {
   sessionId: string;
   agent: string;
-  kind: 'secret.request' | 'skill.proposed' | 'skill.request' | 'host.proposed' | 'policy.proposal';
+  kind: 'secret.request' | 'skill.proposed' | 'skill.request' | 'host.proposed' | 'policy.proposal' | 'automation.proposed';
   title: string;
   summary: string;
+}
+
+/** The spec an agent proposes for a new automation — the subset of `AddAutomationInput` an agent may
+ *  suggest. It rides in the `automation.proposed` review-card args and is fed to `Automations.add` only
+ *  once a human approves (so an unapproved automation is never created and can never fire). */
+export interface ProposedAutomation {
+  agentId: string;
+  name: string;
+  type: 'cron' | 'webhook' | 'composio' | 'slack' | 'discord';
+  schedule?: string;
+  filter?: string;
+  task: string;
+  mode?: 'headless' | 'interactive';
 }
 
 /** What the session-event notifier sink receives when one of a member's own sessions changes state — it
@@ -3356,6 +3369,66 @@ export class TerminalManager {
         return { id: r.id, agent: r.agent, delta: a.delta as PolicyDelta, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, createdAt: r.created_at };
       })
       .filter((p) => p.delta);
+  }
+
+  /**
+   * An agent proposes a NEW automation for a human to approve — the automations twin of `proposePolicy`.
+   * Nothing is created here (an unapproved automation must not fire): the full spec lives in the review
+   * card's args, and the approve route calls `Automations.add` only once an owner/admin signs off. Same
+   * queue-cap + identical-spec dedupe as the other propose lanes. Cron validity is checked at approve
+   * time (by `add`), so a bad expression fails loudly for the human rather than being silently created.
+   */
+  proposeAutomation(sessionId: string, agent: string, spec: ProposedAutomation, rationale?: string): { ok: boolean; preview?: string; error?: string } {
+    const agentId = (spec.agentId || agent).trim();
+    if (!this.os.agents.has(agentId)) return { ok: false, error: `unknown agent "${agentId}"` };
+    const name = (spec.name || '').trim();
+    const task = (spec.task || '').trim();
+    if (!name) return { ok: false, error: 'a name is required' };
+    if (!task) return { ok: false, error: 'a task template is required' };
+    const type = (['cron', 'webhook', 'composio', 'slack', 'discord'] as const).includes(spec.type as never) ? spec.type : 'cron';
+    if (type === 'cron' && !(spec.schedule || '').trim()) return { ok: false, error: 'a cron automation needs a schedule (5-field cron expression)' };
+    const clean: ProposedAutomation = { agentId, name, type, task, ...(spec.schedule ? { schedule: String(spec.schedule).trim() } : {}), ...(spec.filter ? { filter: String(spec.filter).trim() } : {}), ...(spec.mode === 'headless' || spec.mode === 'interactive' ? { mode: spec.mode } : {}) };
+    // Cap the queue + dedupe an identical open proposal from this agent (mirrors proposePolicy).
+    const open = this.db.prepare(`SELECT id, args FROM messages WHERE type = 'automation.proposed' AND status = 'open' AND agent = ?`).all<{ id: string; args: string | null }>(agent);
+    if (open.length >= 10) return { ok: false, error: 'you already have 10 open automation proposals awaiting review — wait for a human to act on them first' };
+    const specKey = JSON.stringify(clean);
+    if (open.some((o) => { try { return JSON.stringify((JSON.parse(o.args || '{}') as { spec?: unknown }).spec) === specKey; } catch { return false; } })) {
+      return { ok: false, error: 'an identical automation proposal from you is already awaiting review' };
+    }
+    const preview = `${type}${clean.schedule ? ` \`${clean.schedule}\`` : ''} → runs \`${agentId}\`: ${task.slice(0, 80)}${task.length > 80 ? '…' : ''}`;
+    this.postReviewCard({
+      type: 'automation.proposed', sessionId, agent,
+      title: `Automation proposed — ${name}`,
+      body: (rationale?.trim() || `${agent} proposes a ${type} automation "${name}".`) + `\n\n${preview}`,
+      args: { spec: clean, preview, ...(rationale ? { rationale } : {}) },
+      summary: rationale?.trim() || `${agent} proposes a ${type} automation "${name}".`,
+    });
+    this.audit(sessionId, agent, 'automation.proposed', { name, type, agentId, schedule: clean.schedule });
+    return { ok: true, preview };
+  }
+
+  /** The proposed-automation review card by id (its spec + status) — for the approve/reject routes. */
+  automationProposalCard(id: string): { agent: string; spec: ProposedAutomation; rationale?: string; preview?: string; status: string } | undefined {
+    const row = this.db.prepare(`SELECT agent, args, status FROM messages WHERE id = ? AND type = 'automation.proposed'`).get<{ agent: string; args: string | null; status: string }>(id);
+    if (!row) return undefined;
+    let a: Record<string, unknown> = {};
+    try { a = row.args ? JSON.parse(row.args) : {}; } catch { /* tolerate a corrupt payload */ }
+    if (!a.spec) return undefined;
+    return { agent: row.agent, spec: a.spec as ProposedAutomation, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, status: row.status };
+  }
+  setAutomationProposalStatus(id: string, status: 'approved' | 'rejected'): void {
+    this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'automation.proposed'`).run(status, id);
+  }
+  openAutomationProposals(): { id: string; agent: string; spec: ProposedAutomation; rationale?: string; preview?: string; createdAt: number }[] {
+    return this.db
+      .prepare(`SELECT id, agent, args, created_at FROM messages WHERE type = 'automation.proposed' AND status = 'open' ORDER BY created_at DESC`)
+      .all<{ id: string; agent: string; args: string | null; created_at: number }>()
+      .map((r) => {
+        let a: Record<string, unknown> = {};
+        try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate corrupt payload */ }
+        return { id: r.id, agent: r.agent, spec: a.spec as ProposedAutomation, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, createdAt: r.created_at };
+      })
+      .filter((p) => p.spec);
   }
 
   /** Agent posts a mid-task progress update to the Inbox feed. Unlike the (now removed) spawn/stop/exit

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -4412,6 +4412,11 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
     Icon = Server; iconCls = 'text-violet-600'; highlight = true
     verb = 'proposed a host'; detail = m.body
     badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">review in Connections</Badge>
+  } else if (m.type === 'automation.proposed') {
+    Icon = Zap; iconCls = 'text-violet-600'; highlight = m.status === 'open'
+    const resolved = m.status === 'approved' ? 'approved' : m.status === 'rejected' ? 'rejected' : ''
+    verb = 'proposed an automation'; detail = m.body
+    badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">{resolved || 'review in Automations'}</Badge>
   } else if (m.type === 'goal.proposed') {
     Icon = Target; iconCls = 'text-indigo-600'; highlight = true
     verb = 'proposed a goal'; detail = m.body
@@ -8112,6 +8117,45 @@ function triggerSummary(a: Automation): string {
   }
 }
 
+/** Owner/admin review of agent-proposed automations — approve (creates + enables it) or reject. Mirrors
+ *  PolicyProposalsPanel; hidden entirely when there are no open proposals. */
+function AutomationProposalsPanel({ agents, onChanged }: { agents: AgentInfo[]; onChanged: () => void }) {
+  const [proposals, setProposals] = useState<AutomationProposal[]>([])
+  const [busy, setBusy] = useState('')
+  const [hint, setHint] = useState('')
+  const load = () => { api.automationProposals().then((r) => setProposals(r.proposals ?? [])).catch(() => {}) }
+  useEffect(load, [])
+  const agentName = (id: string) => agents.find((a) => a.id === id)?.id || id
+  const approve = async (id: string) => { setBusy(id); setHint(''); const r = await api.approveAutomationProposal(id); setBusy(''); if (!r.ok) return setHint('⚠ ' + (r.error || 'failed')); load(); onChanged() }
+  const reject = async (id: string) => { setBusy(id); setHint(''); const r = await api.rejectAutomationProposal(id); setBusy(''); if (!r.ok) return setHint('⚠ ' + (r.error || 'failed')); load() }
+  if (!proposals.length) return null
+  return (
+    <div>
+      <div className="mb-2 flex items-center gap-1.5 text-[11px] uppercase tracking-wider text-muted-foreground"><Sparkles className="h-3.5 w-3.5" />Proposed by agents · {proposals.length}</div>
+      <div className="space-y-2">
+        {proposals.map((pr) => (
+          <Card key={pr.id} className="border-amber-200">
+            <CardContent className="space-y-2 p-3">
+              <div className="flex flex-wrap items-center gap-1.5">
+                <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">{pr.spec.type}</Badge>
+                <span className="text-sm font-medium">{pr.spec.name}</span>
+                <span className="text-[11px] text-muted-foreground">runs <span className="font-mono">{agentName(pr.spec.agentId)}</span> · by <span className="font-mono">{pr.agent}</span>{pr.createdAt ? ` · ${timeAgo(pr.createdAt)}` : ''}</span>
+              </div>
+              {pr.preview && <div className="rounded bg-muted/50 px-2 py-1 font-mono text-[11px]">{pr.preview}</div>}
+              {pr.rationale && <p className="text-[11px] italic text-muted-foreground">“{pr.rationale}”</p>}
+              <div className="flex items-center gap-2">
+                <Button size="sm" disabled={!!busy} onClick={() => approve(pr.id)}>Approve &amp; enable</Button>
+                <Button size="sm" variant="ghost" disabled={!!busy} onClick={() => reject(pr.id)}>Reject</Button>
+                {hint && busy === '' && <span className="text-[11px] text-amber-600">{hint}</span>}
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  )
+}
+
 function AutomationsPage({ me, agents, serverTz, onOpen, nav, agentFilter }: { me: Member; agents: AgentInfo[]; serverTz?: string; onOpen: (tmux: string, title: string) => void; nav: (r: Route, detail?: string) => void; agentFilter?: string }) {
   const [items, setItems] = useState<Automation[] | null>(null)
   const [busy, setBusy] = useState('')
@@ -8211,6 +8255,8 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav, agentFilter }: { m
 
   return (
     <div className="max-w-4xl space-y-6">
+      {/* Agent-proposed automations awaiting sign-off — the automations twin of the Policy "Agent proposals". */}
+      {(me.role === 'owner' || me.role === 'admin') && <AutomationProposalsPanel agents={agents} onChanged={load} />}
       {/* "Run now" asks headless vs interactive for this one-off run, without touching the saved default. */}
       <Dialog open={!!runPrompt} onOpenChange={(o) => { if (!o) setRunPrompt(null) }}>
         <DialogContent className="max-w-md">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -590,7 +590,7 @@ export interface AddGoalReq {
 
 export interface Msg {
   id: string
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed'
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed'
   sessionId: string
   agent: string
   title: string
@@ -663,6 +663,16 @@ export interface Automation {
   /** Member id the fired session acts as — binds THAT member's connectors/Composio (e.g. personal
    *  ClickUp) instead of the company fallback. Empty/absent = company identity. */
   runAs?: string
+}
+/** An agent-proposed automation awaiting owner/admin approval — the spec lives in the review card until
+ *  approved (then it's created via Automations.add). Mirrors PolicyProposal. */
+export interface AutomationProposal {
+  id: string
+  agent: string
+  spec: { agentId: string; name: string; type: Automation['type']; schedule?: string; filter?: string; task: string; mode?: ExecMode }
+  rationale?: string
+  preview?: string
+  createdAt: number
 }
 export interface AddAutomationReq {
   agentId: string
@@ -1266,6 +1276,9 @@ export const api = {
   /** Fire an automation once now. `mode` overrides its saved default for this run only (headless =
    *  fire-and-forget, interactive = watch/steer the live TUI); omit to keep the automation's own mode. */
   runAutomation: (id: string, mode?: 'interactive' | 'headless') => call<{ ok: boolean; sessionId?: string; reason?: string; error?: string }>('POST', `/api/automations/${id}/run`, mode ? { mode } : {}),
+  automationProposals: () => call<{ proposals: AutomationProposal[]; error?: string }>('GET', '/api/automations/proposals'),
+  approveAutomationProposal: (id: string) => call<{ ok: boolean; automation?: Automation; error?: string }>('POST', `/api/automations/proposals/${id}/approve`),
+  rejectAutomationProposal: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/automations/proposals/${id}/reject`),
   automationRuns: (id: string) => call<{ runs: Session[]; error?: string }>('GET', `/api/automations/${id}/runs`),
 
   memory: (agent: string, q = '', limit = 50, scope: 'all' | 'agent' | 'tenant' = 'all') =>


### PR DESCRIPTION
## Backlog gap #1 — the fourth "propose lane"

From the backlog mapping, most "owner-intelligence takes action" features already exist (memory consolidation, memory cleanup, KB tidy, `skill_propose`/`policy_propose`/`host_propose`, stuck-goals, troubled-automations, goals autoplan). The clearest genuine gap in the **propose lanes** was **automations**: agents could `schedule` their own one-shots but had no way to propose a durable, recurring automation for a human to approve.

### What this adds
A new agent tool **`automation_propose`** — the automations twin of `policy_propose`. An agent that notices recurring work (a daily report, a periodic audit, a reaction to an inbound event) drafts an automation; a human approves it.

- **Non-destructive & safe by construction:** nothing is created and **nothing can ever fire** until approved. The spec rides in an `automation.proposed` review card (same pattern as policy proposals — **no DB migration**); only on approve does `Automations.add` create + enable it. Cron validity is checked at approve time, so a bad expression fails loudly for the human, not silently.
- Same **10-deep queue cap + identical-spec dedupe** as the other propose lanes.
- Owner/admin approve/reject at **Automations → "Proposed by agents"** (`GET /api/automations/proposals`, `POST …/:id/approve|reject`), plus an inbox review card (`automation.proposed`) + DM (⚡, deep-links to Automations).
- Audited `automation.proposed` / `automation.proposal.approved` / `automation.proposal.rejected`.

### Surfaces touched
- `src/memory/memory-mcp.ts` — `automation_propose` tool def + dispatch + impl
- `src/terminal.ts` — `proposeAutomation` + card helpers, `ProposedAutomation` type, review-card kind
- `src/server.ts` — loopback propose route + admin list/approve/reject routes
- `src/tenant-registry.ts` — review-DM presentation (⚡ → Automations)
- `web/` — "Proposed by agents" panel on the Automations page + inbox card rendering + API

### Verification
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → **68/68** ✓ · `npm run demo` ✓
- In-process harness on built `dist`: propose → creates one open review card with the right spec; identical re-propose → rejected (dedupe); unknown `agentId` → rejected; card reads back with correct schedule. ✅

Note: as a new MCP tool, agents pick it up on their next session respawn (standard for tool-schema changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)