### PR TITLE
feat(sessions): hard max-runtime backstop for headless runs — fix the stuck-mid-turn leak (v0.266.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.266.0] — 2026-07-24
+### Added
+- **Hard max-runtime backstop for headless/unattended runs — the stuck-mid-turn session leak.** An
+  automation/task/chat run is an attachable interactive TUI torn down at turn-end by the Stop beacon; if it
+  hangs mid-turn it never beacons, so `last_activity` stays NULL and the idle-straggler sweep (which requires
+  a beacon) never touches it, and the idle-interactive janitor skips it (headless). Such a run lingered for
+  **days** holding a ~500 MB `claude` process + a concurrency-cap slot — observed on instawp as unattended
+  runs stuck at 60 h+, a primary driver of the box's memory pressure. New sweep reaps a headless run purely on
+  wall-clock age once it exceeds the ceiling (**Settings → Runtime → "Force-close headless runs after"**,
+  default **24 h**, `0` = off; clamped 1 h–30 d), regardless of the beacon — cancelling any dangling
+  question/approval and staying Resumable. Guards preserved: never reaps a pane a human is attached to, and
+  **headed (interactive member) sessions are never cut mid-work** — they keep the separate idle-based janitor,
+  which only closes a *detached* one. Audited `session.reaped` `reason:'max-runtime'`.
+
 ## [0.265.3] — 2026-07-24
 ### Fixed
 - **Inbox/session polling no longer degrades on data-heavy tenants.** The console polls `/api/messages`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.265.3",
+  "version": "0.266.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.265.3",
+      "version": "0.266.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.265.3",
+  "version": "0.266.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -74,6 +74,7 @@ const ROUTER_CONFIG_KEY = 'router_config'; // auto-router tuning (JSON RouterCon
 const CHAT_IDLE_MIN_KEY = 'chat_idle_timeout_min'; // resident (warm) chat session idle-kill, minutes
 const MAX_CONCURRENT_KEY = 'max_concurrent_sessions'; // whole-box concurrency cap override; unset → RAM-derived default, 0 → unlimited
 const INTERACTIVE_IDLE_HOURS_KEY = 'interactive_idle_timeout_hours'; // auto-close a detached member session idle past this; unset → 48h, 0 → off
+const UNATTENDED_MAX_HOURS_KEY = 'unattended_max_runtime_hours'; // hard runtime ceiling for a headless/unattended run (stuck-mid-turn backstop); unset → 24h, 0 → off
 const KILL_SWITCH_KEY = 'kill_switch'; // workspace-wide emergency stop (JSON KillSwitchState)
 const SUPPRESSED_BUILTINS_KEY = 'suppressed_builtins'; // built-in agent ids an admin deleted (JSON string[]); boot won't re-seed them
 
@@ -888,6 +889,27 @@ export class SettingsStore {
     const clamped = !Number.isFinite(n) || n < 0 ? 48 : n === 0 ? 0 : Math.min(Math.max(Math.round(n), 1), 24 * 30);
     this.set(INTERACTIVE_IDLE_HOURS_KEY, String(clamped), by);
     return this.interactiveIdleTimeoutHours();
+  }
+
+  /** Hard runtime ceiling (hours) for an UNATTENDED (headless) run — the stuck-mid-turn backstop. Unlike the
+   *  idle-based reapers, this reaps a headless run purely on wall-clock age, so a run that hangs mid-turn and
+   *  never beacons a turn-end (`last_activity` stays NULL → invisible to the idle-straggler sweep) can't
+   *  linger for days holding ~500 MB + a cap slot. Applies ONLY to headless/unattended runs — a member's
+   *  headed interactive session is never cut mid-work; it keeps the idle-based janitor
+   *  (`interactiveIdleTimeoutHours`), which only closes a *detached* one. Default **24 h**; clamped 1 h–30 d;
+   *  `0` disables. */
+  unattendedMaxHours(): number {
+    const n = Number(this.getRow(UNATTENDED_MAX_HOURS_KEY)?.value);
+    if (!Number.isFinite(n)) return 24; // unset → default
+    if (n <= 0) return 0;               // explicit 0 → disabled
+    return Math.min(Math.max(Math.round(n), 1), 24 * 30);
+  }
+
+  setUnattendedMaxHours(hours: number, by?: string): number {
+    const n = Number(hours);
+    const clamped = !Number.isFinite(n) || n < 0 ? 24 : n === 0 ? 0 : Math.min(Math.max(Math.round(n), 1), 24 * 30);
+    this.set(UNATTENDED_MAX_HOURS_KEY, String(clamped), by);
+    return this.unattendedMaxHours();
   }
 
   // ── kill switch (workspace emergency stop) ───────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -3985,11 +3985,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const value = os.settings.maxConcurrentSessions(); // operator override (null = unset)
     const resolved = autos.concurrencyCap();           // effective cap the scheduler enforces (0 = unlimited)
     const source = envLocked ? 'env' : value != null ? 'setting' : 'derived';
