### PR TITLE
feat(governance): auto-approval list — 'always approve THIS action' by brief signature (v0.268.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.268.0] — 2026-07-27
+### Added
+- **Auto-approval list — "always approve THIS action", by decision-brief signature.** The old "Always"
+  button on an approval card added a capability-wide `allow` policy rule (allowing *all* `connector.connect`
+  / `net.connect` — far too broad). It now adds the approval's **brief signature**
+  (`capability|verb|targetKind|key`) to a dedicated **auto-approval list**, so it silences exactly one
+  recurring action shape (e.g. "Reach 5.135.136.192", "Grant Composio initiate connection") and nothing
+  broader. At gate time a pending `approve` whose signature is listed clears automatically (audited
+  `approval.auto_approved` via `auto-approve-list`) — no card, no notification. **Safety:** the list is
+  only ever consulted for an `approve`; a `deny` (never-tier: destructive / over-cap / prod-build) is a
+  different decision the list never sees, so it stays blocked (verified end-to-end). New
+  **Settings → Governance → Auto-approvals** panel shows the full, legible registry — what each rule
+  auto-approves (human label + raw signature), who added it, an example, and how many times it has fired —
+  with one-click **Revoke** (owner). New `src/state/auto-approvals.ts` (`AutoApprovalStore` + `auto_approvals`
+  table), `describeBrief()` in the briefer, and `GET`/`DELETE /api/auto-approvals`. Owner-only to add/revoke.
+
 ## [0.267.0] — 2026-07-27
 ### Added
 - **Automations can run as a member, so a scheduled/headless run reaches that person's personal Composio

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.267.0",
+  "version": "0.268.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.267.0",
+      "version": "0.268.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.267.0",
+  "version": "0.268.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/briefer.ts
+++ b/src/governance/briefer.ts
@@ -179,3 +179,17 @@ export function briefFor(capability: string, args: Record<string, unknown>, deci
   const signature = signatureFor(capability, verb, target, args, input);
   return { headline, verb, target, rationale, riskClass: decision.riskClass, suggestedAction, signature };
 }
+
+/** A short, stable human phrase for a brief's ACTION SHAPE — the label shown for an auto-approval rule
+ *  ("Run `git` commands", "Reach 5.135.136.192 (ssh)", "Grant stripe refund"). Unlike `headline` (which
+ *  varies per call), this reflects only the parts the signature keys on, so it reads the same every time. */
+export function describeBrief(brief: DecisionBrief): string {
+  const t = brief.target;
+  if (t.kind === 'host') return `Reach ${t.label}`;
+  if (t.kind === 'command') return `Run \`${t.label}\` commands`;
+  if (t.kind === 'file') return `Write files like ${t.label}`;
+  // Money is keyed on the payment TOOL, not the amount — the money-cap `never` rule still bounds the sum.
+  if (t.kind === 'money') return `Approve payments with this tool (money cap still applies)`;
+  if (t.kind === 'recipient') return `Send to ${t.label}`;
+  return `${VERB_WORD[brief.verb]} ${t.label}`;
+}

--- a/src/id.ts
+++ b/src/id.ts
@@ -45,6 +45,7 @@ export const ID_PREFIX = {
   goalEvent: 'gev', // goal event-log entries
   agentRevision: 'arev', // agent self-edit revisions
   policyRevision: 'prev', // policy revisions
+  autoApproval: 'aappr', // auto-approval list rules
 } as const;
 
 export type IdEntity = keyof typeof ID_PREFIX;

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -23,6 +23,7 @@ import { createMemoryProvider } from './memory';
 import { CapabilityRegistry } from './capabilities/registry';
 import { ConnectorStore } from './connectors/connectors';
 import { HostStore } from './hosts/hosts';
+import { AutoApprovalStore } from './state/auto-approvals';
 import { Gateway } from './gateway/gateway';
 import { InMemoryAuditSink, JsonlAuditSink, SqliteAuditSink, TeeAuditSink } from './governance/audit';
 import { InMemoryBudgetLedger } from './governance/budget';
@@ -112,6 +113,8 @@ export class AgentOS {
   readonly connectors: ConnectorStore;
   /** Host connections — governed reachable destinations (SSH / internal HTTP / DB). See host-connections-plan.md. */
   readonly hosts: HostStore;
+  /** "Always approve THIS action" list, keyed on the decision-brief signature (auto-approvals.ts). */
+  readonly autoApprovals: AutoApprovalStore;
   /**
    * Persistent agent memory (recall across sessions). SQLite by default; libsql/automem optional.
    * Mutable so Settings → Memory can hot-swap the backend live (new requests use the new provider).
@@ -133,6 +136,7 @@ export class AgentOS {
     this.secrets = new SqliteSecretsVault(this.db, resolveMasterKey(opts.paths?.home), new EnvSecretsVault());
     this.connectors = new ConnectorStore(this.db);
     this.hosts = new HostStore(this.db);
+    this.autoApprovals = new AutoApprovalStore(this.db);
     this.approvals = new SqliteApprovals(this.db);
     this.team = new TeamStore(this.db);
     this.settings = new SettingsStore(this.db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,11 +50,12 @@ import { GithubIdentity } from './edge/github-identity';
 import { convertAppManifest, userInstallationStatus } from './connectors/github';
 import { redactHost, type HostProtocol, type HostPosture } from './hosts/hosts';
 import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUserId, initiateConnection, verifyComposioWebhook, parseComposioEvent } from './connectors/composio';
-import { JsonPolicyEngine, PolicyDocument, applyProposal, validatePolicyDocument, withAlwaysAllow } from './governance/policy';
+import { JsonPolicyEngine, PolicyDocument, applyProposal, validatePolicyDocument } from './governance/policy';
+import { briefFor, describeBrief } from './governance/briefer';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
 import { parseBundle } from './governance/bundle-import';
-import { AgentManifest, AppManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, isValidAppSlug, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeAppDomains, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, sanitizeUsableSubagents, TaskStatus, GoalStatus } from './types';
+import { AgentManifest, AppManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, isValidAppSlug, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeAppDomains, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, sanitizeUsableSubagents, TaskStatus, GoalStatus, riskClassForLevel } from './types';
 import { AgentConfigSnapshot } from './state/agent-revisions';
 import { computeAgentStats, computeAgentStat } from './state/agent-stats';
 
@@ -5572,29 +5573,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { events, types });
   }
   if (method === 'GET' && p === '/api/approvals') return sendJson(res, 200, os.approvals.pending(os.tenant).filter((a) => tm.canViewSession(a.runId, me)).map(approvalView));
-  // "Always approve": approve THIS attempt AND teach the policy an `allow` rule for its capability, so
-  // future matching attempts pass the gate without a card. Adding a rule is a POLICY EDIT, so it's
-  // OWNER-ONLY — the same guard as PUT /api/policy (an admin can approve once but must not rewrite the
-  // ruleset to bypass future owner sign-off). The rule is inserted AFTER all `never` rules, so deny
-  // guardrails (destructive / over-cap) stay in force; a capability under an unconditional `never` is
-  // refused (approved once, rule not added, with a note). Audited `policy.rule.added` + `policy.updated`.
+  // "Always approve": approve THIS attempt AND add its decision-brief SIGNATURE to the auto-approval list,
+  // so future attempts of the SAME action shape (e.g. "reach 5.135.136.192", "use stripe refund") clear
+  // without a card. Narrower + safer than a capability-wide allow rule — it only silences this one shape,
+  // is fully legible in Settings → Auto-approvals, and one-click revocable. OWNER-ONLY (it durably loosens
+  // gating). Only reachable for an `approve`, so it can never wave through a never-tier (deny) action.
   const alwaysMatch = p.match(/^\/api\/approvals\/([\w-]+)\/always$/);
   if (method === 'POST' && alwaysMatch) {
     const ap = os.approvals.get(alwaysMatch[1]);
     if (!ap) return sendJson(res, 404, { error: 'approval not found' });
-    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required — “always approve” edits policy' });
-    if (!(os.policy instanceof JsonPolicyEngine)) return sendJson(res, 400, { error: 'active policy engine is not editable' });
-    const cap = ap.attempt.capabilityId;
-    const result = withAlwaysAllow(os.policy.document, cap);
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required — “always approve” loosens the gate durably' });
+    const decision = { effect: 'approve' as const, level: ap.level, riskClass: riskClassForLevel(ap.level), reason: ap.reason };
+    const brief = briefFor(ap.attempt.capabilityId, ap.attempt.args, decision);
     // The run is waiting — approve this attempt regardless of whether the durable rule lands.
     os.approvals.resolve(alwaysMatch[1], true, me.email);
-    if ('error' in result) return sendJson(res, 200, { ok: true, ruleAdded: false, note: result.error });
-    if (result.added) {
-      os.applyPolicyDocument(result.doc, me.email, `always-approve ${cap}`); // snapshot + persist + hot reload
-      os.audit.append({ ts: Date.now(), runId: ap.runId, tenant: os.tenant, principal: me.email, type: 'policy.rule.added', data: { capability: cap, effect: 'allow', from: 'inbox.always_approve' } });
-      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'policy.updated', data: { id: result.doc.id, rules: result.doc.rules.length } });
-    }
-    return sendJson(res, 200, { ok: true, ruleAdded: result.added, note: result.added ? undefined : `“${cap}” is already always-allowed` });
+    const { rule, added } = os.autoApprovals.add({ signature: brief.signature, capability: ap.attempt.capabilityId, label: describeBrief(brief), example: brief.headline, addedBy: me.email });
+    if (added) os.audit.append({ ts: Date.now(), runId: ap.runId, tenant: os.tenant, principal: me.email, type: 'autoapproval.added', data: { signature: rule.signature, capability: rule.capability, label: rule.label } });
+    return sendJson(res, 200, { ok: true, ruleAdded: added, label: rule.label, note: added ? undefined : `“${rule.label}” is already auto-approved` });
   }
   // "Trust host & allow": approve THIS attempt AND add a durable org HOST grant (posture `allow`) for
   // the target host, so future reaches to it pass the gate without a card — the phase-2 answer to the
@@ -5620,6 +5615,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.hosts.add({ name: host, match: host, protocol: proto, posture: 'allow', scope: 'org' });
     os.audit.append({ ts: Date.now(), runId: ap.runId, tenant: os.tenant, principal: me.email, type: 'host.trusted', data: { host, protocol: proto, from: 'inbox.trust_host' } });
     return sendJson(res, 200, { ok: true, trusted: true, host });
+  }
+  // Auto-approval list — the legible registry of "always approve THIS action" rules (Settings surface).
+  // Readable by owner/admin (oversight); revocable by owner only (removing a rule tightens the gate — safe,
+  // but keeping the durable-loosening symmetry that only the owner manages the list).
+  if (method === 'GET' && p === '/api/auto-approvals') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    return sendJson(res, 200, { rules: os.autoApprovals.list() });
+  }
+  const autoApprDel = p.match(/^\/api\/auto-approvals\/([\w-]+)$/);
+  if (method === 'DELETE' && autoApprDel) {
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
+    const ok = os.autoApprovals.remove(autoApprDel[1]);
+    if (ok) os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'autoapproval.removed', data: { id: autoApprDel[1] } });
+    return sendJson(res, ok ? 200 : 404, ok ? { ok: true } : { error: 'not found' });
   }
   const apMatch = p.match(/^\/api\/approvals\/([\w-]+)$/);
   if (method === 'POST' && apMatch) {

--- a/src/state/auto-approvals.ts
+++ b/src/state/auto-approvals.ts
@@ -1,0 +1,99 @@
+/**
+ * The AUTO-APPROVAL list — a durable, legible registry of "always approve THIS action" decisions.
+ *
+ * The capability-wide "Always approve" (a policy `allow <capability>` rule) is too blunt for the
+ * recurring-benign-approval problem — allowing all `connector.connect` or all `net.connect` is a huge
+ * grant. This list is keyed on the decision-brief SIGNATURE (`capability|verb|targetKind|key`), so an
+ * owner can silence exactly one recurring action shape (e.g. "reach host 5.135.136.192", "use Stripe
+ * refund") and nothing broader. At gate time a pending APPROVE whose signature is on the list is cleared
+ * automatically (audited `approval.auto_approved` via `auto-approve-list`) — no card, no notification.
+ *
+ * Safety: this only ever short-circuits an `approve` (yellow/red). A `deny` (never-tier: destructive /
+ * over-cap / prod-build) is a different decision the list never sees, so it stays blocked regardless.
+ *
+ * Every row records WHAT is auto-approved (a human `label` + the raw `signature`), an `example` of the
+ * action, WHO added it, and how many times it has fired — so the Settings surface is fully legible and
+ * revocable. Per-workspace DB = the tenant boundary (no tenant column, like HostStore).
+ */
+import { Db } from './db';
+import { newId } from '../id';
+
+export interface AutoApproval {
+  id: string;
+  /** The decision-brief signature this rule matches (the auto-approve key). */
+  signature: string;
+  capability: string;
+  /** Human phrase for the Settings list ("Reach host 5.135.136.192", "Use stripe refund"). */
+  label: string;
+  /** An example headline from the approval it was created from (concrete illustration). */
+  example: string;
+  addedBy: string;
+  addedAt: number;
+  /** How many pending approvals this rule has auto-cleared, and when it last fired. */
+  hits: number;
+  lastHitAt?: number;
+}
+
+interface Row {
+  id: string;
+  signature: string;
+  capability: string;
+  label: string;
+  example: string | null;
+  added_by: string;
+  added_at: number;
+  hits: number;
+  last_hit_at: number | null;
+}
+
+const toRule = (r: Row): AutoApproval => ({
+  id: r.id,
+  signature: r.signature,
+  capability: r.capability,
+  label: r.label,
+  example: r.example ?? '',
+  addedBy: r.added_by,
+  addedAt: r.added_at,
+  hits: r.hits,
+  lastHitAt: r.last_hit_at ?? undefined,
+});
+
+export class AutoApprovalStore {
+  constructor(private readonly db: Db) {}
+
+  list(): AutoApproval[] {
+    return this.db.prepare('SELECT * FROM auto_approvals ORDER BY added_at DESC').all<Row>().map(toRule);
+  }
+
+  /** Add a signature to the list (idempotent on signature). Returns the rule + whether it was new. */
+  add(input: { signature: string; capability: string; label: string; example?: string; addedBy: string }): { rule: AutoApproval; added: boolean } {
+    const sig = (input.signature || '').trim();
+    if (!sig) throw new Error('a signature is required');
+    const existing = this.db.prepare('SELECT * FROM auto_approvals WHERE signature = ?').get<Row>(sig);
+    if (existing) return { rule: toRule(existing), added: false };
+    const rule: AutoApproval = {
+      id: newId('autoApproval'), signature: sig, capability: input.capability, label: input.label,
+      example: input.example ?? '', addedBy: input.addedBy, addedAt: Date.now(), hits: 0,
+    };
+    this.db
+      .prepare('INSERT INTO auto_approvals (id, signature, capability, label, example, added_by, added_at, hits) VALUES (?, ?, ?, ?, ?, ?, ?, 0)')
+      .run(rule.id, rule.signature, rule.capability, rule.label, rule.example, rule.addedBy, rule.addedAt);
+    return { rule, added: true };
+  }
+
+  /**
+   * If `signature` is on the list, record a hit (count + timestamp) and return the rule — the caller
+   * then clears the pending approval. Returns undefined when not listed. Called on the gate hot path only
+   * for an `approve` decision, so the write is rare.
+   */
+  match(signature: string): AutoApproval | undefined {
+    const r = this.db.prepare('SELECT * FROM auto_approvals WHERE signature = ?').get<Row>(signature);
+    if (!r) return undefined;
+    this.db.prepare('UPDATE auto_approvals SET hits = hits + 1, last_hit_at = ? WHERE id = ?').run(Date.now(), r.id);
+    return toRule(r);
+  }
+
+  remove(id: string): boolean {
+    return this.db.prepare('DELETE FROM auto_approvals WHERE id = ?').run(id).changes > 0;
+  }
+}

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -116,6 +116,20 @@ function migrate(db: Db): void {
       created_at  INTEGER NOT NULL
     );
 
+    -- Auto-approval list — "always approve THIS action" by decision-brief signature (auto-approvals.ts).
+    -- A pending APPROVE whose signature is here is cleared without a card. Never sees a deny (never-tier).
+    CREATE TABLE IF NOT EXISTS auto_approvals (
+      id          TEXT PRIMARY KEY,
+      signature   TEXT NOT NULL UNIQUE,          -- the brief signature (capability|verb|targetKind|key)
+      capability  TEXT NOT NULL,
+      label       TEXT NOT NULL,                 -- human phrase for the Settings list
+      example     TEXT,                          -- an example headline from the source approval
+      added_by    TEXT NOT NULL,                 -- member email
+      added_at    INTEGER NOT NULL,
+      hits        INTEGER NOT NULL DEFAULT 0,    -- times it has auto-cleared an approval
+      last_hit_at INTEGER
+    );
+
     -- Terminal-native agent sessions (each a tmux shell).
     CREATE TABLE IF NOT EXISTS term_sessions (
       id         TEXT PRIMARY KEY,

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2659,6 +2659,15 @@ export class TerminalManager {
     }
     if (decision.effect === 'deny') return { decision: 'deny' };
 
+    // Auto-approval list: an owner has said "always approve THIS action" for this exact brief signature,
+    // so clear it without a card or notification. Only reachable for an `approve` (the deny/never tier
+    // returned above), so a listed signature can never wave through an irreversible action.
+    const listed = this.os.autoApprovals.match(brief.signature);
+    if (listed) {
+      this.audit(sessionId, agent, 'approval.auto_approved', { capability, level: decision.level, via: 'auto-approve-list', signature: brief.signature, by: listed.addedBy });
+      return { decision: 'allow' };
+    }
+
     // Context-aware `ask` (governance P5): if an attended human who can approve this level started the
     // run, clear it without a self-addressed card — audited as auto-approved. The never tier (deny)
     // already returned above, so this can never auto-clear an irreversible action.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,7 +13,7 @@ import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
 import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard } from '@/lib/api'
-import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief } from '@/lib/api'
+import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
 import { docPages } from '@/docs'
@@ -4582,13 +4582,15 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
     const rc = m.riskClass ?? (m.level === 'owner' ? 'red' : 'yellow')
     const approverLabel = m.level === 'owner' ? 'owner' : 'admin'
     const resolve = async (approved: boolean) => { setBusy(true); const r = await api.resolve(m.approvalId!, approved); if (r.error) setBusy(false) }
-    // "Always approve" also teaches policy an allow rule for this capability — a policy edit, so owner-only.
+    // "Always approve" adds THIS action's brief signature to the auto-approval list (Settings →
+    // Auto-approvals) — narrow + revocable, owner-only. Not a capability-wide policy rule.
     const always = async () => {
       setBusy(true)
       const r = await api.alwaysApprove(m.approvalId!)
       if (r.error) { setBusy(false); alert(r.error) }          // 403/404 — not resolved; leave the card
-      else if (r.ruleAdded === false && r.note) alert(`Approved once — ${r.note}`)  // resolved, rule not added
+      else if (r.ruleAdded === false && r.note) alert(`Approved once — ${r.note}`)  // resolved, already listed
     }
+    const briefLabel = (m.args as { brief?: Brief } | undefined)?.brief?.headline
     // Phase-2 host trust: for a "host not yet trusted" approval, offer a durable, NARROW "trust this host"
     // grant (posture allow) — better than "Always", which would allow the whole net.connect/ssh.exec
     // capability. Owner-only (loosens the gate durably). Shown only when the brief identifies a host.
@@ -4622,7 +4624,7 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
               {me.role === 'owner' && (
                 trustHost
                   ? <Button size="sm" variant="outline" className="h-7 px-2.5 text-xs" disabled={busy} onClick={trust} title={`Trust ${trustHost} and stop asking — adds an "allow" host grant for it (this host only)`}><Shield className="mr-1 h-3.5 w-3.5" />Trust host</Button>
-                  : <Button size="sm" variant="outline" className="h-7 px-2.5 text-xs" disabled={busy} onClick={always} title={`Approve this and stop asking — adds an "allow ${m.capability ?? ''}" rule to policy`}><Shield className="mr-1 h-3.5 w-3.5" />Always</Button>
+                  : <Button size="sm" variant="outline" className="h-7 px-2.5 text-xs" disabled={busy} onClick={always} title={`Approve this and stop asking for this same action${briefLabel ? ` (“${briefLabel}”)` : ''} — adds it to the auto-approval list (Settings → Auto-approvals), revocable anytime`}><Shield className="mr-1 h-3.5 w-3.5" />Always</Button>
               )}
               <Button size="sm" variant="destructive" className="h-7 px-2.5 text-xs" disabled={busy} onClick={() => resolve(false)}><X className="mr-1 h-3.5 w-3.5" />Reject</Button>
             </>
@@ -12961,7 +12963,61 @@ function GovernanceSettings({ me }: { me: Member }) {
           </label>
         </CardContent>
       </Card>
+
+      <AutoApprovalsCard me={me} />
     </div>
+  )
+}
+
+/** Settings → Governance → Auto-approvals: the legible registry of "always approve THIS action" rules.
+ *  Each row shows WHAT is auto-approved (label + raw signature), who added it, and how many times it has
+ *  fired. Owner can revoke. Populated by the "Always" button on an approval card. */
+function AutoApprovalsCard({ me }: { me: Member }) {
+  const [rules, setRules] = useState<AutoApproval[] | null>(null)
+  const [busy, setBusy] = useState('')
+  const load = () => api.autoApprovals().then((r) => { if (!r.error) setRules(r.rules) }).catch(() => {})
+  useEffect(() => { load() }, [])
+  const revoke = async (id: string) => {
+    setBusy(id); const r = await api.revokeAutoApproval(id); setBusy('')
+    if (r.error) alert(r.error); else load()
+  }
+  const rel = (t?: number) => (t ? new Date(t).toLocaleDateString() : '')
+  return (
+    <Card>
+      <CardContent className="space-y-3 p-4">
+        <div>
+          <div className="text-sm font-medium">Auto-approvals</div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Actions you chose to <span className="font-medium">always approve</span> (the “Always” button on an approval). Each
+            silences one specific action shape — never a whole capability — and the <strong>never</strong> tier (destructive /
+            over-cap) is unaffected. This is the full list of what runs without asking; revoke anytime.
+          </p>
+        </div>
+        {rules === null ? <p className="text-xs text-muted-foreground">Loading…</p>
+          : rules.length === 0 ? <p className="rounded border border-dashed px-3 py-4 text-center text-xs text-muted-foreground">Nothing is auto-approved. Approvals that recur can be silenced with the “Always” button on the card.</p>
+          : (
+            <div className="divide-y rounded border">
+              {rules.map((r) => (
+                <div key={r.id} className="flex items-start gap-3 px-3 py-2">
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm font-medium">{r.label}</div>
+                    <div className="mt-0.5 font-mono text-[10px] text-muted-foreground/80">{r.signature}</div>
+                    <div className="mt-0.5 text-[11px] text-muted-foreground">
+                      <span className="font-mono">{r.capability}</span> · auto-approved <strong>{r.hits}×</strong> · added by {r.addedBy} {rel(r.addedAt)}
+                      {r.example ? <> · e.g. “{r.example}”</> : null}
+                    </div>
+                  </div>
+                  {me.role === 'owner' && (
+                    <Button size="sm" variant="outline" className="h-7 shrink-0 px-2 text-xs" disabled={busy === r.id} onClick={() => revoke(r.id)}>
+                      <X className="mr-1 h-3.5 w-3.5" />Revoke
+                    </Button>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+      </CardContent>
+    </Card>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -622,6 +622,19 @@ export interface Brief {
   signature: string
 }
 
+/** An "always approve THIS action" rule — the durable, legible registry (Settings → Auto-approvals). */
+export interface AutoApproval {
+  id: string
+  signature: string
+  capability: string
+  label: string
+  example: string
+  addedBy: string
+  addedAt: number
+  hits: number
+  lastHitAt?: number
+}
+
 export interface Msg {
   id: string
   type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed' | 'agent.update.proposed'
@@ -1308,7 +1321,10 @@ export const api = {
     call<{ ok: boolean; path?: string; error?: string }>('POST', `/api/sessions/${id}/attach-file`, { dataB64, ext, name }),
   resolve: (id: string, approved: boolean) => call<{ ok: boolean; error?: string }>('POST', '/api/approvals/' + id, { approved }),
   /** Approve this attempt AND add a persistent policy `allow` rule for its capability (owner-only). */
-  alwaysApprove: (id: string) => call<{ ok: boolean; ruleAdded?: boolean; note?: string; error?: string }>('POST', `/api/approvals/${id}/always`),
+  alwaysApprove: (id: string) => call<{ ok: boolean; ruleAdded?: boolean; label?: string; note?: string; error?: string }>('POST', `/api/approvals/${id}/always`),
+  /** The auto-approval list ("always approve THIS action" rules), owner/admin. */
+  autoApprovals: () => call<{ rules: AutoApproval[]; error?: string }>('GET', '/api/auto-approvals'),
+  revokeAutoApproval: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/auto-approvals/${id}`),
   /** Approve this attempt AND add a durable org host grant (posture allow) for its target host, so
    *  future reaches to it pass the gate without a card. Owner-only. */
   trustHost: (id: string) => call<{ ok: boolean; trusted?: boolean; host?: string; note?: string; error?: string }>('POST', `/api/approvals/${id}/trust-host`),


### PR DESCRIPTION
## What & why

The owner asked for "a better way to manage" recurring benign approvals, and that the always-approved items be **kept somewhere** and **clear what we're approving**. This delivers exactly that.

The old **"Always"** button added a capability-wide `allow` policy rule — allowing *all* `connector.connect` / `net.connect`, far too broad. It now adds the approval's **decision-brief signature** (`capability | verb | targetKind | key`) to a dedicated **auto-approval list**, silencing exactly one recurring action shape and nothing more.

## How it works
- Owner clicks **Always** on an approval → the brief signature is added to the list (owner-only; DM/card confirms with the human label).
- At gate time, a pending `approve` whose signature is listed **clears automatically** — no card, no notification — audited `approval.auto_approved` `via: auto-approve-list`.
- **Settings → Governance → Auto-approvals** is the durable, legible registry: for each rule, the **human label** ("Reach 5.135.136.192", "Grant Composio initiate connection"), the **raw signature**, the capability, **who added it**, an **example**, and **how many times it has fired** — with one-click **Revoke** (owner).

## Safety (verified end-to-end)
The list is only ever consulted for an `approve` decision. A `deny` (never-tier: destructive / over-cap / prod-build) is a *different* decision the list never sees — so it **stays blocked** regardless of what's listed. The E2E test asserts a `rm -rf /etc` is still denied while a listed connector shape auto-clears.

## Implementation
- `src/state/auto-approvals.ts` — `AutoApprovalStore` + `auto_approvals` table (signature-unique).
- `TerminalManager.gate` — checks the list right after the deny-return, before creating a card.
- `POST /api/approvals/:id/always` — recomputes the brief, adds the signature (replaces `withAlwaysAllow`); `GET`/`DELETE /api/auto-approvals`.
- `describeBrief()` in the briefer for the human label; money label stays honest (keyed on the tool, money-cap still bounds the amount).
- Web: Settings panel + `Always` button tooltip/behavior.

## Verification
- `npm run build` ✓ · `cd web && npm run build` ✓ · `npm run test:governance` **102/102 ✓**
- **E2E (in-process gate harness):** 1st attempt pends → add rule → 2nd attempt auto-allows with no new card, hit counted, audited via list; **destructive still denied**. 8/8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019zMSbnPEbqSVPGLasTKENp