### PR TITLE
feat(sessions): take over an ended headless run — resume-and-attach (v0.255.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.255.0] — 2026-07-21
+### Added
+- **Take over an ENDED headless run.** "Take over" now works on a headless session that already exited
+  (an automation/cron/task/chat turn that ran to `done`/`stopped`/`crashed`), not just a still-live one.
+  The unified take-over (`POST /api/sessions/:id/interactive` → `TerminalManager.takeoverRun`) attaches to
+  the streaming pane when the run is live, and otherwise **resurrects it in place** — `claude --resume` the
+  same transcript as a claimed, non-resident interactive TUI (writes the launch env so it becomes resumable
+  and reattachable from there on, marks it sticky so the reapers leave it alone). The human lands straight
+  in the resumed conversation to steer it. Requires a claude-code runtime and a pinned claude session id
+  (headless runs persist one via `--session-id`); a run with no conversation to resume returns a clear
+  error. The console now offers "Take over" on any unattended run — live OR ended — with a state-aware
+  tooltip. `web/src/App.tsx` (`canGoInteractive`/`takeOverTip`), `src/terminal.ts`, `src/server.ts`.
+
 ## [0.254.0] — 2026-07-21
 ### Added
 - **Cockpit intent layer + Chat/Terminal launch choice (auto-router Phase 2).** Cockpit no longer always

--- a/docs/attachable-sessions-plan.md
+++ b/docs/attachable-sessions-plan.md
@@ -65,13 +65,23 @@ Reuse existing columns; add two nullable ones (non-destructive `ALTER TABLE`):
    else:
        no-op                               # human is watching, or blocked on an ask → keep alive
    ```
-3. **Take over** — `goInteractive` is replaced by `claimSession(id, by)`:
+3. **Take over** — `goInteractive` is replaced by `takeoverRun(id, by)`, which handles BOTH states:
    ```
-   UPDATE term_sessions SET headless=0, claimed_by=?, claimed_at=? WHERE id=?
-   audit 'session.claimed'   # NO kill, NO relaunch — the live TUI keeps streaming
+   live → claimSession(id, by):
+     UPDATE term_sessions SET headless=0, claimed_by=?, claimed_at=? WHERE id=?
+     audit 'session.claimed'   # NO kill, NO relaunch — the live TUI keeps streaming
+   ended headless (no pane) → resurrect in place:
+     UPDATE term_sessions SET status='running', headless=0, resident=0, claimed_by=?, … WHERE id=?
+     audit 'session.claimed' {via:'takeover-resume'}
+     launchClaudeCode({ resume:true, claudeSessionId, headless:false, resident:false })  # claude --resume
    ```
-   `POST /api/sessions/:id/interactive` calls `claimSession`; the frontend then opens ttyd exactly as
-   before. The user lands in the live pane, mid-work, and can type.
+   `POST /api/sessions/:id/interactive` calls `takeoverRun`; the frontend then opens ttyd exactly as
+   before. For a live run the user lands in the streaming pane mid-work; for an ended headless run they
+   land in the freshly-`--resume`d conversation (needs a pinned claude session id — a headless run with no
+   conversation to resume returns an error). Writing the launch env on the resurrect path makes the run
+   `resumable`/reattachable from there on; non-resident + claimed means only the long idle-interactive
+   janitor can reclaim it. The frontend offers "Take over" on any unattended run — live OR ended
+   (`canGoInteractive` = `!resumable && !claimedBy && (isLive || forkable)`).
 4. **Backstop reaper** — `reapIdleResidents` generalizes to `reapIdleSessions`: still reaps resident chats
    on idle-timeout, and additionally reaps any `immediate` session that is idle with **no client
    attached** (covers a missed Stop beacon, or a human who attached then detached without a further turn).
@@ -112,9 +122,9 @@ reaper honor `claimed_by`, so a claimed session is never reaped regardless of at
   wiring; pane capture.
 - `terminal/stop-hook.sh` — **new**, turn-end beacon → `/api/turn-idle`.
 - `src/edge/session-backend.ts` — `hasClient()` on both backends.
-- `src/terminal.ts` — `launchClaudeCode` routing; `markTurnIdle`; `claimSession` (replaces
+- `src/terminal.ts` — `launchClaudeCode` routing; `markTurnIdle`; `takeoverRun`/`claimSession` (replaces
   `goInteractive`); `reapIdleResidents` → `reapIdleSessions`; capture-pane on teardown.
-- `src/server.ts` — `POST /api/turn-idle`; repoint `/api/sessions/:id/interactive` → `claimSession`.
+- `src/server.ts` — `POST /api/turn-idle`; repoint `/api/sessions/:id/interactive` → `takeoverRun`.
 - `src/state/db.ts` — `claimed_by` / `claimed_at` columns.
 - `web/src/App.tsx` — copy/tooltip updates; optional "taken over by X" badge.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.254.0",
+  "version": "0.255.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.254.0",
+      "version": "0.255.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.254.0",
+  "version": "0.255.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2752,15 +2752,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
     return sendJson(res, 200, { ok: tm.stopSession(id, me.email) });
   }
-  // Take over an unattended run: CLAIM its live TUI so the caller can attach and steer — no kill, no
-  // resume, nothing interrupted (the run is already an attachable interactive session). Marks it sticky so
-  // it isn't auto-closed at turn-end. The frontend opens ttyd right after. Same per-member gate as stop.
+  // Take over a run: if it's still LIVE, CLAIM its TUI and attach — no kill, no resume, nothing
+  // interrupted. If it ENDED/STOPPED as a headless run, RESURRECT it in place (`claude --resume` the same
+  // transcript) as a claimed interactive TUI. Either way it's marked sticky so it isn't auto-closed at
+  // turn-end; the frontend opens ttyd right after. Same per-member gate as stop.
   const interactiveMatch = p.match(/^\/api\/sessions\/([\w-]+)\/interactive$/);
   if (method === 'POST' && interactiveMatch) {
     const id = interactiveMatch[1];
     if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to manage this session' });
-    const r = tm.claimSession(id, me.email);
+    const r = tm.takeoverRun(id, me.email);
     return sendJson(res, r.ok ? 200 : 400, r);
   }
   // Fork a session: branch it into a NEW independent session that inherits the parent's full conversation

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1719,6 +1719,48 @@ export class TerminalManager {
   }
 
   /**
+   * Take over a run REGARDLESS of whether it is still live — the unified "Take over" entry point the
+   * console's take-over action hits. Two cases, one call:
+   *  - LIVE → delegate to {@link claimSession}: nothing to relaunch, just mark it claimed and the caller
+   *    attaches to the still-streaming pane.
+   *  - ENDED/STOPPED/CRASHED HEADLESS run (an unattended automation/task/cron/chat turn that already
+   *    exited — no live pane, no persisted launch env, so it is NOT `resumable`) → RESURRECT it in place:
+   *    `claude --resume` the SAME transcript as a claimed, non-resident interactive TUI, seeded with no
+   *    prompt (drop the human straight into a steerable claude). Writes the launch env (so ttyd can attach
+   *    + later reattach → it becomes `resumable` from here on) and marks it claimed/sticky (non-resident +
+   *    claimed → the reapers all skip it, only the long idle-interactive janitor reclaims it). The caller
+   *    then opens the terminal on `aos-<id>` and lands in the resumed conversation.
+   * Returns an error only for an unknown / non-claude-code run, or a dead run with no conversation to
+   * resume (a headless run that never got a pinned claude session id — nothing to `--resume`).
+   */
+  takeoverRun(sessionId: string, by: string): { ok: boolean; error?: string } {
+    const row = this.db.prepare('SELECT agent, secret, claude_session_id, run_as, spawned_by FROM term_sessions WHERE id = ?')
+      .get<{ agent: string; secret: string | null; claude_session_id: string | null; run_as: string | null; spawned_by: string | null }>(sessionId);
+    if (!row) return { ok: false, error: 'unknown session' };
+    const manifest = this.os.agents.get(row.agent);
+    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be taken over' };
+    // A turn is still generating → attach to the live pane, no relaunch (identical to a live take-over).
+    if (this.isAlive(sessionId)) return this.claimSession(sessionId, by);
+    // Dead → resurrect the transcript. Needs the pinned claude session id to `--resume` from.
+    if (!row.claude_session_id) return { ok: false, error: 'this run has no conversation to resume yet' };
+    this.allowResume(sessionId);
+    // Mirror claimSession's end-state (headless→0, running, claimed/sticky) but non-resident, so the run
+    // is owned by the human and reaped only by the long idle-interactive janitor — never the chat-idle or
+    // turn-end reapers. Then actually relaunch claude (unlike the live path, there is a dead pane here).
+    this.db.prepare("UPDATE term_sessions SET status = 'running', headless = 0, resident = 0, claimed_by = ?, claimed_at = ?, last_activity = ?, updated_at = ? WHERE id = ?")
+      .run(by, Date.now(), Date.now(), Date.now(), sessionId);
+    const hasSlack = !!this.db.prepare('SELECT 1 FROM slack_threads WHERE session_id = ?').get(sessionId);
+    const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
+    this.audit(sessionId, by, 'session.claimed', { agent: row.agent, via: 'takeover-resume' });
+    this.launchClaudeCode({
+      id: sessionId, agent: row.agent, task: '', secret: row.secret ?? randomBytes(24).toString('hex'),
+      actingMember: row.run_as ?? undefined, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord,
+      headless: false, resident: false, resume: true, claudeSessionId: row.claude_session_id,
+    });
+    return { ok: true };
+  }
+
+  /**
    * Take a native-console CHAT session over into the Terminal. A chat session is headless per-turn (no
    * persisted launch env, and between turns its pane is gone), so unlike {@link claimSession} we can't
    * always just attach. Two cases:

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -155,15 +155,24 @@ const resumeAndOpen = (s: Session, onOpen: (tmux: string, title: string) => void
   void api.resumeSession(s.id).finally(() => onOpen(s.tmux, s.agent + ' · ' + s.id))
 }
 
-/** An unattended run (automation/cron/chat/task) is now an ATTACHABLE interactive TUI (not `claude -p`),
- *  so while it's LIVE you can "take over" — claim it and attach to the still-streaming pane with nothing
- *  interrupted. Offered only while live: a finished run has no pane to attach to (you view its transcript
- *  instead). Interactive runs already have a live/Resume path, so they never show this. */
+/** An unattended run (automation/cron/chat/task) can be "taken over" — pulled into an attachable
+ *  interactive TUI a human watches and steers. Two flavours, one affordance:
+ *   • LIVE  → claim the still-streaming pane and attach (nothing interrupted).
+ *   • ENDED headless run → resurrect it in place (`claude --resume` the same transcript) and attach.
+ *  Offered whenever the run is unattended (`!resumable` — an interactive run already has its own
+ *  live/Resume path), not already claimed, and either still live OR has a conversation to resume
+ *  (`forkable` ⇒ a pinned claude session id exists). */
 const canGoInteractive = (s: Session): boolean =>
-  !s.resumable && !s.claimedBy && isLive(s)
+  !s.resumable && !s.claimedBy && (isLive(s) || Boolean(s.forkable))
 
-/** Take over an unattended run: CLAIM it server-side (no kill, no resume — nothing interrupted), THEN
- *  open/focus its terminal so the user lands in the live, attachable TUI it was already running in. */
+/** Tooltip for the take-over affordance — states which flavour applies for THIS run. */
+const takeOverTip = (s: Session): string =>
+  isLive(s)
+    ? 'take over — attach to this live run and steer it; nothing is interrupted'
+    : 'take over — resume this ended run (claude --resume) and steer it in the terminal'
+
+/** Take over an unattended run — CLAIM it live, or resurrect it if it already ended — server-side, THEN
+ *  open/focus its terminal so the user lands in the attachable TUI (streaming, or freshly resumed). */
 const takeOverAndOpen = (s: Session, onOpen: (tmux: string, title: string) => void): void => {
   void api.goInteractive(s.id).finally(() => onOpen(s.tmux, s.agent + ' · ' + s.id))
 }
@@ -2887,7 +2896,7 @@ function RowActionsMenu({ session: s, members, me, onOpen, onStop, onDelete, onT
           </DropdownMenuItem>
         )}
         {canGoInteractive(s) && (
-          <DropdownMenuItem className="gap-2 text-xs" onClick={() => takeOverAndOpen(s, onOpen)}>
+          <DropdownMenuItem className="gap-2 text-xs" onClick={() => takeOverAndOpen(s, onOpen)} title={takeOverTip(s)}>
             <Terminal className="h-3.5 w-3.5 shrink-0 text-sky-500" /> <span>Take over</span>
           </DropdownMenuItem>
         )}
@@ -3276,7 +3285,7 @@ function SessionsPage({
             </button>
           )}
           {canGoInteractive(s) && (
-            <button className="rounded p-0.5 text-sky-400 hover:bg-neutral-600 hover:text-sky-300" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — attach to this live run and steer it; nothing is interrupted">
+            <button className="rounded p-0.5 text-sky-400 hover:bg-neutral-600 hover:text-sky-300" onClick={() => takeOverAndOpen(s, onOpen)} title={takeOverTip(s)}>
               <Terminal className="h-3 w-3" />
             </button>
           )}
@@ -3535,7 +3544,7 @@ function SessionsPage({
                   </Button>
                 )}
                 {canGoInteractive(s) && (
-                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title="take over — attach to this live run and steer it; nothing is interrupted">
+                  <Button size="sm" variant="ghost" className="h-6 gap-1 px-2 text-xs text-sky-600" onClick={() => takeOverAndOpen(s, onOpen)} title={takeOverTip(s)}>
                     <Terminal className="h-3 w-3" /> Take over
                   </Button>
                 )}


### PR DESCRIPTION
## What

Extends **Take over** to headless sessions that have already *ended*. Previously "Take over" only worked while an unattended run was still live (attach to its streaming pane); an automation/cron/task/chat turn that had run to `done`/`stopped`/`crashed` had no way back into an interactive TUI — you could only read its transcript or *fork* it into a new session.

Now the take-over route is unified in `TerminalManager.takeoverRun`:

- **Live run** → `claimSession` (unchanged): mark it claimed, attach to the still-streaming pane, nothing interrupted.
- **Ended headless run** → **resurrect in place**: `claude --resume` the same transcript as a claimed, non-resident interactive TUI. Writes the launch env (so the run becomes `resumable`/reattachable from there on) and marks it sticky (non-resident + claimed → only the long idle-interactive janitor can reclaim it). The human lands directly in the resumed conversation to steer it.

Requires a claude-code runtime and a pinned claude session id (headless runs persist one via `--session-id`); a run with no conversation to resume returns a clear error.

## UI

`POST /api/sessions/:id/interactive` now calls `takeoverRun`. The console offers **Take over** on any unattended run — live *or* ended — via a broadened `canGoInteractive` (`!resumable && !claimedBy && (isLive || forkable)`) with a state-aware tooltip (attach vs. `claude --resume`). Rendered in all three session-list affordance surfaces (dropdown, icon button, labelled card button).

## Verification

- `npm run typecheck` + `cd web && npm run build` clean.
- Isolated in-process harness on a scratch home (13/13 asserts): unknown/no-conversation/non-claude guards return the right errors; a dead headless run w/ a conversation flips to `running`, `headless=0`, `resident=0`, `claimed_by=<me>` and launches with `resume:true` + the pinned claude id; a live run delegates to `claimSession` with no relaunch.
- `npm run test:governance` → 68/68.

Server route + store change → needs build + server restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVfxDWBcQLbAqJPshB4Ha2