### PR TITLE
fix(tasks): Discussion room renders in the content area (v0.263.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.263.3] — 2026-07-24
+### Changed
+- **Task room renders inside the content area, not as a full-page overlay.** The Discussion room now
+  replaces the board *within* the main content column (the app nav/sidebar stays visible), instead of a
+  fixed full-screen layer over everything.
+
 ## [0.263.2] — 2026-07-24
 ### Added
 - **`/agent-os <agent>` namespace prefix for the chat router.** `/agent-os engineer fix X` (or `/agentos …`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.263.2",
+  "version": "0.263.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.263.2",
+      "version": "0.263.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.263.2",
+  "version": "0.263.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7925,7 +7925,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
     const t = detail.task
     const parts = discussions[t.id]?.participants ?? []
     return (
-      <div className="flex h-[calc(100vh-2rem)] flex-col overflow-hidden rounded-lg border bg-background">
+      <div className="flex h-[calc(100vh-5.5rem)] flex-col overflow-hidden rounded-lg border bg-background">
         <div className="flex items-center gap-3 border-b px-4 py-2.5">
           <button onClick={closeTask} className="inline-flex items-center gap-1 rounded-md px-1.5 py-1 text-sm text-muted-foreground hover:bg-muted hover:text-foreground"><ArrowLeft className="h-4 w-4" />Tasks</button>
           <div className="flex min-w-0 flex-1 items-center gap-2">
@@ -7951,7 +7951,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
 
   return (
     <div className="space-y-4">
-      {detail && view !== 'focus' && <div className="fixed inset-4 z-50">{roomView()}</div>}
+      {detail && view !== 'focus' ? roomView() : (<>
       <div className="flex flex-wrap items-center gap-2">
         <p className="mr-auto max-w-xl text-sm text-muted-foreground">
           The shared work queue humans and agents drain together. Assign to an agent with <strong>auto-dispatch</strong> and it
@@ -8243,7 +8243,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
         )}
 
       </div>
-
+      </>)}
     </div>
   )
 }


### PR DESCRIPTION
Keeps the app nav/sidebar visible — the Discussion room now replaces the board *within* the main content column instead of a fixed full-page overlay. Per feedback on #449. typecheck ✓ / web build ✓.