### PR TITLE
feat(governance): host-trust learning — Trust host on approval cards (v0.258.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.258.0] — 2026-07-23
+### Added
+- **Host-trust learning — "Trust host" on an approval card (phase 2 of the decision-brief layer).**
+  The fleet study found that nearly all human-in-the-loop friction is host identification — an agent
+  reaches a legitimate new host (a deploy target, `curl` to its own site, `ssh` to an infra box) and the
+  gate escalates "host is not a granted connection", the owner approves, and the *same host escalates
+  again next run*. Now, when the decision brief identifies a host, the owner sees a **"Trust host"**
+  button (`POST /api/approvals/:id/trust-host`): it approves this attempt AND adds a durable org host
+  grant (`posture: allow`, scoped to that exact host + protocol) so future reaches pass the gate without
+  a card. Owner-only (it loosens the gate durably, like "always approve"); it replaces the too-broad
+  "Always" button for host approvals (Always would allow the entire `net.connect`/`ssh.exec` capability —
+  trust is scoped to the one host). Idempotent (already-trusted → approve once + note); the never-tier
+  still binds, so `ssh box 'rm -rf /'` stays denied regardless of host trust. Verified end-to-end:
+  `approve(host not granted) → allow` after trusting. Audited `host.trusted`. See
+  `docs/decision-brief-layer-plan.md` §7.
+
 ## [0.257.0] — 2026-07-23
 ### Added
 - **Decision briefs on approval cards + the audit trail (phase 1 of the unified decision-brief layer).**

