### PR TITLE
fix(memory): truncate long content to fit automem's 2000-char limit (v0.251.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.251.0] — 2026-07-21
+## [0.251.1] — 2026-07-21
+### Fixed
+- **Long memories are no longer silently dropped by the automem backend.** automem hard-rejects any
+  content over 2000 chars (`POST /memory → 400 "Content exceeds maximum length"`), and end-of-session
+  **episodes** routinely run longer (3–9k chars) — so the store THREW and the memory was lost from BOTH
+  automem AND the local mirror (the mirror only copies a record the backend *returns*). A 7-day fleet
+  review found this dropping **22–46% of episodes** (instawp 141/165 = 46%), starving the self-learning
+  loop of its richest input. The automem provider now **truncates content to fit** (1980-char cap + a
+  `… [truncated]` marker) on both `store` and `update`, and returns the fitted content so the local
+  mirror matches what the backend holds. Memory is truncated-and-kept, never rejected-and-lost.
 ### Added
 - **Automatic agent routing — a chat/ticket message reaches the right agent without anyone naming one.**
   The `/agent` chat router already made the whole fleet reachable, but only if the sender knew the agent and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.251.0",
+  "version": "0.251.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.251.0",
+      "version": "0.251.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.251.0",
+  "version": "0.251.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/automem-provider.ts
+++ b/src/memory/automem-provider.ts
@@ -20,6 +20,16 @@
 import { DeleteInput, MemoryProvider, MemoryRecord, MemoryScope, RecallQuery, StoreInput, UpdateInput } from '../types';
 
 const TIMEOUT_MS = 8000;
+// automem hard-rejects content over 2000 chars (`POST /memory → 400 "Content exceeds maximum length"`).
+// Episodes (end-of-session recaps) routinely run longer — 3-9k chars — so without this cap the store
+// THROWS and the memory is lost from BOTH automem and the local mirror (the mirror only copies a record
+// the backend RETURNED). Truncate to fit with a marker so the memory survives (head-kept: the task /
+// outcome / summary lead an episode; the tail is event detail). A small margin under 2000 absorbs any
+// server-side counting difference.
+const MAX_CONTENT = 1980;
+function fitContent(content: string): string {
+  return content.length <= MAX_CONTENT ? content : content.slice(0, MAX_CONTENT - 15).trimEnd() + '\n… [truncated]';
+}
 /** Marks a tenant-shared memory in the single collection: recall for `scope:'tenant'` matches on it. */
 const SHARED_TAG = 'scope:tenant';
 
@@ -44,8 +54,11 @@ export class AutomemMemoryProvider implements MemoryProvider {
     const tags = [...(input.tags ?? []), ...this.ns(input.agentId, input.tenant)];
     if (scope === 'tenant') tags.push(SHARED_TAG);
     const ts = Date.now();
+    // Fit the backend's length limit so a long memory is truncated-and-kept, never rejected-and-lost.
+    // Store the SAME fitted content on the returned record so the local mirror matches what automem holds.
+    const content = fitContent(input.content);
     const body = {
-      content: input.content,
+      content,
       tags,
       type: input.type,
       importance: input.importance,
@@ -57,7 +70,7 @@ export class AutomemMemoryProvider implements MemoryProvider {
       id: String((res as { memory_id?: string }).memory_id ?? ''),
       tenant: input.tenant,
       agentId: input.agentId,
-      content: input.content,
+      content,
       tags,
       type: input.type,
       importance: input.importance,
@@ -123,7 +136,7 @@ export class AutomemMemoryProvider implements MemoryProvider {
     const existing = await this.fetchOwned(input.id, input.agentId, input.tenant, input.admin);
     if (!existing) return null;
     const body: Record<string, unknown> = {};
-    if (input.content !== undefined) body.content = input.content;
+    if (input.content !== undefined) body.content = fitContent(input.content);
     if (input.type !== undefined) body.type = input.type;
     if (input.importance !== undefined) body.importance = input.importance;
     if (input.tags !== undefined) {
@@ -136,7 +149,7 @@ export class AutomemMemoryProvider implements MemoryProvider {
     if (Object.keys(body).length) await this.req('PATCH', `/memory/${input.id}`, undefined, body);
     return {
       ...existing,
-      content: input.content ?? existing.content,
+      content: input.content !== undefined ? fitContent(input.content) : existing.content,
       tags: (body.tags as string[] | undefined) ?? existing.tags,
       type: input.type ?? existing.type,
       importance: input.importance ?? existing.importance,


### PR DESCRIPTION
## From the 7-day fleet review — the top new finding

The memory backend on all three tenants is **automem**, which hard-rejects any content over 2000 chars (`POST /memory → 400 "Content exceeds maximum length"`). End-of-session **episodes** (the self-learning loop's richest input) routinely run longer — 2,699 / 3,927 / **9,341** chars observed. Because the mirror stores **backend-first** (`await backend.store()` *then* copy the returned record into the local `memories` table), a rejected episode is lost from **both** stores.

Measured over 7 days:

| tenant | stored | dropped (`episode.error`) | loss |
|---|---|---|---|
| instawp | 165 | **141** | **46%** |
| expresstech | 42 | 17 | 29% |
| instapods | 57 | 16 | 22% |

The **longest** episodes (most signal) are exactly the ones lost — quietly starving Dreaming/consolidation.

### Fix
The automem provider now **truncates content to fit** its limit (1980-char cap + a `… [truncated]` marker) on both `store` and `update`, and returns the **fitted** content so the local mirror matches what the backend holds. Head-kept (an episode leads with task / outcome / summary; the tail is event detail). Memory is **truncated-and-kept, never rejected-and-lost**. Localized to `src/memory/automem-provider.ts`; other backends (sqlite/libsql have no such limit) are untouched.

### Verification
- `npm run typecheck` ✓ · `npm run test:governance` → **68/68** ✓ · `npm run demo` ✓
- Fetch-stub harness on built `dist`: `store()` with the real failing sizes (1500 / 2699 / 3927 / 9341) → the POST body is **≤2000** in every over-limit case, ends with the marker, and the returned record's content **equals what was sent** (so the mirror stays consistent); 1500-char content passes through unchanged. ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)