### PR TITLE
fix(tasks): /goal guard measures the full payload, not just criteria (v0.261.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.261.1] — 2026-07-24
+### Fixed
+- **Dispatch no longer hard-rejects a `/goal` when the criteria fits but the whole prompt doesn't.**
+  The `claude` CLI counts *everything* after `/goal ` as the goal condition — the acceptance criteria
+  **plus** the task/ask boilerplate we append, not just the first line (per
+  code.claude.com/docs/en/goal). The v0.247.1 guard measured only `criteria.length`, so a criteria well
+  under 4000 chars still blew the limit once the base prompt was appended, and the run failed at launch
+  with `Goal condition is limited to 4000 characters (got 4463)`. Both `/goal` emitters
+  (`buildTaskPrompt` for dispatched tasks, `buildAskAgentPrompt` for `ask_agent` delegates) now gate on
+  the **full emitted payload's** length and fall back to plain mode (criteria embedded in the body) when
+  it won't fit — the run still knows the definition of done, it just isn't evaluator-driven.
+
 ## [0.261.0] — 2026-07-24
 ### Added
 - **Native ClickUp ingress (comment → agent).** A ClickUp Automation ("comment posted" → `POST

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.261.0",
+  "version": "0.261.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.261.0",
+      "version": "0.261.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.261.0",
+  "version": "0.261.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -271,24 +271,32 @@ const GOAL_AUTOPLAN_MAX_PER_TICK = Number(process.env.AOS_GOAL_AUTOPLAN_MAX_PER_
  * goal clearing and the task closing are atomic; the existing attempt-ceiling/guard net covers a miss.
  *
  * The `claude` CLI hard-rejects a `/goal` condition over `GOAL_MAX_CHARS` (it errors and the run never
- * starts). An overlong `criteria` therefore falls back to plain mode with the acceptance condition
- * embedded in the prompt body — the run still knows what "done" means, it just isn't evaluator-driven.
+ * starts). Critically, the CLI counts EVERYTHING after `/goal ` as the condition — the criteria AND the
+ * base prompt we append below (not just the first line; see code.claude.com/docs/en/goal). So the guard
+ * measures the WHOLE emitted payload, not `criteria` alone: a criteria that fits on its own still blows
+ * the limit once the boilerplate is appended (the "got 4463" the criteria-only check missed). When the
+ * full payload won't fit, we fall back to plain mode with the acceptance condition embedded in the body —
+ * the run still knows what "done" means, it just isn't evaluator-driven.
  */
 export function buildTaskPrompt(t: { id: string; title: string; body: string; criteria?: string }, opts: { goalMode?: boolean } = {}): string {
-  const goalFits = !!t.criteria && t.criteria.length <= GOAL_MAX_CHARS;
-  const converging = !!(opts.goalMode && goalFits);
-  // Criteria we want to honour but can't route through `/goal` (too long) still belongs in the prompt.
-  const embedCriteria = !!t.criteria && !converging;
-  const close = converging
-    ? `When you have satisfied the goal above, call task_update({ id: "${t.id}", status: "done", note: "<what you did>" }) in that same turn.\n`
-    : `When finished, call task_update({ id: "${t.id}", status: "done", note: "<what you did>" }).\n`;
-  const base =
-    `You are working task ${t.id}: ${t.title}\n\n` +
-    `${t.body || '(no description provided)'}\n\n` +
-    (embedCriteria ? `Acceptance criteria (the definition of done): ${t.criteria}\n\n` : '') +
-    close +
-    `If you cannot proceed, call task_update({ id: "${t.id}", status: "blocked", note: "<why>" }).\n` +
-    `Break large work into sub-tasks with task_create({ parentId: "${t.id}", ... }).`;
+  const buildBase = (converging: boolean) => {
+    // Criteria we want to honour but can't route through `/goal` still belongs in the prompt.
+    const embedCriteria = !!t.criteria && !converging;
+    const close = converging
+      ? `When you have satisfied the goal above, call task_update({ id: "${t.id}", status: "done", note: "<what you did>" }) in that same turn.\n`
+      : `When finished, call task_update({ id: "${t.id}", status: "done", note: "<what you did>" }).\n`;
+    return (
+      `You are working task ${t.id}: ${t.title}\n\n` +
+      `${t.body || '(no description provided)'}\n\n` +
+      (embedCriteria ? `Acceptance criteria (the definition of done): ${t.criteria}\n\n` : '') +
+      close +
+      `If you cannot proceed, call task_update({ id: "${t.id}", status: "blocked", note: "<why>" }).\n` +
+      `Break large work into sub-tasks with task_create({ parentId: "${t.id}", ... }).`
+    );
+  };
+  // The `/goal` condition is the criteria PLUS the appended base — gate on the full payload's length.
+  const converging = !!(opts.goalMode && t.criteria) && `${t.criteria}\n\n${buildBase(true)}`.length <= GOAL_MAX_CHARS;
+  const base = buildBase(converging);
   return converging ? `/goal ${t.criteria}\n\n${base}` : base;
 }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3156,9 +3156,10 @@ export class TerminalManager {
     // `answer` tool); run-as passes the accountable human through. Headless one-off — reaped at turn end.
     // A `goal` (when the installed claude supports `/goal`) opens the prompt under a convergence condition
     // so the delegate works to the objective before answering — the taskless "delegate with a goal" path.
-    // Over-limit goals would make the `claude` CLI hard-reject the run ("Goal condition is limited to
-    // 4000 characters"); fall back to a plain prompt (question still carries the objective) rather than fail.
-    const goalMode = !!(goal && goal.trim() && goal.trim().length <= GOAL_MAX_CHARS) && claudeSupportsGoal();
+    // An over-limit goal would make the `claude` CLI hard-reject the run ("Goal condition is limited to
+    // 4000 characters" — counting the WHOLE payload after `/goal `, not just this string); the builder
+    // measures the full payload and falls back to a plain prompt (question still carries the objective).
+    const goalMode = !!(goal && goal.trim()) && claudeSupportsGoal();
     const s = this.createSession(target, `Ask ← ${callerAgent}`, buildAskAgentPrompt(id, callerAgent, question, goalMode ? goal!.trim() : undefined), `ask:${callerAgent}`, true, undefined, undefined, runAs);
     this.db.prepare('UPDATE agent_asks SET delegate_run_id = ? WHERE id = ?').run(s.id, id);
     this.audit(callerSession, callerAgent, 'agent.asked', { askId: id, target, delegate: s.id, runAs: runAs ?? null });
@@ -4809,8 +4810,12 @@ function buildAskAgentPrompt(id: string, callerAgent: string, question: string, 
     `this run. Put EVERYTHING they need in that one call — they receive only the \`answer\` text, not the ` +
     `rest of your output. If you genuinely cannot help, still call answer with a short explanation of why.`;
   // A `goal` opens the run under a `/goal` convergence condition, so an independent evaluator drives the
-  // delegate across turns until the objective holds; it then returns via `answer` in that same turn.
-  return goal ? `/goal ${goal}\n\n${base}` : base;
+  // delegate across turns until the objective holds; it then returns via `answer` in that same turn. The
+  // CLI counts the WHOLE payload after `/goal ` (goal + this base, not just the first line) against
+  // GOAL_MAX_CHARS, so gate on the full length — else a fitting goal still hard-rejects once base is
+  // appended. Over-limit falls back to a plain prompt (the question still carries the objective).
+  const converging = !!goal && `${goal}\n\n${base}`.length <= GOAL_MAX_CHARS;
+  return converging ? `/goal ${goal}\n\n${base}` : base;
 }
 
 function toSession(r: SessionRow): Session {


### PR DESCRIPTION
## Problem

An agent-scheduled task (or an `ask_agent` delegate) with acceptance `criteria` still failed at launch with:

```
Goal condition is limited to 4000 characters (got 4463)
```

even though the criteria itself was well under 4000 — the v0.247.1 fix was thought to close this.

## Root cause

The `claude` CLI counts **everything after `/goal `** as the goal condition — not just the first line ([docs](https://code.claude.com/docs/en/goal.md): "The condition can be up to 4,000 characters"). We emit `/goal <criteria>\n\n<base prompt>` as a single positional arg (`claude … "$TASK"`), so the *whole* message — criteria **plus** the appended task/ask boilerplate — is measured. The v0.247.1 guard only checked `criteria.length`, so a fitting criteria still blew the limit once the base prompt was appended.

## Fix

Both `/goal` emitters now gate on the **full emitted payload's** length:
- `buildTaskPrompt` (`src/edge/automations.ts`) — dispatched tasks
- `buildAskAgentPrompt` (`src/terminal.ts`) — `ask_agent` delegates (length decision moved into the builder, single source of truth)

When the full payload exceeds `GOAL_MAX_CHARS`, it falls back to plain mode with the criteria embedded in the body — the run still knows the definition of done, it just isn't evaluator-driven.

## Verification

`npm run typecheck` + `npm run build` clean. In-process checks against built `buildTaskPrompt`:
- short criteria + huge body → **falls back** to plain mode (was: `/goal` → hard-reject)
- short criteria + short body → converges, condition ≤ 4000
- near-limit criteria + base → falls back (the original v0.247.1 case still handled)
- `goalMode` off → criteria embedded in body

🤖 Generated with [Claude Code](https://claude.com/claude-code)