--- a/docs/decision-brief-layer-plan.md
+++ b/docs/decision-brief-layer-plan.md
@@ -184,7 +184,17 @@ Server plumbing: `approvals` row already stores `args` + `reason` (`src/governan
 `ApprovalRow`). Add a nullable `brief` column (JSON) via a `src/state/db.ts` migration; `toRequest`
 hydrates it; the inbox card API (`/api/inbox` / messages) passes `brief` through to the client `Msg`.
 
-## 7. Consumer 3: host-trust learning (kills most escalations)
+## 7. Consumer 3: host-trust learning (kills most escalations) — ✅ SHIPPED (phase 2, v0.258.0)
+
+Implemented as `POST /api/approvals/:id/trust-host` + a **"Trust host"** button on the card (owner-only,
+shown when `brief.suggestedAction === 'trust-host'`). It resolves the approval AND adds a durable org
+`HostStore` grant (`posture: 'allow'`, `match` = the exact target host, protocol from the enriched
+`netProtocol`), so `computeHostFacts` → `hostGovernanceDecision` returns `allow` on the next reach.
+Idempotent (an existing allow grant → approve-once + note); the never-tier still binds
+(`ssh box 'rm -rf /'` stays denied). Verified end-to-end: `approve(host not granted) → allow` after
+trust. It deliberately REPLACES the too-broad "Always" for host cards (Always would allow the whole
+`net.connect`/`ssh.exec` capability; trust is scoped to the one host). Original design below.
+
 
 Evidence §2: the dominant escalation is "host not yet trusted". Today an owner approves it and the
 *same host escalates again next run*. With the brief we can close the loop:
@@ -280,8 +290,8 @@ Design consequences, now load-bearing:
    `approvals.brief` column + migration, `BriefCard` in the console, brief in audit rows. Ship behind
    nothing — pure improvement, backward-compatible (missing brief → today's rendering). This alone
    fixes the owner's complaint and makes the 62%-never-recalled audit legible.
-2. **Host-trust button.** `suggestedAction: 'trust-host'` + the "Trust host & allow" action reusing
-   `HostGrant` + the always-approve append. Biggest friction cut.
+2. ✅ **Host-trust button (SHIPPED v0.258.0).** `suggestedAction: 'trust-host'` + the "Trust host"
+   action adding an allow-posture `HostStore` grant. Biggest friction cut. See §7.
 3. **`instruct` verb + loop detector.** The single most unambiguous behavioural detector, plus the
    soft-steer verb. Small, self-contained.
 4. **Runaway / drift / hallucination detectors + Dreaming feedback.** The full reliability plane and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.257.0",
+  "version": "0.258.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.257.0",
+      "version": "0.258.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.257.0",
+  "version": "0.258.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/briefer.ts
+++ b/src/governance/briefer.ts
@@ -170,8 +170,12 @@ export function briefFor(capability: string, args: Record<string, unknown>, deci
   const target = targetFor(capability, args, input);
   const headline = headlineFor(capability, args, input, verb, target);
   const rationale = rationaleFor(decision, args, target);
+  // For a host approval we can offer a durable "trust this host" resolution (phase 2) instead of a
+  // one-off approve — only when the target host is actually known (else there's nothing to trust).
   const suggestedAction: DecisionBrief['suggestedAction'] =
-    decision.effect === 'deny' ? 'deny' : decision.effect === 'approve' ? 'approve' : 'allow';
+    decision.effect === 'deny' ? 'deny'
+      : decision.effect === 'approve' ? (target.kind === 'host' && target.host ? 'trust-host' : 'approve')
+      : 'allow';
   const signature = signatureFor(capability, verb, target, args, input);
   return { headline, verb, target, rationale, riskClass: decision.riskClass, suggestedAction, signature };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -5457,6 +5457,31 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     }
     return sendJson(res, 200, { ok: true, ruleAdded: result.added, note: result.added ? undefined : `“${cap}” is already always-allowed` });
   }
+  // "Trust host & allow": approve THIS attempt AND add a durable org HOST grant (posture `allow`) for
+  // the target host, so future reaches to it pass the gate without a card — the phase-2 answer to the
+  // fleet's #1 friction (nearly all approvals are "host not yet trusted"). Adding an allow-posture grant
+  // durably loosens the gate for the whole fleet, so like "always approve" it is OWNER-ONLY (an admin can
+  // still approve once). The host + protocol come from the enriched attempt args the gate captured. The
+  // never-tier still binds (a destructive `ssh box 'rm -rf /'` is denied by the engine regardless of host
+  // trust). Audited `host.trusted`.
+  const trustHostMatch = p.match(/^\/api\/approvals\/([\w-]+)\/trust-host$/);
+  if (method === 'POST' && trustHostMatch) {
+    const ap = os.approvals.get(trustHostMatch[1]);
+    if (!ap) return sendJson(res, 404, { error: 'approval not found' });
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required — trusting a host loosens the gate durably' });
+    const a = ap.attempt.args as Record<string, unknown>;
+    const host = typeof a.host === 'string' ? a.host : '';
+    if (!host) return sendJson(res, 400, { error: 'this approval has no identified host to trust' });
+    const proto = a.netProtocol === 'ssh' || a.netProtocol === 'http' || a.netProtocol === 'postgres' ? a.netProtocol : 'any';
+    // Approve the waiting run regardless of whether the durable grant lands.
+    os.approvals.resolve(trustHostMatch[1], true, me.email);
+    // Idempotent: if an enabled allow grant already matches this exact host, don't add a duplicate row.
+    const already = os.hosts.list().some((h) => h.enabled && !h.proposed && h.posture === 'allow' && h.match === host);
+    if (already) return sendJson(res, 200, { ok: true, trusted: false, note: `“${host}” is already trusted` });
+    os.hosts.add({ name: host, match: host, protocol: proto, posture: 'allow', scope: 'org' });
+    os.audit.append({ ts: Date.now(), runId: ap.runId, tenant: os.tenant, principal: me.email, type: 'host.trusted', data: { host, protocol: proto, from: 'inbox.trust_host' } });
+    return sendJson(res, 200, { ok: true, trusted: true, host });
+  }
   const apMatch = p.match(/^\/api\/approvals\/([\w-]+)$/);
   if (method === 'POST' && apMatch) {
     const ap = os.approvals.get(apMatch[1]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4567,6 +4567,17 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
       if (r.error) { setBusy(false); alert(r.error) }          // 403/404 — not resolved; leave the card
       else if (r.ruleAdded === false && r.note) alert(`Approved once — ${r.note}`)  // resolved, rule not added
     }
+    // Phase-2 host trust: for a "host not yet trusted" approval, offer a durable, NARROW "trust this host"
+    // grant (posture allow) — better than "Always", which would allow the whole net.connect/ssh.exec
+    // capability. Owner-only (loosens the gate durably). Shown only when the brief identifies a host.
+    const briefOf = (m.args as { brief?: Brief } | undefined)?.brief
+    const trustHost = briefOf?.suggestedAction === 'trust-host' ? briefOf.target.host : undefined
+    const trust = async () => {
+      setBusy(true)
+      const r = await api.trustHost(m.approvalId!)
+      if (r.error) { setBusy(false); alert(r.error) }
+      else if (r.trusted === false && r.note) alert(`Approved once — ${r.note}`)
+    }
     return (
       <div className="rounded-lg border border-amber-300 bg-amber-50/40 px-3 py-2.5">
         <div className="flex items-start gap-2.5">
@@ -4587,7 +4598,9 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
             <>
               <Button size="sm" className="h-7 px-2.5 text-xs" disabled={busy} onClick={() => resolve(true)}><Check className="mr-1 h-3.5 w-3.5" />Approve</Button>
               {me.role === 'owner' && (
-                <Button size="sm" variant="outline" className="h-7 px-2.5 text-xs" disabled={busy} onClick={always} title={`Approve this and stop asking — adds an "allow ${m.capability ?? ''}" rule to policy`}><Shield className="mr-1 h-3.5 w-3.5" />Always</Button>
+                trustHost
+                  ? <Button size="sm" variant="outline" className="h-7 px-2.5 text-xs" disabled={busy} onClick={trust} title={`Trust ${trustHost} and stop asking — adds an "allow" host grant for it (this host only)`}><Shield className="mr-1 h-3.5 w-3.5" />Trust host</Button>
+                  : <Button size="sm" variant="outline" className="h-7 px-2.5 text-xs" disabled={busy} onClick={always} title={`Approve this and stop asking — adds an "allow ${m.capability ?? ''}" rule to policy`}><Shield className="mr-1 h-3.5 w-3.5" />Always</Button>
               )}
               <Button size="sm" variant="destructive" className="h-7 px-2.5 text-xs" disabled={busy} onClick={() => resolve(false)}><X className="mr-1 h-3.5 w-3.5" />Reject</Button>
             </>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1292,6 +1292,9 @@ export const api = {
   resolve: (id: string, approved: boolean) => call<{ ok: boolean; error?: string }>('POST', '/api/approvals/' + id, { approved }),
   /** Approve this attempt AND add a persistent policy `allow` rule for its capability (owner-only). */
   alwaysApprove: (id: string) => call<{ ok: boolean; ruleAdded?: boolean; note?: string; error?: string }>('POST', `/api/approvals/${id}/always`),
+  /** Approve this attempt AND add a durable org host grant (posture allow) for its target host, so
+   *  future reaches to it pass the gate without a card. Owner-only. */
+  trustHost: (id: string) => call<{ ok: boolean; trusted?: boolean; host?: string; note?: string; error?: string }>('POST', `/api/approvals/${id}/trust-host`),
   answerQuestion: (id: string, answer: string) => call<{ ok: boolean; error?: string }>('POST', '/api/questions/' + id, { answer }),
   /** Dismiss a pending question without answering (cancels it; unblocks a still-live agent's `ask`). */
   cancelQuestion: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/questions/${id}/cancel`),


### PR DESCRIPTION
## What & why

**Phase 2** of the unified decision-brief layer (`docs/decision-brief-layer-plan.md` §7). The 45-day fleet study found that **nearly all** human-in-the-loop friction is host identification: an agent reaches a legitimate new host (a deploy target, `curl` to its own site, `ssh` to an infra box), the gate escalates `"host is not a granted connection"`, the owner approves — and the **same host escalates again next run**.

## The change

When the decision brief identifies a host, the owner sees a **"Trust host"** button on the approval card (`POST /api/approvals/:id/trust-host`):
- Approves this attempt **and** adds a durable org `HostStore` grant (`posture: allow`, scoped to the **exact** host + protocol from the enriched `netProtocol`).
- Next reach: `computeHostFacts` → `hostGovernanceDecision` returns `allow` → passes the gate with no card.
- **Owner-only** (it loosens the gate durably, same stance as "always approve").
- **Replaces the too-broad "Always"** for host cards — Always would allow the entire `net.connect`/`ssh.exec` capability; trust is scoped to the one host.
- **Idempotent** (already-trusted → approve once + note). The **never-tier still binds** — `ssh box 'rm -rf /'` stays denied regardless of host trust.

`briefFor` now emits `suggestedAction: 'trust-host'` when the target is an identified host.

## Verification
- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run build` ✓ · `npm run test:governance` **68/68 ✓**
- **End-to-end behavioural check** (isolated home): `ssh.exec → approve(owner)` "host is not a granted connection" + brief offers `trust-host`; after adding the grant → `ssh.exec → allow`. **PASS.**

## Notes
- Only meaningful where host governance is enabled (instapods has it on — that's where these escalations come from). Where it's off, no host is identified, so the button never shows.
- Audited `host.trusted`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMSbnPEbqSVPGLasTKENp