### PR TITLE
feat(clickup): 👀 reaction on read, drop the 'on it' ack comment (v0.262.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.262.2] — 2026-07-24
+### Changed
+- **ClickUp: 👀 reaction instead of an "on it" comment.** When a `/agentname` comment is picked up, the
+  ingress now reacts 👀 (`eyes`) on the triggering comment as the "read / processing" signal, and no
+  longer posts a "🤖 On it…" ack comment (noise) — the reaction + the agent's eventual `clickup_reply`
+  are enough. (Routing help / disambiguation still posts a comment, since it carries text.) New
+  `addReaction()` connector fn (ClickUp reactions take an emoji SHORTCODE array, e.g. `{reactions:["eyes"]}`).
+
 ## [0.262.1] — 2026-07-24
 ### Fixed
 - **ClickUp loop-guard broke personal API tokens (agents ignored your own comments).** The guard skipped

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.262.1",
+  "version": "0.262.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.262.1",
+      "version": "0.262.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.262.1",
+  "version": "0.262.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/connectors/clickup.ts
+++ b/src/connectors/clickup.ts
@@ -70,6 +70,25 @@ export async function addComment(token: string, taskId: string, text: string): P
   }
 }
 
+/** Add an emoji reaction to a comment (ClickUp wants the emoji SHORTCODE, e.g. `eyes` for 👀 — NOT the
+ *  unicode char). Used to mark a triggering comment as "read / processing". Never throws. */
+export async function addReaction(token: string, commentId: string, reaction = 'eyes'): Promise<{ ok: true } | { error: string }> {
+  if (!token || !commentId) return { error: 'missing token or comment id' };
+  try {
+    const res = await fetch(`${CLICKUP_API}/comment/${encodeURIComponent(commentId)}/reaction`, {
+      method: 'POST',
+      headers: { authorization: token, 'content-type': 'application/json' },
+      body: JSON.stringify({ reactions: [reaction] }),
+    });
+    const j: any = await res.json().catch(() => ({}));
+    // `{ added: [...] }` on success; an ALREADY-reacted comment returns a benign error we treat as ok.
+    if (res.ok || (Array.isArray(j?.added))) return { ok: true };
+    return { error: String(j?.err || `reaction POST failed (${res.status})`) };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'reaction POST failed' };
+  }
+}
+
 /** Fetch the authorized user for a token: `{ id, email, name }`, or `{ error }`. Used by Settings →
  *  Integrations "test connection" and by the ingress loop-guard (the bot posts comments as THIS user,
  *  so we skip comments authored by it to avoid re-triggering on our own replies). Never throws. */

--- a/src/edge/clickup-ingress.ts
+++ b/src/edge/clickup-ingress.ts
@@ -21,7 +21,7 @@
  */
 import type { AgentOS } from '../kernel';
 import type { Automations } from './automations';
-import { addComment, fetchLatestComment, taskUrl } from '../connectors/clickup';
+import { addComment, addReaction, fetchLatestComment, taskUrl } from '../connectors/clickup';
 
 export class ClickupIngress {
   /**
@@ -78,6 +78,10 @@ export class ClickupIngress {
     // comment (ClickUp fetches "latest", which may still be this one) doesn't double-spawn.
     this.remember(comment.id);
 
+    // 👀 "read / processing" signal — react to the triggering comment so the caller knows we picked it up
+    // (lighter + less noisy than an "on it" comment). Best-effort; the eventual reply is the real answer.
+    void addReaction(token, comment.id, 'eyes');
+
     const member = comment.userEmail ? this.os.team.getMemberByEmail(comment.userEmail) : undefined;
     const runAs = member?.id;
     const actorLabel = member?.name || comment.userEmail || 'a ClickUp user';
@@ -93,13 +97,11 @@ export class ClickupIngress {
       { taskId, commentId: comment.id, text, taskUrl: taskUrl(taskId), actorLabel, raw },
       runAs,
     );
-    // Ack in-thread: a routing/disambiguation reply, or an "on it" when a session started. Remember the
-    // posted comment id so the webhook it triggers is skipped (loop-guard).
+    // A routing/disambiguation reply (help list / "which agent?") carries TEXT, so it's a comment — and
+    // we remember its id to skip the webhook it triggers. A successful dispatch posts NO "on it" comment:
+    // the 👀 reaction above is the acknowledgement; the agent's own `clickup_reply` is the result.
     if (r.reply) {
       const a = await addComment(token, taskId, r.reply);
-      if ('ok' in a) this.remember(a.id);
-    } else if (r.sessions.length) {
-      const a = await addComment(token, taskId, `🤖 On it — ${r.sessions.length === 1 ? 'an agent is' : 'agents are'} working on this; I'll post the result here.`);
       if ('ok' in a) this.remember(a.id);
     }
     return { ok: true, status: r.sessions.length ? 'dispatched' : 'ignored', sessions: r.sessions };


### PR DESCRIPTION
When a `/agentname` comment is picked up, the ingress now reacts **👀** (`eyes`) on the triggering comment as the read/processing signal, and no longer posts a **"🤖 On it…"** ack comment (noise). The reaction + the agent's `clickup_reply` are enough; routing help/disambiguation still comments (it carries text).

New `addReaction()` connector fn — ClickUp reactions take an emoji **shortcode** array (`{reactions:["eyes"]}`), not the unicode char (verified live).

Verified separately: your `/engineer` run executed end-to-end (dispatched → `clickup.reply` 443 chars back to the task; loop-guard drops the follow-up webhooks as 'already handled').

🤖 Generated with [Claude Code](https://claude.com/claude-code)