### PR TITLE
feat(cockpit): intent layer + Chat/Terminal launch choice — auto-router Phase 2 (v0.254.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.254.0] — 2026-07-21
+### Added
+- **Cockpit intent layer + Chat/Terminal launch choice (auto-router Phase 2).** Cockpit no longer always
+  spawns a session — a deterministic, LLM-free classifier (`src/edge/intent.ts`) first decides *what kind*
+  of ask a message is and does the right thing:
+  - **work** → the auto-router picks the best-fit agent, and you choose **Chat or Terminal** to launch it
+    (a remembered toggle; Terminal spawns the attachable TUI via `/api/sessions`, Chat via `/api/chat/start`
+    — both run-as you, both gated). This is the "let me pick where it opens" ask.
+  - **ask** (a question *about* the workspace — "which agents are idle?", "how many tasks are open?") →
+    answered **inline, no session**, by an LLM constrained to a compact live-workspace context
+    (`cockpitWorkspaceContext`: agents + session/task/automation counts + KB sections — the only ground it
+    may answer from). Degrades gracefully to routing when no LLM is configured, with a Settings hint.
+  - **action** ("schedule the churn report every morning", "create a task to…") → a safe **deep-link** into
+    that primitive's surface (Automations/Tasks), or "have an agent do it" — no ungoverned auto-execution
+    (that's Phase 3's governed meta-agent).
+  Classification is fail-safe (default `work`; a `force:'work'` escape hatch on every ask/action result).
+  New: `src/edge/intent.ts`, `src/edge/llm.ts` (shared OpenAI-compatible chat helper — the router's near-tie
+  tie-break now reuses it too), extended `POST /api/router/preview` (intent + inline `answer`/`surface`),
+  `web/src/App.tsx` (`CockpitPage` intents + launch toggle). Same governance throughout — the classifier
+  only decides routing; every spawned effect still passes the gate hook.
+
 ## [0.253.0] — 2026-07-21
 ### Added
 - **Cockpit — the natural-language front door in the web console (auto-router Phase 1).** A new primary

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.253.0",
+  "version": "0.254.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.253.0",
+      "version": "0.254.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.253.0",
+  "version": "0.254.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/intent.ts
+++ b/src/edge/intent.ts
@@ -1,0 +1,49 @@
+/**
+ * Cockpit intent classifier — decides what KIND of ask a free-text message is, so the front door does
+ * the right thing instead of always spawning an agent session:
+ *   - `work`   → the user wants an agent to DO something → route to an agent (Chat or Terminal).
+ *   - `ask`    → a question ABOUT the workspace ("which agents are idle?", "how do automations work?")
+ *                → answer inline (LLM over a compact workspace context), NO session.
+ *   - `action` → a request to operate an OS primitive ("schedule the churn agent every morning", "create
+ *                a task to…") → deep-link into that surface (Automations/Tasks); execution stays human-driven.
+ *
+ * Deterministic + fail-safe: classification needs no LLM (so it works on any workspace), and the default
+ * is `work` — the safe fallback, since an agent can handle anything. Only a clear signal diverts to
+ * `ask`/`action`. The `ask` ANSWER needs an LLM, but the CLASSIFICATION here never does.
+ */
+
+export type Intent = 'work' | 'ask' | 'action';
+
+export interface IntentResult {
+  intent: Intent;
+  /** For `action`: which primitive surface the request maps to. */
+  surface?: 'automations' | 'tasks';
+}
+
+// A request to stand up a recurring/scheduled run, or an explicit "create a task" → an OS primitive.
+const SCHEDULE_RE = /\b(schedul(e|ing)|automat(e|ion)|recurring|every\s+(morning|day|night|week|hour|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|daily|weekly|hourly|nightly|each\s+(day|morning|week)|set\s+up\s+a?\s*(cron|automation|schedule)|remind\s+me)\b/i;
+const TASK_RE = /\b(create|add|open|file|make|log)\s+(a\s+|an\s+|the\s+)?(task|to-?do|ticket|work\s*item)\b/i;
+
+// Meta-nouns that mean "about the agent-os / this workspace" rather than a domain topic an agent works on.
+const OS_NOUN_RE = /\b(agent|agents|fleet|session|sessions|automation|automations|task|tasks|memory|memories|polic(y|ies)|approval|approvals|budget|spend|cost|costs|audit|team|member|members|skill|skills|connector|connectors|integration|integrations|knowledge\s*base|\bkb\b|agent\s*-?\s*os|this\s+(system|workspace|console)|the\s+(system|fleet|workspace))\b/i;
+// Question-shaped openers (also matched by a trailing '?').
+const QUESTION_RE = /^(how|what|which|why|when|who|whose|where|is|are|am|do|does|did|can|could|should|would|will|list|show|tell\s+me|explain|describe|give\s+me|summar(y|ise|ize)|status)\b/i;
+
+/** Classify a message. Pure, synchronous, LLM-free. */
+export function classifyIntent(text: string): IntentResult {
+  const t = (text || '').trim();
+  if (!t) return { intent: 'work' };
+
+  // 1) Action — an explicit request to operate a primitive. Checked first: "schedule …" is unambiguous.
+  if (TASK_RE.test(t)) return { intent: 'action', surface: 'tasks' };
+  if (SCHEDULE_RE.test(t)) return { intent: 'action', surface: 'automations' };
+
+  // 2) Ask — a question that's ABOUT the workspace (question-shaped or '?'-terminated, AND references an
+  //    OS meta-noun). "how do I fix my pod" is question-shaped but about a DOMAIN thing (pod) → stays
+  //    `work` (an agent answers). "which agents are idle" references an OS noun → `ask`.
+  const questionish = QUESTION_RE.test(t) || /\?\s*$/.test(t);
+  if (questionish && OS_NOUN_RE.test(t)) return { intent: 'ask' };
+
+  // 3) Default — hand it to an agent.
+  return { intent: 'work' };
+}

--- a/src/edge/llm.ts
+++ b/src/edge/llm.ts
@@ -1,0 +1,51 @@
+/**
+ * Tiny OpenAI-compatible chat-completion helper, shared by the router's near-tie tie-break and the
+ * Cockpit `ask` tier (answering questions about the workspace). Endpoint/key/model resolve from the
+ * router's own config first (`router_config.llm`), falling back to the router/memory embedder's endpoint
+ * — so a workspace that configured either gets an LLM here for free. Returns null on any failure (no
+ * config, network, non-200, malformed) so every caller degrades gracefully rather than throwing.
+ */
+import { AgentOS } from '../kernel';
+
+export interface LlmConfig {
+  url: string;
+  apiKey?: string;
+  model: string;
+}
+
+/** Resolve the chat LLM: `router_config.llm` (model required), with url/apiKey falling back to the
+ *  resolved embedder (router-owned, else memory sqlite). Null when no model+endpoint is available. */
+export function resolveLlm(os: AgentOS): LlmConfig | null {
+  const rc = os.settings.routerConfig();
+  const emb = rc.embeddings ?? os.settings.memoryConfig()?.sqlite?.embeddings;
+  const url = (rc.llm?.url || emb?.url || '').replace(/\/$/, '');
+  const apiKey = rc.llm?.apiKey || emb?.apiKey;
+  const model = rc.llm?.model;
+  return url && model ? { url, apiKey, model } : null;
+}
+
+/** POST /chat/completions; return the assistant text (trimmed) or null on any failure. */
+export async function chatComplete(
+  llm: LlmConfig,
+  messages: { role: 'system' | 'user' | 'assistant'; content: string }[],
+  opts?: { maxTokens?: number; temperature?: number; timeoutMs?: number },
+): Promise<string | null> {
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), opts?.timeoutMs ?? 15000);
+  try {
+    const res = await fetch(`${llm.url}/chat/completions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', ...(llm.apiKey ? { authorization: `Bearer ${llm.apiKey}` } : {}) },
+      body: JSON.stringify({ model: llm.model, temperature: opts?.temperature ?? 0, max_tokens: opts?.maxTokens ?? 400, messages }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { choices?: { message?: { content?: string } }[] };
+    const text = (json.choices?.[0]?.message?.content || '').trim();
+    return text || null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/edge/router.ts
+++ b/src/edge/router.ts
@@ -24,6 +24,7 @@
  */
 import { AgentManifest, EmbeddingsConfig, RouterConfig } from '../types';
 import { AgentOS } from '../kernel';
+import { resolveLlm, chatComplete } from './llm';
 
 export interface RouterCandidate {
   agentId: string;
@@ -182,7 +183,7 @@ export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecis
 
   // Near-tie → try the LLM tie-break before bothering the human. A clear pick routes; unsure → disambiguate.
   if (decision.kind === 'disambiguate' && cfg.llm?.model) {
-    const pick = await llmTieBreak(os, cfg, text, decision.candidates, agents);
+    const pick = await llmTieBreak(os, text, decision.candidates, agents);
     if (pick) {
       const c = decision.candidates.find((x) => x.agentId === pick);
       if (c) return { kind: 'route', agentId: c.agentId, score: c.score, runnerUp: decision.candidates.find((x) => x.agentId !== pick), method: 'llm' };
@@ -228,16 +229,12 @@ async function tryEmbeddingBlend(
 
 async function llmTieBreak(
   os: AgentOS,
-  cfg: RouterConfig,
   text: string,
   candidates: RouterCandidate[],
   agents: AgentManifest[],
 ): Promise<string | null> {
-  const emb = resolveEmbeddings(os, cfg);
-  const url = (cfg.llm?.url || emb?.url || '').replace(/\/$/, '');
-  const apiKey = cfg.llm?.apiKey || emb?.apiKey;
-  const model = cfg.llm?.model;
-  if (!url || !model) return null;
+  const llm = resolveLlm(os);
+  if (!llm) return null;
   const roster = candidates
     .map((c) => {
       const a = agents.find((x) => x.id === c.agentId);
@@ -248,23 +245,9 @@ async function llmTieBreak(
     'You route an incoming message to exactly one agent. Reply with ONLY the agent id from the list, ' +
     'or the single word UNSURE if none clearly fits. No punctuation, no explanation.';
   const user = `Agents:\n${roster}\n\nMessage:\n${text.slice(0, 1500)}\n\nBest agent id:`;
-  const ctrl = new AbortController();
-  const timer = setTimeout(() => ctrl.abort(), 8000);
-  try {
-    const res = await fetch(`${url}/chat/completions`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json', ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}) },
-      body: JSON.stringify({ model, temperature: 0, max_tokens: 24, messages: [{ role: 'system', content: sys }, { role: 'user', content: user }] }),
-      signal: ctrl.signal,
-    });
-    if (!res.ok) return null;
-    const json = (await res.json()) as { choices?: { message?: { content?: string } }[] };
-    const raw = (json.choices?.[0]?.message?.content || '').trim().replace(/[^A-Za-z0-9_-]/g, '');
-    const hit = candidates.find((c) => c.agentId === raw);
-    return hit ? hit.agentId : null;
-  } catch {
-    return null;
-  } finally {
-    clearTimeout(timer);
-  }
+  const out = await chatComplete(llm, [{ role: 'system', content: sys }, { role: 'user', content: user }], { maxTokens: 24, timeoutMs: 8000 });
+  if (!out) return null;
+  const raw = out.replace(/[^A-Za-z0-9_-]/g, '');
+  const hit = candidates.find((c) => c.agentId === raw);
+  return hit ? hit.agentId : null;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,8 @@ import { readConversation, type ChatArtifactRef, type ChatKbRef, type ChatAppRef
 import { summarizeConversation } from './edge/summarize';
 import { Automation, Automations, nextCronRun, derivedConcurrencyCap, chatTitle } from './edge/automations';
 import { chooseAgent } from './edge/router';
+import { classifyIntent } from './edge/intent';
+import { resolveLlm, chatComplete } from './edge/llm';
 import { SlackSocket } from './edge/slack-socket';
 import { DiscordSocket } from './edge/discord-socket';
 import { AppSupervisor } from './edge/app-supervisor';
@@ -211,6 +213,30 @@ function applyAgentSnapshot(os: AgentOS, ag: AgentManifest, snap: AgentConfigSna
  *  `deletable` = lives under the data home (user-created), so it can be removed; the bundled
  *  examples that ship with the software are read-only. `builtIn` = one of the agents Agent OS
  *  provisions itself, so the console can label it as shipped-with-the-software vs. user-authored. */
+/** A compact, factual snapshot of the workspace for the Cockpit `ask` tier — the ONLY ground the LLM
+ *  may answer from. Kept small (agents + live counts + KB sections) and derived live, so answers reflect
+ *  the real fleet, not a hallucination. Member-scoped where it matters (sessions the viewer can see). */
+function cockpitWorkspaceContext(os: AgentOS, tm: TerminalManager, autos: Automations, me: Member): string {
+  const agents = [...os.agents.values()].filter((a) => a.runtime === 'claude-code');
+  const agentLines = agents.map((a) => `  - ${a.id}: ${(a.description || '').replace(/\s+/g, ' ').slice(0, 140)}`).join('\n');
+  const sessions = tm.listSessions(me);
+  const live = sessions.filter((s) => s.alive).length;
+  const waiting = sessions.filter((s) => s.blocked).length;
+  const tc = os.tasks.counts(os.tenant);
+  const autoList = autos.list();
+  const autoOn = autoList.filter((a) => a.enabled);
+  const autoNames = autoOn.slice(0, 20).map((a) => a.name).join(', ');
+  const sections = os.kb.sections(os.tenant);
+  return [
+    `Workspace: ${os.tenantName} (tenant ${os.tenant}).`,
+    `Agents (${agents.length}):\n${agentLines || '  (none)'}`,
+    `Sessions: ${sessions.length} total, ${live} running, ${waiting} blocked/waiting on a human.`,
+    `Tasks: ${tc.todo} todo, ${tc.doing} in progress, ${tc.blocked} blocked, ${tc.done} done.`,
+    `Automations: ${autoList.length} total, ${autoOn.length} enabled${autoNames ? ` (${autoNames})` : ''}.`,
+    `Knowledge Base sections: ${sections.join(', ') || '(none)'}.`,
+  ].join('\n');
+}
+
 function terminalAgents(os: AgentOS): { id: string; description: string; category?: string; runtime: string; deletable: boolean; builtIn: boolean; model?: string; effort?: string; examplePrompts?: string[]; icon?: string }[] {
   const userRoot = os.paths ? path.resolve(os.paths.userAgents) + path.sep : null;
   return [...os.agents.values()].map((a) => ({
@@ -2391,11 +2417,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { id: s.id, tmux: s.tmux });
   }
 
-  // Cockpit: preview which agent a free-text message would route to, WITHOUT spawning anything. The
-  // caller shows the suggestion (or the disambiguation shortlist / the runnable fleet) and dispatches
-  // via /api/chat/start once the human picks. Read-only, member-scoped: only agents THIS member can run
-  // are offered (the auto-router scores the whole fleet; we filter the result to the runnable set, and
-  // /api/chat/start re-enforces canRun on dispatch). Same inference the Slack/Discord front door uses.
+  // Cockpit front door: classify the message's INTENT, then do the right thing WITHOUT spawning anything
+  // until the human commits. `work` → route to an agent (the caller then dispatches to Chat or Terminal);
+  // `ask` → answer inline from a compact workspace context (LLM; degrades to `work` when unconfigured);
+  // `action` → deep-link into the matching primitive surface (Automations/Tasks) — execution stays
+  // human-driven. Read-only + member-scoped: only agents THIS member can run are offered; dispatch
+  // (/api/sessions or /api/chat/start) re-enforces canRun. `force:'work'` skips classification (the
+  // caller's "route to an agent anyway" escape hatch from an ask/action result).
   if (method === 'POST' && p === '/api/router/preview') {
     const b = await readBody(req);
     const text = String(b.text || '').trim();
@@ -2406,21 +2434,41 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return { id, description: a?.description || '', category: a?.category, icon: a?.icon, score };
     };
     const fleet = () =>
-      [...os.agents.values()]
-        .filter((a) => a.runtime === 'claude-code' && runnable(a.id))
-        .map((a) => card(a.id));
-    const decision = await chooseAgent(os, text);
-    if (decision.kind === 'route' && runnable(decision.agentId)) {
-      const alts = [decision.runnerUp?.agentId].filter((x): x is string => !!x && runnable(x));
-      return sendJson(res, 200, { kind: 'route', method: decision.method, suggested: card(decision.agentId, decision.score), candidates: alts.map((id) => card(id)) });
+      [...os.agents.values()].filter((a) => a.runtime === 'claude-code' && runnable(a.id)).map((a) => card(a.id));
+    // The `work` responder: the agent-routing decision, filtered to what this member can run.
+    const respondWork = async (askFallback?: boolean) => {
+      const decision = await chooseAgent(os, text);
+      const base = { intent: 'work' as const, askFallback: askFallback || undefined };
+      if (decision.kind === 'route' && runnable(decision.agentId)) {
+        const alts = [decision.runnerUp?.agentId].filter((x): x is string => !!x && runnable(x));
+        return sendJson(res, 200, { ...base, kind: 'route', method: decision.method, suggested: card(decision.agentId, decision.score), candidates: alts.map((id) => card(id)) });
+      }
+      if (decision.kind === 'disambiguate') {
+        const list = decision.candidates.filter((c) => runnable(c.agentId));
+        if (list.length >= 2) return sendJson(res, 200, { ...base, kind: 'disambiguate', candidates: list.map((c) => card(c.agentId, c.score)) });
+        if (list.length === 1) return sendJson(res, 200, { ...base, kind: 'route', method: 'keyword', suggested: card(list[0].agentId, list[0].score), candidates: [] });
+      }
+      return sendJson(res, 200, { ...base, kind: 'none', candidates: fleet() });
+    };
+
+    const intent = b.force === 'work' ? { intent: 'work' as const } : classifyIntent(text);
+
+    if (intent.intent === 'action' && intent.surface) {
+      return sendJson(res, 200, { intent: 'action', surface: intent.surface });
     }
-    if (decision.kind === 'disambiguate') {
-      const list = decision.candidates.filter((c) => runnable(c.agentId));
-      if (list.length >= 2) return sendJson(res, 200, { kind: 'disambiguate', candidates: list.map((c) => card(c.agentId, c.score)) });
-      if (list.length === 1) return sendJson(res, 200, { kind: 'route', method: 'keyword', suggested: card(list[0].agentId, list[0].score), candidates: [] });
+
+    if (intent.intent === 'ask') {
+      const llm = resolveLlm(os);
+      if (!llm) return respondWork(true); // no LLM → route to an agent, but flag why (Settings hint)
+      const answer = await chatComplete(llm, [
+        { role: 'system', content: 'You are the assistant for this Agent OS workspace. Answer the question ONLY from the CONTEXT below — the live state of this workspace. Be concise (2–5 sentences). If the answer is not in the context, say you do not have that information and suggest the relevant console page. Never invent agents, numbers, or names.' },
+        { role: 'user', content: `CONTEXT:\n${cockpitWorkspaceContext(os, tm, autos, me)}\n\nQUESTION: ${text}` },
+      ], { maxTokens: 500, timeoutMs: 15000 });
+      if (!answer) return respondWork(true); // LLM failed → don't dead-end; route instead
+      return sendJson(res, 200, { intent: 'ask', answer });
     }
-    // none, or nothing runnable in the shortlist → let the human pick from the agents they can run.
-    return sendJson(res, 200, { kind: 'none', candidates: fleet() });
+
+    return respondWork();
   }
   // Read the friendly conversation timeline for a session (poll this like the rest of the console).
   const convoMatch = p.match(/^\/api\/sessions\/([\w-]+)\/conversation$/);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1458,7 +1458,7 @@ function Console({ me }: { me: Member }) {
           {route === 'sessions' && <SessionsPage me={me} members={members} sessions={sessions} waiting={waiting} selected={selected} hiddenTabs={hiddenTabs} metrics={state?.sessionMetrics ?? 'both'} onOpen={openTerminal} onCloseTab={closeTab} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onRate={rateSession} onRename={renameSession} onTransfer={transferSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
           {route === 'overview' && me.role === 'owner' && <OverviewPage me={me} sessions={sessions} members={members} agents={state?.agents ?? []} maturity={maturity} onOpen={openTerminal} nav={nav} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} members={members} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} onOpenGoal={(id) => nav('goals', id)} />}
-          {route === 'cockpit' && <CockpitPage onOpenChat={(id) => nav('chat', id)} />}
+          {route === 'cockpit' && <CockpitPage onOpenChat={(id) => nav('chat', id)} onOpenTerminal={openTerminal} nav={nav} />}
           {route === 'chat' && <ChatPage agents={state?.agents ?? []} sessions={sessions} messages={messages} selected={detail} onSelect={(id) => nav('chat', id)} onOpenTerminal={openTerminal} />}
           {route === 'connectors' && <ConnectionsPage me={me} tab={detail} onTab={(t) => nav('connectors', t)} />}
           {route === 'team' && <TeamPage me={me} onProfileChange={refreshState} />}
@@ -3832,42 +3832,57 @@ function prettyAgent(id: string): string {
   return id.replace(/[-_]+/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 }
 
-/** Cockpit — the natural-language front door. Type what you need; the auto-router (the same inference the
- *  Slack/Discord chat front door uses) picks the best-fit agent, and you drop straight into a chat with it.
- *  Phase 1: route → dispatch → hand off to the Chat conversation view. Later phases (answer questions about
- *  agent-os, invoke OS primitives directly) build on this same box. */
-function CockpitPage({ onOpenChat }: {
+/** Cockpit — the natural-language front door. Type what you need; the intent layer decides:
+ *   - work   → the auto-router picks the best-fit agent; you launch it in **Chat or Terminal**.
+ *   - ask    → a question about the workspace is answered **inline** (no session).
+ *   - action → "schedule…/create a task…" deep-links into that primitive's surface.
+ *  Every "work" dispatch still runs through the governed chat/terminal spawn (run-as you, gate hook). */
+function CockpitPage({ onOpenChat, onOpenTerminal, nav }: {
   onOpenChat: (id: string) => void
+  onOpenTerminal: (tmux: string, title?: string) => void
+  nav: (r: Route, detail?: string) => void
 }) {
   const [draft, setDraft] = useState('')
   const [busy, setBusy] = useState(false)
   const [preview, setPreview] = useState<RouterPreviewResp | null>(null)
   const [err, setErr] = useState('')
+  // How a routed agent launches — remembered across submits.
+  const [mode, setMode] = useState<'chat' | 'terminal'>(() => (localStorage.getItem('cockpitLaunch') === 'terminal' ? 'terminal' : 'chat'))
+  const setLaunch = (m: 'chat' | 'terminal') => { setMode(m); localStorage.setItem('cockpitLaunch', m) }
 
-  const runPreview = async () => {
+  const runPreview = async (force?: 'work') => {
     const text = draft.trim()
     if (!text || busy) return
     setBusy(true); setErr(''); setPreview(null)
-    const r = await api.routerPreview(text)
+    const r = await api.routerPreview(text, force)
     setBusy(false)
     if (r.error) { setErr(r.error); return }
     setPreview(r)
   }
 
-  // Dispatch: spawn a chat with the chosen agent using the original message, then open the conversation.
+  // Dispatch the chosen agent in the selected launch mode, using the ORIGINAL message as its task.
   const dispatch = async (agentId: string) => {
     const text = draft.trim()
     if (!text || busy) return
     setBusy(true); setErr('')
-    const r = await api.startChat(agentId, text)
-    setBusy(false)
-    if (r.error || !r.id) { setErr(r.error || 'could not start the chat'); return }
-    onOpenChat(r.id)
+    if (mode === 'terminal') {
+      const r = await api.run(agentId, text)
+      setBusy(false)
+      if (r.error || !r.tmux) { setErr(r.error || 'could not start the session'); return }
+      onOpenTerminal(r.tmux, `${prettyAgent(agentId)} · ${r.id}`)
+    } else {
+      const r = await api.startChat(agentId, text)
+      setBusy(false)
+      if (r.error || !r.id) { setErr(r.error || 'could not start the chat'); return }
+      onOpenChat(r.id)
+    }
   }
 
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); runPreview() }
   }
+
+  const isWork = !preview?.intent || preview.intent === 'work'
 
   const card = (c: RouterCard, opts?: { primary?: boolean }) => (
     <button
@@ -3893,7 +3908,7 @@ function CockpitPage({ onOpenChat }: {
       <div className="text-center">
         <div className="mx-auto mb-3 grid h-11 w-11 place-items-center rounded-xl bg-primary/10"><Gauge className="h-6 w-6 text-primary" /></div>
         <h2 className="text-lg font-semibold">What do you need?</h2>
-        <p className="mt-1 text-sm text-muted-foreground">Describe it in your own words — I'll route you to the right agent. No need to pick one.</p>
+        <p className="mt-1 text-sm text-muted-foreground">Describe it in plain words — I'll route you to the right agent, answer a question, or point you to the right place.</p>
       </div>
 
       <div className="rounded-xl border bg-card p-2 shadow-sm">
@@ -3902,13 +3917,13 @@ function CockpitPage({ onOpenChat }: {
           value={draft}
           onChange={(e) => { setDraft(e.target.value); if (preview) setPreview(null) }}
           onKeyDown={onKeyDown}
-          placeholder="e.g. my pod is throwing a 500 after a plugin update — or — draft a reply to this refund request"
+          placeholder="e.g. my pod is throwing a 500 after a plugin update — or — which agents are idle? — or — schedule the churn report every morning"
           className="min-h-[96px] resize-none border-0 bg-transparent shadow-none focus-visible:ring-0"
         />
         <div className="flex items-center justify-between px-1 pb-1">
-          <span className="text-[11px] text-muted-foreground">Enter to route · Shift+Enter for a new line</span>
-          <Button size="sm" disabled={busy || !draft.trim()} onClick={runPreview}>
-            {busy ? 'Routing…' : 'Route'}<Send className="ml-1.5 h-3.5 w-3.5" />
+          <span className="text-[11px] text-muted-foreground">Enter to send · Shift+Enter for a new line</span>
+          <Button size="sm" disabled={busy || !draft.trim()} onClick={() => runPreview()}>
+            {busy ? 'Thinking…' : 'Go'}<Send className="ml-1.5 h-3.5 w-3.5" />
           </Button>
         </div>
       </div>
@@ -3917,44 +3932,86 @@ function CockpitPage({ onOpenChat }: {
 
       {preview && (
         <div className="flex flex-col gap-3">
-          {preview.kind === 'route' && preview.suggested && (
-            <>
-              <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                <CheckCircle2 className="h-3.5 w-3.5 text-primary" />
-                <span>Best match{preview.method === 'llm' ? ' (AI-picked)' : preview.method === 'embedding' ? ' (semantic)' : ''} — press to start, or choose another below.</span>
-              </div>
-              {card(preview.suggested, { primary: true })}
-              {preview.candidates.length > 0 && (
-                <div className="flex flex-col gap-2">
-                  <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Or</span>
-                  {preview.candidates.map((c) => card(c))}
+          {/* ASK — answered inline from the workspace context; no session spawned. */}
+          {preview.intent === 'ask' && preview.answer && (
+            <div className="rounded-xl border bg-card p-4">
+              <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground"><Sparkles className="h-3.5 w-3.5 text-primary" /><span>Answered from your workspace</span></div>
+              <div className="prose prose-sm max-w-none dark:prose-invert prose-p:my-1.5"><ReactMarkdown remarkPlugins={[remarkGfm]}>{preview.answer}</ReactMarkdown></div>
+              <button onClick={() => runPreview('work')} className="mt-3 text-xs text-muted-foreground underline-offset-2 hover:underline">Not what you meant? Route to an agent instead →</button>
+            </div>
+          )}
+
+          {/* ACTION — deep-link into the primitive's surface; execution stays human-driven. */}
+          {preview.intent === 'action' && preview.surface && (
+            <div className="rounded-xl border bg-card p-4">
+              <div className="flex items-start gap-3">
+                <span className="grid h-9 w-9 shrink-0 place-items-center rounded-lg bg-primary/10">{preview.surface === 'automations' ? <Zap className="h-4.5 w-4.5 text-primary" /> : <ListChecks className="h-4.5 w-4.5 text-primary" />}</span>
+                <div className="min-w-0 flex-1">
+                  <div className="font-medium">This looks like {preview.surface === 'automations' ? 'scheduling an automation' : 'creating a task'}.</div>
+                  <div className="mt-0.5 text-xs text-muted-foreground">Open the {preview.surface === 'automations' ? 'Automations' : 'Tasks'} page to set it up — or have an agent do it for you.</div>
                 </div>
+              </div>
+              <div className="mt-3 flex gap-2">
+                <Button size="sm" onClick={() => nav(preview.surface === 'automations' ? 'automations' : 'tasks')}>Open {preview.surface === 'automations' ? 'Automations' : 'Tasks'}</Button>
+                <Button size="sm" variant="outline" disabled={busy} onClick={() => runPreview('work')}>Have an agent do it</Button>
+              </div>
+            </div>
+          )}
+
+          {/* WORK — route to an agent, launched in the chosen mode (Chat or Terminal). */}
+          {isWork && (
+            <>
+              {preview.askFallback && (
+                <div className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2 text-xs text-muted-foreground">That looked like a question about your workspace. Configure an LLM in <button className="underline underline-offset-2" onClick={() => nav('settings')}>Settings</button> to answer those here directly — for now, an agent can help:</div>
               )}
-            </>
-          )}
-          {preview.kind === 'disambiguate' && (
-            <>
-              <div className="text-sm text-muted-foreground">A few agents could take this — which one?</div>
-              {preview.candidates.map((c) => card(c))}
-            </>
-          )}
-          {preview.kind === 'none' && (
-            <>
-              <div className="text-sm text-muted-foreground">I couldn't confidently match an agent. Pick one to start:</div>
-              <div className="max-h-[46vh] overflow-y-auto rounded-lg border">
-                <div className="flex flex-col divide-y">
-                  {preview.candidates.length === 0 && <div className="p-3 text-sm text-muted-foreground">No agents you can run yet.</div>}
-                  {preview.candidates.map((c) => (
-                    <button key={c.id} onClick={() => dispatch(c.id)} disabled={busy} className="flex items-start gap-3 p-3 text-left hover:bg-muted/60 disabled:opacity-60">
-                      <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-muted"><AgentIcon icon={c.icon} className="h-4 w-4 text-foreground/70" /></span>
-                      <span className="min-w-0 flex-1">
-                        <span className="block font-medium">{prettyAgent(c.id)}</span>
-                        {c.description && <span className="mt-0.5 line-clamp-2 block text-xs text-muted-foreground">{c.description}</span>}
-                      </span>
-                    </button>
-                  ))}
+              <div className="flex items-center gap-2 text-xs">
+                <span className="text-muted-foreground">Launch in</span>
+                <div className="inline-flex rounded-lg border p-0.5">
+                  <button onClick={() => setLaunch('chat')} className={`flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'chat' ? 'bg-muted font-medium' : 'text-muted-foreground'}`}><MessageSquare className="h-3.5 w-3.5" />Chat</button>
+                  <button onClick={() => setLaunch('terminal')} className={`flex items-center gap-1 rounded-md px-2 py-1 ${mode === 'terminal' ? 'bg-muted font-medium' : 'text-muted-foreground'}`}><TerminalSquare className="h-3.5 w-3.5" />Terminal</button>
                 </div>
               </div>
+
+              {preview.kind === 'route' && preview.suggested && (
+                <>
+                  <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                    <CheckCircle2 className="h-3.5 w-3.5 text-primary" />
+                    <span>Best match{preview.method === 'llm' ? ' (AI-picked)' : preview.method === 'embedding' ? ' (semantic)' : ''} — press to start in {mode}, or choose another.</span>
+                  </div>
+                  {card(preview.suggested, { primary: true })}
+                  {preview.candidates.length > 0 && (
+                    <div className="flex flex-col gap-2">
+                      <span className="text-[11px] uppercase tracking-wider text-muted-foreground">Or</span>
+                      {preview.candidates.map((c) => card(c))}
+                    </div>
+                  )}
+                </>
+              )}
+              {preview.kind === 'disambiguate' && (
+                <>
+                  <div className="text-sm text-muted-foreground">A few agents could take this — which one?</div>
+                  {preview.candidates.map((c) => card(c))}
+                </>
+              )}
+              {preview.kind === 'none' && (
+                <>
+                  <div className="text-sm text-muted-foreground">I couldn't confidently match an agent. Pick one to start:</div>
+                  <div className="max-h-[46vh] overflow-y-auto rounded-lg border">
+                    <div className="flex flex-col divide-y">
+                      {preview.candidates.length === 0 && <div className="p-3 text-sm text-muted-foreground">No agents you can run yet.</div>}
+                      {preview.candidates.map((c) => (
+                        <button key={c.id} onClick={() => dispatch(c.id)} disabled={busy} className="flex items-start gap-3 p-3 text-left hover:bg-muted/60 disabled:opacity-60">
+                          <span className="grid h-8 w-8 shrink-0 place-items-center rounded-lg bg-muted"><AgentIcon icon={c.icon} className="h-4 w-4 text-foreground/70" /></span>
+                          <span className="min-w-0 flex-1">
+                            <span className="block font-medium">{prettyAgent(c.id)}</span>
+                            {c.description && <span className="mt-0.5 line-clamp-2 block text-xs text-muted-foreground">{c.description}</span>}
+                          </span>
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </>
+              )}
             </>
           )}
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1166,12 +1166,22 @@ export interface RouterCard {
   score?: number
 }
 export interface RouterPreviewResp {
-  /** `route` → confident single pick in `suggested`; `disambiguate` → choose from `candidates`;
-   *  `none` → nothing matched, `candidates` is the runnable fleet to pick from. */
-  kind: 'route' | 'disambiguate' | 'none'
+  /** The classified intent. `work` → route to an agent (see `kind`); `ask` → an inline `answer`;
+   *  `action` → open the `surface`. Absent on older responses ⇒ treat as `work`. */
+  intent?: 'work' | 'ask' | 'action'
+  /** work only: `route` → confident single pick in `suggested`; `disambiguate` → choose from
+   *  `candidates`; `none` → nothing matched, `candidates` is the runnable fleet to pick from. */
+  kind?: 'route' | 'disambiguate' | 'none'
   method?: 'keyword' | 'embedding' | 'llm'
   suggested?: RouterCard
   candidates: RouterCard[]
+  /** ask only: the inline answer composed from the workspace context. */
+  answer?: string
+  /** action only: the primitive surface this request maps to. */
+  surface?: 'automations' | 'tasks'
+  /** work only: this was classified `ask` but no LLM is configured, so it fell back to routing (show a
+   *  "configure an LLM to answer here" hint). */
+  askFallback?: boolean
   error?: string
 }
 
@@ -1250,10 +1260,11 @@ export const api = {
   /** Start a chat with an agent — spawns a warm resident session. Returns its id. */
   startChat: (agent: string, message: string) =>
     call<{ id?: string; tmux?: string; error?: string }>('POST', '/api/chat/start', { agent, message }),
-  /** Cockpit: preview which agent a message routes to (no spawn). `route` → one suggested agent (+ any
-   *  runner-up); `disambiguate` → a shortlist to choose from; `none` → the runnable fleet to pick from. */
-  routerPreview: (text: string) =>
-    call<RouterPreviewResp>('POST', '/api/router/preview', { text }),
+  /** Cockpit: classify a message's intent + preview the outcome (no spawn). `work` → an agent to launch
+   *  (route/disambiguate/none as before); `ask` → an inline `answer`; `action` → a `surface` to open.
+   *  `force:'work'` skips classification (the "route to an agent anyway" escape hatch). */
+  routerPreview: (text: string, force?: 'work') =>
+    call<RouterPreviewResp>('POST', '/api/router/preview', force ? { text, force } : { text }),
   /** Send the human's next turn into a chat session — a clean headless resume run. `busy` = a prior
    *  turn is still generating (keep the draft, resend shortly). */
   reply: (id: string, message: string) =>


### PR DESCRIPTION
Answers the two things about Phase 1: Cockpit no longer *always* spawns a chat session, and you can choose **where a routed agent opens**.

## Intent layer

A deterministic, **LLM-free** classifier (`src/edge/intent.ts`) decides what kind of ask a message is, then Cockpit does the right thing:

| Intent | Example | Behavior | Session? |
|---|---|---|---|
| **work** | "my pod is throwing a 500" | auto-route → launch in **Chat or Terminal** | yes |
| **ask** | "which agents are idle?", "how many tasks are open?" | answered **inline** from live workspace context | **no** |
| **action** | "schedule the churn report every morning", "create a task to…" | **deep-link** to Automations/Tasks (or "have an agent do it") | **no** (or your choice) |

Fail-safe: default is `work` (an agent can handle anything), and every ask/action result has a **"route to an agent anyway"** escape hatch (`force:'work'`).

## Launch choice (Chat / Terminal)

For `work`, a remembered toggle picks how the agent launches:
- **Chat** → `/api/chat/start` (the conversation view)
- **Terminal** → `/api/sessions` (the attachable interactive TUI)

Both run **as you** and pass the gate hook — the classifier only decides routing, never governance.

## `ask` — answered inline, no session

An LLM (the router's — `router_config.llm`, endpoint/key falling back to the embedder) answers from `cockpitWorkspaceContext`: the agent roster + live session/task/automation counts + KB sections — **the only ground it may answer from** (system prompt forbids inventing agents/numbers). No LLM configured → it degrades to routing with a Settings hint, so it's never a dead end.

## Files

- `src/edge/intent.ts` (new) — the classifier
- `src/edge/llm.ts` (new) — shared OpenAI-compatible chat helper; the router's near-tie **tie-break now reuses it** (DRY)
- `src/server.ts` — extended `/api/router/preview` (intent + inline `answer`/`surface`) + `cockpitWorkspaceContext`
- `web/src/App.tsx` — `CockpitPage` intent rendering + launch toggle
- `web/src/lib/api.ts` — `routerPreview(text, force?)` + response fields

## Verification

- `typecheck` + `web build` clean; `test:governance` → 68/68 ✓
- Classifier over 13 cases (work/ask/action incl. the tricky "how do I fix my pod" → work vs "which agents are idle" → ask)
- Intent route branching end-to-end with a fake OpenAI server: work→route, "which agents do I have"→ask (answer correctly reflects the 20-agent context), schedule→action/automations, create-task→action/tasks, force-work escape → routes
- Router semantic + tie-break **re-verified** through the refactored `llm.ts` (unchanged behavior + vector cache intact)

## Note

On live instapods there's no LLM configured yet, so the **ask** tier degrades to routing (with the Settings hint) until an embeddings/LLM endpoint is set — same lever as semantic routing. **work** (+ launch choice) and **action** deep-links work with no LLM.

## Follow-ups

- Phase 3: `action`/`ask` execution via a governed meta-agent that calls primitives directly
- Prefill the target surface from an `action` (carry the text into the new-automation/new-task form)
- Settings → Chat panel to configure the router/LLM from the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)