### PR TITLE
fix(codex): the gate was not running — wrong tool names + hook trust (v0.273.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.273.0] — 2026-07-28
+### Fixed
+- **Codex sessions were running UNGOVERNED — two independent silent failures.** Found by driving a real
+  Codex run on the live box and watching the audit stay empty while it executed `git status` and wrote to
+  `/tmp`.
+  1. **The tool→capability routing table used the wrong names.** Codex's PreToolUse actually reports
+     Claude Code's exact spellings — `Bash`, `apply_patch`, `mcp__<server>__<tool>` — not the
+     `shell`/`local_shell` names its internal protocol uses. The Codex-specific table keyed on `shell`
+     matched nothing, so every shell command fell through the allow-by-default arm. There is now ONE
+     routing table for all runtimes: a runtime whose names diverge fails loudly at the `*)` arm instead
+     of silently allowing.
+  2. **Hook trust.** Codex silently SKIPS a hook whose hash it hasn't recorded as trusted, and
+     `--dangerously-bypass-hook-trust` is ignored in TUI mode (openai/codex#24093) — so an interactive
+     Codex session ran with no PreToolUse hook at all. Every Codex run now uses `codex exec`, the one
+     lane where the gate provably fires. A Codex session is therefore not attachable; an ungoverned
+     interactive session would be a security hole, and we take the feature gap.
+  Also removed `[features] codex_hooks = true` from the generated config — there is no such key (the
+  flag is `hooks`, already stable and on), so it was silently ignored and implied hooks had been enabled.
+- **Codex `apply_patch` writes were mis-classified.** Codex carries the target path inside the patch
+  envelope (`*** Add File: …`) rather than a `file_path` field, so the enricher saw no path and fail-safed
+  `outsideWorkdir = true` for EVERY edit — safe, but it would have paused a human approval on every file
+  an agent writes. New `applyPatchTargets()` parses the `Add`/`Update`/`Delete File:` and `Move to:`
+  verbs, so in-folder edits pass and an escape (absolute path, `..`, or a move out of the workdir) is
+  still caught.
+
+### Changed
+- Codex capabilities corrected now that the gate is proven: `fileWriteGate` and `mcpGate` are **true**
+  (PreToolUse covers `apply_patch` and `mcp__*`), making the OS sandbox defence in depth rather than the
+  only line. `attachableUnattended`/`residentChat` stay false, now for the hook-trust reason above.
+
 ## [0.272.2] — 2026-07-28
 ### Fixed
 - **A Codex session with no credentials dropped into an interactive login menu inside the agent pane.**

--- a/docs/codex-runtime.md
+++ b/docs/codex-runtime.md
@@ -23,20 +23,35 @@ invariant is unchanged; only the mechanism differs.
 
 | Effect | Claude Code | Codex |
 | --- | --- | --- |
-| Shell (incl. all `curl`/`git`/`npm` egress) | PreToolUse hook → `/api/gate` | **same hook, same gate** |
-| File writes | PreToolUse hook (`Edit`/`Write`/…) | OS sandbox: `writable_roots` = the agent folder |
-| MCP / connectors | PreToolUse hook (`mcp__*`) | server-side at the loopback `/api/*` routes |
+| Shell | PreToolUse hook → `/api/gate` | **same hook, same gate** (`Bash`) |
+| File writes | PreToolUse hook | **same hook** (`apply_patch`) + OS sandbox as defence in depth |
+| MCP / connectors | PreToolUse hook | **same hook** (`mcp__<server>__<tool>`) |
 | The CLI's own prompts | `--dangerously-skip-permissions` | `approval_policy = "never"` |
 
-Notes:
+**Codex reports Claude's exact tool names.** Verified against 0.145: PreToolUse hands the hook
+`Bash`, `apply_patch` and `mcp__<server>__<tool>` — *not* the `shell` / `local_shell` names its internal
+protocol uses. So there is ONE routing table in `gate-hook.sh` for both runtimes. An earlier
+Codex-specific table keyed on `shell` matched nothing, and every shell command fell through the
+allow-by-default arm **ungoverned**; a single table makes that class of bug impossible, because a
+runtime whose names diverge fails loudly at the `*)` arm instead of silently allowing.
 
-- Codex applies most edits by piping `apply_patch` **through the shell tool**, so those are already
-  covered by the gate. The sandbox is the backstop for anything that isn't — and it is *structural*: a
-  write outside the agent folder is impossible at the OS level, not merely denied by policy.
-- `network_access` stays **true**. Egress driven from the shell is already gated, and cutting it would
-  break `git push` / `npm install` for every agent.
-- `approval_policy = "never"` removes Codex's *own* prompts (nobody is at the pane to answer them). It
-  does **not** touch our gate: the hook still runs and still blocks for inbox approval.
+**`apply_patch` carries its target inside the patch envelope**, not a `file_path` field:
+
+```
+*** Begin Patch
+*** Add File: demo.txt
++apple
+*** End Patch
+```
+
+`applyPatchTargets()` in `src/governance/enricher.ts` parses the four verbs (`Add`/`Update`/`Delete
+File:` and `Move to:`) so `outsideWorkdir` is computed correctly. Without it the enricher saw no path
+and fail-safed to "outside" for *every* edit — technically safe, but it would pause a human approval on
+every file an agent writes. `Move to:` counts as a target in its own right: moving a file OUT of the
+workdir is exactly the escape worth catching.
+
+`network_access` stays **true** — shell egress is already gated, and cutting it would break
+`git push` / `npm install` for every agent.
 
 ### One shared hook
 
@@ -78,6 +93,34 @@ pane is written to that session's scratch dir and thrown away with it. The launc
 whole fleet. If neither that file nor `OPENAI_API_KEY` is present the launcher **refuses to start** and
 prints the fix — it will not let Codex's interactive sign-in menu appear inside an agent session.
 
+## Hook trust — why Codex is `codex exec` only
+
+Codex will not run a hook whose hash it has not recorded as trusted. An untrusted hook is **silently
+skipped** — no warning, no error, the run just proceeds ungoverned. `--dangerously-bypass-hook-trust`
+lifts that, but only "for that invocation", and it is **ignored in TUI mode**
+([openai/codex#24093](https://github.com/openai/codex/issues/24093)).
+
+Both halves were verified locally:
+
+```
+codex exec WITHOUT --dangerously-bypass-hook-trust  → hook skipped   (trust is load-bearing)
+codex exec WITH    --dangerously-bypass-hook-trust  → hook fires on Bash / apply_patch / mcp__*
+```
+
+So **every** Codex run — console, automation, task, chat — goes down `codex exec`, the one lane where
+the gate provably runs. The cost is that a Codex session is not attachable or take-over-able
+(`attachableUnattended: false`, `residentChat: false`). That is a feature gap; an interactive session
+with no PreToolUse hook would be a security hole, and we take the gap.
+
+**Re-enabling the interactive TUI requires pre-seeding hook trust** — Codex stores it as a
+`trusted_hash` on the hook entry, but the hashing scheme is not documented and the docs say trust is
+recorded only through the interactive `/hooks` review. That is the blocker for attachable Codex
+sessions.
+
+> Do **not** write `[features] codex_hooks = true`. There is no such key — `codex features list` names
+> the flag `hooks`, and it is already stage=stable and enabled by default. The bogus key was silently
+> ignored and gave a false impression that hooks had been switched on.
+
 Two trust gates have to be pre-accepted or every session hangs or dies — the same class of bug as the
 Claude lane's `~/.claude.json` seed:
 
@@ -99,12 +142,12 @@ with `runtimeSupports(runtime, cap)`; use `isCodingRuntime(runtime)` for "is thi
 | --- | --- | --- | --- |
 | `pinnedSessionId` | ✅ | ❌ | Codex mints its own rollout UUID; no `--session-id` |
 | `resume` / `fork` | ✅ | ✅ | `codex resume <id>` / `codex fork <id>` |
-| `attachableUnattended` | ✅ | ❌ | unattended lane is `codex exec`, which exits at turn end |
+| `attachableUnattended` | ✅ | ❌ | exec-only lane, forced by hook trust — see above |
 | `residentChat` | ✅ | ❌ | needs a TUI that survives a turn |
 | `transcript` (cost, engaged time, chat timeline) | ✅ | ❌ | the parser only reads Claude's JSONL |
 | `nativeSkills` / `nativeSubagents` | ✅ | ❌ | `.claude/skills` + `.claude/agents` are Claude conventions |
 | `statusLine` / `permissionMode` | ✅ | ❌ | no equivalent |
-| `fileWriteGate` / `mcpGate` | ✅ | ❌ | contained by sandbox / server-side instead — see above |
+| `fileWriteGate` / `mcpGate` | ✅ | ✅ | PreToolUse covers `apply_patch` and `mcp__*` (verified) |
 | `steerOnAllow` | ✅ | ✅ | both support `additionalContext` |
 
 **Session ids.** Because Codex won't take a pinned id, `codex-launch.sh` watches its per-session

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.272.2",
+  "version": "0.273.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.272.2",
+      "version": "0.273.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.272.2",
+  "version": "0.273.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/enricher.ts
+++ b/src/governance/enricher.ts
@@ -226,6 +226,30 @@ export function commandText(v: unknown): string {
 }
 
 /**
+ * Paths targeted by a Codex `apply_patch` call. Codex does not pass a `file_path`; it hands the whole
+ * patch envelope in `command`:
+ *
+ *     *** Begin Patch
+ *     *** Add File: demo.txt
+ *     +apple
+ *     *** End Patch
+ *
+ * Without parsing it the enricher sees NO path and (correctly, but uselessly) fails safe to
+ * `outsideWorkdir = true` for every edit — which would pause a human approval on literally every file
+ * an agent writes, including ones inside its own folder. Extract the real targets instead, so an
+ * in-folder edit is allowed and an escape attempt is still caught.
+ *
+ * Handles the four envelope verbs. `Move to:` is the rename DESTINATION and is treated as a target in
+ * its own right — moving a file OUT of the workdir is exactly the escape we care about.
+ */
+export function applyPatchTargets(command: string): string[] {
+  const out: string[] = [];
+  for (const m of command.matchAll(/^\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+?)\s*$/gm)) out.push(m[1]);
+  for (const m of command.matchAll(/^\*\*\*\s+Move\s+to:\s*(.+?)\s*$/gm)) out.push(m[1]);
+  return out;
+}
+
+/**
  * Compute governance facts and return a NEW args object (original + facts). Pure; no I/O.
  * `args` is what the gate received: `{ tool?, input?, command?, ...callerFacts }`.
  * `orgDomains` are the workspace's internal email domains (lowercased, no `@`) — passed in by the
@@ -283,13 +307,20 @@ export function enrichArgs(
   // (opaque write needs a human). Left undefined when it's not a file write or no workdir was provided.
   let outsideWorkdir = typeof args.outsideWorkdir === 'boolean' ? (args.outsideWorkdir as boolean) : undefined;
   if (outsideWorkdir === undefined && isFileWrite && workdir) {
+    const escapes = (t: string): boolean => {
+      const rel = path.relative(workdir, path.resolve(workdir, t));
+      return rel !== '' && (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel));
+    };
     const target = typeof input.file_path === 'string' ? input.file_path
       : typeof input.notebook_path === 'string' ? input.notebook_path : '';
-    if (!target) {
-      outsideWorkdir = true;
+    // Codex's apply_patch carries its targets inside the patch envelope rather than a path field.
+    const patched = !target && typeof input.command === 'string' ? applyPatchTargets(input.command) : [];
+    if (target) {
+      outsideWorkdir = escapes(target);
+    } else if (patched.length) {
+      outsideWorkdir = patched.some(escapes);   // one escaping target taints the whole patch
     } else {
-      const rel = path.relative(workdir, path.resolve(workdir, target));
-      outsideWorkdir = rel !== '' && (rel === '..' || rel.startsWith(`..${path.sep}`) || path.isAbsolute(rel));
+      outsideWorkdir = true;                    // no path we can see → opaque write needs a human
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1133,13 +1133,18 @@ export const CODING_RUNTIMES: Readonly<Record<CodingRuntimeId, CodingRuntimeSpec
       // Codex mints its own rollout id (`codex exec resume <id>` / `codex fork <id>`), so the id is
       // captured after launch rather than pinned. The unattended lane is `codex exec`, which exits at
       // turn end — no Stop hook needed, but also nothing to attach to, which rules out resident chat.
-      pinnedSessionId: false, resume: true, fork: true, attachableUnattended: false,
-      residentChat: false, transcript: false, nativeSkills: false, nativeSubagents: false,
+      pinnedSessionId: false, resume: true, fork: true,
+      // Every Codex run uses `codex exec`. Not a preference: Codex silently SKIPS a hook whose hash it
+      // hasn't recorded as trusted, and `--dangerously-bypass-hook-trust` is ignored in TUI mode
+      // (openai/codex#24093) — so an interactive Codex session would run with no gate at all. Until hook
+      // trust can be pre-seeded we take the feature gap over the security hole. See docs/codex-runtime.md.
+      attachableUnattended: false, residentChat: false,
+      transcript: false, nativeSkills: false, nativeSubagents: false,
       statusLine: false, permissionMode: false,
-      // PreToolUse reliably sees the `shell` tool; `apply_patch` writes are confined instead by the
-      // sandbox's `writable_roots`, and MCP calls are governed server-side at the loopback API every
-      // OS tool already goes through. See the RuntimeCapabilities note on mechanism vs. invariant.
-      fileWriteGate: false, mcpGate: false,
+      // PreToolUse covers Bash, apply_patch AND mcp__* — verified empirically against codex 0.145 (its
+      // hook reports Claude's exact tool names). So the gate, not just the sandbox, governs writes and
+      // connector calls; the sandbox's `writable_roots` is now defence in depth rather than the only line.
+      fileWriteGate: true, mcpGate: true,
       // Codex 0.145's PreToolUse output wire matches Claude's: permissionDecision allow|deny|ask plus
       // `additionalContext` (verified against the JSON schema embedded in the binary), so the gate's
       // `instruct` verb carries over unchanged.

--- a/terminal/codex-launch.sh
+++ b/terminal/codex-launch.sh
@@ -154,9 +154,9 @@ node -e '
   // Egress via the shell IS governed (the hook sees every shell call), so the sandbox does not need
   // to cut the network — doing so would break git push / npm install for every agent.
   out.push("network_access = true");
-  out.push("");
-  out.push("[features]");
-  out.push("codex_hooks = true");
+  // NOTE: do NOT write `[features] codex_hooks = true`. There is no such key — `codex features list`
+  // names the flag `hooks`, and it is already stage=stable/enabled by default, so the bogus key was
+  // silently ignored and gave a false sense that hooks had been switched on.
   // Pre-accept the workspace-TRUST gate for this agent folder — the exact analogue of the
   // `~/.claude.json` hasTrustDialogAccepted seed on the Claude lane, and the same failure mode if
   // missing: agent folders are freshly created and are NOT git repos, so without this `codex exec`
@@ -301,68 +301,30 @@ COMMON_ARGS=(--dangerously-bypass-hook-trust -C "$AGENT_DIR")
 # lives in a separate array. Belt-and-braces with the `[projects.…] trust_level` seed above.
 EXEC_ARGS=("${COMMON_ARGS[@]}" --skip-git-repo-check)
 
-if [ "${UNATTENDED:-}" = "1" ]; then
-  # UNATTENDED lane — `codex exec`, which runs the turn and EXITS. Teardown is therefore by process
-  # exit (like the pre-attachable `claude -p` lane), not by a server-driven Stop hook: notify_ended
-  # below flips the row idle and releases the automations pile-up guard. Consequence, recorded in the
-  # capability matrix as attachableUnattended:false — there is no live TUI to "take over" mid-run.
-  dim "unattended run — codex exec (gate hook governs every shell call). Exits at turn end."
-  echo
-  if [ "${RESUME:-}" = "1" ] && [ -n "${RUNTIME_SESSION_ID:-}" ]; then
-    notify_resumed
-    codex exec resume "$RUNTIME_SESSION_ID" "${EXEC_ARGS[@]}" ${TASK:+"$TASK"} \
-      || codex exec "${EXEC_ARGS[@]}" "$TASK"
-  elif [ -n "${FORK_FROM:-}" ]; then
-    codex exec resume "$FORK_FROM" "${EXEC_ARGS[@]}" ${TASK:+"$TASK"} \
-      || codex exec "${EXEC_ARGS[@]}" "$TASK"
-  else
-    codex exec "${EXEC_ARGS[@]}" "$TASK"
-  fi
-  notify_ended
-  exit 0
-fi
-
-# INTERACTIVE lane — the attachable TUI a member drives from the browser terminal.
+# ── launch ────────────────────────────────────────────────────────────────────────────────────────
+# EXEC-ONLY, ON PURPOSE. Codex will not run a hook whose hash it has not recorded as trusted — an
+# untrusted hook is SILENTLY SKIPPED (no warning, no error), and `--dangerously-bypass-hook-trust` is
+# documented as applying only "for that invocation". Critically, that flag is IGNORED IN TUI MODE
+# (openai/codex#24093), so an interactive `codex` session runs with NO PreToolUse hook at all — i.e.
+# completely ungoverned. We proved both halves locally: exec WITHOUT the flag → hook skipped; exec WITH
+# it → hook fires on Bash/apply_patch/mcp__*.
+#
+# So every Codex run — console, automation, task, chat — goes down `codex exec`, the one lane where the
+# gate provably runs. The cost is that a Codex session is not attachable/take-over-able (already
+# declared as attachableUnattended:false + residentChat:false in the capability matrix). That is a
+# feature gap; an ungoverned interactive session would be a security hole, and we take the gap.
+# Re-enabling the TUI requires pre-seeding hook trust — tracked in docs/codex-runtime.md.
+dim "codex exec — the gate hook governs every Bash / apply_patch / MCP call. Exits at turn end."
+echo
 if [ "${RESUME:-}" = "1" ] && [ -n "${RUNTIME_SESSION_ID:-}" ]; then
   notify_resumed
-  dim "resuming codex session $RUNTIME_SESSION_ID …"
-  echo
-  # A browser reattach must NOT re-seed $TASK (it is already in the transcript); a server-driven
-  # follow-up spawns a fresh pane with no ENV_FILE and a genuinely new $TASK, so it does seed.
-  if [ -n "${RESUMED_FROM_ENV:-}" ]; then
-    codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
-  else
-    codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" ${TASK:+"$TASK"} || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
-  fi
+  codex exec resume "$RUNTIME_SESSION_ID" "${EXEC_ARGS[@]}" ${TASK:+"$TASK"} \
+    || codex exec "${EXEC_ARGS[@]}" "$TASK"
 elif [ -n "${FORK_FROM:-}" ]; then
-  dim "forking codex session $FORK_FROM …"
-  echo
-  codex fork "$FORK_FROM" "${COMMON_ARGS[@]}" ${TASK:+"$TASK"} || codex "${COMMON_ARGS[@]}" "$TASK"
+  codex exec resume "$FORK_FROM" "${EXEC_ARGS[@]}" ${TASK:+"$TASK"} \
+    || codex exec "${EXEC_ARGS[@]}" "$TASK"
 else
-  codex "${COMMON_ARGS[@]}" "$TASK"
+  codex exec "${EXEC_ARGS[@]}" "$TASK"
 fi
 notify_ended
-
-# SECURITY: do NOT drop to a raw shell when codex exits. A tmux shell has NO PreToolUse gate hook and
-# NO sandbox, so `exec bash` here would hand whoever is attached full, ungoverned access as the app
-# user — reading ~/.ssh, the workspace DB, every tenant's data, the network. Keep the pane alive (so
-# ttyd doesn't loop "Reconnecting") with a no-shell holding prompt that can ONLY re-open codex.
-echo
-while true; do
-  dim "codex session ended — press [r] to resume, [q] to close the tab."
-  key=""
-  IFS= read -rsn1 key || { sleep 2; continue; }   # blocked read is fine; EOF/detached → idle, no spin
-  case "$key" in
-    r|R)
-      notify_resumed
-      if [ -n "${RUNTIME_SESSION_ID:-}" ]; then
-        codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
-      else
-        codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
-      fi
-      notify_ended
-      ;;
-    q|Q) exit 0 ;;
-    *) : ;;   # ignore any other key — never spawn a shell
-  esac
-done
+exit 0

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -72,39 +72,28 @@ esac
 # Route the tool to an Agent OS capability (structural — the only thing the hook still decides). All
 # riskiness/destructiveness classification now happens server-side in the enricher + policy.
 #
-# The routing table is per-runtime because each CLI names its tools differently; everything BELOW this
-# block (the fail-closed gate call, the approval wait, the decision wire) is deliberately shared, so a
-# governance fix can't land for one runtime and miss the other.
-case "${AOS_RUNTIME:-claude-code}" in
-  codex)
-    # Codex tool inventory. `shell` is the exec tool (its aliases are matched too, defensively).
-    # NOTE: Codex applies most edits by piping `apply_patch` THROUGH the shell tool, so those already
-    # arrive here as shell.exec; the explicit apply_patch arm covers the native-tool spelling. Writes
-    # that dodge the hook entirely are still contained by the sandbox's `writable_roots` (set to the
-    # agent folder in codex-launch.sh) — see the RuntimeCapabilities note in src/types.ts.
-    case "$TOOL" in
-      shell|local_shell|exec_command|unified_exec) CAP="shell.exec" ;;
-      apply_patch) CAP="file.write" ;;
-      *INITIATE_CONNECTION*) CAP="connector.connect" ;;
-      mcp__*|*composio*) CAP="connector.call" ;;
-      *) exit 0 ;;  # read_file / update_plan / web_search / … aren't world side effects → allow
-    esac ;;
-  *)
-    case "$TOOL" in
-      Bash) CAP="shell.exec" ;;
-      # File writes go through the gateway too (the enricher decides inside-vs-outside the agent's folder
-      # from the path in tool_input). The hook stays dumb transport — it only names the capability.
-      Edit|Write|MultiEdit|NotebookEdit) CAP="file.write" ;;
-      mcp__composio-company__*INITIATE_CONNECTION*)
-        # INITIATE_CONNECTION starts an OAuth grant that gives the whole fleet access to an app — the actual
-        # privilege-bearing op, so it's an owner/admin call (connector.connect).
-        CAP="connector.connect" ;;
-      # MANAGE_CONNECTIONS is a management/STATUS tool — in practice agents call it to LIST/check connections
-      # (`{toolkits:["gmail"]}`), a benign read that was needlessly owner-gated. Route it to connector.call
-      # (allowed) like any other connector tool; a real grant goes through INITIATE_CONNECTION above.
-      mcp__*) CAP="connector.call" ;;
-      *) exit 0 ;;  # any other built-in tool (Read/Glob/Grep/…) isn't a world side effect → allow
-    esac ;;
+# ONE table for every runtime, because the tool names are the SAME. Verified empirically against codex
+# 0.145: its PreToolUse emits `Bash`, `apply_patch` and `mcp__<server>__<tool>` — Claude Code's exact
+# spellings, not the `shell`/`local_shell` names its internal protocol uses. An earlier codex-specific
+# table keyed on `shell` therefore matched NOTHING and every shell command fell through to the
+# allow-by-default arm, ungoverned. Keeping one table makes that class of bug impossible: a runtime whose
+# names diverge fails loudly at the `*)` arm rather than silently allowing.
+case "$TOOL" in
+  Bash|shell|local_shell|exec_command|unified_exec) CAP="shell.exec" ;;
+  # File writes go through the gateway too (the enricher decides inside-vs-outside the agent's folder
+  # from the path in tool_input). The hook stays dumb transport — it only names the capability.
+  # `apply_patch` is Codex's editor tool and DOES fire PreToolUse (verified), so writes are gated there
+  # as well as contained by the sandbox.
+  Edit|Write|MultiEdit|NotebookEdit|apply_patch) CAP="file.write" ;;
+  mcp__composio-company__*INITIATE_CONNECTION*|*INITIATE_CONNECTION*)
+    # INITIATE_CONNECTION starts an OAuth grant that gives the whole fleet access to an app — the actual
+    # privilege-bearing op, so it's an owner/admin call (connector.connect).
+    CAP="connector.connect" ;;
+  # MANAGE_CONNECTIONS is a management/STATUS tool — in practice agents call it to LIST/check connections
+  # (`{toolkits:["gmail"]}`), a benign read that was needlessly owner-gated. Route it to connector.call
+  # (allowed) like any other connector tool; a real grant goes through INITIATE_CONNECTION above.
+  mcp__*) CAP="connector.call" ;;
+  *) exit 0 ;;  # any other built-in tool (Read/Glob/Grep/…) isn't a world side effect → allow
 esac
 
 payload=$(node -e 'const[s,a,cap,t,inp,st,si]=process.argv.slice(1);let input={};try{input=JSON.parse(inp||"{}")}catch(e){};const o={sessionId:s,agent:a,capability:cap,args:{tool:t,input},reasoning:(process.env.AOS_RUNTIME||"claude-code")+" PreToolUse: "+t};if(st){o.subagentType=st;if(si)o.subagentId=si;}console.log(JSON.stringify(o))' "$SESSION" "$AGENT" "$CAP" "$TOOL" "$INPUT" "$SUBTYPE" "$SUBID")


### PR DESCRIPTION
**Codex sessions were running ungoverned.** Found by doing what I said I'd do — driving a real Codex run on the live box with a shell-forcing prompt and watching the audit trail.

The agent happily ran `git status` and `echo hello > /tmp/aos-codex-probe.txt`. Audit events: **6, all from launch. Zero policy decisions.** Two independent silent failures, either of which alone defeats the gate:

### 1. The routing table used the wrong tool names

Codex's PreToolUse reports **Claude Code's exact spellings** — `Bash`, `apply_patch`, `mcp__<server>__<tool>` — not the `shell` / `local_shell` names that appear in its internal protocol (and that the third-party write-ups describe). My Codex-specific table keyed on `shell`, matched nothing, and every command fell through the allow-by-default arm.

Fixed by collapsing to **one routing table for all runtimes**, since the names are identical. That also makes the bug class impossible: a runtime whose names diverge now fails loudly at the `*)` arm instead of silently allowing.

### 2. Hook trust

Codex **silently skips** a hook whose hash it hasn't recorded as trusted — no warning, no error. `--dangerously-bypass-hook-trust` lifts that, but only per-invocation, and it is **ignored in TUI mode** ([openai/codex#24093](https://github.com/openai/codex/issues/24093)).

```
codex exec WITHOUT the flag  → hook skipped   (trust is load-bearing)
codex exec WITH    the flag  → fires on Bash / apply_patch / mcp__*
interactive TUI              → flag ignored, no hook at all
```

So every Codex run now goes down `codex exec`. **Codex sessions are no longer attachable** — a real feature loss, taken deliberately over an ungoverned interactive session. Re-enabling the TUI needs pre-seeded `trusted_hash`, which is undocumented; that's now the tracked blocker for attachable Codex.

Also removed `[features] codex_hooks = true` — **there is no such key.** `codex features list` names the flag `hooks`, already stable and enabled. The bogus key was silently ignored while implying hooks had been switched on.

### 3. `apply_patch` targets

Codex carries the path inside the patch envelope, not a `file_path` field:

```
*** Begin Patch
*** Add File: demo.txt
+apple
*** End Patch
```

The enricher saw no path and fail-safed `outsideWorkdir = true` for **every** edit — safe, but it would have paused a human approval on every file an agent writes. `applyPatchTargets()` parses `Add`/`Update`/`Delete File:` and `Move to:` (a move out of the workdir is exactly the escape worth catching).

```
add inside      -> outside=false      update OUTSIDE -> outside=true
update inside   -> outside=false      escape via ..  -> outside=true
                                      move OUT       -> outside=true
                                      mixed in+out   -> outside=true
                                      opaque         -> outside=true
```

### Verification

Gate matrix through the real hook against an isolated server, using the **real payload shapes**:

```
Bash  ls               -> allow      mcp__probe__ping     -> allow
Bash  rm -rf /         -> deny       mcp__agentos__recall -> (ungated, OS-owned)
apply_patch in folder  -> allow      Read                 -> (ungated)
```

Tool names and MCP coverage confirmed by running real `codex exec` turns and capturing what the hook actually receives. `npm run test:governance` 119/119.

`fileWriteGate` / `mcpGate` flip to **true** — PreToolUse does cover `apply_patch` and `mcp__*`, so the OS sandbox becomes defence in depth rather than the only line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)