### PR TITLE
fix(runtime): map the 'token' account kind (was treated as oauth) (v0.278.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.278.1] — 2026-07-28
+### Fixed
+- **A `token` rotation account was silently ignored — never selected, its token never injected.** The
+  row→object mapper (`toAccount`) only special-cased `apikey` and collapsed every other kind, including the
+  new `token`, to `oauth`. So at launch `applyRuntimeAccount` took the oauth branch, found no `configDir`,
+  and early-returned — no `CLAUDE_CODE_OAUTH_TOKEN` injected, no `runtime.account.selected` audit, the row's
+  `runtime_account` left blank (the session just ran on the box default). Map `token` through correctly.
+
 ## [0.278.0] — 2026-07-28
 ### Added
 - **Connect a Claude account by pasting a subscription token — no CLI wrangling on the box.** The rotation

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.278.0",
+  "version": "0.278.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.278.0",
+      "version": "0.278.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.278.0",
+  "version": "0.278.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/state/runtime-accounts.ts
+++ b/src/state/runtime-accounts.ts
@@ -61,7 +61,7 @@ interface Row {
 const toAccount = (r: Row): RuntimeAccount => ({
   runtime: r.runtime as CodingRuntimeId,
   name: r.name,
-  kind: r.kind === 'apikey' ? 'apikey' : 'oauth',
+  kind: r.kind === 'apikey' ? 'apikey' : r.kind === 'token' ? 'token' : 'oauth',
   configDir: r.config_dir ?? undefined,
   apiKeyRef: r.api_key_ref ?? undefined,
   enabled: r.enabled === 1,


### PR DESCRIPTION
Found while e2e-testing a pasted-token rotation account on instapods: the session ran but on the **box default**, not the account — `CLAUDE_CODE_OAUTH_TOKEN` was never injected and no `runtime.account.selected` audit fired.

**Root cause:** `toAccount` (row→object) only special-cased `apikey` and collapsed every other kind — including the new `token` — to `oauth`. So `applyRuntimeAccount` took the oauth branch, found no `configDir`, and early-returned silently.

**Fix:** map `token` through. Verified against the live instapods DB: `get().kind` now returns `token`. Governance 130/130.