### PR TITLE
feat(agents): private (owner-only) agent sharing (v0.264.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.263.6] — 2026-07-24
+## [0.264.0] — 2026-07-24
+### Added
+- **Private (owner-only) agents — a tier below the owner+admin default.** Until now the tightest an
+  agent could be shared was the empty-assignment floor: owners **and** admins. `AgentAccess` gains an
+  `ownerOnly` flag so an owner can restrict an agent to the **owner role only** — admins are excluded and
+  the role/member grants are void (`canRun` returns true iff `role === 'owner'`). Owner-settable only: an
+  admin's assignment write preserves the flag but can't toggle it, and a private agent is filtered out of
+  the admin's `/api/team` agent + assignment lists entirely (invisible, not just un-runnable). Surfaced in
+  the Share dialog as a "Private — owners only" switch (shown to owners), which disables the All-members /
+  per-member controls while on. New `assignments.owner_only` column (idempotent migration; existing rows
+  default to the unchanged owner+admin floor).
 ### Fixed
 - **Enricher: two more content-vs-intent false positives (`gh api -f body=` PR bodies, `grep`/`echo`
   trigger words).** A live docs-bot session was still hard-denied post-v0.260 because `sanitizeForIntent`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.263.6",
+  "version": "0.264.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.263.6",
+      "version": "0.264.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.263.6",
+  "version": "0.264.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -345,21 +345,23 @@ export class TeamStore {
   // ── agent assignment ─────────────────────────────────────────────────────────
   getAssignment(agentId: string): AgentAccess {
     const r = this.db
-      .prepare('SELECT allowed_roles, allowed_members FROM assignments WHERE agent_id = ?')
-      .get<{ allowed_roles: string; allowed_members: string }>(agentId);
+      .prepare('SELECT allowed_roles, allowed_members, owner_only FROM assignments WHERE agent_id = ?')
+      .get<{ allowed_roles: string; allowed_members: string; owner_only: number | null }>(agentId);
     return {
       allowedRoles: r ? (JSON.parse(r.allowed_roles) as Role[]) : [],
       allowedMembers: r ? (JSON.parse(r.allowed_members) as string[]) : [],
+      ownerOnly: !!r?.owner_only,
     };
   }
   listAssignments(): Record<string, AgentAccess> {
     const out: Record<string, AgentAccess> = {};
     for (const r of this.db
-      .prepare('SELECT agent_id, allowed_roles, allowed_members FROM assignments')
-      .all<{ agent_id: string; allowed_roles: string; allowed_members: string }>()) {
+      .prepare('SELECT agent_id, allowed_roles, allowed_members, owner_only FROM assignments')
+      .all<{ agent_id: string; allowed_roles: string; allowed_members: string; owner_only: number | null }>()) {
       out[r.agent_id] = {
         allowedRoles: JSON.parse(r.allowed_roles) as Role[],
         allowedMembers: JSON.parse(r.allowed_members) as string[],
+        ownerOnly: !!r.owner_only,
       };
     }
     return out;
@@ -367,10 +369,10 @@ export class TeamStore {
   setAssignment(agentId: string, access: AgentAccess): void {
     this.db
       .prepare(
-        `INSERT INTO assignments (agent_id, allowed_roles, allowed_members) VALUES (?, ?, ?)
-         ON CONFLICT(agent_id) DO UPDATE SET allowed_roles = excluded.allowed_roles, allowed_members = excluded.allowed_members`,
+        `INSERT INTO assignments (agent_id, allowed_roles, allowed_members, owner_only) VALUES (?, ?, ?, ?)
+         ON CONFLICT(agent_id) DO UPDATE SET allowed_roles = excluded.allowed_roles, allowed_members = excluded.allowed_members, owner_only = excluded.owner_only`,
       )
-      .run(agentId, JSON.stringify(access.allowedRoles), JSON.stringify(access.allowedMembers));
+      .run(agentId, JSON.stringify(access.allowedRoles), JSON.stringify(access.allowedMembers), access.ownerOnly ? 1 : 0);
   }
 
   /** Drop an agent's access row — called when the agent itself is deleted. */
@@ -378,10 +380,14 @@ export class TeamStore {
     this.db.prepare('DELETE FROM assignments WHERE agent_id = ?').run(agentId);
   }
 
-  /** May this member run this agent? owner/admin always; member iff granted by role or id. */
+  /**
+   * May this member run this agent? owner-only agents → owner role ONLY (admins & grants void).
+   * Otherwise owner/admin always; member iff granted by role or id.
+   */
   canRun(member: Member, agentId: string): boolean {
-    if (member.role === 'owner' || member.role === 'admin') return true;
     const a = this.getAssignment(agentId);
+    if (a.ownerOnly) return member.role === 'owner';
+    if (member.role === 'owner' || member.role === 'admin') return true;
     return a.allowedRoles.includes(member.role) || a.allowedMembers.includes(member.id);
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2143,12 +2143,21 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
 
   // ── team / members / assignments ─────────────────────────────────────────────
   if (method === 'GET' && p === '/api/team') {
+    // Owner-only agents are invisible to admins — filter both the agent list and the assignment map so
+    // an admin can't see or manage a private-to-owner agent from the Team/Share surfaces.
+    const allAssignments = os.team.listAssignments();
+    const assignments = me.role === 'owner'
+      ? allAssignments
+      : Object.fromEntries(Object.entries(allAssignments).filter(([, a]) => !a.ownerOnly));
+    const agents = me.role === 'owner'
+      ? terminalAgents(os)
+      : terminalAgents(os).filter((a) => !allAssignments[a.id]?.ownerOnly);
     return sendJson(res, 200, {
       me,
       members: os.team.listMembers(),
-      assignments: os.team.listAssignments(),
+      assignments,
       identities: os.team.identitiesByMember(), // member id → external accounts (chat run-as join keys)
-      agents: terminalAgents(os), // ALL agents, so owner/admin can assign access
+      agents, // owner sees ALL to assign access; admins never see owner-only agents
     });
   }
   if (method === 'POST' && p === '/api/team/invite') {
@@ -2244,10 +2253,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   const teamAssign = p.match(/^\/api\/team\/assignments\/([\w.-]+)$/);
   if (method === 'PUT' && teamAssign) {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const current = os.team.getAssignment(teamAssign[1]);
+    // A private (owner-only) agent is invisible to admins and its access is an owner's call — an admin
+    // can neither edit its grants nor flip the flag off to grant themselves in.
+    if (current.ownerOnly && me.role !== 'owner') return sendJson(res, 403, { error: 'this agent is private to owners' });
     const b = await readBody(req);
     const allowedRoles = (Array.isArray(b.allowedRoles) ? b.allowedRoles : []).map(roleOf).filter(Boolean) as Role[];
     const allowedMembers = (Array.isArray(b.allowedMembers) ? b.allowedMembers : []).map(String);
-    os.team.setAssignment(teamAssign[1], { allowedRoles, allowedMembers });
+    // Only an owner may set/clear owner-only; an admin's write preserves the existing flag.
+    const ownerOnly = me.role === 'owner' ? !!b.ownerOnly : current.ownerOnly;
+    os.team.setAssignment(teamAssign[1], { allowedRoles, allowedMembers, ownerOnly });
     return sendJson(res, 200, { ok: true, assignment: os.team.getAssignment(teamAssign[1]) });
   }
 

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -898,6 +898,10 @@ function migrate(db: Db): void {
   // re-nudged; a timestamp = we already sent the reminder. A resolved/answered row is skipped by status.
   addColumn(db, 'approvals', 'escalated_at', 'INTEGER');       // when the stale-approval reminder fired
   addColumn(db, 'questions', 'escalated_at', 'INTEGER');       // when the stale-question reminder fired
+
+  // Private-to-owners agents: when 1, ONLY the owner role runs/sees the agent (admins excluded, the
+  // role/member grants void) — the tightest tier below the owner+admin default. NULL/0 = default floor.
+  addColumn(db, 'assignments', 'owner_only', 'INTEGER');       // 1 = owner-role-only
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -175,6 +175,12 @@ export interface MemberIdentity {
 export interface AgentAccess {
   allowedRoles: Role[];
   allowedMembers: string[];
+  /**
+   * Private-to-owners: when true, ONLY the owner role can run/see this agent — admins are
+   * excluded and the role/member grants are void (the tightest tier, below the owner+admin
+   * default). Only an owner may set or clear this flag. Absent/false → the default owner+admin floor.
+   */
+  ownerOnly?: boolean;
 }
 
 /** Can a role resolve an approval routed to `level`? owner→any, admin→head only, member→never. */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1826,7 +1826,7 @@ function MiniSwitch({ on, disabled, onClick, label }: { on: boolean; disabled?: 
  *  lives next to the agent it governs. Owners & admins always run every agent (shown as read-only);
  *  members are granted per-agent, or opened to everyone via the "All members" switch. Edits persist
  *  optimistically through PUT /api/team/assignments/:id (admin-gated server-side). */
-function ShareAgentDialog({ agent, open, onOpenChange }: { agent: AgentInfo; open: boolean; onOpenChange: (o: boolean) => void }) {
+function ShareAgentDialog({ me, agent, open, onOpenChange }: { me: Member; agent: AgentInfo; open: boolean; onOpenChange: (o: boolean) => void }) {
   const [members, setMembers] = useState<Member[] | null>(null)
   const [access, setAccess] = useState<AgentAccess>({ allowedRoles: [], allowedMembers: [] })
   const [busy, setBusy] = useState(false)
@@ -1850,16 +1850,21 @@ function ShareAgentDialog({ agent, open, onOpenChange }: { agent: AgentInfo; ope
     if ('assignment' in r && r.assignment) setAccess(r.assignment)
   }
 
+  const ownerOnly = !!access.ownerOnly
+  const isOwner = me.role === 'owner'
   const allMembers = access.allowedRoles.includes('member')
+  const toggleOwnerOnly = () => persist({ ...access, ownerOnly: !ownerOnly })
   const toggleAll = () => persist({ ...access, allowedRoles: allMembers ? access.allowedRoles.filter((r) => r !== 'member') : [...access.allowedRoles, 'member'] })
   const toggleMember = (mid: string) => persist({ ...access, allowedMembers: access.allowedMembers.includes(mid) ? access.allowedMembers.filter((x) => x !== mid) : [...access.allowedMembers, mid] })
 
   const privileged = (members ?? []).filter((m) => m.role !== 'member')
+  const owners = privileged.filter((m) => m.role === 'owner')
   const plain = (members ?? []).filter((m) => m.role === 'member')
   const grantedCount = allMembers ? plain.length : plain.filter((m) => access.allowedMembers.includes(m.id)).length
 
   // A one-line, human summary of who can run this agent.
   const summary = (() => {
+    if (ownerOnly) return owners.length ? `Private — ${owners.length} owner${owners.length > 1 ? 's' : ''} only` : 'Private — owners only'
     const parts: string[] = []
     if (privileged.length) parts.push(`${privileged.length} owner/admin`)
     if (allMembers) parts.push('all members')
@@ -1882,32 +1887,46 @@ function ShareAgentDialog({ agent, open, onOpenChange }: { agent: AgentInfo; ope
           <div className="p-8 text-center text-sm text-muted-foreground">Loading…</div>
         ) : (
           <div className="max-h-[60vh] space-y-4 overflow-y-auto p-4">
+            {/* Private (owner only) — the tightest tier, owner-settable. Excludes admins & voids grants. */}
+            {isOwner && (
+              <div className={`flex items-center gap-3 rounded-lg border p-3 transition-colors ${ownerOnly ? 'border-amber-500/40 bg-amber-500/5' : ''}`}>
+                <span className={`grid h-8 w-8 shrink-0 place-items-center rounded-full ${ownerOnly ? 'bg-amber-500/15 text-amber-600' : 'bg-muted text-muted-foreground'}`}>
+                  <Lock className="h-4 w-4" />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium">Private — owners only</div>
+                  <div className="text-xs text-muted-foreground">{ownerOnly ? 'Hidden from admins & members — only owners can run it.' : 'Restrict to owners; even admins are excluded.'}</div>
+                </div>
+                <MiniSwitch on={ownerOnly} disabled={busy} onClick={toggleOwnerOnly} label="Make private to owners" />
+              </div>
+            )}
+
             {/* All members — the "open to everyone" master switch */}
-            <div className={`flex items-center gap-3 rounded-lg border p-3 transition-colors ${allMembers ? 'border-primary/40 bg-primary/5' : ''}`}>
-              <span className={`grid h-8 w-8 shrink-0 place-items-center rounded-full ${allMembers ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'}`}>
-                {allMembers ? <Globe className="h-4 w-4" /> : <Lock className="h-4 w-4" />}
+            <div className={`flex items-center gap-3 rounded-lg border p-3 transition-colors ${ownerOnly ? 'opacity-50' : allMembers ? 'border-primary/40 bg-primary/5' : ''}`}>
+              <span className={`grid h-8 w-8 shrink-0 place-items-center rounded-full ${allMembers && !ownerOnly ? 'bg-primary/15 text-primary' : 'bg-muted text-muted-foreground'}`}>
+                {allMembers && !ownerOnly ? <Globe className="h-4 w-4" /> : <Lock className="h-4 w-4" />}
               </span>
               <div className="min-w-0 flex-1">
                 <div className="text-sm font-medium">All members</div>
-                <div className="text-xs text-muted-foreground">{allMembers ? 'Everyone on the team can run this agent.' : 'Only the people you pick below.'}</div>
+                <div className="text-xs text-muted-foreground">{ownerOnly ? 'Disabled while the agent is private to owners.' : allMembers ? 'Everyone on the team can run this agent.' : 'Only the people you pick below.'}</div>
               </div>
-              <MiniSwitch on={allMembers} disabled={busy} onClick={toggleAll} label="Open to all members" />
+              <MiniSwitch on={allMembers && !ownerOnly} disabled={busy || ownerOnly} onClick={toggleAll} label="Open to all members" />
             </div>
 
-            {/* Individually-grantable members */}
+            {/* Individually-grantable members — void while owner-only */}
             {plain.length > 0 ? (
-              <div className="space-y-1">
+              <div className={`space-y-1 ${ownerOnly ? 'opacity-50' : ''}`}>
                 <div className="px-1 text-[11px] uppercase tracking-wider text-muted-foreground">Members</div>
                 {plain.map((m) => {
-                  const on = allMembers || access.allowedMembers.includes(m.id)
+                  const on = !ownerOnly && (allMembers || access.allowedMembers.includes(m.id))
                   return (
-                    <div key={m.id} className={`flex items-center gap-2.5 rounded-md px-2 py-1.5 ${allMembers ? 'opacity-60' : 'hover:bg-muted/50'}`}>
+                    <div key={m.id} className={`flex items-center gap-2.5 rounded-md px-2 py-1.5 ${allMembers || ownerOnly ? 'opacity-60' : 'hover:bg-muted/50'}`}>
                       <MemberAvatar member={m} className="h-7 w-7 text-[11px]" />
                       <div className="min-w-0 flex-1">
                         <div className="truncate text-sm">{m.name}</div>
                         <div className="truncate text-[11px] text-muted-foreground">{m.email}</div>
                       </div>
-                      <MiniSwitch on={on} disabled={busy || allMembers} onClick={() => toggleMember(m.id)} label={`Let ${m.name} run this agent`} />
+                      <MiniSwitch on={on} disabled={busy || allMembers || ownerOnly} onClick={() => toggleMember(m.id)} label={`Let ${m.name} run this agent`} />
                     </div>
                   )
                 })}
@@ -1916,19 +1935,22 @@ function ShareAgentDialog({ agent, open, onOpenChange }: { agent: AgentInfo; ope
               <div className="rounded-md border border-dashed px-3 py-2 text-[11px] text-muted-foreground">No members yet — invite teammates from the Team page.</div>
             )}
 
-            {/* Owners & admins — always have access, shown read-only */}
+            {/* Who always has access — owners always; admins too UNLESS the agent is private to owners */}
             {privileged.length > 0 && (
               <div className="space-y-1">
                 <div className="px-1 text-[11px] uppercase tracking-wider text-muted-foreground">Always has access</div>
                 <div className="flex flex-wrap gap-1.5">
-                  {privileged.map((m) => (
-                    <span key={m.id} title={`${m.role}s run every agent`} className="inline-flex items-center gap-1.5 rounded-full border bg-muted/40 py-0.5 pl-0.5 pr-2 text-xs">
+                  {(ownerOnly ? owners : privileged).map((m) => (
+                    <span key={m.id} title={ownerOnly ? 'only owners run this private agent' : `${m.role}s run every agent`} className="inline-flex items-center gap-1.5 rounded-full border bg-muted/40 py-0.5 pl-0.5 pr-2 text-xs">
                       <MemberAvatar member={m} className="h-5 w-5 text-[9px]" />
                       <span className="truncate">{m.name}</span>
                       <RoleBadge role={m.role} />
                     </span>
                   ))}
                 </div>
+                {ownerOnly && privileged.length > owners.length && (
+                  <div className="px-1 pt-0.5 text-[11px] text-muted-foreground">Admins are excluded while this agent is private.</div>
+                )}
               </div>
             )}
           </div>
@@ -2183,7 +2205,7 @@ function AgentsPage({
       {canEdit && <AgentLibrary open={libraryOpen} onOpenChange={setLibraryOpen} onInstalled={onRefresh} />}
 
       {/* share — pick which teammates can run the selected agent (opened from the composer header) */}
-      {canEdit && agent && <ShareAgentDialog agent={agent} open={shareOpen} onOpenChange={setShareOpen} />}
+      {canEdit && agent && <ShareAgentDialog me={me} agent={agent} open={shareOpen} onOpenChange={setShareOpen} />}
 
       {/* search — only worth showing once the fleet is more than a glance */}
       {agents.length > 6 && (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -31,6 +31,8 @@ export interface MemberIdentity {
 export interface AgentAccess {
   allowedRoles: Role[]
   allowedMembers: string[]
+  /** Private-to-owners: only the owner role runs/sees this agent (admins excluded). Owner-settable only. */
+  ownerOnly?: boolean
 }
 export type Effort = 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 export const EFFORTS: Effort[] = ['low', 'medium', 'high', 'xhigh', 'max']


### PR DESCRIPTION
## What

Adds a **Private (owner-only)** sharing tier for agents — one step tighter than the current default.

Today an agent's tightest sharing is the empty-assignment floor: **owners _and_ admins** can always run it. There was no way to keep an agent to just the owner. This adds an `ownerOnly` flag to `AgentAccess`:

- `canRun` returns true **iff `role === 'owner'`** when `ownerOnly` is set — admins are excluded and the role/member grants are void.
- **Owner-settable only.** An admin's `PUT /api/team/assignments/:id` preserves the existing flag but cannot toggle it, and a private agent is filtered out of the admin's `/api/team` agent + assignment lists (invisible, not just un-runnable).
- Default is unchanged: absent/false → the owner+admin floor.

## UI

The Share dialog gains a **"Private — owners only"** switch (shown to owners). While on, the All-members and per-member controls are disabled and the summary/"always has access" list reflect owners-only (admins shown as excluded).

## Data

New `assignments.owner_only` column via the idempotent `addColumn` migration; existing rows default to the unchanged owner+admin floor.

## Verify

`npm run typecheck` + `cd web && npm run build` clean. In-process `canRun` check:
- default → owner ✓ / admin ✓ / member ✗
- private → owner ✓ / admin ✗ / member ✗ (grants void)
- roundtrip + listAssignments persist the flag; clearing restores the default and honors grants again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVfxDWBcQLbAqJPshB4Ha2