### PR TITLE
feat(runtime): a second coding runtime — OpenAI Codex (v0.272.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,44 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.272.0] — 2026-07-28
+### Added
+- **A second coding runtime: OpenAI Codex.** An agent manifest can now declare `"runtime": "codex"`
+  alongside `claude-code` and `mock`, and it launches as a real, governed `codex` session in the agent's
+  folder (`terminal/codex-launch.sh`). The gateway invariant is unchanged, but the *mechanism* differs
+  because Codex's PreToolUse hook doesn't reliably cover file writes and MCP calls: shell (and therefore
+  all `curl`/`git`/`npm` egress) goes through the SAME `terminal/gate-hook.sh` → `/api/gate`; writes are
+  contained structurally by the OS sandbox (`sandbox_mode = workspace-write`, `writable_roots` = the
+  agent folder); MCP/connector calls stay governed server-side at the loopback API; and
+  `approval_policy = "never"` makes Agent OS the sole authority (the mirror of
+  `--dangerously-skip-permissions`). The launcher generates a per-session `$CODEX_HOME` holding a fresh
+  `config.toml` (model/effort, sandbox, MCP servers translated to Codex's TOML schema incl. Composio's
+  `http_headers`, and a `trust_level = "trusted"` seed for the agent folder), a `hooks.json` wiring the
+  gate, and an `AGENTS.md` composed from the agent persona + Company context (Codex has no
+  `--append-system-prompt-file`). See `docs/codex-runtime.md`.
+- **Runtime capability matrix.** `CODING_RUNTIMES` / `RuntimeCapabilities` / `runtimeSupports()` /
+  `isCodingRuntime()` in `src/types.ts` declare what each CLI actually supports (pinned session ids,
+  resume, fork, attachable-unattended, resident chat, transcript parsing, native skills/sub-agents,
+  status line, permission mode, file-write & MCP gating, allow-time steering). The ~20 scattered
+  `runtime === 'claude-code'` checks — which had quietly become the shorthand for "is this a real agent"
+  — now probe a named capability or `isCodingRuntime()`, so a Codex agent is first-class where it is
+  supported and cleanly refused (with a reason) where it is not.
+- `POST /api/runtime-session` — session-secret-gated loopback route for a runtime that mints its OWN
+  transcript id. Codex has no `--session-id` to pin, so the launcher discovers the rollout UUID from its
+  per-session `$CODEX_HOME` and reports it back; first write wins, so a resume can't re-point an existing
+  conversation at a different transcript.
+
+### Fixed
+- **Shell commands sent as an argv array were classified against an empty string.** The enricher (and the
+  briefer) only accepted a `command` of type `string` — Claude Code's `Bash` shape. Codex's `shell` tool
+  sends `["bash","-lc","…"]`, so `typeof` fell through to `''`: no destructive/risky pattern could ever
+  match and the gate **allowed `rm -rf /`**. `commandText()` in `src/governance/enricher.ts` now
+  normalises both shapes (and any future runtime that sends argv arrays); approval cards no longer render
+  an empty command either. Found by the Codex gate smoke test.
+- An unknown `runtime` string in a manifest (a typo, or a manifest from a newer build) used to fail
+  silently — every capability check returned false and the agent quietly ran the scripted mock runner.
+  `registerAgent` now warns once, naming the known runtimes.
+
 ## [0.271.0] — 2026-07-27
 ### Added
 - **Agent-driven Composio connection requests — default to personal (`connection_request`).** An agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,12 @@ Key modules:
 - `src/gateway/gateway.ts` — the 7-step mediated effect boundary. The heart of the trust layer.
 - `src/server.ts` — zero-dependency Node `http` server: JSON API + serves `web/dist` + terminal sessions.
 - `src/terminal.ts` — tmux-backed agent sessions; routes every effect through the same gateway via the
-  PreToolUse gate hook (`terminal/gate-hook.sh`). At launch it resolves each claude-code agent's
+  PreToolUse gate hook (`terminal/gate-hook.sh`). **Two real runtimes** — `claude-code` and `codex`
+  (`AgentManifest.runtime`; `CODING_RUNTIMES` in `src/types.ts` declares what each supports, probed via
+  `runtimeSupports()` / `isCodingRuntime()` — never compare runtime ids). `launchAgentRuntime` picks
+  `terminal/<runtime>-launch.sh`; the gate hook is SHARED and switches its tool→capability routing table
+  on `$AOS_RUNTIME`. Codex holds the invariant differently (shell via the hook, writes via an OS sandbox,
+  MCP server-side) and degrades on attach/resident-chat/cost/skills — see `docs/codex-runtime.md`. At launch it resolves each claude-code agent's
   **runtime tuning** (`resolveRuntimeTuning` in `src/types.ts`: agent manifest → workspace default → CLI
   default) and exports `CLAUDE_MODEL`/`CLAUDE_EFFORT`/`CLAUDE_PERMISSION_MODE`, which `claude-launch.sh`
   maps onto `--model`/`--effort`/`--permission-mode` (model+effort both lanes; permission-mode interactive

--- a/docs/PILLARS.md
+++ b/docs/PILLARS.md
@@ -54,8 +54,10 @@ Capabilities`), the taxonomy north-star that sits beside [`governance-model.md`]
 
 **Today.** Agents are folders with an `agent.json` manifest (`src/types.ts` → `AgentManifest`), loaded
 from bundled examples (`config/agents/`) and the user's data home (`<home>/agents/`, user wins on id
-collision). Two runtimes: `mock` (scripted demo) and `claude-code` (real Claude opened in the agent's
-folder, governed by the PreToolUse gate hook — `terminal/claude-launch.sh` + `terminal/gate-hook.sh`).
+collision). Three runtimes: `mock` (scripted demo), `claude-code` (real Claude opened in the agent's
+folder) and `codex` (OpenAI Codex, same folder) — both real CLIs governed by the SHARED PreToolUse gate
+hook (`terminal/<runtime>-launch.sh` + `terminal/gate-hook.sh`, which picks its tool→capability routing
+table from `$AOS_RUNTIME`).
 Sessions are tmux shells (`src/terminal.ts`), attachable in the browser via ttyd, persisted in the
 `term_sessions` table with who spawned them. Spawning is permission-checked (`TeamStore.canRun`), and
 the same gate covers their lifecycle: **Stop** (`POST /api/sessions/:id/stop`) kills a runaway shell
@@ -75,8 +77,14 @@ resolves agent-value → workspace-default → CLI-default (`resolveRuntimeTunin
 `--model`/`--effort`/`--permission-mode`. Model+effort apply to both lanes; permission-mode only to the
 interactive lane (headless keeps `--dangerously-skip-permissions`). Permission-mode is the agent's *own*
 posture — the PreToolUse gate hook still gates risky effects underneath it, even under `bypassPermissions`.
-The runtime registry stays a two-value union (`mock | claude-code`); a foreign-CLI runtime (Codex etc.) is
-deliberately **parked** — its governance has no PreToolUse-hook equivalent (see Gaps).
+Codex takes `model`/`effort` (via the generated `config.toml`) but has no permission-mode — Agent OS is
+its sole authority through `approval_policy = "never"`, so that knob is not forwarded.
+
+**Runtime capabilities.** `CODING_RUNTIMES` in `src/types.ts` declares what each CLI supports
+(`pinnedSessionId`, `resume`, `fork`, `attachableUnattended`, `residentChat`, `transcript`,
+`nativeSkills`, `nativeSubagents`, `statusLine`, `permissionMode`, `fileWriteGate`, `mcpGate`,
+`steerOnAllow`). Call sites probe a named capability via `runtimeSupports()` rather than comparing
+runtime ids, and `isCodingRuntime()` answers the plain "is this a real CLI agent" question.
 
 Agents have full **console CRUD** (owner/admin): **create** (`POST /api/agents` writes a `claude-code`
 folder — `agent.json` + `CLAUDE.md` — under the data home and registers it live), **edit** the
@@ -85,10 +93,12 @@ assignment, refusing while a session runs). Only agents under the data home are 
 examples are read-only (`deletable` flag on each agent).
 
 **Gaps.** Session cleanup is manual only (no retention sweep / auto-archive of old idle sessions); no
-per-agent run history view tying sessions to audit. **Swappable foreign CLIs (Codex/Gemini/etc.) are not
-implemented** — the runtime seam (manifest `runtime`, env→flag launcher) is general enough to add one, but
-the gateway invariant ("every side effect through the gateway") relies on Claude Code's PreToolUse hook,
-which foreign CLIs lack; bringing one in needs an MCP-fronted-only or sandbox-based enforcement model first.
+per-agent run history view tying sessions to audit. **Codex is a first cut** (see `docs/codex-runtime.md`):
+its unattended lane is `codex exec`, which exits at turn end, so a Codex run is not attachable/takeover-able
+and has no resident warm chat; cost, engaged-time and the friendly chat timeline are unavailable because the
+transcript parser only understands Claude Code's JSONL; skills/sub-agents are Claude-only; and it is
+local-lane only (refused under `AOS_UID_ISOLATION`). There is still no console picker for an agent's
+runtime — set `"runtime": "codex"` in `agent.json`. **Other foreign CLIs (Gemini etc.) remain unimplemented.**
 
 ## 2. Inbox — ✅ Working
 

--- a/docs/codex-runtime.md
+++ b/docs/codex-runtime.md
@@ -1,0 +1,142 @@
+# The Codex runtime
+
+Agent OS can drive **OpenAI Codex** as well as Claude Code. An agent picks its runtime in its manifest:
+
+```json
+{ "id": "my-agent", "runtime": "codex", "...": "..." }
+```
+
+`runtime` is one of `mock` | `claude-code` | `codex`. An unrecognised value is warned about loudly at
+registration (it would otherwise silently fall back to the scripted mock runner).
+
+Requires `codex` on PATH (`npm i -g @openai/codex`) and a logged-in account (`codex login`, or
+`OPENAI_API_KEY`). Verified against **codex-cli 0.145.0**.
+
+---
+
+## How the invariant holds
+
+The one invariant is that *every side effect passes through the gateway*. Claude Code upholds it with a
+single mechanism — a PreToolUse hook that intercepts `Bash`, file writes and MCP calls. **Codex's hook
+does not reliably cover all three**, so containment is assembled from three complementary parts. The
+invariant is unchanged; only the mechanism differs.
+
+| Effect | Claude Code | Codex |
+| --- | --- | --- |
+| Shell (incl. all `curl`/`git`/`npm` egress) | PreToolUse hook → `/api/gate` | **same hook, same gate** |
+| File writes | PreToolUse hook (`Edit`/`Write`/…) | OS sandbox: `writable_roots` = the agent folder |
+| MCP / connectors | PreToolUse hook (`mcp__*`) | server-side at the loopback `/api/*` routes |
+| The CLI's own prompts | `--dangerously-skip-permissions` | `approval_policy = "never"` |
+
+Notes:
+
+- Codex applies most edits by piping `apply_patch` **through the shell tool**, so those are already
+  covered by the gate. The sandbox is the backstop for anything that isn't — and it is *structural*: a
+  write outside the agent folder is impossible at the OS level, not merely denied by policy.
+- `network_access` stays **true**. Egress driven from the shell is already gated, and cutting it would
+  break `git push` / `npm install` for every agent.
+- `approval_policy = "never"` removes Codex's *own* prompts (nobody is at the pane to answer them). It
+  does **not** touch our gate: the hook still runs and still blocks for inbox approval.
+
+### One shared hook
+
+`terminal/gate-hook.sh` serves both runtimes. Codex 0.145 uses the same PreToolUse stdin fields
+(`tool_name` / `tool_input` / `agent_type`) and the same output wire (`permissionDecision` of
+`allow|deny|ask`, plus `additionalContext` — so the `instruct` verb carries over) as Claude Code.
+Only the tool→capability routing table differs, selected by `$AOS_RUNTIME`.
+
+This is deliberate: two copies would let a governance fix land for one runtime and silently miss the
+other.
+
+---
+
+## What the launcher generates
+
+`terminal/codex-launch.sh` redirects Codex at a **per-session `$CODEX_HOME`** (`<home>/connectors/
+session-<id>.codex/`, 0700, cleaned up with the rest of the session's files). That keeps our generated
+config out of the operator's own `~/.codex`, and it means `sessions/` holds exactly one rollout file —
+which is how we discover the id Codex minted.
+
+It writes, fresh on every launch:
+
+- **`config.toml`** — model / `model_reasoning_effort`, the sandbox + approval posture above,
+  `features.codex_hooks = true`, the session's MCP servers translated from JSON to Codex's
+  `[mcp_servers.<name>]` schema (with nested `.env` for stdio and `.http_headers` for streamable HTTP,
+  so Composio's `x-api-key` survives), and a `[projects."<agent dir>"] trust_level = "trusted"` seed.
+- **`hooks.json`** — `PreToolUse` with matcher `.*`, so every tool reaches the hook and *our* routing
+  table decides what is governed.
+- **`AGENTS.md`** in the agent folder — Codex has no `--append-system-prompt-file`, so the persona
+  (`CLAUDE.md`, the runtime-neutral persona file every agent already has) and the workspace Company
+  context are composed into the file Codex discovers. Regenerated each launch and marked as such.
+- **`auth.json`** — symlinked from the real `$CODEX_HOME` so a re-login/token refresh is picked up and
+  no credential is duplicated to disk.
+
+Two trust gates have to be pre-accepted or every session hangs or dies — the same class of bug as the
+Claude lane's `~/.claude.json` seed:
+
+- `[projects."<dir>"] trust_level = "trusted"` — agent folders are freshly created and are **not git
+  repos**, so without it `codex exec` fails with *"Not inside a trusted directory"* and the TUI parks on
+  a trust prompt. `--skip-git-repo-check` is passed to `exec` as well (it is an exec-only flag).
+- `--dangerously-bypass-hook-trust` — Codex refuses a `hooks.json` whose hash it hasn't seen. Ours is
+  regenerated every launch from the OS's own hook path, so the hash legitimately changes and there is no
+  human to confirm it. Without this the gate would simply never run, which is the unsafe outcome.
+
+---
+
+## Capabilities and what degrades
+
+`CODING_RUNTIMES` in `src/types.ts` is the single declaration of what each runtime supports. Probe it
+with `runtimeSupports(runtime, cap)`; use `isCodingRuntime(runtime)` for "is this a real CLI agent".
+
+| Capability | claude-code | codex | Why |
+| --- | --- | --- | --- |
+| `pinnedSessionId` | ✅ | ❌ | Codex mints its own rollout UUID; no `--session-id` |
+| `resume` / `fork` | ✅ | ✅ | `codex resume <id>` / `codex fork <id>` |
+| `attachableUnattended` | ✅ | ❌ | unattended lane is `codex exec`, which exits at turn end |
+| `residentChat` | ✅ | ❌ | needs a TUI that survives a turn |
+| `transcript` (cost, engaged time, chat timeline) | ✅ | ❌ | the parser only reads Claude's JSONL |
+| `nativeSkills` / `nativeSubagents` | ✅ | ❌ | `.claude/skills` + `.claude/agents` are Claude conventions |
+| `statusLine` / `permissionMode` | ✅ | ❌ | no equivalent |
+| `fileWriteGate` / `mcpGate` | ✅ | ❌ | contained by sandbox / server-side instead — see above |
+| `steerOnAllow` | ✅ | ✅ | both support `additionalContext` |
+
+**Session ids.** Because Codex won't take a pinned id, `codex-launch.sh` watches its per-session
+`sessions/` dir for `rollout-<ts>-<uuid>.jsonl`, extracts the UUID and POSTs it to
+`POST /api/runtime-session` (session-secret gated, first write wins). It is stored in the existing
+`term_sessions.claude_session_id` column, which now holds the transcript id for whichever runtime drove
+the run — left un-renamed to avoid a migration plus ~25 call sites for no behavioural gain.
+
+**Not supported:** `AOS_UID_ISOLATION`. The Phase A launcher materialises a fixed set of files into the
+member home and knows nothing about a per-session `$CODEX_HOME`, so the config and hooks would land
+outside the member's reach. A Codex launch under the flag is **refused** and the session is marked
+crashed with the reason — never spawned with the gate unwired.
+
+---
+
+## Testing it
+
+`npm run test:governance` covers the shared policy engine. For the Codex path specifically, the check
+that matters is that a Codex-shaped tool call reaches the gate and is classified correctly:
+
+```
+tool_name=shell, tool_input={"command":["bash","-lc","ls -la"]}                  → allow
+tool_name=shell, tool_input={"command":["bash","-lc","rm -rf / --no-preserve-root"]} → deny
+tool_name=read_file                                                             → silent exit 0
+tool_name=agentos__recall                                                       → silent exit 0
+```
+
+Drive `terminal/gate-hook.sh` with `AOS_RUNTIME=codex` and that stdin, against a server booted on an
+**isolated `AGENT_OS_HOME`**. Two traps when writing such a harness:
+
+- Invoke the hook **asynchronously**. If the server is in-process, a synchronous `execFileSync` blocks
+  Node's event loop and the hook's `curl` never gets a reply — which looks exactly like "gate unreachable".
+- `loadAgentOS()` with no env resolves to the **live** `./data` home. Always set `AGENT_OS_HOME`.
+
+### The bug this found
+
+Codex sends `command` as an **argv array** (`["bash","-lc","…"]`); Claude sends a **string**. The
+enricher's extraction was `typeof v === 'string' ? v : ''`, so every Codex shell call was classified
+against an *empty* command — no destructive pattern could match and the gate allowed `rm -rf /`.
+Fixed by `commandText()` in `src/governance/enricher.ts`, which normalises both shapes; the briefer uses
+it too, so approval cards don't render an empty command. Any future runtime that sends argv arrays is
+covered.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.271.0",
+  "version": "0.272.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.271.0",
+      "version": "0.272.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.271.0",
+  "version": "0.272.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -16,7 +16,7 @@ import { Strategist } from './strategist';
 import { AgentOS } from '../kernel';
 import { Db } from '../state/db';
 import { TerminalManager } from '../terminal';
-import { Task, TaskTimelineEntry } from '../types';
+import { isCodingRuntime, Task, TaskTimelineEntry } from '../types';
 import { chooseAgent, RouterCandidate } from './router';
 
 // ── minimal cron (5 fields: minute hour day-of-month month day-of-week) ──────────
@@ -625,7 +625,7 @@ export class Automations {
   }
 
   private routeChat(text: string): { agentId?: string; help?: string } {
-    const claudeAgents = [...this.os.agents.values()].filter((a) => a.runtime === 'claude-code');
+    const claudeAgents = [...this.os.agents.values()].filter((a) => isCodingRuntime(a.runtime));
     // Only agents opted-in to the open chat front door (`chatReachable !== false`) are addressable here.
     const chatAgents = claudeAgents.filter((a) => a.chatReachable !== false).map((a) => a.id);
     const m = this.normalizeChatCommand(text).trim().match(/^\/([A-Za-z0-9][\w-]*)\b\s*([\s\S]*)$/);

--- a/src/edge/improvements.ts
+++ b/src/edge/improvements.ts
@@ -10,6 +10,7 @@
  */
 import type { AgentOS } from '../kernel';
 import type { Insights } from './insights';
+import { isCodingRuntime } from '../types';
 import { BUILTIN_SEED_IDS } from './agent-catalog';
 import { CONSOLIDATOR_ID } from './consolidation';
 import { ANALYST_ID } from './diagnosis';
@@ -145,7 +146,7 @@ export function buildImprovements(os: AgentOS, insights: Insights, now = Date.no
   const lastRun = new Map(db.prepare("SELECT agent, MAX(created_at) AS m FROM term_sessions GROUP BY agent").all<{ agent: string; m: number }>().map((r) => [r.agent, r.m]));
   const idleAgents = [...os.agents.values()].filter((a) => {
     const last = lastRun.get(a.id);
-    return a.runtime === 'claude-code' && !BUILT_IN_AGENTS.has(a.id) && last != null && last < now - AGENT_IDLE_DAYS * DAY;
+    return isCodingRuntime(a.runtime) && !BUILT_IN_AGENTS.has(a.id) && last != null && last < now - AGENT_IDLE_DAYS * DAY;
   });
   tiles.push({
     domain: 'idle-agents', count: idleAgents.length,

--- a/src/edge/router.ts
+++ b/src/edge/router.ts
@@ -22,7 +22,7 @@
  * only bad outcome, and it's gated behind a clear score margin. The router only PICKS an id — the spawn
  * is still fully governed downstream (provenance, run-as, gate hook), so routing carries no privilege.
  */
-import { AgentManifest, EmbeddingsConfig, RouterConfig } from '../types';
+import { isCodingRuntime, AgentManifest, EmbeddingsConfig, RouterConfig } from '../types';
 import { AgentOS } from '../kernel';
 import { resolveLlm, chatComplete } from './llm';
 
@@ -168,7 +168,7 @@ function profileHash(s: string): string {
  */
 export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecision> {
   const cfg = os.settings.routerConfig();
-  const agents = [...os.agents.values()].filter((a) => a.runtime === 'claude-code');
+  const agents = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime));
   if (agents.length === 0) return { kind: 'none' };
 
   let scored = scoreAgents(text, agents);

--- a/src/edge/subagents.ts
+++ b/src/edge/subagents.ts
@@ -20,7 +20,7 @@
  */
 import * as fs from 'fs';
 import * as path from 'path';
-import { AgentManifest } from '../types';
+import { isCodingRuntime, AgentManifest } from '../types';
 
 /**
  * The toolset a materialised fleet sub-agent is allowed to use, written verbatim into the `tools:`
@@ -104,7 +104,7 @@ export function resolveSubagents(
   defaultMode: 'all' | 'none',
 ): AgentManifest[] {
   const eligible = (m: AgentManifest | undefined): m is AgentManifest =>
-    !!m && m.id !== parent.id && m.runtime === 'claude-code' && m.spawnableAsSubagent !== false;
+    !!m && m.id !== parent.id && isCodingRuntime(m.runtime) && m.spawnableAsSubagent !== false;
   const explicit = parent.usableSubagents ?? [];
   if (explicit.length) return explicit.map((id) => fleet.get(id)).filter(eligible);
   return defaultMode === 'all' ? [...fleet.values()].filter(eligible) : [];

--- a/src/governance/briefer.ts
+++ b/src/governance/briefer.ts
@@ -10,8 +10,11 @@
  * is already a one-line human summary of the command, so we prefer it for the headline.
  */
 import { ActionVerb, BriefTarget, Decision, DecisionBrief } from '../types';
+import { commandText } from './enricher';
 
 const str = (v: unknown): string => (typeof v === 'string' ? v : '');
+// Shell `command` arrives as a string (Claude `Bash`) OR an argv array (Codex `shell`) — the shared
+// normaliser handles both, so an approval card never renders an empty command for a Codex run.
 const num = (v: unknown): number | undefined => (typeof v === 'number' && Number.isFinite(v) ? v : undefined);
 const truncate = (s: string, n: number): string => (s.length > n ? s.slice(0, n - 1).trimEnd() + '…' : s);
 
@@ -57,7 +60,7 @@ function verbFor(capability: string, args: Record<string, unknown>): ActionVerb 
     case 'secret.put': return 'grant';
     case 'connector.connect': return 'grant';
     case 'shell.exec': {
-      const cmd = `${str(args.command)} ${str(inputOf(args).command)}`;
+      const cmd = `${commandText(args.command)} ${commandText(inputOf(args).command)}`;
       if (/\b(deploy|kubectl|systemctl|terraform|helm)\b/i.test(cmd)) return 'deploy';
       return 'execute';
     }
@@ -97,7 +100,7 @@ function targetFor(capability: string, args: Record<string, unknown>, input: Rec
   }
   if (capability === 'secret.put') return { kind: 'resource', label: str(input.key) || 'a secret' };
   if (capability === 'shell.exec') {
-    const head = commandHead(str(args.command) || str(input.command));
+    const head = commandHead(commandText(args.command) || commandText(input.command));
     return { kind: 'command', label: head || 'a shell command' };
   }
   return { kind: 'unknown', label: capability };
@@ -128,7 +131,7 @@ function headlineFor(capability: string, args: Record<string, unknown>, input: R
     return truncate(tool ? `${VERB_WORD[verb]} ${prettyTool(tool)}` : `${VERB_WORD[verb]} a connector`, 120);
   }
   if (isShellish(capability)) {
-    const cmd = str(args.command) || str(input.command);
+    const cmd = commandText(args.command) || commandText(input.command);
     return truncate(cmd ? `Run: ${cmd}` : `${VERB_WORD[verb]} ${target.label}`, 120);
   }
   return truncate(`${VERB_WORD[verb]} ${target.label}`, 120);
@@ -155,7 +158,7 @@ function signatureFor(capability: string, verb: ActionVerb, target: BriefTarget,
   let key = '';
   if (target.host) key = target.host;
   else if (capability === 'file.write') key = pathFamily(str(input.file_path) || str(input.path) || '');
-  else if (capability === 'shell.exec') key = commandHead(str(args.command) || str(input.command));
+  else if (capability === 'shell.exec') key = commandHead(commandText(args.command) || commandText(input.command));
   else if (capability.startsWith('connector')) key = str(args.tool);
   return `${capability}|${verb}|${target.kind}|${key}`.toLowerCase();
 }

--- a/src/governance/enricher.ts
+++ b/src/governance/enricher.ts
@@ -208,6 +208,24 @@ export function redactSecrets(text: string): string {
 }
 
 /**
+ * Normalise a tool's `command` field to matchable text, accepting BOTH shapes a coding runtime sends:
+ *   - Claude Code's `Bash` tool → a string:  `"rm -rf /tmp/x"`
+ *   - Codex's `shell` tool      → an argv array: `["bash", "-lc", "rm -rf /tmp/x"]`
+ *
+ * This is load-bearing, not cosmetic. The previous `typeof === 'string'` test silently yielded `''`
+ * for an array, so EVERY Codex shell call was classified against an empty command — no destructive
+ * pattern could ever match and the gate blanket-allowed `rm -rf /`. Caught by the codex gate smoke
+ * test. Joining with spaces is right for intent-matching: it loses shell quoting, but the dangerous
+ * text is what we scan for, and `sanitizeForIntent` strips DATA payloads downstream either way.
+ * Non-string array members are dropped rather than stringified into `[object Object]` noise.
+ */
+export function commandText(v: unknown): string {
+  if (typeof v === 'string') return v;
+  if (Array.isArray(v)) return v.filter((p): p is string => typeof p === 'string').join(' ');
+  return '';
+}
+
+/**
  * Compute governance facts and return a NEW args object (original + facts). Pure; no I/O.
  * `args` is what the gate received: `{ tool?, input?, command?, ...callerFacts }`.
  * `orgDomains` are the workspace's internal email domains (lowercased, no `@`) — passed in by the
@@ -224,7 +242,7 @@ export function enrichArgs(
   const tool = typeof args.tool === 'string' ? args.tool : '';
   const input = (args.input && typeof args.input === 'object' ? args.input : args) as Record<string, unknown>;
   // Text to pattern-match: an explicit shell command (Bash) and/or the connector input's string values.
-  const command = typeof args.command === 'string' ? args.command : typeof input.command === 'string' ? input.command : '';
+  const command = commandText(args.command) || commandText(input.command);
   const { text: inputText, entries } = scan(input);
   const haystack = `${command}\n${inputText}`;
 

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -12,6 +12,8 @@ import {
   AgentManifest,
   AuditSink,
   Capability,
+  CODING_RUNTIMES,
+  isCodingRuntime,
   MemoryConfig,
   MemoryMaintenanceResult,
   MemoryProvider,
@@ -232,6 +234,20 @@ export class AgentOS {
   }
   registerAgent(manifest: AgentManifest): this {
     this.agents.set(manifest.id, manifest);
+    // An unrecognised `runtime` (a typo like "codeex", or a manifest written for a newer build) is not a
+    // type error — manifests are parsed as untyped JSON — and it fails SILENTLY in the worst way: every
+    // `isCodingRuntime` check returns false, so the agent quietly spawns the scripted mock runner instead
+    // of a real CLI, and looks like it "did nothing". Say so once, loudly, at registration.
+    if (manifest.runtime !== undefined && manifest.runtime !== 'mock' && !isCodingRuntime(manifest.runtime)) {
+      const key = `runtime:${manifest.id}:${manifest.runtime}`;
+      if (!this.warnedPolicyContexts.has(key)) {
+        this.warnedPolicyContexts.add(key);
+        console.warn(
+          `agent "${manifest.id}" declares unknown runtime "${manifest.runtime}" — it will run as the mock ` +
+          `demo agent, not a real CLI. Known runtimes: mock, ${Object.keys(CODING_RUNTIMES).join(', ')}.`,
+        );
+      }
+    }
     // Surface a `policyContext` that names a ruleset the engine isn't enforcing (see policyContextMismatch)
     // — a silent mismatch means the agent's declared guardrails aren't the ones actually applied.
     const key = `${manifest.id} ${manifest.policyContext ?? ''}`;

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,7 +55,7 @@ import { briefFor, describeBrief } from './governance/briefer';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
 import { parseBundle } from './governance/bundle-import';
-import { AgentManifest, AppManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, isValidAppSlug, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeAppDomains, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, sanitizeUsableSubagents, TaskStatus, GoalStatus, riskClassForLevel } from './types';
+import { isCodingRuntime, AgentManifest, AppManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, isValidAppSlug, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeAppDomains, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning, sanitizeShellSecrets, sanitizeUsableSubagents, TaskStatus, GoalStatus, riskClassForLevel } from './types';
 import { AgentConfigSnapshot } from './state/agent-revisions';
 import { computeAgentStats, computeAgentStat } from './state/agent-stats';
 
@@ -219,7 +219,7 @@ function applyAgentSnapshot(os: AgentOS, ag: AgentManifest, snap: AgentConfigSna
  *  may answer from. Kept small (agents + live counts + KB sections) and derived live, so answers reflect
  *  the real fleet, not a hallucination. Member-scoped where it matters (sessions the viewer can see). */
 function cockpitWorkspaceContext(os: AgentOS, tm: TerminalManager, autos: Automations, me: Member): string {
-  const agents = [...os.agents.values()].filter((a) => a.runtime === 'claude-code');
+  const agents = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime));
   const agentLines = agents.map((a) => `  - ${a.id}: ${(a.description || '').replace(/\s+/g, ' ').slice(0, 140)}`).join('\n');
   const sessions = tm.listSessions(me);
   const live = sessions.filter((s) => s.alive).length;
@@ -676,7 +676,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!self) return sendJson(res, 404, { error: 'unknown session' });
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
     const agents = [...os.agents.values()]
-      .filter((a) => a.runtime === 'claude-code' && a.id !== self)
+      .filter((a) => isCodingRuntime(a.runtime) && a.id !== self)
       .map((a) => ({ id: a.id, description: a.description, category: a.category }));
     return sendJson(res, 200, { agents });
   }
@@ -1450,6 +1450,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     tm.notify(session, String(b.agent || ''), String(b.kind || ''), String(b.message || ''));
     return sendJson(res, 200, { ok: true });
   }
+  // Runtime session-id capture. Claude Code lets the OS PIN the transcript id up front
+  // (`--session-id`), so it never calls this. Codex mints its OWN rollout UUID, so codex-launch.sh
+  // discovers it (the per-session CODEX_HOME contains exactly one rollout file) and reports it back
+  // here — that id is what `codex exec resume <id>` / `codex fork <id>` need later. Session-secret
+  // gated like the rest of the loopback signals; first write wins, so a resumed run can't re-point an
+  // existing conversation at a different transcript.
+  if (method === 'POST' && p === '/api/runtime-session') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const ok = tm.recordRuntimeSessionId(session, String(b.runtimeSessionId || ''));
+    return sendJson(res, 200, { ok });
+  }
   // attach-wrapper signal that a stopped session was resurrected (→ mark running again).
   if (method === 'POST' && p === '/api/resumed') {
     const b = await readBody(req);
@@ -1552,7 +1566,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (assignee && assignee.startsWith('agent:')) {
       const targetId = assignee.slice('agent:'.length);
       if (!os.agents.get(targetId)) {
-        const valid = [...os.agents.values()].filter((a) => a.runtime === 'claude-code').map((a) => a.id).join(', ');
+        const valid = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime)).map((a) => a.id).join(', ');
         return sendJson(res, 200, { ok: false, error: `no agent "${targetId}" — assign to one of: ${valid} (call list_agents to see the roster)` });
       }
     }
@@ -1837,7 +1851,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return sendJson(res, 200, { ok: false, error: `you can only edit your own listing ("${id}"), not "${String(b.id).trim().toLowerCase()}"` });
     const ag = os.agents.get(id);
     if (!ag?.dir) return sendJson(res, 200, { ok: false, error: `unknown agent "${id}"` });
-    if (ag.runtime !== 'claude-code') return sendJson(res, 200, { ok: false, error: 'only claude-code agents can be edited' });
+    if (!isCodingRuntime(ag.runtime)) return sendJson(res, 200, { ok: false, error: 'only CLI-backed agents can be edited' });
     // Only agents that live under the data home are editable (the read-only bundled examples are not).
     const userRoot = path.resolve(os.paths.userAgents) + path.sep;
     if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return sendJson(res, 200, { ok: false, error: 'built-in agents cannot be edited' });
@@ -2402,7 +2416,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!os.team.canRun(me, card.target)) return sendJson(res, 403, { error: `you cannot run "${card.target}", so you cannot approve edits to it` });
     const ag = os.agents.get(card.target);
     if (!ag?.dir) { tm.setAgentUpdateProposalStatus(card.id, 'rejected'); return sendJson(res, 200, { ok: false, error: `target agent "${card.target}" no longer exists` }); }
-    if (ag.runtime !== 'claude-code') return sendJson(res, 200, { ok: false, error: 'only claude-code agents can be edited' });
+    if (!isCodingRuntime(ag.runtime)) return sendJson(res, 200, { ok: false, error: 'only CLI-backed agents can be edited' });
     const userRoot = path.resolve(os.paths.userAgents) + path.sep;
     if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return sendJson(res, 200, { ok: false, error: 'built-in agents cannot be edited' });
     const f = card.fields; // the proposed field delta (only present keys are applied — same shape as the self-edit body)
@@ -2543,7 +2557,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return { id, description: a?.description || '', category: a?.category, icon: a?.icon, score };
     };
     const fleet = () =>
