### PR TITLE
feat(governance): loop detection + the instruct verb — behavioural-failure plane (v0.259.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.259.0] — 2026-07-23
+### Added
+- **Loop detection + the `instruct` verb (phase 3 of the decision-brief layer — the behavioural-failure
+  plane).** Agent OS now watches a RUN for failure patterns across effects, not just individual effects.
+  The first detector catches a **no-progress loop** — the same action repeated ≥5× in a 5-minute window.
+  On a loop the gate lets the effect through but attaches an advisory **`instruct`**: an `allow` that also
+  injects a note into the agent's next context (via the PreToolUse hook's `additionalContext` — the one
+  channel verified to reach the model; `permissionDecisionReason` on allow is audit-only). The note is
+  branded, non-coercive advisory copy ("this is about the 5× near-identical action… if you're stuck, try
+  a different approach or `ask` a human") — the framing a spike showed the model heeds rather than flagging
+  as prompt-injection. It's a **nudge, not a control**: the model may ignore it; anything that must stop an
+  effect still routes through deny/approve. New `src/edge/reliability.ts` (`ReliabilityMonitor`,
+  in-memory per session); the loop key folds digit runs so a `?v=$RANDOM` cache-buster or timestamp
+  doesn't mask a real poll loop, while distinct commands never accumulate. Realised as an `allow` + a
+  `GateResult.note` overlay — **not** a new policy `Decision` variant, so `classify`/the gateway are
+  untouched. Audited `reliability.loop`; disable with `AOS_RELIABILITY=0`. See
+  `docs/decision-brief-layer-plan.md` §8/§8a.
+
 ## [0.258.0] — 2026-07-23
 ### Added
 - **Host-trust learning — "Trust host" on an approval card (phase 2 of the decision-brief layer).**

--- a/docs/decision-brief-layer-plan.md
+++ b/docs/decision-brief-layer-plan.md
@@ -227,8 +227,10 @@ verbs plus one new soft verb:
 
 - **`instruct`** (new, soft) — allow the effect but inject a corrective note into the agent's next
   context. Neither blocks nor pages a human. This is the one decision verb agent-os lacks today (we
-  have allow / approve / deny); Failproof's `instruct()` is the idea worth borrowing. Add it to
-  `Decision` as `{ effect: 'instruct'; riskClass: 'green'; reason: string; note: string }`.
+  have allow / approve / deny); Failproof's `instruct()` is the idea worth borrowing. **As shipped
+  (v0.259.0) it is NOT a new `Decision` variant** — the policy verdict stays `allow`, and the note is an
+  overlay the gate returns (`GateResult.note`) so nothing in `classify`/the gateway changes. Realising it
+  as a Decision remains an option if a future consumer needs the policy engine itself to emit it.
 - **escalate** — on repeat after an `instruct`, promote to the existing `approve` (human) or, for a
   hard runaway, `TerminalManager.stopSession` (the same halt the console kill button performs).
 
@@ -292,8 +294,15 @@ Design consequences, now load-bearing:
    fixes the owner's complaint and makes the 62%-never-recalled audit legible.
 2. ✅ **Host-trust button (SHIPPED v0.258.0).** `suggestedAction: 'trust-host'` + the "Trust host"
    action adding an allow-posture `HostStore` grant. Biggest friction cut. See §7.
-3. **`instruct` verb + loop detector.** The single most unambiguous behavioural detector, plus the
-   soft-steer verb. Small, self-contained.
+3. ✅ **`instruct` verb + loop detector (SHIPPED v0.259.0).** Realised as **allow + an advisory `note`**
+   at the gate-return boundary — NOT a new `Decision` variant (keeps `classify`/the gateway untouched).
+   `src/edge/reliability.ts` (`ReliabilityMonitor`) watches each run's allowed effects and, on a
+   no-progress loop (same normalised action ≥5× in a 5-min window), returns a branded, non-coercive note;
+   `TerminalManager.gate` returns `{decision:'allow', note}`, `/api/gate` passes it through, and
+   `gate-hook.sh` emits `allow` + `additionalContext` (the one channel the spike proved reaches the
+   model, §8a). Loop key folds digit runs so a `?v=$RANDOM` cache-buster / timestamp doesn't hide a real
+   poll loop, while distinct commands never accumulate. Audited `reliability.loop`; off via
+   `AOS_RELIABILITY=0`. See §8/§8a.
 4. **Runaway / drift / hallucination detectors + Dreaming feedback.** The full reliability plane and
    a console "reliability" surface.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.258.0",
