### PR TITLE
feat(insights): declutter the Sessions list — soft-archive old runs (v0.248.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.248.0] — 2026-07-20
+### Added
+- **Insights can now declutter the Sessions list — a 9th improvement tile.** The run history grows
+  without bound (every dispatched task, chat reply, and cron fire leaves a terminal session row), burying
+  the handful that still matter. The new **Sessions** tile soft-archives the clutter: **done** runs 14+
+  days old are archivable (the run is over); **stopped/crashed** old runs are surfaced for review (a
+  failure may be worth a look before it's hidden), never auto-archived. It **never** touches running,
+  blocked-on-a-human (pending ask/approval), or recent sessions. Archiving is a soft `archived_at` — the
+  row **and transcript survive**, so it's reversible AND every by-id reference stays intact (task
+  reconcile's `last_session_id` join, audit, cost); the Sessions list grows a **"N archived · Restore"**
+  section and `POST /api/sessions/:id/unarchive` restores. Preview → "Archive N done" mirrors the other
+  declutter tiles. `src/edge/session-tidy.ts` + `GET`/`POST /api/insights/sessions/tidy` +
+  `GET /api/sessions?archived=1`; audited `sessions.tidied` / `session.unarchived`. Completes the
+  consolidation/declutter set (memory · KB · library · sessions).
+
 ## [0.247.1] — 2026-07-20
 ### Fixed
 - **A dispatched task with a long acceptance criterion no longer fails to launch.** Task dispatch put the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.247.0",
+  "version": "0.248.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.247.0",
+      "version": "0.248.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.247.1",
+  "version": "0.248.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/improvements.ts
+++ b/src/edge/improvements.ts
@@ -14,7 +14,7 @@ import type { Insights } from './insights';
 const DAY = 24 * 3_600_000;
 type Db = AgentOS['db'];
 
-export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library';
+export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library' | 'sessions';
 export interface ImprovementTile {
   domain: ImprovementDomain;
   count: number;                 // opportunities found (0 = nothing to improve)
@@ -111,6 +111,18 @@ export function buildImprovements(os: AgentOS, insights: Insights, now = Date.no
     title: libDead + libStale ? `${libDead + libStale} artifact${libDead + libStale === 1 ? '' : 's'} to declutter` : 'Library is tidy',
     detail: libDead + libStale ? `${libDead} orphaned (run gone, never shared — archivable), ${libStale} old &amp; private — review the gallery.` : 'No orphaned or long-stale artifacts.',
     actionLabel: 'Open Library', href: '#/artifacts',
+  });
+
+  // 9) Sessions — declutter the run history: old cleanly-done runs (archivable) + old failed/stopped runs
+  // (review). Never counts blocked-on-a-human or recent runs. See src/edge/session-tidy.ts.
+  const notBlocked = "id NOT IN (SELECT run_id FROM questions WHERE status = 'pending') AND id NOT IN (SELECT run_id FROM approvals WHERE status = 'pending')";
+  const sessDead = num(db, `SELECT count(*) AS n FROM term_sessions WHERE archived_at IS NULL AND status = 'done' AND created_at < ? AND ${notBlocked}`, now - 14 * DAY);
+  const sessStale = num(db, `SELECT count(*) AS n FROM term_sessions WHERE archived_at IS NULL AND status IN ('stopped','crashed') AND created_at < ? AND ${notBlocked}`, now - 14 * DAY);
+  tiles.push({
+    domain: 'sessions', count: sessDead + sessStale,
+    title: sessDead + sessStale ? `${sessDead + sessStale} old session${sessDead + sessStale === 1 ? '' : 's'} to archive` : 'Session list is tidy',
+    detail: sessDead + sessStale ? `${sessDead} cleanly done 14d+ ago (archivable), ${sessStale} stopped/crashed — review before hiding.` : 'No old settled sessions.',
+    actionLabel: 'Open Sessions', href: '#/sessions',
   });
 
   return tiles;

--- a/src/edge/session-tidy.ts
+++ b/src/edge/session-tidy.ts
@@ -1,0 +1,70 @@
+/**
+ * Sessions improvement tile — **declutter the Sessions list** (Sessions domain of Insights v2).
+ *
+ * The run history grows without bound: every dispatched task, chat reply, and cron fire leaves a terminal
+ * session row. Old finished runs bury the handful that still matter. This turns that into a REVIEWABLE
+ * **soft-archive**: a deterministic preview of exactly which old, settled sessions would be hidden, then an
+ * apply that sets `archived_at` (the row + transcript survive — one click restores it, and every by-id
+ * reference stays intact: task-reconcile's `last_session_id` join, audit, cost). Same reversibility
+ * posture as KB tidy / Library declutter — a hide, never a delete.
+ *
+ * Conservative on purpose:
+ *  · **done**    — cleanly completed AND older than the floor → archivable (the run is over, nothing to see).
+ *  · **stopped/crashed** — interrupted or failed AND old → surfaced for REVIEW (a failure may still be worth
+ *    a look before it's hidden; never auto-archived).
+ * NEVER touches running, blocked-on-a-human (pending ask/approval), or recent sessions. Pure over
+ * `term_sessions`; no LLM.
+ */
+import type { AgentOS } from '../kernel';
+
+const DAY = 86_400_000;
+const DEAD_AFTER_DAYS = 14;  // cleanly-done AND older than this → archivable
+const SAMPLE = 8;
+
+export interface SessionTidyItem { id: string; title: string; agent: string; status: string; outcome: string | null; ageDays: number }
+export interface SessionTidyPlan {
+  deadAfterDays: number;
+  dead: { total: number; sample: SessionTidyItem[] };    // clean `done`, old → archivable
+  stale: { total: number; sample: SessionTidyItem[] };   // stopped/crashed, old → review only
+}
+
+interface Row { id: string; title: string; agent: string; status: string; outcome: string | null; created_at: number }
+
+function toItem(r: Row, now: number): SessionTidyItem {
+  return { id: r.id, title: r.title || r.id, agent: r.agent, status: r.status, outcome: r.outcome, ageDays: Math.floor((now - r.created_at) / DAY) };
+}
+
+// Blocked-on-a-human rows are never clutter, even if old — exclude any with a pending ask/approval.
+const NOT_BLOCKED =
+  "id NOT IN (SELECT run_id FROM questions WHERE status = 'pending') " +
+  "AND id NOT IN (SELECT run_id FROM approvals WHERE status = 'pending')";
+
+/** Compute the archivable (done) + review (stopped/crashed) session lists WITHOUT mutating anything. */
+export function planSessionTidy(os: AgentOS, now = Date.now()): SessionTidyPlan {
+  const db = os.db;
+  const cutoff = now - DEAD_AFTER_DAYS * DAY;
+  const deadRows = db
+    .prepare(`SELECT id, title, agent, status, outcome, created_at FROM term_sessions WHERE archived_at IS NULL AND status = 'done' AND created_at < ? AND ${NOT_BLOCKED} ORDER BY created_at`)
+    .all<Row>(cutoff);
+  const staleRows = db
+    .prepare(`SELECT id, title, agent, status, outcome, created_at FROM term_sessions WHERE archived_at IS NULL AND status IN ('stopped','crashed') AND created_at < ? AND ${NOT_BLOCKED} ORDER BY created_at`)
+    .all<Row>(cutoff);
+  return {
+    deadAfterDays: DEAD_AFTER_DAYS,
+    dead: { total: deadRows.length, sample: deadRows.slice(0, SAMPLE).map((r) => toItem(r, now)) },
+    stale: { total: staleRows.length, sample: staleRows.slice(0, SAMPLE).map((r) => toItem(r, now)) },
+  };
+}
+
+/** Soft-archive the DEAD (clean `done`, aged) sessions — reversible (restore from the list). Audited. */
+export function applySessionTidy(os: AgentOS, tm: { archiveSession(id: string, now?: number): boolean }, by = 'system', now = Date.now()): { archived: number } {
+  const rows = os.db
+    .prepare(`SELECT id FROM term_sessions WHERE archived_at IS NULL AND status = 'done' AND created_at < ? AND ${NOT_BLOCKED}`)
+    .all<{ id: string }>(now - DEAD_AFTER_DAYS * DAY);
+  let archived = 0;
+  for (const r of rows) if (tm.archiveSession(r.id, now)) archived++;
+  if (archived) {
+    os.audit.append({ ts: now, runId: '-', tenant: os.tenant, principal: by, type: 'sessions.tidied', data: { archived, via: 'insights-tidy', deadAfterDays: DEAD_AFTER_DAYS } });
+  }
+  return { archived };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,6 +36,7 @@ import { SkillScout, SCOUT_ID } from './edge/skill-scout';
 import { planKbTidy, applyKbTidy } from './edge/kb-tidy';
 import { planTaskReconcile, applyTaskReconcile } from './edge/task-reconcile';
 import { planLibraryTidy, applyLibraryTidy } from './edge/library-tidy';
+import { planSessionTidy, applySessionTidy } from './edge/session-tidy';
 import { Strategist, STRATEGIST_ID } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
@@ -2291,7 +2292,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   }
 
   // ── terminal-native sessions ────────────────────────────────────────────────
-  if (method === 'GET' && p === '/api/sessions') return sendJson(res, 200, tm.listSessions(me));
+  // `?archived=1` returns the soft-archived set (the Sessions "show archived / restore" view); default is live.
+  if (method === 'GET' && p === '/api/sessions') return sendJson(res, 200, url.searchParams.get('archived') === '1' ? tm.listArchivedSessions(me) : tm.listSessions(me));
   if (method === 'POST' && p === '/api/sessions') {
     const b = await readBody(req);
     const agent = String(b.agent || '').trim();
@@ -2529,6 +2531,15 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     } catch (e) {
       return sendJson(res, 502, { error: e instanceof Error ? e.message : String(e) });
     }
+  }
+  // Restore a soft-archived session back into the list (the reverse of the Insights sessions declutter).
+  const sessUnarchiveMatch = p.match(/^\/api\/sessions\/([\w-]+)\/unarchive$/);
+  if (method === 'POST' && sessUnarchiveMatch) {
+    const id = sessUnarchiveMatch[1];
+    if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed' });
+    const ok = tm.unarchiveSession(id);
+    if (ok) os.audit.append({ ts: Date.now(), runId: id, tenant: os.tenant, principal: me.email, type: 'session.unarchived', data: { id } });
+    return sendJson(res, ok ? 200 : 404, ok ? { ok: true } : { error: 'not found or not archived' });
   }
   const sayMatch = p.match(/^\/api\/sessions\/([\w-]+)\/say$/);
   if (method === 'POST' && sayMatch) {
@@ -3241,6 +3252,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     if (method === 'GET') return sendJson(res, 200, { ok: true, plan: planLibraryTidy(os) });
     const r = applyLibraryTidy(os, me.email);
+    return sendJson(res, 200, { ok: true, ...r });
+  }
+  // Sessions domain "declutter": preview old settled sessions, then apply SOFT-ARCHIVES the cleanly-done
+  // ones (hidden from the list, transcript retained — restore from Sessions). Reversible, audited.
+  if (p === '/api/insights/sessions/tidy' && (method === 'GET' || method === 'POST')) {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    if (method === 'GET') return sendJson(res, 200, { ok: true, plan: planSessionTidy(os) });
+    const r = applySessionTidy(os, tm, me.email);
     return sendJson(res, 200, { ok: true, ...r });
   }
   // Skills domain "generate the fix": spawn the skill-scout to mine recent successful fleet runs for a

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -876,6 +876,10 @@ function migrate(db: Db): void {
   addColumn(db, 'term_sessions', 'effort', 'TEXT');            // low | medium | high | …
   addColumn(db, 'term_sessions', 'blocked_ms', 'INTEGER');     // total human-wait (approvals + questions)
   addColumn(db, 'term_sessions', 'artifacts', 'INTEGER');      // deliverables published by the run
+  // Soft-archive for the Sessions-list declutter (Insights): an archived session is hidden from the
+  // list but its row + transcript survive, so archiving is reversible (unarchive) AND keeps every
+  // reference intact — task-reconcile's `tasks.last_session_id` join, audit, cost. NULL = live.
+  addColumn(db, 'term_sessions', 'archived_at', 'INTEGER');
 
   // Stale-prompt escalation: a once-per-item marker so the scheduler's re-nudge sweep DMs the approver /
   // operator EXACTLY ONCE when an approval or question has sat pending past the threshold, and never

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -347,6 +347,7 @@ interface SessionRow {
   active_ms: number | null;
   turns: number | null;
   tool_calls: number | null;
+  archived_at?: number | null;
   gov_actions: number | null;
   gov_approvals: number | null;
   gov_denied: number | null;
@@ -637,7 +638,9 @@ export class TerminalManager {
    * regular member sees only sessions they spawned, plus sessions fired by an automation they created.
    */
   listSessions(viewer?: Member): Session[] {
-    const rows = this.db.prepare('SELECT * FROM term_sessions ORDER BY created_at DESC').all<SessionRow>();
+    // Archived sessions are hidden from the list (reversible soft-archive via the Insights declutter tile);
+    // their rows survive for every by-id reference (task-reconcile, audit, cost).
+    const rows = this.db.prepare('SELECT * FROM term_sessions WHERE archived_at IS NULL ORDER BY created_at DESC').all<SessionRow>();
     // Lazy liveness: a row stays 'running' until its tmux session is gone. A running row whose pane
     // vanished with NO end signal (no `report`/`markEnded`/`stopSession`) died abruptly — kill/OOM/
     // reboot — so it's a `crashed`, not a clean end. Grace-period new rows (tmux may not have finished
@@ -677,6 +680,22 @@ export class TerminalManager {
       runAsLabel: this.runAsLabel(r.run_as),
       ratedByLabel: this.runAsLabel(r.rated_by),
     }));
+  }
+
+  /** The soft-archived sessions (hidden from `listSessions`) — for the "show archived / restore" view.
+   *  Same viewer-visibility rule as the live list; no liveness/cost work (they're terminal + settled). */
+  listArchivedSessions(viewer?: Member): Session[] {
+    const rows = this.db.prepare('SELECT * FROM term_sessions WHERE archived_at IS NOT NULL ORDER BY archived_at DESC').all<SessionRow>();
+    const visible = viewer ? rows.filter((r) => this.canViewRow(r.spawned_by, r.run_as, viewer)) : rows;
+    return visible.map((r) => ({ ...toSession(r), spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as), sourceKind: this.sourceKind(r.spawned_by), runAsLabel: this.runAsLabel(r.run_as), ratedByLabel: this.runAsLabel(r.rated_by) }));
+  }
+  /** Soft-archive a session — hide it from the list, keep the row + transcript (reversible). */
+  archiveSession(id: string, now = Date.now()): boolean {
+    return this.db.prepare('UPDATE term_sessions SET archived_at = ? WHERE id = ? AND archived_at IS NULL').run(now, id).changes > 0;
+  }
+  /** Restore a soft-archived session back into the list. */
+  unarchiveSession(id: string): boolean {
+    return this.db.prepare('UPDATE term_sessions SET archived_at = NULL WHERE id = ?').run(id).changes > 0;
   }
 
   /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -3054,6 +3054,11 @@ function SessionsPage({
 }) {
   const [view, setView] = useState<'grid' | 'list'>(() => (localStorage.getItem('aos_sessions_view') === 'list' ? 'list' : 'grid'))
   const setMode = (v: 'grid' | 'list') => { localStorage.setItem('aos_sessions_view', v); setView(v) }
+  const [archived, setArchived] = useState<Session[]>([])   // soft-archived runs (Insights declutter)
+  const [showArchived, setShowArchived] = useState(false)
+  const loadArchived = () => api.sessions(true).then((r) => setArchived(Array.isArray(r) ? r : [])).catch(() => {})
+  useEffect(() => { loadArchived() }, [])
+  const restoreSession = async (id: string) => { const r = await api.unarchiveSession(id); if (!r.error) loadArchived() }
   // Terminal switcher bar: live tabs stay pinned; ended (stopped/done/crashed) ones collapse behind a
   // toggle so the bar doesn't accrete every past run. The open session always shows even if it ended.
   const [showEnded, setShowEnded] = useState(false)
@@ -3353,6 +3358,25 @@ function SessionsPage({
   }
   return (
     <div className="space-y-3">
+      {archived.length > 0 && (
+        <div className="rounded-lg border bg-muted/20 p-2 text-xs">
+          <button onClick={() => setShowArchived((v) => !v)} className="flex items-center gap-1.5 font-medium text-muted-foreground hover:text-foreground">
+            <Package className="h-3.5 w-3.5" />{archived.length} archived {showArchived ? '▾' : '▸'}
+          </button>
+          {showArchived && (
+            <ul className="mt-2 space-y-1">
+              {archived.slice(0, 50).map((s) => (
+                <li key={s.id} className="flex items-center gap-2">
+                  <span className="truncate text-muted-foreground">{s.title}</span>
+                  <span className="ml-auto shrink-0 text-[10px] text-muted-foreground">{s.agent} · {s.status}</span>
+                  <button onClick={() => restoreSession(s.id)} className="shrink-0 text-[11px] text-primary underline underline-offset-2">Restore</button>
+                </li>
+              ))}
+              {archived.length > 50 && <li className="text-[10px] text-muted-foreground">+{archived.length - 50} more…</li>}
+            </ul>
+          )}
+        </div>
+      )}
       {/* header: select-all + count (or bulk toolbar) · grid/list view toggle */}
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
@@ -10487,6 +10511,7 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
   const [kbTidy, setKbTidy] = useState<KbTidyPlan | null>(null)
   const [taskRec, setTaskRec] = useState<TaskReconcilePlan | null>(null)
   const [libTidy, setLibTidy] = useState<LibraryTidyPlan | null>(null)
+  const [sessTidy, setSessTidy] = useState<SessionTidyPlan | null>(null)
   const [stuckGoals, setStuckGoals] = useState<StuckGoal[]>([])
   const [goalsOpen, setGoalsOpen] = useState(false)
   const [troubledAutos, setTroubledAutos] = useState<TroubledAutomation[]>([])
@@ -10597,6 +10622,16 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
     setDxHint(r.error ? `⚠ ${r.error}` : `Archived ${r.archived ?? 0} artifact${r.archived === 1 ? '' : 's'} — restore any from the Library.`)
     setTimeout(() => setDxHint(''), 6000); refresh()
   }
+  const previewSessionTidy = async () => {
+    setCleanupBusy(true); const r = await api.sessionTidyPreview(); setCleanupBusy(false)
+    if (r.error || !r.plan) return setDxHint(`⚠ ${r.error ?? 'could not build a plan'}`)
+    setSessTidy(r.plan)
+  }
+  const applySessionTidy = async () => {
+    setCleanupBusy(true); const r = await api.sessionTidyApply(); setCleanupBusy(false); setSessTidy(null)
+    setDxHint(r.error ? `⚠ ${r.error}` : `Archived ${r.archived ?? 0} session${r.archived === 1 ? '' : 's'} — restore any from Sessions.`)
+    setTimeout(() => setDxHint(''), 6000); refresh()
+  }
   const previewCleanup = async () => {
     setCleanupBusy(true); const r = await api.memoryCleanupPreview(); setCleanupBusy(false)
     if (r.error || !r.plan) return setDxHint(`⚠ ${r.error ?? 'could not build a plan'}`)
@@ -10704,6 +10739,13 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                 <button key={t.domain} onClick={previewLibraryTidy} disabled={cleanupBusy} className={`${cls} disabled:opacity-50`}>
                   {inner}
                   <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview declutter →'}</div>
+                </button>
+              )
+              // Sessions tile is generative: preview old settled runs; apply soft-archives the done ones.
+              if (t.domain === 'sessions' && t.count > 0) return (
+                <button key={t.domain} onClick={previewSessionTidy} disabled={cleanupBusy} className={`${cls} disabled:opacity-50`}>
+                  {inner}
+                  <div className="mt-2 text-[11px] font-medium text-primary">{cleanupBusy ? 'building preview…' : 'Preview archive →'}</div>
                 </button>
               )
               // Goals tile: expand the stuck goals in place, each with a "plan" that spawns the strategist.
@@ -10862,6 +10904,38 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
                     </ul>
                   )}
                   <div className="mt-1 text-[10px] text-muted-foreground">These still belong to a live run — keep, share, or delete them by hand in <a href="#/artifacts" className="underline">Library</a>.</div>
