### PR TITLE
feat(automations): run-as identity for proposed automations → scheduled/headless runs reach a member's personal Composio Gmail (v0.267.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.267.0] — 2026-07-27
+### Added
+- **Automations can run as a member, so a scheduled/headless run reaches that person's personal Composio
+  apps (e.g. their Gmail) — and the agent that proposes an automation now knows it.** A fired automation
+  defaults to the *company* identity, which sees only the shared company Composio + org/shared connectors,
+  never one person's personal connections; the fix isn't new mechanism (the console form already had a
+  "Run as" selector) but closing the discoverability gap that hid it:
+  - `automation_propose` (the agent-facing MCP tool) gains a `runAs` field and its description now spells
+    out the identity→connector rule — an agent proposing e.g. a daily Gmail triage suggests the member to
+    act as (by id or email, resolved at propose time) instead of silently landing a company-identity run
+    with no Gmail. `proposeAutomation` validates the member and surfaces *whose* credentials will be used
+    in the proposal preview.
+  - The **Inbox → Proposed-by-agents** approval card gains a **Run as** picker, so the approving owner/admin
+    confirms or changes the identity at approval time (`POST /api/automations/proposals/:id/approve` accepts
+    an optional validated `runAs` override); the automations form's "Run as" help now names Gmail and states
+    it's the only way an unattended run reaches a personal app.
+### Fixed
+- **Fresh-DB boot crash (`no such column: archived_at`) — broke new-tenant provisioning and every
+  scratch-home test harness.** The hot-path `idx_sessions_live` index is built on
+  `term_sessions(archived_at, …)`, but that column's `addColumn` runs LATER in the same migration pass,
+  so on a brand-new database the index create ran before the column existed and threw at `openDb`.
+  Existing DBs already had the column, so it only bit fresh ones. The column is now ensured (idempotently)
+  immediately before the index block.
+
 ## [0.266.2] — 2026-07-27
 ### Fixed
 - **Two approval-noise fixes: benign `MANAGE_CONNECTIONS` reads no longer owner-gated, and the Slack/Discord

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.266.2",
+  "version": "0.267.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.266.2",
+      "version": "0.267.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.266.2",
+  "version": "0.267.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -652,7 +652,13 @@ const TOOLS = [
       '`name`, the `task` (the prompt the spawned session receives), and the trigger: for `type:"cron"` ' +
       '(the default) a 5-field `schedule` (e.g. "0 9 * * 1-5" = 9am weekdays); for webhook/composio/slack/' +
       'discord an optional `filter`. `agentId` defaults to you (the proposing agent). Always include a ' +
-      '`rationale` — the approver reads it to decide.',
+      '`rationale` — the approver reads it to decide. ' +
+      'IDENTITY MATTERS FOR CONNECTORS: a fired automation runs by default as the COMPANY identity, which ' +
+      'sees only the shared company account + org/shared connectors — NOT any one person\'s personal apps. ' +
+      'If the task needs a specific human\'s OWN connected tools (e.g. THEIR Composio Gmail, their ClickUp), ' +
+      'those are injected only when the run acts AS that member — so set `runAs` to them (a member id or ' +
+      'email; use `directory_lookup` if unsure). Otherwise the scheduled run silently won\'t have those ' +
+      'tools. The approver sees whose credentials will be used and can change it.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -664,6 +670,7 @@ const TOOLS = [
         filter: { type: 'string', description: 'For event triggers — composio trigger slug, or slack/discord event type or channel id ("" = any).' },
         agentId: { type: 'string', description: 'Which agent the automation runs. Defaults to you (the proposing agent).' },
         mode: { type: 'string', enum: ['headless', 'interactive'], description: 'headless (unattended, default for event triggers) or interactive.' },
+        runAs: { type: 'string', description: 'Optional member (id or email) the fired session should ACT AS, so THEIR personal connectors — e.g. their own Composio Gmail — are injected. Omit to run as the company identity (shared connectors only). Suggest this whenever the task uses a person\'s personal apps.' },
         rationale: { type: 'string', description: 'Why this automation is worth running — the approver reads this to decide.' },
       },
       required: ['name', 'task'],
@@ -1795,6 +1802,7 @@ async function automationPropose(args: Record<string, unknown>): Promise<string>
       filter: args.filter ? String(args.filter) : undefined,
       agentId: args.agentId ? String(args.agentId) : undefined,
       mode: args.mode ? String(args.mode) : undefined,
+      runAs: args.runAs ? String(args.runAs) : undefined,
       rationale: args.rationale ? String(args.rationale) : undefined,
     }),
   });

--- a/src/server.ts
+++ b/src/server.ts
@@ -765,6 +765,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       filter: b.filter != null ? String(b.filter) : undefined,
       task: String(b.task || ''),
       mode: (b.mode === 'headless' || b.mode === 'interactive' ? b.mode : undefined) as ProposedAutomation['mode'],
+      runAs: b.runAs != null ? String(b.runAs) : undefined,
     };
     const out = tm.proposeAutomation(session, agent, spec, b.rationale != null ? String(b.rationale) : undefined);
     return sendJson(res, out.ok ? 200 : 400, out);
@@ -2306,14 +2307,29 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const card = tm.automationProposalCard(autoPropApprove[1]);
     if (!card) return sendJson(res, 404, { error: 'no such automation proposal' });
     if (card.status !== 'open') return sendJson(res, 409, { error: 'this proposal was already resolved' });
+    // The approver may confirm or CHANGE the run-as identity at approval time (the field that decides
+    // whether the fired session gets a member's personal Composio Gmail/etc. or only the company account):
+    // body `runAs` = a member id overrides the agent's suggestion; '' clears it back to company identity;
+    // absent = keep what the agent proposed. Validate an override so a bad id can't be persisted.
+    const ab = await readBody(req);
+    let runAs = card.spec.runAs;
+    if (ab.runAs !== undefined) {
+      const raw = String(ab.runAs || '').trim();
+      if (!raw) runAs = undefined;
+      else {
+        const m = os.team.getMember(raw) ?? os.team.getMemberByEmail(raw);
+        if (!m) return sendJson(res, 400, { error: `unknown member "${raw}" for runAs` });
+        runAs = m.id;
+      }
+    }
     try {
       const created = autos.add({
         agentId: card.spec.agentId, name: card.spec.name, type: card.spec.type,
         mode: card.spec.mode, schedule: card.spec.schedule, filter: card.spec.filter,
-        task: card.spec.task, createdBy: me.id,
+        task: card.spec.task, createdBy: me.id, runAs,
       });
       tm.setAutomationProposalStatus(autoPropApprove[1], 'approved');
-      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'automation.proposal.approved', data: { by: me.email, agent: card.agent, id: created.id, name: created.name, type: created.type } });
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'automation.proposal.approved', data: { by: me.email, agent: card.agent, id: created.id, name: created.name, type: created.type, runAs: runAs ?? null } });
       return sendJson(res, 200, { ok: true, automation: automationView(created, req, true) });
     } catch (e) {
       // A bad cron / unknown agent surfaces to the human here (validated by `add`); the proposal stays open.

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -769,7 +769,12 @@ function migrate(db: Db): void {
   //    ORDER BY ts DESC. The existing idx_audit_run (run_id only) is left in place; this composite
   //    additionally serves the type-filtered + ts-ordered lookups.
   // (message_state's (message_id, member_id) join is already served by its composite PRIMARY KEY.)
-  // Placed after the addColumn calls above so the columns are guaranteed to exist on older DBs.
+  // Every column an index below references must already exist. `dismissed_at` is in the base messages
+  // schema, but `term_sessions.archived_at` is added by a LATER addColumn (further down this same pass),
+  // so on a FRESH DB the idx_sessions_live create used to run before the column existed and crashed boot
+  // ("no such column: archived_at") — breaking new-tenant provisioning + every scratch-home harness.
+  // Ensure it here (addColumn is idempotent) so the index build is safe regardless of ordering.
+  addColumn(db, 'term_sessions', 'archived_at', 'INTEGER');
   db.exec('CREATE INDEX IF NOT EXISTS idx_messages_feed ON messages(dismissed_at, created_at)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_sessions_live ON term_sessions(archived_at, created_at)');
   db.exec('CREATE INDEX IF NOT EXISTS idx_audit_run_type ON audit_events(run_id, type, ts)');

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -486,6 +486,12 @@ export interface ProposedAutomation {
   filter?: string;
   task: string;
   mode?: 'headless' | 'interactive';
+  /** The member id the fired session should act AS. An unattended run defaults to the company identity
+   *  (only the shared company Composio + org/shared connectors); set this when the task needs a person's
+   *  OWN connected apps (their personal Composio Gmail/ClickUp/etc.), which are injected only under their
+   *  identity. The proposing agent may suggest it (by member id or email, resolved at propose time); the
+   *  approving owner/admin sees whose credentials will be used and consents by approving. */
+  runAs?: string;
 }
 
 /** What the session-event notifier sink receives when one of a member's own sessions changes state — it
@@ -3729,7 +3735,18 @@ export class TerminalManager {
     if (!task) return { ok: false, error: 'a task template is required' };
     const type = (['cron', 'webhook', 'composio', 'slack', 'discord'] as const).includes(spec.type as never) ? spec.type : 'cron';
     if (type === 'cron' && !(spec.schedule || '').trim()) return { ok: false, error: 'a cron automation needs a schedule (5-field cron expression)' };
-    const clean: ProposedAutomation = { agentId, name, type, task, ...(spec.schedule ? { schedule: String(spec.schedule).trim() } : {}), ...(spec.filter ? { filter: String(spec.filter).trim() } : {}), ...(spec.mode === 'headless' || spec.mode === 'interactive' ? { mode: spec.mode } : {}) };
+    // Resolve the suggested run-as identity to a canonical member id. Agents name a member by id or email
+    // (e.g. from `directory_lookup`); the automations store keys run_as by member id (fire → createSession
+    // runAs → composioUserId(member).email). Reject an unresolvable value so a typo can't silently degrade
+    // the approved automation back to company identity (the exact surprise that hides a missing Gmail).
+    let runAs: string | undefined;
+    if ((spec.runAs || '').trim()) {
+      const raw = String(spec.runAs).trim();
+      const m = this.os.team.getMember(raw) ?? this.os.team.getMemberByEmail(raw);
+      if (!m) return { ok: false, error: `unknown member "${raw}" for runAs — pass a member id or email (use directory_lookup), or omit runAs to run as the company identity` };
+      runAs = m.id;
+    }
+    const clean: ProposedAutomation = { agentId, name, type, task, ...(spec.schedule ? { schedule: String(spec.schedule).trim() } : {}), ...(spec.filter ? { filter: String(spec.filter).trim() } : {}), ...(spec.mode === 'headless' || spec.mode === 'interactive' ? { mode: spec.mode } : {}), ...(runAs ? { runAs } : {}) };
     // Cap the queue + dedupe an identical open proposal from this agent (mirrors proposePolicy).
     const open = this.db.prepare(`SELECT id, args FROM messages WHERE type = 'automation.proposed' AND status = 'open' AND agent = ?`).all<{ id: string; args: string | null }>(agent);
     if (open.length >= 10) return { ok: false, error: 'you already have 10 open automation proposals awaiting review — wait for a human to act on them first' };
@@ -3737,7 +3754,11 @@ export class TerminalManager {
     if (open.some((o) => { try { return JSON.stringify((JSON.parse(o.args || '{}') as { spec?: unknown }).spec) === specKey; } catch { return false; } })) {
       return { ok: false, error: 'an identical automation proposal from you is already awaiting review' };
     }
-    const preview = `${type}${clean.schedule ? ` \`${clean.schedule}\`` : ''} → runs \`${agentId}\`: ${task.slice(0, 80)}${task.length > 80 ? '…' : ''}`;
+    // Surface the run-as identity in the preview: it decides which connectors the fired session gets
+    // (a member → their personal Composio Gmail/etc.; unset → company identity only), so the approver
+    // consciously consents to whose credentials will be used.
+    const asWho = runAs ? (this.os.team.getMember(runAs)?.name || this.os.team.getMember(runAs)?.email || runAs) : 'company identity';
+    const preview = `${type}${clean.schedule ? ` \`${clean.schedule}\`` : ''} → runs \`${agentId}\` as ${asWho}: ${task.slice(0, 80)}${task.length > 80 ? '…' : ''}`;
     this.postReviewCard({
       type: 'automation.proposed', sessionId, agent,
       title: `Automation proposed — ${name}`,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8784,12 +8784,18 @@ function triggerSummary(a: Automation): string {
  *  PolicyProposalsPanel; hidden entirely when there are no open proposals. */
 function AutomationProposalsPanel({ agents, onChanged }: { agents: AgentInfo[]; onChanged: () => void }) {
   const [proposals, setProposals] = useState<AutomationProposal[]>([])
+  const [members, setMembers] = useState<Member[]>([])
+  const [runAsEdit, setRunAsEdit] = useState<Record<string, string>>({}) // proposal id → chosen member id ('' = company)
   const [busy, setBusy] = useState('')
   const [hint, setHint] = useState('')
   const load = () => { api.automationProposals().then((r) => setProposals(r.proposals ?? [])).catch(() => {}) }
   useEffect(load, [])
+  useEffect(() => { api.team().then((r) => setMembers(r.members ?? [])).catch(() => {}) }, [])
   const agentName = (id: string) => agents.find((a) => a.id === id)?.id || id
-  const approve = async (id: string) => { setBusy(id); setHint(''); const r = await api.approveAutomationProposal(id); setBusy(''); if (!r.ok) return setHint('⚠ ' + (r.error || 'failed')); load(); onChanged() }
+  // The run-as identity decides which connectors the fired session gets (a member → their personal Composio
+  // Gmail/etc.; company → shared account only), so let the approver confirm/override the agent's suggestion.
+  const runAsFor = (pr: AutomationProposal) => runAsEdit[pr.id] ?? pr.spec.runAs ?? ''
+  const approve = async (pr: AutomationProposal) => { setBusy(pr.id); setHint(''); const r = await api.approveAutomationProposal(pr.id, runAsFor(pr)); setBusy(''); if (!r.ok) return setHint('⚠ ' + (r.error || 'failed')); load(); onChanged() }
   const reject = async (id: string) => { setBusy(id); setHint(''); const r = await api.rejectAutomationProposal(id); setBusy(''); if (!r.ok) return setHint('⚠ ' + (r.error || 'failed')); load() }
   if (!proposals.length) return null
   return (
@@ -8806,8 +8812,18 @@ function AutomationProposalsPanel({ agents, onChanged }: { agents: AgentInfo[]; 
               </div>
               {pr.preview && <div className="rounded bg-muted/50 px-2 py-1 font-mono text-[11px]">{pr.preview}</div>}
               {pr.rationale && <p className="text-[11px] italic text-muted-foreground">“{pr.rationale}”</p>}
+              <div className="flex flex-wrap items-center gap-2">
+                <label className="text-[11px] text-muted-foreground" title="The fired session acts as this member, so their personal connectors (e.g. their own Composio Gmail) are injected. Company identity = shared company account only.">Run as</label>
+                <Select value={runAsFor(pr) || '__company'} onValueChange={(v) => setRunAsEdit((m) => ({ ...m, [pr.id]: v && v !== '__company' ? v : '' }))}>
+                  <SelectTrigger className="h-7 w-[180px] text-xs"><SelectValue /></SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__company">Company identity (no member)</SelectItem>
+                    {members.map((mm) => (<SelectItem key={mm.id} value={mm.id}>{mm.name || mm.email}</SelectItem>))}
+                  </SelectContent>
+                </Select>
+              </div>
               <div className="flex items-center gap-2">
-                <Button size="sm" disabled={!!busy} onClick={() => approve(pr.id)}>Approve &amp; enable</Button>
+                <Button size="sm" disabled={!!busy} onClick={() => approve(pr)}>Approve &amp; enable</Button>
                 <Button size="sm" variant="ghost" disabled={!!busy} onClick={() => reject(pr.id)}>Reject</Button>
                 {hint && busy === '' && <span className="text-[11px] text-amber-600">{hint}</span>}
               </div>
@@ -9045,7 +9061,7 @@ function AutomationsPage({ me, agents, serverTz, onOpen, nav, agentFilter }: { m
                     <Input value={filter} onChange={(e) => setFilter(e.target.value)} className="font-mono" placeholder="SLACK_DIRECT_MESSAGE_RECEIVED  (blank = any)" />
                   </Field>
                 )}
-                <Field label="Run as" help="The fired session acts as this member, so their personal connectors (e.g. their own ClickUp / Composio apps) are injected instead of the shared company account. Company identity = the company Composio only.">
+                <Field label="Run as" help="The fired session acts as this member, so THEIR personal connectors (e.g. their own Composio Gmail / ClickUp) are injected. This is the only way a scheduled/unattended run reaches a person's personal apps. Company identity (the default) = the shared company Composio only — a personal Gmail won't be available.">
                   <Select value={runAs || '__company'} onValueChange={(v) => setRunAs(v && v !== '__company' ? v : '')}>
                     <SelectTrigger><SelectValue /></SelectTrigger>
                     <SelectContent>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -703,7 +703,7 @@ export interface Automation {
 export interface AutomationProposal {
   id: string
   agent: string
-  spec: { agentId: string; name: string; type: Automation['type']; schedule?: string; filter?: string; task: string; mode?: ExecMode }
+  spec: { agentId: string; name: string; type: Automation['type']; schedule?: string; filter?: string; task: string; mode?: ExecMode; runAs?: string }
   rationale?: string
   preview?: string
   createdAt: number
@@ -1368,7 +1368,7 @@ export const api = {
    *  fire-and-forget, interactive = watch/steer the live TUI); omit to keep the automation's own mode. */
   runAutomation: (id: string, mode?: 'interactive' | 'headless') => call<{ ok: boolean; sessionId?: string; reason?: string; error?: string }>('POST', `/api/automations/${id}/run`, mode ? { mode } : {}),
   automationProposals: () => call<{ proposals: AutomationProposal[]; error?: string }>('GET', '/api/automations/proposals'),
-  approveAutomationProposal: (id: string) => call<{ ok: boolean; automation?: Automation; error?: string }>('POST', `/api/automations/proposals/${id}/approve`),
+  approveAutomationProposal: (id: string, runAs?: string) => call<{ ok: boolean; automation?: Automation; error?: string }>('POST', `/api/automations/proposals/${id}/approve`, runAs !== undefined ? { runAs } : {}),
   rejectAutomationProposal: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/automations/proposals/${id}/reject`),
   agentUpdateProposals: (target?: string) => call<{ proposals: AgentUpdateProposal[]; canApprove?: boolean; error?: string }>('GET', '/api/agents/proposals' + (target ? '?target=' + encodeURIComponent(target) : '')),
   approveAgentUpdateProposal: (id: string) => call<{ ok: boolean; target?: string; rev?: number; error?: string }>('POST', `/api/agents/proposals/${id}/approve`),


### PR DESCRIPTION
## Why

A member set up a scheduled automation that needed **their Gmail**, left **Run as = Company identity** (the default), and it silently had no Gmail. The mechanism to run as a member already existed (the console form's "Run as" selector injects that member's personal Composio apps), but **nothing surfaced it** — and critically, the agent-facing `automation_propose` tool had no `runAs` field and no notion that connector access depends on run-as identity. So an agent proposing a "daily Gmail triage" lands a company-identity run with no Gmail, and the human doesn't know why.

This isn't new mechanism — it's closing the discoverability gap end-to-end.

## What

- **`automation_propose` (agent-facing MCP tool)** gains a `runAs` field; its description now spells out the identity→connector rule. An agent suggests the member to act as (by id or email, resolved + validated in `proposeAutomation`) instead of silently landing a company-identity run. The proposal **preview names whose credentials** will be used, and an unresolvable member is rejected (no silent fallback to company identity).
- **Inbox → "Proposed by agents"** approval card gains a **Run as** picker, so the approving owner/admin confirms or changes the identity at approval time. `POST /api/automations/proposals/:id/approve` accepts an optional **validated** `runAs` override.
- The automations form's **"Run as" help** now names Gmail explicitly and states it's the only way an unattended run reaches a personal app.

## Also fixed (pre-existing)

- **Fresh-DB boot crash (`no such column: archived_at`)** — `idx_sessions_live` was built on `term_sessions(archived_at, …)` before that column's `addColumn` ran in the same migration pass, so a brand-new database crashed at `openDb` (broke new-tenant provisioning + every scratch-home harness; existing DBs already had the column, so it was latent). The column is now ensured (idempotently) immediately before the index block.

## Verification

- `npm run typecheck` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` → 102/102 ✓
- In-process propose→approve harness: email→member-id resolution, unknown-member rejection, `run_as` persisted on the created automation, company-identity default when omitted — 9/9 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)