### PR TITLE
feat(insights): declutter the Library — soft-archive orphaned artifacts (v0.247.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.247.0] — 2026-07-20
+### Added
+- **Insights can now declutter the Library — an 8th improvement tile.** The artifacts gallery accumulates
+  throwaway output (a generated test image, a scratch file, a one-off render from a run that's since been
+  deleted) with nothing to prune it. The new **Library** tile detects clutter and soft-archives it: the
+  **dead** set — **orphaned** (produced by a session that no longer exists) AND never shared (no team
+  share, no public link) AND 30+ days old — is safely archivable (an artifact whose run is gone and nobody
+  ever shared is throwaway by definition); **old-but-still-owned** private artifacts are surfaced for
+  manual review, never auto-touched. Archiving is a **soft `archived_at`** (row + files retained, hidden
+  from the gallery) so it's fully reversible — the Library grows a collapsible **"N archived · Restore"**
+  section, and `POST /api/artifacts/:id/unarchive` restores. Preview → "Archive N" mirrors the KB-tidy /
+  task-reconcile generative tiles. `src/edge/library-tidy.ts` + `GET`/`POST /api/insights/library/tidy` +
+  `GET /api/artifacts?archived=1`; audited `library.tidied` / `artifact.unarchived`.
+
 ## [0.246.0] — 2026-07-20
 ### Added
 - **Insights now reconciles the Tasks board against what sessions actually did — a 7th improvement tile.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.246.0",
+  "version": "0.247.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.246.0",
+      "version": "0.247.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.246.0",
+  "version": "0.247.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/improvements.ts
+++ b/src/edge/improvements.ts
@@ -14,7 +14,7 @@ import type { Insights } from './insights';
 const DAY = 24 * 3_600_000;
 type Db = AgentOS['db'];
 
-export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks';
+export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library';
 export interface ImprovementTile {
   domain: ImprovementDomain;
   count: number;                 // opportunities found (0 = nothing to improve)
@@ -101,6 +101,16 @@ export function buildImprovements(os: AgentOS, insights: Insights, now = Date.no
     title: tFinished + tStalled ? `${tFinished + tStalled} task${tFinished + tStalled === 1 ? '' : 's'} to reconcile` : 'Task board is in sync',
     detail: tFinished + tStalled ? `${tFinished} finished but still open (auto-closable), ${tStalled} stalled after a failed run — review the board.` : 'Every dispatched task matches its run.',
     actionLabel: 'Open Tasks', href: '#/tasks',
+  });
+
+  // 8) Library — declutter orphaned/never-shared artifacts (soft-archive, reversible). See library-tidy.ts.
+  const libDead = num(db, "SELECT count(*) AS n FROM artifacts WHERE archived_at IS NULL AND shared_team = 0 AND share_token IS NULL AND session_id NOT IN (SELECT id FROM term_sessions) AND created_at < ?", now - 30 * DAY);
+  const libStale = num(db, "SELECT count(*) AS n FROM artifacts WHERE archived_at IS NULL AND shared_team = 0 AND share_token IS NULL AND session_id IN (SELECT id FROM term_sessions) AND created_at < ?", now - 60 * DAY);
+  tiles.push({
+    domain: 'library', count: libDead + libStale,
+    title: libDead + libStale ? `${libDead + libStale} artifact${libDead + libStale === 1 ? '' : 's'} to declutter` : 'Library is tidy',
+    detail: libDead + libStale ? `${libDead} orphaned (run gone, never shared — archivable), ${libStale} old &amp; private — review the gallery.` : 'No orphaned or long-stale artifacts.',
+    actionLabel: 'Open Library', href: '#/artifacts',
   });
 
   return tiles;

