### PR TITLE
feat(agents): accept #/agent/<id>/edit as an alias for the agent page (v0.252.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.252.2] — 2026-07-21
+### Added
+- **`#/agent/<id>/edit` is now an accepted alias for the agent page.** The agent detail/editor lives at
+  `#/agent/<id>`; a trailing `/edit` segment now resolves to the same page (agent ids never contain a
+  slash, so it's unambiguous), so an explicit edit URL can be linked or bookmarked. `web/src/App.tsx`.
+
 ## [0.252.1] — 2026-07-21
 ### Fixed
 - **Auto-router: semantic matching now works on any memory backend, and confident routes stop

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.252.1",
+  "version": "0.252.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.252.1",
+      "version": "0.252.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.252.1",
+  "version": "0.252.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -979,8 +979,9 @@ function Console({ me }: { me: Member }) {
       ? { tmux: detail, title: sessions.find((s) => s.tmux === detail)?.title ?? detail }
       : null
   // The agent being edited is a URL detail (`#/agent/<id>`) so the editor survives a refresh instead
-  // of falling back to a blank page.
-  const editAgent = route === 'agent' ? detail : ''
+  // of falling back to a blank page. `#/agent/<id>/edit` is an accepted alias for the same page (agent
+  // ids never contain a slash, so a trailing `/edit` segment is unambiguous) — strip it to the bare id.
+  const editAgent = route === 'agent' ? detail.replace(/\/edit$/, '') : ''
 
   // Per-member pinned nav: which secondary items sit up in Main vs. under Manage. Seeded from the
   // navPins that rode in on /api/auth/me (null → the default layout), toggled optimistically and


### PR DESCRIPTION
The agent detail/editor page lives at `#/agent/<id>`. This makes `#/agent/<id>/edit` resolve to the same page, so an explicit edit URL can be linked or bookmarked.

**Change (`web/src/App.tsx`, one line):** when resolving the agent route, strip a trailing `/edit` segment from the detail. Agent ids match `^[a-z][a-z0-9-]{1,39}$` (never contain a slash), so a `<id>/edit` detail is unambiguous.

Verified the parse/strip against 7 cases incl. the id-literally-`editor` edge (`editor` → `editor`, `editor/edit` → `editor`). web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)