### PR TITLE
feat(insights): surface idle agents to retire — 10th improvement tile (v0.249.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.249.0] — 2026-07-21
+### Added
+- **Insights now surfaces idle agents to retire — a 10th improvement tile.** A user-created agent that
+  ran before but has gone quiet (no run in 30+ days) clutters the roster and the spawn picker. The new
+  **idle-agents** tile detects them off `MAX(created_at)` per agent and points to the Agents page. It
+  never flags the OS's own built-in helpers (consolidator / skill-scout / strategist / … — on-demand by
+  design) or a brand-new agent that has simply never run (the "ran before" check is the age proxy).
+  Detect + navigate only — retiring an agent is destructive and its automations/assignments would need
+  handling, so the human makes the call (no auto-delete). `src/edge/improvements.ts`; rides the existing
+  `GET /api/insights` tile grid (now 10 tiles: agents · kb · goals · skills · memory · automations ·
+  tasks · library · sessions · idle-agents).
+  - *Deferred, by design:* a destructive `agent_merge` primitive (fold two redundant agents into one) —
+    it needs an explicit decision on what happens to the merged agent's sessions/tasks/automations/memory,
+    so it's left for a human to green-light separately rather than shipped autonomously.
+
 ## [0.248.0] — 2026-07-20
 ### Added
 - **Insights can now declutter the Sessions list — a 9th improvement tile.** The run history grows

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.248.0",
+  "version": "0.249.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.248.0",
+      "version": "0.249.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.248.0",
+  "version": "0.249.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/improvements.ts
+++ b/src/edge/improvements.ts
@@ -10,11 +10,23 @@
  */
 import type { AgentOS } from '../kernel';
 import type { Insights } from './insights';
+import { BUILTIN_SEED_IDS } from './agent-catalog';
+import { CONSOLIDATOR_ID } from './consolidation';
+import { ANALYST_ID } from './diagnosis';
+import { IMPROVER_ID } from './improver';
+import { SCOUT_ID } from './skill-scout';
+import { STRATEGIST_ID } from './strategist';
+
+// The agents Agent OS provisions itself — never a "retire" candidate, however idle (they're on-demand
+// helpers: the consolidator/scout/strategist/… only run when the self-learning loop needs them). Mirrors
+// the `BUILT_IN_AGENT_IDS` set the server uses to mark agents read-only.
+const BUILT_IN_AGENTS = new Set<string>([...BUILTIN_SEED_IDS, CONSOLIDATOR_ID, SCOUT_ID, STRATEGIST_ID, IMPROVER_ID, ANALYST_ID]);
+const AGENT_IDLE_DAYS = 30;   // ran before but not in this long → idle (a retire candidate)
 
 const DAY = 24 * 3_600_000;
 type Db = AgentOS['db'];
 
-export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library' | 'sessions';
+export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library' | 'sessions' | 'idle-agents';
 export interface ImprovementTile {
   domain: ImprovementDomain;
   count: number;                 // opportunities found (0 = nothing to improve)
@@ -123,6 +135,23 @@ export function buildImprovements(os: AgentOS, insights: Insights, now = Date.no
     title: sessDead + sessStale ? `${sessDead + sessStale} old session${sessDead + sessStale === 1 ? '' : 's'} to archive` : 'Session list is tidy',
     detail: sessDead + sessStale ? `${sessDead} cleanly done 14d+ ago (archivable), ${sessStale} stopped/crashed — review before hiding.` : 'No old settled sessions.',
     actionLabel: 'Open Sessions', href: '#/sessions',
+  });
+
+  // 10) Idle agents — user-created claude-code agents that RAN before but have gone quiet (no run in
+  // 30+ days). Retiring an agent is destructive (and its automations/assignments would need handling),
+  // so this is DETECT + NAVIGATE only — surface the candidates and let a human decide on the Agents page.
+  // "Ran before" (in the map) is the age proxy — it avoids flagging a brand-new, never-run agent — and
+  // never flags the OS's own built-in helpers (on-demand by design).
+  const lastRun = new Map(db.prepare("SELECT agent, MAX(created_at) AS m FROM term_sessions GROUP BY agent").all<{ agent: string; m: number }>().map((r) => [r.agent, r.m]));
+  const idleAgents = [...os.agents.values()].filter((a) => {
+    const last = lastRun.get(a.id);
+    return a.runtime === 'claude-code' && !BUILT_IN_AGENTS.has(a.id) && last != null && last < now - AGENT_IDLE_DAYS * DAY;
+  });
+  tiles.push({
+    domain: 'idle-agents', count: idleAgents.length,
+    title: idleAgents.length ? `${idleAgents.length} idle agent${idleAgents.length === 1 ? '' : 's'}` : 'No idle agents',
+    detail: idleAgents.length ? `No run in ${AGENT_IDLE_DAYS}+ days: ${idleAgents.slice(0, 3).map((a) => a.id).join(', ')}${idleAgents.length > 3 ? '…' : ''}. Retire the ones you no longer need to keep the roster focused.` : 'Every agent has run recently.',
+    actionLabel: 'Review agents', href: '#/agents',
   });
 
   return tiles;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -399,7 +399,7 @@ export interface AgentScore { agent: string; runs: number; success: number; fail
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
-export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library' | 'sessions'
+export type ImprovementDomain = 'agents' | 'kb' | 'goals' | 'skills' | 'memory' | 'automations' | 'tasks' | 'library' | 'sessions' | 'idle-agents'
 export interface ImprovementTile { domain: ImprovementDomain; count: number; title: string; detail: string; actionLabel: string; href: string }
 export interface CleanupPruneItem { id: string; agent: string; snippet: string; ageDays: number; importance: number | null }
 export interface CleanupMergeGroup { agent: string; keepSnippet: string; drop: number }


### PR DESCRIPTION
## Backlog gap #5 — agent lifecycle (retire)

The last backlog item. Most of agent lifecycle already exists (`agent_create`, self-only `agent_update`/`agent_history`/`agent_revert`, the underperformer diagnose/tune tile). The genuine gap was surfacing agents that should be **retired** from usage patterns.

### What this adds — a 10th "idle-agents" improvement tile
A user-created agent that **ran before but has gone quiet** (no run in 30+ days) clutters the roster and the spawn picker. The tile detects them off `MAX(created_at)` per agent and points to the Agents page.

- **"Ran before" is the age proxy** — it flags an agent that was used and went quiet (a real retire signal), while excluding a brand-new agent that has simply never run yet.
- **Never flags the OS's own built-in helpers** (consolidator / skill-scout / strategist / improver / analyst / agent-author) — they're on-demand by design.
- **Detect + navigate only** — retiring an agent is destructive (and its automations/assignments would need handling), so the human makes the call on the Agents page. No auto-delete.

Rides the existing `GET /api/insights` tile grid — now **10 tiles**: agents · kb · goals · skills · memory · automations · tasks · library · sessions · **idle-agents**.

### Deferred, by design
A destructive **`agent_merge`** primitive (fold two redundant agents into one) is intentionally **not** shipped autonomously — it needs an explicit decision on what happens to the merged agent's sessions/tasks/automations/memory. Flagged for a human to green-light separately.

### Verification
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → **68/68** ✓ · `npm run demo` ✓
- In-process harness on built `dist`: registered ran-40d-ago / ran-2d-ago / never-run / built-in(consolidator, idle) agents → the tile counts **only** the ran-but-quiet non-built-in one (`idle_one`); active, never-run, and the idle built-in are all excluded. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)