+                </div>
+              </div>
+            </div>
+          )}
+          {sessTidy && (
+            <div className="mt-3 rounded-lg border bg-muted/30 p-3 text-xs">
+              <div className="mb-2 flex items-center justify-between">
+                <div className="font-medium">Session archive preview <span className="font-normal text-muted-foreground">— archiving hides them (restore from Sessions)</span></div>
+                <div className="flex items-center gap-2">
+                  <button onClick={applySessionTidy} disabled={cleanupBusy || sessTidy.dead.total === 0} className="rounded bg-red-600 px-2 py-1 text-[11px] font-medium text-white hover:bg-red-700 disabled:opacity-50">{cleanupBusy ? 'archiving…' : `Archive ${sessTidy.dead.total} done`}</button>
+                  <button onClick={() => setSessTidy(null)} className="text-[11px] text-muted-foreground underline underline-offset-2">Cancel</button>
+                </div>
+              </div>
+              <div className="mt-2 grid gap-3 md:grid-cols-2">
+                <div>
+                  <div className="mb-1 font-medium">Archive — {sessTidy.dead.total} done <span className="font-normal text-muted-foreground">(cleanly finished, {sessTidy.deadAfterDays}d+ old)</span></div>
+                  {sessTidy.dead.total === 0 ? <div className="text-muted-foreground">nothing to archive</div> : (
+                    <ul className="space-y-0.5">
+                      {sessTidy.dead.sample.map((s) => <li key={s.id} className="truncate text-muted-foreground"><span className="text-foreground">{s.title}</span> · {s.agent} · {s.ageDays}d</li>)}
+                      {sessTidy.dead.total > sessTidy.dead.sample.length && <li className="text-muted-foreground">+{sessTidy.dead.total - sessTidy.dead.sample.length} more…</li>}
+                    </ul>
+                  )}
+                </div>
+                <div>
+                  <div className="mb-1 font-medium">Review — {sessTidy.stale.total} stopped/crashed</div>
+                  {sessTidy.stale.total === 0 ? <div className="text-muted-foreground">nothing failed</div> : (
+                    <ul className="space-y-0.5">
+                      {sessTidy.stale.sample.map((s) => <li key={s.id} className="truncate text-muted-foreground"><span className="text-foreground">{s.title}</span> · <span className={s.status === 'crashed' ? 'text-red-600' : ''}>{s.status}</span> · {s.ageDays}d</li>)}
+                      {sessTidy.stale.total > sessTidy.stale.sample.length && <li className="text-muted-foreground">+{sessTidy.stale.total - sessTidy.stale.sample.length} more…</li>}
+                    </ul>
+                  )}
+                  <div className="mt-1 text-[10px] text-muted-foreground">A failed run may be worth a look — review in <a href="#/sessions" className="underline">Sessions</a> before hiding by hand.</div>
                 </div>
               </div>
             </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -399,7 +399,7 @@ export interface AgentScore { agent: string; runs: number; success: number; fail
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
-export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library'
+export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library' | 'sessions'
 export interface ImprovementTile { domain: ImprovementDomain; count: number; title: string; detail: string; actionLabel: string; href: string }
 export interface CleanupPruneItem { id: string; agent: string; snippet: string; ageDays: number; importance: number | null }
 export interface CleanupMergeGroup { agent: string; keepSnippet: string; drop: number }
@@ -410,6 +410,8 @@ export interface TaskDriftItem { id: string; title: string; assignee: string | n
 export interface TaskReconcilePlan { finished: { total: number; sample: TaskDriftItem[] }; stalled: { total: number; sample: TaskDriftItem[] } }
 export interface LibraryTidyItem { id: string; title: string; kind: string; agent: string; ageDays: number; bytes: number }
 export interface LibraryTidyPlan { deadAfterDays: number; staleAfterDays: number; dead: { total: number; bytes: number; sample: LibraryTidyItem[] }; stale: { total: number; sample: LibraryTidyItem[] } }
+export interface SessionTidyItem { id: string; title: string; agent: string; status: string; outcome: string | null; ageDays: number }
+export interface SessionTidyPlan { deadAfterDays: number; dead: { total: number; sample: SessionTidyItem[] }; stale: { total: number; sample: SessionTidyItem[] } }
 export interface StuckGoal { id: string; title: string; days: number }
 export interface TroubledAutomation { id: string; name: string; type: string; reason: 'errored' | 'idle'; detail: string }
 export interface MeasureTrendBucket { start: number; label: string; total: number; success: number; rate: number | null }
@@ -1171,7 +1173,10 @@ export const api = {
   applyUpdate: () => call<UpdateApplyResult>('POST', '/api/update/apply'),
   /** Owner-only: plain restart, no pull/rebuild. The process bounces ~1.5s after the response. */
   restart: () => call<RestartResult>('POST', '/api/restart'),
-  sessions: () => call<Session[]>('GET', '/api/sessions'),
+  sessions: (archived?: boolean) => call<Session[]>('GET', '/api/sessions' + (archived ? '?archived=1' : '')),
+  unarchiveSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/unarchive`),
+  sessionTidyPreview: () => call<{ ok: boolean; plan?: SessionTidyPlan; error?: string }>('GET', '/api/insights/sessions/tidy'),
+  sessionTidyApply: () => call<{ ok: boolean; archived?: number; error?: string }>('POST', '/api/insights/sessions/tidy'),
   /** Inbox feed. `scope='all'` is the owner/admin oversight view (every session's cards); the default
    *  `mine` is the personal feed — only cards addressed to you, so overseers aren't flooded. */
   messages: (scope: 'mine' | 'all' = 'mine') => call<Msg[]>('GET', `/api/messages${scope === 'all' ? '?scope=all' : ''}`),


### PR DESCRIPTION
## Backlog gap #3 — Session cleanup

The second consolidation/declutter tile. The run history grows without bound — every dispatched task, chat reply, and cron fire leaves a terminal session row — burying the handful that still matter.

### What this adds — a 9th "Sessions" improvement tile
Soft-archives clutter, mirroring the Library/KB-tidy tiles:

| bucket | definition | action |
|---|---|---|
| **done** | cleanly finished AND 14d+ old | **archivable** (the run is over, nothing to see) |
| **stopped/crashed** | interrupted/failed AND old | **review only** — a failure may be worth a look before it's hidden |

**Never** touches running, **blocked-on-a-human** (pending ask/approval), or recent sessions.

**Reversible + reference-safe** — archiving sets a soft `archived_at`: the row **and transcript survive**, so it's one-click restorable AND every by-id reference stays intact — crucially **task-reconcile's `last_session_id` join** (a hard delete would break that), plus audit and cost. The Sessions list grows a collapsible **"N archived · Restore"** section, and `POST /api/sessions/:id/unarchive` restores.

`src/edge/session-tidy.ts` · `GET`/`POST /api/insights/sessions/tidy` · `GET /api/sessions?archived=1` · `improvements.ts` (`sessions` domain) · web tile + preview + Sessions restore UI. Audited `sessions.tidied` / `session.unarchived`.

This completes the **consolidation/declutter** set: memory · KB · **library** · **sessions**. The Insights improvements grid now has **9 tiles**.

### Verification
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → **68/68** ✓ · `npm run demo` ✓
- In-process harness on built `dist`: seeded done-old / crashed-old / done-recent / done-but-blocked → **dead** = done-old only, **stale** = crashed-old only, recent + blocked excluded; apply archived exactly 1, `listSessions` excludes it, `listArchivedSessions` has it, **the row is retained** (task-reconcile safety), and `unarchive` restores it to the list. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)