+  "version": "0.259.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.258.0",
+      "version": "0.259.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.258.0",
+  "version": "0.259.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/reliability.ts
+++ b/src/edge/reliability.ts
@@ -1,0 +1,101 @@
+/**
+ * The RELIABILITY MONITOR — the online, behavioural-failure counterpart to Dreaming's offline
+ * reflection (docs/decision-brief-layer-plan.md §8). Where Policy governs a single effect, this watches
+ * a RUN for failure PATTERNS across effects. Phase 3 ships the first, most unambiguous detector: a
+ * no-progress LOOP — the same action repeated over and over in a short window.
+ *
+ * On a loop it returns an advisory NOTE, delivered to the agent as an `instruct` — an ALLOW that also
+ * injects the note into the model's next context (via the PreToolUse hook's `additionalContext`, the one
+ * channel verified to reach the model — §8a). It is a NUDGE, not a control: the model can, and sometimes
+ * should, ignore it; anything that must actually stop an effect stays on deny/approve. The note is framed
+ * as legitimate, branded, purpose-explained advisory copy — NOT a coercive "you MUST" override, which the
+ * spike showed the model correctly flags as prompt-injection (§8a).
+ *
+ * State is in-memory per session (like the approval waiters) — it does not survive a restart, which is
+ * fine: a loop that matters will re-form. `forget()` drops a session's history when its run ends.
+ */
+
+/** A detected no-progress loop and the advisory note to inject. */
+export interface LoopSignal {
+  kind: 'loop';
+  count: number;
+  note: string;
+}
+
+export interface ReliabilityOptions {
+  /** Repeats within this window count toward a loop; a longer gap resets the streak. Default 5 min. */
+  windowMs?: number;
+  /** Nudge once the same action has repeated this many times in-window. Default 5. */
+  threshold?: number;
+  /** After nudging, stay quiet until this many further repeats accrue (avoids nagging). Default 5. */
+  renudge?: number;
+}
+
+/** Normalise a shell command / connector input into a loop key: same action → same key, so a genuine
+ *  retry loop collapses while distinct work stays distinct. We lowercase, collapse whitespace, and
+ *  replace digit runs with `#` so volatile bits (a `?v=$RANDOM` cache-buster, a timestamp, a pid) don't
+ *  make two otherwise-identical calls look different. Deliberately coarse on digits — a poll of the same
+ *  URL and a retry of the same command are exactly what we want to catch. */
+function loopKey(capability: string, args: Record<string, unknown>): string {
+  const input = args.input && typeof args.input === 'object' ? (args.input as Record<string, unknown>) : args;
+  let payload = '';
+  const command = typeof args.command === 'string' ? args.command : typeof input.command === 'string' ? input.command : '';
+  if (command) payload = command;
+  else if (typeof args.tool === 'string') {
+    // A connector call: the tool name + its input (minus the human `description`) identifies the action.
+    const { description: _d, ...rest } = input as Record<string, unknown> & { description?: unknown };
+    payload = `${args.tool} ${JSON.stringify(rest)}`;
+  } else return '';
+  const norm = payload.toLowerCase().replace(/\s+/g, ' ').replace(/\d+/g, '#').trim();
+  return norm ? `${capability}|${norm}` : '';
+}
+
+/** Branded, advisory, non-coercive — the framing the spike (§8a) showed the model heeds rather than
+ *  flags as injection. No imperatives, no tokens; explains the observation and offers a way out. */
+function loopNote(count: number, headline: string): string {
+  return (
+    `Agent OS reliability monitor: this is about the ${count}× near-identical action in a short ` +
+    `window (“${headline}”) with no apparent progress — a possible loop. If you're stuck, it ` +
+    `usually helps to pause and try a different approach, or use the \`ask\` tool to reach a human, ` +
+    `rather than repeating the same step.`
+  );
+}
+
+export class ReliabilityMonitor {
+  private readonly sessions = new Map<string, Map<string, { count: number; lastTs: number; nudgedAt: number }>>();
+  private readonly windowMs: number;
+  private readonly threshold: number;
+  private readonly renudge: number;
+
+  constructor(opts: ReliabilityOptions = {}) {
+    this.windowMs = opts.windowMs ?? 5 * 60_000;
+    this.threshold = opts.threshold ?? 5;
+    this.renudge = opts.renudge ?? 5;
+  }
+
+  /**
+   * Record an ALLOWED effect and, if it completes a no-progress loop, return the nudge. Call only on the
+   * allow path (an approve/deny already interrupts the run). Pure aside from the in-memory streak state.
+   */
+  observe(sessionId: string, capability: string, args: Record<string, unknown>, headline: string, now: number): LoopSignal | undefined {
+    const key = loopKey(capability, args);
+    if (!key) return undefined;
+    let m = this.sessions.get(sessionId);
+    if (!m) { m = new Map(); this.sessions.set(sessionId, m); }
+    const prev = m.get(key);
+    const inWindow = prev && now - prev.lastTs <= this.windowMs;
+    const count = inWindow ? prev!.count + 1 : 1;
+    const nudgedAt = inWindow ? prev!.nudgedAt : 0;
+    if (count >= this.threshold && (nudgedAt === 0 || count - nudgedAt >= this.renudge)) {
+      m.set(key, { count, lastTs: now, nudgedAt: count });
+      return { kind: 'loop', count, note: loopNote(count, headline) };
+    }
+    m.set(key, { count, lastTs: now, nudgedAt });
+    return undefined;
+  }
+
+  /** Drop a session's streak state when its run ends. */
+  forget(sessionId: string): void {
+    this.sessions.delete(sessionId);
+  }
+}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -18,6 +18,7 @@ import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './con
 import { ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval } from './governance/enricher';
 import { briefFor } from './governance/briefer';
