### PR TITLE
fix(tasks): dispatch no longer fails on an over-4000-char /goal criterion (v0.247.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.247.1] — 2026-07-20
+### Fixed
+- **A dispatched task with a long acceptance criterion no longer fails to launch.** Task dispatch put the
+  task's single-line `criteria` on line 1 as `/goal <criteria>`, but the `claude` CLI hard-rejects any
+  `/goal` condition over 4000 characters ("Goal condition is limited to 4000 characters"), so the run
+  never started. `buildTaskPrompt` now falls back gracefully when the criteria exceeds the ceiling
+  (`GOAL_MAX_CHARS` in `src/edge/claude-cli.ts`): it drops `/goal` mode and embeds the full criteria in
+  the prompt body as an "Acceptance criteria (the definition of done)" section — the run still knows what
+  done means, it just isn't evaluator-driven. Short criteria keep the `/goal` convergence treatment. The
+  same guard covers the `ask_agent`-with-goal delegation path in `src/terminal.ts`.
+
 ## [0.247.0] — 2026-07-20
 ### Added
 - **Insights can now declutter the Library — an 8th improvement tile.** The artifacts gallery accumulates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.247.0",
+  "version": "0.247.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -268,15 +268,23 @@ const GOAL_AUTOPLAN_MAX_PER_TICK = Number(process.env.AOS_GOAL_AUTOPLAN_MAX_PER_
  * drives the session across turns until the criteria hold (autonomous convergence; spiked viable, see
  * goals-plan.md §C). `task_update(done)` stays the OS system-of-record, folded into the same turn so the
  * goal clearing and the task closing are atomic; the existing attempt-ceiling/guard net covers a miss.
