### PR TITLE
fix(chat): router semantic matching on any memory backend; confident routes stop collapsing to ask (v0.252.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.252.1] — 2026-07-21
+### Fixed
+- **Auto-router: semantic matching now works on any memory backend, and confident routes stop
+  collapsing into "ask".** Two issues surfaced dogfooding the router over the real instapods fleet.
+  (1) The embedding blend + LLM tie-break only read `memory.sqlite.embeddings`, so a tenant on the
+  `automem`/`libsql` backend (whose embeddings aren't a local `Embedder`) got **keyword-only** routing —
+  and terse agent descriptions (`pod-troubleshooter`: *"Checks why a pod has errored out"*) starve keyword
+  matching, so real support intents ("I want a refund, I was double charged" → the billing/support agent)
+  scored 0 and fell to the help list. Added a **router-owned** `router_config.embeddings` (+ the `llm`
+  endpoint/key falls back to it), so semantic routing works regardless of the memory backend; verified
+  end-to-end that "refund/double charged" now reaches the support agent via cosine when keyword scores 0.
+  (2) Scores are now on a stable **0..1 confidence** via *smooth* saturation (`raw/(raw+K)`) instead of a
+  hard clamp — the clamp pinned every strong candidate to 1.0, so two strong-but-different agents tied and
+  a clear winner became a disambiguation. Decisions use a **three-band** model: a viability floor
+  (`minScore`), a **route-confidence** gate (`routeConfidence`, new — a weak-but-relatively-ahead match now
+  *asks* instead of silently mis-routing), and the top-vs-second **margin judged on the raw score** (where
+  the true separation survives saturation). Also caches per-agent profile vectors (keyed by embedder +
+  agent + profile hash), so steady-state routing is **one** embed call (the message), not one-per-agent.
+  `src/edge/router.ts`, `src/types.ts` (`RouterConfig.embeddings`/`routeConfidence`).
+
 ## [0.252.0] — 2026-07-21
 ### Added
 - **Code review policy — a first-class, fleet-wide steer for how agents review a diff/PR.** Settings →

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.252.0",
+  "version": "0.252.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.252.0",
+      "version": "0.252.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.252.0",
+  "version": "0.252.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/router.ts
+++ b/src/edge/router.ts
@@ -6,10 +6,14 @@
  * is down", "refund on invoice 4821"), it infers the best-fit claude-code agent so a Slack/Discord/web
  * message — or a support ticket — reaches the right teammate without anyone naming one.
  *
- * Matching is **deterministic first** (idf-weighted token overlap over each agent's id + description +
- * example prompts), with two opt-in upgrades that only ever run when configured:
- *   - **embedding blend** — when a memory embedder is configured, cosine(message, agent-profile) is
- *     min-max blended with the keyword score for nuance the bag-of-words misses.
+ * Every signal is mapped onto a common **0..1 confidence** by *absolute saturation* (not min-max, which
+ * makes the best-of-a-bad-batch look confident and would route "hello there" the moment embeddings turn
+ * on). Matching is **deterministic first** (idf-weighted token overlap over each agent's id + description
+ * + example prompts), with two opt-in upgrades that only run when configured:
+ *   - **embedding blend** — cosine(message, agent-profile) averaged with the keyword confidence, closing
+ *     the lexical gap ("refund" ≈ an agent whose description says "invoice/billing"). Uses the router's
+ *     OWN embedder config, falling back to the memory embedder — so a tenant on the automem/libsql memory
+ *     backend (whose embeddings aren't a local `Embedder`) can still route semantically.
  *   - **LLM tie-break** — on a near-tie, a cheap chat model picks the winner; absent/unsure, we fall
  *     through to disambiguation (asking the human), never a coin-flip.
  *
@@ -18,12 +22,16 @@
  * only bad outcome, and it's gated behind a clear score margin. The router only PICKS an id — the spawn
  * is still fully governed downstream (provenance, run-as, gate hook), so routing carries no privilege.
  */
-import { AgentManifest, RouterConfig } from '../types';
+import { AgentManifest, EmbeddingsConfig, RouterConfig } from '../types';
 import { AgentOS } from '../kernel';
 
 export interface RouterCandidate {
   agentId: string;
+  /** 0..1 confidence (smooth-saturated), used for the viability floor + the route-confidence gate. */
   score: number;
+  /** Pre-saturation raw score, carried for the top-vs-second MARGIN test — saturation compresses the top
+   *  (two strong-but-different candidates both approach 1), so margin is judged on the raw separation. */
+  raw?: number;
 }
 
 /** The router's verdict for one message. `route` → spawn it; `disambiguate` → ask the human to pick
@@ -33,7 +41,22 @@ export type RouteDecision =
   | { kind: 'disambiguate'; candidates: RouterCandidate[] }
   | { kind: 'none' };
 
-const DEFAULTS = { minScore: 0.5, margin: 0.3 };
+// All scores live on a 0..1 confidence scale (smooth saturation, below), so the thresholds are
+// scale-stable whether or not the embedder is on. Three bands: `minScore` = the floor to be a candidate
+// at all; `routeConfidence` = how strong the winner must be to route SILENTLY (below it, but viable →
+// ask); `margin` = the raw top-vs-second separation the winner must also clear to route.
+const DEFAULTS = { minScore: 0.22, routeConfidence: 0.5, margin: 0.15 };
+
+// Smooth saturation maps a raw score onto 0..1 (`raw/(raw+K)`) — monotonic, so it PRESERVES ordering (a
+// raw 0 stays 0, so a no-signal message can't be normalized into a confident route; two strong-but-
+// different candidates keep distinct scores, unlike a hard clamp that pins both to 1). The margin test
+// still uses the RAW separation, where the true gap lives.
+const KW_SAT = 1.5; //  a raw idf-overlap of 1.5 → keyword confidence 0.5; a clear multi-term intent → ~1.
+const COS_LO = 0.22; // cosine below this is noise → 0.
+const COS_HI = 0.55; // cosine at/above this → 1 (cosine's "clearly related text" band is ~0.22–0.55).
+
+const clamp01 = (x: number) => (x < 0 ? 0 : x > 1 ? 1 : x);
+const smoothSat = (raw: number) => (raw > 0 ? raw / (raw + KW_SAT) : 0);
 
 // Common words that carry no routing signal — dropped from both the message and agent profiles so the
 // idf weighting isn't diluted. Deliberately small: idf already suppresses fleet-wide-common terms.
@@ -61,8 +84,8 @@ function agentProfile(a: AgentManifest): string {
 
 /**
  * Deterministic keyword scoring: idf-weighted overlap between the message tokens and each agent's
- * profile tokens, normalized by message length so scores are comparable across messages. Rare-to-the-
- * fleet terms ("billing", "kubernetes") discriminate; terms every agent shares contribute ~0. Pure and
+ * profile tokens, normalized by message length then saturated to a 0..1 confidence. Rare-to-the-fleet
+ * terms ("billing", "kubernetes") discriminate; terms every agent shares contribute ~0. Pure and
  * synchronous — the unit-testable core. Returns candidates sorted best-first.
  */
 export function scoreAgents(text: string, agents: AgentManifest[]): RouterCandidate[] {
@@ -78,25 +101,33 @@ export function scoreAgents(text: string, agents: AgentManifest[]): RouterCandid
     .map((p) => {
       let s = 0;
       for (const t of msgTokens) if (p.tokens.has(t)) s += idf(t);
-      return { agentId: p.id, score: s / norm };
+      const raw = s / norm;
+      return { agentId: p.id, score: smoothSat(raw), raw };
     })
     .sort((x, y) => y.score - x.score);
 }
 
-/** Turn a sorted candidate list into a decision under the confidence thresholds. Pure. */
+/**
+ * Turn a sorted candidate list into a decision under the three confidence bands. Pure.
+ *   - nothing clears `minScore` → none (help list).
+ *   - one lone viable candidate → route it (asking to pick from a list of one is pointless).
+ *   - top clears `routeConfidence` AND beats the runner-up by `margin` (on RAW) → route silently.
+ *   - otherwise (viable but not confident, or a close top-two) → disambiguate.
+ */
 export function decide(scored: RouterCandidate[], cfg: RouterConfig): RouteDecision {
   const minScore = cfg.minScore ?? DEFAULTS.minScore;
+  const routeConf = cfg.routeConfidence ?? DEFAULTS.routeConfidence;
   const margin = cfg.margin ?? DEFAULTS.margin;
-  const viable = scored.filter((c) => c.score > 0);
+  const viable = scored.filter((c) => c.score >= minScore);
   const top = viable[0];
   const second = viable[1];
-  if (!top || top.score < minScore) {
-    // No candidate clears the floor. If two-plus at least registered, let the human pick; else help list.
-    return viable.length >= 2 ? { kind: 'disambiguate', candidates: viable.slice(0, 3) } : { kind: 'none' };
-  }
+  if (!top) return { kind: 'none' };
   if (!second) return { kind: 'route', agentId: top.agentId, score: top.score, method: 'keyword' };
-  const gap = (top.score - second.score) / top.score;
-  if (gap >= margin) return { kind: 'route', agentId: top.agentId, score: top.score, runnerUp: second, method: 'keyword' };
+  const rTop = top.raw ?? top.score;
+  const gap = rTop > 0 ? (rTop - (second.raw ?? second.score)) / rTop : 0;
+  if (top.score >= routeConf && gap >= margin) {
+    return { kind: 'route', agentId: top.agentId, score: top.score, runnerUp: second, method: 'keyword' };
+  }
   return { kind: 'disambiguate', candidates: viable.slice(0, 3) };
 }
 
@@ -111,16 +142,27 @@ function cosine(a: number[], b: number[]): number {
   const nb = Math.sqrt(dot(b, b));
   return na && nb ? dot(a, b) / (na * nb) : 0;
 }
-/** Min-max scale a list to 0..1 (flat list → all 0). */
-function minmax(xs: number[]): number[] {
-  const lo = Math.min(...xs);
-  const hi = Math.max(...xs);
-  const span = hi - lo;
-  return span > 0 ? xs.map((x) => (x - lo) / span) : xs.map(() => 0);
+
+/** The router's embedder config: its OWN (`router_config.embeddings`) first, else the memory backend's
+ *  local embedder (`memory.sqlite.embeddings`). The fallback means an sqlite-memory tenant needs no extra
+ *  setup; the router-owned field is what lets an automem/libsql tenant (no local `Embedder`) route
+ *  semantically. Returns undefined when neither is set → the embedding blend stays off. */
+function resolveEmbeddings(os: AgentOS, cfg: RouterConfig): EmbeddingsConfig | undefined {
+  return cfg.embeddings ?? os.settings.memoryConfig()?.sqlite?.embeddings;
+}
+
+// Agent-profile vectors change rarely (only on an agent edit), but a message routes often — so cache the
+// per-agent embedding keyed by embedder + agent + a cheap profile hash. Steady state = ONE embed call per
+// route (the message), not one-per-agent. Process-local, unbounded-but-tiny (fleet-sized).
+const agentVecCache = new Map<string, number[]>();
+function profileHash(s: string): string {
+  let h = 5381;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  return String(h >>> 0);
 }
 
 /**
- * The full async router: deterministic scoring, an optional embedding blend when a memory embedder is
+ * The full async router: deterministic scoring, an optional embedding blend when an embedder is
  * configured, and an optional LLM tie-break on a near-tie. Returns a fail-safe decision.
  */
 export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecision> {
@@ -131,16 +173,16 @@ export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecis
   let scored = scoreAgents(text, agents);
   if (scored.length === 0) return { kind: 'none' };
 
-  // Optional embedding blend: cosine(message, profile) min-max-blended with the keyword score. Only when
-  // an embedder is configured AND the message embeds cleanly; any failure silently keeps the keyword rank.
-  const embedded = await tryEmbeddingBlend(os, text, agents, scored);
+  // Optional embedding blend: cosine(message, profile) averaged with the keyword confidence. Only when an
+  // embedder resolves AND the message embeds cleanly; any failure silently keeps the keyword rank.
+  const embedded = await tryEmbeddingBlend(os, cfg, text, agents, scored);
   if (embedded) scored = embedded;
 
   const decision = decide(scored, cfg);
 
   // Near-tie → try the LLM tie-break before bothering the human. A clear pick routes; unsure → disambiguate.
   if (decision.kind === 'disambiguate' && cfg.llm?.model) {
-    const pick = await llmTieBreak(os, text, decision.candidates, agents, cfg);
+    const pick = await llmTieBreak(os, cfg, text, decision.candidates, agents);
     if (pick) {
       const c = decision.candidates.find((x) => x.agentId === pick);
       if (c) return { kind: 'route', agentId: c.agentId, score: c.score, runnerUp: decision.candidates.find((x) => x.agentId !== pick), method: 'llm' };
@@ -151,11 +193,12 @@ export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecis
 
 async function tryEmbeddingBlend(
   os: AgentOS,
+  cfg: RouterConfig,
   text: string,
   agents: AgentManifest[],
   keyword: RouterCandidate[],
 ): Promise<RouterCandidate[] | null> {
-  const emb = os.settings.memoryConfig()?.sqlite?.embeddings;
+  const emb = resolveEmbeddings(os, cfg);
   if (!emb) return null;
   try {
     const { Embedder } = await import('../memory/embedding');
@@ -163,16 +206,21 @@ async function tryEmbeddingBlend(
     const qv = await embedder.embed(text);
     if (!qv) return null;
     const byId = new Map(keyword.map((c) => [c.agentId, c.score]));
-    const cos: { agentId: string; c: number }[] = [];
+    const blended: RouterCandidate[] = [];
     for (const a of agents) {
-      const av = await embedder.embed(agentProfile(a).slice(0, 2000));
-      cos.push({ agentId: a.id, c: av ? cosine(qv, av) : 0 });
+      const profile = agentProfile(a).slice(0, 2000);
+      const cacheKey = `${embedder.label}:${a.id}:${profileHash(profile)}`;
+      let av = agentVecCache.get(cacheKey);
+      if (!av) {
+        const v = await embedder.embed(profile);
+        if (v) agentVecCache.set(cacheKey, (av = v));
+      }
+      const cos01 = av ? clamp01((cosine(qv, av) - COS_LO) / (COS_HI - COS_LO)) : 0;
+      const kw01 = byId.get(a.id) ?? 0;
+      const score = (kw01 + cos01) / 2; // agreement between channels → toward 1
+      blended.push({ agentId: a.id, score, raw: score }); // already 0..1 + continuous → margin on it directly
     }
-    const kn = minmax(agents.map((a) => byId.get(a.id) ?? 0));
-    const cn = minmax(cos.map((x) => x.c));
-    return agents
-      .map((a, i) => ({ agentId: a.id, score: (kn[i] + cn[i]) / 2 }))
-      .sort((x, y) => y.score - x.score);
+    return blended.sort((x, y) => y.score - x.score);
   } catch {
     return null;
   }
@@ -180,12 +228,12 @@ async function tryEmbeddingBlend(
 
 async function llmTieBreak(
   os: AgentOS,
+  cfg: RouterConfig,
   text: string,
   candidates: RouterCandidate[],
   agents: AgentManifest[],
-  cfg: RouterConfig,
 ): Promise<string | null> {
-  const emb = os.settings.memoryConfig()?.sqlite?.embeddings;
+  const emb = resolveEmbeddings(os, cfg);
   const url = (cfg.llm?.url || emb?.url || '').replace(/\/$/, '');
   const apiKey = cfg.llm?.apiKey || emb?.apiKey;
   const model = cfg.llm?.model;

--- a/src/types.ts
+++ b/src/types.ts
@@ -618,14 +618,24 @@ export interface RouterConfig {
   /** Master switch. Unset → follows `chatRouterEnabled` (auto-route rides on the `/agent` front door).
    *  Explicit `false` keeps the classic name-only router with no inference. */
   enabled?: boolean;
-  /** Absolute floor a top candidate must clear to count as a match. Below it → help list. Default 0.5. */
+  /** Viability floor (0..1 confidence) a candidate must clear to be considered at all. Below it → help
+   *  list. Default 0.22. */
   minScore?: number;
-  /** Relative gap `(top-second)/top` the winner must clear to route SILENTLY. Below it → disambiguate.
-   *  Default 0.3. */
+  /** How strong the top candidate must be (0..1 confidence) to route SILENTLY. Viable but below this →
+   *  ask the human. This is what keeps a weak-but-relatively-ahead match from silently mis-routing.
+   *  Default 0.5. */
+  routeConfidence?: number;
+  /** Relative gap `(top-second)/top` (on the RAW score) the winner must ALSO clear to route silently.
+   *  Below it → disambiguate. Default 0.15. */
   margin?: number;
+  /** The router's OWN embedder for the semantic blend (cosine of message vs. agent profile). Falls back
+   *  to the memory backend's local embedder (`memory.sqlite.embeddings`) when omitted — set this to route
+   *  semantically on a tenant whose memory backend is automem/libsql (no local `Embedder`). Omit both →
+   *  keyword-only. */
+  embeddings?: EmbeddingsConfig;
   /** Optional cheap chat model for the near-tie tie-break (OpenAI-compatible `/chat/completions`).
-   *  `url`/`apiKey` default to the configured memory embedder's endpoint when omitted. No model → no
-   *  LLM tie-break (near-ties just disambiguate). */
+   *  `url`/`apiKey` default to the resolved embedder's endpoint when omitted. No model → no LLM tie-break
+   *  (near-ties just disambiguate). */
   llm?: { model: string; url?: string; apiKey?: string };
 }
 


### PR DESCRIPTION
Follow-up to the auto-router (#420), from dogfooding it over the **real 20-agent instapods fleet**. Two issues, both fixed here.

## 1. Semantic routing didn't work on this tenant (the important one)

The embedding blend + LLM tie-break only read `memory.sqlite.embeddings`. instapods runs the **automem** backend, so that field is empty → the router silently ran **keyword-only**, its weakest tier. Combined with terse agent descriptions (`pod-troubleshooter`'s *entire* corpus is *"Checks why a pod has errored out"*), real intents fell through:

- "I want a refund, I was double charged" → **HELP LIST** (should hit `check-resolve-tickets`, whose description literally says "why is this invoice wrong?" — but "refund/charged" aren't in its text, so keyword scores 0). A lexical gap only semantics closes.

**Fix:** a **router-owned** `router_config.embeddings` (and the `llm` endpoint/key falls back to it), independent of the memory backend. Verified end-to-end with a fake OpenAI-compatible server + the real fleet: "refund/double charged" now routes to `check-resolve-tickets` via cosine when keyword scores 0. Per-agent profile vectors are **cached** (embedder+agent+profile-hash), so steady-state is **one** embed call per route (the message), not one-per-agent.

## 2. Confident routes collapsed into "ask"

Scores were hard-clamped to 0..1, pinning every strong candidate to 1.0 — so "research our competitors" tied `researcher` (raw 2.89) with `marketing-manager` (1.95) and became a disambiguation instead of a clean route.

**Fix:** smooth saturation (`raw/(raw+K)`) preserves ordering, and a **three-band** decision:

| Band | Behavior |
|---|---|
| below `minScore` (0.22) | not a candidate → help list |
| viable but below `routeConfidence` (0.5, **new**) | **ask** — stops a weak-but-relatively-ahead match from silently mis-routing |
| above `routeConfidence` **and** clears `margin` (on the **raw** score, where separation survives saturation) | route |

## Result on the live fleet

| Message | Before (this PR) | After |
|---|---|---|
| "research our competitors" | ASK (tie) | ✅ ROUTE → researcher |
| "migrate to a bigger pod" | ASK | ✅ ROUTE → pod-migrator |
| "spam and abusive content" | ROUTE | ✅ ROUTE → trust-safety |
| "my pod is throwing a 500" | ASK (churn shortlisted) | ASK — correctly *not* confident (right agent needs a better description or the embedder) |
| "hello there" / gibberish | HELP LIST | ✅ HELP LIST (saturation keeps noise at 0) |
| "refund, double charged" (with embedder) | HELP LIST | ✅ ROUTE → check-resolve-tickets (semantic) |

## Verification

- `npm run typecheck` + `build` clean; `test:governance` → 68/68 ✓
- Keyword-only regression: driven over the real fleet (table above)
- Semantic + LLM + cache: end-to-end via a fake OpenAI-compatible server through the router-owned config (automem-tenant path) — semantic rescue confirmed, cache confirmed (3rd route = 1 embed call), tie-break confirmed

## Note

To actually turn semantics on for a tenant, set `router_config.embeddings` (an OpenAI-compatible embeddings endpoint + key). Without it the router stays keyword-only (still fail-safe). The other lever is enriching thin agent descriptions (`pod-troubleshooter` especially).

🤖 Generated with [Claude Code](https://claude.com/claude-code)