### PR TITLE
feat(chat): /agent-os <agent> namespace prefix alias (v0.263.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.263.2] — 2026-07-24
+### Added
+- **`/agent-os <agent>` namespace prefix for the chat router.** `/agent-os engineer fix X` (or `/agentos …`)
+  now routes identically to the bare `/engineer fix X` — the `/agent-os` prefix is normalised away in
+  `routeChat`/`stripChatPrefix`, so it works on every channel (Slack/Discord/ClickUp). Clearer in shared
+  spaces like ClickUp task comments (a bare `/name` is ambiguous there); the bare form still works.
+
 ## [0.263.1] — 2026-07-24
 ### Changed
 - **ClickUp: 👀 reaction instead of an "on it" comment.** When a `/agentname` comment is picked up, the

--- a/docs/connectors-and-triggers.md
+++ b/docs/connectors-and-triggers.md
@@ -203,7 +203,8 @@ workspace ClickUp webhook secret, then `ClickupIngress.dispatch` (`src/edge/clic
 the latest comment via the API (the Automation payload has no text), **loop-guards** its own bot
 comments, resolves run-as (commenter email → member, `getMemberByEmail`), and either
 `continueClickupThread` (a follow-up on a task bound in `clickup_threads` → resume) or `fireClickup` → the
-same `/agentname` front door (`routeUnmatched`) — so `/ceoagent <request>` reaches any agent with no
+same `/agentname` front door (`routeUnmatched`) — so `/agent-os <agent> <request>` (or the bare
+`/<agent>`; the `/agent-os` namespace prefix is normalised away and works on every channel) reaches any agent with no
 per-agent automation. The agent replies with the `clickup_reply` MCP tool (gated `CLICKUP_REPLY=1`),
 which posts back on the bound task — never handed a task id. Config lives in **Settings → Integrations →
 ClickUp** (API token + the generated hook URL to paste into ClickUp); a `clickup` automation trigger type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.263.1",
+  "version": "0.263.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.263.1",
+      "version": "0.263.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.263.1",
+  "version": "0.263.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -616,14 +616,22 @@ export class Automations {
    * is the fallback used by fireSlack/fireDiscord when NO automation matched, so connecting the bot once
    * makes the whole fleet reachable ("/pod-troubleshooter why is X down?").
    */
+  /** Normalise the optional `/agent-os` namespace prefix: `/agent-os engineer …` (or `/agentos …`, with
+   *  an optional second slash) collapses to `/engineer …`, so a namespaced invocation and the bare
+   *  `/<agent>` form route identically. Useful in shared spaces (ClickUp task comments) where a bare
+   *  `/name` is ambiguous; a no-op for a plain `/<agent>`. */
+  private normalizeChatCommand(text: string): string {
+    return (text || '').replace(/^(\s*)\/agent-?os\s+\/?/i, '$1/');
+  }
+
   private routeChat(text: string): { agentId?: string; help?: string } {
     const chatAgents = [...this.os.agents.values()].filter((a) => a.runtime === 'claude-code').map((a) => a.id);
-    const m = (text || '').trim().match(/^\/([A-Za-z0-9][\w-]*)\b\s*([\s\S]*)$/);
+    const m = this.normalizeChatCommand(text).trim().match(/^\/([A-Za-z0-9][\w-]*)\b\s*([\s\S]*)$/);
     if (m && chatAgents.includes(m[1])) return { agentId: m[1] };
     const list = chatAgents.length ? chatAgents.map((id) => `• \`/${id}\``).join('\n') : '_(no agents available)_';
     const help = m
-      ? `I don't have an agent named \`/${m[1]}\`. Address one with \`/<agent>\` and your request:\n${list}`
-      : `👋 Address an agent with \`/<agent>\` followed by your request. Available:\n${list}`;
+      ? `I don't have an agent named \`/${m[1]}\`. Address one with \`/agent-os <agent>\` (or just \`/<agent>\`) and your request:\n${list}`
+      : `👋 Address an agent with \`/agent-os <agent>\` (or just \`/<agent>\`) followed by your request. Available:\n${list}`;
     return { help };
   }
 
@@ -1084,7 +1092,7 @@ export class Automations {
    *  tokens from a follow-up before it's typed into a live claude — so a re-mention doesn't land as a
    *  slash command. Returns the cleaned message (never undefined). */
   private stripChatPrefix(text: string): string {
-    const t = (text || '').replace(/<@[^>]+>/g, '').trim();
+    const t = this.normalizeChatCommand((text || '').replace(/<@[^>]+>/g, '')).trim();
     const m = t.match(/^\/([A-Za-z0-9][\w-]*)\s+([\s\S]*)$/);
     if (m && this.os.agents.has(m[1])) return m[2].trim();
     return t;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13862,7 +13862,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
                 : <Badge variant="outline" className="px-1.5 py-0 text-[10px]">not configured</Badge>}
             </div>
             <p className="text-xs text-muted-foreground">
-              Reach any agent from a ClickUp task comment: <code className="text-[11px]">/agent-name your request</code>.
+              Reach any agent from a ClickUp task comment: <code className="text-[11px]">/agent-os &lt;agent&gt; your request</code> (or just <code className="text-[11px]">/&lt;agent&gt;</code>).
               The agent works the task and posts its answer back as a comment; follow-up comments continue the same
               conversation. One company ClickUp API token reads the comment and posts the reply.
             </p>


### PR DESCRIPTION
`/agent-os engineer fix X` now routes the same as `/engineer fix X` — the `/agent-os` (or `/agentos`) namespace prefix is normalised away in `routeChat`/`stripChatPrefix`, so it works on **every** channel (Slack/Discord/ClickUp). Clearer for shared spaces like ClickUp task comments (a bare `/name` is ambiguous there); the bare `/<agent>` form still works. Console card + docs updated to recommend `/agent-os <agent> <request>`.

Normalization verified: `/agent-os engineer fix X`→`/engineer fix X`, `/agentos docs-bot hi`→`/docs-bot hi`, `/agent-os /qa run`→`/qa run`, bare/plain unchanged. Build + governance 86/86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)