### PR TITLE
fix(tasks): embedded Session terminal fills the Session tab (v0.264.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.264.1] — 2026-07-24
+### Fixed
+- **The embedded Session terminal now fills the Session tab.** `TerminalFrame` is `flex-1`/`min-h-0` and
+  needs a flex-column parent with height; the room's Session-tab wrapper was a plain block, so the pane
+  collapsed to almost nothing. Wrapped it in `flex h-full flex-col`.
+
 ## [0.264.0] — 2026-07-24
 ### Added
 - **Private (owner-only) agents — a tier below the owner+admin default.** Until now the tightest an

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.264.0",
+  "version": "0.264.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.264.0",
+      "version": "0.264.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.264.0",
+  "version": "0.264.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7952,7 +7952,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
                     : <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground"><FileText className="h-6 w-6 opacity-40" />No description. <button className="text-primary underline" onClick={() => setEditing(true)}>Add one</button></div>}
                 </div>
               )}
-              {roomTab === 'session' && sessTmux && <div className="h-full"><TerminalFrame session={live ?? undefined} tmux={sessTmux} standalone /></div>}
+              {roomTab === 'session' && sessTmux && <div className="flex h-full min-h-0 flex-col"><TerminalFrame session={live ?? undefined} tmux={sessTmux} standalone /></div>}
             </div>
           </div>
           <div className="overflow-y-auto bg-muted/20 p-4">


### PR DESCRIPTION
The Session tab's TerminalFrame collapsed because its wrapper was a plain block; TerminalFrame needs a flex-column parent with height. Wrapped in `flex h-full flex-col`. web build ✓.