### PR TITLE
perf(inbox): index the 1.5s poll hot paths + bound the inbox feed (v0.265.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.265.3] — 2026-07-24
+### Fixed
+- **Inbox/session polling no longer degrades on data-heavy tenants.** The console polls `/api/messages`
+  (`listMessages`) and `/api/sessions` (`listSessions`) every 1.5s per open tab, and `node:sqlite` is
+  synchronous — a slow query on either blocks the entire server event loop, which surfaced as laggy
+  approval/inbox notifications (and contributed to the server feeling unresponsive) on tenants with a large
+  history. Added hot-path indexes matching each poll's `WHERE` + `ORDER BY`
+  (`messages(dismissed_at, created_at)`, `term_sessions(archived_at, created_at)`,
+  `audit_events(run_id, type, ts)` for the per-session insight tallies), so each poll is now an indexed
+  range scan instead of a full-table scan + sort. Also bounded the inbox feed query to the newest 500
+  non-dismissed cards (owner/admin see all, `mine` narrows further) so a pathological undismissed backlog
+  can't grow the per-poll cost without limit. Indexes apply to existing DBs on next boot.
+
 ## [0.265.2] — 2026-07-24
 ### Fixed
 - **The `consolidator` (memory gardener) crashed at launch on every tenant — and so could any run with a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.265.2",
+  "version": "0.265.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.265.2",
+      "version": "0.265.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.265.2",
+  "version": "0.265.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -759,6 +759,21 @@ function migrate(db: Db): void {
   addColumn(db, 'memories', 'scope', "TEXT NOT NULL DEFAULT 'agent'");
   db.exec('CREATE INDEX IF NOT EXISTS idx_mem_scope ON memories(tenant, scope, created_at)');
 
+  // Hot-path poll indexes. The console polls /api/messages (listMessages) and /api/sessions
+  // (listSessions) every 1.5s per open tab, and node:sqlite is synchronous — a slow query on these
+  // blocks the WHOLE server event loop. On a data-heavy tenant these were full table scans + sorts.
+  // These indexes make each poll an indexed range scan matching its WHERE + ORDER BY:
+  //  • messages:      WHERE dismissed_at IS NULL ORDER BY created_at DESC   (the inbox feed)
+  //  • term_sessions: WHERE archived_at  IS NULL ORDER BY created_at DESC   (the session list)
+  //  • audit_events:  the per-live-session insight tallies (stampInsights) — WHERE run_id=? [AND type=?]
+  //    ORDER BY ts DESC. The existing idx_audit_run (run_id only) is left in place; this composite
+  //    additionally serves the type-filtered + ts-ordered lookups.
+  // (message_state's (message_id, member_id) join is already served by its composite PRIMARY KEY.)
+  // Placed after the addColumn calls above so the columns are guaranteed to exist on older DBs.
+  db.exec('CREATE INDEX IF NOT EXISTS idx_messages_feed ON messages(dismissed_at, created_at)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_sessions_live ON term_sessions(archived_at, created_at)');
+  db.exec('CREATE INDEX IF NOT EXISTS idx_audit_run_type ON audit_events(run_id, type, ts)');
+
   // How a dispatched task session runs (headless work-to-completion vs. an attachable interactive TUI).
   // Older `tasks` rows (created before this column) default to today's behavior: headless.
   addColumn(db, 'tasks', 'mode', "TEXT NOT NULL DEFAULT 'headless'");

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1282,8 +1282,14 @@ export class TerminalManager {
          LEFT JOIN term_sessions ts ON m.session_id = ts.id
          LEFT JOIN message_state ms ON ms.message_id = m.id AND ms.member_id = ?
          WHERE m.dismissed_at IS NULL AND ms.dismissed_at IS NULL AND m.type NOT IN ('task.chat', 'task.mention')
-         ORDER BY m.created_at DESC`,
+         ORDER BY m.created_at DESC
+         LIMIT 500`,
       )
+      // Bound the newest 500 non-dismissed cards. This poll runs every 1.5s per open console tab and,
+      // on a busy tenant, the un-capped scan (+4 joins) grew with all-time inbox history — the synchronous
+      // node:sqlite call blocking the whole event loop. 500 far exceeds what the inbox usefully renders;
+      // owner/admin see all and the `mine` scope narrows further below, so this only caps a pathological
+      // backlog of undismissed cards (mark-all-read/dismiss iterate this list — capped to the same 500).
       .all<MessageRow>(viewerId);
     let visible = viewer ? rows.filter((r) => this.canViewMessageRow(r, viewer)) : rows;
     // `mine` (the default) narrows the visible set to what's ADDRESSED to the viewer, so owner/admin


### PR DESCRIPTION
## Why
The console polls `/api/messages` (`listMessages`) and `/api/sessions` (`listSessions`) **every 1.5s per open tab**, and `node:sqlite` is **synchronous** — a slow query on either blocks the entire server event loop. On data-heavy tenants (e.g. instawp) this surfaced as **laggy approval/inbox notifications** and contributed to the server feeling **unresponsive**. Both queries were full-table scans + sorts, growing with all-time history.

## What
- **Hot-path indexes** matching each poll's `WHERE` + `ORDER BY`:
  - `messages(dismissed_at, created_at)` — the inbox feed
  - `term_sessions(archived_at, created_at)` — the session list
  - `audit_events(run_id, type, ts)` — the per-live-session insight tallies (`stampInsights`, run every poll)
- **Bounded** `listMessages` to the newest **500** non-dismissed cards, so a pathological undismissed backlog can't grow per-poll cost without limit (owner/admin see all; `mine` narrows further downstream; mark-all-read/dismiss iterate the same capped list).

`message_state`'s `(message_id, member_id)` join is already served by its composite PRIMARY KEY — no new index needed there.

## Verification
- `npm run typecheck` + `npm run build` clean.
- `EXPLAIN QUERY PLAN` on all four hot queries: each now `SEARCH ... USING INDEX` with **no** `USE TEMP B-TREE FOR ORDER BY` (the index satisfies the sort).

Indexes apply to existing DBs on next boot (engine-level, not JSON policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)