### PR TITLE
fix(codex): refuse to start unauthenticated instead of showing a login menu (v0.272.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.272.2] — 2026-07-28
+### Fixed
+- **A Codex session with no credentials dropped into an interactive login menu inside the agent pane.**
+  Codex's fallback when it finds no auth is a "Sign in with ChatGPT" picker that waits on a keypress —
+  harmful in both lanes. Unattended, nobody is there to answer, so the run parked forever (the same
+  permanent-hang class as the Claude lane's folder-trust dialog). Interactive, a human COULD complete it,
+  but `codex login` writes `auth.json` into whatever `$CODEX_HOME` is current — here the **per-session**
+  dir — so the credential was discarded with the session's files and the next run prompted again, making
+  it look like the login "didn't take". The launcher now **pre-flights auth and fails closed** with the
+  fix spelled out (`codex login` once, from a normal shell), exiting non-zero on an unattended run so
+  tmux drops the pane and the pile-up guard releases, and holding the pane — never dropping to an
+  ungoverned shell — on an interactive one. An injected `OPENAI_API_KEY` satisfies the check too
+  (API-key mode needs no `auth.json`).
+
 ## [0.272.1] — 2026-07-28
 ### Fixed
 - **Codex sessions stored a meaningless transcript id, breaking resume/fork.** `createSession` (and

--- a/docs/codex-runtime.md
+++ b/docs/codex-runtime.md
@@ -71,6 +71,13 @@ It writes, fresh on every launch:
 - **`auth.json`** — symlinked from the real `$CODEX_HOME` so a re-login/token refresh is picked up and
   no credential is duplicated to disk.
 
+**Authentication is a one-time, out-of-band step.** Run `codex login` **from a normal shell as the
+service user**, never inside an agent session: `$CODEX_HOME` is per-session, so a login performed in a
+pane is written to that session's scratch dir and thrown away with it. The launcher symlinks
+`$REAL_CODEX_HOME/auth.json` (default `~/.codex/auth.json`) into each session, so one login covers the
+whole fleet. If neither that file nor `OPENAI_API_KEY` is present the launcher **refuses to start** and
+prints the fix — it will not let Codex's interactive sign-in menu appear inside an agent session.
+
 Two trust gates have to be pre-accepted or every session hangs or dies — the same class of bug as the
 Claude lane's `~/.claude.json` seed:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.272.1",
+  "version": "0.272.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.272.1",
+      "version": "0.272.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.272.1",
+  "version": "0.272.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/terminal/codex-launch.sh
+++ b/terminal/codex-launch.sh
@@ -89,6 +89,45 @@ if [ -f "$REAL_CODEX_HOME/auth.json" ] && [ ! -e "$CODEX_HOME/auth.json" ]; then
   ln -s "$REAL_CODEX_HOME/auth.json" "$CODEX_HOME/auth.json" 2>/dev/null || true
 fi
 
+# PRE-FLIGHT: refuse to start unauthenticated. Codex's fallback when it finds no credentials is an
+# INTERACTIVE "Sign in with ChatGPT" menu that waits on a keypress, and that is harmful in both lanes:
+#   - unattended: nobody is at the pane, so the run parks on the menu forever — the same permanent-hang
+#     class as the Claude lane's folder-trust dialog (see CLAUDE.md).
+#   - interactive: a human CAN complete it, but `codex login` writes auth.json into whatever $CODEX_HOME
+#     is current — which here is the PER-SESSION dir. The credential is then thrown away with the
+#     session's files, the next run prompts again, and it looks like the login "didn't take". (Exactly
+#     what happened on the first live run: the login landed in session-<id>.codex/auth.json.)
+# So fail closed with the fix spelled out, and never let the login flow appear inside an agent session.
+# API-key mode needs no auth.json, so an injected OPENAI_API_KEY (shellSecret / assignment) counts.
+if [ ! -e "$CODEX_HOME/auth.json" ] && [ -z "${OPENAI_API_KEY:-}" ]; then
+  red "Codex is not authenticated — refusing to start."
+  echo
+  dim "Agent OS looked for credentials at:  $REAL_CODEX_HOME/auth.json"
+  dim "Fix it ONCE, from a normal shell as this user (NOT inside an agent session):"
+  echo
+  cyan "    codex login"
+  echo
+  dim "…then re-run this agent. Every session symlinks that file, so one login covers the fleet."
+  dim "Alternatively give this agent an OPENAI_API_KEY (Settings → Secrets) for usage-based billing."
+  dim "Do NOT run 'codex login' in here: \$CODEX_HOME is per-session, so the credential would be discarded."
+  echo
+  notify_ended_early() {
+    curl -s -X POST "$AOS_URL/api/ended" -H 'content-type: application/json' -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" \
+      -d "$(node -e 'console.log(JSON.stringify({session:process.argv[1]}))' "$SESSION")" >/dev/null 2>&1 || true
+  }
+  notify_ended_early
+  # Unattended runs must EXIT so tmux drops the pane and the pile-up guard releases. An interactive
+  # session holds the pane (so the operator can read this) but never drops to a shell — a raw tmux
+  # shell has no gate hook and no sandbox.
+  [ "${UNATTENDED:-}" = "1" ] && exit 1
+  while true; do
+    dim "Press [q] to close this tab."
+    key=""
+    IFS= read -rsn1 key || { sleep 5; continue; }
+    case "$key" in q|Q) exit 1 ;; *) : ;; esac
+  done
+fi
+
 # ── config.toml ───────────────────────────────────────────────────────────────────────────────────
 # Generated fresh each launch (so hook paths are always correct and portable across machines), from
 # the session's MCP JSON. Codex's schema is `[mcp_servers.<name>]` with command/args + a nested


### PR DESCRIPTION
Found by running a second Codex session on the live box, which greeted the operator with:

```
  Welcome to Codex, OpenAI's command-line coding agent
  Sign in with ChatGPT to use Codex as part of your paid plan
> 1. Sign in with ChatGPT   2. Sign in with Device Code   3. Provide your own API key
```

That menu should never appear inside an agent session. It's bad in both lanes:

- **Unattended** — nobody is at the pane, so the run parks on the picker forever. Same permanent-hang class as the Claude lane's folder-trust dialog (CLAUDE.md).
- **Interactive** — a human *can* complete it, but `codex login` writes `auth.json` into whatever `$CODEX_HOME` is current, which here is the **per-session** dir. The credential is discarded with the session's files and the next run prompts again, so the login looks like it "didn't take".

That second case is exactly what happened on the very first live Codex run: its login landed in `connectors/session-ses_9f3f620451489837.codex/auth.json` (a real ChatGPT token) instead of `~/.codex/auth.json` — which is *why* that run succeeded and every later one didn't.

**Fix:** pre-flight the credentials and fail closed with the remedy spelled out. Unattended exits non-zero so tmux drops the pane and the automations pile-up guard releases; interactive holds the pane so the operator can read the message, and never drops to a raw shell (no gate hook, no sandbox there). An injected `OPENAI_API_KEY` satisfies the check, since API-key mode needs no `auth.json`.

Verified:

```
A. no auth, UNATTENDED=1  → rc=1 immediately, message printed, no hang
B. auth present           → rc=0, config.toml generated, auth.json symlinked through
```

`npm run test:governance` 119/119. Docs updated with the "log in out-of-band, never in a pane" rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)