-    return sendJson(res, 200, { value, resolved, derived: derivedConcurrencyCap(), source, envLocked, alive: tm.aliveSessionCount(), idleHours: os.settings.interactiveIdleTimeoutHours() });
+    return sendJson(res, 200, { value, resolved, derived: derivedConcurrencyCap(), source, envLocked, alive: tm.aliveSessionCount(), idleHours: os.settings.interactiveIdleTimeoutHours(), unattendedMaxHours: os.settings.unattendedMaxHours() });
   }
   if (method === 'PUT' && p === '/api/settings/concurrency') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    const b = await readBody(req) as { value?: unknown; idleHours?: unknown };
+    const b = await readBody(req) as { value?: unknown; idleHours?: unknown; unattendedMaxHours?: unknown };
     // Cap: `null`/'' clears the override (→ derived default); 0 = unlimited; N>0 = cap. Only touched when the
     // key is present, so a PUT that only sets idleHours leaves the cap alone.
     if ('value' in b) {
@@ -4007,7 +4007,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       const savedH = os.settings.setInteractiveIdleTimeoutHours(h, me.email);
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.interactiveIdle.updated', data: { idleHours: savedH } });
     }
-    return sendJson(res, 200, { ok: true, value: os.settings.maxConcurrentSessions(), resolved: autos.concurrencyCap(), derived: derivedConcurrencyCap(), idleHours: os.settings.interactiveIdleTimeoutHours() });
+    // Hard max-runtime backstop for headless/unattended runs (hours): 0 = off; else clamped 1h–30d. Present-only.
+    if ('unattendedMaxHours' in b) {
+      const h = Number(b.unattendedMaxHours);
+      if (!Number.isFinite(h) || h < 0) return sendJson(res, 400, { error: 'unattendedMaxHours must be a non-negative number (0 = off)' });
+      const savedH = os.settings.setUnattendedMaxHours(h, me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.unattendedMax.updated', data: { unattendedMaxHours: savedH } });
+    }
+    return sendJson(res, 200, { ok: true, value: os.settings.maxConcurrentSessions(), resolved: autos.concurrencyCap(), derived: derivedConcurrencyCap(), idleHours: os.settings.interactiveIdleTimeoutHours(), unattendedMaxHours: os.settings.unattendedMaxHours() });
   }
 
   // ── UI branding (per-tenant accent colour + favicon badge) — owner/admin edits ──

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1913,8 +1913,14 @@ export class TerminalManager {
     // back to the classic time-based rule for RUNNING rows only (never blind-sweep a 'done' row, or we'd
     // re-teardown it every tick with no way to know its pane already died). Uses the single `alive` poll
     // taken at the top of the sweep.
-    const unattended = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, headless, last_activity FROM term_sessions WHERE resident = 0 AND claimed_by IS NULL AND (status = 'done' OR (headless = 1 AND status = 'running'))")
-      .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; headless: number; last_activity: number | null }>();
+    // Hard runtime ceiling for a headless run (stuck-mid-turn backstop, Settings → Runtime; default 24h). A
+    // headless run that hangs mid-turn never beacons a turn-end, so `last_activity` stays NULL — invisible to
+    // the idle-straggler rule below, which requires a beacon. Without this it lingers for DAYS holding a
+    // ~500MB claude process + a cap slot (confirmed on instawp: unattended runs stuck at 60h+). `0` disables.
+    const maxHours = this.os.settings.unattendedMaxHours();
+    const maxAgeCutoff = maxHours > 0 ? Date.now() - maxHours * 3600_000 : null;
+    const unattended = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, headless, last_activity, created_at FROM term_sessions WHERE resident = 0 AND claimed_by IS NULL AND (status = 'done' OR (headless = 1 AND status = 'running'))")
+      .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; headless: number; last_activity: number | null; created_at: number }>();
     for (const r of unattended) {
       try {
         // A MEMBER's own interactive console session is never a done-orphan: the human owns its lifecycle,
@@ -1923,19 +1929,27 @@ export class TerminalManager {
         // to the idle-interactive janitor (sweep 3); reaping it here yanks the TUI out from under an active
         // user seconds after the agent reports. Unattended-lane done runs fall through and are reaped below.
         if (r.status === 'done' && !r.headless && r.spawned_by && !r.spawned_by.includes(':')) continue;
+        // A headless run past the hard runtime ceiling is reaped on wall-clock age ALONE — no turn-end beacon
+        // required (that's the whole point: it's stuck mid-turn). Headed sessions never reach here (the query
+        // only pulls headless running rows besides done orphans), so this can't cut a member mid-work.
+        const overMaxAge = maxAgeCutoff != null && r.headless === 1 && r.status === 'running' && r.created_at < maxAgeCutoff;
         if (alive) {
           if (!alive.has(r.tmux)) continue;                          // pane already gone — nothing to reap
           // a 'running' straggler is only idle-reaped once it has seen a turn-end beacon AND gone quiet past the
           // cutoff; a 'done' orphan is reaped on sight — it should never still be holding an interactive pane.
-          if (r.status === 'running' && (r.last_activity == null || r.last_activity >= cutoff)) continue;
+          // The hard-age backstop (overMaxAge) reaps regardless of the beacon.
+          if (r.status === 'running' && !overMaxAge && (r.last_activity == null || r.last_activity >= cutoff)) continue;
         } else {
           // no liveness signal: classic straggler rule, running-only, so we can't re-sweep a done row blind.
-          if (r.status !== 'running' || r.last_activity == null || r.last_activity >= cutoff) continue;
+          if (r.status !== 'running' || (!overMaxAge && (r.last_activity == null || r.last_activity >= cutoff))) continue;
         }
         const space = this.spaceFor(r.run_as ?? r.spawned_by);
         if (this.backend.hasClient(space, r.tmux) === true) continue; // a human is still watching — leave it
-        if (this.hasPendingHumanBlock(r.id)) continue;               // blocked on an answer/approval — keep alive
-        this.teardownUnattended(r.id, space, r.tmux, r.status === 'done' ? 'done-orphan' : 'idle-backstop');
+        // The idle-straggler path keeps a run that's legitimately blocked on a person; but a run past the hard
+        // ceiling is abandoned by definition (nobody has answered in a full day), so the backstop reaps it
+        // anyway — teardownUnattended cancels its dangling question/approval so nothing is left waiting.
+        if (!overMaxAge && this.hasPendingHumanBlock(r.id)) continue;
+        this.teardownUnattended(r.id, space, r.tmux, overMaxAge ? 'max-runtime' : r.status === 'done' ? 'done-orphan' : 'idle-backstop');
       } catch { /* one bad row must not stop the sweep */ }
     }
 
@@ -2013,6 +2027,11 @@ export class TerminalManager {
   private teardownUnattended(sessionId: string, space: string, tmux: string, reason: string): void {
     this.captureTranscript(sessionId, space, tmux);
     this.markEnded(sessionId);   // status → done (if still running), blockResume, writeEpisode
+    // Release any dangling human-block so nothing is left waiting on a reaped run. A no-op for the
+    // idle-backstop/turn-end paths (they skip a blocked run upstream), but essential for the hard
+    // max-runtime backstop, which reaps an abandoned run that IS still blocked on a person.
+    this.cancelPendingQuestions(sessionId, 'system');
+    this.cancelPendingApprovals(sessionId, 'system');
     this.backend.kill(space, tmux);
     this.audit(sessionId, 'system', 'session.reaped', { reason });
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13090,6 +13090,7 @@ function ConcurrencySettings({ me }: { me: Member }) {
   const [data, setData] = useState<Concurrency | null>(null)
   const [input, setInput] = useState('')   // '' = use default; '0' = unlimited; N = cap
   const [idle, setIdle] = useState('')      // hours; '0' = off
+  const [maxRun, setMaxRun] = useState('')  // headless hard runtime ceiling, hours; '0' = off
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const canEdit = me.role === 'owner' || me.role === 'admin'
@@ -13099,17 +13100,20 @@ function ConcurrencySettings({ me }: { me: Member }) {
     setData(r)
     setInput(r.value == null ? '' : String(r.value)) // box reflects only an explicit operator override
     setIdle(String(r.idleHours))
+    setMaxRun(String(r.unattendedMaxHours))
   }).catch(() => {})
   useEffect(() => { load() }, [])
 
   const capDirty = data != null && input.trim() !== (data.value == null ? '' : String(data.value))
   const idleDirty = data != null && idle.trim() !== String(data.idleHours)
-  const dirty = capDirty || idleDirty
+  const maxRunDirty = data != null && maxRun.trim() !== String(data.unattendedMaxHours)
+  const dirty = capDirty || idleDirty || maxRunDirty
   const save = async () => {
     setBusy(true); setHint('')
-    const body: { value?: number | null; idleHours?: number } = {}
+    const body: { value?: number | null; idleHours?: number; unattendedMaxHours?: number } = {}
     if (capDirty) body.value = input.trim() === '' ? null : Number(input)
     if (idleDirty) body.idleHours = Number(idle)
+    if (maxRunDirty) body.unattendedMaxHours = Number(maxRun)
     const r = await api.saveConcurrency(body)
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
@@ -13170,6 +13174,24 @@ function ConcurrencySettings({ me }: { me: Member }) {
           <p className="text-[11px] text-muted-foreground">
             A forgotten interactive session holds a <span className="font-mono">claude</span> process and a cap slot for days. This closes one
             left idle this long (nobody attached) so it stops starving scheduled work.
+          </p>
+        </div>
+        <div className="space-y-1.5 border-t pt-4">
+          <label className="text-xs font-medium text-muted-foreground">Force-close headless runs after (hours)</label>
+          <div className="flex items-center gap-3">
+            <Input
+              type="number" min={0} step={1} value={maxRun}
+              onChange={(e) => setMaxRun(e.target.value)}
+              placeholder="24"
+              disabled={!canEdit}
+              className="h-8 w-40 font-mono text-xs"
+            />
+            <span className="text-[11px] text-muted-foreground">headless/unattended runs only; 0 = never</span>
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            A hard wall-clock ceiling. Unlike the idle timeout above, this reaps a headless run purely on age — the safety net for one
+            that hangs mid-turn and never signals completion, so it can't sit for days holding a <span className="font-mono">claude</span>{' '}
+            process. Headed (interactive) sessions are never cut mid-work by this.
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -60,6 +60,8 @@ export interface Concurrency {
   alive: number
   /** Auto-close a detached member session idle past this many hours (0 = off; default 48). */
   idleHours: number
+  /** Hard runtime ceiling (hours) for a headless/unattended run — the stuck-mid-turn backstop (0 = off; default 24). */
+  unattendedMaxHours: number
 }
 
 export interface AgentInfo {
@@ -1477,7 +1479,7 @@ export const api = {
   saveSubagentDefault: (mode: 'all' | 'none') => call<{ ok: boolean; mode?: 'all' | 'none'; error?: string }>('PUT', '/api/settings/subagent-default', { mode }),
   saveSessionMetrics: (value: SessionMetrics) => call<{ ok: boolean; sessionMetrics?: SessionMetrics; error?: string }>('PUT', '/api/settings/session-metrics', { value }),
   concurrency: () => call<Concurrency & { error?: string }>('GET', '/api/settings/concurrency'),
-  saveConcurrency: (body: { value?: number | null; idleHours?: number }) => call<{ ok: boolean; error?: string; value?: number | null; resolved?: number; derived?: number; idleHours?: number }>('PUT', '/api/settings/concurrency', body),
+  saveConcurrency: (body: { value?: number | null; idleHours?: number; unattendedMaxHours?: number }) => call<{ ok: boolean; error?: string; value?: number | null; resolved?: number; derived?: number; idleHours?: number; unattendedMaxHours?: number }>('PUT', '/api/settings/concurrency', body),
 
   governance: () => call<GovernanceThresholds & { hostGovernanceEnabled?: boolean; updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/governance'),
   saveGovernance: (t: GovernanceThresholds & { hostGovernanceEnabled?: boolean }) => call<{ ok: boolean; error?: string; hostGovernanceEnabled?: boolean } & GovernanceThresholds>('PUT', '/api/settings/governance', t),


### PR DESCRIPTION
## Why
Diagnosing why the **instawp** box goes suddenly unresponsive turned up a session leak. A headless/unattended run (automation/task/chat/ask) is now an attachable interactive TUI, torn down at turn-end by the Stop beacon. **If it hangs mid-turn it never beacons** → `last_activity` stays `NULL`:
- the **idle-straggler** sweep skips it (it requires a turn-end beacon — the "never touch a mid-first-turn long run" guard), and
- the **idle-interactive janitor** skips it (headless-only exclusion).

Reaped by *nothing*, it lingers for **days** holding a ~500 MB `claude` process + a concurrency-cap slot. Confirmed live on instawp: unattended runs **stuck at 60 h+** with `last_activity=NULL` — a primary driver of memory pressure (service peak 57.4 G / 62 G).

## What
- **New reaper pass** (extends sweep 2 in `reapIdleSessions`): reaps a headless `running` row purely on **wall-clock age** once it exceeds the ceiling — no beacon required. `Settings → Runtime → "Force-close headless runs after"`, **default 24 h**, `0` = off, clamped 1 h–30 d (`unattendedMaxHours`).
- **Scoped to the headless lane only.** Headed (interactive member) sessions are never selected here, so a human is never cut mid-work — they keep the existing idle-based interactive janitor (which only closes a *detached* one).
- **Guards preserved / added:** never reaps a pane a human is attached to (`hasClient`); `teardownUnattended` now cancels any dangling question/approval, so an abandoned *blocked* run past the ceiling is released cleanly (the idle path still keeps a legitimately-blocked run alive). Row stays **Resumable**.
- Audited `session.reaped` `reason:'max-runtime'` + `settings.unattendedMax.updated`.

## Verification
- `npm run typecheck` + `npm run build` + `web` build clean.
- **Decision logic proven with an 8-case truth table:** the 60 h no-beacon leak → reaped; a legit 5 h first turn → protected; watched pane past ceiling → never yanked; classic idle straggler → unchanged; done-orphan → unchanged; `0` → disabled/no-op.

Follow-up lever (not in this PR): the headed idle timeout on instawp is set to 72 h — worth lowering operationally to shed the 14 idle member sessions faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)