--- a/src/edge/library-tidy.ts
+++ b/src/edge/library-tidy.ts
@@ -1,0 +1,71 @@
+/**
+ * Library improvement tile — **declutter the artifacts gallery** (Library domain of Insights v2).
+ *
+ * The Library accumulates throwaway output: a generated test image, a scratch file, a one-off render from
+ * a run that's since been deleted. Nothing prunes it, so the gallery fills with dead weight. This turns
+ * that into a REVIEWABLE **soft-archive**: a deterministic preview of exactly which artifacts would be
+ * hidden, then an apply that sets `archived_at` (the row + files survive — an archived artifact is one
+ * click from restored, `ArtifactStore.unarchive`). Same reversibility posture as KB tidy.
+ *
+ * Conservative on purpose. Only **orphaned** artifacts — produced by a session that no longer exists — that
+ * are old AND were never shared (no team-share, no public link) are archivable: an artifact whose run is
+ * gone and that nobody ever shared is throwaway by definition. Old-but-still-owned artifacts are surfaced
+ * for MANUAL review (never auto-archived) — a deliverable shouldn't vanish on a timer. Pure over
+ * `artifacts` (⋈ `term_sessions` for the orphan test); no LLM.
+ */
+import type { AgentOS } from '../kernel';
+
+const DAY = 86_400_000;
+const DEAD_AFTER_DAYS = 30;  // orphaned + never-shared + older than this → archivable clutter
+const STALE_AFTER_DAYS = 60; // never-shared, older than this, session still exists → surface for review
+const SAMPLE = 8;
+
+export interface LibraryTidyItem { id: string; title: string; kind: string; agent: string; ageDays: number; bytes: number }
+export interface LibraryTidyPlan {
+  deadAfterDays: number;
+  staleAfterDays: number;
+  dead: { total: number; bytes: number; sample: LibraryTidyItem[] };   // archivable now (orphaned, never shared)
+  stale: { total: number; sample: LibraryTidyItem[] };                  // review-only (old, still owned)
+}
+
+interface Row { id: string; title: string; kind: string; agent: string; created_at: number; bytes: number }
+
+function toItem(r: Row, now: number): LibraryTidyItem {
+  return { id: r.id, title: r.title || r.id, kind: r.kind, agent: r.agent, ageDays: Math.floor((now - r.created_at) / DAY), bytes: r.bytes };
+}
+
+// Never-shared = no team share AND no (live) public link. Orphaned = its producing session is gone;
+// OWNED = the producing session still exists (the review set that must NOT be auto-archived).
+const NEVER_SHARED = "shared_team = 0 AND share_token IS NULL";
+const ORPHANED = "session_id NOT IN (SELECT id FROM term_sessions)";
+const OWNED = "session_id IN (SELECT id FROM term_sessions)";
+
+/** Compute the archivable (dead) + review (stale) artifact lists WITHOUT mutating anything. */
+export function planLibraryTidy(os: AgentOS, now = Date.now()): LibraryTidyPlan {
+  const db = os.db;
+  const deadRows = db
+    .prepare(`SELECT id, title, kind, agent, created_at, bytes FROM artifacts WHERE archived_at IS NULL AND ${NEVER_SHARED} AND ${ORPHANED} AND created_at < ? ORDER BY created_at`)
+    .all<Row>(now - DEAD_AFTER_DAYS * DAY);
+  const staleRows = db
+    .prepare(`SELECT id, title, kind, agent, created_at, bytes FROM artifacts WHERE archived_at IS NULL AND ${NEVER_SHARED} AND ${OWNED} AND created_at < ? ORDER BY created_at`)
+    .all<Row>(now - STALE_AFTER_DAYS * DAY);
+  return {
+    deadAfterDays: DEAD_AFTER_DAYS,
+    staleAfterDays: STALE_AFTER_DAYS,
+    dead: { total: deadRows.length, bytes: deadRows.reduce((s, r) => s + (r.bytes || 0), 0), sample: deadRows.slice(0, SAMPLE).map((r) => toItem(r, now)) },
+    stale: { total: staleRows.length, sample: staleRows.slice(0, SAMPLE).map((r) => toItem(r, now)) },
+  };
+}
+
+/** Soft-archive the DEAD (orphaned, never-shared, aged) artifacts — reversible (restore from Library). Audited. */
+export function applyLibraryTidy(os: AgentOS, by = 'system', now = Date.now()): { archived: number } {
+  const rows = os.db
+    .prepare(`SELECT id FROM artifacts WHERE archived_at IS NULL AND ${NEVER_SHARED} AND ${ORPHANED} AND created_at < ?`)
+    .all<{ id: string }>(now - DEAD_AFTER_DAYS * DAY);
+  let archived = 0;
+  for (const r of rows) if (os.artifacts.archive(r.id, now)) archived++;
+  if (archived) {
+    os.audit.append({ ts: now, runId: '-', tenant: os.tenant, principal: by, type: 'library.tidied', data: { archived, via: 'insights-tidy', deadAfterDays: DEAD_AFTER_DAYS } });
+  }
+  return { archived };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,6 +35,7 @@ import { planMemoryCleanup, applyMemoryCleanup, cleanupOpts } from './edge/memor
 import { SkillScout, SCOUT_ID } from './edge/skill-scout';
 import { planKbTidy, applyKbTidy } from './edge/kb-tidy';
 import { planTaskReconcile, applyTaskReconcile } from './edge/task-reconcile';
+import { planLibraryTidy, applyLibraryTidy } from './edge/library-tidy';
 import { Strategist, STRATEGIST_ID } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -3234,6 +3235,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const r = applyTaskReconcile(os, me.email);
     return sendJson(res, 200, { ok: true, ...r });
   }
