### PR TITLE
fix(agents): steer generated media to the Library, not the harness scratchpad (v0.268.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.268.1] — 2026-07-27
+### Fixed
+- **Generated media now reliably lands in the Library instead of the scratchpad.** Agents (esp. via the
+  `dataviz`/`artifact-design` skills) were rendering charts/images/PDFs into the Claude Code harness
+  scratchpad (`/private/tmp/.../scratchpad/`), following the harness's emphatic "put ALL temporary files
+  in the scratchpad" instruction. Those files sit **outside** the agent's working folder, so
+  `publishArtifact` (which resolves paths strictly under `manifest.dir`) can't reach them — the media
+  never reaches the Library and is deleted when the session ends. Strengthened the launch operating-notes
+  guidance (`AGENT_OS_OPERATING_NOTES` in `src/terminal.ts`) to explicitly override the harness rule: throwaway
+  intermediates → scratchpad, but any deliverable a human should see → the working folder, then `publish`.
+
 ## [0.268.0] — 2026-07-27
 ### Added
 - **Auto-approval list — "always approve THIS action", by decision-brief signature.** The old "Always"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.268.0",
+  "version": "0.268.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.268.0",
+      "version": "0.268.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.268.0",
+  "version": "0.268.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -96,8 +96,15 @@ Your terminal output may not be read. The operator lives in the Inbox:
 - \`report\` exactly once when you finish, with the outcome and a one-line summary, so the result is
   visible without anyone reading the terminal. If the task taught you something durable, pass it in
   \`lessons\` — it's saved to your memory as a note to your future self.
-- \`publish\` real deliverables (a document, PDF, image, chart) to the Library — not scratch
-  files.
+- \`publish\` real deliverables (a document, PDF, image, chart, generated media) to the Library. Two
+  rules that override the harness's "put ALL temporary files in the scratchpad" instruction: (1) the
+  scratchpad is ONLY for throwaway intermediates — anything a human should see or download is a
+  deliverable, so **write it into your working folder (your cwd)**, never the scratchpad; (2) then
+  \`publish\` it (\`path\` is relative to your working folder). A file left in the scratchpad **cannot be
+  published** — it's outside your working folder, so \`publish\` can't reach it — and it's deleted when
+  the session ends, so the operator never sees it. When a skill or tool renders an image/PDF/chart to
+  the scratchpad by default, move it into your working folder first, then publish. (Images you make
+  with \`image_generate\` are auto-published — this is about media you write yourself.)
 
 ## Opening a pull request — always link back to this session
 When you raise a pull request (or any similar external deliverable that carries a description), add a


### PR DESCRIPTION
## Problem

Agents — especially via the `dataviz` / `artifact-design` skills — render charts, images, and PDFs into the Claude Code harness scratchpad (`/private/tmp/.../scratchpad/`), obeying the harness's emphatic *"Always use this scratchpad directory for ALL temporary file needs"* instruction.

But that scratchpad sits **outside** the agent's working folder. `publishArtifact` (`src/terminal.ts`) resolves publish paths **strictly under `manifest.dir`**, so a file in the scratchpad literally **cannot be published** — the containment check rejects it. Result: generated media never reaches the Library and is deleted when the session ends. The operator never sees the chart the agent made.

The only counter-guidance was a single buried line in the operating notes (`publish … not scratch files`), which loses to the harness's much louder all-caps instruction.

## Fix

Strengthen `AGENT_OS_OPERATING_NOTES` to explicitly override the harness rule:
- scratchpad is **only** for throwaway intermediates;
- any deliverable a human should see → **write it into the working folder (cwd)**, then `publish` (path is relative to the working folder);
- calls out that a scratchpad file *cannot* be published and is deleted at session end;
- notes that skill/tool output rendered to the scratchpad must be moved into the working folder first;
- clarifies `image_generate` output is already auto-published.

Prompt-only, one file. Takes effect next session launch (MCP/agent-facing prompt), no server restart of behavior semantics beyond the standard build + relaunch.

## Test

`npm run typecheck` clean. No runtime surface — this is launch-prompt guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)