### PR TITLE
fix(agents): deep-link agent.update.proposed card + surface review at top (v0.251.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.251.2] — 2026-07-21
+### Fixed
+- **`agent.update.proposed` inbox card now deep-links to the target agent's page, and its review card
+  sits at the top of that page.** Following v0.250.0, an owner who got the "proposed an edit to X" inbox
+  notification had no way to reach the review UI — clicking the card fell through to the proposer's
+  session terminal, and even on the right page the "Proposed edits from other agents" card was buried
+  below the tuning + CLAUDE.md editor. The inbox card now routes to `#/agent/<target>` (click and
+  new-tab both), and the proposals card renders at the **top** of the agent page (mirroring the
+  PolicyEditor's atop-the-editor review queue), so the deep-link lands the owner right on the pending
+  approval. `web/src/App.tsx`.
+
 ## [0.251.1] — 2026-07-21
 ### Fixed
 - **Long memories are no longer silently dropped by the automem backend.** automem hard-rejects any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.251.1",
+  "version": "0.251.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.251.1",
+      "version": "0.251.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.251.1",
+  "version": "0.251.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4380,16 +4380,19 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
  *  gallery); the timestamp swaps to a dismiss button on hover. */
 function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenGoal, onDismiss, unread }: { m: Msg; members?: Member[]; onOpen: (tmux: string, title: string) => void; onOpenArtifact?: (id: string) => void; onOpenTask?: (id: string) => void; onOpenGoal?: (id: string) => void; onDismiss?: (id: string) => void; unread?: boolean }) {
   const open = () => onOpen('aos-' + m.sessionId, m.agent + ' · ' + m.sessionId)
-  const meta = (m.args ?? {}) as { artifactId?: string; filename?: string; taskId?: string; goalId?: string; event?: string }
+  const meta = (m.args ?? {}) as { artifactId?: string; filename?: string; taskId?: string; goalId?: string; event?: string; target?: string }
   const goArtifact = m.type === 'artifact' && meta.artifactId && onOpenArtifact ? () => onOpenArtifact(meta.artifactId!) : null
   // A 'task' card has no session — it deep-links to the board (its taskId), not a terminal.
   const goTask = m.type === 'task' && meta.taskId && onOpenTask ? () => onOpenTask(meta.taskId!) : null
   // A 'goal.proposed' card deep-links to the Goals page for that goal (no session).
   const goGoal = m.type === 'goal.proposed' && meta.goalId && onOpenGoal ? () => onOpenGoal(meta.goalId!) : null
-  const rowAction = goArtifact ?? goTask ?? goGoal ?? open
+  // An 'agent.update.proposed' card deep-links to the TARGET agent's page, where the owner review
+  // card lives — not the proposer's session terminal. Hash routing, so setting the hash routes in place.
+  const goAgentEdit = m.type === 'agent.update.proposed' && meta.target ? () => { window.location.hash = navHref('agent', meta.target!) } : null
+  const rowAction = goArtifact ?? goTask ?? goGoal ?? goAgentEdit ?? open
   // The new-tab target mirrors the click action — each deep-links fully (artifact by id, task by
-  // id, goal by id, else the session terminal).
-  const rowHref = goArtifact ? navHref('artifacts', meta.artifactId!) : goTask ? navHref('tasks', meta.taskId!) : goGoal ? navHref('goals', meta.goalId!) : navHref('sessions', 'aos-' + m.sessionId)
+  // id, goal by id, agent edit by target, else the session terminal).
+  const rowHref = goArtifact ? navHref('artifacts', meta.artifactId!) : goTask ? navHref('tasks', meta.taskId!) : goGoal ? navHref('goals', meta.goalId!) : goAgentEdit ? navHref('agent', meta.target!) : navHref('sessions', 'aos-' + m.sessionId)
 
   let Icon = Clock
   let iconCls = 'text-muted-foreground'
@@ -9541,6 +9544,9 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
           </Button>
         )}
       </div>
+      {/* Pending cross-agent edit proposals sit at the TOP so an owner arriving from the inbox deep-link
+          sees the review queue first (mirrors the PolicyEditor's atop-the-editor review pattern). */}
+      {info?.runtime === 'claude-code' && <AgentUpdateProposalsCard agentId={agentId} onApplied={() => { setRevBump((n) => n + 1); onSaved?.() }} />}
       <p className="text-sm text-muted-foreground">
         <span className="font-medium text-foreground">{agentId}</span>
         {info && <RuntimeBadge runtime={info.runtime} />} — this agent's <span className="font-mono text-xs">CLAUDE.md</span> is its
@@ -9569,7 +9575,6 @@ function AgentPage({ agentId, agents, onSaved }: { agentId: string; agents: Agen
           )}
         </CardContent>
       </Card>
-      {info?.runtime === 'claude-code' && <AgentUpdateProposalsCard agentId={agentId} onApplied={() => { setRevBump((n) => n + 1); onSaved?.() }} />}
       {info?.runtime === 'claude-code' && <AgentRevisionsCard agentId={agentId} onReverted={() => { setRevBump((n) => n + 1); onSaved?.() }} />}
     </div>
   )


### PR DESCRIPTION
Follow-up to #418 (agent_propose_update), from live dogfooding on instapods.

**Problem (reported after shipping v0.250.0):** an owner who got the "proposed an edit to X" inbox notification couldn't reach the review UI — clicking the card fell through to the *proposer's* session terminal, and even on the correct agent page the "Proposed edits from other agents" card was buried below the tuning + CLAUDE.md editor.

**Fix (`web/src/App.tsx`, web-only):**
- Inbox `agent.update.proposed` card now deep-links to `#/agent/<target>` — both plain click (hash routing in place) and new-tab (`rowHref`), instead of the proposer session terminal.
- The `AgentUpdateProposalsCard` moves to the **top** of the agent page (mirrors the PolicyEditor's atop-the-editor review queue), so the deep-link lands the owner directly on the pending approval.

**Verified live end-to-end** before this fix: relaunched a `researcher` session → it called `agent_propose_update` targeting a scratch agent → owner-addressed card → owner approved → applied, rev 2 recorded (`proposed by researcher, approved by owner@localhost`). The only gap was navigation, addressed here.

web build + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)