### PR TITLE
feat(tasks): full-page Discussion room + card affordances (v0.263.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.263.0] — 2026-07-24
+### Changed
+- **Task Discussions now match the redesign — a full-page room, not a modal panel.** Opening a task from the
+  board/list shows a **full-page two-column room**: the Discussion (merged chat + state timeline, mention
+  composer) as the main column, the task's state controls (status/assignee/priority/deps/dispatch/
+  attachments) as a sidebar — replacing the old modal drawer. Board/list **cards gain Discussion
+  affordances**: an unread badge, a last-message preview, and a participant avatar stack, backed by a new
+  per-task rollup (`TaskDiscussionSummary` via `tm.taskDiscussionSummaries`, returned on `GET /api/tasks`).
+  (The Focus view keeps its inline master-detail.)
+
 ## [0.262.1] — 2026-07-24
 ### Fixed
 - **ClickUp loop-guard broke personal API tokens (agents ignored your own comments).** The guard skipped

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.262.1",
+  "version": "0.263.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.262.1",
+      "version": "0.263.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.262.1",
+  "version": "0.263.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -3112,7 +3112,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   const taskAttachment = p.match(/^\/api\/tasks\/[\w-]+\/attachments\/([\w-]+)$/);
   if (method === 'GET' && p === '/api/tasks') {
     const tasks = os.tasks.list({ tenant: os.tenant, status: (url.searchParams.get('status') as TaskStatus) || undefined, query: url.searchParams.get('q') || undefined, limit: 500 });
-    return sendJson(res, 200, { tasks, counts: os.tasks.counts(os.tenant), agents: terminalAgents(os).map((a) => a.id) });
+    return sendJson(res, 200, { tasks, counts: os.tasks.counts(os.tenant), agents: terminalAgents(os).map((a) => a.id), discussions: tm.taskDiscussionSummaries(me) });
   }
   if (taskId && method === 'GET') {
     const found = os.tasks.withEvents(taskId[1]);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,7 +15,7 @@ import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { containedPath, mimeOf } from './state/artifacts';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
-import { ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskTimelineEntry, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
+import { ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskTimelineEntry, TaskDiscussionSummary, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval, redactSecrets } from './governance/enricher';
 import { briefFor } from './governance/briefer';
 import { ReliabilityMonitor } from './edge/reliability';
@@ -2949,6 +2949,28 @@ export class TerminalManager {
                    AND ms.read_at IS NULL AND (m.source IS NULL OR m.source != ?)`)
       .get<{ n: number }>(viewer.id, `task:${taskId}`, viewer.id);
     return row?.n ?? 0;
+  }
+
+  /** Per-task Discussion rollups for the board/list cards (unread for `viewer`, last-message preview,
+   *  participant set), keyed by task id. One scan over the tenant's `task.chat` rows. */
+  taskDiscussionSummaries(viewer: Member): Record<string, TaskDiscussionSummary> {
+    const rows = this.db
+      .prepare(`SELECT m.session_id AS sid, m.source AS source, m.agent AS agent, m.body AS body, m.created_at AS at, ms.read_at AS read_at
+                  FROM messages m
+                  LEFT JOIN message_state ms ON ms.message_id = m.id AND ms.member_id = ?
+                 WHERE m.type = 'task.chat' AND m.session_id LIKE 'task:%'
+                 ORDER BY m.created_at ASC`)
+      .all<{ sid: string; source: string | null; agent: string | null; body: string; at: number; read_at: number | null }>(viewer.id);
+    const out: Record<string, TaskDiscussionSummary> = {};
+    for (const r of rows) {
+      const taskId = r.sid.slice('task:'.length);
+      const e = out[taskId] ?? (out[taskId] = { unread: 0, participants: [] });
+      const who = r.source ?? (r.agent ? `agent:${r.agent}` : 'system');
+      e.last = { body: r.body, author: who, agentId: r.agent || undefined };
+      if (!e.participants.includes(who)) e.participants.push(who);
+      if (r.read_at === null && r.source !== viewer.id) e.unread++;
+    }
+    return out;
   }
 
   /** Mark a task's Discussion read for a member (per-member upsert over its `task.chat` rows). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -834,6 +834,14 @@ export type TaskTimelineEntry =
   | { kind: 'chat'; id: string; author: string; agentId?: string; body: string; mentions: string[]; at: number }
   | { kind: 'event'; id: string; eventKind: TaskEvent['kind']; body?: string; author: string; at: number };
 
+/** Per-task Discussion rollup for the board/list cards: unread count for the viewer, the last message
+ *  (preview), and the set of participants (humans + agents) — see `docs/task-rooms-plan.md`. */
+export interface TaskDiscussionSummary {
+  unread: number;
+  last?: { body: string; author: string; agentId?: string };
+  participants: string[]; // member id | 'agent:<id>' | 'system'
+}
+
 /** A file attached to a task — a durable on-disk snapshot (mirrors {@link Artifact}, keyed to a task). */
 export interface TaskAttachment {
   id: string;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -7468,6 +7468,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
   useEffect(() => { api.goals().then((r) => setGoals(r.goals ?? [])).catch(() => {}) }, [])
   const goalTitle = (id?: string) => (id ? goals.find((g) => g.id === id)?.title || id : '')
   const [tasks, setTasks] = useState<Task[] | null>(null)
+  const [discussions, setDiscussions] = useState<Record<string, TaskDiscussionSummary>>({})
   const [counts, setCounts] = useState<Record<TaskStatus, number>>({ todo: 0, doing: 0, blocked: 0, done: 0, cancelled: 0 })
   // Live sessions, cross-referenced against a task's lastSessionId to know which cards are running right now.
   const [sessions, setSessions] = useState<Session[]>([])
@@ -7575,6 +7576,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
   const load = async () => {
     const [r, ss] = await Promise.all([api.tasks(q), api.sessions().catch(() => [] as Session[])])
     setTasks(r.tasks ?? [])
+    setDiscussions(r.discussions ?? {})
     if (r.counts) setCounts(r.counts)
     setSessions(ss)
   }
@@ -7696,6 +7698,19 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
           <span className="ml-auto font-mono text-[10px] opacity-60">{t.id}</span>
         </div>
         {blockerChips(t)}
+        {(() => {
+          const d = discussions[t.id]
+          if (!d || (!d.last && d.participants.length === 0)) return null
+          return (
+            <div className="mt-2 flex items-center gap-2 border-t border-dashed pt-1.5">
+              {d.last
+                ? <span className="min-w-0 flex-1 truncate text-[11px] text-muted-foreground"><b className="font-medium text-foreground">{discussionAuthor(d.last.author, d.last.agentId, members).name}</b>: {d.last.body}</span>
+                : <span className="flex-1" />}
+              <DiscussionAvatars participants={d.participants} members={members} />
+              {d.unread > 0 && <span className="inline-flex h-4 shrink-0 items-center gap-0.5 rounded-full bg-sky-500 px-1.5 text-[10px] font-semibold text-white"><MessageSquare className="h-2.5 w-2.5" />{d.unread}</span>}
+            </div>
+          )
+        })()}
         {/* The session, running inside the task — live tape with elapsed clock + attach, or an ended-run note. */}
         {doing && live && (
           <div
@@ -7725,9 +7740,10 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
     )
   }
 
-  // The task detail — shared verbatim by the modal drawer (Board/List) and the inline Focus panel, so a
-  // task edits identically in both. Guards on `detail` being loaded.
-  const detailBody = () => {
+  // The task detail — shared by the inline Focus panel and the full-page room's sidebar. `withDiscussion`
+  // (default true) inlines the Discussion; the room renders the Discussion as its own main column instead,
+  // so it passes `withDiscussion:false` here. Guards on `detail` being loaded.
+  const detailBody = (opts?: { withDiscussion?: boolean }) => {
     if (!detail) return null
     const live = liveOf(detail.task)
     return editing ? (
@@ -7742,7 +7758,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
     ) : (
       <div className="space-y-3.5">
         <div className="font-mono text-xs text-muted-foreground">{detail.task.id}{detail.task.owner ? ` · as ${nameOf(detail.task.owner)}` : ''}</div>
-        {detail.task.body && <div className="max-h-56 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap [&_pre]:break-words"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{detail.task.body}</ReactMarkdown></div>}
+        {opts?.withDiscussion !== false && detail.task.body && <div className="max-h-56 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap [&_pre]:break-words"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{detail.task.body}</ReactMarkdown></div>}
 
         {live && (
           <button onClick={() => attach(detail.task, live)} className="flex w-full items-center gap-2 rounded-md border border-sky-500/30 bg-sky-500/5 px-3 py-2 text-left hover:border-sky-500/60">
@@ -7837,15 +7853,17 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
         )}
         {hint && <div className="font-mono text-xs text-destructive">{hint}</div>}
 
-        <TaskDiscussion
-          taskId={detail.task.id}
-          entries={detail.discussion}
-          unread={detail.unread}
-          me={me}
-          members={members}
-          agents={agents}
-          onChange={() => refreshDetail(detail.task.id)}
-        />
+        {opts?.withDiscussion !== false && (
+          <TaskDiscussion
+            taskId={detail.task.id}
+            entries={detail.discussion}
+            unread={detail.unread}
+            me={me}
+            members={members}
+            agents={agents}
+            onChange={() => refreshDetail(detail.task.id)}
+          />
+        )}
 
         <TaskAttachments
           taskId={detail.task.id}
@@ -7900,8 +7918,40 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
     </>
   ))
 
+  // Full-page room (Board/List): the task's Discussion as the main column + its state controls as a
+  // sidebar, replacing the old modal drawer. Focus view keeps its own inline master-detail (detailBody).
+  const roomView = () => {
+    if (!detail) return null
+    const t = detail.task
+    const parts = discussions[t.id]?.participants ?? []
+    return (
+      <div className="flex h-[calc(100vh-2rem)] flex-col overflow-hidden rounded-lg border bg-background">
+        <div className="flex items-center gap-3 border-b px-4 py-2.5">
+          <button onClick={closeTask} className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"><ArrowLeft className="h-4 w-4" />Tasks</button>
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <TaskStatusPill status={t.status} />
+            <span className="truncate text-[15px] font-semibold">{t.title}</span>
+            <span className="shrink-0 font-mono text-[11px] text-muted-foreground">{t.id}</span>
+          </div>
+          {parts.length > 0 && <span className="hidden items-center gap-1.5 text-[11px] text-muted-foreground sm:flex"><DiscussionAvatars participants={parts} members={members} />{parts.filter((p) => p !== 'system').length} in discussion</span>}
+          <button onClick={closeTask} className="rounded-md p-1 text-muted-foreground hover:bg-muted hover:text-foreground"><X className="h-4 w-4" /></button>
+        </div>
+        <div className="grid min-h-0 flex-1 grid-cols-1 lg:grid-cols-[minmax(0,1fr)_340px]">
+          <div className="min-w-0 overflow-y-auto border-b p-4 lg:border-b-0 lg:border-r">
+            {detail.task.body && <div className="mb-3 max-h-40 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{detail.task.body}</ReactMarkdown></div>}
+            <TaskDiscussion taskId={t.id} entries={detail.discussion} unread={detail.unread} me={me} members={members} agents={agents} onChange={() => refreshDetail(t.id)} />
+          </div>
+          <div className="overflow-y-auto p-4">
+            {detailBody({ withDiscussion: false })}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="space-y-4">
+      {detail && view !== 'focus' && <div className="fixed inset-4 z-50">{roomView()}</div>}
       <div className="flex flex-wrap items-center gap-2">
         <p className="mr-auto max-w-xl text-sm text-muted-foreground">
           The shared work queue humans and agents drain together. Assign to an agent with <strong>auto-dispatch</strong> and it
@@ -8194,16 +8244,6 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
 
       </div>
 
-      {detail && view !== 'focus' && (
-        <Dialog open onOpenChange={(o) => { if (!o) closeTask() }}>
-          <DialogContent className="max-h-[88vh] w-full max-w-[calc(100%-2rem)] overflow-y-auto sm:max-w-2xl lg:max-w-3xl">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2 pr-8">{detailHeader()}</DialogTitle>
-            </DialogHeader>
-            {detailBody()}
-          </DialogContent>
-        </Dialog>
-      )}
     </div>
   )
 }
@@ -8315,6 +8355,20 @@ function discussionAuthor(author: string, agentId: string | undefined, members: 
   const m = members.find((x) => x.id === author)
   const name = m?.name || m?.email?.split('@')[0] || author
   return { name, kind: 'human', initials: name.replace(/[^a-z0-9]/gi, '').slice(0, 2).toUpperCase() || '?' }
+}
+
+/** A small overlapping avatar stack of a task Discussion's participants (humans + agents). */
+function DiscussionAvatars({ participants, members }: { participants: string[]; members: Member[] }) {
+  const shown = participants.filter((p) => p !== 'system').slice(0, 4)
+  if (!shown.length) return null
+  return (
+    <span className="flex shrink-0 -space-x-1.5">
+      {shown.map((p) => {
+        const a = discussionAuthor(p, undefined, members)
+        return <span key={p} title={a.name} className={`flex h-4 w-4 items-center justify-center rounded-[4px] text-[8px] font-semibold ring-2 ring-background ${a.kind === 'agent' ? 'bg-sky-500/20 text-sky-600' : 'bg-muted text-foreground'}`}>{a.initials}</span>
+      })}
+    </span>
+  )
 }
 
 /** Render Discussion body text with @mentions highlighted (agent mentions get the sky accent). */

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -540,6 +540,12 @@ export interface TaskAttachment {
 export type TaskTimelineEntry =
   | { kind: 'chat'; id: string; author: string; agentId?: string; body: string; mentions: string[]; at: number }
   | { kind: 'event'; id: string; eventKind: TaskEvent['kind']; body?: string; author: string; at: number }
+/** Per-task Discussion rollup for the board/list cards (unread, last message, participants). */
+export interface TaskDiscussionSummary {
+  unread: number
+  last?: { body: string; author: string; agentId?: string }
+  participants: string[]
+}
 export interface AddTaskReq {
   title: string
   body?: string
@@ -1390,7 +1396,7 @@ export const api = {
   kbRevert: (id: string, rev: number) => call<{ ok: boolean; page?: KbPage; error?: string }>('POST', `/api/kb/page/${id}/revert`, { rev }),
   kbDelete: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/kb/page/${id}`),
 
-  tasks: (q = '', status = '') => call<{ tasks: Task[]; counts: Record<TaskStatus, number>; agents: string[] }>('GET', `/api/tasks?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
+  tasks: (q = '', status = '') => call<{ tasks: Task[]; counts: Record<TaskStatus, number>; agents: string[]; discussions?: Record<string, TaskDiscussionSummary> }>('GET', `/api/tasks?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
   task: (id: string) => call<{ task?: Task; events?: TaskEvent[]; attachments?: TaskAttachment[]; dependents?: string[]; discussion?: TaskTimelineEntry[]; unread?: number; error?: string }>('GET', `/api/tasks/${id}`),
   postTaskMessage: (id: string, body: string) => call<{ ok: boolean; entry?: TaskTimelineEntry; mentioned?: string[]; agents?: { agent: string; status: string }[]; error?: string }>('POST', `/api/tasks/${id}/messages`, { body }),
   readTaskDiscussion: (id: string) => call<{ ok: boolean }>('POST', `/api/tasks/${id}/read`),


### PR DESCRIPTION
Follow-up to #447 — makes the live Tasks UI match the mockup artifact.

- **Full-page room** replaces the modal drawer: clicking a task opens a two-column view — Discussion (merged timeline + mention composer) as the main column, task state controls as a sidebar. Back-arrow returns to the board.
- **Board/list card affordances:** unread badge, last-message preview, participant avatar stack — backed by a per-task rollup (`TaskDiscussionSummary` on `GET /api/tasks`).
- Focus view keeps its inline master-detail.

Verified: `typecheck` ✓, `web build` ✓, `governance 86/86` ✓. Not screenshot-verified (no Playwright in this env) — visual QA on the live instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)