### PR TITLE
feat(runtime): connect a Claude account by pasting a setup-token (v0.278.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.278.0] — 2026-07-28
+### Added
+- **Connect a Claude account by pasting a subscription token — no CLI wrangling on the box.** The rotation
+  pool gains a **token** account kind: run `claude setup-token` on your own computer (the browser
+  authorization completes there via the CLI's localhost loopback — no code to copy back), paste the printed
+  ~1-year token into Settings → Runtime → Runtime accounts, and it's sealed in the vault and injected as
+  `CLAUDE_CODE_OAUTH_TOKEN` at launch. This is the cleanest rotation credential — no `CLAUDE_CONFIG_DIR` to
+  build, works identically on local and remote boxes (the box never needs a browser or a reachable
+  callback), and the token value never touches the account row, audit, or logs. Runtimes declare an optional
+  `tokenVar` in `CodingRuntimeSpec.credentialEnv`; a runtime without one (codex, no OAuth-token env) simply
+  doesn't offer the option and stays dir/key-based. NB: Claude Code's OAuth redirect URI is hardcoded to
+  localhost loopback and not configurable, and it has no device-code flow, so a server-driven in-browser
+  "connect" that redirects back to the console isn't possible — pasting the token is the robust path.
+
 ## [0.276.1] — 2026-07-28
 ### Fixed
 - **OAuth-backed MCP connectors could never work under Codex.** Codex keeps remote-MCP OAuth tokens in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.276.1",
+  "version": "0.278.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.276.1",
+      "version": "0.278.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.276.1",
+  "version": "0.278.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4117,12 +4117,26 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   }
   if (method === 'POST' && p === '/api/runtime-accounts') {
     if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
-    const b = await readBody(req) as { runtime?: unknown; name?: unknown; kind?: unknown; configDir?: unknown; apiKeyRef?: unknown };
+    const b = await readBody(req) as { runtime?: unknown; name?: unknown; kind?: unknown; configDir?: unknown; apiKeyRef?: unknown; token?: unknown };
     const runtime = String(b.runtime ?? '') as RuntimeId;
     if (!isCodingRuntime(runtime)) return sendJson(res, 400, { error: `unknown runtime: ${runtime}` });
-    const kind = b.kind === 'apikey' ? 'apikey' : 'oauth';
+    const name = String(b.name ?? '').trim();
+    const kind = b.kind === 'apikey' ? 'apikey' : b.kind === 'token' ? 'token' : 'oauth';
+    let apiKeyRef = b.apiKeyRef ? String(b.apiKeyRef) : undefined;
     try {
-      const acct = os.runtimeAccounts.add({ runtime, name: String(b.name ?? ''), kind, configDir: b.configDir ? String(b.configDir) : undefined, apiKeyRef: b.apiKeyRef ? String(b.apiKeyRef) : undefined });
+      // A 'token' account carries the raw long-lived OAuth token (from `claude setup-token`): seal it in the
+      // vault HERE (never stored on the row, never in audit) and hand the account only its key ref. The value
+      // never leaves this call except into the encrypted vault.
+      if (kind === 'token') {
+        const token = String(b.token ?? '').trim();
+        if (!name) return sendJson(res, 400, { error: 'account name required' });
+        if (!token) return sendJson(res, 400, { error: 'token value required' });
+        if (!CODING_RUNTIMES[runtime].credentialEnv.tokenVar) return sendJson(res, 400, { error: `${runtime} has no OAuth-token env — use an API key or credential dir instead` });
+        const key = `runtime-token:${runtime}:${name}`;
+        os.secrets.set(os.tenant, key, token, { principal: '*', updatedBy: me.email });
+        apiKeyRef = key;
+      }
+      const acct = os.runtimeAccounts.add({ runtime, name, kind, configDir: b.configDir ? String(b.configDir) : undefined, apiKeyRef });
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'runtime.account.added', data: { runtime, name: acct.name, kind } });
       return sendJson(res, 200, { ok: true, account: acct });
     } catch (e) { return sendJson(res, 400, { error: (e as Error).message }); }

--- a/src/state/runtime-accounts.ts
+++ b/src/state/runtime-accounts.ts
@@ -22,18 +22,20 @@
 import { Db } from './db';
 import { CodingRuntimeId } from '../types';
 
-export type RuntimeAccountKind = 'oauth' | 'apikey';
+export type RuntimeAccountKind = 'oauth' | 'apikey' | 'token';
 
 export interface RuntimeAccount {
   /** The coding runtime this account authenticates (claude-code | codex | …). */
   runtime: CodingRuntimeId;
   /** Operator-chosen label, unique per runtime (composite PK with `runtime`). */
   name: string;
-  /** 'oauth' → a credential DIRECTORY (configDir); 'apikey' → a usage-billed key held in the vault. */
+  /** 'oauth' → a credential DIRECTORY (configDir); 'apikey' → a usage-billed key held in the vault;
+   *  'token' → a long-lived OAuth token held in the vault, exported via the runtime's `tokenVar`
+   *  (the `claude setup-token` path — no config dir, cleanest to rotate). */
   kind: RuntimeAccountKind;
   /** kind=oauth: dir exported via the runtime's `configDirVar` (holds .credentials.json / auth.json). */
   configDir?: string;
-  /** kind=apikey: the secrets-vault key whose value is exported via the runtime's `apiKeyVar`. */
+  /** kind=apikey|token: the secrets-vault key whose value is exported via the runtime's `apiKeyVar`/`tokenVar`. */
   apiKeyRef?: string;
   enabled: boolean;
   status: 'available' | 'limited';
@@ -93,7 +95,7 @@ export class RuntimeAccountStore {
     const name = a.name.trim();
     if (!name) throw new Error('account name required');
     if (a.kind === 'oauth' && !a.configDir) throw new Error('oauth account needs a configDir');
-    if (a.kind === 'apikey' && !a.apiKeyRef) throw new Error('apikey account needs an apiKeyRef');
+    if (a.kind !== 'oauth' && !a.apiKeyRef) throw new Error(`${a.kind} account needs a vault ref`);
     this.db.prepare(`INSERT INTO runtime_accounts (runtime, name, kind, config_dir, api_key_ref, enabled, status, created_at)
                      VALUES (?, ?, ?, ?, ?, 1, 'available', ?)`)
       .run(a.runtime, name, a.kind, a.configDir ?? null, a.apiKeyRef ?? null, Date.now());

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2234,14 +2234,17 @@ export class TerminalManager {
     try {
       const acct = this.os.runtimeAccounts.pick(runtime);
       if (!acct) return; // empty pool (inert) or all limited → box default
-      const { configDirVar, apiKeyVar } = CODING_RUNTIMES[runtime].credentialEnv;
-      if (acct.kind === 'apikey') {
-        const value = acct.apiKeyRef ? this.os.secrets.getSync(this.os.tenant, agent, acct.apiKeyRef) : undefined;
-        if (!value) { this.audit(sessionId, agent, 'runtime.account.unresolved', { runtime, account: acct.name, ref: acct.apiKeyRef }); return; }
-        env[apiKeyVar] = value;
-      } else {
+      const { configDirVar, apiKeyVar, tokenVar } = CODING_RUNTIMES[runtime].credentialEnv;
+      if (acct.kind === 'oauth') {
         if (!acct.configDir) return;
         env[configDirVar] = acct.configDir;
+      } else {
+        // apikey | token: the value lives in the vault; the KIND picks which env var carries it (a usage-billed
+        // API key vs. a long-lived OAuth token). A runtime that has no tokenVar can't honour a token account.
+        const varName = acct.kind === 'token' ? tokenVar : apiKeyVar;
+        const value = varName && acct.apiKeyRef ? this.os.secrets.getSync(this.os.tenant, agent, acct.apiKeyRef) : undefined;
+        if (!value) { this.audit(sessionId, agent, 'runtime.account.unresolved', { runtime, account: acct.name, kind: acct.kind, ref: acct.apiKeyRef, var: varName ?? null }); return; }
+        env[varName!] = value;
       }
       this.db.prepare('UPDATE term_sessions SET runtime_account = ? WHERE id = ?').run(acct.name, sessionId);
       this.audit(sessionId, agent, 'runtime.account.selected', { runtime, account: acct.name, kind: acct.kind });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1107,8 +1107,10 @@ export interface CodingRuntimeSpec {
    *  from `$AOS_REAL_CODEX_HOME`. `apiKeyVar` is the usage-billed API-key env (`ANTHROPIC_API_KEY` /
    *  `OPENAI_API_KEY`). Rotation exports ONE of these per session; both unset → the runtime uses the box's
    *  default single account, i.e. today's behavior. Generic so a third runtime slots in by declaring its
-   *  own two vars — no rotation code changes. */
-  credentialEnv: { configDirVar: string; apiKeyVar: string };
+   *  own two vars — no rotation code changes. `tokenVar` (optional) is a long-lived OAuth-token env the
+   *  runtime accepts for headless auth (claude: `CLAUDE_CODE_OAUTH_TOKEN` from `claude setup-token`) — the
+   *  cleanest rotation credential (a vault-stored token, no config dir); a runtime without one (codex) omits it. */
+  credentialEnv: { configDirVar: string; apiKeyVar: string; tokenVar?: string };
   /** A few known-good model ids, offered as suggestions in the console. NOT an allowlist — a custom or
    *  newer id must still be settable, so validation only rejects ids that clearly belong to ANOTHER
    *  runtime (see `foreignModel`). */
@@ -1128,7 +1130,7 @@ export const CODING_RUNTIMES: Readonly<Record<CodingRuntimeId, CodingRuntimeSpec
     bin: 'claude',
     launchScript: 'claude-launch.sh',
     gateHook: 'gate-hook.sh',
-    credentialEnv: { configDirVar: 'CLAUDE_CONFIG_DIR', apiKeyVar: 'ANTHROPIC_API_KEY' },
+    credentialEnv: { configDirVar: 'CLAUDE_CONFIG_DIR', apiKeyVar: 'ANTHROPIC_API_KEY', tokenVar: 'CLAUDE_CODE_OAUTH_TOKEN' },
     suggestedModels: ['claude-opus-4-8', 'claude-sonnet-4-8', 'claude-haiku-4-5'],
     foreignModel: /^(gpt|o[0-9]|codex)/i,
     capabilities: {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type RuntimeAccount, type RuntimeAccountsResp, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type AuditEvent, type Effort, type RuntimeTuning, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -13462,8 +13462,9 @@ function RuntimeAccountsSettings({ me }: { me: Member }) {
   const [hint, setHint] = useState('')
   const [runtime, setRuntime] = useState('claude-code')
   const [name, setName] = useState('')
-  const [kind, setKind] = useState<'oauth' | 'apikey'>('oauth')
-  const [cred, setCred] = useState('')
+  const [kind, setKind] = useState<RuntimeAccountKind>('token')
+  const [cred, setCred] = useState('')   // configDir (oauth) or vault key ref (apikey)
+  const [token, setToken] = useState('') // raw setup-token value (token kind)
   const canEdit = me.role === 'owner'
 
   const load = () => api.runtimeAccounts().then((r) => { if (!r.error) setResp(r) }).catch(() => {})
@@ -13471,15 +13472,21 @@ function RuntimeAccountsSettings({ me }: { me: Member }) {
 
   const runtimes = resp?.runtimes ?? []
   const spec = runtimes.find((r) => r.id === runtime)
-  const credVar = spec ? (kind === 'oauth' ? spec.credentialEnv.configDirVar : spec.credentialEnv.apiKeyVar) : ''
+  const hasToken = !!spec?.credentialEnv.tokenVar
+  // A runtime with no token env (codex) can't offer the paste-token option; fall back to a dir/key.
+  const effKind: RuntimeAccountKind = kind === 'token' && !hasToken ? 'oauth' : kind
+  const credVar = spec ? (effKind === 'oauth' ? spec.credentialEnv.configDirVar : effKind === 'token' ? (spec.credentialEnv.tokenVar ?? '') : spec.credentialEnv.apiKeyVar) : ''
   const add = async () => {
     setBusy(true); setHint('')
-    const body = { runtime, name: name.trim(), kind, ...(kind === 'oauth' ? { configDir: cred.trim() } : { apiKeyRef: cred.trim() }) }
+    const body = effKind === 'token'
+      ? { runtime, name: name.trim(), kind: effKind, token: token.trim() }
+      : { runtime, name: name.trim(), kind: effKind, ...(effKind === 'oauth' ? { configDir: cred.trim() } : { apiKeyRef: cred.trim() }) }
     const r = await api.addRuntimeAccount(body)
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
-    setName(''); setCred(''); setHint('added'); setTimeout(() => setHint(''), 2000); load()
+    setName(''); setCred(''); setToken(''); setHint('added'); setTimeout(() => setHint(''), 2000); load()
   }
+  const addDisabled = busy || !name.trim() || (effKind === 'token' ? !token.trim() : !cred.trim())
   const toggle = async (a: RuntimeAccount) => { await api.setRuntimeAccountEnabled(a.runtime, a.name, !a.enabled); load() }
   const remove = async (a: RuntimeAccount) => { if (!confirm(`Remove account "${a.name}" (${a.runtime})?`)) return; await api.removeRuntimeAccount(a.runtime, a.name); load() }
   const labelFor = (id: string) => runtimes.find((r) => r.id === id)?.label ?? id
@@ -13551,23 +13558,26 @@ function RuntimeAccountsSettings({ me }: { me: Member }) {
                 <SelectContent>{runtimes.map((r) => <SelectItem key={r.id} value={r.id}>{r.label}</SelectItem>)}</SelectContent>
               </Select>
               <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="name (e.g. overflow-1)" className="h-8 w-44 font-mono text-xs" />
-              <Select value={kind} onValueChange={(v) => setKind((v as 'oauth' | 'apikey') ?? 'oauth')}>
-                <SelectTrigger className="h-8 w-32 text-xs"><SelectValue /></SelectTrigger>
+              <Select value={effKind} onValueChange={(v) => setKind((v as RuntimeAccountKind) ?? 'token')}>
+                <SelectTrigger className="h-8 w-44 text-xs"><SelectValue /></SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="oauth">Subscription</SelectItem>
+                  {hasToken && <SelectItem value="token">Subscription token (recommended)</SelectItem>}
                   <SelectItem value="apikey">API key</SelectItem>
+                  <SelectItem value="oauth">Credential dir</SelectItem>
                 </SelectContent>
               </Select>
-              <Input value={cred} onChange={(e) => setCred(e.target.value)}
-                placeholder={kind === 'oauth' ? 'credential dir path' : 'vault key name'}
-                className="h-8 w-52 font-mono text-xs" />
-              <Button onClick={add} disabled={busy || !name.trim() || !cred.trim()}>Add</Button>
+              {effKind === 'token'
+                ? <Input type="password" value={token} onChange={(e) => setToken(e.target.value)} placeholder="paste setup-token output" autoComplete="off" className="h-8 w-64 font-mono text-xs" />
+                : <Input value={cred} onChange={(e) => setCred(e.target.value)} placeholder={effKind === 'oauth' ? 'credential dir path' : 'vault key name'} className="h-8 w-52 font-mono text-xs" />}
+              <Button onClick={add} disabled={addDisabled}>Add</Button>
               {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
             </div>
             <p className="text-[11px] text-muted-foreground">
-              {kind === 'oauth'
+              {effKind === 'token'
+                ? <>On your own computer run <span className="font-mono">claude setup-token</span>, authorize in the browser (it completes there — no code to copy back), then paste the printed token here. It's sealed in the vault and injected as <span className="font-mono">{credVar || 'CLAUDE_CODE_OAUTH_TOKEN'}</span> — valid ~1 year. Nothing to install on this box.</>
+                : effKind === 'oauth'
                 ? <>A directory holding this account's credentials, exported to the session as <span className="font-mono">{credVar || 'the config dir'}</span> (for Claude, a full <span className="font-mono">CLAUDE_CONFIG_DIR</span> from <span className="font-mono">CLAUDE_CONFIG_DIR=&lt;dir&gt; claude login</span>).</>
-                : <>A key in the secrets vault whose value is this account's API key, exported as <span className="font-mono">{credVar || 'the API-key var'}</span>. Store the value in Settings → Secrets first.</>}
+                : <>A key already in the secrets vault whose value is this account's API key, exported as <span className="font-mono">{credVar || 'the API-key var'}</span>. Store the value in Settings → Secrets first.</>}
             </p>
           </div>
         )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -67,10 +67,11 @@ export interface Concurrency {
 }
 
 /** One credential set in the runtime rotation pool (never carries the api-key value, only its vault ref). */
+export type RuntimeAccountKind = 'oauth' | 'apikey' | 'token'
 export interface RuntimeAccount {
   runtime: string
   name: string
-  kind: 'oauth' | 'apikey'
+  kind: RuntimeAccountKind
   configDir?: string
   apiKeyRef?: string
   enabled: boolean
@@ -79,7 +80,7 @@ export interface RuntimeAccount {
   lastUsedAt?: number
   createdAt: number
 }
-export interface RuntimeSpecInfo { id: string; label: string; credentialEnv: { configDirVar: string; apiKeyVar: string } }
+export interface RuntimeSpecInfo { id: string; label: string; credentialEnv: { configDirVar: string; apiKeyVar: string; tokenVar?: string } }
 export interface RuntimeAccountsResp { accounts: RuntimeAccount[]; runtimes: RuntimeSpecInfo[]; error?: string }
 
 export interface AgentInfo {
@@ -1521,7 +1522,7 @@ export const api = {
   concurrency: () => call<Concurrency & { error?: string }>('GET', '/api/settings/concurrency'),
   saveConcurrency: (body: { value?: number | null; idleHours?: number; unattendedMaxHours?: number; unattendedNoProgressMinutes?: number }) => call<{ ok: boolean; error?: string; value?: number | null; resolved?: number; derived?: number; idleHours?: number; unattendedMaxHours?: number; unattendedNoProgressMinutes?: number }>('PUT', '/api/settings/concurrency', body),
   runtimeAccounts: () => call<RuntimeAccountsResp>('GET', '/api/runtime-accounts'),
-  addRuntimeAccount: (body: { runtime: string; name: string; kind: 'oauth' | 'apikey'; configDir?: string; apiKeyRef?: string }) => call<{ ok: boolean; error?: string; account?: RuntimeAccount }>('POST', '/api/runtime-accounts', body),
+  addRuntimeAccount: (body: { runtime: string; name: string; kind: RuntimeAccountKind; configDir?: string; apiKeyRef?: string; token?: string }) => call<{ ok: boolean; error?: string; account?: RuntimeAccount }>('POST', '/api/runtime-accounts', body),
   setRuntimeAccountEnabled: (runtime: string, name: string, enabled: boolean) => call<{ ok: boolean; error?: string }>('PATCH', `/api/runtime-accounts/${encodeURIComponent(runtime)}/${encodeURIComponent(name)}`, { enabled }),
   removeRuntimeAccount: (runtime: string, name: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/runtime-accounts/${encodeURIComponent(runtime)}/${encodeURIComponent(name)}`),
 


### PR DESCRIPTION
## Why
Follow-up to the rotation pool: make adding a Claude account painless. The user asked "can we build OAuth from the UI — click and grab the token?" Ground truth (verified against Claude Code docs): the OAuth **redirect URI is hardcoded to localhost loopback and not configurable**, and there's **no device-code flow** — so a server-driven "click → authorize → redirect back to our console" is impossible, and any remote box needs a paste. But `claude setup-token` prints a **~1-year token** and `CLAUDE_CODE_OAUTH_TOKEN` is honored for headless auth, which gives a clean path.

## What
A **token** account kind: run `claude setup-token` on your own computer (the browser authorization completes there via the CLI's own loopback — no code to copy back), paste the printed token into **Settings → Runtime → Runtime accounts**. It's sealed in the vault and injected as `CLAUDE_CODE_OAUTH_TOKEN` at launch.

Why this is the best option, not a fallback:
- Browser bounce happens on **your** machine, where loopback works → completes automatically, nothing to copy back.
- **Works identically on every box** (local Mac / remote droplets) — the box never needs a browser or a reachable callback.
- No `CLAUDE_CONFIG_DIR` to build; token value **never** touches the account row, audit, or logs.
- 1-year TTL → a rotation account is long-lived.

Generic: runtimes declare an optional `tokenVar` in `CodingRuntimeSpec.credentialEnv`; codex has no OAuth-token env, so it doesn't offer the option (stays dir/key-based). Dir + API-key kinds kept as fallbacks.

## Test
`npm run build` clean · `npm run test:governance` → **130/130** · `cd web && npm run build` clean.

## Rollout
Deploy to instapods (build root+web, kickstart). Additive — no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)