+import { ReliabilityMonitor } from './edge/reliability';
 import { hostGovernanceDecision, stricterDecision } from './governance/host-match';
 import { Audience, approvalAudience, resolveRecipients } from './governance/recipients';
 import { JsonPolicyEngine, PolicyDelta, applyProposal, describeProposal } from './governance/policy';
@@ -318,7 +319,7 @@ export interface FeedMessage {
 }
 
 type GateStatus = 'pending' | 'allow' | 'deny';
-type GateResult = { decision: 'allow' | 'deny' | 'pending'; gateId?: string };
+type GateResult = { decision: 'allow' | 'deny' | 'pending'; gateId?: string; note?: string };
 
 interface SessionRow {
   id: string;
@@ -513,6 +514,10 @@ export class TerminalManager {
   private readonly uidIsolation = process.env.AOS_UID_ISOLATION === '1';
   /** Idle grace before a member's uid/ttyd is reclaimed once they have no running sessions (A5). */
   private readonly idleGraceMs = Number(process.env.AOS_IDLE_GRACE_MS) || 15 * 60_000;
+  /** Online behavioural-failure watch (phase 3): detects a no-progress LOOP within a run and nudges the
+   *  agent via an `instruct` (allow + advisory note). In-memory per session. Off when AOS_RELIABILITY=0. */
+  private readonly reliability = new ReliabilityMonitor();
+  private readonly reliabilityOn = process.env.AOS_RELIABILITY !== '0';
   /** Optional sink notified when an approval card lands, so an out-of-band channel (Slack/Discord DM)
    *  can ping the approver. Set by the registry once the chat sockets exist; absent = no notifications. */
   private approvalNotifier?: (notice: ApprovalNotice) => void;
@@ -2549,7 +2554,20 @@ export class TerminalManager {
     this.audit(sessionId, agent, 'gate.attempt', { capability, args, reasoning, ...sub });
     this.audit(sessionId, agent, 'gate.decision', { capability, decision, brief, ...sub });
 
-    if (decision.effect === 'allow') return { decision: 'allow' };
+    if (decision.effect === 'allow') {
+      // Behavioural-failure watch (phase 3): the effect is allowed, but if it completes a no-progress
+      // LOOP we let it through WITH an advisory note — an `instruct` (allow + additionalContext) that
+      // nudges the agent to break the loop. Soft by design: the model may ignore it. Sub-agent calls
+      // don't carry a distinct run to loop within, so watch only top-level effects.
+      if (this.reliabilityOn && !sub) {
+        const sig = this.reliability.observe(sessionId, capability, args, brief.headline, Date.now());
+        if (sig) {
+          this.audit(sessionId, agent, 'reliability.loop', { capability, signature: brief.signature, count: sig.count });
+          return { decision: 'allow', note: sig.note };
+        }
+      }
+      return { decision: 'allow' };
+    }
     if (decision.effect === 'deny') return { decision: 'deny' };
 
     // Context-aware `ask` (governance P5): if an attended human who can approve this level started the
@@ -4166,6 +4184,7 @@ export class TerminalManager {
       try { this.chatMirror?.(sessionId, (p) => `☑️ ${s.agent} finished — the session ended.\n${chatLink(p, inboxLink, 'Open in Agent OS')}`); } catch { /* advisory */ }
     }
     this.audit(sessionId, s.agent, 'session.ended', {});
+    this.reliability.forget(sessionId); // drop the loop-detector streak state for this run
   }
 
   /** A stopped/ended session was reconnected and is live again — the ttyd attach wrapper resurrected

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -32,6 +32,15 @@ emit() {
   exit 0
 }
 
+# Emit an ALLOW that also injects an advisory note into the model's next context — the `instruct` verb
+# (phase 3). `additionalContext` is the ONE PreToolUse field verified to reach the model on an allow
+# (docs/decision-brief-layer-plan.md §8a); permissionDecisionReason on allow is audit-only. $1 = reason,
+# $2 = note. Used for a reliability nudge (e.g. a detected loop) — soft; the model may ignore it.
+emit_allow_note() {
+  node -e 'const[r,c]=process.argv.slice(1);console.log(JSON.stringify({hookSpecificOutput:{hookEventName:"PreToolUse",permissionDecision:"allow",permissionDecisionReason:r,additionalContext:c}}))' "$1" "$2"
+  exit 0
+}
+
 # This hook is now DUMB TRANSPORT (governance PR #2): it only routes the tool to a capability and ships
 # the FULL tool_input to the server, which enriches it into facts (case-insensitive, argument-aware —
 # it sees the SQL inside db_query/execute_php, the dollar amount, the delete count) and classifies.
@@ -73,8 +82,10 @@ while :; do
   resp=$(curl -s --max-time 10 -X POST "$AOS_URL/api/gate" -H 'content-type: application/json' -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" -d "$payload")
   dec=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.decision||"")})')
   gid=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.gateId||"")})')
+  # An `instruct`: the gate allowed the effect but attached an advisory note (e.g. a detected loop).
+  note=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");process.stdout.write(o.note||"")})')
   case "$dec" in
-    allow) emit allow "Agent OS: allowed by policy." ;;
+    allow) if [ -n "$note" ]; then emit_allow_note "Agent OS: allowed by policy." "$note"; else emit allow "Agent OS: allowed by policy."; fi ;;
     deny)  emit deny "Agent OS policy: denied — this action is blocked (irreversible or not permitted)." ;;
     pending) break ;;
     *) echo "Agent OS: gate unreachable — blocking this action until it responds…" >&2; sleep 2 ;;


### PR DESCRIPTION
## What & why

**Phase 3** of the unified decision-brief layer (`docs/decision-brief-layer-plan.md` §8) — the behavioural-failure plane, the one capability the Failproof AI study showed agent-os genuinely lacked. Agent OS now watches a **run** for failure patterns across effects, not just individual effects.

## The change

**First detector: no-progress loop** — the same normalised action repeated ≥5× in a 5-minute window. On a loop, the gate lets the effect through but attaches an **`instruct`**:
- An `allow` that **injects an advisory note into the agent's next context** via the PreToolUse hook's **`additionalContext`** — the one channel a spike verified reaches the model (`permissionDecisionReason` on allow is audit-only; `systemMessage` is user-only).
- The note is **branded, non-coercive advisory copy** ("this is about the 5× near-identical action… if you're stuck, try a different approach or `ask` a human") — the framing the spike showed the model **heeds** rather than flagging as prompt-injection.
- A **nudge, not a control**: the model may ignore it. Anything that must *stop* an effect still routes through deny/approve; the gateway stays the single chokepoint.

**Design choice:** realised as `allow` + a `GateResult.note` overlay — **not** a new policy `Decision` variant — so `classify` and the gateway are untouched (the note is the reliability monitor's overlay, not a policy verdict).

New `src/edge/reliability.ts` (`ReliabilityMonitor`, in-memory per session, `forget()` on session end). The loop key **folds digit runs** so a `?v=$RANDOM` cache-buster / timestamp doesn't mask a real poll loop, while **distinct commands never accumulate**. `gate-hook.sh` gains `emit_allow_note`.

## Verification
- `npm run typecheck` ✓ · `npm run build` ✓ · `npm run test:governance` **68/68 ✓** · `bash -n gate-hook.sh` ✓
- **Loop-detector scenarios** (built module): nudge exactly at the 5th repeat then quiet; `?v=111/222/333` fold to one key (catches real polls); 5 different commands → never nudge; repeats spaced beyond the window never accumulate; `forget()` clears state. **All pass.**
- **Hook shape**: `emit_allow_note` emits valid `{permissionDecision:"allow", additionalContext:"…"}` — the exact spike-verified instruct channel.

## Config / safety
- Conservative by design (threshold 5, 5-min window, re-nudge only every +5). The note is soft; a false positive just injects an ignorable advisory.
- Disable with `AOS_RELIABILITY=0`. Audited `reliability.loop`. Sub-agent calls are excluded (no distinct run to loop within).

## Not in this PR (future)
- Runaway / drift / hallucination detectors; escalation to `stopSession` on hard runaway; feeding detected patterns to Dreaming; a console "reliability" surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMSbnPEbqSVPGLasTKENp