### PR TITLE
feat(codex): read Codex transcripts — cost, engaged time, chat timeline (v0.275.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.275.0] — 2026-07-28
+### Added
+- **Codex transcript reader — cost, engaged time and the chat timeline now work for Codex runs**
+  (`src/edge/codex-transcript.ts`). Codex sessions previously showed `cost_usd`/`activeMs`/`turns` as
+  null and an empty conversation view, because the readers only understood Claude Code's JSONL. Four
+  things differ and each was a trap: the rollout lives in the run's OWN `$CODEX_HOME` (not a global
+  projects tree); records are `{timestamp, type, payload}` with the interesting variants nested under
+  `payload.type`; **`token_count` is CUMULATIVE**, so the last one is taken rather than summed (summing
+  would multiply the bill by the turn count); and `input_tokens` INCLUDES the cached portion, so uncached
+  input is `input_tokens - cached_input_tokens`. `TerminalManager` gained `sessionConversation()` and an
+  internal cost dispatcher, so the sweep and all three `/conversation` routes are runtime-agnostic.
+  The `transcript` capability flips to true.
+
 ## [0.274.0] — 2026-07-28
 ### Added
 - **Runtime picker on the agent config card.** An agent's runtime was manifest-only — you had to hand-edit

--- a/docs/codex-runtime.md
+++ b/docs/codex-runtime.md
@@ -133,6 +133,33 @@ Claude lane's `~/.claude.json` seed:
 
 ---
 
+
+## Reading a Codex transcript
+
+`src/edge/codex-transcript.ts` is the Codex half of `conversation.ts` + `session-cost.ts`. Four things
+differ from Claude Code, and each one is a trap if assumed away:
+
+- **Location.** Claude's transcripts sit in a global `~/.claude/projects/<cwd>/<id>.jsonl`, findable by
+  filename. Codex writes `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`, and every run has
+  its OWN `$CODEX_HOME` — so the reader walks that one session dir.
+- **Shape.** One record per line: `{timestamp, type, payload}`, with the interesting variants nested
+  under `payload.type` (`event_msg` → `user_message` / `agent_message` / `token_count` / `task_complete`;
+  `response_item` → `message` / `custom_tool_call` / `custom_tool_call_output`).
+- **Usage is CUMULATIVE.** Claude reports per-request usage that we sum; Codex's `token_count` carries a
+  running `total_token_usage` for the whole session. Take the LAST one — summing would multiply the bill
+  by the number of turns.
+- **`input_tokens` includes the cached portion**, where Anthropic reports them separately. Uncached input
+  is `input_tokens - cached_input_tokens`, which is what the input rate applies to.
+
+The timeline is built from `event_msg`, not `response_item`: the response items also carry the
+developer/system preamble Codex injects (permissions instructions, plugin lists), which is machinery
+rather than conversation and would swamp the view.
+
+One thing to expect: Codex often batches several shell commands into a single `exec` tool call that
+scripts `tools.exec_command` internally. So a run's `toolCalls` can read 1 while the gate recorded 3
+governed `Bash` effects. Both are right — they measure tool invocations and governed effects
+respectively.
+
 ## Capabilities and what degrades
 
 `CODING_RUNTIMES` in `src/types.ts` is the single declaration of what each runtime supports. Probe it
@@ -144,7 +171,7 @@ with `runtimeSupports(runtime, cap)`; use `isCodingRuntime(runtime)` for "is thi
 | `resume` / `fork` | ✅ | ✅ | `codex resume <id>` / `codex fork <id>` |
 | `attachableUnattended` | ✅ | ❌ | exec-only lane, forced by hook trust — see above |
 | `residentChat` | ✅ | ❌ | needs a TUI that survives a turn |
-| `transcript` (cost, engaged time, chat timeline) | ✅ | ❌ | the parser only reads Claude's JSONL |
+| `transcript` (cost, engaged time, chat timeline) | ✅ | ✅ | `src/edge/codex-transcript.ts` reads the rollout JSONL |
 | `nativeSkills` / `nativeSubagents` | ✅ | ❌ | `.claude/skills` + `.claude/agents` are Claude conventions |
 | `statusLine` / `permissionMode` | ✅ | ❌ | no equivalent |
 | `fileWriteGate` / `mcpGate` | ✅ | ✅ | PreToolUse covers `apply_patch` and `mcp__*` (verified) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.274.0",
+      "version": "0.275.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.274.0",
+  "version": "0.275.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/codex-transcript.ts
+++ b/src/edge/codex-transcript.ts
@@ -1,0 +1,201 @@
+// Reading a CODEX session's transcript — the Codex half of `conversation.ts` + `session-cost.ts`.
+//
+// Codex writes a JSONL "rollout" per session, but nothing else about it matches Claude Code:
+//
+//   - LOCATION. Claude's transcripts live in a global `~/.claude/projects/<cwd>/<id>.jsonl`, so
+//     `findTranscript` can search by filename alone. Codex writes into `$CODEX_HOME/sessions/YYYY/MM/DD/
+//     rollout-<ts>-<uuid>.jsonl`, and Agent OS gives every run its OWN `$CODEX_HOME` — so the file is
+//     found by walking that one session dir, and the id in the name is the id we captured at launch.
+//   - SHAPE. One record per line, `{timestamp, type, payload}`. `type` is `session_meta` |
+//     `turn_context` | `event_msg` | `response_item` | `world_state`, and the interesting variants are
+//     nested under `payload.type`.
+//   - USAGE IS CUMULATIVE. Claude reports per-request usage that we SUM; Codex's `token_count` carries a
+//     running `total_token_usage` for the whole session, so we take the LAST one and must NOT add them
+//     up (doing so would multiply the bill by the number of turns).
+//   - `input_tokens` INCLUDES the cached portion, where Anthropic reports them separately. Uncached
+//     input is therefore `input_tokens - cached_input_tokens`, which is what `SessionCost.inputTokens`
+//     means and what the input rate is applied to.
+//
+// Read-only and best-effort: an unreadable/absent rollout yields `null` (cost "not known yet") or an
+// empty conversation, exactly like the Claude path.
+import * as fs from 'fs';
+import * as path from 'path';
+import { Conversation, ChatTurn } from './conversation';
+import { SessionCost } from './session-cost';
+
+/** One line of a rollout file. */
+interface Rec {
+  timestamp?: string;
+  type?: string;
+  payload?: Record<string, unknown>;
+}
+
+/** Per-model sticker pricing, USD per 1M tokens, for the models Codex actually runs. Cached input is
+ *  billed at 0.1× input (OpenAI's cached-input discount). Unknown ids fall back to the GPT-5 tier
+ *  rather than 0, so an unrecognised model under-reports nothing. */
+const RATES: Array<[RegExp, { input: number; output: number }]> = [
+  [/gpt-5.*codex/i, { input: 1.25, output: 10 }],
+  [/gpt-5/i, { input: 1.25, output: 10 }],
+  [/o[34]/i, { input: 2, output: 8 }],
+];
+const FALLBACK = { input: 1.25, output: 10 };
+const rateFor = (model: string) => RATES.find(([re]) => re.test(model))?.[1] ?? FALLBACK;
+
+/** A gap longer than this between records is a human who walked away (or a run parked on an approval),
+ *  not work — excluded from engaged time. Mirrors the Claude reader's IDLE_GAP_MS. */
+const IDLE_GAP_MS = 5 * 60_000;
+
+/**
+ * The rollout file for a session, given the per-session `$CODEX_HOME` Agent OS created for it
+ * (`<connectors>/session-<id>.codex`). That dir holds exactly one session, so we take the newest
+ * rollout under it rather than matching the id — which also works for a resumed run, where Codex
+ * appends to the SAME file. Returns undefined before the run has written one.
+ */
+export function findCodexRollout(codexHome: string): string | undefined {
+  const root = path.join(codexHome, 'sessions');
+  const out: { file: string; mtime: number }[] = [];
+  const walk = (dir: string, depth: number): void => {
+    if (depth > 4) return;
+    let entries: fs.Dirent[];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) walk(full, depth + 1);
+      else if (e.name.startsWith('rollout-') && e.name.endsWith('.jsonl')) {
+        try { out.push({ file: full, mtime: fs.statSync(full).mtimeMs }); } catch { /* vanished */ }
+      }
+    }
+  };
+  walk(root, 0);
+  if (!out.length) return undefined;
+  out.sort((a, b) => b.mtime - a.mtime);
+  return out[0].file;
+}
+
+/** Parse a rollout into records, skipping anything malformed (a half-written last line is normal on a
+ *  live run). */
+function readRecords(file: string): Rec[] {
+  let raw: string;
+  try { raw = fs.readFileSync(file, 'utf8'); } catch { return []; }
+  const out: Rec[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try { out.push(JSON.parse(line) as Rec); } catch { /* skip */ }
+  }
+  return out;
+}
+
+const ts = (r: Rec): number => {
+  const t = Date.parse(r.timestamp ?? '');
+  return Number.isFinite(t) ? t : 0;
+};
+const sub = (r: Rec): string => String((r.payload as { type?: unknown } | undefined)?.type ?? '');
+
+/**
+ * Cost + shape for a Codex run. Same contract as `readSessionCost`, so callers can swap on runtime and
+ * everything downstream (the console, insights, episode salience) is unchanged.
+ */
+export function readCodexCost(file: string): SessionCost | null {
+  const recs = readRecords(file);
+  if (!recs.length) return null;
+
+  // Model: recorded on turn_context (and repeated per turn). Last one wins — a run can be resumed
+  // under a different model.
+  let model = '';
+  for (const r of recs) if (r.type === 'turn_context' && typeof r.payload?.model === 'string') model = r.payload.model as string;
+
+  // Usage: CUMULATIVE, so take the last token_count rather than summing (see the header note).
+  let input = 0, cached = 0, cacheWrite = 0, output = 0;
+  for (const r of recs) {
+    if (r.type !== 'event_msg' || sub(r) !== 'token_count') continue;
+    const total = (r.payload as { info?: { total_token_usage?: Record<string, number> } }).info?.total_token_usage;
+    if (!total) continue;
+    input = total.input_tokens ?? 0;
+    cached = total.cached_input_tokens ?? 0;
+    cacheWrite = total.cache_write_input_tokens ?? 0;
+    output = total.output_tokens ?? 0;
+  }
+  // `input_tokens` includes the cached portion; the input rate applies only to the uncached remainder.
+  const uncached = Math.max(0, input - cached);
+
+  const rate = rateFor(model);
+  const costUsd = (uncached * rate.input + output * rate.output + cached * rate.input * 0.1) / 1_000_000;
+
+  // Engaged time: sum the gaps between consecutive records, ignoring idle ones.
+  const stamps = recs.map(ts).filter((t) => t > 0).sort((a, b) => a - b);
+  let activeMs = 0;
+  for (let i = 1; i < stamps.length; i++) {
+    const gap = stamps[i] - stamps[i - 1];
+    if (gap > 0 && gap < IDLE_GAP_MS) activeMs += gap;
+  }
+
+  // Turns = real user prompts. Tool calls = the model's function/custom tool invocations.
+  const turns = recs.filter((r) => r.type === 'event_msg' && sub(r) === 'user_message').length;
+  const toolCalls = recs.filter((r) => r.type === 'response_item'
+    && ['custom_tool_call', 'function_call', 'local_shell_call'].includes(sub(r))).length;
+
+  return {
+    costUsd, inputTokens: uncached, outputTokens: output,
+    cacheReadTokens: cached, cacheWriteTokens: cacheWrite,
+    activeMs, turns, toolCalls,
+  };
+}
+
+/** Friendly label + detail for a Codex tool call, mirroring the Claude reader's activity cards. */
+function activityFor(name: string, input: string): { label: string; detail?: string } {
+  const first = (input || '').trim().split('\n')[0].slice(0, 120);
+  if (name === 'exec' || name === 'shell' || name === 'local_shell') return { label: 'Ran a command', detail: first };
+  if (name === 'apply_patch') {
+    const m = /\*\*\*\s+(?:Add|Update|Delete)\s+File:\s*(.+)/.exec(input || '');
+    return { label: 'Edited a file', detail: m ? m[1].trim() : undefined };
+  }
+  if (name.startsWith('mcp__')) {
+    const parts = name.split('__');
+    return { label: `Used ${parts[1] ?? 'a connector'}`, detail: parts[2] };
+  }
+  return { label: name.replace(/_/g, ' '), detail: first || undefined };
+}
+
+/**
+ * A NON-TECHNICAL timeline for a Codex run — the same `ChatTurn[]` the Claude reader produces, so the
+ * console's chat view renders both identically.
+ *
+ * Deliberately built from `event_msg` (`user_message` / `agent_message`) rather than `response_item`:
+ * the response items also carry the developer/system preamble Codex injects (permissions instructions,
+ * plugin lists), which is machinery, not conversation, and would swamp the view.
+ */
+export function readCodexConversation(file: string): Conversation {
+  const recs = readRecords(file);
+  if (!recs.length) return { turns: [], found: false };
+
+  const turns: ChatTurn[] = [];
+  // call_id → index of the activity turn, so its output can flip status to ok/error.
+  const pending = new Map<string, number>();
+
+  for (const r of recs) {
+    const at = ts(r);
+    if (r.type === 'event_msg') {
+      const p = r.payload as { type?: string; message?: string };
+      if (p.type === 'user_message' && p.message) turns.push({ kind: 'user', text: p.message, ts: at });
+      // `phase: "commentary"` is Codex thinking aloud mid-turn; keep it, it reads as progress.
+      else if (p.type === 'agent_message' && p.message) turns.push({ kind: 'assistant', text: p.message, ts: at });
+      continue;
+    }
+    if (r.type !== 'response_item') continue;
+    const p = r.payload as { type?: string; name?: string; input?: string; call_id?: string; output?: unknown };
+    if (p.type === 'custom_tool_call' || p.type === 'function_call' || p.type === 'local_shell_call') {
+      const { label, detail } = activityFor(String(p.name ?? ''), String(p.input ?? ''));
+      if (p.call_id) pending.set(p.call_id, turns.length);
+      turns.push({ kind: 'activity', tool: String(p.name ?? 'tool'), label, detail, status: 'running', ts: at });
+    } else if (p.type === 'custom_tool_call_output' || p.type === 'function_call_output') {
+      const idx = p.call_id ? pending.get(p.call_id) : undefined;
+      if (idx === undefined) continue;
+      const t = turns[idx];
+      if (t?.kind !== 'activity') continue;
+      const text = JSON.stringify(p.output ?? '');
+      t.status = /"?(error|failed|exception|traceback)"?/i.test(text) ? 'error' : 'ok';
+      pending.delete(p.call_id!);
+    }
+  }
+  return { turns, found: true };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,7 +17,7 @@ import { exampleCapabilities } from './capabilities/examples';
 import { evaluate } from './observability/evaluation';
 import { TerminalManager, AGENT_OS_OPERATING_NOTES, type ProposedAutomation } from './terminal';
 import { classifyActivity, clipText, ActivityCategory, ActivityEffect, ActivityTarget } from './state/session-activity';
-import { readConversation, type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from './edge/conversation';
+import { type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from './edge/conversation';
 import { summarizeConversation } from './edge/summarize';
 import { Automation, Automations, nextCronRun, derivedConcurrencyCap, chatTitle } from './edge/automations';
 import { chooseAgent } from './edge/router';
@@ -1037,8 +1037,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const target = tm.sessionsForAgent(agent).find((s) => s.id === id);
     if (!target) return sendJson(res, 403, { error: 'not one of your sessions' });
     const meta = { id: target.id, title: target.title, task: target.task, status: target.status, createdAt: target.createdAt, updatedAt: target.updatedAt, rating: target.rating };
-    const claudeId = tm.sessionClaudeId(id);
-    const convo = claudeId ? readConversation(claudeId) : { turns: [], found: false };
+    const convo = tm.sessionConversation(id);
     if (url.searchParams.get('summary') === '1') {
       const out = await summarizeConversation(convo);
       os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: 'session.summarized', data: { target: id, via: out.via, found: out.found } });
@@ -2600,8 +2599,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const agent = tm.sessionAgent(id);
     if (!agent) return sendJson(res, 404, { error: 'unknown session' });
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to view this session' });
-    const claudeId = tm.sessionClaudeId(id);
-    const convo = claudeId ? readConversation(claudeId) : { turns: [], found: false };
+    const convo = tm.sessionConversation(id);
     // Resolve the deliverables an activity produced (a Library artifact, a KB page, a hosted app) into
     // viewer-safe preview cards the chat UI renders inline — dropping anything the viewer may not see or
     // that no longer exists. The viewer already passed canViewSession, so their own run's outputs resolve;
@@ -2860,8 +2858,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const id = summarizeMatch[1];
     if (!tm.sessionAgent(id)) return sendJson(res, 404, { error: 'unknown session' });
     if (!tm.canViewSession(id, me)) return sendJson(res, 403, { error: 'not allowed to view this session' });
-    const claudeId = tm.sessionClaudeId(id);
-    const convo = claudeId ? readConversation(claudeId) : { turns: [], found: false };
+    const convo = tm.sessionConversation(id);
     const out = await summarizeConversation(convo);
     os.audit.append({ ts: Date.now(), runId: id, tenant: os.tenant, principal: me.email, type: 'session.summarized', data: { via: out.via, found: out.found } });
     return sendJson(res, 200, out);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -32,6 +32,8 @@ import { VendorError, retryableStatus, timedFetch, withRetry, vendorErrorInfo } 
 import { DEFAULT_VIDEO_COST_PER_SEC_USD, DEFAULT_VIDEO_DURATION_SEC, resolveVideoBackend, videoBackend, VideoBackend } from './edge/video-gen';
 import { understandMedia } from './edge/media-understand';
 import { readSessionCost } from './edge/session-cost';
+import { findCodexRollout, readCodexCost, readCodexConversation } from './edge/codex-transcript';
+import { readConversation, Conversation } from './edge/conversation';
 
 // Video render tuning: a submitted job renders async. The in-call path polls briefly for the fast case;
 // the tick poller finishes the rest, bounded by a TTL + a poll ceiling so a stuck render can't linger.
@@ -752,7 +754,7 @@ export class TerminalManager {
       budget--;
       let cost;
       try {
-        cost = readSessionCost(r.claude_session_id);
+        cost = this.readCostFor(r.id, r.agent, r.claude_session_id);
       } catch {
         continue;                                       // transcript unreadable — retry on a later poll
       }
@@ -1708,6 +1710,42 @@ export class TerminalManager {
    * It lives beside the other `session-<id>.*` artefacts, so `removeSessionFiles` — which is prefix
    * matched and recursive — already cleans it up when the session is deleted.
    */
+  /** The per-session `$CODEX_HOME` path WITHOUT creating it — for readers that only want to look. */
+  private codexHomePath(sessionId: string): string | undefined {
+    return this.os.paths ? path.join(this.os.paths.connectors, `session-${sessionId}.codex`) : undefined;
+  }
+
+  /**
+   * Cost + shape for a session, read from whichever transcript its runtime writes. Claude Code's lives
+   * in the global `~/.claude/projects` tree keyed by the pinned id; Codex's is a rollout inside the run's
+   * own `$CODEX_HOME`. One dispatcher so every caller (the sweep, the console, insights) stays runtime-
+   * agnostic. `null` = no transcript yet / unreadable, exactly as before.
+   */
+  private readCostFor(sessionId: string, agent: string, runtimeSessionId: string) {
+    if (this.os.agents.get(agent)?.runtime === 'codex') {
+      const home = this.codexHomePath(sessionId);
+      const file = home ? findCodexRollout(home) : undefined;
+      return file ? readCodexCost(file) : null;
+    }
+    return readSessionCost(runtimeSessionId);
+  }
+
+  /**
+   * The friendly chat timeline for a session, from whichever transcript its runtime writes. Returns the
+   * same `Conversation` shape for both, so the console renders them identically.
+   */
+  sessionConversation(sessionId: string): Conversation {
+    const row = this.db.prepare('SELECT agent, claude_session_id FROM term_sessions WHERE id = ?')
+      .get<{ agent: string; claude_session_id: string | null }>(sessionId);
+    if (!row) return { turns: [], found: false };
+    if (this.os.agents.get(row.agent)?.runtime === 'codex') {
+      const home = this.codexHomePath(sessionId);
+      const file = home ? findCodexRollout(home) : undefined;
+      return file ? readCodexConversation(file) : { turns: [], found: false };
+    }
+    return row.claude_session_id ? readConversation(row.claude_session_id) : { turns: [], found: false };
+  }
+
   private ensureCodexHome(sessionId: string): string {
     if (!this.os.paths) return '';
     const dir = path.join(this.os.paths.connectors, `session-${sessionId}.codex`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1152,7 +1152,9 @@ export const CODING_RUNTIMES: Readonly<Record<CodingRuntimeId, CodingRuntimeSpec
       // (openai/codex#24093) — so an interactive Codex session would run with no gate at all. Until hook
       // trust can be pre-seeded we take the feature gap over the security hole. See docs/codex-runtime.md.
       attachableUnattended: false, residentChat: false,
-      transcript: false, nativeSkills: false, nativeSubagents: false,
+      // Codex's rollout JSONL is parsed by src/edge/codex-transcript.ts, so cost / engaged time /
+      // turns / tool calls and the friendly chat timeline all work.
+      transcript: true, nativeSkills: false, nativeSubagents: false,
       statusLine: false, permissionMode: false,
       // PreToolUse covers Bash, apply_patch AND mcp__* — verified empirically against codex 0.145 (its
       // hook reports Claude's exact tool names). So the gate, not just the sandbox, governs writes and


### PR DESCRIPTION
Codex sessions showed `cost_usd` / `activeMs` / `turns` / `toolCalls` as **null** and an empty conversation view, because `conversation.ts` and `session-cost.ts` only understand Claude Code's JSONL. `src/edge/codex-transcript.ts` is the Codex half.

## Four differences, each a trap

- **Location.** Claude's transcripts sit in a global `~/.claude/projects/<cwd>/<id>.jsonl`, findable by filename alone. Codex writes `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl`, and every run has its **own** `$CODEX_HOME`.
- **Shape.** `{timestamp, type, payload}` per line, with the interesting variants nested under `payload.type`.
- **`token_count` is CUMULATIVE.** Claude reports per-request usage that we sum; Codex carries a running `total_token_usage` for the whole session. Take the **last** one — summing would multiply the bill by the number of turns.
- **`input_tokens` includes the cached portion**, where Anthropic reports them separately. Uncached input is `input_tokens - cached_input_tokens`, which is what the input rate applies to.

The timeline is built from `event_msg`, **not** `response_item` — the response items also carry the developer/system preamble Codex injects (permissions instructions, plugin lists, multi-agent notes), which is machinery rather than conversation and would swamp the view.

`TerminalManager` gained `sessionConversation()` plus an internal cost dispatcher, so the cost sweep and all three `/conversation` routes are runtime-agnostic rather than each branching on runtime.

## Verified against the real live rollout

From the governed run in #481:

```
cost:     $0.022116 · 11877 uncached in / 311 out / 33280 cached · 14.1s engaged · 1 turn · 1 tool call
timeline: user      Do these three things with the SHELL …
          assistant I'll run exactly those three shell commands, in order …
          activity  Ran a command [ok]
          assistant 1. `git status` failed: fatal: not a git repository …
```

**One thing to expect:** Codex often batches several shell commands into a single `exec` tool call that scripts `tools.exec_command` internally. So `toolCalls` can read 1 while the gate recorded 3 governed `Bash` effects. Both are right — they measure tool invocations and governed effects respectively. Documented.

`transcript` capability flips to true, so the agent config card stops listing "cost + timeline" as unsupported. typecheck + build + web build clean; `npm run test:governance` 119/119.

🤖 Generated with [Claude Code](https://claude.com/claude-code)