### PR TITLE
feat(review): fleet-wide code-review policy + bundle glm-review (v0.252.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.252.0] — 2026-07-21
+### Added
+- **Code review policy — a first-class, fleet-wide steer for how agents review a diff/PR.** Settings →
+  Company now has a dedicated **Code review policy** document (its own `code_review_md` setting +
+  `PUT /api/settings/review`), injected into every claude-code agent's prompt as its own section by
+  `buildCompanyMd`. Left blank, it emits a **built-in default**: prefer a cheap cross-model second
+  opinion (the `glm-review` skill, named concretely only when the workspace has it installed) and
+  **never** trigger a paid/cloud-billed review such as `/code-review ultra` on the agent's own
+  initiative — a free local review is the default. The steer rides the prompt, so it reaches existing
+  tenants immediately (no tenant re-seed). Owners can override the default with their own standard.
+- **`glm-review` is now a bundled skill.** The fast cross-model (z.ai GLM) diff/PR review previously
+  living only in the instawp tenant ships in the software's skill catalog (`config/skills/glm-review`),
+  so every tenant can one-click install it from Skills. Requires `ZAI_API_KEY` in the agent's shell
+  (assign it in Settings → Secrets).
+
 ## [0.251.1] — 2026-07-21
 ### Fixed
 - **Long memories are no longer silently dropped by the automem backend.** automem hard-rejects any

