### PR TITLE
fix(runtime): default new agents to the `opus` alias, not pinned claude-opus-4-8 (v0.278.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.278.2] — 2026-07-30
+### Changed
+- **New agents now default to the `opus` model alias instead of a pinned `claude-opus-4-8`.** The sample
+  manifest (`agent-os init`), the console's create-agent form default + placeholder, and the import doc
+  example all baked in `claude-opus-4-8`, so every agent created since pinned that exact version and would
+  not follow a newer Opus. Default to the `opus` alias, which tracks the latest Opus. Existing agents are
+  unaffected (their manifests keep whatever they pinned); this only changes the default for *newly* created
+  agents. A specific version can still be typed in explicitly, and the model dropdown still suggests pinned
+  version ids for anyone who wants to pin.
+
 ## [0.278.1] — 2026-07-28
 ### Fixed
 - **A `token` rotation account was silently ignored — never selected, its token never injected.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.278.1",
+  "version": "0.278.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.278.1",
+      "version": "0.278.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.278.1",
+  "version": "0.278.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/init.ts
+++ b/src/init.ts
@@ -33,7 +33,7 @@ function sampleManifest(id: string): string {
       principal: `svc-${id}`,
       policyContext: 'default@v3',
       runtime: 'claude-code',
-      model: 'claude-opus-4-8',
+      model: 'opus',
       budget: { usdCap: 2.0, tokenCap: 400000, wallClockMs: 1800000 },
     },
     null,

--- a/src/server.ts
+++ b/src/server.ts
@@ -3683,8 +3683,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
     if (tErr) return sendJson(res, 400, { error: tErr });
     // No forced model default: a blank field means "inherit the workspace default" (Settings →
-    // Runtime defaults), same as effort/permission. The create form pre-fills claude-opus-4-8, so the
-    // common case still pins a model explicitly; clearing it opts the agent into the fleet default.
+    // Runtime defaults), same as effort/permission. The create form pre-fills the `opus` alias (which
+    // tracks the latest Opus rather than a pinned version), so the common case still sets a model
+    // explicitly; clearing it opts the agent into the fleet default.
     if (!/^[a-z][a-z0-9-]{1,39}$/.test(id)) return sendJson(res, 400, { error: 'id must be lowercase letters, digits and hyphens (2–40 chars, starting with a letter)' });
     if (os.agents.get(id)) return sendJson(res, 409, { error: `an agent named "${id}" already exists` });
     if (!claudeMd.trim()) return sendJson(res, 400, { error: 'a CLAUDE.md is required' });

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9880,7 +9880,7 @@ function NewAgentPage({ me, onCreated }: { me: Member; onCreated: (id: string) =
   const [description, setDescription] = useState('')
   const [category, setCategory] = useState('')
   const [icon, setIcon] = useState<string | undefined>(undefined)
-  const [tuning, setTuning] = useState<RuntimeTuning>({ model: 'claude-opus-4-8' })
+  const [tuning, setTuning] = useState<RuntimeTuning>({ model: 'opus' })
   const [claudeMd, setClaudeMd] = useState(NEW_AGENT_CLAUDE_TEMPLATE)
   const [prompts, setPrompts] = useState('')
   const [busy, setBusy] = useState(false)
@@ -9942,7 +9942,7 @@ function NewAgentPage({ me, onCreated }: { me: Member; onCreated: (id: string) =
             <p className="text-[11px] text-muted-foreground">Optional. The first becomes the spawn box’s prefill; the rest are one-click chips. Up to 6.</p>
           </div>
           <div className="space-y-1">
-            <TuningFields tuning={tuning} onChange={setTuning} modelPlaceholder="claude-opus-4-8" />
+            <TuningFields tuning={tuning} onChange={setTuning} modelPlaceholder="opus" />
             <p className="text-[11px] text-muted-foreground">Per-agent overrides. Leave effort/permission on <span className="font-mono">inherit</span> to follow the workspace default (Settings → Runtime defaults). The gate-hook governs regardless of permission mode.</p>
           </div>
           <div className="space-y-1">

--- a/web/src/docs/import-into-aos.md
+++ b/web/src/docs/import-into-aos.md
@@ -84,7 +84,7 @@ header so it can be reconstructed.
      "description": "<one sentence: what you do and when to run you>",
      "category": "<Support|Engineering|Marketing|Sales|Research|Ops|System>",
      "runtime": "claude-code",
-     "model": "claude-opus-4-8",
+     "model": "opus",
      "examplePrompts": ["<2-4 prompts that show how you're typically invoked>"]
    }
    (Leave out principal/policyContext/budget — AOS assigns safe defaults.)


### PR DESCRIPTION
## What

New agents were being pinned to the exact version `claude-opus-4-8` by default, in four places:
- `src/init.ts` — the `agent-os init` sample manifest
- `web/src/App.tsx` — the console create-agent form default (`useState({ model: 'claude-opus-4-8' })`) + the field placeholder
- `web/src/docs/import-into-aos.md` — the example manifest in the import guide

So every agent created since kept that pinned version and would **not** follow a newer Opus (e.g. Opus 5). This changes the default to the **`opus` alias**, which tracks the latest Opus release.

## Scope / safety
- **Existing agents are unaffected** — their `agent.json` keeps whatever model they already pinned.
- This only changes the default applied to *newly* created agents.
- A specific version can still be typed in explicitly, and the model dropdown still suggests pinned version ids (`suggestedModels`) for anyone who wants to pin.
- Server-side create still treats a blank model field as "inherit the workspace runtime default" — unchanged; only the pre-filled value changed. Updated the stale comment accordingly.

## Verify
- `npm run typecheck` ✓
- `cd web && npm run build` ✓
- `npm run test:governance` → 130/130 ✓

## Note (ops, out of band)
The live fleet's *already-created* agents were separately migrated off `claude-opus-4-8` → `opus` (per-agent manifests + workspace runtime default), applied live via `/api/agents/rescan` on each tenant — instapods, instawp, expresstech, insta-ai, plus the dormant acme demo tenant. That's a data change on the boxes, not part of this code PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)