### PR TITLE
fix(codex): share the MCP OAuth store so remote connectors work (v0.276.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.276.1] — 2026-07-28
+### Fixed
+- **OAuth-backed MCP connectors could never work under Codex.** Codex keeps remote-MCP OAuth tokens in
+  `$CODEX_HOME/mcp_oauth.age`, and Agent OS points `$CODEX_HOME` at a throwaway per-session dir — so every
+  run started with an empty store, the server answered 401, and rmcp logged
+  `AuthRequired … token is null or empty` into the pane while that connector's tools silently went
+  missing. Same shape as the `auth.json` bug in 0.272.2, and equally invisible: the run still succeeds,
+  just without those tools. The launcher now symlinks the OAuth store back to the real `$CODEX_HOME`
+  alongside `auth.json`, and makes the link even when the target doesn't exist yet — writing through a
+  dangling symlink creates the real file, so a `codex mcp login` lands in the shared home instead of
+  being discarded with the session. Surfaced by a live DataForSEO connector that works under Claude Code
+  (which has its own persisted OAuth store) but 401'd under Codex.
+
 ## [0.277.0] — 2026-07-28
 ### Added
 - **Settings → Runtime → "Runtime accounts" panel.** The per-runtime credential pool (v0.276.0's

--- a/docs/codex-runtime.md
+++ b/docs/codex-runtime.md
@@ -86,7 +86,23 @@ It writes, fresh on every launch:
 - **`auth.json`** — symlinked from the real `$CODEX_HOME` so a re-login/token refresh is picked up and
   no credential is duplicated to disk.
 
-**Authentication is a one-time, out-of-band step.** Run `codex login` **from a normal shell as the
+**Remote (OAuth) MCP connectors need a one-time `codex mcp login`.** A connector registered as a
+hosted HTTP endpoint with no auth headers — e.g. DataForSEO — authenticates by OAuth, and Codex keeps
+those tokens in `$CODEX_HOME/mcp_oauth.age`. The launcher symlinks that store back to the real
+`$CODEX_HOME` (like `auth.json`), so a login done once is shared by every session; without the link
+every run starts with an empty store and rmcp logs
+`AuthRequired … token is null or empty` into the pane while that one connector's tools go missing.
+The login itself can't happen inside a session (`codex exec` is non-interactive), so do it once:
+
+```
+codex mcp add   dataforseo --url https://mcp.dataforseo.com/mcp   # so the name resolves
+codex mcp login dataforseo                                        # opens the browser once
+```
+
+Note this is per-CLI: Claude Code has its own OAuth store, so a connector working under Claude tells
+you nothing about whether Codex can reach it.
+
+**Account authentication is a one-time, out-of-band step.** Run `codex login` **from a normal shell as the
 service user**, never inside an agent session: `$CODEX_HOME` is per-session, so a login performed in a
 pane is written to that session's scratch dir and thrown away with it. The launcher symlinks
 `$REAL_CODEX_HOME/auth.json` (default `~/.codex/auth.json`) into each session, so one login covers the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.277.0",
+  "version": "0.276.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.277.0",
+      "version": "0.276.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.277.0",
+  "version": "0.276.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/terminal/codex-launch.sh
+++ b/terminal/codex-launch.sh
@@ -81,12 +81,24 @@ export CODEX_HOME="${AOS_CODEX_HOME:-$AGENT_DIR/.aos-codex}"
 mkdir -p "$CODEX_HOME"
 chmod 700 "$CODEX_HOME" 2>/dev/null || true
 
-# Auth: Codex reads auth.json from $CODEX_HOME, so link the real one in. Without this every session
-# would demand its own `codex login`. Symlink (not copy) so a re-login/token refresh is picked up and
-# no credential is duplicated onto disk.
+# Auth: Codex keeps its credentials in $CODEX_HOME, which we've just pointed at a throwaway per-session
+# dir — so every credential store has to be linked back to the REAL home or it dies with the session.
+#   • auth.json     — the account login (`codex login`).
+#   • mcp_oauth.age — OAuth tokens for REMOTE MCP servers (`codex mcp login <name>`). Without this an
+#     OAuth-backed connector can NEVER work under Codex: each run starts with an empty store, the server
+#     answers 401, and rmcp logs `AuthRequired … token is null or empty` into the pane. (Seen live with
+#     a DataForSEO connector that works fine under Claude Code, which has its own persisted OAuth store.)
+# Symlinks, not copies, so a re-login or a token refresh performed in ANY session is picked up by all of
+# them and no credential is duplicated onto disk. The OAuth link is made even when the target doesn't
+# exist yet: writing through a dangling symlink creates the real file, so a login lands in the shared
+# home rather than being thrown away with the session.
 REAL_CODEX_HOME="${AOS_REAL_CODEX_HOME:-$HOME/.codex}"
+mkdir -p "$REAL_CODEX_HOME" 2>/dev/null || true
 if [ -f "$REAL_CODEX_HOME/auth.json" ] && [ ! -e "$CODEX_HOME/auth.json" ]; then
   ln -s "$REAL_CODEX_HOME/auth.json" "$CODEX_HOME/auth.json" 2>/dev/null || true
+fi
+if [ ! -e "$CODEX_HOME/mcp_oauth.age" ]; then
+  ln -s "$REAL_CODEX_HOME/mcp_oauth.age" "$CODEX_HOME/mcp_oauth.age" 2>/dev/null || true
 fi
 
 # PRE-FLIGHT: refuse to start unauthenticated. Codex's fallback when it finds no credentials is an


### PR DESCRIPTION
From a live run that produced:

```
ERROR rmcp::transport::worker: worker quit with fatal: Transport channel closed, when
AuthRequired(... "token is null or empty" ... https://mcp.dataforseo.com/...)
```

**The run itself was fine** — two governed shell calls, both gated, session completed. But that connector's tools were silently unavailable.

## Cause

Codex keeps remote-MCP OAuth tokens in `$CODEX_HOME/mcp_oauth.age`. Agent OS points `$CODEX_HOME` at a **throwaway per-session dir**, so every run began with an empty store → 401 → rmcp bails.

This is the same shape as the `auth.json` bug fixed in 0.272.2, and just as invisible: nothing fails loudly, the agent simply can't see those tools.

Worth noting the connector row has **empty headers** and works fine under Claude Code — because Claude has its own persisted OAuth store. So "it works under Claude" told us nothing about Codex, and the connector wasn't misconfigured.

## Fix

Symlink `mcp_oauth.age` back to the real `$CODEX_HOME` alongside `auth.json`. The link is made **even when the target doesn't exist yet** — writing through a dangling symlink creates the real file, so a login lands in the shared home instead of being discarded with the session.

```
auth.json     -> <real>/auth.json
mcp_oauth.age -> <real>/mcp_oauth.age
write-through creates the real file: yes ✓
```

## Operator step (documented)

OAuth can't be completed inside a session (`codex exec` is non-interactive), so it's one-time and out-of-band:

```
codex mcp add   dataforseo --url https://mcp.dataforseo.com/mcp
codex mcp login dataforseo
```

Docs also now note that OAuth stores are **per-CLI**, so a connector working under Claude says nothing about whether Codex can reach it.

`npm run test:governance` 130/130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)