--- a/config/skills/glm-review/SKILL.md
+++ b/config/skills/glm-review/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: glm-review
+description: Get a fast CROSS-MODEL code review of the current git diff (or a GitHub PR) from z.ai's GLM model — an independent second opinion alongside your primary reviewer. Use before opening or merging a PR, when the user asks to "review with GLM / z.ai / a different model", or to sanity-check a Claude review. Requires ZAI_API_KEY in the environment.
+license: MIT
+---
+
+# GLM code review
+
+A fast, **one-shot cross-model** review of a code diff using z.ai's GLM models (via their
+Anthropic-compatible API) — a cheap second opinion that catches what a single reviewer misses.
+Different model, different blind spots: agreement across models raises confidence; disagreement
+flags a spot worth a closer look.
+
+It reviews the diff of the **current git repo**, so run it from inside the checkout you're working in.
+
+## Requirements
+- **`ZAI_API_KEY`** in the environment (a z.ai API key). Without it the tool exits with a clear error.
+- `curl` + `jq` on PATH; `gh` only for `--pr`.
+- Optional: `ZAI_ANTHROPIC_URL` to point at a different Anthropic-compatible base (default `https://api.z.ai/api/anthropic`).
+
+## Use it
+Run the bundled script from your repo:
+
+```bash
+bash .claude/skills/glm-review/glm-review.sh              # review uncommitted changes (git diff HEAD)
+bash .claude/skills/glm-review/glm-review.sh --staged     # staged changes
+bash .claude/skills/glm-review/glm-review.sh --base main  # main...HEAD (your feature branch)
+bash .claude/skills/glm-review/glm-review.sh --pr 2310    # a GitHub PR (needs gh)
+bash .claude/skills/glm-review/glm-review.sh --model glm-5.2   # pick a model (default: glm-4.6)
+bash .claude/skills/glm-review/glm-review.sh --json       # raw API JSON instead of just the text
+```
+
+It prints GLM's review — concrete bugs, security issues, missed edge-cases/callers, and clear
+simplifications, most-severe first with `file:line` + a one-line fix (or "no blocking issues").
+
+## How to use the result
+Treat it as a **second opinion, not a verdict**: verify each point against the code before acting.
+It pairs well with a primary review (e.g. the host's own `/code-review`) — run both and reconcile.
+The gateway still governs any change you make as a result; this skill only reads a diff and calls an API.

--- a/config/skills/glm-review/glm-review.sh
+++ b/config/skills/glm-review/glm-review.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# glm-review.sh — a fast, one-shot CROSS-MODEL code review using z.ai's GLM models
+# (via their Anthropic-compatible API). An independent second opinion alongside your
+# primary reviewer. Reviews a diff from the CURRENT git repo — run it from inside the
+# checkout you're working in.
+#
+# Requires: $ZAI_API_KEY in the environment (z.ai API key); `curl` + `jq`; `gh` only for --pr.
+#
+# Usage:
+#   glm-review.sh                  # review uncommitted changes (git diff HEAD)
+#   glm-review.sh --staged         # review staged changes
+#   glm-review.sh --base <branch>  # review <branch>...HEAD (e.g. your feature branch vs main)
+#   glm-review.sh --pr <N>         # review a GitHub PR (needs gh)
+#   glm-review.sh --model <name>   # override model (default: glm-4.6; e.g. glm-5.2, glm-4.7)
+#   glm-review.sh --json           # print the raw API JSON instead of just the review text
+set -euo pipefail
+
+MODEL="glm-4.6"; MODE="uncommitted"; BASE=""; PR=""; JSON=0
+ENDPOINT="${ZAI_ANTHROPIC_URL:-https://api.z.ai/api/anthropic}/v1/messages"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --staged)  MODE="staged"; shift ;;
+    --base)    MODE="base"; BASE="${2:?--base needs a branch}"; shift 2 ;;
+    --pr)      MODE="pr"; PR="${2:?--pr needs a number}"; shift 2 ;;
+    --model)   MODEL="${2:?--model needs a name}"; shift 2 ;;
+    --json)    JSON=1; shift ;;
+    -h|--help) sed -n '2,14p' "$0"; exit 0 ;;
+    *) echo "unknown arg: $1 (see --help)" >&2; exit 2 ;;
+  esac
+done
+
+: "${ZAI_API_KEY:?set ZAI_API_KEY (z.ai API key) in the environment}"
+command -v jq   >/dev/null || { echo "glm-review needs jq" >&2; exit 3; }
+command -v curl >/dev/null || { echo "glm-review needs curl" >&2; exit 3; }
+
+case "$MODE" in
+  uncommitted) DIFF="$(git diff HEAD)" ;;
+  staged)      DIFF="$(git diff --staged)" ;;
+  base)        DIFF="$(git diff "${BASE}...HEAD")" ;;
+  pr)          command -v gh >/dev/null || { echo "glm-review --pr needs gh" >&2; exit 3; }
+               DIFF="$(gh pr diff "$PR")" ;;
+esac
+
+# Nothing to review?
+if [ -z "${DIFF//[$'\t\r\n ']}" ]; then echo "glm-review: no diff to review (mode=$MODE)"; exit 0; fi
+# Cap the diff so a huge changeset still fits the request.
+DIFF="$(printf '%s' "$DIFF" | head -c 120000)"
+
+SYS='You are a senior code reviewer giving a fast, cross-model second opinion. Review ONLY the provided diff. Report concrete correctness bugs, security issues, missed edge cases / callers, and clear simplifications — most-severe first, each with a file:line and a one-line fix. Be terse; skip praise. If the diff is clean, say "no blocking issues".'
+
+REQ="$(jq -n --arg m "$MODEL" --arg s "$SYS" --arg d "Review this diff:"$'\n\n'"$DIFF" \
+  '{model:$m, max_tokens:2048, system:$s, messages:[{role:"user", content:$d}]}')"
+
+RESP="$(curl -sS --max-time 180 "$ENDPOINT" \
+  -H "x-api-key: ${ZAI_API_KEY}" -H "anthropic-version: 2023-06-01" -H "content-type: application/json" \
+  -d "$REQ")"
+
+if [ "$JSON" = 1 ]; then echo "$RESP"; exit 0; fi
+echo "── GLM review (${MODEL}) ─────────────────────────────────────────"
+echo "$RESP" | jq -r '.content[0].text // .error.message // ("unexpected response: " + (.|tostring))'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.251.1",
+  "version": "0.252.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.251.1",
+      "version": "0.252.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.251.1",
+  "version": "0.252.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -13,6 +13,7 @@ import { Db } from '../state/db';
 import { Branding, EnrichPattern, MemoryConfig, Recommendation, RouterConfig, RuntimeTuning, sanitizeBranding, sanitizeRuntimeTuning } from '../types';
 
 const COMPANY_KEY = 'company_md';
+const REVIEW_KEY = 'code_review_md'; // the fleet-wide code-review policy (how agents review a diff/PR)
 const COMPOSIO_KEY = 'composio_api_key';
 const COMPOSIO_WEBHOOK_KEY = 'composio_webhook_secret';
 const SLACK_APP_TOKEN_KEY = 'slack_app_token'; // xapp-… (Socket Mode, connections:write)
@@ -85,8 +86,18 @@ export interface KillSwitchState {
 export interface CompanySettings {
   /** The company-wide markdown context. Empty string when unset. */
   companyMd: string;
+  /**
+   * The fleet-wide **code-review policy** — how agents should review a diff / PR (which tool, cost
+   * posture, what to check). Empty string when unset; `buildCompanyMd` then injects a sensible default
+   * instead. A separate document from `companyMd` so it can carry its own guidance without bloating the
+   * general context, and be edited/cleared independently.
+   */
+  reviewMd: string;
   updatedAt?: number;
   updatedBy?: string;
+  /** Last-touched metadata for the review policy specifically (independent of the company doc). */
+  reviewUpdatedAt?: number;
+  reviewUpdatedBy?: string;
 }
 
 interface SettingRow {
@@ -111,14 +122,28 @@ export class SettingsStore {
       .run(key, value, Date.now(), by ?? null);
   }
 
-  /** The Company context document + who last touched it. */
+  /** The Company context document + the code-review policy + who last touched each. */
   company(): CompanySettings {
     const row = this.getRow(COMPANY_KEY);
-    return { companyMd: row?.value ?? '', updatedAt: row?.updated_at, updatedBy: row?.updated_by ?? undefined };
+    const review = this.getRow(REVIEW_KEY);
+    return {
+      companyMd: row?.value ?? '',
+      updatedAt: row?.updated_at,
+      updatedBy: row?.updated_by ?? undefined,
+      reviewMd: review?.value ?? '',
+      reviewUpdatedAt: review?.updated_at,
+      reviewUpdatedBy: review?.updated_by ?? undefined,
+    };
   }
 
   setCompany(md: string, by?: string): CompanySettings {
     this.set(COMPANY_KEY, md, by);
+    return this.company();
+  }
+
+  /** The fleet-wide code-review policy ('' = fall back to the built-in default in `buildCompanyMd`). */
+  setReview(md: string, by?: string): CompanySettings {
+    this.set(REVIEW_KEY, md, by);
     return this.company();
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -3952,6 +3952,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const updated = os.settings.setCompany(String(b.companyMd ?? ''), me.email);
     return sendJson(res, 200, { ok: true, ...updated });
   }
+  if (method === 'PUT' && p === '/api/settings/review') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req);
+    const updated = os.settings.setReview(String(b.reviewMd ?? ''), me.email);
+    return sendJson(res, 200, { ok: true, ...updated });
+  }
 
   // ── integration credentials (Composio now; Slack app etc. later) — instance-wide secrets ──
   if (method === 'GET' && p === '/api/settings/integrations') {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2208,7 +2208,36 @@ export class TerminalManager {
             .join('\n');
       }
     }
-    return [company, memberCtx, AGENT_OS_OPERATING_NOTES, messaging, github, goalsSection, fleet, team, preamble, learned]
+    // Code-review steer — the fleet-wide policy for how an agent reviews a diff / PR before it opens or
+    // merges one. Owner-editable in Settings → Company; when unset we inject a sensible DEFAULT so it's a
+    // real standard from day one (existing tenants included — it rides the prompt, not a tenant seed). The
+    // default steers toward a cheap cross-model second opinion and explicitly AWAY from any paid/cloud
+    // review, and only names the `glm-review` skill concretely when this workspace actually has it
+    // installed (so the guidance never dangles where it isn't).
+    const customReview = this.os.settings.company().reviewMd.trim();
+    let codeReview = '';
+    if (customReview) {
+      codeReview = `# Code review — how this workspace reviews changes\n\n${customReview}`;
+    } else {
+      const hasGlm = (() => {
+        try { return !!this.os.skills.get('glm-review'); } catch { return false; }
+      })();
+      const secondOpinion = hasGlm
+        ? 'run the **`glm-review`** skill for a fast cross-model second opinion (a cheap, independent ' +
+          'reviewer that catches what one model misses), then reconcile its points against the code'
+        : 'get a second opinion from a cheaper/independent reviewer where one is available, then reconcile ' +
+          'its points against the code';
+      codeReview =
+        '# Code review — how this workspace reviews changes\n\n' +
+        'Before you open or merge a pull request, review your own diff. ' +
+        `First, ${secondOpinion}. ` +
+        'Do NOT trigger a paid or cloud-billed review (e.g. `/code-review ultra`) on your own initiative — ' +
+        'it costs money and a human decides when it is worth it. A local review (the host\'s own ' +
+        '`/code-review` with no argument, or a cross-model pass) is free and is the default. Treat any ' +
+        'review as a second opinion, not a verdict: verify each point against the code before acting, and ' +
+        'remember every change you make still passes through the gateway.';
+    }
+    return [company, memberCtx, AGENT_OS_OPERATING_NOTES, messaging, github, codeReview, goalsSection, fleet, team, preamble, learned]
       .filter(Boolean)
       .join('\n\n');
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13632,11 +13632,19 @@ function CompanySettings({ me }: { me: Member }) {
   const [meta, setMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
+  // Code-review policy — a separate document from the company context, injected into every agent's
+  // prompt. Blank = the built-in default (steer to a cheap cross-model review, never the paid cloud one).
+  const [review, setReview] = useState('')
+  const [reviewSaved, setReviewSaved] = useState('')
+  const [reviewMeta, setReviewMeta] = useState<{ updatedAt?: number; updatedBy?: string }>({})
+  const [reviewBusy, setReviewBusy] = useState(false)
+  const [reviewHint, setReviewHint] = useState('')
 
   useEffect(() => {
     api.settings().then((s) => {
       if (s.error) return setHint('⚠ ' + s.error)
       setMd(s.companyMd ?? ''); setSaved(s.companyMd ?? ''); setMeta({ updatedAt: s.updatedAt, updatedBy: s.updatedBy })
+      setReview(s.reviewMd ?? ''); setReviewSaved(s.reviewMd ?? ''); setReviewMeta({ updatedAt: s.reviewUpdatedAt, updatedBy: s.reviewUpdatedBy })
     }).catch(() => {})
   }, [])
 
@@ -13650,39 +13658,88 @@ function CompanySettings({ me }: { me: Member }) {
     setTimeout(() => setHint(''), 1500)
   }
 
+  const reviewDirty = review !== reviewSaved
+  const saveReview = async () => {
+    setReviewBusy(true); setReviewHint('')
+    const r = await api.saveReview(review)
+    setReviewBusy(false)
+    if (r.error) return setReviewHint('⚠ ' + r.error)
+    setReviewSaved(review); setReviewMeta({ updatedAt: r.reviewUpdatedAt, updatedBy: r.reviewUpdatedBy }); setReviewHint('saved')
+    setTimeout(() => setReviewHint(''), 1500)
+  }
+
   if (!isAdmin) return <div className="text-sm text-muted-foreground">Owner or admin access required.</div>
 
   return (
-    <div className="max-w-3xl space-y-4">
-      <p className="text-sm text-muted-foreground">
-        The <strong>Company context</strong> is one shared document — voice, facts, conventions, links, how this
-        workspace works — appended to the system prompt of <strong>every claude-code agent</strong> you spawn. Edit it
-        once here instead of repeating it in each agent's CLAUDE.md. (Leave it blank to inject nothing.)
-      </p>
+    <div className="max-w-3xl space-y-6">
+      <div className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          The <strong>Company context</strong> is one shared document — voice, facts, conventions, links, how this
+          workspace works — appended to the system prompt of <strong>every claude-code agent</strong> you spawn. Edit it
+          once here instead of repeating it in each agent's CLAUDE.md. (Leave it blank to inject nothing.)
+        </p>
 
-      <Card>
-        <CardContent className="space-y-3 p-4">
-          <Field label="Company context (markdown)">
-            <Textarea
-              value={md}
-              onChange={(e) => setMd(e.target.value)}
-              className="min-h-[320px] font-mono text-xs leading-relaxed"
-              placeholder={'# Acme Inc.\n\n## Voice\nConcise, friendly, no emoji in customer-facing copy.\n\n## Facts\n- Support hours: 9–5 ET, Mon–Fri\n- Billing runs on Stripe\n\n## Conventions\n- Recall relevant context before non-trivial work; remember durable decisions, fixes, and gotchas.'}
-            />
-          </Field>
-          <div className="flex items-center gap-3">
-            <Button onClick={save} disabled={busy || !dirty}>
-              {dirty ? 'Save' : 'Saved'}
-            </Button>
-            {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
-            {meta.updatedAt && (
-              <span className="ml-auto text-[11px] text-muted-foreground">
-                last updated {new Date(meta.updatedAt).toLocaleString()}{meta.updatedBy ? ` by ${meta.updatedBy}` : ''}
-              </span>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+        <Card>
+          <CardContent className="space-y-3 p-4">
+            <Field label="Company context (markdown)">
+              <Textarea
+                value={md}
+                onChange={(e) => setMd(e.target.value)}
+                className="min-h-[320px] font-mono text-xs leading-relaxed"
+                placeholder={'# Acme Inc.\n\n## Voice\nConcise, friendly, no emoji in customer-facing copy.\n\n## Facts\n- Support hours: 9–5 ET, Mon–Fri\n- Billing runs on Stripe\n\n## Conventions\n- Recall relevant context before non-trivial work; remember durable decisions, fixes, and gotchas.'}
+              />
+            </Field>
+            <div className="flex items-center gap-3">
+              <Button onClick={save} disabled={busy || !dirty}>
+                {dirty ? 'Save' : 'Saved'}
+              </Button>
+              {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
+              {meta.updatedAt && (
+                <span className="ml-auto text-[11px] text-muted-foreground">
+                  last updated {new Date(meta.updatedAt).toLocaleString()}{meta.updatedBy ? ` by ${meta.updatedBy}` : ''}
+                </span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <h3 className="text-sm font-semibold">Code review policy</h3>
+          <p className="mt-1 text-sm text-muted-foreground">
+            How the fleet reviews a diff or PR — injected into every agent's prompt as its own steer.
+            <strong> Leave it blank</strong> and agents get the built-in default: prefer a cheap cross-model
+            second opinion (the <code>glm-review</code> skill when installed) and <strong>never</strong> trigger a
+            paid/cloud review like <code>/code-review ultra</code> on their own. Override it here to set your own
+            standard.
+          </p>
+        </div>
+
+        <Card>
+          <CardContent className="space-y-3 p-4">
+            <Field label="Code review policy (markdown)">
+              <Textarea
+                value={review}
+                onChange={(e) => setReview(e.target.value)}
+                className="min-h-[220px] font-mono text-xs leading-relaxed"
+                placeholder={'# Code review\n\nBefore opening or merging a PR:\n- Run the `glm-review` skill for a cross-model second opinion, then reconcile.\n- Do NOT run a paid/cloud review (e.g. `/code-review ultra`) unless a human asks.\n- Treat any review as a second opinion, not a verdict — verify each point against the code.'}
+              />
+            </Field>
+            <div className="flex items-center gap-3">
+              <Button onClick={saveReview} disabled={reviewBusy || !reviewDirty}>
+                {reviewDirty ? 'Save' : 'Saved'}
+              </Button>
+              {reviewHint && <span className="font-mono text-xs text-muted-foreground">{reviewHint}</span>}
+              {reviewMeta.updatedAt && (
+                <span className="ml-auto text-[11px] text-muted-foreground">
+                  last updated {new Date(reviewMeta.updatedAt).toLocaleString()}{reviewMeta.updatedBy ? ` by ${reviewMeta.updatedBy}` : ''}
+                </span>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -948,6 +948,9 @@ export interface CompanySettings {
   companyMd: string
   updatedAt?: number
   updatedBy?: string
+  reviewMd: string
+  reviewUpdatedAt?: number
+  reviewUpdatedBy?: string
   error?: string
 }
 
@@ -1434,6 +1437,7 @@ export const api = {
 
   settings: () => call<CompanySettings>('GET', '/api/settings'),
   saveCompany: (companyMd: string) => call<CompanySettings & { ok: boolean; error?: string }>('PUT', '/api/settings/company', { companyMd }),
+  saveReview: (reviewMd: string) => call<CompanySettings & { ok: boolean; error?: string }>('PUT', '/api/settings/review', { reviewMd }),
   connections: () => call<ConnectionsResp>('GET', '/api/connections'),
   integrationsOverview: () => call<IntegrationsOverview>('GET', '/api/integrations/overview'),
   composioToolkits: () => call<{ toolkits: { slug: string; name: string }[]; error?: string }>('GET', '/api/composio/toolkits'),


### PR DESCRIPTION
## Why
Claude keeps nudging toward `/code-review ultra` (a paid cloud review) after a PR. This makes the *cheap* path the fleet standard and puts PR-review guidance where it belongs — company context — instead of relying on each agent (or each owner) to remember it.

## What
**1. New "Code review policy" Settings field (Settings → Company).**
- Own setting `code_review_md` + `PUT /api/settings/review`; `GET /api/settings` now also returns `reviewMd` (+ its own last-updated metadata).
- `buildCompanyMd` injects it into **every** claude-code agent's prompt as a dedicated section.
- **Blank ⇒ built-in default:** steer to a cheap cross-model second opinion (names the `glm-review` skill concretely *only* when the workspace has it installed, so it never dangles) and **never** trigger a paid/cloud review like `/code-review ultra` on the agent's own initiative — a free local review is the default. Owners can override with their own standard.
- Reaches **existing tenants immediately** — it rides the prompt, not a tenant seed (dodges the known "default rules don't reach existing tenants" trap).

**2. `glm-review` bundled repo-wide.** Promoted from an instawp-tenant-local skill to the software catalog (`config/skills/glm-review`), so every tenant can one-click install it from Skills. (Needs `ZAI_API_KEY` in the agent's shell — assign in Settings → Secrets.)

## Verify
- `npm run typecheck` ✓, `cd web && npm run build` ✓, `npm run test:governance` → 68/68 ✓
- In-process test on an isolated home: `reviewMd` present in the settings shape, set/read-back with attribution works, company doc untouched, `glm-review` appears in the bundled catalog.

## Note
Server + web changes → needs a build + server restart to take effect on a running instance; the MCP tool list is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PX3EPzxB13gehNcfsU3Hnk