### PR TITLE
fix(sessions): web-resume of a resident chat session no longer replays the trigger message or gets reaped (v0.266.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.266.1] — 2026-07-25
+### Fixed
+- **Resuming a resident chat session (Slack/Discord/`/agent`) from the web no longer replays the trigger
+  message, nor gets reaped seconds later.** When the browser reattaches to a stopped resident session,
+  `attach.sh` resurrects it via `RESUME=1 ENV_FILE=…`, sourcing the persisted env — which carries the
+  *original* launch `TASK` (e.g. the Discord message that started it). The unattended/resident resume branch
+  re-seeded that `$TASK` on `claude --resume`, so the resumed pane replayed the first prompt. Fixed: the
+  launcher now marks an env-file resurrect (`RESUMED_FROM_ENV`) and skips re-seeding the original task on the
+  primary resume (the fallback still seeds so a lost transcript gets a prompt); a genuine server-driven
+  follow-up (`reviveResident`/`chatSend`) spawns a fresh pane with no env file, so its new message is still
+  seeded. Second bug on the same path: `markResumed` refreshed only `updated_at`, leaving `last_activity`
+  stale, so the resurrected resident session tripped the 30-min resident idle reaper on the very next 60 s
+  sweep and was killed "shortly after resumption" — it now refreshes `last_activity` too, giving a
+  deliberately re-opened session a fresh idle window.
+
 ## [0.266.0] — 2026-07-24
 ### Added
 - **Hard max-runtime backstop for headless/unattended runs — the stuck-mid-turn session leak.** An

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.266.0",
+  "version": "0.266.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.266.0",
+      "version": "0.266.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.266.0",
+  "version": "0.266.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4454,7 +4454,11 @@ export class TerminalManager {
   markResumed(sessionId: string): void {
     const s = this.db.prepare('SELECT agent, status FROM term_sessions WHERE id = ?').get<{ agent: string; status: string }>(sessionId);
     if (!s || s.status === 'running') return;
-    this.db.prepare("UPDATE term_sessions SET status = 'running', updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
+    // Refresh last_activity too, not just updated_at: a resident chat session resurrected via attach.sh
+    // keeps its STALE last_activity (from the original run), so the very next idle sweep would reap it as
+    // long-idle within ≤60s ("killed shortly after resumption"). A deliberate re-open means the human is
+    // actively using it — give it a fresh idle window (the resident reaper keys off last_activity).
+    this.db.prepare("UPDATE term_sessions SET status = 'running', last_activity = ?, updated_at = ? WHERE id = ?").run(Date.now(), Date.now(), sessionId);
     // No "Resumed" card — reconnecting is lifecycle noise, not something the operator needs in the feed.
     this.audit(sessionId, s.agent, 'session.resumed', {});
   }

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -20,9 +20,16 @@ set -u
 # was killed (stopped/ended). The new tmux session does NOT inherit the original launch env, so
 # recover it from the persisted file before doing anything else. Sets AGENT_DIR/HOOK/AOS_*/
 # MCP_CONFIG/COMPANY_FILE/CLAUDE_SESSION_ID exactly as the first launch had them.
+RESUMED_FROM_ENV=
 if [ "${RESUME:-}" = "1" ] && [ -n "${ENV_FILE:-}" ] && [ -f "${ENV_FILE}" ]; then
   # shellcheck disable=SC1090
   . "$ENV_FILE"
+  # attach.sh browser-reattach resurrect: the sourced env carries the ORIGINAL launch TASK, which is
+  # ALREADY in the transcript we're about to `--resume`. The unattended/resident resume branch below must
+  # NOT re-seed it (doing so replays the first prompt — e.g. re-pasting the Slack/Discord trigger message).
+  # A server-driven follow-up (reviveResident/chatSend) instead spawns a FRESH pane with a genuinely new
+  # $TASK and no ENV_FILE, so this stays unset there and its new message IS seeded.
+  RESUMED_FROM_ENV=1
 fi
 # The `claude` CLI is commonly installed under ~/.local/bin; make sure it's findable even
 # when the parent process (e.g. a hardened systemd unit) ships a minimal PATH.
@@ -291,8 +298,17 @@ if [ "${RESIDENT:-}" = "1" ] || [ "${UNATTENDED:-}" = "1" ]; then
   echo
   if [ "${RESUME:-}" = "1" ] && [ -n "${CLAUDE_SESSION_ID:-}" ]; then
     notify_resumed
-    claude --resume "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" ${TASK:+"$TASK"} \
-      || claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" ${TASK:+"$TASK"}
+    if [ -n "${RESUMED_FROM_ENV:-}" ]; then
+      # Browser reattach: resume the conversation WITHOUT re-seeding $TASK (it's the original prompt,
+      # already in the transcript) — the human just wants to land back in the live TUI. The fallback still
+      # seeds so a lost transcript gets a prompt, mirroring the interactive lane below.
+      claude --resume "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" \
+        || claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" ${TASK:+"$TASK"}
+    else
+      # Server-driven follow-up (reviveResident/chatSend): $TASK is a genuinely NEW message → seed it.
+      claude --resume "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" ${TASK:+"$TASK"} \
+        || claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" ${TASK:+"$TASK"}
+    fi
   elif [ -n "${CLAUDE_SESSION_ID:-}" ]; then
     claude --session-id "$CLAUDE_SESSION_ID" "${RES_ARGS[@]}" "$TASK"
   else


### PR DESCRIPTION
## Symptom

Resuming a Discord-triggered (resident chat) session from the web console: it (1) re-pasted the original Discord message on resume, and (2) got killed within ~a minute of resuming.

## Root cause

The session is a **resident chat session** (`resident=1`, `spawned_by=chat:<agent>`). Its persisted launch env (`session-<id>.env`) carries `RESIDENT=1` + `TASK_FILE=<the original trigger message>`. When the browser reattaches, `attach.sh` resurrects it via `RESUME=1 ENV_FILE=… claude-launch.sh`, which sources that env.

1. **Re-pastes the trigger message.** The unattended/resident resume branch ran `claude --resume "$CLAUDE_SESSION_ID" … ${TASK:+"$TASK"}` — re-seeding the *original* task (already in the transcript) as a fresh prompt. The interactive lane never had this bug (it passes no task on the primary resume).
2. **Killed shortly after.** `markResumed` set `status='running'` but left `last_activity` stale (from the original run). The next 60 s idle sweep (`reapIdleSessions` case 1, 30-min resident timeout) saw it as long-idle and reaped it → `stopped` + `blockResume`.

## Fix

- **`terminal/claude-launch.sh`** — mark an env-file resurrect (`RESUMED_FROM_ENV`); in the resident/unattended resume branch, skip re-seeding `$TASK` on the primary `claude --resume` when resurrected from a sourced env (the fallback still seeds so a lost transcript gets a prompt). A server-driven follow-up (`reviveResident`/`chatSend`) spawns a fresh pane with **no** env file → `RESUMED_FROM_ENV` unset → its genuinely-new message is still seeded, so thread continuity is unaffected.
- **`src/terminal.ts` `markResumed`** — also refresh `last_activity`, giving a deliberately re-opened session a fresh idle window instead of tripping the reaper on the next sweep.

## Validation

- `npm run typecheck` ✓ · `bash -n terminal/claude-launch.sh` ✓ · `cd web && npm run build` ✓
- `npm run test:governance` → 102/102 ✓

Note: a `claude-launch.sh` change only affects **new** session launches — an already-stopped session picks it up on its next reattach after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVfxDWBcQLbAqJPshB4Ha2