### PR TITLE
fix(governance): stop gating benign MANAGE_CONNECTIONS reads + brief headline in approval DMs (v0.266.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.266.2] — 2026-07-27
+### Fixed
+- **Two approval-noise fixes: benign `MANAGE_CONNECTIONS` reads no longer owner-gated, and the Slack/Discord
+  approval DM now leads with the decision-brief headline.** A fleet review found approval notifications were
+  dominated by false positives that were always approved: (1) the gate routed any Composio
+  `*MANAGE_CONNECTION*` tool to the owner-approval `connector.connect`, but in practice agents call
+  `COMPOSIO_MANAGE_CONNECTIONS` to LIST/check connection status (`{toolkits:["gmail"]}`) — a benign read
+  (26 such approvals across the fleet in 14 days, 0 rejected). The gate-hook now routes only
+  `*INITIATE_CONNECTION*` (the actual OAuth grant) to `connector.connect`; `MANAGE_CONNECTIONS` falls
+  through to `connector.call` (allowed). (2) The out-of-band approval DM said only
+  `` `shell.exec` (owner) … why: shell.exec: risky `` — the raw capability + terse rule. It now leads with
+  the **decision-brief headline** (e.g. "Deploy the marketing site to production via the deploy script"),
+  with the capability/reason as secondary detail (falls back to the old line when no brief is present).
+
 ## [0.266.1] — 2026-07-25
 ### Fixed
 - **Resuming a resident chat session (Slack/Discord/`/agent`) from the web no longer replays the trigger

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.266.1",
+  "version": "0.266.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.266.1",
+      "version": "0.266.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.266.1",
+  "version": "0.266.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -395,9 +395,11 @@ export async function notifyApprovers(os: AgentOS, tm: Pick<TerminalManager, 'bi
   // Plain text + backticks render fine in both Slack mrkdwn and Discord markdown (no */** ambiguity).
   const dot = notice.riskClass === 'red' ? '🔴' : '🟡';
   const inbox = consolePage(consoleOrigin, 'inbox');
+  // Lead with the decision-brief headline (WHAT the agent wants) when we have it; the capability + terse
+  // reason are the secondary "why". Falls back to the old capability-first line for notices without a brief.
   const text = (p: ChatPlatform) =>
-    `${dot} ${notice.riskClass.toUpperCase()} approval needed — \`${notice.capability}\` (${notice.level}) requested by agent ${notice.agent}.` +
-    (notice.reason ? `\nwhy: ${notice.reason}` : '') +
+    `${dot} ${notice.riskClass.toUpperCase()} approval — ${notice.agent}: ${notice.headline || `\`${notice.capability}\``}` +
+    `\n\`${notice.capability}\` (${notice.level})${notice.reason ? ` — ${notice.reason}` : ''}` +
     `\n*Reply "approve" or "deny"* to decide, or open the ${chatLink(p, inbox, 'Agent OS Inbox')}.`;
   const dms = await deliverDM(slack, discord, os, approvers, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'approval.notified', data: { capability: notice.capability, level: notice.level, approvers: approvers.length, dms } });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -410,6 +410,9 @@ export interface ApprovalNotice {
   level: ApprovalLevel;
   riskClass: 'yellow' | 'red';
   reason?: string;
+  /** The decision-brief headline — a legible summary of the effect ("Run a deploy-status check…"),
+   *  so the out-of-band DM leads with WHAT the agent wants, not just the capability + terse reason. */
+  headline?: string;
 }
 
 /**
@@ -2687,7 +2690,7 @@ export class TerminalManager {
     });
     this.audit(sessionId, agent, 'approval.requested', { approvalId: req.id, level: decision.level, capability, brief });
     // Out-of-band ping (Slack/Discord DM to whoever can approve) — best-effort, never blocks the gate.
-    try { this.approvalNotifier?.({ approvalId: req.id, sessionId, agent, capability, level: decision.level, riskClass: decision.riskClass, reason: decision.reason }); } catch { /* notifications are advisory */ }
+    try { this.approvalNotifier?.({ approvalId: req.id, sessionId, agent, capability, level: decision.level, riskClass: decision.riskClass, reason: decision.reason, headline: brief.headline }); } catch { /* notifications are advisory */ }
     // If the run was triggered from chat, surface the gate in that thread too (the approver DM reaches
     // the approver; this reaches everyone watching the thread). No-op for non-chat runs.
     const dot = decision.riskClass === 'red' ? '🔴' : '🟡';

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -66,9 +66,13 @@ case "$TOOL" in
   # File writes go through the gateway too (the enricher decides inside-vs-outside the agent's folder
   # from the path in tool_input). The hook stays dumb transport — it only names the capability.
   Edit|Write|MultiEdit|NotebookEdit) CAP="file.write" ;;
-  mcp__composio-company__*MANAGE_CONNECTION*|mcp__composio-company__*INITIATE_CONNECTION*)
-    # Managing a COMPANY-wide connection grants the whole fleet access to an app — an owner/admin call.
+  mcp__composio-company__*INITIATE_CONNECTION*)
+    # INITIATE_CONNECTION starts an OAuth grant that gives the whole fleet access to an app — the actual
+    # privilege-bearing op, so it's an owner/admin call (connector.connect).
     CAP="connector.connect" ;;
+  # MANAGE_CONNECTIONS is a management/STATUS tool — in practice agents call it to LIST/check connections
+  # (`{toolkits:["gmail"]}`), a benign read that was needlessly owner-gated. Route it to connector.call
+  # (allowed) like any other connector tool; a real grant goes through INITIATE_CONNECTION above.
   mcp__*) CAP="connector.call" ;;
   *) exit 0 ;;  # any other built-in tool (Read/Glob/Grep/…) isn't a world side effect → allow
 esac


### PR DESCRIPTION
## What & why

The owner reported drowning in approval notifications, "most look benign," specifically flagging `mcp__composio-company__COMPOSIO_MANAGE_CONNECTIONS`, and that the Slack DM (`why: shell.exec: risky`) is unclear. A fleet review (all 3 tenants, 14d) confirmed approvals are dominated by always-approved false positives.

**1. `MANAGE_CONNECTIONS` reads were owner-gated.** The gate-hook routed any `*MANAGE_CONNECTION*` tool to `connector.connect` (owner/admin approval). But every observed call is a **read** — `COMPOSIO_MANAGE_CONNECTIONS {"toolkits":["gmail"]}` / `{"mode":"STATUS"}` — listing/checking connection status. **26 such approvals fleet-wide in 14 days, 0 rejected.** Now only `*INITIATE_CONNECTION*` (the actual OAuth grant that gives the fleet app access) routes to `connector.connect`; `MANAGE_CONNECTIONS` falls through to `connector.call` (allowed).

**2. The approval DM was unclear.** It read `` `shell.exec` (owner) … why: shell.exec: risky `` — raw capability + terse rule name. It now **leads with the decision-brief headline** (e.g. *"Deploy the marketing site to production via the deploy script"*), with capability/reason as secondary detail. Falls back to the old line when a notice has no brief. Threaded `brief.headline` through `ApprovalNotice`.

```
Before:  🔴 RED approval needed — `shell.exec` (owner) requested by agent website-bot.
         why: shell.exec: risky
After:   🔴 RED approval — website-bot: Deploy the marketing site to production via the deploy script
         `shell.exec` (owner) — shell.exec: risky
```

## Verification
- `npm run build` ✓ · `npm run test:governance` → **102/102 ✓** · gate-hook routing tested (MANAGE→call, INITIATE→connect) · notification format previewed.

## Companion (not in this PR — applied to the box)
- **instawp policy**: remove `ask shell.exec :: risky` (the blunt rule the default dropped in #139 — ~70 approvals/14d on instawp; every real guardrail is a separate rule, verified). Tenant-config edit.

## The bigger picture
This removes the bulk of the current noise. The systematic next step is an **"always approve THIS action" (by decision-brief signature)** affordance — narrower than the capability-wide "Always" — so a recurring benign approval can be silenced in one click. Tracked with the decision-brief/blocked-card work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMSbnPEbqSVPGLasTKENp