### PR TITLE
feat(agents): gated cross-agent edits — agent_propose_update (v0.250.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.250.0] — 2026-07-21
+### Added
+- **Agents can now propose edits to *other* agents — gated, never applied unattended (`agent_propose_update`).**
+  The self-only `agent_update` stays as-is (an agent edits its own listing/CLAUDE.md, no approval). The new
+  tool is its cross-agent counterpart, kept deliberately *gated* rather than a widening of `agent_update`:
+  rewriting another agent's system prompt is a side effect on a different principal (a lateral-privilege /
+  prompt-injection vector), so it follows the propose-don't-apply pattern of `policy_propose` /
+  `automation_propose`. The agent's call writes **nothing** — it posts an owner-addressed
+  `agent.update.proposed` review card carrying the field delta + rationale. Application is **owner-only, and
+  the owner must be able to run the target** (`os.team.canRun`) — an admin cannot approve. On approval the
+  server runs the same apply path as the self-edit route (sanitizers + disk write + `AgentRevisions.commit`,
+  author = the approving owner, summary naming the proposer), so it's accountable to both parties and
+  one-click revertable in the existing Revision history panel. Guards mirror `agent_update` (user-home
+  claude-code targets only, never self) plus a 10-open queue cap and identical-delta dedupe. Console: an
+  owner-only **"Proposed edits from other agents"** card on the agent page with a full CLAUDE.md before→after;
+  an inbox card links there. `src/memory/memory-mcp.ts` (`agent_propose_update`), `src/terminal.ts`
+  (`proposeAgentUpdate` + card store), `src/server.ts` (`/api/agent/agent/propose`, `/api/agents/proposals`
+  + `:id/approve`/`reject`), `web/src/App.tsx`. Audited `agent.update.proposed` /
+  `agent.update.proposal.approved` / `agent.update.proposal.rejected`. See `docs/agent-mcp-tools.md`.
+
 ## [0.249.0] — 2026-07-21
 ### Added
 - **Insights now surfaces idle agents to retire — a 10th improvement tile.** A user-created agent that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,7 +205,7 @@ Key modules:
   `mirror.ts` (`MirroredMemoryProvider`) which copies every write into that table — recall goes to the
   upgraded store, the self-learning loop keeps working. The `sqlite` backend IS the table (no wrap).
   Backend + ranking + maintenance (prune/dedupe) + **shared `scope` (agent | tenant)** are all config in
-  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 57 always-on tools
+  **Settings → Memory**, hot-swapped live. `memory-mcp.ts` = the OS-owned stdio MCP server injected into every session — 58 always-on tools
   + 11 conditional (chat-reply / egress / media, each exposed only when its env flag is set; full list
   in `docs/agent-mcp-tools.md`). Memory: `recall`/`remember`/`revise`/`forget` (recall returns each memory's id, the
   handle for revise/forget). Episodic self-query (the run-history companion to semantic memory):
@@ -264,8 +264,12 @@ Key modules:
   (build + self-improve): `agent_create` (spin up a new governed teammate) and the **self-only**
   `agent_update`/`agent_history`/`agent_revert` — an agent refines its OWN listing (description, starter
   prompts, tuning) + CLAUDE.md system prompt and can roll back a bad self-edit; every change snapshots a
-  reversible revision (`src/state/agent-revisions.ts`, the KB-style rollback backbone; no agent can edit
-  another agent). Governance (propose, don't apply): `policy_propose` — an agent that spots a weak
+  reversible revision (`src/state/agent-revisions.ts`, the KB-style rollback backbone). To edit ANOTHER
+  agent, `agent_propose_update` is the **gated** cross-agent path (propose-don't-apply): it writes nothing,
+  posts an owner-addressed `agent.update.proposed` card, and applies only when an **owner who can run the
+  target** approves (`POST /api/agents/proposals/:id/approve` → the same self-edit apply + revision snapshot,
+  author = approver) — an admin can't approve, since rewriting another agent's prompt is a privilege-bearing
+  side effect. Governance (propose, don't apply): `policy_propose` — an agent that spots a weak
   guardrail proposes a **TIGHTEN-ONLY** ruleset change (`tighten` a rule stricter, `reorder` a conditional
   rule above the unconditional allows — the first-match ordering fix, or `add` a new `ask`/`never`
   guardrail). `applyProposal` (`src/governance/policy.ts`) refuses any loosening (by construction + an

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -54,6 +54,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `goal_propose` | `POST /api/goals/propose` | `GoalStore.create` (status `draft`) + `TerminalManager.postGoalCard` | W | drafts a NOT-YET-ACTIVE goal + posts a `goal.proposed` inbox card to admins; owner = run-as; auto-apply + audited `goal.proposed`. Agents READ + PROPOSE only — activating/editing a goal is a human owner/admin console action (no agent write path) |
 | `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
 | `agent_update` | `POST /api/agents/update` | `AgentOS.registerAgent` + `AgentRevisions.commit` | W | **self-only** (edits the caller's OWN manifest/CLAUDE.md — a body `id` must equal the session's agent); user-home agents only; snapshots a revision; audited `agent.config.updated` |
+| `agent_propose_update` | `POST /api/agent/agent/propose` | `TerminalManager.proposeAgentUpdate` | W(gated) | **cross-agent, propose-don't-apply** — proposes an edit to ANOTHER agent's listing/CLAUDE.md; writes nothing, posts an owner-addressed `agent.update.proposed` review card; applied only when an **owner who can run the target** approves (`POST /api/agents/proposals/:id/approve`, then the self-edit apply + `AgentRevisions.commit`, author = approver); user-home claude-code targets only; 10-open cap + identical-delta dedupe; audited `agent.update.proposed` / `agent.update.proposal.approved`/`rejected` |
 | `agent_history` | `POST /api/agents/history` | `AgentRevisions.list` | R | the caller's own listing revisions (rev/author/summary/date), newest first |
 | `agent_revert` | `POST /api/agents/revert` | `AgentRevisions` + `AgentOS.registerAgent` | W | **self-only**; restores a prior revision (description/prompts/tuning/CLAUDE.md), records the revert as a new revision; audited `agent.config.reverted` |
 | `app_create` | `POST /api/apps/create` | `AppStore.scaffold` | W | builds a hosted app (single-file `server.js` for v1) under `<home>/apps/<slug>/`; lands **proposed** (`published:false`, inert until a human publishes); posts an `app.proposed` review card; audited `app.created` |
@@ -78,7 +79,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `video_generate` | `POST /api/agent/video/generate` | `TerminalManager.generateVideo` → `VideoBackend` + `VideoJobStore` + `ArtifactStore.ingest` | W | text→video (async). Governed as capability `video.generate` with `amountUsd`=per-second×duration estimate (money-cap rule applies), then SUBMITS to the vendor (fal.ai default / Atlas alt, `resolveVideoBackend`) and persists an opaque job handle to `video_jobs`. Renders take minutes: a brief in-call poll catches the fast case, else returns `{status:'rendering', jobId}`; the **Automations-tick poller** (`pollVideoJobs`) finishes it — downloads the mp4, `ingest`s it (`kind:'video'`, folder `generated-videos`) + an owner inbox card, audits `video.generated` (cost = estimate; video is per-second, rarely in-band). Only when `VIDEO_GEN=1` (fal/Atlas key set) |
 | `video_understand` | `POST /api/agent/video/understand` | `TerminalManager.understandVideo` → `VideoBackend` (multimodal) | W | WATCH a video and return a TEXT answer (video→text) — Claude can't see video natively; also handles a still with `kind:"image"`. `video` = a Library artifact id, a working-folder file, or an http(s) URL; optional `prompt` for what to find out ("summarise", "transcribe on-screen text"). No artifact produced. Governed as capability `video.understand` (`amountUsd` estimate, money-cap rule); audited `video.understood`. Only when `VIDEO_UNDERSTAND=1` (set when an **Atlas** multimodal key is configured) |
 
-57 always-on tools + 11 conditional (the conditional ones — `answer`, `slack_reply`/`discord_reply`,
+58 always-on tools + 11 conditional (the conditional ones — `answer`, `slack_reply`/`discord_reply`,
 `slack_send`/`slack_dm`, `discord_send`/`discord_dm`, `image_generate`/`image_edit`, `video_generate`,
 `video_understand` — are exposed only when their env flag is set, i.e. the run is chat-triggered or the
 backend/integration is configured). Read-only tools carry `annotations.readOnlyHint`; `forget`
@@ -203,7 +204,7 @@ scheduler `tick()` fires it once when due, then disables it. Recurring (cron) sc
 human-only. A future tightening could classify `schedule` through Policy for workspaces that want
 sign-off on deferred runs.
 
-### `agent_create` / `agent_update` / `agent_history` / `agent_revert` — governance model
+### `agent_create` / `agent_update` / `agent_propose_update` / `agent_history` / `agent_revert` — governance model
 
 `agent_create` is the **agent-author's** build tool (the default *System* agent provisioned by
 `src/edge/agent-author.ts`), though — like the Tasks tools — it's the general **delegation surface**
@@ -223,6 +224,21 @@ revision into `agent_revisions` (`src/state/agent-revisions.ts`), so any change 
 **agent page → Revision history** panel is the human rollback. `agent_update` only touches agents under the
 data home (bundled examples can't be edited) and rewrites only the fields the caller supplied. A future
 tightening could classify CLAUDE.md/model self-edits through Policy for workspaces that want sign-off.
+
+`agent_propose_update` is the **cross-agent** counterpart, deliberately kept *gated* rather than an open
+widening of `agent_update`. Rewriting **another** agent's system prompt is a genuine side effect on a
+different principal — a lateral-privilege / prompt-injection vector if left ungated (agents don't share a
+trust level; the target may hold different `shellSecrets`/assignments) — so it follows the **propose-don't-apply**
+pattern of `policy_propose` / `automation_propose`: the agent's loopback call writes **nothing**, it only
+posts an owner-addressed `agent.update.proposed` card carrying the field delta + rationale. Application is
+**owner-only, and the owner must be able to run the target** (`os.team.canRun`; owners run everything, so
+this also future-proofs a narrower run model) — an admin cannot approve. On approval the server runs the
+**same** apply path as the self-edit route (sanitizers + disk write + `AgentRevisions.commit`, author = the
+approving owner, summary naming the proposer), so accountability captures both parties and the result is
+one-click revertable in the same Revision history panel. Same target guards as `agent_update` (user-home
+claude-code agents only, never `id === self`), plus a 10-open queue cap and identical-delta dedupe. The
+console surfaces open proposals on the **agent page → "Proposed edits from other agents"** card (owner-only,
+with a full CLAUDE.md before→after).
 
 ### `goal_list` / `goal_get` / `goal_propose` — the strategic layer (read + propose only)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.249.0",
+  "version": "0.250.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.249.0",
+      "version": "0.250.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.249.0",
+  "version": "0.250.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -1124,12 +1124,13 @@ const TOOLS = [
       'description, category, model, effort, example prompts, or icon). This is how you self-improve: when ' +
       "you notice a recurring gap in your instructions or a better way to describe what you do, refine it " +
       'here. Takes effect on your next session. Every edit is snapshotted — inspect them with agent_history ' +
-      'and undo with agent_revert. You can only edit yourself (the id defaults to you); a human edits others.',
+      'and undo with agent_revert. You can only edit yourself (the id defaults to you); to edit ANOTHER ' +
+      'agent, use agent_propose_update (an owner approves it).',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
       properties: {
-        id: { type: 'string', description: 'Optional — defaults to you. Must be your own id; you cannot edit another agent.' },
+        id: { type: 'string', description: 'Optional — defaults to you. Must be your own id; to edit another agent use agent_propose_update.' },
         description: { type: 'string', description: 'New one-line description of what you do.' },
         claudeMd: { type: 'string', description: "Replacement CLAUDE.md (your full system prompt). Send the complete new text, not a diff." },
         category: { type: 'string', description: 'New grouping label (empty string clears it → Uncategorized).' },
@@ -1138,6 +1139,32 @@ const TOOLS = [
         examplePrompts: { type: 'array', items: { type: 'string' }, description: 'Replacement starter prompts shown on your spawn card.' },
         icon: { type: 'string', description: 'New lucide icon name (or raw <svg>).' },
       },
+    },
+  },
+  {
+    name: 'agent_propose_update',
+    description:
+      "Propose an edit to ANOTHER agent's listing or CLAUDE.md system prompt — the gated counterpart to " +
+      'agent_update (which only edits you). You CANNOT change another agent directly: this posts a review ' +
+      'card to an owner and changes nothing until they approve. Pass only the fields to change, plus a ' +
+      'rationale the owner will read. Use it when you spot a concrete, well-justified improvement to a ' +
+      'teammate agent (a stale instruction, a missing convention, a better description). The target must be ' +
+      'a user-created claude-code agent (not a bundled example), and must not be you.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string', description: 'The agent to edit (required; must differ from you).' },
+        rationale: { type: 'string', description: 'Why this change is worth making — shown to the approving owner (required).' },
+        description: { type: 'string', description: 'New one-line description of what the target does.' },
+        claudeMd: { type: 'string', description: "Replacement CLAUDE.md (the target's full system prompt). Send the complete new text, not a diff — the owner sees a full before→after." },
+        category: { type: 'string', description: 'New grouping label (empty string clears it → Uncategorized).' },
+        model: { type: 'string', description: 'Model override (empty string clears → inherit the workspace default).' },
+        effort: { type: 'string', enum: ['low', 'medium', 'high', 'xhigh', 'max'], description: 'Reasoning-effort override.' },
+        examplePrompts: { type: 'array', items: { type: 'string' }, description: "Replacement starter prompts on the target's spawn card." },
+        icon: { type: 'string', description: 'New lucide icon name (or raw <svg>).' },
+      },
+      required: ['id', 'rationale'],
     },
   },
   {
@@ -2340,6 +2367,27 @@ async function agentUpdate(args: Record<string, unknown>): Promise<string> {
   return `Updated your listing "${id}"${d.rev ? ` (saved as rev ${d.rev} — revert with agent_revert)` : ''}. The next session you run will use it.`;
 }
 
+async function agentProposeUpdate(args: Record<string, unknown>): Promise<string> {
+  // Cross-agent + gated: propose an edit to ANOTHER agent. Nothing changes until an owner approves the card.
+  const id = String(args.id ?? '').trim().toLowerCase();
+  if (!id) return 'agent_propose_update needs id — the agent you want to edit.';
+  if (!String(args.rationale ?? '').trim()) return 'agent_propose_update needs a rationale — the owner sees it on the review card.';
+  const body: Record<string, unknown> = { session: SESSION, id, rationale: String(args.rationale) };
+  for (const k of ['description', 'claudeMd', 'category', 'model', 'effort', 'icon'] as const) {
+    if (args[k] !== undefined) body[k] = String(args[k]);
+  }
+  if (Array.isArray(args.examplePrompts)) body.examplePrompts = args.examplePrompts.map(String);
+  const res = await fetch(AOS_URL + '/api/agent/agent/propose', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify(body),
+  });
+  const d = (await res.json()) as { ok?: boolean; preview?: string; error?: string };
+  return d.ok
+    ? `Proposed an edit to "${id}"${d.preview ? ` (${d.preview})` : ''} — it's in an owner's inbox for review. NOTHING changes until an owner who can run "${id}" approves it; the target picks it up on its next session once applied.`
+    : `Could not propose the edit: ${d.error ?? 'unknown error'}`;
+}
+
 async function agentHistory(): Promise<string> {
   const res = await fetch(AOS_URL + '/api/agents/history', {
     method: 'POST',
@@ -2822,6 +2870,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'goal_propose' ? await goalPropose(args)
         : name === 'agent_create' ? await agentCreate(args)
         : name === 'agent_update' ? await agentUpdate(args)
+        : name === 'agent_propose_update' ? await agentProposeUpdate(args)
         : name === 'agent_history' ? await agentHistory()
         : name === 'agent_revert' ? await agentRevert(args)
         : name === 'app_create' ? await appCreate(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -725,6 +725,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, out.ok ? 200 : 400, out);
   }
 
+  // Agent PROPOSES an edit to ANOTHER agent's listing / CLAUDE.md (`agent_propose_update`) — the gated,
+  // cross-agent sibling of the self-only `agent_update`. Nothing is written here; a valid proposal posts an
+  // owner-addressed 'agent.update.proposed' card and applies NOTHING until an OWNER who can run the target
+  // approves. Pre-auth loopback, session-secret gated (proposer resolved from the session row, not the body).
+  if (method === 'POST' && p === '/api/agent/agent/propose') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const proposer = tm.sessionAgent(session);
+    if (!proposer) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const out = tm.proposeAgentUpdate(session, proposer, b);
+    return sendJson(res, out.ok ? 200 : 400, out);
+  }
+
   // ── Secrets vault, agent-facing (loopback, session-scoped) — the A2A credential-handoff path ──
   // Shared-scope model: writes land tenant-wide (`*`) so any agent can read them; the value NEVER
   // touches audit/approval-card/policy args (see TerminalManager.putSecret/getSecret). `put` is
@@ -2230,6 +2244,60 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const b = await readBody(req);
     tm.setAutomationProposalStatus(autoPropReject[1], 'rejected');
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'automation.proposal.rejected', data: { by: me.email, agent: card.agent, name: card.spec.name, note: b.note ? String(b.note) : undefined } });
+    return sendJson(res, 200, { ok: true });
+  }
+
+  // Agent-proposed edits to OTHER agents' listings / CLAUDE.md, awaiting human sign-off (the agents twin of
+  // /api/automations/proposals). Rewriting another agent's system prompt is a privilege-bearing act — the
+  // approve gate is OWNER-only AND the owner must be able to run the target (owners run everything, so this
+  // is belt-and-suspenders that also future-proofs a narrower run model). Nothing is applied until approve.
+  if (method === 'GET' && p === '/api/agents/proposals') {
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
+    const target = url.searchParams.get('target') || undefined;
+    return sendJson(res, 200, { proposals: tm.openAgentUpdateProposals(target), canApprove: true });
+  }
+  const agUpdApprove = p.match(/^\/api\/agents\/proposals\/([\w.-]+)\/approve$/);
+  if (method === 'POST' && agUpdApprove) {
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required — editing another agent\'s prompt is an owner act' });
+    if (!os.paths) return sendJson(res, 200, { ok: false, error: 'editing agents requires a data home' });
+    const card = tm.agentUpdateProposalCard(agUpdApprove[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such agent-edit proposal' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this proposal was already resolved' });
+    if (!os.team.canRun(me, card.target)) return sendJson(res, 403, { error: `you cannot run "${card.target}", so you cannot approve edits to it` });
+    const ag = os.agents.get(card.target);
+    if (!ag?.dir) { tm.setAgentUpdateProposalStatus(card.id, 'rejected'); return sendJson(res, 200, { ok: false, error: `target agent "${card.target}" no longer exists` }); }
+    if (ag.runtime !== 'claude-code') return sendJson(res, 200, { ok: false, error: 'only claude-code agents can be edited' });
+    const userRoot = path.resolve(os.paths.userAgents) + path.sep;
+    if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return sendJson(res, 200, { ok: false, error: 'built-in agents cannot be edited' });
+    const f = card.fields; // the proposed field delta (only present keys are applied — same shape as the self-edit body)
+    const { tuning, error: tErr } = sanitizeRuntimeTuning({ model: 'model' in f ? f.model : ag.model, effort: 'effort' in f ? f.effort : ag.effort });
+    if (tErr) return sendJson(res, 200, { ok: false, error: tErr });
+    const before = readAgentSnapshot(ag);
+    const description = 'description' in f ? String(f.description ?? '').trim() : ag.description;
+    const category = 'category' in f ? sanitizeCategory(f.category) : ag.category;
+    const icon = 'icon' in f ? sanitizeIcon(f.icon) : ag.icon;
+    const examplePrompts = 'examplePrompts' in f ? sanitizeExamplePrompts(f.examplePrompts) : ag.examplePrompts;
+    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, category, icon, examplePrompts };
+    const { dir: _dir, ...onDisk } = next;
+    fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
+    if ('claudeMd' in f) fs.writeFileSync(path.join(ag.dir, 'CLAUDE.md'), String(f.claudeMd ?? ''));
+    os.registerAgent(next);
+    const after = manifestToSnapshot(next, 'claudeMd' in f ? String(f.claudeMd ?? '') : before.claudeMd);
+    // Author = the approving owner; the summary preserves who proposed it, so the revision log names both parties.
+    const rev = os.agentRevisions.commit(os.tenant, card.target, before, after, `proposed by ${card.agent}, approved by ${me.email}`, me.email);
+    tm.setAgentUpdateProposalStatus(card.id, 'approved');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.update.proposal.approved', data: { target: card.target, proposer: card.agent, by: me.email, fields: Object.keys(f), claudeMd: 'claudeMd' in f, rev } });
+    return sendJson(res, 200, { ok: true, target: card.target, rev });
+  }
+  const agUpdReject = p.match(/^\/api\/agents\/proposals\/([\w.-]+)\/reject$/);
+  if (method === 'POST' && agUpdReject) {
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
+    const card = tm.agentUpdateProposalCard(agUpdReject[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such agent-edit proposal' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this proposal was already resolved' });
+    const b = await readBody(req);
+    tm.setAgentUpdateProposalStatus(card.id, 'rejected');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.update.proposal.rejected', data: { by: me.email, agent: card.agent, target: card.target, note: b.note ? String(b.note) : undefined } });
     return sendJson(res, 200, { ok: true });
   }
   const autoRun = p.match(/^\/api\/automations\/([\w-]+)\/run$/);

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -553,6 +553,7 @@ const REVIEW_PRESENTATION: Record<ReviewNotice['kind'], { icon: string; page: st
   'host.proposed': { icon: '🌐', page: 'connectors' },
   'policy.proposal': { icon: '🛡️', page: 'settings/policy' },
   'automation.proposed': { icon: '⚡', page: 'automations' },
+  'agent.update.proposed': { icon: '✏️', page: 'agents' },
 };
 
 /**

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -278,7 +278,7 @@ export interface Session {
 
 export interface FeedMessage {
   id: string;
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'app.proposed' | 'policy.proposal' | 'automation.proposed';
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'app.proposed' | 'policy.proposal' | 'automation.proposed' | 'agent.update.proposed';
   sessionId: string;
   agent: string;
   title: string;
@@ -462,7 +462,7 @@ export interface MemberNotice {
 export interface ReviewNotice {
   sessionId: string;
   agent: string;
-  kind: 'secret.request' | 'skill.proposed' | 'skill.request' | 'host.proposed' | 'policy.proposal' | 'automation.proposed';
+  kind: 'secret.request' | 'skill.proposed' | 'skill.request' | 'host.proposed' | 'policy.proposal' | 'automation.proposed' | 'agent.update.proposed';
   title: string;
   summary: string;
 }
@@ -3450,6 +3450,78 @@ export class TerminalManager {
         return { id: r.id, agent: r.agent, spec: a.spec as ProposedAutomation, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, createdAt: r.created_at };
       })
       .filter((p) => p.spec);
+  }
+
+  /**
+   * An agent PROPOSES an edit to ANOTHER agent's listing / CLAUDE.md — the cross-agent, gated sibling of
+   * the self-only `agent_update`. Nothing is written here (an unapproved prompt edit must not take effect):
+   * the field delta lives in the review card's args, and the approve route applies it only once an OWNER
+   * who can run the target signs off. Validates the target the SAME way the self-edit route does
+   * (claude-code only, under the user-agents root, not a bundled example), so an agent can't propose edits
+   * to something a human couldn't edit either. Same queue-cap + identical-delta dedupe as the other propose
+   * lanes; `id === proposer` is refused (that's what `agent_update` is for).
+   */
+  proposeAgentUpdate(sessionId: string, proposer: string, body: Record<string, unknown>): { ok: boolean; preview?: string; error?: string } {
+    const target = String(body.id ?? '').trim().toLowerCase();
+    if (!target) return { ok: false, error: 'id (the agent to edit) is required' };
+    if (target === proposer) return { ok: false, error: 'use agent_update to edit your own listing' };
+    if (!String(body.rationale ?? '').trim()) return { ok: false, error: 'a rationale is required — the approver sees it on the card' };
+    if (!this.os.paths) return { ok: false, error: 'editing agents requires a data home' };
+    const ag = this.os.agents.get(target);
+    if (!ag?.dir) return { ok: false, error: `unknown agent "${target}"` };
+    if (ag.runtime !== 'claude-code') return { ok: false, error: 'only claude-code agents can be edited' };
+    const userRoot = path.resolve(this.os.paths.userAgents) + path.sep;
+    if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return { ok: false, error: 'built-in agents cannot be edited' };
+    // Only the fields actually present become the delta; store them verbatim on the card for the approve route.
+    const fields: Record<string, unknown> = {};
+    for (const k of ['description', 'claudeMd', 'category', 'model', 'effort', 'icon'] as const) {
+      if (k in body) fields[k] = String(body[k] ?? '');
+    }
+    if ('examplePrompts' in body && Array.isArray(body.examplePrompts)) fields.examplePrompts = body.examplePrompts.map(String);
+    if (!Object.keys(fields).length) return { ok: false, error: 'nothing to change — pass at least one field (description, claudeMd, category, model, effort, icon, examplePrompts)' };
+    // Cap the queue + dedupe an identical open proposal from this agent for this target (mirrors proposeAutomation).
+    const open = this.db.prepare(`SELECT args FROM messages WHERE type = 'agent.update.proposed' AND status = 'open' AND agent = ?`).all<{ args: string | null }>(proposer);
+    if (open.length >= 10) return { ok: false, error: 'you already have 10 open edit proposals awaiting review — wait for a human to act on them first' };
+    const deltaKey = JSON.stringify({ target, fields });
+    if (open.some((o) => { try { const a = JSON.parse(o.args || '{}') as { target?: string; fields?: unknown }; return JSON.stringify({ target: a.target, fields: a.fields }) === deltaKey; } catch { return false; } })) {
+      return { ok: false, error: 'an identical edit proposal from you is already awaiting review' };
+    }
+    const rationale = String(body.rationale).trim();
+    const preview = Object.keys(fields).map((k) => (k === 'claudeMd' ? 'CLAUDE.md (system prompt)' : k)).join(', ');
+    this.postReviewCard({
+      type: 'agent.update.proposed', sessionId, agent: proposer,
+      title: `Edit proposed for ${target}`,
+      body: `${rationale}\n\nChanges to \`${target}\`: ${preview}`,
+      args: { target, fields, rationale, preview },
+      summary: `${proposer} proposes editing ${target} (${preview})`,
+    });
+    this.audit(sessionId, proposer, 'agent.update.proposed', { target, fields: Object.keys(fields) });
+    return { ok: true, preview };
+  }
+
+  /** The proposed agent-edit review card by id (its target + field delta + status) — for the approve/reject routes. */
+  agentUpdateProposalCard(id: string): { id: string; agent: string; target: string; fields: Record<string, unknown>; rationale?: string; preview?: string; status: string } | undefined {
+    const row = this.db.prepare(`SELECT agent, args, status FROM messages WHERE id = ? AND type = 'agent.update.proposed'`).get<{ agent: string; args: string | null; status: string }>(id);
+    if (!row) return undefined;
+    let a: Record<string, unknown> = {};
+    try { a = row.args ? JSON.parse(row.args) : {}; } catch { /* tolerate a corrupt payload */ }
+    if (!a.target || !a.fields) return undefined;
+    return { id, agent: row.agent, target: String(a.target), fields: a.fields as Record<string, unknown>, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, status: row.status };
+  }
+  setAgentUpdateProposalStatus(id: string, status: 'approved' | 'rejected'): void {
+    this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'agent.update.proposed'`).run(status, id);
+  }
+  /** Open agent-edit proposals (all targets, or just one when `target` is given) — for the console review list. */
+  openAgentUpdateProposals(target?: string): { id: string; agent: string; target: string; fields: Record<string, unknown>; rationale?: string; preview?: string; createdAt: number }[] {
+    return this.db
+      .prepare(`SELECT id, agent, args, created_at FROM messages WHERE type = 'agent.update.proposed' AND status = 'open' ORDER BY created_at DESC`)
+      .all<{ id: string; agent: string; args: string | null; created_at: number }>()
+      .map((r) => {
+        let a: Record<string, unknown> = {};
+        try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate corrupt payload */ }
+        return { id: r.id, agent: r.agent, target: String(a.target ?? ''), fields: (a.fields ?? {}) as Record<string, unknown>, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, createdAt: r.created_at };
+      })
+      .filter((p) => p.target && (!target || p.target === target.trim().toLowerCase()));
   }
 
   /** Agent posts a mid-task progress update to the Inbox feed. Unlike the (now removed) spawn/stop/exit

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -4441,6 +4441,12 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
     const resolved = m.status === 'approved' ? 'approved' : m.status === 'rejected' ? 'rejected' : ''
     verb = 'proposed an automation'; detail = m.body
     badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">{resolved || 'review in Automations'}</Badge>
+  } else if (m.type === 'agent.update.proposed') {
+    Icon = Pencil; iconCls = 'text-violet-600'; highlight = m.status === 'open'
+    const resolved = m.status === 'approved' ? 'applied' : m.status === 'rejected' ? 'rejected' : ''
+    const tgt = (m.args as { target?: string } | undefined)?.target
+    verb = tgt ? `proposed an edit to ${tgt}` : 'proposed an agent edit'; detail = m.body
+    badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">{resolved || 'review in Agents'}</Badge>
   } else if (m.type === 'goal.proposed') {
     Icon = Target; iconCls = 'text-indigo-600'; highlight = true
     verb = 'proposed a goal'; detail = m.body
@@ -9563,6 +9569,7 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
           )}
         </CardContent>
       </Card>
+      {info?.runtime === 'claude-code' && <AgentUpdateProposalsCard agentId={agentId} onApplied={() => { setRevBump((n) => n + 1); onSaved?.() }} />}
       {info?.runtime === 'claude-code' && <AgentRevisionsCard agentId={agentId} onReverted={() => { setRevBump((n) => n + 1); onSaved?.() }} />}
     </div>
   )
@@ -9571,6 +9578,77 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
 /** Revision history for an agent's listing + CLAUDE.md — the human rollback for a self-editing agent.
  *  Every edit (by the agent via agent_update, or a human here) snapshots a full version; revert restores
  *  one and records a new revision, so nothing is ever lost. */
+/** Owner-only review queue for cross-agent edit proposals targeting THIS agent (agent_propose_update).
+ *  Non-owners get a 403 from the API → the card renders nothing. Approving applies the field delta and
+ *  snapshots a revision (visible in the Revision history card below); rejecting discards it. */
+function AgentUpdateProposalsCard({ agentId, onApplied }: { agentId: string; onApplied: () => void }) {
+  const [props, setProps] = useState<AgentUpdateProposal[] | null>(null)
+  const [current, setCurrent] = useState('')      // current CLAUDE.md, for before→after on claudeMd edits
+  const [expanded, setExpanded] = useState<string | null>(null)
+  const [busy, setBusy] = useState('')
+  const [hint, setHint] = useState('')
+  const load = () => api.agentUpdateProposals(agentId).then((r) => setProps(r.error ? [] : (r.proposals ?? []))).catch(() => setProps([]))
+  useEffect(() => { setProps(null); setHint(''); setExpanded(null); load(); api.agentClaude(agentId).then((r) => setCurrent(r.content ?? '')).catch(() => {}) }, [agentId]) // eslint-disable-line react-hooks/exhaustive-deps
+  const act = async (id: string, approve: boolean) => {
+    if (approve && !window.confirm(`Apply this edit to ${agentId}?\n\nIt rewrites the agent's listing/CLAUDE.md and records a revision (revertable below). The change applies on the agent's next session.`)) return
+    setBusy(id); setHint('')
+    const r = approve ? await api.approveAgentUpdateProposal(id) : await api.rejectAgentUpdateProposal(id)
+    setBusy('')
+    if (r.error || !r.ok) return setHint('⚠ ' + (r.error ?? 'failed'))
+    setHint(approve ? 'applied — see Revision history' : 'rejected')
+    load(); if (approve) { onApplied(); api.agentClaude(agentId).then((x) => setCurrent(x.content ?? '')).catch(() => {}) }
+    setTimeout(() => setHint(''), 3000)
+  }
+  if (!props || props.length === 0) return null // silent for non-owners and when nothing is pending
+  const FIELD_LABEL: Record<string, string> = { description: 'description', claudeMd: 'CLAUDE.md (system prompt)', category: 'category', model: 'model', effort: 'effort', icon: 'icon', examplePrompts: 'starter prompts' }
+  return (
+    <Card className="border-violet-300 bg-violet-50/40">
+      <CardContent className="space-y-3 p-4">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2 text-xs font-medium text-violet-800"><Pencil className="h-3.5 w-3.5" /> Proposed edits from other agents ({props.length})</div>
+          {hint && <span className="font-mono text-[11px] text-muted-foreground">{hint}</span>}
+        </div>
+        {props.map((pr) => {
+          const keys = Object.keys(pr.fields)
+          const isExp = expanded === pr.id
+          return (
+            <div key={pr.id} className="space-y-2 rounded border border-violet-200 bg-background p-3">
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <Bot className="h-3 w-3 shrink-0" /><span className="font-medium text-foreground">{pr.agent}</span>
+                <span>· {new Date(pr.createdAt).toLocaleString()}</span>
+              </div>
+              {pr.rationale && <div className="text-sm">{pr.rationale}</div>}
+              <div className="flex flex-wrap gap-1">
+                {keys.map((k) => <Badge key={k} variant="outline" className="px-1.5 py-0 text-[10px] font-normal">{FIELD_LABEL[k] ?? k}</Badge>)}
+              </div>
+              {/* Non-CLAUDE.md fields: show the proposed value inline. */}
+              {keys.filter((k) => k !== 'claudeMd').map((k) => (
+                <div key={k} className="text-xs"><span className="text-muted-foreground">{FIELD_LABEL[k] ?? k}: </span><span className="font-mono">{k === 'examplePrompts' ? (pr.fields.examplePrompts ?? []).join(' · ') : String((pr.fields as Record<string, unknown>)[k] ?? '') || '(cleared)'}</span></div>
+              ))}
+              {/* CLAUDE.md: the risky one — full before→after, collapsed by default. */}
+              {'claudeMd' in pr.fields && (
+                <div className="text-xs">
+                  <button className="text-violet-700 underline" onClick={() => setExpanded(isExp ? null : pr.id)}>{isExp ? 'Hide' : 'Show'} CLAUDE.md before → after</button>
+                  {isExp && (
+                    <div className="mt-2 grid grid-cols-1 gap-2 md:grid-cols-2">
+                      <div><div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">Current</div><pre className="max-h-64 overflow-auto rounded bg-muted p-2 font-mono text-[11px] whitespace-pre-wrap">{current || '(empty)'}</pre></div>
+                      <div><div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">Proposed</div><pre className="max-h-64 overflow-auto rounded bg-muted p-2 font-mono text-[11px] whitespace-pre-wrap">{pr.fields.claudeMd || '(empty)'}</pre></div>
+                    </div>
+                  )}
+                </div>
+              )}
+              <div className="flex items-center gap-2 pt-1">
+                <Button size="sm" disabled={!!busy} onClick={() => act(pr.id, true)}>Approve & apply</Button>
+                <Button size="sm" variant="outline" disabled={!!busy} onClick={() => act(pr.id, false)}>Reject</Button>
+              </div>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}
+
 function AgentRevisionsCard({ agentId, onReverted }: { agentId: string; onReverted: () => void }) {
   const [revs, setRevs] = useState<AgentRevision[] | null>(null)
   const [open, setOpen] = useState(false)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -598,7 +598,7 @@ export interface AddGoalReq {
 
 export interface Msg {
   id: string
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed'
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed' | 'agent.update.proposed'
   sessionId: string
   agent: string
   title: string
@@ -678,6 +678,17 @@ export interface AutomationProposal {
   id: string
   agent: string
   spec: { agentId: string; name: string; type: Automation['type']; schedule?: string; filter?: string; task: string; mode?: ExecMode }
+  rationale?: string
+  preview?: string
+  createdAt: number
+}
+/** An agent-proposed edit to ANOTHER agent's listing / CLAUDE.md, awaiting owner sign-off. `fields` holds
+ *  only the changed keys (the delta); `claudeMd`, when present, is the full replacement system prompt. */
+export interface AgentUpdateProposal {
+  id: string
+  agent: string          // the proposing agent
+  target: string         // the agent to be edited
+  fields: { description?: string; claudeMd?: string; category?: string; model?: string; effort?: string; icon?: string; examplePrompts?: string[] }
   rationale?: string
   preview?: string
   createdAt: number
@@ -1290,6 +1301,9 @@ export const api = {
   automationProposals: () => call<{ proposals: AutomationProposal[]; error?: string }>('GET', '/api/automations/proposals'),
   approveAutomationProposal: (id: string) => call<{ ok: boolean; automation?: Automation; error?: string }>('POST', `/api/automations/proposals/${id}/approve`),
   rejectAutomationProposal: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/automations/proposals/${id}/reject`),
+  agentUpdateProposals: (target?: string) => call<{ proposals: AgentUpdateProposal[]; canApprove?: boolean; error?: string }>('GET', '/api/agents/proposals' + (target ? '?target=' + encodeURIComponent(target) : '')),
+  approveAgentUpdateProposal: (id: string) => call<{ ok: boolean; target?: string; rev?: number; error?: string }>('POST', `/api/agents/proposals/${id}/approve`),
+  rejectAgentUpdateProposal: (id: string, note?: string) => call<{ ok: boolean; error?: string }>('POST', `/api/agents/proposals/${id}/reject`, { note }),
   automationRuns: (id: string) => call<{ runs: Session[]; error?: string }>('GET', `/api/automations/${id}/runs`),
 
   memory: (agent: string, q = '', limit = 50, scope: 'all' | 'agent' | 'tenant' = 'all') =>


### PR DESCRIPTION
## What

Adds **`agent_propose_update`** — the gated, cross-agent counterpart to the self-only `agent_update`. An agent can propose an edit to **another** agent's listing (description, starter prompts, tuning, icon) or its **CLAUDE.md system prompt**, but nothing is applied until an owner approves.

## Why gated, not just "let agents edit other agents"

Rewriting another agent's system prompt is a side effect on a **different principal** — a lateral-privilege / prompt-injection vector, since agents don't share a trust level (different `shellSecrets`, secret assignments, run-as identities). So it follows the established **propose-don't-apply** pattern of `policy_propose` / `automation_propose` rather than widening the self-only gate.

## How it works

- **Propose** (`agent_propose_update` → `POST /api/agent/agent/propose`): writes nothing; posts an owner-addressed `agent.update.proposed` review card with the field delta + rationale.
- **Approve** (`POST /api/agents/proposals/:id/approve`): **owner-only, and the owner must be able to run the target** (`os.team.canRun`) — an admin cannot approve. Runs the *same* apply path as the self-edit route (sanitizers + disk write + `AgentRevisions.commit`, author = approver, summary names the proposer), so it's accountable to both parties and one-click revertable in the existing Revision history panel.
- **Guards:** user-home claude-code targets only (never bundled examples), never `id === self`, 10-open queue cap, identical-delta dedupe.
- **Console:** owner-only "Proposed edits from other agents" card on the agent page with a full CLAUDE.md before→after; inbox card links there.

## Files

`src/memory/memory-mcp.ts` (tool + handler), `src/terminal.ts` (`proposeAgentUpdate` + card store, `ReviewNotice`/message-type unions), `src/server.ts` (propose + list/approve/reject routes), `src/tenant-registry.ts` (DM presentation), `web/src/App.tsx` + `web/src/lib/api.ts` (review card + inbox), `docs/agent-mcp-tools.md`, `CLAUDE.md`, `CHANGELOG.md`, version → 0.250.0.

## Verification

- `npm run typecheck` clean, `web` build clean, `npm run test:governance` 68/68.
- New isolated in-process e2e (scratch home): **19/19** — propose validation (self / unknown / empty-delta / bad-secret refused), owner lists 1, **admin list & approve both 403** (owner-only enforced), dedupe, owner approve applies CLAUDE.md + description to disk, revision recorded, re-approve 409, list drains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)