### PR TITLE
feat(tasks): descriptive titles for delegation poke-back sessions (v0.269.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.269.1] — 2026-07-27
+### Changed
+- **Descriptive titles for delegation poke-back sessions.** When a delegate finishes a `poke_on_done`
+  hand-off and the caller agent has already exited, the resume-path session that wakes the caller now
+  gets a human-readable title — `Poke ← <delegate> done: <task title>` (or `blocked`, task title
+  truncated at 48 chars) — instead of the opaque `Poke ← <task-id>`. Provenance (`poke:<id>`) and the
+  `agent.poked` audit `source` field are unchanged; only the console-facing title improved.
+
 ## [0.269.0] — 2026-07-27
 ### Added
 - **Semantic guard (Tier 1) — prompt-injection / secret-exfiltration screening.** A new pure, synchronous

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.269.0",
+  "version": "0.269.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.269.0",
+      "version": "0.269.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.269.0",
+  "version": "0.269.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -457,7 +457,7 @@ export class Automations {
    * Fires IMMEDIATELY (unlike schedule(), whose 1-min floor makes it a scheduler, not a wake). The delegate
    * (task assignee) is always the actor, never the caller, so this can't self-wake. Audited `agent.poked`.
    */
-  pokeCaller(input: { callerAgent: string; callerClaudeId: string; runAs?: string; message: string; source: string }): FireResult {
+  pokeCaller(input: { callerAgent: string; callerClaudeId: string; runAs?: string; message: string; source: string; title?: string }): FireResult {
     const agentId = input.callerAgent.startsWith('agent:') ? input.callerAgent.slice('agent:'.length) : input.callerAgent;
     if (!this.os.agents.has(agentId)) return { ok: false, reason: `unknown caller agent: ${agentId}` };
     if (!input.callerClaudeId) return { ok: false, reason: 'no caller transcript to resume' };
@@ -481,7 +481,7 @@ export class Automations {
       // (unreadable pane) fall through to a resume so the poke is never silently dropped.
       if (injected.ok) return { ok: true, sessionId: liveSession.id, tmux: liveSession.tmux };
     }
-    const s = this.tm.createSession(agentId, `Poke ← ${input.source}`, input.message, `poke:${input.source}`, true, undefined, undefined, input.runAs, input.callerClaudeId);
+    const s = this.tm.createSession(agentId, input.title ?? `Poke ← ${input.source}`, input.message, `poke:${input.source}`, true, undefined, undefined, input.runAs, input.callerClaudeId);
     this.os.audit.append({
       ts: Date.now(),
       runId: s.id,

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -520,7 +520,10 @@ function maybePokeCaller(autos: Automations, os: AgentOS, notice: TaskNotice): v
       `Result: ${note}\n\nPick your own work back up from here.`
     : `⛔ Handed back: ${delegate} is BLOCKED on the task you handed off (${t.id}: "${t.title}")${goal}.\n\n` +
       `Why: ${note}\n\nDecide how to proceed — unblock it, re-scope it, or take it on yourself.`;
-  autos.pokeCaller({ callerAgent: t.callerAgent, callerClaudeId: t.callerClaudeId, runAs: t.owner, message, source: t.id });
+  const verb = t.status === 'done' ? 'done' : 'blocked';
+  const shortTitle = t.title.length > 48 ? `${t.title.slice(0, 47)}…` : t.title;
+  const title = `Poke ← ${delegate} ${verb}: ${shortTitle}`;
+  autos.pokeCaller({ callerAgent: t.callerAgent, callerClaudeId: t.callerClaudeId, runAs: t.owner, message, source: t.id, title });
 }
 
 /**


### PR DESCRIPTION
## What

The resume-path session that wakes an **exited** caller agent after a delegate finishes a `poke_on_done` hand-off now gets a human-readable title:

- **Before:** `Poke ← t_a1b2c3` (raw task id)
- **After:** `Poke ← support done: Fix login bug` (delegate · done/blocked · task title, truncated at 48 chars)

The inject path (live/idle caller) is unaffected — it types into the existing pane and spawns no session.

## Why

These `Poke ←` sessions are the fallback that closes the fire-and-forget delegation loop: when agent A hands work to agent B and A has already exited, B finishing would otherwise be silent. The raw task-id title made them opaque in the console.

## Safe by construction

- `source` stays `t.id`, so session provenance (`poke:<id>`) and the `agent.poked` audit `source` field are **unchanged** — only the console-facing title improved.
- `pokeCaller`'s new `title` is optional and falls back to the old `Poke ← <source>`.

## Verify

- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 119/119 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)