-      [...os.agents.values()].filter((a) => a.runtime === 'claude-code' && runnable(a.id)).map((a) => card(a.id));
+      [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime) && runnable(a.id)).map((a) => card(a.id));
     // The `work` responder: the agent-routing decision, filtered to what this member can run.
     const respondWork = async (askFallback?: boolean) => {
       const decision = await chooseAgent(os, text);
@@ -3845,7 +3859,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const srcId = agentDup[1];
     const src = os.agents.get(srcId);
     if (!src?.dir) return sendJson(res, 404, { error: `unknown agent "${srcId}"` });
-    if (src.runtime !== 'claude-code') return sendJson(res, 400, { error: 'only claude-code agents can be duplicated' });
+    if (!isCodingRuntime(src.runtime)) return sendJson(res, 400, { error: 'only CLI-backed agents can be duplicated' });
     const newId = String(b.newId || `${srcId}-copy`).trim().toLowerCase();
     if (!/^[a-z][a-z0-9-]{1,39}$/.test(newId)) return sendJson(res, 400, { error: 'id must be lowercase letters, digits and hyphens (2–40 chars, starting with a letter)' });
     if (os.agents.get(newId)) return sendJson(res, 409, { error: `an agent named "${newId}" already exists` });
@@ -3926,7 +3940,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const ag = os.agents.get(agentConfig[1]);
     if (!ag?.dir) return sendJson(res, 404, { error: 'agent not found or has no folder' });
-    if (ag.runtime !== 'claude-code') return sendJson(res, 400, { error: 'runtime tuning applies to claude-code agents only' });
+    if (!isCodingRuntime(ag.runtime)) return sendJson(res, 400, { error: 'runtime tuning applies to CLI-backed agents only' });
     if (method === 'GET') {
       return sendJson(res, 200, { agent: ag.id, description: ag.description, model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, usableSubagents: ag.usableSubagents ?? [], spawnableAsSubagent: ag.spawnableAsSubagent !== false, chatReachable: ag.chatReachable !== false, netMode: ag.netMode ?? 'open', category: ag.category, icon: ag.icon });
     }
@@ -3979,7 +3993,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const ag = os.agents.get(agentRevert[1]);
     if (!ag?.dir) return sendJson(res, 404, { error: 'agent not found or has no folder' });
-    if (ag.runtime !== 'claude-code') return sendJson(res, 400, { error: 'only claude-code agents can be reverted' });
+    if (!isCodingRuntime(ag.runtime)) return sendJson(res, 400, { error: 'only CLI-backed agents can be reverted' });
     const b = await readBody(req);
     const rev = Number(b.rev);
     const target = os.agentRevisions.get(ag.id, rev);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,7 +15,7 @@ import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { containedPath, mimeOf } from './state/artifacts';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
-import { ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskTimelineEntry, TaskDiscussionSummary, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
+import { isCodingRuntime, runtimeSupports, CODING_RUNTIMES, CodingRuntimeId, ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskTimelineEntry, TaskDiscussionSummary, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval, redactSecrets } from './governance/enricher';
 import { briefFor } from './governance/briefer';
 import { ReliabilityMonitor } from './edge/reliability';
@@ -523,11 +523,16 @@ export interface SessionEventNotice {
 export class TerminalManager {
   /** Scripted demo runner — for `runtime: mock` agents. */
   private readonly runner = path.resolve(__dirname, '../terminal/agent-runner.sh');
-  /** Real-Claude launcher — for `runtime: claude-code` agents. Opens claude in the agent's folder. */
+  /** Real-Claude launcher — for `runtime: claude-code` agents. Opens claude in the agent's folder.
+   *  Kept as a named field because the uid-isolation launcher path still references it directly. */
   private readonly launcher = path.resolve(__dirname, '../terminal/claude-launch.sh');
-  /** PreToolUse gate hook the launched claude is wired to. */
+  /** The launcher for a given coding runtime (`terminal/<spec.launchScript>`). */
+  private launchScriptFor(runtime: CodingRuntimeId): string {
+    return path.resolve(__dirname, '..', 'terminal', CODING_RUNTIMES[runtime].launchScript);
+  }
+  /** PreToolUse gate hook every runtime is wired to (shared; $AOS_RUNTIME picks its routing table). */
   private readonly hook = path.resolve(__dirname, '../terminal/gate-hook.sh');
-  /** OS-owned memory MCP server (compiled JS), injected into every claude-code session. */
+  /** OS-owned memory MCP server (compiled JS), injected into every CLI-backed session. */
   private readonly memoryMcp = path.resolve(__dirname, 'memory/memory-mcp.js');
   private readonly db: Db;
   /** Where sessions actually run: the shared local socket (default) or per-member uids via the
@@ -704,7 +709,7 @@ export class TerminalManager {
       alive: alive ? alive.has(r.tmux) : undefined,
       blocked: r.status === 'running' && blocked.has(r.id),
       resumable: resumable.has(r.id),
-      forkable: !!r.claude_session_id && this.os.agents.get(r.agent)?.runtime === 'claude-code',
+      forkable: !!r.claude_session_id && runtimeSupports(this.os.agents.get(r.agent)?.runtime, 'fork'),
       spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as),
       sourceKind: this.sourceKind(r.spawned_by),
       runAsLabel: this.runAsLabel(r.run_as),
@@ -1470,8 +1475,8 @@ export class TerminalManager {
         .run(id, clickup.taskId, clickup.commentId || '', Date.now());
     }
 
-    // Pick the runtime from the agent's manifest: claude-code → real claude in its folder;
-    // anything else (incl. unknown/demo names) → the scripted mock runner.
+    // Pick the runtime from the agent's manifest: a coding runtime (claude-code / codex) → that real
+    // CLI in the agent's folder; anything else (incl. unknown/demo names) → the scripted mock runner.
     const manifest = this.os.agents.get(agent);
     const runtime = manifest?.runtime ?? 'mock';
     // Audit records BOTH provenance and the run-as principal — when they differ (a trigger acting as
@@ -1487,8 +1492,8 @@ export class TerminalManager {
       this.fireSessionEvent(id, agent, 'started', `Started — ${agent}`, task || 'A delegated run began.');
     }
 
-    if (runtime === 'claude-code' && manifest?.dir) {
-      this.launchClaudeCode({ id, agent, task, secret, actingMember, spawnedBy, hasSlack: !!slack?.channel, hasDiscord: !!discord?.channel, hasClickup: !!clickup?.taskId, headless, resident, resume: !!resumeClaudeId, claudeSessionId, tuning });
+    if (isCodingRuntime(runtime) && manifest?.dir) {
+      this.launchAgentRuntime({ id, agent, task, secret, actingMember, spawnedBy, hasSlack: !!slack?.channel, hasDiscord: !!discord?.channel, hasClickup: !!clickup?.taskId, headless, resident, resume: !!resumeClaudeId, claudeSessionId, tuning });
     } else {
       this.backend.spawn(this.spaceFor(actingMember ?? spawnedBy), { sessionId: id, agent, tmuxName: tmux, env: this.sessionEnv(id, agent, task, secret), argv: ['bash', this.runner] });
     }
@@ -1510,7 +1515,7 @@ export class TerminalManager {
       .get<{ agent: string; claude_session_id: string | null; run_as: string | null }>(sourceId);
     if (!src) return { ok: false, error: 'unknown session' };
     const manifest = this.os.agents.get(src.agent);
-    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be forked' };
+    if (!runtimeSupports(manifest?.runtime, 'fork') || !manifest?.dir) return { ok: false, error: `forking is not supported by this agent's runtime` };
     if (!src.claude_session_id) return { ok: false, error: 'this session has no conversation to fork yet' };
 
     const id = newId('session');
@@ -1530,7 +1535,7 @@ export class TerminalManager {
       .prepare('INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, secret, claude_session_id, resident, last_activity, headless, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)')
       .run(id, src.agent, title, seed, tmux, 'running', by ?? null, actingMember ?? null, secret, claudeSessionId, 0, null, 0, now, now);
     this.audit(id, src.agent, 'session.forked', { from: sourceId, fromClaudeId: src.claude_session_id, claudeSessionId, runAs: actingMember ?? null, by });
-    this.launchClaudeCode({
+    this.launchAgentRuntime({
       id, agent: src.agent, task: seed, secret, actingMember, spawnedBy: by,
       hasSlack: false, hasDiscord: false, hasClickup: false, headless: false, resident: false, resume: false,
       claudeSessionId, forkFrom: src.claude_session_id,
@@ -1545,7 +1550,7 @@ export class TerminalManager {
    * Memory + connectors are delivered purely as MCP tools via the per-session `.mcp.json`; the
    * orchestrator injects nothing into the prompt.
    */
-  private launchClaudeCode(o: {
+  private launchAgentRuntime(o: {
     id: string; agent: string; task: string; secret: string;
     actingMember?: string; spawnedBy?: string; hasSlack: boolean; hasDiscord: boolean; hasClickup: boolean;
     headless: boolean; resident: boolean; resume: boolean; claudeSessionId: string;
@@ -1567,8 +1572,14 @@ export class TerminalManager {
     const askAnswer = (o.spawnedBy ?? '').startsWith('ask:');
     const mcpJson = this.buildMcpConfigJson(o.id, o.agent, o.actingMember, o.secret, o.hasSlack, o.hasDiscord, askAnswer, o.hasClickup);
     const companyMd = this.buildCompanyMd(o.agent, o.actingMember);
-    this.materializeSkills(o.id, o.agent, manifest.dir);
-    this.materializeSubagents(o.id, o.agent, manifest);
+    const runtime: CodingRuntimeId = isCodingRuntime(manifest.runtime) ? manifest.runtime : 'claude-code';
+    const caps = CODING_RUNTIMES[runtime].capabilities;
+    // Skills + sub-agents are materialised as native filesystem conventions (`.claude/skills`,
+    // `.claude/agents`), so they only apply to a runtime that discovers them. Codex has its own
+    // (differently-shaped) skills mechanism — not wired yet, so we skip rather than write files it
+    // would ignore. The agent still gets its persona + Company context via the launcher's AGENTS.md.
+    if (caps.nativeSkills) this.materializeSkills(o.id, o.agent, manifest.dir);
+    if (caps.nativeSubagents) this.materializeSubagents(o.id, o.agent, manifest);
     // Unattended (automation/cron/task) runs are now an attachable interactive TUI, not `claude -p` — so a
     // human can take one over mid-run by simply attaching (no kill, no resume). The launcher's UNATTENDED
     // lane runs interactive + `--dangerously-skip-permissions` (the gate hook still governs every effect),
@@ -1580,19 +1591,37 @@ export class TerminalManager {
     if (o.resident) env.RESIDENT = '1';
     env.AGENT_DIR = manifest.dir;
     env.HOOK = this.hook;
+    // Tells the shared gate hook which tool→capability routing table to use.
+    env.AOS_RUNTIME = runtime;
     // No OS sandbox env: the gate hook (PreToolUse) is the sole authority for governed side effects, so
     // we don't wrap the shell in Seatbelt/bubblewrap. Real OS containment is the Linux uid-isolation path.
     // Per-agent model / effort / permission-mode fall back to the workspace default; the launcher maps
     // them onto `--model`/`--effort`/`--permission-mode` (permission-mode on the interactive lane only).
     const tuning = resolveRuntimeTuning(manifest, this.os.settings.runtimeDefaults(), o.tuning);
-    if (tuning.model) env.CLAUDE_MODEL = tuning.model;
-    if (tuning.effort) env.CLAUDE_EFFORT = tuning.effort;
-    if (tuning.permissionMode) env.CLAUDE_PERMISSION_MODE = tuning.permissionMode;
-    this.audit(o.id, o.agent, 'session.tuning', { model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, override: o.tuning ?? null });
-    // A stable claude session id we choose (vs letting claude mint its own), so a stopped session can be
-    // resumed in-place with `claude --resume <id>`. `resume` continues that transcript (a thread
-    // follow-up or a console reconnect) instead of starting fresh.
-    env.CLAUDE_SESSION_ID = o.claudeSessionId;
+    if (runtime === 'codex') {
+      // Codex reads model/effort from the config.toml the launcher generates; it has no
+      // --permission-mode (Agent OS is the sole authority there via approval_policy = "never"), so
+      // permissionMode is deliberately not forwarded.
+      if (tuning.model) env.CODEX_MODEL = tuning.model;
+      if (tuning.effort) env.CODEX_EFFORT = tuning.effort;
+    } else {
+      if (tuning.model) env.CLAUDE_MODEL = tuning.model;
+      if (tuning.effort) env.CLAUDE_EFFORT = tuning.effort;
+      if (tuning.permissionMode) env.CLAUDE_PERMISSION_MODE = tuning.permissionMode;
+    }
+    this.audit(o.id, o.agent, 'session.tuning', { runtime, model: tuning.model, effort: tuning.effort, permissionMode: caps.permissionMode ? tuning.permissionMode : undefined, override: o.tuning ?? null });
+    if (caps.pinnedSessionId) {
+      // A stable claude session id we choose (vs letting claude mint its own), so a stopped session can be
+      // resumed in-place with `claude --resume <id>`. `resume` continues that transcript (a thread
+      // follow-up or a console reconnect) instead of starting fresh.
+      env.CLAUDE_SESSION_ID = o.claudeSessionId;
+    } else {
+      // Codex mints its OWN rollout id, so there is nothing to pin: the launcher discovers it from the
+      // per-session CODEX_HOME and POSTs it to /api/runtime-session. On a resume we hand back whatever
+      // it reported (persisted in the same column) so it can continue that transcript.
+      if (o.resume && o.claudeSessionId) env.RUNTIME_SESSION_ID = o.claudeSessionId;
+      env.AOS_CODEX_HOME = this.ensureCodexHome(o.id);
+    }
     if (o.resume) env.RESUME = '1';
     // Fork: on FIRST launch, branch off the parent conversation. RESUME is never set alongside forkFrom
     // (a fork's first run resumes nothing), and the launcher checks RESUME before FORK_FROM, so a later
@@ -1617,12 +1646,25 @@ export class TerminalManager {
     // Phase 2c: granted Host connections' SSH keys → a session ssh_config + ssh/scp PATH shim, so the
     // agent's plain `ssh` authenticates to a host without ever handling the key. (Local-lane only.)
     this.injectHostCredentials(env, o.agent, o.actingMember, o.id);
+    const launchScript = this.launchScriptFor(runtime);
     if (this.uidIsolation) {
       // Flag on: the launcher writes the files INTO the member's home and sets MCP_CONFIG/COMPANY_FILE/
       // TASK_FILE itself. The task rides as a FILE (not the inline TASK_B64 env) for the same reason as the
       // local lane below — see the delete note there; the launcher points TASK_FILE at the member-home copy.
+      //
+      // Codex is LOCAL-LANE ONLY for now: the Phase A launcher materialises a fixed set of files into the
+      // member home and knows nothing about a per-session CODEX_HOME, so the config/hooks the codex
+      // launcher needs would land outside the member's reach. Fail loudly rather than spawn a session
+      // whose gate hook was never wired — an ungoverned agent is the one outcome we never allow.
+      if (runtime !== 'claude-code') {
+        const why = `${CODING_RUNTIMES[runtime].label} sessions are not supported under AOS_UID_ISOLATION yet`;
+        this.audit(o.id, o.agent, 'session.launch.refused', { runtime, reason: why });
+        this.db.prepare("UPDATE term_sessions SET status = 'crashed', updated_at = ? WHERE id = ?").run(Date.now(), o.id);
+        this.addMessage({ type: 'completed', sessionId: o.id, agent: o.agent, title: `Could not start — ${o.agent}`, body: why, status: 'open', outcome: 'crashed', audienceKind: 'sessionOwner', audienceId: o.id });
+        return;
+      }
       delete env.TASK_B64;
-      this.backend.spawn(this.spaceFor(o.actingMember ?? o.spawnedBy), { sessionId: o.id, agent: o.agent, tmuxName: tmux, env, argv: ['bash', this.launcher], files: { mcp: mcpJson || undefined, company: companyMd || undefined, task: o.task || undefined }, agentSrc: manifest.dir });
+      this.backend.spawn(this.spaceFor(o.actingMember ?? o.spawnedBy), { sessionId: o.id, agent: o.agent, tmuxName: tmux, env, argv: ['bash', launchScript], files: { mcp: mcpJson || undefined, company: companyMd || undefined, task: o.task || undefined }, agentSrc: manifest.dir });
     } else {
       // Flag off: materialise into the app's connectors dir and persist the launch context so the ttyd
       // attach wrapper can resurrect a dead session. Headless automation runs write no resurrect env.
@@ -1640,8 +1682,24 @@ export class TerminalManager {
       const taskFile = this.writeSessionFile(o.id, 'task', o.task);
       if (taskFile) { env.TASK_FILE = taskFile; delete env.TASK_B64; }
       if (!o.headless) this.writeEnvFile(o.id, env);
-      this.backend.spawn(this.spaceFor(o.actingMember ?? o.spawnedBy), { sessionId: o.id, agent: o.agent, tmuxName: tmux, env, argv: ['bash', this.launcher] });
+      this.backend.spawn(this.spaceFor(o.actingMember ?? o.spawnedBy), { sessionId: o.id, agent: o.agent, tmuxName: tmux, env, argv: ['bash', launchScript] });
     }
+  }
+
+  /**
+   * Create (0700) the per-session `$CODEX_HOME` a Codex run redirects all of its config + state into,
+   * and return its path. Two reasons it is per-SESSION rather than per-agent:
+   *  - the generated config.toml/hooks.json can't disturb the operator's own `~/.codex`; and
+   *  - `sessions/` then holds EXACTLY ONE rollout file, which is how the launcher discovers the id
+   *    Codex minted (there is no `--session-id` to pin) before POSTing it to /api/runtime-session.
+   * It lives beside the other `session-<id>.*` artefacts, so `removeSessionFiles` — which is prefix
+   * matched and recursive — already cleans it up when the session is deleted.
+   */
+  private ensureCodexHome(sessionId: string): string {
+    if (!this.os.paths) return '';
+    const dir = path.join(this.os.paths.connectors, `session-${sessionId}.codex`);
+    this.ensureSecureDir(dir);
+    return dir;
   }
 
   /**
@@ -1716,7 +1774,7 @@ export class TerminalManager {
     this.db.prepare("UPDATE term_sessions SET status = 'running', resident = 1, task = ?, run_as = ?, last_activity = ?, updated_at = ? WHERE id = ?")
       .run(body, actingMember ?? row.run_as ?? null, Date.now(), Date.now(), sessionId);
     this.audit(sessionId, row.agent, 'chat.revived', { runAs: actingMember ?? null });
-    this.launchClaudeCode({
+    this.launchAgentRuntime({
       id: sessionId, agent: row.agent, task: body, secret: row.secret ?? randomBytes(24).toString('hex'),
       actingMember, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord, hasClickup,
       headless: false, resident: true, resume: true, claudeSessionId: row.claude_session_id,
@@ -1751,7 +1809,7 @@ export class TerminalManager {
     this.db.prepare("UPDATE term_sessions SET status = 'running', headless = 1, resident = 0, task = ?, run_as = ?, last_activity = ?, updated_at = ? WHERE id = ?")
       .run(body, actingMember ?? row.run_as ?? null, Date.now(), Date.now(), sessionId);
     this.audit(sessionId, row.agent, 'chat.turn', { runAs: actingMember ?? null });
-    this.launchClaudeCode({
+    this.launchAgentRuntime({
       id: sessionId, agent: row.agent, task: body, secret: row.secret ?? randomBytes(24).toString('hex'),
       actingMember, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord, hasClickup,
       headless: true, resident: false, resume: true, claudeSessionId: row.claude_session_id,
@@ -1773,9 +1831,13 @@ export class TerminalManager {
     const row = this.db.prepare('SELECT agent, claimed_by FROM term_sessions WHERE id = ?')
       .get<{ agent: string; claimed_by: string | null }>(sessionId);
     if (!row) return { ok: false, error: 'unknown session' };
-    // Only the real claude-code runtime has an attachable governed TUI; a mock/other runtime has nothing to take over.
+    // Take-over needs a runtime whose UNATTENDED lane is a live, attachable TUI. Claude Code qualifies;
+    // Codex's unattended lane is `codex exec`, a one-shot process that exits at turn end, so there is no
+    // pane to claim (and mock has no pane at all).
     const manifest = this.os.agents.get(row.agent);
-    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be taken over' };
+    if (!runtimeSupports(manifest?.runtime, 'attachableUnattended') || !manifest?.dir) {
+      return { ok: false, error: `this agent's runtime has no attachable session to take over` };
+    }
     if (row.claimed_by) return { ok: true }; // already taken over — the pane is already sticky/attachable
     // A prior stop must not veto the deliberate take-over; clear any sentinel so a re-open resurrects.
     this.allowResume(sessionId);
@@ -1812,7 +1874,9 @@ export class TerminalManager {
       .get<{ agent: string; secret: string | null; claude_session_id: string | null; run_as: string | null; spawned_by: string | null }>(sessionId);
     if (!row) return { ok: false, error: 'unknown session' };
     const manifest = this.os.agents.get(row.agent);
-    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be taken over' };
+    if (!runtimeSupports(manifest?.runtime, 'attachableUnattended') || !manifest?.dir) {
+      return { ok: false, error: `this agent's runtime has no attachable session to take over` };
+    }
     // A turn is still generating → attach to the live pane, no relaunch (identical to a live take-over).
     if (this.isAlive(sessionId)) return this.claimSession(sessionId, by);
     // Dead → resurrect the transcript. Needs the pinned claude session id to `--resume` from.
@@ -1827,7 +1891,7 @@ export class TerminalManager {
     const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
     const hasClickup = !!this.db.prepare('SELECT 1 FROM clickup_threads WHERE session_id = ?').get(sessionId);
     this.audit(sessionId, by, 'session.claimed', { agent: row.agent, via: 'takeover-resume' });
-    this.launchClaudeCode({
+    this.launchAgentRuntime({
       id: sessionId, agent: row.agent, task: '', secret: row.secret ?? randomBytes(24).toString('hex'),
       actingMember: row.run_as ?? undefined, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord, hasClickup,
       headless: false, resident: false, resume: true, claudeSessionId: row.claude_session_id,
@@ -1851,7 +1915,10 @@ export class TerminalManager {
       .get<{ agent: string; secret: string | null; claude_session_id: string | null; run_as: string | null; spawned_by: string | null }>(sessionId);
     if (!row) return { ok: false, error: 'unknown session' };
     const manifest = this.os.agents.get(row.agent);
-    if (manifest?.runtime !== 'claude-code' || !manifest.dir) return { ok: false, error: 'only claude-code sessions can be taken over' };
+    // Resurrecting a chat as a warm resident TUI needs the resident-chat capability, not just resume.
+    if (!runtimeSupports(manifest?.runtime, 'residentChat') || !manifest?.dir) {
+      return { ok: false, error: `this agent's runtime does not support resident chat sessions` };
+    }
     if (!row.claude_session_id) return { ok: false, error: 'this chat has no conversation to open yet' };
     // A turn is still generating → attach to the live pane, no relaunch.
     if (this.isAlive(sessionId)) return this.claimSession(sessionId, by);
@@ -1863,7 +1930,7 @@ export class TerminalManager {
     const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
     const hasClickup = !!this.db.prepare('SELECT 1 FROM clickup_threads WHERE session_id = ?').get(sessionId);
     this.audit(sessionId, by, 'session.claimed', { agent: row.agent, via: 'chat-takeover' });
-    this.launchClaudeCode({
+    this.launchAgentRuntime({
       id: sessionId, agent: row.agent, task: '', secret: row.secret ?? randomBytes(24).toString('hex'),
       actingMember: row.run_as ?? undefined, spawnedBy: row.spawned_by ?? undefined, hasSlack, hasDiscord, hasClickup,
       headless: false, resident: true, resume: true, claudeSessionId: row.claude_session_id,
@@ -2147,10 +2214,34 @@ export class TerminalManager {
     return this.db.prepare('SELECT run_as FROM term_sessions WHERE id = ?').get<{ run_as: string | null }>(id)?.run_as ?? undefined;
   }
 
-  /** The pinned claude transcript id for a session — so a self-scheduled follow-up can `--resume` this
-   *  same conversation (context continuity) instead of starting fresh. */
+  /** The runtime transcript id for a session — so a self-scheduled follow-up can resume this same
+   *  conversation (context continuity) instead of starting fresh.
+   *
+   *  NOTE ON THE COLUMN NAME: `claude_session_id` predates multi-runtime support and now holds the
+   *  transcript id for WHICHEVER runtime drove the run — Claude Code's pinned `--session-id` or the
+   *  Codex rollout UUID captured via `/api/runtime-session`. Both are consumed the same way (resume /
+   *  fork by id), so the column is generic in meaning if not in name; it is left un-renamed on purpose
+   *  to avoid a migration + ~25-callsite churn for zero behavioural gain. */
   sessionClaudeId(id: string): string | undefined {
     return this.db.prepare('SELECT claude_session_id FROM term_sessions WHERE id = ?').get<{ claude_session_id: string | null }>(id)?.claude_session_id ?? undefined;
+  }
+
+  /**
+   * Record a runtime-minted transcript id (Codex). FIRST WRITE WINS: once a session has an id, a later
+   * report is ignored, so a resumed run can't silently re-point an existing conversation at a different
+   * transcript (which would strand the original and break `resume`/`fork`). Returns whether it stored.
+   */
+  recordRuntimeSessionId(sessionId: string, runtimeSessionId: string): boolean {
+    const id = runtimeSessionId.trim();
+    // Codex rollout ids are UUIDs; reject anything else so a malformed scrape can't poison the column.
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) return false;
+    const row = this.db.prepare('SELECT agent, claude_session_id FROM term_sessions WHERE id = ?')
+      .get<{ agent: string; claude_session_id: string | null }>(sessionId);
+    if (!row || row.claude_session_id) return false;
+    this.db.prepare('UPDATE term_sessions SET claude_session_id = ?, updated_at = ? WHERE id = ?')
+      .run(id, Date.now(), sessionId);
+    this.audit(sessionId, row.agent, 'session.runtime_id', { runtimeSessionId: id });
+    return true;
   }
 
   /** Resolve a tmux session name (`aos-xxxx`) to its session id — for the terminal-attach authz check. */
@@ -2223,7 +2314,7 @@ export class TerminalManager {
     // answerable straight from the prompt without a discovery round-trip (`list_agents` is the live
     // equivalent). Excludes self and mock agents, so it only lists peers this agent can actually dispatch.
     const roster = [...this.os.agents.values()]
-      .filter((a) => a.runtime === 'claude-code' && a.id !== selfAgent)
+      .filter((a) => isCodingRuntime(a.runtime) && a.id !== selfAgent)
       .map((a) => `- \`agent:${a.id}\`${a.category ? ` (${a.category})` : ''} — ${a.description}`)
       .join('\n');
     const fleet = roster
@@ -2530,7 +2621,7 @@ export class TerminalManager {
    */
   refreshAgentSkills(agent: string): { reloaded: number } {
     const manifest = this.os.agents.get(agent);
-    if (!manifest || manifest.runtime !== 'claude-code' || !manifest.dir) return { reloaded: 0 };
+    if (!manifest || !runtimeSupports(manifest.runtime, 'nativeSkills') || !manifest.dir) return { reloaded: 0 };
     const rows = this.db
       .prepare(`SELECT id, tmux, run_as, spawned_by FROM term_sessions WHERE agent = ? AND status = 'running' AND headless = 0`)
       .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null }>(agent)
@@ -3362,7 +3453,7 @@ export class TerminalManager {
     if (target === callerAgent) return { error: 'an agent cannot ask itself — pick a different teammate' };
     const manifest = this.os.agents.get(target);
     if (!manifest) return { error: `unknown agent: ${target}` };
-    if (manifest.runtime !== 'claude-code') return { error: `${target} is not an interactive agent that can answer` };
+    if (!isCodingRuntime(manifest.runtime)) return { error: `${target} is not an interactive agent that can answer` };
     // Run-as passthrough: the delegate acts AS the caller's accountable human, so budget/approvals/identity
     // ladder to the same person the caller already answers to (mirrors task-owner passthrough).
     const runAs = this.db.prepare('SELECT run_as FROM term_sessions WHERE id = ?').get<{ run_as: string | null }>(callerSession)?.run_as ?? undefined;
@@ -3911,7 +4002,7 @@ export class TerminalManager {
     if (!this.os.paths) return { ok: false, error: 'editing agents requires a data home' };
     const ag = this.os.agents.get(target);
     if (!ag?.dir) return { ok: false, error: `unknown agent "${target}"` };
-    if (ag.runtime !== 'claude-code') return { ok: false, error: 'only claude-code agents can be edited' };
+    if (!isCodingRuntime(ag.runtime)) return { ok: false, error: 'only CLI-backed agents can be edited' };
     const userRoot = path.resolve(this.os.paths.userAgents) + path.sep;
     if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return { ok: false, error: 'built-in agents cannot be edited' };
     // Only the fields actually present become the delta; store them verbatim on the card for the approve route.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1034,6 +1034,136 @@ export interface RuntimeTuning {
   permissionMode?: PermissionMode;
 }
 
+/** Every runtime an agent manifest may declare. `mock` is the in-process demo adapter (no CLI, no
+ *  tmux); the others are real coding CLIs. */
+export type RuntimeId = 'mock' | 'claude-code' | 'codex';
+/** The runtimes that spawn a real CLI in a governed tmux pane — everything except `mock`. */
+export type CodingRuntimeId = Exclude<RuntimeId, 'mock'>;
+
+/**
+ * What a coding runtime can actually do.
+ *
+ * These differ enough between CLIs that call sites MUST probe a capability rather than compare
+ * runtime ids — `runtime === 'claude-code'` was the old shorthand for "a real agent", and widening
+ * the union turned every one of those into a latent bug. Use {@link isCodingRuntime} for the
+ * "is this a real agent at all" question and a named flag for anything finer.
+ *
+ * The two governance flags (`fileWriteGate`, `mcpGate`) describe how the invariant is upheld, NOT
+ * whether it is: Claude Code intercepts file writes and MCP calls at the PreToolUse hook, while
+ * Codex's hook only sees the `shell` tool — so a Codex session instead confines writes with an OS
+ * sandbox (`writable_roots`) and relies on the loopback API to govern MCP calls server-side. Both
+ * routes close the hole; only the mechanism changes.
+ */
+export interface RuntimeCapabilities {
+  /** Can the OS CHOOSE the transcript id up front? Claude takes `--session-id <uuid>`; Codex mints
+   *  its own rollout id, so the launcher has to capture and report it back after the fact. */
+  pinnedSessionId: boolean;
+  /** Can a prior conversation be continued by id? */
+  resume: boolean;
+  /** Can a conversation be branched, leaving the parent transcript intact? */
+  fork: boolean;
+  /** Does an UNATTENDED run stay attachable so a human can take it over mid-turn? True when the
+   *  unattended lane is an interactive TUI torn down by the server at turn-end (Claude); false when
+   *  it is a one-shot process that exits on its own (Codex `exec`). */
+  attachableUnattended: boolean;
+  /** Can a warm chat session be kept resident and fed follow-ups via tmux send-keys? Needs an
+   *  interactive TUI that survives a turn — so it tracks `attachableUnattended`. */
+  residentChat: boolean;
+  /** Does the OS know how to parse this CLI's transcript into cost + engaged-time + a chat timeline? */
+  transcript: boolean;
+  /** Native Agent Skills discovered from a project directory (`.claude/skills`). */
+  nativeSkills: boolean;
+  /** Native in-process sub-agents (`.claude/agents`). */
+  nativeSubagents: boolean;
+  /** A custom status line renderer. */
+  statusLine: boolean;
+  /** Honours {@link RuntimeTuning.permissionMode}. */
+  permissionMode: boolean;
+  /** Does the PreToolUse hook intercept FILE WRITES? False → containment is the OS sandbox instead. */
+  fileWriteGate: boolean;
+  /** Does the PreToolUse hook intercept MCP/connector tool calls? False → those are governed
+   *  server-side at the loopback API, which every OS tool already goes through. */
+  mcpGate: boolean;
+  /** Can the gate steer the model on an ALLOW (Claude's `additionalContext`)? Codex's hook contract
+   *  acts on `deny` only, so the `instruct` verb degrades to a plain allow there. */
+  steerOnAllow: boolean;
+}
+
+/** Static description of a coding runtime: which binary drives it, which launch script + gate hook
+ *  wire it to the gateway, and what it supports. The single place a new CLI is declared. */
+export interface CodingRuntimeSpec {
+  id: CodingRuntimeId;
+  /** Human-facing name for the console + error messages. */
+  label: string;
+  /** The executable that must be on PATH for a session to launch. */
+  bin: string;
+  /** Basename of the launcher under `terminal/`. */
+  launchScript: string;
+  /** Basename of the PreToolUse gate hook under `terminal/`. */
+  gateHook: string;
+  capabilities: RuntimeCapabilities;
+}
+
+export const CODING_RUNTIMES: Readonly<Record<CodingRuntimeId, CodingRuntimeSpec>> = {
+  'claude-code': {
+    id: 'claude-code',
+    label: 'Claude Code',
+    bin: 'claude',
+    launchScript: 'claude-launch.sh',
+    gateHook: 'gate-hook.sh',
+    capabilities: {
+      pinnedSessionId: true, resume: true, fork: true, attachableUnattended: true,
+      residentChat: true, transcript: true, nativeSkills: true, nativeSubagents: true,
+      statusLine: true, permissionMode: true, fileWriteGate: true, mcpGate: true,
+      steerOnAllow: true,
+    },
+  },
+  codex: {
+    id: 'codex',
+    label: 'Codex',
+    bin: 'codex',
+    launchScript: 'codex-launch.sh',
+    // Same hook binary as Claude Code: Codex 0.145 uses identical PreToolUse stdin fields
+    // (`tool_name`/`tool_input`/`agent_type`) and an identical decision wire, so only the
+    // tool→capability routing table differs — selected inside the hook by $AOS_RUNTIME. Sharing the
+    // file keeps the fail-closed retry + approval-wait logic in ONE place; two copies would let a
+    // security fix land in one runtime and silently miss the other.
+    gateHook: 'gate-hook.sh',
+    capabilities: {
+      // Codex mints its own rollout id (`codex exec resume <id>` / `codex fork <id>`), so the id is
+      // captured after launch rather than pinned. The unattended lane is `codex exec`, which exits at
+      // turn end — no Stop hook needed, but also nothing to attach to, which rules out resident chat.
+      pinnedSessionId: false, resume: true, fork: true, attachableUnattended: false,
+      residentChat: false, transcript: false, nativeSkills: false, nativeSubagents: false,
+      statusLine: false, permissionMode: false,
+      // PreToolUse reliably sees the `shell` tool; `apply_patch` writes are confined instead by the
+      // sandbox's `writable_roots`, and MCP calls are governed server-side at the loopback API every
+      // OS tool already goes through. See the RuntimeCapabilities note on mechanism vs. invariant.
+      fileWriteGate: false, mcpGate: false,
+      // Codex 0.145's PreToolUse output wire matches Claude's: permissionDecision allow|deny|ask plus
+      // `additionalContext` (verified against the JSON schema embedded in the binary), so the gate's
+      // `instruct` verb carries over unchanged.
+      steerOnAllow: true,
+    },
+  },
+};
+
+/** Is this a real CLI-backed agent (as opposed to the `mock` demo adapter)? This is what almost every
+ *  former `runtime === 'claude-code'` check actually meant. */
+export function isCodingRuntime(runtime: RuntimeId | undefined): runtime is CodingRuntimeId {
+  return runtime === 'claude-code' || runtime === 'codex';
+}
+
+/** The spec for a runtime, or undefined for `mock`/unknown. */
+export function codingRuntime(runtime: RuntimeId | undefined): CodingRuntimeSpec | undefined {
+  return isCodingRuntime(runtime) ? CODING_RUNTIMES[runtime] : undefined;
+}
+
+/** Does `runtime` support `cap`? False for `mock` and unknown runtimes. */
+export function runtimeSupports(runtime: RuntimeId | undefined, cap: keyof RuntimeCapabilities): boolean {
+  return codingRuntime(runtime)?.capabilities[cap] ?? false;
+}
+
 export interface AgentManifest extends RuntimeTuning {
   id: string;
   version: string;
@@ -1047,9 +1177,12 @@ export interface AgentManifest extends RuntimeTuning {
    *  a mismatch is warned at registration (see {@link policyContextMismatch}) because the agent would
    *  otherwise be governed by a different policy than it declares. */
   policyContext: string;
-  runtime: 'mock' | 'claude-code';
+  /** Which coding CLI drives this agent. `mock` is the in-process demo adapter; the rest are real
+   *  CLIs launched in a tmux pane and governed by a PreToolUse gate hook. See {@link CODING_RUNTIMES}
+   *  for what each one can actually do — capabilities differ, so probe rather than compare ids. */
+  runtime: RuntimeId;
   budget: Budget;
-  /** claude-code runtime extras. */
+  /** Coding-runtime extras. */
   maxTurns?: number;
   allowedTools?: string[];
   path?: string;

--- a/terminal/codex-launch.sh
+++ b/terminal/codex-launch.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# Real-Codex launcher — opens an OpenAI Codex session DIRECTLY IN THE AGENT'S FOLDER, governed by
+# Agent OS. The Claude Code counterpart is claude-launch.sh; read that one first, this is the same
+# shape with the runtime-specific bits swapped.
+#
+# HOW THE INVARIANT IS UPHELD HERE (it differs from the Claude lane, deliberately):
+#   1. shell.exec — Codex's PreToolUse hook fires on the `shell` tool, so every command (including
+#      curl / git / npm, i.e. all network egress the agent drives) goes through terminal/gate-hook.sh
+#      → POST /api/gate → Policy/Approvals/Budget/Audit. Same hook file as Claude; $AOS_RUNTIME picks
+#      the tool→capability routing table.
+#   2. file.write — Codex applies most edits by piping `apply_patch` through the shell tool, so those
+#      are already covered by (1). Anything that ISN'T is contained STRUCTURALLY instead: the sandbox
+#      is `workspace-write` with `writable_roots` pinned to the agent folder, so a write outside the
+#      agent's own directory is impossible at the OS level rather than merely denied by policy.
+#   3. connector.call — Codex's hook coverage for MCP tools isn't guaranteed, so those are governed
+#      SERVER-SIDE: every OS tool is a loopback call to /api/* that derives identity from the session
+#      row and enforces the real governance there (secret_put still blocks for approval, memory is
+#      namespaced to this agent, …). Composio connector calls likewise mint per-session, per-identity
+#      Tool Router URLs. Nothing reaches the world on a bare token the agent holds.
+#   4. approval_policy = "never" — Agent OS is the SOLE authority, exactly as the Claude lane sets
+#      --dangerously-skip-permissions. It removes Codex's OWN prompts (which nobody is there to
+#      answer), NOT our gate: the PreToolUse hook still runs and still blocks for inbox approval.
+#
+# Env (exported by the server when it spawns the tmux session):
+#   AOS_URL        base url of the agent-os server   (e.g. http://127.0.0.1:3010)
+#   SESSION        session id
+#   AGENT          agent id (matches the manifest / its folder name)
+#   AGENT_DIR      the agent's folder — codex opens here and writes its scratch here
+#   TASK_FILE      path to the opening prompt (TASK_B64 is the legacy inline fallback)
+#   HOOK           absolute path to gate-hook.sh (the PreToolUse gate)
+#   AOS_RUNTIME    "codex" — selects the hook's routing table
+#   AOS_CODEX_HOME per-session $CODEX_HOME the server created (0700); holds our generated config
+#   MCP_CONFIG     path to the session's mcpServers JSON (converted to TOML below)
+#   COMPANY_FILE   workspace Company context markdown (folded into AGENTS.md below)
+#   CODEX_MODEL / CODEX_EFFORT   resolved runtime tuning ("" → inherit the CLI default)
+#   UNATTENDED     "1" → an automation/cron/task run: `codex exec`, which exits at turn end
+#   RESUME         "1" → continue RUNTIME_SESSION_ID instead of starting fresh
+#   FORK_FROM      branch a new conversation off this rollout id (first launch only)
+set -u
+
+# RESUME path: the ttyd attach wrapper re-launches us against a session whose tmux shell was killed.
+# The new tmux session does NOT inherit the original launch env, so recover it first.
+RESUMED_FROM_ENV=
+if [ "${RESUME:-}" = "1" ] && [ -n "${ENV_FILE:-}" ] && [ -f "${ENV_FILE}" ]; then
+  # shellcheck disable=SC1090
+  . "$ENV_FILE"
+  RESUMED_FROM_ENV=1
+fi
+
+# `codex` is commonly installed under a node prefix bin; make sure it's findable even when the parent
+# process (e.g. a hardened systemd unit) ships a minimal PATH.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+
+# The opening task prompt. Prefer TASK_FILE (a path the server materialised) over the inline TASK_B64
+# env — LocalSessionBackend puts every env var on the `tmux new-session` command line, which tmux caps
+# at ~16KB, so a large base64 task there makes new-session fail and the run never launches.
+if [ -n "${TASK_FILE:-}" ] && [ -f "${TASK_FILE}" ]; then
+  TASK=$(cat "${TASK_FILE}")
+else
+  TASK=$(printf '%s' "${TASK_B64:-}" | base64 -d 2>/dev/null)
+fi
+
+cyan() { printf '\033[36m%s\033[0m\n' "$1"; }
+dim()  { printf '\033[2m%s\033[0m\n' "$1"; }
+red()  { printf '\033[31m%s\033[0m\n' "$1"; }
+
+cd "$AGENT_DIR" 2>/dev/null || { red "agent folder not found: $AGENT_DIR"; exec bash; }
+
+if ! command -v codex >/dev/null 2>&1; then
+  red "the 'codex' CLI is not on PATH — install it (npm i -g @openai/codex) or adjust PATH."
+  red "the session cannot start ungoverned, so this pane will idle."
+  exec bash
+fi
+
+# ── per-session CODEX_HOME ────────────────────────────────────────────────────────────────────────
+# Everything Codex reads (config.toml, hooks.json) and writes (sessions/) is redirected into a
+# per-session 0700 dir the server created. Two payoffs: (a) our generated config can't disturb the
+# operator's own ~/.codex, and (b) `sessions/` then contains EXACTLY ONE rollout file, which is how
+# we discover the id Codex minted (it has no --session-id to pin, unlike claude).
+export CODEX_HOME="${AOS_CODEX_HOME:-$AGENT_DIR/.aos-codex}"
+mkdir -p "$CODEX_HOME"
+chmod 700 "$CODEX_HOME" 2>/dev/null || true
+
+# Auth: Codex reads auth.json from $CODEX_HOME, so link the real one in. Without this every session
+# would demand its own `codex login`. Symlink (not copy) so a re-login/token refresh is picked up and
+# no credential is duplicated onto disk.
+REAL_CODEX_HOME="${AOS_REAL_CODEX_HOME:-$HOME/.codex}"
+if [ -f "$REAL_CODEX_HOME/auth.json" ] && [ ! -e "$CODEX_HOME/auth.json" ]; then
+  ln -s "$REAL_CODEX_HOME/auth.json" "$CODEX_HOME/auth.json" 2>/dev/null || true
+fi
+
+# ── config.toml ───────────────────────────────────────────────────────────────────────────────────
+# Generated fresh each launch (so hook paths are always correct and portable across machines), from
+# the session's MCP JSON. Codex's schema is `[mcp_servers.<name>]` with command/args + a nested
+# `.env` table for stdio servers, or url + a nested `.http_headers` table for streamable HTTP —
+# verified against `codex mcp add` output and re-parsed under `--strict-config`.
+AOS_MCP_CONFIG="${MCP_CONFIG:-}" \
+AOS_AGENT_DIR="$AGENT_DIR" \
+AOS_MODEL="${CODEX_MODEL:-}" \
+AOS_EFFORT="${CODEX_EFFORT:-}" \
+node -e '
+  const fs = require("fs");
+  const q = (v) => JSON.stringify(String(v));            // TOML basic string ⊂ JSON string
+  const out = [];
+  if (process.env.AOS_MODEL)  out.push(`model = ${q(process.env.AOS_MODEL)}`);
+  if (process.env.AOS_EFFORT) out.push(`model_reasoning_effort = ${q(process.env.AOS_EFFORT)}`);
+  // Agent OS is the sole authority (see header note 4); the gate hook still blocks for approval.
+  out.push(`approval_policy = "never"`);
+  out.push(`sandbox_mode = "workspace-write"`);
+  out.push("");
+  out.push("[sandbox_workspace_write]");
+  // Structural containment for any write that does not pass through the shell tool. The workdir is
+  // already writable implicitly; naming it here is explicit and survives a future cwd change.
+  out.push(`writable_roots = [${q(process.env.AOS_AGENT_DIR)}]`);
+  // Egress via the shell IS governed (the hook sees every shell call), so the sandbox does not need
+  // to cut the network — doing so would break git push / npm install for every agent.
+  out.push("network_access = true");
+  out.push("");
+  out.push("[features]");
+  out.push("codex_hooks = true");
+  // Pre-accept the workspace-TRUST gate for this agent folder — the exact analogue of the
+  // `~/.claude.json` hasTrustDialogAccepted seed on the Claude lane, and the same failure mode if
+  // missing: agent folders are freshly created and are NOT git repos, so without this `codex exec`
+  // dies on "Not inside a trusted directory" and the interactive TUI parks on a trust prompt nobody
+  // is there to answer. (Verified against codex 0.145 in a dry run.) Trust only bypasses that
+  // one-time gate; the PreToolUse hook and the sandbox still govern every effect.
+  out.push("");
+  out.push(`[projects.${q(process.env.AOS_AGENT_DIR)}]`);
+  out.push(`trust_level = "trusted"`);
+  const file = process.env.AOS_MCP_CONFIG;
+  if (file && fs.existsSync(file)) {
+    let cfg = {};
+    try { cfg = JSON.parse(fs.readFileSync(file, "utf8")); } catch (_) { cfg = {}; }
+    for (const [name, s] of Object.entries(cfg.mcpServers || {})) {
+      if (!/^[A-Za-z0-9_-]+$/.test(name)) continue;      // TOML bare key; skip anything exotic
+      out.push("", `[mcp_servers.${name}]`);
+      if (s && s.url) {
+        out.push(`url = ${q(s.url)}`);
+      } else if (s && s.command) {
+        out.push(`command = ${q(s.command)}`);
+        out.push(`args = [${(s.args || []).map(q).join(", ")}]`);
+      } else {
+        out.pop(); out.pop(); continue;                   // neither shape → drop the empty table
+      }
+      // Give the OS server room to boot under load; the default is tight enough to flake on a cold
+      // node start, and a dropped agentos server means the agent silently loses all its OS tools.
+      out.push("startup_timeout_sec = 30");
+      const env = (s && s.env) || {};
+      if (Object.keys(env).length) {
+        out.push("", `[mcp_servers.${name}.env]`);
+        for (const [k, v] of Object.entries(env)) if (/^[A-Za-z0-9_]+$/.test(k)) out.push(`${k} = ${q(v)}`);
+      }
+      const headers = (s && s.headers) || {};
+      if (Object.keys(headers).length) {
+        out.push("", `[mcp_servers.${name}.http_headers]`);
+        for (const [k, v] of Object.entries(headers)) out.push(`${q(k)} = ${q(v)}`);
+      }
+    }
+  }
+  fs.writeFileSync(process.env.CODEX_HOME + "/config.toml", out.join("\n") + "\n", { mode: 0o600 });
+' || { red "failed to generate codex config — refusing to start ungoverned."; exec bash; }
+
+# ── hooks.json (the gate) ─────────────────────────────────────────────────────────────────────────
+# matcher ".*" so EVERY tool reaches the hook and OUR routing table decides what is a governed
+# capability — the hook itself is dumb transport, exactly as on the Claude lane.
+node -e '
+  const fs = require("fs");
+  const hook = process.argv[1];
+  fs.writeFileSync(process.env.CODEX_HOME + "/hooks.json", JSON.stringify({
+    hooks: {
+      PreToolUse: [{ matcher: ".*", hooks: [{ type: "command", command: `bash ${JSON.stringify(hook)}` }] }],
+    },
+  }, null, 2), { mode: 0o600 });
+' "$HOOK" || { red "failed to write the gate hook config — refusing to start ungoverned."; exec bash; }
+
+# ── AGENTS.md (system prompt) ─────────────────────────────────────────────────────────────────────
+# Codex has no `--append-system-prompt-file`; it discovers AGENTS.md from the workspace root. So the
+# OS composes one from the agent's own persona (CLAUDE.md, which is the runtime-neutral persona file
+# every agent already has) plus the workspace Company context. Regenerated each launch and clearly
+# marked, so a human editing it knows it is not hand-maintained.
+node -e '
+  const fs = require("fs");
+  const [persona, company, dest] = process.argv.slice(1);
+  const read = (p) => { try { return p && fs.existsSync(p) ? fs.readFileSync(p, "utf8").trim() : ""; } catch (_) { return ""; } };
+  const parts = ["<!-- Generated by Agent OS at launch. Edits are overwritten; change the agent or Company context instead. -->"];
+  const p = read(persona), c = read(company);
+  if (p) parts.push(p);
+  if (c) parts.push(c);
+  if (p || c) fs.writeFileSync(dest, parts.join("\n\n") + "\n");
+' "$AGENT_DIR/CLAUDE.md" "${COMPANY_FILE:-}" "$AGENT_DIR/AGENTS.md" 2>/dev/null || true
+
+# ── report the rollout id back to the server ──────────────────────────────────────────────────────
+# Codex mints its own session UUID (there is no --session-id to pin), but we need it for resume/fork.
+# Because CODEX_HOME is per-session, sessions/ holds exactly one rollout file named
+# `rollout-<ts>-<uuid>.jsonl` — so watch for it, POST the id once, and exit. Backgrounded so it never
+# delays the run; bounded so it can't linger if the session dies early.
+report_runtime_id() {
+  local i=0 f id
+  while [ "$i" -lt 120 ]; do
+    f=$(find "$CODEX_HOME/sessions" -name 'rollout-*.jsonl' -type f 2>/dev/null | head -1)
+    if [ -n "$f" ]; then
+      id=$(basename "$f" .jsonl | sed -n 's/.*-\([0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}\)$/\1/p')
+      if [ -n "$id" ]; then
+        curl -s --max-time 10 -X POST "$AOS_URL/api/runtime-session" \
+          -H 'content-type: application/json' -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" \
+          -d "$(node -e 'console.log(JSON.stringify({session:process.argv[1],runtimeSessionId:process.argv[2]}))' "$SESSION" "$id")" \
+          >/dev/null 2>&1
+        return 0
+      fi
+    fi
+    i=$((i + 1))
+    sleep 1
+  done
+}
+REPORTER_PID=
+if [ "${RESUME:-}" != "1" ]; then
+  report_runtime_id >/dev/null 2>&1 &
+  REPORTER_PID=$!
+fi
+# The poller MUST be reaped before this script exits. It inherits the pane's stdout/stderr, so a
+# still-running child keeps the pane's pipes open — which on the UNATTENDED lane means tmux never
+# drops the session at turn end, the liveness sweep keeps seeing it alive, and the automations
+# pile-up guard never releases. (Found exactly this way in a stub-codex dry run.)
+stop_reporter() { [ -n "${REPORTER_PID:-}" ] && kill "$REPORTER_PID" 2>/dev/null; return 0; }
+trap stop_reporter EXIT
+trap 'exit 129' HUP
+trap 'exit 143' TERM
+trap 'exit 130' INT
+
+notify_ended() {
+  curl -s -X POST "$AOS_URL/api/ended" -H 'content-type: application/json' -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" \
+    -d "$(node -e 'console.log(JSON.stringify({session:process.argv[1]}))' "$SESSION")" >/dev/null 2>&1 || true
+}
+notify_resumed() {
+  curl -s -X POST "$AOS_URL/api/resumed" -H 'content-type: application/json' -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" \
+    -d "$(node -e 'console.log(JSON.stringify({session:process.argv[1]}))' "$SESSION")" >/dev/null 2>&1 || true
+}
+
+clear
+cyan "┌─ Agent OS · governed codex ─────────────────────────────────"
+cyan "│ agent:   $AGENT"
+cyan "│ session: $SESSION"
+cyan "│ folder:  $AGENT_DIR"
+cyan "│ task:    $TASK"
+cyan "└─────────────────────────────────────────────────────────────"
+echo
+dim "Real codex, opened in this agent's folder. Every shell call is gated by Agent OS;"
+dim "risky ones pause here and surface as an inbox approval. Writes are sandboxed to this folder."
+[ -f "$CODEX_HOME/auth.json" ] || dim "note: no codex auth found at $REAL_CODEX_HOME/auth.json — run 'codex login' as this user."
+[ -n "${CODEX_MODEL:-}${CODEX_EFFORT:-}" ] && dim "tuning: model=${CODEX_MODEL:-default} effort=${CODEX_EFFORT:-default}"
+MCP_NAMES=$(node -e 'try{const c=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8"));console.log(Object.keys(c.mcpServers||{}).join(", "))}catch(e){}' "${MCP_CONFIG:-/nonexistent}" 2>/dev/null)
+[ -n "$MCP_NAMES" ] && dim "connectors: $MCP_NAMES"
+echo
+
+# `--dangerously-bypass-hook-trust`: Codex refuses to run a hooks.json it has not seen before unless
+# the config's hash is in its trust store. Ours is REGENERATED EVERY LAUNCH from the OS's own hook
+# path, so the hash legitimately changes and there is no human at the pane to confirm it. This is
+# precisely the documented "automation that already vets hook sources" case — the hook is ours. It
+# does NOT weaken the gate; without it the gate would simply never run, which is the unsafe outcome.
+COMMON_ARGS=(--dangerously-bypass-hook-trust -C "$AGENT_DIR")
+# `--skip-git-repo-check` is an exec-only flag (the TUI has no such option and errors on it), so it
+# lives in a separate array. Belt-and-braces with the `[projects.…] trust_level` seed above.
+EXEC_ARGS=("${COMMON_ARGS[@]}" --skip-git-repo-check)
+
+if [ "${UNATTENDED:-}" = "1" ]; then
+  # UNATTENDED lane — `codex exec`, which runs the turn and EXITS. Teardown is therefore by process
+  # exit (like the pre-attachable `claude -p` lane), not by a server-driven Stop hook: notify_ended
+  # below flips the row idle and releases the automations pile-up guard. Consequence, recorded in the
+  # capability matrix as attachableUnattended:false — there is no live TUI to "take over" mid-run.
+  dim "unattended run — codex exec (gate hook governs every shell call). Exits at turn end."
+  echo
+  if [ "${RESUME:-}" = "1" ] && [ -n "${RUNTIME_SESSION_ID:-}" ]; then
+    notify_resumed
+    codex exec resume "$RUNTIME_SESSION_ID" "${EXEC_ARGS[@]}" ${TASK:+"$TASK"} \
+      || codex exec "${EXEC_ARGS[@]}" "$TASK"
+  elif [ -n "${FORK_FROM:-}" ]; then
+    codex exec resume "$FORK_FROM" "${EXEC_ARGS[@]}" ${TASK:+"$TASK"} \
+      || codex exec "${EXEC_ARGS[@]}" "$TASK"
+  else
+    codex exec "${EXEC_ARGS[@]}" "$TASK"
+  fi
+  notify_ended
+  exit 0
+fi
+
+# INTERACTIVE lane — the attachable TUI a member drives from the browser terminal.
+if [ "${RESUME:-}" = "1" ] && [ -n "${RUNTIME_SESSION_ID:-}" ]; then
+  notify_resumed
+  dim "resuming codex session $RUNTIME_SESSION_ID …"
+  echo
+  # A browser reattach must NOT re-seed $TASK (it is already in the transcript); a server-driven
+  # follow-up spawns a fresh pane with no ENV_FILE and a genuinely new $TASK, so it does seed.
+  if [ -n "${RESUMED_FROM_ENV:-}" ]; then
+    codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
+  else
+    codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" ${TASK:+"$TASK"} || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
+  fi
+elif [ -n "${FORK_FROM:-}" ]; then
+  dim "forking codex session $FORK_FROM …"
+  echo
+  codex fork "$FORK_FROM" "${COMMON_ARGS[@]}" ${TASK:+"$TASK"} || codex "${COMMON_ARGS[@]}" "$TASK"
+else
+  codex "${COMMON_ARGS[@]}" "$TASK"
+fi
+notify_ended
+
+# SECURITY: do NOT drop to a raw shell when codex exits. A tmux shell has NO PreToolUse gate hook and
+# NO sandbox, so `exec bash` here would hand whoever is attached full, ungoverned access as the app
+# user — reading ~/.ssh, the workspace DB, every tenant's data, the network. Keep the pane alive (so
+# ttyd doesn't loop "Reconnecting") with a no-shell holding prompt that can ONLY re-open codex.
+echo
+while true; do
+  dim "codex session ended — press [r] to resume, [q] to close the tab."
+  key=""
+  IFS= read -rsn1 key || { sleep 2; continue; }   # blocked read is fine; EOF/detached → idle, no spin
+  case "$key" in
+    r|R)
+      notify_resumed
+      if [ -n "${RUNTIME_SESSION_ID:-}" ]; then
+        codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
+      else
+        codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
+      fi
+      notify_ended
+      ;;
+    q|Q) exit 0 ;;
+    *) : ;;   # ignore any other key — never spawn a shell
+  esac
+done

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
-# Claude Code PreToolUse hook — the AUTHENTIC path.
+# PreToolUse hook — the AUTHENTIC path. Shared by every coding runtime.
 #
-# Wire this in a session's settings.json (see terminal/claude-settings.json) so a REAL
-# `claude` agent running in tmux is governed by Agent OS: before every tool call, Claude
-# runs this hook. The server decides: allow / ask (create an inbox approval and BLOCK here
-# until a human decides) / never (denied outright).
+# Wire this in a session's runtime config (Claude Code: `.claude/aos-settings.json`, written by
+# claude-launch.sh; Codex: `$CODEX_HOME/hooks.json`, written by codex-launch.sh) so a REAL agent
+# running in tmux is governed by Agent OS: before every tool call, the CLI runs this hook. The server
+# decides: allow / ask (create an inbox approval and BLOCK here until a human decides) / never
+# (denied outright).
+#
+# MULTI-RUNTIME: $AOS_RUNTIME (`claude-code` | `codex`, default `claude-code`) selects the
+# tool→capability routing table below. Everything else — the fail-closed gate call, the approval
+# wait, the decision wire — is identical, because Codex 0.145 uses the same PreToolUse stdin fields
+# (`tool_name`/`tool_input`/`agent_type`) and the same `permissionDecision` allow|deny|ask +
+# `additionalContext` output wire as Claude Code (verified against the schema embedded in the codex
+# binary). One file on purpose: a governance fix must never land for one runtime and miss the other.
 #
 # Contract (AUTHORITATIVE-DECISION mode): for the capabilities Agent OS governs (Bash,
 # connector.*), the hook emits a PreToolUse `permissionDecision` on stdout and exits 0.
@@ -22,7 +30,7 @@
 # the hook stays silent (bare exit 0) and defers to Claude's normal permission flow — that's
 # what keeps the crown-jewel `permissions.deny` Read rules in force for the built-in Read tool.
 #
-# Env: AOS_URL, SESSION, AGENT  (exported when the claude session is launched)
+# Env: AOS_URL, SESSION, AGENT, AOS_RUNTIME  (exported when the session is launched)
 set -u
 EVENT=$(cat)
 
@@ -54,30 +62,52 @@ emit_allow_note() {
 IFS=$'\x1f' read -r TOOL SUBTYPE SUBID INPUT <<<"$(printf '%s' "$EVENT" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const e=JSON.parse(d||"{}");const S="\x1f";process.stdout.write([e.tool_name||"",e.agent_type||"",e.agent_id||"",JSON.stringify(e.tool_input||{})].join(S))})')"
 
 # The OS-owned tools (memory recall/remember, ask/report, policy preview) are internal and never
-# touch the outside world, so they bypass the gate entirely.
+# touch the outside world, so they bypass the gate entirely. Claude namespaces MCP tools
+# `mcp__<server>__<tool>`; Codex may present the bare `<server>__<tool>` — accept both spellings so the
+# OS's own server is never gated under either runtime.
 case "$TOOL" in
-  mcp__agentos__*) exit 0 ;;
+  mcp__agentos__*|agentos__*) exit 0 ;;
 esac
 
 # Route the tool to an Agent OS capability (structural — the only thing the hook still decides). All
 # riskiness/destructiveness classification now happens server-side in the enricher + policy.
-case "$TOOL" in
-  Bash) CAP="shell.exec" ;;
-  # File writes go through the gateway too (the enricher decides inside-vs-outside the agent's folder
-  # from the path in tool_input). The hook stays dumb transport — it only names the capability.
-  Edit|Write|MultiEdit|NotebookEdit) CAP="file.write" ;;
-  mcp__composio-company__*INITIATE_CONNECTION*)
-    # INITIATE_CONNECTION starts an OAuth grant that gives the whole fleet access to an app — the actual
-    # privilege-bearing op, so it's an owner/admin call (connector.connect).
-    CAP="connector.connect" ;;
-  # MANAGE_CONNECTIONS is a management/STATUS tool — in practice agents call it to LIST/check connections
-  # (`{toolkits:["gmail"]}`), a benign read that was needlessly owner-gated. Route it to connector.call
-  # (allowed) like any other connector tool; a real grant goes through INITIATE_CONNECTION above.
-  mcp__*) CAP="connector.call" ;;
-  *) exit 0 ;;  # any other built-in tool (Read/Glob/Grep/…) isn't a world side effect → allow
+#
+# The routing table is per-runtime because each CLI names its tools differently; everything BELOW this
+# block (the fail-closed gate call, the approval wait, the decision wire) is deliberately shared, so a
+# governance fix can't land for one runtime and miss the other.
+case "${AOS_RUNTIME:-claude-code}" in
+  codex)
+    # Codex tool inventory. `shell` is the exec tool (its aliases are matched too, defensively).
+    # NOTE: Codex applies most edits by piping `apply_patch` THROUGH the shell tool, so those already
+    # arrive here as shell.exec; the explicit apply_patch arm covers the native-tool spelling. Writes
+    # that dodge the hook entirely are still contained by the sandbox's `writable_roots` (set to the
+    # agent folder in codex-launch.sh) — see the RuntimeCapabilities note in src/types.ts.
+    case "$TOOL" in
+      shell|local_shell|exec_command|unified_exec) CAP="shell.exec" ;;
+      apply_patch) CAP="file.write" ;;
+      *INITIATE_CONNECTION*) CAP="connector.connect" ;;
+      mcp__*|*composio*) CAP="connector.call" ;;
+      *) exit 0 ;;  # read_file / update_plan / web_search / … aren't world side effects → allow
+    esac ;;
+  *)
+    case "$TOOL" in
+      Bash) CAP="shell.exec" ;;
+      # File writes go through the gateway too (the enricher decides inside-vs-outside the agent's folder
+      # from the path in tool_input). The hook stays dumb transport — it only names the capability.
+      Edit|Write|MultiEdit|NotebookEdit) CAP="file.write" ;;
+      mcp__composio-company__*INITIATE_CONNECTION*)
+        # INITIATE_CONNECTION starts an OAuth grant that gives the whole fleet access to an app — the actual
+        # privilege-bearing op, so it's an owner/admin call (connector.connect).
+        CAP="connector.connect" ;;
+      # MANAGE_CONNECTIONS is a management/STATUS tool — in practice agents call it to LIST/check connections
+      # (`{toolkits:["gmail"]}`), a benign read that was needlessly owner-gated. Route it to connector.call
+      # (allowed) like any other connector tool; a real grant goes through INITIATE_CONNECTION above.
+      mcp__*) CAP="connector.call" ;;
+      *) exit 0 ;;  # any other built-in tool (Read/Glob/Grep/…) isn't a world side effect → allow
+    esac ;;
 esac
 