+ *
+ * The `claude` CLI hard-rejects a `/goal` condition over `GOAL_MAX_CHARS` (it errors and the run never
+ * starts). An overlong `criteria` therefore falls back to plain mode with the acceptance condition
+ * embedded in the prompt body — the run still knows what "done" means, it just isn't evaluator-driven.
  */
 export function buildTaskPrompt(t: { id: string; title: string; body: string; criteria?: string }, opts: { goalMode?: boolean } = {}): string {
-  const converging = !!(opts.goalMode && t.criteria);
+  const goalFits = !!t.criteria && t.criteria.length <= GOAL_MAX_CHARS;
+  const converging = !!(opts.goalMode && goalFits);
+  // Criteria we want to honour but can't route through `/goal` (too long) still belongs in the prompt.
+  const embedCriteria = !!t.criteria && !converging;
   const close = converging
     ? `When you have satisfied the goal above, call task_update({ id: "${t.id}", status: "done", note: "<what you did>" }) in that same turn.\n`
     : `When finished, call task_update({ id: "${t.id}", status: "done", note: "<what you did>" }).\n`;
   const base =
     `You are working task ${t.id}: ${t.title}\n\n` +
     `${t.body || '(no description provided)'}\n\n` +
+    (embedCriteria ? `Acceptance criteria (the definition of done): ${t.criteria}\n\n` : '') +
     close +
     `If you cannot proceed, call task_update({ id: "${t.id}", status: "blocked", note: "<why>" }).\n` +
     `Break large work into sub-tasks with task_create({ parentId: "${t.id}", ... }).`;
@@ -285,7 +293,7 @@ export function buildTaskPrompt(t: { id: string; title: string; body: string; cr
 
 // `/goal` CLI support (v2.1.139+) is probed + cached in the shared claude-cli module; imported for use
 // here and re-exported so existing importers (tests) keep their import path. See goals-plan.md §C.
-import { claudeSupportsGoal } from './claude-cli';
+import { claudeSupportsGoal, GOAL_MAX_CHARS } from './claude-cli';
 export { claudeSupportsGoal };
 
 /** RAM-derived default concurrency cap: ~1 session per 1.5 GB of host memory, floored at 3. Adapts to the

--- a/src/edge/claude-cli.ts
+++ b/src/edge/claude-cli.ts
@@ -42,6 +42,11 @@ export function claudeSupportsGoal(): boolean {
   return v ? atLeastVersion(v, [2, 1, 139]) : false;
 }
 
+/** The `claude` CLI rejects a `/goal` condition longer than this many characters
+ *  ("Goal condition is limited to 4000 characters"). Callers must not emit a `/goal`
+ *  above it — fall back to embedding the criteria in the prompt body instead. */
+export const GOAL_MAX_CHARS = 4000;
+
 /** Whether the installed `claude` supports `/reload-skills` (v2.1.152+) — used for same-session skill
  *  delivery: after a skill is materialised into a live session's watched `.claude/skills`, we inject
  *  `/reload-skills` to force a re-scan + re-surface descriptions. On an older binary we skip the inject

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -23,7 +23,7 @@ import { JsonPolicyEngine, PolicyDelta, applyProposal, describeProposal } from '
 import { ChatPlatform, chatLink, consolePage } from './governance/chat-links';
 import { SkillSummary, CatalogSkill } from './governance/skills';
 import { browseRepo, RemoteCatalog } from './governance/skill-registry';
-import { claudeSupportsReloadSkills, claudeSupportsGoal } from './edge/claude-cli';
+import { claudeSupportsReloadSkills, claudeSupportsGoal, GOAL_MAX_CHARS } from './edge/claude-cli';
 import { DEFAULT_IMAGE_COST_USD, resolveImageBackend, imageErrorInfo } from './edge/image-gen';
 import { VendorError, retryableStatus, timedFetch, withRetry, vendorErrorInfo } from './edge/vendor-fetch';
 import { DEFAULT_VIDEO_COST_PER_SEC_USD, DEFAULT_VIDEO_DURATION_SEC, resolveVideoBackend, videoBackend, VideoBackend } from './edge/video-gen';
@@ -3001,7 +3001,9 @@ export class TerminalManager {
     // `answer` tool); run-as passes the accountable human through. Headless one-off — reaped at turn end.
     // A `goal` (when the installed claude supports `/goal`) opens the prompt under a convergence condition
     // so the delegate works to the objective before answering — the taskless "delegate with a goal" path.
-    const goalMode = !!(goal && goal.trim()) && claudeSupportsGoal();
+    // Over-limit goals would make the `claude` CLI hard-reject the run ("Goal condition is limited to
+    // 4000 characters"); fall back to a plain prompt (question still carries the objective) rather than fail.
+    const goalMode = !!(goal && goal.trim() && goal.trim().length <= GOAL_MAX_CHARS) && claudeSupportsGoal();
     const s = this.createSession(target, `Ask ← ${callerAgent}`, buildAskAgentPrompt(id, callerAgent, question, goalMode ? goal!.trim() : undefined), `ask:${callerAgent}`, true, undefined, undefined, runAs);
     this.db.prepare('UPDATE agent_asks SET delegate_run_id = ? WHERE id = ?').run(s.id, id);
     this.audit(callerSession, callerAgent, 'agent.asked', { askId: id, target, delegate: s.id, runAs: runAs ?? null });


### PR DESCRIPTION
## Problem

Dispatching a task with a long acceptance criterion failed to launch with:

> Goal condition is limited to 4000 characters (got 5554)

Task dispatch puts the task's single-line `criteria` on line 1 as `/goal <criteria>`. The `claude` CLI hard-rejects any `/goal` condition over 4000 characters, and `criteria` was only collapsed to a single line — nothing capped its length — so a long criterion blew up the run before it started.

## Fix

Never emit an over-limit `/goal`, and keep the criteria either way — rather than truncate (which would silently drop the definition of done):

- Added `GOAL_MAX_CHARS = 4000` in `src/edge/claude-cli.ts` (the CLI's documented ceiling).
- `buildTaskPrompt` (`src/edge/automations.ts`): if `criteria.length > GOAL_MAX_CHARS`, it drops `/goal` mode and embeds the full criteria in the prompt body as `Acceptance criteria (the definition of done): …`. The run still knows what "done" means — it just isn't evaluator-driven for that one over-long case. Short criteria are unchanged: they still get `/goal` convergence.
- Applied the same guard to the `ask_agent`-with-goal delegation path in `src/terminal.ts`.

## Verification

- `npm run typecheck` clean; server + web build clean.
- `npm run test:governance` → 68/68.
- In-process check: short criteria → `/goal` line as before; 5554-char criteria → no `/goal`, criteria embedded in body; no-criteria → neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVfxDWBcQLbAqJPshB4Ha2