### PR TITLE
fix(codex): don't pre-mint a transcript id a runtime can't pin (v0.272.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.272.1] — 2026-07-28
+### Fixed
+- **Codex sessions stored a meaningless transcript id, breaking resume/fork.** `createSession` (and
+  `forkSession`) unconditionally pre-filled `claude_session_id` with a fresh `randomUUID()` — correct for
+  Claude Code, which PINS that id via `--session-id`, but wrong for Codex, which mints its own rollout
+  UUID. Because `recordRuntimeSessionId` is first-write-wins, the pre-filled random id then **rejected the
+  real id the launcher reported**, so the column held a UUID matching no transcript and a later
+  `codex exec resume <id>` / `codex fork <id>` would silently fall back to a fresh conversation. The id is
+  now only minted for a runtime with the `pinnedSessionId` capability; Codex leaves it NULL so the
+  launcher's report is the first write. Caught on the live box on the first real Codex run (stored
+  `712b2de7-…` vs the actual rollout `019fa7a4-…`).
+
 ## [0.272.0] — 2026-07-28
 ### Added
 - **A second coding runtime: OpenAI Codex.** An agent manifest can now declare `"runtime": "codex"`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.272.0",
+  "version": "0.272.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.272.0",
+      "version": "0.272.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.272.0",
+  "version": "0.272.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1434,10 +1434,17 @@ export class TerminalManager {
   createSession(agent: string, title: string, task: string, spawnedBy?: string, headless = false, slack?: { channel: string; threadTs: string }, discord?: { channel: string; messageId: string }, runAs?: string, resumeClaudeId?: string, resident = false, tuning?: RuntimeTuning, clickup?: { taskId: string; commentId: string }): Session {
     const id = newId('session');
     const tmux = `aos-${id}`;
-    // The claude conversation this run drives. A fresh run mints a new id (pinned via `--session-id`);
-    // a thread follow-up passes the PRIOR run's id so the launcher `--resume`s the same transcript and
-    // keeps context. Persisted on the row so a later follow-up can look it up (see sessionForSlackThread).
-    const claudeSessionId = resumeClaudeId || randomUUID();
+    // The conversation this run drives. A thread follow-up passes the PRIOR run's id so the launcher
+    // resumes the same transcript and keeps context. Persisted on the row so a later follow-up can look
+    // it up (see sessionForSlackThread).
+    //
+    // For a fresh run we may only MINT the id when the runtime lets us PIN it (`claude --session-id`).
+    // Codex mints its own rollout UUID and has no such flag, so pre-filling the column here would store
+    // a random id that matches no real transcript — and, because `recordRuntimeSessionId` is
+    // first-write-wins, it would then REJECT the real id the launcher reports, silently breaking
+    // resume/fork for every Codex run. Leave it NULL and let the launcher's report be the first write.
+    const runtimeOf = this.os.agents.get(agent)?.runtime;
+    const claudeSessionId = resumeClaudeId || (runtimeSupports(runtimeOf, 'pinnedSessionId') ? randomUUID() : null);
     // P2 — provenance vs identity:
     //   `spawnedBy`     = what TRIGGERED this run (an `automation:<id>` or the console member). Stays
     //                     provenance: drives the inbox source label, the audit principal, isolation
@@ -1521,8 +1528,11 @@ export class TerminalManager {
     const id = newId('session');
     const tmux = `aos-${id}`;
     // The fork's OWN new conversation id (distinct from the parent's) — `--fork-session --session-id`
-    // copies the parent history into it, leaving the parent's transcript intact.
-    const claudeSessionId = randomUUID();
+    // copies the parent history into it, leaving the parent's transcript intact. Only mint it when the
+    // runtime lets us pin it: `codex fork <parent>` mints the branch's id ITSELF, so pre-filling the
+    // column would store an id matching no transcript AND block the launcher's real report (see the
+    // same trap in createSession).
+    const claudeSessionId = runtimeSupports(manifest.runtime, 'pinnedSessionId') ? randomUUID() : null;
     // Inherit the branch identity (connectors/Composio/uid follow run_as); fall back to the forker when
     // the parent had none. Provenance (`spawned_by`) is the forking member — this fork was console-driven.
     const actingMember = src.run_as ?? (by || undefined);
@@ -1553,7 +1563,10 @@ export class TerminalManager {
   private launchAgentRuntime(o: {
     id: string; agent: string; task: string; secret: string;
     actingMember?: string; spawnedBy?: string; hasSlack: boolean; hasDiscord: boolean; hasClickup: boolean;
-    headless: boolean; resident: boolean; resume: boolean; claudeSessionId: string;
+    headless: boolean; resident: boolean; resume: boolean;
+    /** The transcript id to pin. NULL for a runtime that mints its own (Codex) — the launcher
+     *  discovers it and reports it back via /api/runtime-session instead. */
+    claudeSessionId: string | null;
     // Per-launch tuning override (highest priority over the agent manifest + workspace default) — e.g. a
     // delegated task pinning the model/effort of its dispatched session. Undefined → resolve as before.
     tuning?: RuntimeTuning;
@@ -1614,7 +1627,7 @@ export class TerminalManager {
       // A stable claude session id we choose (vs letting claude mint its own), so a stopped session can be
       // resumed in-place with `claude --resume <id>`. `resume` continues that transcript (a thread
       // follow-up or a console reconnect) instead of starting fresh.
-      env.CLAUDE_SESSION_ID = o.claudeSessionId;
+      if (o.claudeSessionId) env.CLAUDE_SESSION_ID = o.claudeSessionId;
     } else {
       // Codex mints its OWN rollout id, so there is nothing to pin: the launcher discovers it from the
       // per-session CODEX_HOME and POSTs it to /api/runtime-session. On a resume we hand back whatever


### PR DESCRIPTION
Follow-up to #478, found on the **first real Codex run on the live box**.

`createSession` (and `forkSession`) unconditionally pre-filled `claude_session_id` with a fresh `randomUUID()`. That's correct for Claude Code — which *pins* the id via `--session-id` — but wrong for Codex, which mints its own rollout UUID and has no such flag.

Because `recordRuntimeSessionId` is first-write-wins, the pre-filled random id then **rejected the real id the launcher reported**. The row ended up holding a UUID matching no transcript, so a later `codex exec resume <id>` / `codex fork <id>` would silently fall back to a fresh conversation.

Observed on session `aos-ses_9f3f620451489837`:

```
stored in DB:    712b2de7-0601-4313-bbf4-96f3f9f222ca   ← random, meaningless
real rollout:    019fa7a4-4fc6-76a2-93d2-e3bcefe5ca2d   ← from the session's CODEX_HOME
```

**Fix:** mint the id only for a runtime with the `pinnedSessionId` capability. Codex leaves it NULL so the launcher's report is the first write. Same guard added to `forkSession`, which had the identical trap (`codex fork` mints the branch's id itself).

Verified in an isolated home:

```
codex  after create : NULL ✓
claude after create : pinned uuid ✓
codex  accepts report: yes ✓  -> stored ✓
codex  2nd report    : rejected ✓   (first-write-wins still holds)
claude rejects report: rejected ✓   (already pinned)
bad uuid rejected    : rejected ✓
```

`npm run test:governance` 119/119; typecheck + build clean. Claude Code's behaviour is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)