-payload=$(node -e 'const[s,a,cap,t,inp,st,si]=process.argv.slice(1);let input={};try{input=JSON.parse(inp||"{}")}catch(e){};const o={sessionId:s,agent:a,capability:cap,args:{tool:t,input},reasoning:"claude PreToolUse: "+t};if(st){o.subagentType=st;if(si)o.subagentId=si;}console.log(JSON.stringify(o))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$INPUT" "$SUBTYPE" "$SUBID")
+payload=$(node -e 'const[s,a,cap,t,inp,st,si]=process.argv.slice(1);let input={};try{input=JSON.parse(inp||"{}")}catch(e){};const o={sessionId:s,agent:a,capability:cap,args:{tool:t,input},reasoning:(process.env.AOS_RUNTIME||"claude-code")+" PreToolUse: "+t};if(st){o.subagentType=st;if(si)o.subagentId=si;}console.log(JSON.stringify(o))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$INPUT" "$SUBTYPE" "$SUBID")
 
 # FAIL-CLOSED classify. Retry the gate until it returns a usable decision; a transient failure (server
 # restart, network blip, the documented stale-server 401/404 window) must NEVER fall through to "allow".


### PR DESCRIPTION
An agent manifest can now declare `"runtime": "codex"` and launch as a real, governed `codex` session in the agent's folder. Verified against **codex-cli 0.145.0**.

## The invariant holds — the mechanism differs

Codex's PreToolUse hook doesn't reliably cover file writes and MCP calls, so containment is assembled from three complementary parts instead of one:

| Effect | Claude Code | Codex |
| --- | --- | --- |
| Shell (incl. all curl/git/npm egress) | PreToolUse hook → `/api/gate` | **same hook, same gate** |
| File writes | PreToolUse hook | OS sandbox: `writable_roots` = the agent folder |
| MCP / connectors | PreToolUse hook | server-side at the loopback `/api/*` routes |
| The CLI's own prompts | `--dangerously-skip-permissions` | `approval_policy = "never"` |

`network_access` stays **true** — shell egress is already gated, and cutting it would break `git push` / `npm install` for every agent.

**One shared gate hook.** Codex 0.145 uses the same PreToolUse stdin fields and the same `allow\|deny\|ask` + `additionalContext` output wire as Claude Code (verified against the JSON schema embedded in the binary), so only the tool→capability routing table differs — selected by `$AOS_RUNTIME`. Two copies would let a governance fix land for one runtime and miss the other.

## 🔴 Governance hole this found and fixes

The enricher only accepted a `command` of type **string** (Claude's `Bash` shape). Codex's `shell` tool sends an **argv array**, so `typeof` fell through to `''` — meaning every Codex shell call was classified against an *empty command*, no destructive pattern could match, and the gate **allowed `rm -rf /`**. `commandText()` in `src/governance/enricher.ts` now normalises both shapes; the briefer uses it too, so approval cards don't render an empty command. Any future runtime sending argv arrays is covered.

## Capability matrix

`CODING_RUNTIMES` in `src/types.ts` declares what each CLI supports. The ~20 scattered `runtime === 'claude-code'` checks — which had quietly become the shorthand for "is this a real agent" — now probe a named capability via `runtimeSupports()` or `isCodingRuntime()`, so a Codex agent is first-class where supported and cleanly refused *with a reason* where not.

Codex is a **first cut**: no attach/take-over or resident warm chat (its unattended lane is `codex exec`, which exits at turn end), no cost/engaged-time/chat timeline (the transcript parser only reads Claude's JSONL), no native skills/sub-agents, and **local-lane only** — a launch under `AOS_UID_ISOLATION` is refused and marked crashed rather than spawned with the gate unwired.

## Two trust gates that would otherwise kill every session

Same class as the Claude lane's `~/.claude.json` seed, both found in a dry run:
- `[projects."<dir>"] trust_level = "trusted"` — agent folders aren't git repos, so `codex exec` dies on *"Not inside a trusted directory"* and the TUI parks on a prompt.
- `--dangerously-bypass-hook-trust` — our `hooks.json` is regenerated every launch, so its hash legitimately changes; without this the gate would simply never run.

## Verification

- `npm run typecheck`, `npm run build`, `cd web && npm run build`, `npm run demo` — all clean
- `npm run test:governance` — **119/119**
- Generated `config.toml` re-parsed by the real binary under `--strict-config` (incl. Composio's `http_headers`)
- **Codex gate smoke test** against an isolated `AGENT_OS_HOME` — a Codex-shaped PreToolUse call reaches the gateway and comes back with a correct decision wire:

```
shell  ["bash","-lc","ls -la"]                      → allow
shell  ["bash","-lc","rm -rf / --no-preserve-root"] → deny     ← was allow before the enricher fix
read_file                                           → silent exit 0 (ungoverned, deferred to the CLI)
agentos__recall                                     → silent exit 0 (OS-owned, bypasses the gate)
```

Claude Code's path is behaviourally unchanged: same skills/sub-agent materialisation, same env vars, same launch script.

Docs: `docs/codex-runtime.md`. Pillar 1 + CLAUDE.md updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)