+  // Library domain "declutter": preview orphaned/never-shared artifacts, then apply SOFT-ARCHIVES the
+  // dead set (hidden from the gallery, files retained — restore from Library). Reversible, audited.
+  if (p === '/api/insights/library/tidy' && (method === 'GET' || method === 'POST')) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (method === 'GET') return sendJson(res, 200, { ok: true, plan: planLibraryTidy(os) });
+    const r = applyLibraryTidy(os, me.email);
+    return sendJson(res, 200, { ok: true, ...r });
+  }
   // Skills domain "generate the fix": spawn the skill-scout to mine recent successful fleet runs for a
   // recurring procedure and draft it as a skill via skill_propose — lands on the existing proposed-skill
   // review queue (published from the Skills page); no new apply surface.
@@ -4718,7 +4727,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // whole tenant. The public share TOKEN is a credential, not display data — surface it (and the
     // resolved link) only to whoever may manage sharing (owner/admin/producer); everyone else gets a
     // plain `public` boolean so the UI can badge it without leaking the URL.
-    const visible = os.artifacts.list().filter((a) => tm.canViewSpawn(a.source ?? null, me) || a.sharedTeam);
+    // `?archived=1` returns the soft-archived set (the Library "show archived / restore" view); default is live.
+    const source = url.searchParams.get('archived') === '1' ? os.artifacts.listArchived() : os.artifacts.list();
+    const visible = source.filter((a) => tm.canViewSpawn(a.source ?? null, me) || a.sharedTeam);
     const shaped = visible.map((a) => {
       const mine = isAdmin(me) || a.source === me.id;
       return {
@@ -4761,6 +4772,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!isAdmin(me) && a.source !== me.id) return sendJson(res, 403, { error: 'forbidden' });
     os.artifacts.remove(a.id);
     os.audit.append({ ts: Date.now(), runId: a.sessionId, tenant: os.tenant, principal: me.email, type: 'artifact.deleted', data: { id: a.id, filename: a.filename } });
+    return sendJson(res, 200, { ok: true });
+  }
+  // Restore a soft-archived artifact back into the Library (the reverse of the Insights declutter apply).
+  const artUnarchive = p.match(/^\/api\/artifacts\/([\w-]+)\/unarchive$/);
+  if (method === 'POST' && artUnarchive) {
+    const a = os.artifacts.get(artUnarchive[1]);
+    if (!a) return sendJson(res, 404, { error: 'not found' });
+    if (!isAdmin(me) && a.source !== me.id) return sendJson(res, 403, { error: 'forbidden' });
+    os.artifacts.unarchive(a.id);
+    os.audit.append({ ts: Date.now(), runId: a.sessionId, tenant: os.tenant, principal: me.email, type: 'artifact.unarchived', data: { id: a.id } });
     return sendJson(res, 200, { ok: true });
   }
   // Share an artifact beyond its producer — same gate as move/delete (owner/admin, or the producing

--- a/src/state/artifacts.ts
+++ b/src/state/artifacts.ts
@@ -42,6 +42,8 @@ export interface Artifact {
   /** Epoch ms when the public link auto-revokes (mint time + {@link PUBLIC_SHARE_TTL_MS}). */
   shareExpiresAt?: number;
   createdAt: number;
+  /** Epoch ms when soft-archived (hidden from the Library, files retained). undefined = live. */
+  archivedAt?: number;
 }
 
 interface ArtifactRow {
@@ -62,6 +64,7 @@ interface ArtifactRow {
   share_token: string | null;
   share_expires_at: number | null;
   created_at: number;
+  archived_at?: number | null; // absent on freshly-built row literals (new artifacts are live)
 }
 
 export type PublishResult =
@@ -236,9 +239,26 @@ export class ArtifactStore {
   /** All artifacts, newest first. The server filters by viewer (inbox visibility rule). */
   list(): Artifact[] {
     return this.db
-      .prepare('SELECT * FROM artifacts ORDER BY created_at DESC')
+      .prepare('SELECT * FROM artifacts WHERE archived_at IS NULL ORDER BY created_at DESC')
       .all<ArtifactRow>()
       .map(toArtifact);
+  }
+
+  /** Soft-archived artifacts (hidden from the Library) — for the "show archived / restore" affordance. */
+  listArchived(): Artifact[] {
+    return this.db
+      .prepare('SELECT * FROM artifacts WHERE archived_at IS NOT NULL ORDER BY archived_at DESC')
+      .all<ArtifactRow>()
+      .map(toArtifact);
+  }
+
+  /** Soft-archive an artifact — hide it from the gallery, keep the row + files (reversible). */
+  archive(id: string, now = Date.now()): boolean {
+    return this.db.prepare('UPDATE artifacts SET archived_at = ? WHERE id = ? AND archived_at IS NULL').run(now, id).changes > 0;
+  }
+  /** Restore a soft-archived artifact back into the Library. */
+  unarchive(id: string): boolean {
+    return this.db.prepare('UPDATE artifacts SET archived_at = NULL WHERE id = ?').run(id).changes > 0;
   }
 
   /** Distinct non-empty folder paths in use (for agent discovery — file into the existing tree
@@ -381,6 +401,7 @@ function toArtifact(r: ArtifactRow): Artifact {
     shareToken: r.share_token ?? undefined,
     shareExpiresAt: r.share_expires_at ?? undefined,
     createdAt: r.created_at,
+    archivedAt: r.archived_at ?? undefined,
   };
 }
 

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -838,6 +838,10 @@ function migrate(db: Db): void {
   // world-reachable forever. Set when the link is minted; the public route rejects an expired token
   // immediately and the scheduler sweep clears it from the row. NULL = no public link (nothing to expire).
   addColumn(db, 'artifacts', 'share_expires_at', 'INTEGER');
+  // Soft-archive for Library declutter: an archived artifact is hidden from the gallery but its row +
+  // files survive, so archiving is fully reversible (unarchive). NULL = live. (The Insights Library tile
+  // archives orphaned/never-shared clutter; a human can always restore it.)
+  addColumn(db, 'artifacts', 'archived_at', 'INTEGER');
 
   // Session insights — what a finished run actually did, so the sessions list can say more than
   // "done" (which only means the process exited). All are stamped ONCE when the run reaches a terminal

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -5469,9 +5469,13 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
   const [agentFilter, setAgentFilter] = useState('')
   const [folder, setFolder] = useState('')
   const [hint, setHint] = useState('')
+  const [archived, setArchived] = useState<Artifact[]>([])   // the soft-archived set (Insights declutter)
+  const [showArchived, setShowArchived] = useState(false)
 
   const load = () => api.artifacts().then((r) => { setArtifacts(r.artifacts ?? []); setEnabled(r.enabled !== false) })
-  useEffect(() => { load() }, [])
+  const loadArchived = () => api.artifacts(true).then((r) => setArchived(r.artifacts ?? [])).catch(() => {})
+  useEffect(() => { load(); loadArchived() }, [])
+  const unarchive = async (id: string) => { const r = await api.unarchiveArtifact(id); if (r.error) return setHint('⚠ ' + r.error); loadArchived(); load() }
 
   // The URL is the source of truth for the open artifact: `#/artifacts/<id>` deep-links to one
   // deliverable (shareable, back/forward, and the Inbox 'artifact' card links straight here).
@@ -5532,6 +5536,26 @@ function ArtifactsPage({ me, permalink, nav }: { me: Member; permalink: string; 
         publish time. {me.role === 'member' ? 'You see deliverables from sessions you started.' : 'Owners and admins see every deliverable.'}
         {!enabled && <span className="text-amber-600"> (no data home configured — publishing is disabled)</span>}
       </p>
+
+      {archived.length > 0 && (
+        <div className="rounded-lg border bg-muted/20 p-2 text-xs">
+          <button onClick={() => setShowArchived((v) => !v)} className="flex items-center gap-1.5 font-medium text-muted-foreground hover:text-foreground">
+            <Package className="h-3.5 w-3.5" />{archived.length} archived {showArchived ? '▾' : '▸'}
+          </button>
+          {showArchived && (
+            <ul className="mt-2 space-y-1">
+              {archived.map((a) => (
+                <li key={a.id} className="flex items-center gap-2">
+                  <ArtifactIcon a={a} className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+                  <span className="truncate text-muted-foreground">{a.title}</span>
+                  <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{a.agent}</span>
+                  <button onClick={() => unarchive(a.id)} className="shrink-0 text-[11px] text-primary underline underline-offset-2">Restore</button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
 
       {agents.length > 1 && (
         <div className="flex flex-wrap items-center gap-1.5">
@@ -10462,6 +10486,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [cleanupBusy, setCleanupBusy] = useState(false)
   const [kbTidy, setKbTidy] = useState<KbTidyPlan | null>(null)
   const [taskRec, setTaskRec] = useState<TaskReconcilePlan | null>(null)
+  const [libTidy, setLibTidy] = useState<LibraryTidyPlan | null>(null)
   const [stuckGoals, setStuckGoals] = useState<StuckGoal[]>([])
   const [goalsOpen, setGoalsOpen] = useState(false)
   const [troubledAutos, setTroubledAutos] = useState<TroubledAutomation[]>([])
@@ -10560,6 +10585,16 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const applyTaskReconcile = async () => {
     setCleanupBusy(true); const r = await api.taskReconcileApply(); setCleanupBusy(false); setTaskRec(null)
     setDxHint(r.error ? `⚠ ${r.error}` : `Closed ${r.closed ?? 0} finished task${r.closed === 1 ? '' : 's'} — reopen any from the board if needed.`)
+    setTimeout(() => setDxHint(''), 6000); refresh()
+  }
+  const previewLibraryTidy = async () => {
+    setCleanupBusy(true); const r = await api.libraryTidyPreview(); setCleanupBusy(false)
+    if (r.error || !r.plan) return setDxHint(`⚠ ${r.error ?? 'could not build a plan'}`)
+    setLibTidy(r.plan)
+  }
+  const applyLibraryTidy = async () => {
+    setCleanupBusy(true); const r = await api.libraryTidyApply(); setCleanupBusy(false); setLibTidy(null)
+    setDxHint(r.error ? `⚠ ${r.error}` : `Archived ${r.archived ?? 0} artifact${r.archived === 1 ? '' : 's'} — restore any from the Library.`)
     setTimeout(() => setDxHint(''), 6000); refresh()
   }
   const previewCleanup = async () => {
@@ -10662,6 +10697,13 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                 <button key={t.domain} onClick={previewTaskReconcile} disabled={cleanupBusy} className={`${cls} disabled:opacity-50`}>
                   {inner}
                   <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview reconcile →'}</div>
+                </button>
+              )
+              // Library tile is generative: preview orphaned artifacts; apply soft-archives them (restorable).
+              if (t.domain === 'library' && t.count > 0) return (
+                <button key={t.domain} onClick={previewLibraryTidy} disabled={cleanupBusy} className={`${cls} disabled:opacity-50`}>
+                  {inner}
+                  <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview declutter →'}</div>
                 </button>
               )
               // Goals tile: expand the stuck goals in place, each with a "plan" that spawns the strategist.
@@ -10788,6 +10830,38 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                     </ul>
                   )}
                   <div className="mt-1 text-[10px] text-muted-foreground">Stalled tasks need a human call — re-dispatch, reassign, or block them in <a href="#/tasks" className="underline">Tasks</a>.</div>
+                </div>
+              </div>
+            </div>
+          )}
+          {libTidy && (
+            <div className="mt-3 rounded-lg border bg-muted/30 p-3 text-xs">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="font-medium">Library declutter preview <span className="font-normal text-muted-foreground">— archiving is soft (restore from the Library)</span></div>
+                <div className="flex items-center gap-2">
+                  <button onClick={applyLibraryTidy} disabled={cleanupBusy || libTidy.dead.total === 0} className="rounded bg-red-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-red-700 disabled:opacity-50">{cleanupBusy ? 'archiving…' : `Archive ${libTidy.dead.total}${libTidy.dead.bytes ? ` · ${fmtBytes(libTidy.dead.bytes)}` : ''}`}</button>
+                  <button onClick={() => setLibTidy(null)} className="text-[11px] text-muted-foreground underline underline-offset-2">Cancel</button>
+                </div>
+              </div>
+              <div className="mt-2 grid gap-3 md:grid-cols-2">
+                <div>
+                  <div className="mb-1 font-medium">Archive — {libTidy.dead.total} orphaned <span className="font-normal text-muted-foreground">(run gone, never shared, {libTidy.deadAfterDays}d+ old)</span></div>
+                  {libTidy.dead.total === 0 ? <div className="text-muted-foreground">nothing orphaned to archive</div> : (
+                    <ul className="space-y-0.5">
+                      {libTidy.dead.sample.map((a) => <li key={a.id} className="truncate text-muted-foreground"><span className="text-foreground">{a.title}</span> · {a.kind} · {a.ageDays}d · {fmtBytes(a.bytes)}</li>)}
+                      {libTidy.dead.total > libTidy.dead.sample.length && <li className="text-muted-foreground">+{libTidy.dead.total - libTidy.dead.sample.length} more…</li>}
+                    </ul>
+                  )}
+                </div>
+                <div>
+                  <div className="mb-1 font-medium">Review — {libTidy.stale.total} old &amp; private <span className="font-normal text-muted-foreground">(unshared {libTidy.staleAfterDays}d+)</span></div>
+                  {libTidy.stale.total === 0 ? <div className="text-muted-foreground">nothing stale</div> : (
+                    <ul className="space-y-0.5">
+                      {libTidy.stale.sample.map((a) => <li key={a.id} className="truncate text-muted-foreground"><a href="#/artifacts" className="text-foreground underline underline-offset-2">{a.title}</a> · {a.ageDays}d</li>)}
+                      {libTidy.stale.total > libTidy.stale.sample.length && <li className="text-muted-foreground">+{libTidy.stale.total - libTidy.stale.sample.length} more…</li>}
+                    </ul>
+                  )}
+                  <div className="mt-1 text-[10px] text-muted-foreground">These still belong to a live run — keep, share, or delete them by hand in <a href="#/artifacts" className="underline">Library</a>.</div>
                 </div>
               </div>
             </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -359,6 +359,8 @@ export interface Artifact {
   /** The resolved public URL (`/shared/<token>`) — present only when `shareToken` is. */
   shareUrl?: string
   createdAt: number
+  /** Epoch ms when soft-archived (only present in the `?archived=1` view). */
+  archivedAt?: number
 }
 
 export interface KbPage {
@@ -397,7 +399,7 @@ export interface AgentScore { agent: string; runs: number; success: number; fail
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
-export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks'
+export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library'
 export interface ImprovementTile { domain: ImprovementDomain; count: number; title: string; detail: string; actionLabel: string; href: string }
 export interface CleanupPruneItem { id: string; agent: string; snippet: string; ageDays: number; importance: number | null }
 export interface CleanupMergeGroup { agent: string; keepSnippet: string; drop: number }
@@ -406,6 +408,8 @@ export interface KbTidyItem { id: string; section: string; slug: string; title: 
 export interface KbTidyPlan { deadAfterDays: number; staleAfterDays: number; dead: { total: number; sample: KbTidyItem[] }; stale: { total: number; sample: KbTidyItem[] } }
 export interface TaskDriftItem { id: string; title: string; assignee: string | null; owner: string | null; sessionId: string; sessionStatus: string; outcome: string; endedDaysAgo: number }
 export interface TaskReconcilePlan { finished: { total: number; sample: TaskDriftItem[] }; stalled: { total: number; sample: TaskDriftItem[] } }
+export interface LibraryTidyItem { id: string; title: string; kind: string; agent: string; ageDays: number; bytes: number }
+export interface LibraryTidyPlan { deadAfterDays: number; staleAfterDays: number; dead: { total: number; bytes: number; sample: LibraryTidyItem[] }; stale: { total: number; sample: LibraryTidyItem[] } }
 export interface StuckGoal { id: string; title: string; days: number }
 export interface TroubledAutomation { id: string; name: string; type: string; reason: 'errored' | 'idle'; detail: string }
 export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
@@ -1508,8 +1512,11 @@ export const api = {
     },
   },
 
-  artifacts: () => call<{ artifacts: Artifact[]; enabled: boolean }>('GET', '/api/artifacts'),
+  artifacts: (archived?: boolean) => call<{ artifacts: Artifact[]; enabled: boolean }>('GET', '/api/artifacts' + (archived ? '?archived=1' : '')),
   deleteArtifact: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', '/api/artifacts/' + id),
+  unarchiveArtifact: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/artifacts/${id}/unarchive`),
+  libraryTidyPreview: () => call<{ ok: boolean; plan?: LibraryTidyPlan; error?: string }>('GET', '/api/insights/library/tidy'),
+  libraryTidyApply: () => call<{ ok: boolean; archived?: number; error?: string }>('POST', '/api/insights/library/tidy'),
   moveArtifact: (id: string, folder: string) => call<{ ok: boolean; artifact?: Artifact; error?: string }>('PATCH', '/api/artifacts/' + id, { folder }),
   /** Share an artifact with the tenant (`team`) and/or mint/revoke its public link (`public`). */
   shareArtifact: (id: string, body: { team?: boolean; public?: boolean }) => call<{ ok: boolean; artifact?: Artifact; error?: string }>('POST', `/api/artifacts/${id}/share`, body),


### PR DESCRIPTION
## Backlog gap #2 — Library / artifacts declutter

The consolidation/declutter half of the backlog. The artifacts gallery accumulates throwaway output (a generated test image, a scratch file, a one-off render from a run since deleted) with nothing to prune it.

### What this adds — an 8th "Library" improvement tile
Detects clutter and **soft-archives** it, mirroring the KB-tidy generative tile:

| bucket | definition | action |
|---|---|---|
| **dead** | **orphaned** (producing session no longer exists) AND never shared (no team share, no public link) AND 30d+ old | **archivable** — an artifact whose run is gone and nobody ever shared is throwaway by definition |
| **stale** | old + private but the session still exists | **review only** — never auto-touched (keep/share/delete by hand) |

**Reversible by design** — archiving is a soft `archived_at`: the row + files are retained and just hidden from the gallery. The Library grows a collapsible **"N archived · Restore"** section, and `POST /api/artifacts/:id/unarchive` restores. (Deliberately *not* a hard delete — artifacts have no revision history like KB, so a destructive apply would violate the reversibility bar the other declutter tiles hold.)

`src/edge/library-tidy.ts` · `GET`/`POST /api/insights/library/tidy` · `GET /api/artifacts?archived=1` · `improvements.ts` (`library` domain) · web tile + preview + Library restore UI. Audited `library.tidied` / `artifact.unarchived`.

### Verification
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → **68/68** ✓ · `npm run demo` ✓
- In-process harness on built `dist`: seeded orphaned-old / orphaned-shared / owned-old / orphaned-recent → **dead** = the orphaned-old-unshared only, **stale** = the owned-old only, shared + recent excluded; apply archived exactly 1, the live `list()` excludes it, `listArchived()` has it, and `unarchive` restores it. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)