### PR TITLE
fix(clickup): /command gate, /ceoagent prompt parity, {id} merge field (v0.261.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.261.2] — 2026-07-24
+### Changed
+- **ClickUp ingress hardening (every comment hits the webhook).** A ClickUp task's comment section is a
+  shared space and the Automation fires on *every* comment, so the dispatcher now **gates on `/agentname`
+  first** — a plain comment is ignored, never delivered into a session bound to that task (only a
+  `/command` acts, matching the old agent-orch behaviour + the bot-comment loop-guard). The task prompt
+  now mirrors the jump-server orchestrator's `/ceoagent`: **fetch the full ClickUp task details first**
+  (the description holds the real content — customer email/`Cx:` fields, issue details, links) before
+  acting, then reply via `clickup_reply`, commenting on the existing task (no duplicate). Console + docs
+  show ClickUp's real `task_id={id}` merge-field syntax (was `{{task.id}}`). Invocations surface on the
+  **Sessions** page ("Chat · <agent> · as <member>") + `trigger.clickup`/`chat.routed`/`clickup.reply` in **Audit**.
+
 ## [0.261.1] — 2026-07-24
 ### Fixed
 - **Dispatch no longer hard-rejects a `/goal` when the criteria fits but the whole prompt doesn't.**
@@ -23,7 +35,7 @@ new version heading in the same commit.
 ## [0.261.0] — 2026-07-24
 ### Added
 - **Native ClickUp ingress (comment → agent).** A ClickUp Automation ("comment posted" → `POST
-  /hooks/clickup?key=…&task_id={{task.id}}`) now reaches any agent from a task comment:
+  /hooks/clickup?key=…&task_id={id}`) now reaches any agent from a task comment:
   `/agent-name your request` spawns a governed session that works the task and posts its answer back as a
   comment; follow-up comments **continue the same conversation** (a `clickup_threads` task→session binding
   + `--resume`, the exact twin of `slack_threads`). This is the direct in-platform replacement for the old

--- a/docs/connectors-and-triggers.md
+++ b/docs/connectors-and-triggers.md
@@ -197,7 +197,7 @@ invite URL is built automatically (no pasting the application id).
 
 **Native ClickUp ingress (webhook, v0.260.0).** The webhook-source twin of the Slack/Discord chat path,
 for the one channel that is genuinely a webhook rather than a socket. A ClickUp Automation ("comment
-posted" → `POST /hooks/clickup?key=…&task_id={{task.id}}`) drives it: the route
+posted" → `POST /hooks/clickup?key=…&task_id={id}`) drives it: the route
 (`server.ts`, in the PUBLIC block beside `/triggers/composio`) authenticates the `?key=` against the
 workspace ClickUp webhook secret, then `ClickupIngress.dispatch` (`src/edge/clickup-ingress.ts`) fetches
 the latest comment via the API (the Automation payload has no text), **loop-guards** its own bot

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.261.1",
+  "version": "0.261.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.261.1",
+      "version": "0.261.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.261.1",
+  "version": "0.261.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -936,9 +936,15 @@ export class Automations {
     const bind = { taskId: event.taskId, commentId: event.commentId };
     const extra =
       `Triggered from ClickUp by ${event.actorLabel} on task ${event.taskId} (${event.taskUrl}).\n` +
-      `Comment:\n${event.text}\n\n` +
-      `When you're done, call the \`clickup_reply\` tool with your answer — it posts back as a comment on ` +
-      `this exact task (you don't need a task id). Keep it concise; ClickUp comments are plain text.\n\n` +
+      `Comment (the user's request):\n${event.text}\n\n` +
+      `Do this IN ORDER:\n` +
+      `1. FIRST fetch the FULL task details for context — the ClickUp task DESCRIPTION holds the real ` +
+      `content (customer email / "Cx:" fields, issue details, links, stack traces), not just this comment. ` +
+      `Use your ClickUp tooling / the ClickUp API on task ${event.taskId}.\n` +
+      `2. Do the work the comment asks, honouring your CLAUDE.md workflow + all guardrails.\n` +
+      `3. Post your result back by calling the \`clickup_reply\` tool — it comments on THIS exact task ` +
+      `(you don't pass a task id). ClickUp comments are plain text (no markdown). Keep it concise.\n` +
+      `This task already exists and IS your tracking task — comment on it; do NOT create a new/duplicate task.\n\n` +
       `Event payload:\n${JSON.stringify(event.raw, null, 2).slice(0, MAX_PAYLOAD_CHARS)}`;
     for (const a of this.list()) {
       if (!a.enabled || a.type !== 'clickup') continue;

--- a/src/edge/clickup-ingress.ts
+++ b/src/edge/clickup-ingress.ts
@@ -63,19 +63,24 @@ export class ClickupIngress {
     if (self && comment.userId && comment.userId === self) return { ok: true, status: 'own comment' };
 
     const text = comment.text || '';
+    // ⚠ EVERY comment on a covered task fires this webhook, and a ClickUp task's comment section is a
+    // SHARED space (not a dedicated bot thread like a Slack thread). So ONLY a comment addressed to an
+    // agent (`/agentname …`) acts — a plain comment is ignored, never delivered into a bound session.
+    // This matches the old agent-orch behaviour (a `/command` each turn); the loop-guard above already
+    // drops our own bot comments. Gate FIRST, before continuity.
+    if (!/^\s*\/[A-Za-z0-9]/.test(text)) return { ok: true, status: 'not a command' };
+
     const member = comment.userEmail ? this.os.team.getMemberByEmail(comment.userEmail) : undefined;
     const runAs = member?.id;
     const actorLabel = member?.name || comment.userEmail || 'a ClickUp user';
 
-    // 1) Continuity: a follow-up on a task already bound to a live/resumable session continues it.
+    // 1) Continuity: a follow-up `/command` on a task already bound to a live/resumable session resumes it.
     const cont = this.autos.continueClickupThread({ taskId, actorLabel, text, raw }, runAs);
     if (cont.status !== 'none') {
       return { ok: true, status: cont.status, sessions: cont.sessionId ? [cont.sessionId] : [] };
     }
 
-    // 2) Fresh: only a `/command` comment routes (else every unrelated comment would spawn/help-spam).
-    if (!/^\s*\/[A-Za-z0-9]/.test(text)) return { ok: true, status: 'not a command' };
-
+    // 2) Fresh: route the `/agentname` to the shared chat front door.
     const r = await this.autos.fireClickup(
       { taskId, commentId: comment.id, text, taskUrl: taskUrl(taskId), actorLabel, raw },
       runAs,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13707,10 +13707,10 @@ function IntegrationsSettings({ me }: { me: Member }) {
               <div className="text-xs font-medium text-foreground">Webhook URL — paste into a ClickUp Automation</div>
               <p className="text-[11px] text-muted-foreground">
                 In ClickUp: <strong>Automations → Add → When a comment is posted → Webhook (POST)</strong>, URL below.
-                (The <code>task_id</code> is filled by ClickUp's <code>{'{{task.id}}'}</code> merge field.)
+                (The <code>{'{id}'}</code> is ClickUp's task-id merge field — it substitutes the real task id when the Automation fires.)
               </p>
               <code className="block break-all rounded bg-background p-2 font-mono text-[11px]">
-                {`${window.location.origin}${clickup.hookPath}&task_id={{task.id}}`}
+                {`${window.location.origin}${clickup.hookPath}&task_id={id}`}
               </code>
             </div>
           )}


### PR DESCRIPTION
Follow-ups after wiring instawp's ClickUp integration live (#444):

- **Every comment hits the webhook** (a ClickUp task's comment section is a shared space, and the Automation fires on all comments) → the dispatcher now **gates on `/agentname` first**; a plain comment is ignored, never delivered into a session bound to that task. Only a `/command` acts (matches the old agent-orch + the bot-comment loop-guard).
- **`/ceoagent` prompt parity** — the task template now mirrors the jump-server orchestrator: **fetch full task details first** (the ClickUp description holds the real content — customer email/`Cx:`/issue detail), then reply via `clickup_reply` on the existing task (no duplicate).
- **`task_id={id}`** — console + docs now show ClickUp's real merge-field syntax (was `{{task.id}}`).

Invocations show on the **Sessions** page ("Chat · <agent> · as <member>") + `trigger.clickup`/`chat.routed`/`clickup.reply` in **Audit**.

Build + web + governance **86/86** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PX3EPzxB13gehNcfsU3Hnk