### PR TITLE
feat(chat): automatic agent routing — infer the right agent from the message (v0.251.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.251.0] — 2026-07-21
+### Added
+- **Automatic agent routing — a chat/ticket message reaches the right agent without anyone naming one.**
+  The `/agent` chat router already made the whole fleet reachable, but only if the sender knew the agent and
+  prefixed `/name`; an unaddressed message just got a help list. The new router (`src/edge/router.ts`,
+  `chooseAgent`) *infers* the best-fit claude-code agent from the message itself — useful for Slack/Discord
+  (and, via the same shared front door, support-ticket triage) where you want to start an agent but not pick
+  one. Matching is **deterministic first** — idf-weighted token overlap over each agent's `id + description +
+  examplePrompts`, so rare-to-the-fleet terms ("billing", "kubernetes") discriminate and fleet-common terms
+  contribute ~0 — with two opt-in upgrades that only run when configured: an **embedding blend** (reuses the
+  Settings → Memory embedder; cosine(message, agent-profile) min-max blended with the keyword score) and an
+  **LLM tie-break** on a near-tie (cheap OpenAI-compatible `/chat/completions`, endpoint/key default to the
+  memory embedder's). The design **fails safe**: a clear winner routes silently, a near-tie or weak match asks
+  the human to **disambiguate** ("reply with a number"), and nothing-scored falls back to the classic help
+  list — a wrong *silent* route is the only bad outcome and it's gated behind a score margin. Explicit `/name`
+  still short-circuits inference. Disambiguation is stateful per thread (an in-memory shortlist keyed by
+  channel+thread; the reply routes the **original** request to the chosen agent). Routing carries no
+  privilege — it only picks an id; the spawn stays fully governed (provenance `chat:<agent>`, run-as the
+  sender, gate hook). Every route is audited `chat.routed` with `routedBy` (`explicit`/`auto`/`auto-llm`/
+  `auto-disambiguated`) + score + runner-up, so mis-routes are measurable. Wired into `fireSlack`/`fireDiscord`
+  via a shared `routeUnmatched` handler. Config: `router_config` (JSON `RouterConfig` — `enabled`/`minScore`/
+  `margin`/`llm`); `autoRouteEnabled()` defaults on, riding the `/agent` chat-router master switch.
+  `src/edge/router.ts` (new), `src/edge/automations.ts`, `src/governance/settings.ts`, `src/types.ts`.
+
 ## [0.250.0] — 2026-07-21
 ### Added
 - **Agents can now propose edits to *other* agents — gated, never applied unattended (`agent_propose_update`).**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.250.0",
+  "version": "0.251.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.250.0",
+      "version": "0.251.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.250.0",
+  "version": "0.251.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -17,6 +17,7 @@ import { AgentOS } from '../kernel';
 import { Db } from '../state/db';
 import { TerminalManager } from '../terminal';
 import { Task } from '../types';
+import { chooseAgent, RouterCandidate } from './router';
 
 // ── minimal cron (5 fields: minute hour day-of-month month day-of-week) ──────────
 // Supports: * , a-b , */n , a-b/n , lists. dow 0-7 (7 ≡ 0 = Sunday).
@@ -619,14 +620,22 @@ export class Automations {
   }
 
   /**
-   * Spawn a one-off chat run for an explicitly-addressed agent (the `/name` router) — no automation row.
-   * Same governance path as fire(): provenance `chat:<agent>`, run-as the sender, reply bound to the
-   * thread, every effect still gated. Audited as `chat.routed`.
+   * Spawn a one-off chat run for a routed agent (explicit `/name`, auto-inference, or a resolved
+   * disambiguation) — no automation row. Same governance path as fire(): provenance `chat:<agent>`,
+   * run-as the sender, reply bound to the thread, every effect still gated. Audited as `chat.routed`,
+   * tagged with HOW it was routed (`route.by` + score + runner-up) so mis-routes are measurable.
    */
   private spawnChatAgent(
     agentId: string,
     task: string,
-    opts: { runAs?: string; slack?: { channel: string; threadTs: string }; discord?: { channel: string; messageId: string }; title?: string; resident?: boolean },
+    opts: {
+      runAs?: string;
+      slack?: { channel: string; threadTs: string };
+      discord?: { channel: string; messageId: string };
+      title?: string;
+      resident?: boolean;
+      route?: { by: 'explicit' | 'auto' | 'auto-llm' | 'auto-disambiguated'; score?: number; runnerUp?: string };
+    },
   ): FireResult {
     // `resident` (Slack chat) → a warm interactive session (headless off) kept alive for fast follow-ups;
     // otherwise the classic one-shot headless run. `title` is the meaningful, message-derived label.
@@ -640,9 +649,119 @@ export class Automations {
       tenant: this.os.tenant,
       principal: opts.runAs ? `member:${opts.runAs}` : 'chat',
       type: 'chat.routed',
-      data: { agent: agentId, runAs: opts.runAs ?? null, channel: opts.slack?.channel ?? opts.discord?.channel ?? null, resident: !!opts.resident },
+      data: {
+        agent: agentId,
+        runAs: opts.runAs ?? null,
+        channel: opts.slack?.channel ?? opts.discord?.channel ?? null,
+        resident: !!opts.resident,
+        routedBy: opts.route?.by ?? 'explicit',
+        score: opts.route?.score ?? null,
+        runnerUp: opts.route?.runnerUp ?? null,
+      },
     });
     return { ok: true, sessionId: s.id, tmux: s.tmux };
+  }
+
+  // ── auto-router: pending disambiguation (in-memory, per thread) ──────────────────
+  // When the router is uncertain it asks the human ("did you mean A or B?"). The reply arrives as a
+  // fresh thread message with NO session bound yet, so we stash the shortlist + the ORIGINAL request
+  // here keyed by thread; the next message in that thread resolves the choice and routes the original
+  // task. In-memory (like the approval decision waiter) — a restart just makes the human re-ask.
+  private pendingRoute = new Map<string, { candidates: string[]; text: string; extra: string; runAs?: string; expires: number }>();
+  private static readonly PENDING_TTL_MS = 15 * 60 * 1000;
+
+  private putPending(key: string, v: { candidates: string[]; text: string; extra: string; runAs?: string }): void {
+    const now = Date.now();
+    for (const [k, p] of this.pendingRoute) if (p.expires <= now) this.pendingRoute.delete(k); // opportunistic prune
+    this.pendingRoute.set(key, { ...v, expires: now + Automations.PENDING_TTL_MS });
+  }
+  private takePending(key: string): { candidates: string[]; text: string; extra: string; runAs?: string } | undefined {
+    const p = this.pendingRoute.get(key);
+    if (!p) return undefined;
+    this.pendingRoute.delete(key);
+    return p.expires > Date.now() ? p : undefined;
+  }
+
+  /** Interpret a disambiguation reply against the offered shortlist: a 1-based number, or an agent id /
+   *  name token appearing in the text. `undefined` → unresolved (treat the message as a fresh route). */
+  private matchDisambiguation(text: string, candidates: string[]): string | undefined {
+    const t = (text || '').toLowerCase().replace(/<@[^>]+>/g, '').trim();
+    const num = t.match(/(?:^|\s)([1-9])(?:\s|$|[.)])/);
+    if (num) {
+      const i = Number(num[1]) - 1;
+      if (i >= 0 && i < candidates.length) return candidates[i];
+    }
+    for (const id of candidates) {
+      if (t.includes(id.toLowerCase())) return id;
+      if (id.toLowerCase().split(/[-_]+/).some((tok) => tok.length >= 3 && t.includes(tok))) return id;
+    }
+    return undefined;
+  }
+
+  private disambiguationPrompt(candidates: RouterCandidate[]): string {
+    const lines = candidates.map((c, i) => {
+      const a = this.os.agents.get(c.agentId);
+      const desc = a?.description ? ` — ${a.description.split('\n')[0].slice(0, 120)}` : '';
+      return `${i + 1}. \`/${c.agentId}\`${desc}`;
+    });
+    return `I'm not sure which agent fits — reply with a number (or the name):\n${lines.join('\n')}`;
+  }
+
+  /**
+   * The shared front door for a chat message that matched no automation: resolve a pending
+   * disambiguation, else honour an explicit `/name`, else auto-route (route silently / ask to
+   * disambiguate / fall back to the help list). Used by both fireSlack and fireDiscord. `key` scopes
+   * the pending-disambiguation store to the thread (Slack: channel+thread; Discord: channel).
+   */
+  private async routeUnmatched(opts: {
+    key: string;
+    text: string;
+    extra: string;
+    runAs?: string;
+    slack?: { channel: string; threadTs: string };
+    discord?: { channel: string; messageId: string };
+  }): Promise<{ sessions: string[]; reply?: string }> {
+    const sessions: string[] = [];
+    const spawn = (agentId: string, task: string, route: NonNullable<Parameters<Automations['spawnChatAgent']>[2]['route']>, text: string, runAs?: string) => {
+      const r = this.spawnChatAgent(agentId, task, { runAs, slack: opts.slack, discord: opts.discord, title: chatTitle(text, agentId), resident: true, route });
+      if (r.ok) sessions.push(r.sessionId);
+    };
+
+    // 1) A reply to a disambiguation we asked in this thread → route the ORIGINAL request to the choice.
+    const pend = this.takePending(opts.key);
+    if (pend) {
+      const chosen = this.matchDisambiguation(opts.text, pend.candidates);
+      if (chosen) {
+        spawn(chosen, pend.extra, { by: 'auto-disambiguated' }, pend.text, pend.runAs ?? opts.runAs);
+        return { sessions };
+      }
+      // Unresolved reply → fall through and treat this message as a fresh routing attempt.
+    }
+
+    // The whole chat front door off → nothing to do (no help list either).
+    if (!this.os.settings.chatRouterEnabled()) return { sessions };
+
+    // 2) Explicit `/name` always wins over inference.
+    const explicit = this.routeChat(opts.text);
+    if (explicit.agentId) {
+      spawn(explicit.agentId, opts.extra, { by: 'explicit' }, opts.text, opts.runAs);
+      return { sessions };
+    }
+
+    // 3) Auto-route (when enabled). Fails safe: confident → route; uncertain → ask; nothing → help list.
+    if (this.os.settings.autoRouteEnabled()) {
+      const decision = await chooseAgent(this.os, opts.text);
+      if (decision.kind === 'route') {
+        spawn(decision.agentId, opts.extra, { by: decision.method === 'llm' ? 'auto-llm' : 'auto', score: decision.score, runnerUp: decision.runnerUp?.agentId }, opts.text, opts.runAs);
+        return { sessions };
+      }
+      if (decision.kind === 'disambiguate') {
+        this.putPending(opts.key, { candidates: decision.candidates.map((c) => c.agentId), text: opts.text, extra: opts.extra, runAs: opts.runAs });
+        return { sessions, reply: this.disambiguationPrompt(decision.candidates) };
+      }
+      // decision.kind === 'none' → fall back to the classic help list.
+    }
+    return { sessions, reply: explicit.help };
   }
 
   /** Inbound webhook: validate id + key, append the payload to the task, fire (guarded). */
@@ -687,10 +806,10 @@ export class Automations {
    * (resolved from the Slack user's email upstream) runs the session AS that member — per-member tools
    * + inbox; absent → the company identity. Event-driven, so no pile-up guard. Returns sessions started.
    */
-  fireSlack(
+  async fireSlack(
     event: { eventType: string; channel: string; threadTs: string; user: string; actorLabel: string; text: string; raw: unknown },
     runAsMember?: string,
-  ): { fired: number; sessions: string[]; reply?: string } {
+  ): Promise<{ fired: number; sessions: string[]; reply?: string }> {
     const sessions: string[] = [];
     const extra =
       `Triggered from Slack by ${event.actorLabel} (${event.eventType}) in channel ${event.channel}` +
@@ -706,17 +825,19 @@ export class Automations {
       const r = this.fire(a, { guard: false, extra, runAs: runAsMember, slack: { channel: event.channel, threadTs: event.threadTs } });
       if (r.ok) sessions.push(r.sessionId);
     }
-    // No specific automation matched → the generic `/agent` router (if enabled) makes the whole fleet
-    // reachable without one. A named agent runs; an unaddressed/unknown name gets a help list to post back.
+    // No specific automation matched → the shared chat front door: resolve a pending disambiguation,
+    // honour an explicit `/name`, else auto-route (route / ask / help list) — reachable fleet-wide.
     let reply: string | undefined;
-    if (sessions.length === 0 && this.os.settings.chatRouterEnabled()) {
-      const routed = this.routeChat(event.text);
-      if (routed.agentId) {
-        const r = this.spawnChatAgent(routed.agentId, extra, { runAs: runAsMember, slack: { channel: event.channel, threadTs: event.threadTs }, title: chatTitle(event.text, routed.agentId), resident: true });
-        if (r.ok) sessions.push(r.sessionId);
-      } else {
-        reply = routed.help;
-      }
+    if (sessions.length === 0) {
+      const r = await this.routeUnmatched({
+        key: `slack:${event.channel}:${event.threadTs || event.channel}`,
+        text: event.text,
+        extra,
+        runAs: runAsMember,
+        slack: { channel: event.channel, threadTs: event.threadTs },
+      });
+      sessions.push(...r.sessions);
+      reply = r.reply;
     }
     return { fired: sessions.length, sessions, reply };
   }
@@ -825,10 +946,10 @@ export class Automations {
    * channel ('' / '*' = any). `runAsMember` runs the session AS that member; absent → the company
    * identity (the current default for Discord — see DiscordSocket.resolveMember). No pile-up guard.
    */
-  fireDiscord(
+  async fireDiscord(
     event: { eventType: string; channel: string; messageId: string; user: string; actorLabel: string; text: string; raw: unknown },
     runAsMember?: string,
-  ): { fired: number; sessions: string[]; reply?: string } {
+  ): Promise<{ fired: number; sessions: string[]; reply?: string }> {
     const sessions: string[] = [];
     const extra =
       `Triggered from Discord by ${event.actorLabel} (${event.eventType}) in channel ${event.channel}.\n` +
@@ -843,16 +964,19 @@ export class Automations {
       const r = this.fire(a, { guard: false, extra, runAs: runAsMember, discord: { channel: event.channel, messageId: event.messageId } });
       if (r.ok) sessions.push(r.sessionId);
     }
-    // No specific automation matched → the generic `/agent` router (if enabled). See fireSlack.
+    // No specific automation matched → the shared chat front door (auto-route / disambiguate / help).
+    // See fireSlack. Discord threads are keyed by channel id (the socket binds the branched thread).
     let reply: string | undefined;
-    if (sessions.length === 0 && this.os.settings.chatRouterEnabled()) {
-      const routed = this.routeChat(event.text);
-      if (routed.agentId) {
-        const r = this.spawnChatAgent(routed.agentId, extra, { runAs: runAsMember, discord: { channel: event.channel, messageId: event.messageId }, title: chatTitle(event.text, routed.agentId), resident: true });
-        if (r.ok) sessions.push(r.sessionId);
-      } else {
-        reply = routed.help;
-      }
+    if (sessions.length === 0) {
+      const r = await this.routeUnmatched({
+        key: `discord:${event.channel}`,
+        text: event.text,
+        extra,
+        runAs: runAsMember,
+        discord: { channel: event.channel, messageId: event.messageId },
+      });
+      sessions.push(...r.sessions);
+      reply = r.reply;
     }
     return { fired: sessions.length, sessions, reply };
   }

--- a/src/edge/discord-socket.ts
+++ b/src/edge/discord-socket.ts
@@ -280,7 +280,7 @@ export class DiscordSocket {
       if ('id' in th) { channel = th.id; replyRef = undefined; }
     }
 
-    const result = this.autos.fireDiscord(
+    const result = await this.autos.fireDiscord(
       {
         eventType: ev.eventType,
         // Bind the THREAD (when we made one) so `discord_reply` posts back into it. Inside a thread we

--- a/src/edge/router.ts
+++ b/src/edge/router.ts
@@ -1,0 +1,222 @@
+/**
+ * Agent router — automatic agent selection from a natural-language message.
+ *
+ * The `/agent-name` chat router (Automations.routeChat) requires the sender to KNOW which agent they
+ * want and prefix it. This module is the automatic counterpart: given an unaddressed message ("my pod
+ * is down", "refund on invoice 4821"), it infers the best-fit claude-code agent so a Slack/Discord/web
+ * message — or a support ticket — reaches the right teammate without anyone naming one.
+ *
+ * Matching is **deterministic first** (idf-weighted token overlap over each agent's id + description +
+ * example prompts), with two opt-in upgrades that only ever run when configured:
+ *   - **embedding blend** — when a memory embedder is configured, cosine(message, agent-profile) is
+ *     min-max blended with the keyword score for nuance the bag-of-words misses.
+ *   - **LLM tie-break** — on a near-tie, a cheap chat model picks the winner; absent/unsure, we fall
+ *     through to disambiguation (asking the human), never a coin-flip.
+ *
+ * The design **fails safe**: a confident win routes silently, a near-tie or weak match asks the human
+ * to disambiguate, and nothing-scored falls back to the `/agent` help list. A wrong SILENT route is the
+ * only bad outcome, and it's gated behind a clear score margin. The router only PICKS an id — the spawn
+ * is still fully governed downstream (provenance, run-as, gate hook), so routing carries no privilege.
+ */
+import { AgentManifest, RouterConfig } from '../types';
+import { AgentOS } from '../kernel';
+
+export interface RouterCandidate {
+  agentId: string;
+  score: number;
+}
+
+/** The router's verdict for one message. `route` → spawn it; `disambiguate` → ask the human to pick
+ *  among `candidates`; `none` → nothing scored, fall back to the help list. */
+export type RouteDecision =
+  | { kind: 'route'; agentId: string; score: number; runnerUp?: RouterCandidate; method: 'keyword' | 'embedding' | 'llm' }
+  | { kind: 'disambiguate'; candidates: RouterCandidate[] }
+  | { kind: 'none' };
+
+const DEFAULTS = { minScore: 0.5, margin: 0.3 };
+
+// Common words that carry no routing signal — dropped from both the message and agent profiles so the
+// idf weighting isn't diluted. Deliberately small: idf already suppresses fleet-wide-common terms.
+const STOPWORDS = new Set(
+  ('a an and the is are was were be been being to of in on for with at by from as it its this that these those ' +
+    'i you he she we they me my your our their can could would should will shall do does did done have has had ' +
+    'not no yes please help need want get got make made about into out up down over under again then than so ' +
+    'what why how when where who which whom whose there here just now new use used using via each any all some ' +
+    'if or but because while during before after').split(/\s+/),
+);
+
+/** Lowercase, split on non-alphanumerics, drop stopwords and <3-char tokens. */
+export function tokenize(s: string): string[] {
+  return (s || '')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+}
+
+/** The routing corpus for one agent: its id (de-slugged), description, category and example prompts —
+ *  everything the agent advertises about what it's for. */
+function agentProfile(a: AgentManifest): string {
+  return [a.id.replace(/[-_]+/g, ' '), a.description || '', a.category || '', ...(a.examplePrompts || [])].join(' \n ');
+}
+
+/**
+ * Deterministic keyword scoring: idf-weighted overlap between the message tokens and each agent's
+ * profile tokens, normalized by message length so scores are comparable across messages. Rare-to-the-
+ * fleet terms ("billing", "kubernetes") discriminate; terms every agent shares contribute ~0. Pure and
+ * synchronous — the unit-testable core. Returns candidates sorted best-first.
+ */
+export function scoreAgents(text: string, agents: AgentManifest[]): RouterCandidate[] {
+  const msgTokens = [...new Set(tokenize(text))];
+  if (msgTokens.length === 0 || agents.length === 0) return [];
+  const profiles = agents.map((a) => ({ id: a.id, tokens: new Set(tokenize(agentProfile(a))) }));
+  const N = profiles.length;
+  const df = new Map<string, number>();
+  for (const p of profiles) for (const t of p.tokens) df.set(t, (df.get(t) || 0) + 1);
+  const idf = (t: string) => Math.log((N + 1) / ((df.get(t) || 0) + 0.5));
+  const norm = Math.sqrt(msgTokens.length);
+  return profiles
+    .map((p) => {
+      let s = 0;
+      for (const t of msgTokens) if (p.tokens.has(t)) s += idf(t);
+      return { agentId: p.id, score: s / norm };
+    })
+    .sort((x, y) => y.score - x.score);
+}
+
+/** Turn a sorted candidate list into a decision under the confidence thresholds. Pure. */
+export function decide(scored: RouterCandidate[], cfg: RouterConfig): RouteDecision {
+  const minScore = cfg.minScore ?? DEFAULTS.minScore;
+  const margin = cfg.margin ?? DEFAULTS.margin;
+  const viable = scored.filter((c) => c.score > 0);
+  const top = viable[0];
+  const second = viable[1];
+  if (!top || top.score < minScore) {
+    // No candidate clears the floor. If two-plus at least registered, let the human pick; else help list.
+    return viable.length >= 2 ? { kind: 'disambiguate', candidates: viable.slice(0, 3) } : { kind: 'none' };
+  }
+  if (!second) return { kind: 'route', agentId: top.agentId, score: top.score, method: 'keyword' };
+  const gap = (top.score - second.score) / top.score;
+  if (gap >= margin) return { kind: 'route', agentId: top.agentId, score: top.score, runnerUp: second, method: 'keyword' };
+  return { kind: 'disambiguate', candidates: viable.slice(0, 3) };
+}
+
+function dot(a: number[], b: number[]): number {
+  let s = 0;
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) s += a[i] * b[i];
+  return s;
+}
+function cosine(a: number[], b: number[]): number {
+  const na = Math.sqrt(dot(a, a));
+  const nb = Math.sqrt(dot(b, b));
+  return na && nb ? dot(a, b) / (na * nb) : 0;
+}
+/** Min-max scale a list to 0..1 (flat list → all 0). */
+function minmax(xs: number[]): number[] {
+  const lo = Math.min(...xs);
+  const hi = Math.max(...xs);
+  const span = hi - lo;
+  return span > 0 ? xs.map((x) => (x - lo) / span) : xs.map(() => 0);
+}
+
+/**
+ * The full async router: deterministic scoring, an optional embedding blend when a memory embedder is
+ * configured, and an optional LLM tie-break on a near-tie. Returns a fail-safe decision.
+ */
+export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecision> {
+  const cfg = os.settings.routerConfig();
+  const agents = [...os.agents.values()].filter((a) => a.runtime === 'claude-code');
+  if (agents.length === 0) return { kind: 'none' };
+
+  let scored = scoreAgents(text, agents);
+  if (scored.length === 0) return { kind: 'none' };
+
+  // Optional embedding blend: cosine(message, profile) min-max-blended with the keyword score. Only when
+  // an embedder is configured AND the message embeds cleanly; any failure silently keeps the keyword rank.
+  const embedded = await tryEmbeddingBlend(os, text, agents, scored);
+  if (embedded) scored = embedded;
+
+  const decision = decide(scored, cfg);
+
+  // Near-tie → try the LLM tie-break before bothering the human. A clear pick routes; unsure → disambiguate.
+  if (decision.kind === 'disambiguate' && cfg.llm?.model) {
+    const pick = await llmTieBreak(os, text, decision.candidates, agents, cfg);
+    if (pick) {
+      const c = decision.candidates.find((x) => x.agentId === pick);
+      if (c) return { kind: 'route', agentId: c.agentId, score: c.score, runnerUp: decision.candidates.find((x) => x.agentId !== pick), method: 'llm' };
+    }
+  }
+  return decision;
+}
+
+async function tryEmbeddingBlend(
+  os: AgentOS,
+  text: string,
+  agents: AgentManifest[],
+  keyword: RouterCandidate[],
+): Promise<RouterCandidate[] | null> {
+  const emb = os.settings.memoryConfig()?.sqlite?.embeddings;
+  if (!emb) return null;
+  try {
+    const { Embedder } = await import('../memory/embedding');
+    const embedder = new Embedder(emb);
+    const qv = await embedder.embed(text);
+    if (!qv) return null;
+    const byId = new Map(keyword.map((c) => [c.agentId, c.score]));
+    const cos: { agentId: string; c: number }[] = [];
+    for (const a of agents) {
+      const av = await embedder.embed(agentProfile(a).slice(0, 2000));
+      cos.push({ agentId: a.id, c: av ? cosine(qv, av) : 0 });
+    }
+    const kn = minmax(agents.map((a) => byId.get(a.id) ?? 0));
+    const cn = minmax(cos.map((x) => x.c));
+    return agents
+      .map((a, i) => ({ agentId: a.id, score: (kn[i] + cn[i]) / 2 }))
+      .sort((x, y) => y.score - x.score);
+  } catch {
+    return null;
+  }
+}
+
+async function llmTieBreak(
+  os: AgentOS,
+  text: string,
+  candidates: RouterCandidate[],
+  agents: AgentManifest[],
+  cfg: RouterConfig,
+): Promise<string | null> {
+  const emb = os.settings.memoryConfig()?.sqlite?.embeddings;
+  const url = (cfg.llm?.url || emb?.url || '').replace(/\/$/, '');
+  const apiKey = cfg.llm?.apiKey || emb?.apiKey;
+  const model = cfg.llm?.model;
+  if (!url || !model) return null;
+  const roster = candidates
+    .map((c) => {
+      const a = agents.find((x) => x.id === c.agentId);
+      return `- ${c.agentId}: ${(a?.description || '').slice(0, 200)}`;
+    })
+    .join('\n');
+  const sys =
+    'You route an incoming message to exactly one agent. Reply with ONLY the agent id from the list, ' +
+    'or the single word UNSURE if none clearly fits. No punctuation, no explanation.';
+  const user = `Agents:\n${roster}\n\nMessage:\n${text.slice(0, 1500)}\n\nBest agent id:`;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 8000);
+  try {
+    const res = await fetch(`${url}/chat/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}) },
+      body: JSON.stringify({ model, temperature: 0, max_tokens: 24, messages: [{ role: 'system', content: sys }, { role: 'user', content: user }] }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { choices?: { message?: { content?: string } }[] };
+    const raw = (json.choices?.[0]?.message?.content || '').trim().replace(/[^A-Za-z0-9_-]/g, '');
+    const hit = candidates.find((c) => c.agentId === raw);
+    return hit ? hit.agentId : null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -227,7 +227,7 @@ export class SlackSocket {
       }
     }
 
-    const result = this.autos.fireSlack(
+    const result = await this.autos.fireSlack(
       {
         eventType: ev.eventType,
         channel: ev.channel,

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -10,7 +10,7 @@
  * so adding more instance-level settings later is just another key.
  */
 import { Db } from '../state/db';
-import { Branding, EnrichPattern, MemoryConfig, Recommendation, RuntimeTuning, sanitizeBranding, sanitizeRuntimeTuning } from '../types';
+import { Branding, EnrichPattern, MemoryConfig, Recommendation, RouterConfig, RuntimeTuning, sanitizeBranding, sanitizeRuntimeTuning } from '../types';
 
 const COMPANY_KEY = 'company_md';
 const COMPOSIO_KEY = 'composio_api_key';
@@ -67,6 +67,7 @@ export const DEFAULT_GOVERNANCE_THRESHOLDS: GovernanceThresholds = { moneyCapUsd
 
 const EMAIL_ORG_DOMAINS_KEY = 'email_org_domains'; // internal email domains (JSON string[]); email.send to these is green
 const CHAT_ROUTER_KEY = 'chat_router_enabled'; // generic Slack/Discord `/agent` router fallback ('off' disables)
+const ROUTER_CONFIG_KEY = 'router_config'; // auto-router tuning (JSON RouterConfig): enabled/minScore/margin/llm
 const CHAT_IDLE_MIN_KEY = 'chat_idle_timeout_min'; // resident (warm) chat session idle-kill, minutes
 const MAX_CONCURRENT_KEY = 'max_concurrent_sessions'; // whole-box concurrency cap override; unset → RAM-derived default, 0 → unlimited
 const INTERACTIVE_IDLE_HOURS_KEY = 'interactive_idle_timeout_hours'; // auto-close a detached member session idle past this; unset → 48h, 0 → off
@@ -737,6 +738,31 @@ export class SettingsStore {
   setChatRouterEnabled(on: boolean, by?: string): boolean {
     this.set(CHAT_ROUTER_KEY, on ? 'on' : 'off', by);
     return this.chatRouterEnabled();
+  }
+
+  /** Auto-router config: when an unaddressed chat/ticket message matches no automation and no explicit
+   *  `/agent` prefix, infer the best-fit agent (see src/edge/router.ts). Stored as JSON; `{}` when
+   *  unset → all defaults. `enabled` unset → follows the `/agent` chat-router switch above. */
+  routerConfig(): RouterConfig {
+    const raw = this.getRow(ROUTER_CONFIG_KEY)?.value;
+    if (!raw) return {};
+    try {
+      return JSON.parse(raw) as RouterConfig;
+    } catch {
+      return {};
+    }
+  }
+
+  setRouterConfig(cfg: RouterConfig, by?: string): RouterConfig {
+    this.set(ROUTER_CONFIG_KEY, JSON.stringify(cfg ?? {}), by);
+    return this.routerConfig();
+  }
+
+  /** Whether automatic agent-routing is on: explicit `router_config.enabled`, else it rides on the
+   *  `/agent` chat-router master switch (so the front door and its inference default on together). */
+  autoRouteEnabled(): boolean {
+    const c = this.routerConfig();
+    return c.enabled ?? this.chatRouterEnabled();
   }
 
   /** How long a resident (warm) Slack/Discord thread session is kept alive after its last turn before

--- a/src/types.ts
+++ b/src/types.ts
@@ -608,6 +608,27 @@ export interface LibsqlMemoryConfig {
 }
 
 /** An OpenAI-compatible or Ollama embeddings endpoint used to vectorize memory content + queries. */
+/**
+ * Auto-router tuning (Settings → Chat; stored as JSON under `router_config`). The router infers the
+ * best-fit agent for an unaddressed chat/ticket message — see src/edge/router.ts. All fields optional;
+ * sane defaults live in the router. A wrong SILENT route is the only bad outcome, so the thresholds
+ * govern when to route silently vs. ask the human to disambiguate.
+ */
+export interface RouterConfig {
+  /** Master switch. Unset → follows `chatRouterEnabled` (auto-route rides on the `/agent` front door).
+   *  Explicit `false` keeps the classic name-only router with no inference. */
+  enabled?: boolean;
+  /** Absolute floor a top candidate must clear to count as a match. Below it → help list. Default 0.5. */
+  minScore?: number;
+  /** Relative gap `(top-second)/top` the winner must clear to route SILENTLY. Below it → disambiguate.
+   *  Default 0.3. */
+  margin?: number;
+  /** Optional cheap chat model for the near-tie tie-break (OpenAI-compatible `/chat/completions`).
+   *  `url`/`apiKey` default to the configured memory embedder's endpoint when omitted. No model → no
+   *  LLM tie-break (near-ties just disambiguate). */
+  llm?: { model: string; url?: string; apiKey?: string };
+}
+
 export interface EmbeddingsConfig {
   /** 'openai' (OpenAI-compatible `/v1/embeddings`) or 'ollama' (local `/api/embed`). Default 'openai'. */
   provider?: 'openai' | 'ollama';


### PR DESCRIPTION
## What

Adds an **automatic agent router**: an unaddressed chat/ticket message reaches the right agent without anyone naming one. The `/agent` router already made the fleet reachable, but only via an explicit `/name` prefix — otherwise you got a help list. Now `chooseAgent` (`src/edge/router.ts`) infers the best-fit claude-code agent from the message itself. Useful for Slack, Discord, and — via the same shared front door — support-ticket triage.

## How it decides

- **Deterministic first** — idf-weighted token overlap over each agent's `id + description + examplePrompts`. Rare-to-the-fleet terms ("billing", "kubernetes") discriminate; fleet-common terms contribute ~0. Pure + unit-testable.
- **Embedding blend** (opt-in) — when a Settings → Memory embedder is configured, cosine(message, agent-profile) is min-max blended with the keyword score.
- **LLM tie-break** (opt-in) — on a near-tie, a cheap OpenAI-compatible `/chat/completions` call picks the winner (endpoint/key default to the memory embedder's). Absent/unsure → disambiguate.

## Fails safe

| Situation | Behavior |
|---|---|
| Clear winner (score ≥ floor, margin met) | route silently |
| Near-tie / weak match | **ask the human to disambiguate** ("reply with a number") |
| Nothing scored | fall back to the classic `/agent` help list |
| Explicit `/name` | short-circuits inference (unchanged) |

Disambiguation is stateful per thread (in-memory shortlist keyed by channel+thread; the reply routes the **original** request to the choice). A wrong *silent* route is the only bad outcome and it's gated behind a score margin.

## Governance

Routing carries **no privilege** — it only picks an id; the spawn stays fully governed (provenance `chat:<agent>`, run-as the sender, gate hook). Every route is audited `chat.routed` with `routedBy` (`explicit`/`auto`/`auto-llm`/`auto-disambiguated`) + score + runner-up, so mis-routes are measurable.

## Wiring

Shared `routeUnmatched` handler used by both `fireSlack`/`fireDiscord` (previously duplicated router blocks). Config: `router_config` (JSON `RouterConfig` — `enabled`/`minScore`/`margin`/`llm`); `autoRouteEnabled()` defaults on, riding the `/agent` chat-router master switch.

Files: `src/edge/router.ts` (new), `src/edge/automations.ts`, `src/edge/slack-socket.ts`, `src/edge/discord-socket.ts`, `src/governance/settings.ts`, `src/types.ts`.

## Verification

- `npm run typecheck` + `npm run build` clean
- `npm run test:governance` → 68/68 ✓
- Deterministic scoring driven over a realistic 4-agent fleet: clear intents route correctly; "site is slow AND change my billing plan" → disambiguate; "hello there" → help list.

## Follow-ups (not in this PR)

- Settings → Chat UI toggle + threshold sliders (config exists; no console surface yet)
- Web console spawn-box "auto-pick" affordance
- Feed `chat.routed` mis-route signal into Insights re-ranking

🤖 Generated with [Claude Code](https://claude.com/claude-code)