### PR TITLE
fix(chat): explicit /agent overrides thread continuity when it names a different agent (v0.271.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.271.1] — 2026-07-28
+### Fixed
+- **Explicit `/agent` overrides thread continuity when it names a different agent.** In a chat "thread"
+  already bound to a session, a follow-up that explicitly addresses a *different* known agent
+  (`/infra-ops …` on a task previously handled by `/migration-ops`) was being delivered into the bound
+  session instead of spawning the named agent — so the wrong agent replied. This bit ClickUp hardest,
+  where a task's comment section is a **shared** space and two agents are routinely addressed on the same
+  task. Continuity now declines when the follow-up redirects to another agent, and the caller spawns it
+  fresh; a plain follow-up (no prefix, the same agent, or a non-agent slash) still continues as before.
+  Applied consistently across ClickUp, Slack, and Discord continuity.
+
 ## [0.271.0] — 2026-07-27
 ### Added
 - **Agent-driven Composio connection requests — default to personal (`connection_request`).** An agent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.271.0",
+  "version": "0.271.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.271.0",
+      "version": "0.271.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.271.0",
+  "version": "0.271.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -982,6 +982,8 @@ export class Automations {
     if (!event.threadTs) return { status: 'none' };
     const bound = this.tm.sessionForSlackThread(event.channel, event.threadTs);
     if (!bound || !bound.claudeSessionId) return { status: 'none' }; // unbound / unresumable → fresh spawn
+    // Explicit `/other-agent …` in the thread overrides continuity → let the caller spawn it fresh.
+    if (this.redirectsToOtherAgent(event.text, bound.agent)) return { status: 'none' };
     // Continuation identity is whoever sent THIS follow-up (accountable human for this turn), falling back
     // to the original run-as when the sender is unmapped.
     const runAs = runAsMember ?? bound.runAs;
@@ -1015,6 +1017,8 @@ export class Automations {
   ): { status: 'delivered' | 'revived' | 'none'; sessionId?: string } {
     const bound = this.tm.sessionForDiscordThread(event.channel);
     if (!bound || !bound.claudeSessionId) return { status: 'none' }; // unbound / unresumable → fresh spawn
+    // Explicit `/other-agent …` in the thread overrides continuity → let the caller spawn it fresh.
+    if (this.redirectsToOtherAgent(event.text, bound.agent)) return { status: 'none' };
     const runAs = runAsMember ?? bound.runAs;
     const msg = this.stripChatPrefix(event.text);
     if (!msg) return { status: 'none' };
@@ -1087,6 +1091,8 @@ export class Automations {
   ): { status: 'delivered' | 'revived' | 'none'; sessionId?: string } {
     const bound = this.tm.sessionForClickupThread(event.taskId);
     if (!bound || !bound.claudeSessionId) return { status: 'none' }; // unbound / unresumable → fresh spawn
+    // Explicit `/other-agent …` on a shared task overrides continuity → let the caller spawn it fresh.
+    if (this.redirectsToOtherAgent(event.text, bound.agent)) return { status: 'none' };
     const runAs = runAsMember ?? bound.runAs;
     const msg = this.stripChatPrefix(event.text);
     if (!msg) return { status: 'none' };
@@ -1131,6 +1137,16 @@ export class Automations {
     const m = t.match(/^\/([A-Za-z0-9][\w-]*)\s+([\s\S]*)$/);
     if (m && this.os.agents.has(m[1])) return m[2].trim();
     return t;
+  }
+
+  /** True when a follow-up explicitly addresses a DIFFERENT known agent than the one bound to this
+   *  thread — a deliberate hand-off. Continuity must then DECLINE so the caller spawns the named agent
+   *  fresh, rather than delivering "/other-agent …" into the wrong live session. Critical in ClickUp's
+   *  SHARED comment space, where `/infra-ops …` and `/migration-ops …` land on the same task; a plain
+   *  follow-up (no `/agent` prefix, or one naming the SAME agent / a non-agent slash) still continues. */
+  private redirectsToOtherAgent(text: string, boundAgent: string): boolean {
+    const m = this.normalizeChatCommand((text || '').replace(/<@[^>]+>/g, '')).trim().match(/^\/([A-Za-z0-9][\w-]*)\b/);
+    return !!m && m[1] !== boundAgent && this.os.agents.has(m[1]);
   }
 
   /**


### PR DESCRIPTION
## Problem

Reported from the **instawp** tenant: a ClickUp comment triggered `/infra-ops` but **`/migration-ops` responded**.

Root cause is in chat thread continuity. `continueClickupThread` (and its Slack/Discord twins) key continuity purely on the "thread" — for ClickUp, the **task id**. A ClickUp task's comment section is a **shared** space, so once the task was bound to a `migration-ops` session, a later `/infra-ops …` comment on the *same task* was delivered straight into the migration-ops session — continuity fired *before* the explicit `/agentname` was ever consulted, so the wrong agent replied.

## Fix

Continuity now declines (`status: 'none'`) when the follow-up **explicitly addresses a different known agent** than the one bound to the thread, letting the caller fall through to a fresh spawn of the named agent (via `fireClickup` → the explicit `/name` route). A plain follow-up — no `/` prefix, the *same* agent, or a non-agent slash — still continues as before.

Applied consistently across **ClickUp, Slack, and Discord** continuity via a shared `redirectsToOtherAgent()` helper (handles the `/agent-os <name>` namespace form and `<@mention>` tokens).

## Verification

- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run test:governance` → 119/119 ✓
- Matching-logic table checked across 8 cases (explicit redirect, same-agent follow-up, plain follow-up, namespaced form, non-agent slash, mention-prefixed) — all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)