### PR TITLE
feat(digest): synthesise the daily digest + fix two wrong self-learning signals (v0.280.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,41 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.280.0] — 2026-07-31
+### Changed
+- **The daily digest is now a synthesis, not a log grouped by author.** On a 94-session day the posted
+  digest listed ~60 lines across 19 agents with no cross-agent structure, and the day's real story — one
+  migration bug and one support ticket — was told nine separate times by four agents, several of the lines
+  explicitly correcting each other and every one of them marked ✓. Four fixes:
+  - **A blocked run no longer reads as a success.** `outcome` is whatever the agent passed to `report()` —
+    its grade of its own *effort* — so runs ended `success` while their summary said "push is BLOCKED: no
+    token can push". Lines whose own text says a person must act are reclassified `⏳ blocked` and hoisted
+    into a new **"⏳ Needs you"** section at the top of the digest — the only part of it that is a to-do
+    rather than a record.
+  - **Cross-agent threads collapse.** Lines sharing a ticket / PR / task id / host (`refsOf` →
+    `clusterIncidents`, transitive union over typed refs) are grouped across agents into a **"🔗 Threads"**
+    section showing the *latest* word on each, plus the update count so revision stays visible. Blocked
+    lines still link a thread together but never headline it.
+  - **The header reconciles.** `tally()` omitted the `other` bucket, so a 94-session day printed 76. Every
+    bucket now prints, the day's **cost** is shown, and the count of sessions with no reportable line is
+    stated ("N routine runs not shown") instead of silently dropped.
+  - **A line must come from a real `report`.** `status === 'done'` and a salient episode were two other ways
+    in, but with no report the only available text is the session title — derived from the incoming task —
+    so those lines printed the human's *prompt* as if it were the day's result ("the backend is too slow",
+    "can you check why this happened?"). They now land in the stated hidden count.
+  Also: digest lines clip at 280 chars rather than 200, which was cutting mid-outcome.
+- **Self-learning: topic extraction now allows by shape instead of blocking by word.** The guidance line
+  injected into every agent's prompt read "The fleet frequently works on: instawp, handed, client-app,
+  read-only, really" — a hand-maintained stop-list is unwinnable, and each leaked word had to be found in
+  production and patched in. Tokenization now preserves case and admits a topic only if the corpus writes it
+  as a name (capitalized away from a sentence start, or ALL-CAPS) or it carries a digit or a dot. Agent ids
+  join member names as stop-words (who did the work, not what the fleet works on).
+- **Self-learning: approval friction is gated on the rejection RATE, not the raw count.** "≥3 rejections"
+  fired on tenants whose approvals are ~100% approved — 3 rejections out of 200 is a healthy gate — telling
+  the owner their policy over-rejects and telling every agent to expect rejection. Both the guidance line and
+  the `policy.review` recommendation now need the count **and** ≥20% of human approval decisions; the
+  recommendation states the rate. The per-pass tally records the approved denominator.
+
 ## [0.278.2] — 2026-07-30
 ### Changed
 - **New agents now default to the `opus` model alias instead of a pinned `claude-opus-4-8`.** The sample

--- a/docs/daily-digest-plan.md
+++ b/docs/daily-digest-plan.md
@@ -161,3 +161,39 @@ is unset → skip the Slack post, still render dashboard + KB page (fail-soft, n
   24:00)` local.
 - **Empty day** — post a terse "quiet day, 0 sessions" or skip the Slack post entirely? (lean: skip
   Slack, still write the KB page so the date exists).
+
+## What shipped (v0.280.0) — from a log to a synthesis
+
+A real posted digest (instawp, 94 sessions, 2026-07-30) exposed the limits of "group the episode lines by
+agent". The lines themselves were excellent — the `report`-first-sentence source is doing its job — but the
+artifact around them wasn't readable, and in two places it was actively misleading.
+
+**What was wrong, and what replaced it:**
+
+| Failure | Cause | Fix |
+| --- | --- | --- |
+| `…push is BLOCKED… ✓` | `outcome` is what the agent passed to `report()` — its grade of its own *effort*, not of the result | `BLOCKED_RE` over the line text → `⏳ blocked` + a **"Needs you"** section |
+| One incident told 9× by 4 agents, several correcting each other, all ✓ | `dedupeLines` clusters by Jaccard **within one agent** only | `refsOf` + `clusterIncidents` — transitive union over ticket/PR/task/host refs, **across** agents → **"Threads"**, newest-wins headline + update count |
+| Header said 94, parts summed to 76 | `tally()` never printed the `other` bucket | every bucket prints; plus cost and an explicit "N routine runs not shown" |
+| Customer complaints and prompts printed as results | no-report sessions fall back to the **title**, which is derived from the incoming task | a body line now requires a real `report`; the rest are counted in `hidden` |
+
+**Design notes worth keeping:**
+- **Needs-you owns its lines.** A blocked line appears there and nowhere else — but it still takes part in
+  clustering, because it's often what *links* a thread ("FS#2569: …awaiting human review" is the same thread
+  as "Root-caused FS#2569…"). Threads count it as an update and name its agent; only the headline excludes it.
+- **Newest-wins is the honest summary of a self-correcting thread.** Four agents diagnosing one bug produce
+  a sequence, not a set; the last diagnosis supersedes. The update count is what tells the reader that
+  revision happened rather than hiding it.
+- **Typed refs with a `num:` alias.** `FS#2701`, `FreeScout 2701` and a later bare `#2701` must fuse; `PR
+  #2701` and `FS#2701` should not. Each numeric ref emits both a typed key and a `num:` alias, so the common
+  case links and the namespaces stay mostly apart. Hostnames need ≥3 labels — an apex brand domain shows up
+  in unrelated marketing work and would fuse unrelated threads.
+- **`BLOCKED_RE` is deliberately explicit**, not clever. It decides what lands in the one section that is a
+  to-do list, and a loose match floods it. Known limitation: a line *describing* blocking as a feature
+  ("downgrades to blocked when…") is a false positive; it reads as obviously-not-a-blocker to a human and the
+  section is short enough to scan.
+- Deliberately absent from `BLOCKED_RE`: `couldn't` / `cannot`. In these reports they describe a **finding**
+  far more often than a blocked agent.
+
+**Still open:** no per-tenant timezone; threads don't detect *contradiction* (only churn); `hidden` is a
+count, not browsable.

--- a/docs/self-learning-plan.md
+++ b/docs/self-learning-plan.md
@@ -125,3 +125,29 @@ Plus `npm run typecheck`, `cd web && npm run build`, `npm run demo`.
   per tenant — distinct `AGENT_OS_HOME` + `AGENT_OS_TENANT` + `PORT`). So the single-`os` schedulers in
   `startServer` are already correct: each process owns exactly one tenant's `os`, and `dream()` keys on
   `os.tenant` throughout. **No per-tenant fan-out needed** — nothing to change here.
+
+## Correction (v0.280.0) — two signals that were wrong in production
+
+Both surfaced by reading a real posted digest's **🧠 Learned** block on the instawp tenant.
+
+1. **"The fleet frequently works on: instawp, handed, client-app, read-only, really."** `topicCounts`
+   lowercased before tokenizing and filtered through a hand-maintained `STOP` list — an unwinnable game
+   where every leaked word ("handed", "really", "read-only") had to be discovered in production and then
+   patched in, and the guidance line rides in **every agent's system prompt**. Inverted to an **allow test
+   on shape**: tokenization preserves case, and a topic is admitted only if the corpus itself writes it as
+   a name (`properNouns` — capitalized away from a sentence start, or ALL-CAPS) or it carries a digit or a
+   dot (`v3`, `php8`, `instawp.com`). Precision over recall: an always-lowercase repo name is missed, but
+   nothing embarrassing gets through, and the line only prints when ≥2 topics survive. Agent ids joined
+   member names as stop-words — both answer *who did the work*, not *what the fleet works on* (the whole
+   id only: `migration-ops` is an agent, `migration` is a topic).
+2. **"⚠ Recommend: Review your policy — actions are often rejected at approval"** on a tenant whose
+   approvals are ~100% approved. The gate was a raw count (`rejected >= 3`) with no denominator — 3
+   rejections out of 200 decisions is a *healthy* gate, and the advice was backwards in both directions:
+   the owner was told to loosen a policy that wasn't over-rejecting, and every agent was told to expect
+   rejection. Friction is a **rate**: the per-pass tally now records `approved` alongside `rejected`, and
+   both the guidance line and the `policy.review` recommendation need the count **and** ≥20% of human
+   decisions. The recommendation states the rate. Legacy `recent` entries have no denominator and read as
+   0, so a stale state can fire once more before self-correcting on the next pass.
+
+The general lesson: a signal injected into every prompt or shown to the owner as advice needs a
+**denominator and a shape test**, not a threshold on a raw count and a blocklist.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.278.2",
+  "version": "0.280.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.278.2",
+      "version": "0.280.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.278.2",
+  "version": "0.280.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/digest.ts
+++ b/src/edge/digest.ts
@@ -1,7 +1,13 @@
 /**
  * The **daily digest** — a tenant-wide "what got done today" standup.
  *
- * Two halves in one artifact:
+ * Three halves in one artifact (the first two are synthesis, not a log — a day of 90 sessions grouped by
+ * author is unreadable, and the raw grouping actively misled: one incident worked by four agents produced
+ * a dozen mutually-correcting lines, each marked ✓):
+ *  0a. **⏳ Needs you** — every line whose own text says a human has to act (`BLOCKED_RE`), hoisted out of
+ *      the agent blocks. This is the only part of the digest that is a to-do rather than a record.
+ *  0b. **🔗 Threads** — lines sharing a ticket / PR / task / host (`refsOf` → `clusterIncidents`) collapsed
+ *      across agents into the LATEST word on the thread, plus the update count so revision is visible.
  *  1. **📋 Today** — the per-session changelog, grouped by agent. The lines are already written for us:
  *     every session end stores an **episode** (`TerminalManager.writeEpisode` → `composeEpisode`), a
  *     deterministic "what this session did" summary graded by `episodeSalience`. The digest just reads
@@ -25,20 +31,35 @@ const SECTION = 'operations';
 const SALIENCE = 0.5;          // episodes at/above this importance make the body; the rest count in the tally only
 const PER_AGENT = 6;           // cap body lines per agent (overflow → "+N more")
 const MAX_POST_ATTEMPTS = 3;   // scheduled EOD post retries per day before giving up (M3 — bound outage churn)
+const MAX_NEEDS = 12;          // cap the "Needs you" list (overflow → "+N more")
+const MAX_INCIDENTS = 8;       // cap the cross-agent thread list
+const MAX_THREAD_AGENTS = 4;   // agents named per thread before "+N"
 
 export interface DigestModel {
   iso: string;                 // YYYY-MM-DD (server-local)
   label: string;               // e.g. "Wed Jul 13"
   total: number;
   buckets: { success: number; partial: number; failure: number; stopped: number; running: number; other: number };
-  byAgent: { agent: string; lines: { title: string; outcome: string; importance: number; count?: number }[]; more: number }[];
-  signals: { tasksCreated: number; tasksCompleted: number; approvals: number; rejected: number; errors: number; budgetStops: number };
+  blocked: number;             // runs whose own report describes a blocker (reclassified OUT of `buckets`)
+  hidden: number;              // sessions with no reportable line — counted, never silently dropped
+  needs: NeedLine[];           // the day's human action list, hoisted out of the agent blocks
+  incidents: Incident[];       // cross-agent threads (one ticket/PR/host worked by several agents)
+  byAgent: { agent: string; lines: DigestLine[]; more: number }[];
+  signals: { tasksCreated: number; tasksCompleted: number; approvals: number; rejected: number; errors: number; budgetStops: number; costUsd: number };
   guidance: string[];          // a few distilled Dreaming imperatives
   recommendations: string[];   // open recommendation titles
 }
 
-interface SessionRow { id: string; agent: string; status: string; title: string; spawned_by: string | null; report: string | null; importance: number | null; outcome: string | null }
-interface DigestLine { title: string; outcome: string; importance: number; count?: number }
+export interface DigestLine { title: string; outcome: string; importance: number; count?: number }
+/** One item waiting on a person — the only part of the digest that is a to-do rather than a record. */
+export interface NeedLine { agent: string; title: string }
+/** Several sessions about the SAME thing (ticket / PR / task / host), collapsed to the latest word on it. */
+export interface Incident { label: string; headline: string; outcome: string; agent: string; agents: string[]; updates: number }
+
+interface SessionRow { id: string; agent: string; status: string; title: string; spawned_by: string | null; created_at: number; cost_usd: number | null; report: string | null; importance: number | null; outcome: string | null }
+/** A candidate body line before it's routed to a thread / an agent block. `blocked` lines are already in
+ *  `needs`; they stay in the pool only so they can still LINK a thread together. */
+interface Cand extends DigestLine { agent: string; ts: number; refs: string[]; blocked: boolean }
 interface AuditRow { type: string; data: string }
 
 /** Server-local day bounds + labels for `now`. Time is the deploy box's tz (single-box deployment). */
@@ -60,7 +81,7 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
   // Each session ⋈ its end-of-session episode (importance + outcome) + the agent's own `report` summary
   // (the richest line source — vs the 72-char title). One episode per session in practice.
   const rows = db.prepare(
-    `SELECT s.id, s.agent, s.status, s.title, s.spawned_by,
+    `SELECT s.id, s.agent, s.status, s.title, s.spawned_by, s.created_at, s.cost_usd,
             (SELECT body FROM messages WHERE session_id = s.id AND type = 'completed' ORDER BY created_at DESC LIMIT 1) AS report,
             MAX(m.importance) AS importance,
             MAX(json_extract(m.metadata,'$.outcome')) AS outcome
@@ -72,8 +93,13 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
   ).all<SessionRow>(start, end);
 
   const buckets = { success: 0, partial: 0, failure: 0, stopped: 0, running: 0, other: 0 };
-  const perAgent = new Map<string, DigestLine[]>();
+  const cands: Cand[] = [];
+  const needs: NeedLine[] = [];
+  let blocked = 0;
+  let included = 0;
+  let costUsd = 0;
   for (const r of rows) {
+    costUsd += r.cost_usd ?? 0;
     const outcome = (r.outcome || (r.status === 'done' ? 'success' : r.status) || 'unknown').toLowerCase();
     if (outcome in buckets) (buckets as Record<string, number>)[outcome]++; else buckets.other++;
     const importance = r.importance ?? 0;
@@ -90,15 +116,41 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
     // isn't fleet work. Detected on the reported LINE (not the audit event, which also fires when a session
     // did real work AND incidentally touched its config — dropping those would lose the real work).
     const selfMaint = /\b(my|its|their|own)\s+(claude\.?md|system prompt|starter prompts?|instructions?)\b/i.test(line);
-    const include = !placeholder && !askSession && !taskish && !selfMaint && (hasReport || importance >= SALIENCE || r.status === 'done');
-    if (include) {
-      const list = perAgent.get(r.agent) ?? [];
-      // A real report ranks at/above the salience line; a done-with-no-report just under it.
-      list.push({ title: line, outcome, importance: importance || (hasReport ? SALIENCE : (r.status === 'done' ? SALIENCE - 0.01 : 0)) });
-      perAgent.set(r.agent, list);
+    // A line must come from a real REPORT. `status === 'done'` and a salient episode used to be two more
+    // ways in, but with no report the only text available is the session TITLE — which is derived from the
+    // incoming task, so those lines were the human's prompt ("the backend is too slow", "can you check
+    // why this happened?") printed as if it were the day's result. They now land in `hidden` and are
+    // counted there rather than dressed up as outcomes.
+    const include = !placeholder && !askSession && !taskish && !selfMaint && hasReport;
+    if (!include) continue;
+    included++;
+    // Fix A — the ✓ was lying. `outcome` is whatever the agent passed to `report()`, i.e. its grade of its
+    // OWN effort, so a run can end `success` while its summary says the push was blocked. The line text is
+    // the honest signal: reclassify out of the outcome buckets and into the human action list.
+    const isBlocked = BLOCKED_RE.test(line);
+    if (isBlocked) {
+      blocked++;
+      if (outcome in buckets) (buckets as Record<string, number>)[outcome]--; else buckets.other--;
+      needs.push({ agent: r.agent, title: line });
     }
+    cands.push({
+      agent: r.agent, title: line, outcome, ts: r.created_at, refs: refsOf(line), blocked: isBlocked,
+      importance: importance || SALIENCE,
+    });
   }
 
+  // Fix B: collapse the day's cross-agent threads BEFORE the per-agent split — otherwise one migration bug
+  // worked by four agents reads as a dozen unrelated wins, several of them contradicting each other.
+  // Blocked lines take part in clustering (they're what LINKS a thread together — "FS#2569: …awaiting human
+  // review" is the same thread as "Root-caused FS#2569…") but never appear in it; "Needs you" owns them.
+  const { incidents, rest } = clusterIncidents(cands);
+
+  const perAgent = new Map<string, DigestLine[]>();
+  for (const c of rest) {
+    const list = perAgent.get(c.agent) ?? [];
+    list.push({ title: c.title, outcome: c.outcome, importance: c.importance });
+    perAgent.set(c.agent, list);
+  }
   const byAgent = [...perAgent.entries()]
     .map(([agent, all]) => {
       // Fix 2: collapse near-identical routine runs (e.g. 3× "fleet sweep — all healthy") into one ×N line.
@@ -108,7 +160,7 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
     .sort((a, b) => b.lines.length - a.lines.length || a.agent.localeCompare(b.agent));
 
   // Governance / throughput signals from the audit stream.
-  const signals = { tasksCreated: 0, tasksCompleted: 0, approvals: 0, rejected: 0, errors: 0, budgetStops: 0 };
+  const signals = { tasksCreated: 0, tasksCompleted: 0, approvals: 0, rejected: 0, errors: 0, budgetStops: 0, costUsd: 0 };
   const audit = db.prepare(
     // `session.error` = a real run error; `episode.error` (a memory-STORE failure) is deliberately excluded
     // so a flaky memory backend doesn't inflate the header with "N errors" that aren't the fleet's doing.
@@ -125,16 +177,124 @@ export function buildDigest(os: AgentOS, now = new Date()): DigestModel {
       case 'session.error': signals.errors++; break;
     }
   }
+  signals.costUsd = costUsd; // what the day actually burned (NULL cost_usd — still-running runs — reads 0)
 
   // The Dreaming half — distilled imperatives + open recommendation titles (already persisted).
   const guidance = os.settings.learnedGuidance()
     .split('\n').map((l) => l.trim()).filter((l) => l.startsWith('- ')).map((l) => l.slice(2).trim()).slice(0, 3);
   const recommendations = os.settings.recommendations().open.map((r) => r.title).slice(0, 3);
 
-  return { iso, label, total: rows.length, buckets, byAgent, signals, guidance, recommendations };
+  return { iso, label, total: rows.length, buckets, blocked, hidden: rows.length - included, needs, incidents, byAgent, signals, guidance, recommendations };
 }
 
-const LINE_MAX = 200; // digest lines can breathe — Slack/Discord/KB all handle it (vs the 72-char title)
+/**
+ * Phrases that mean **a person has to do something before this moves**. Deliberately explicit rather than
+ * clever: this list decides what lands in "Needs you", and a loose match would flood the one section of
+ * the digest that is a to-do list. Notably absent are `couldn't` / `cannot` — in these reports they far
+ * more often describe a FINDING ("the origin path cannot be observed per-vhost") than a blocked agent.
+ */
+const BLOCKED_RE = /(?:\bblocked\b|\bawaiting (?:a )?(?:human|owner|admin|review|approval|reply|response|direction|sign-?off)|\basked (?:the )?(?:owner|admin|a human) for\b|\bneeds? (?:a )?human\b|\bneeds? (?:owner|admin)\b|\bpending (?:human|owner|approval)\b|\bhuman (?:sends|review|approval)\b|\bnot sent\b|\bnothing sent\b|\bdraft[- ]only\b|\bunable to\b|\bpermission denied\b|\baccess denied\b|\bno access\b)/i;
+
+/** Ref kinds, most→least specific: the label for a thread prefers the most specific id it has. */
+const REF_PRIORITY = ['fs', 'pr', 'task', 'clickup', 'host', 'num'];
+
+/**
+ * The identifiers a line is ABOUT — the join key for cross-agent threads. Typed keys keep numeric
+ * namespaces apart (`FS#2701` is not `PR #2701`), but each numeric ref also emits a bare `num:` alias so
+ * "FreeScout 2701", "FS#2701" and a later bare "#2701" still land in one thread. Hostnames need a
+ * subdomain (≥3 labels) so an apex brand domain — which shows up in unrelated marketing/SEO work — can
+ * never fuse two threads. Exported for testing.
+ */
+export function refsOf(line: string): string[] {
+  const refs = new Set<string>();
+  const add = (kind: string, id: string) => {
+    refs.add(`${kind}:${id.toLowerCase()}`);
+    if (/^\d+$/.test(id)) refs.add(`num:${id}`);
+  };
+  for (const m of line.matchAll(/\b(?:fs|freescout|ticket)\s*#?\s*(\d{2,7})\b/gi)) add('fs', m[1]);
+  for (const m of line.matchAll(/\b(?:pr|pull request)\s*#?\s*(\d{2,7})\b/gi)) add('pr', m[1]);
+  for (const m of line.matchAll(/\b(tsk_[0-9a-f]{6,})\b/gi)) add('task', m[1]);
+  for (const m of line.matchAll(/\b(86[a-z0-9]{7,})\b/gi)) add('clickup', m[1]); // ClickUp task ids
+  for (const m of line.matchAll(/#(\d{3,7})\b/g)) add('num', m[1]);
+  for (const m of line.matchAll(/\b([a-z0-9][a-z0-9-]*(?:\.[a-z0-9-]+){2,})\b/gi)) {
+    const h = m[1].toLowerCase();
+    if (/\.(?:com|io|dev|site|xyz|me|tech|info|net|org|ai|co|app|cloud)$/.test(h)) add('host', h);
+  }
+  return [...refs];
+}
+
+function prettyRef(ref: string): string {
+  const i = ref.indexOf(':');
+  const kind = ref.slice(0, i);
+  const id = ref.slice(i + 1);
+  if (kind === 'fs') return `FS#${id}`;
+  if (kind === 'pr') return `PR #${id}`;
+  if (kind === 'num') return `#${id}`;
+  return id;
+}
+
+/** The thread's display label: the ref shared by the most of its lines, tie-broken by specificity. */
+function labelFor(refs: Set<string>, lines: Cand[]): string {
+  let best = '';
+  let bestScore = -1;
+  for (const ref of refs) {
+    const kind = ref.slice(0, ref.indexOf(':'));
+    const p = REF_PRIORITY.indexOf(kind);
+    const score = lines.filter((l) => l.refs.includes(ref)).length * 10 + (p < 0 ? 0 : REF_PRIORITY.length - p);
+    if (score > bestScore) { bestScore = score; best = ref; }
+  }
+  return best ? prettyRef(best) : '—';
+}
+
+/**
+ * Group the day's lines into **threads** — several sessions about the same ticket / PR / task / host —
+ * and represent each by its LATEST line. This is the fix for the digest's worst readability failure: one
+ * incident worked by four agents produced a dozen lines, several of them explicitly correcting each other
+ * ("confirmed and corrected the root cause"), every one of them marked ✓. Newest-wins is the honest
+ * summary of a thread that revised itself; the update count tells the reader revision happened.
+ *
+ * A cluster only becomes a thread when it's genuinely one — ≥2 agents, or ≥3 lines from one agent. A
+ * single agent's pair of related lines stays in its own block, where it reads fine. Exported for testing.
+ */
+export function clusterIncidents(cands: Cand[]): { incidents: Incident[]; rest: Cand[] } {
+  const byRef = new Map<string, Cand[]>();     // ref → the cluster (array identity IS the cluster id)
+  const clusters = new Set<Cand[]>();
+  for (const c of cands) {
+    if (!c.refs.length) continue;
+    const hits = [...new Set(c.refs.map((r) => byRef.get(r)).filter((x): x is Cand[] => !!x))];
+    let cl: Cand[];
+    if (!hits.length) { cl = []; clusters.add(cl); } else {
+      cl = hits[0];
+      for (const other of hits.slice(1)) {      // transitively linked → merge into the first
+        cl.push(...other);
+        for (const [ref, target] of byRef) if (target === other) byRef.set(ref, cl);
+        clusters.delete(other);
+      }
+    }
+    cl.push(c);
+    for (const r of c.refs) byRef.set(r, cl);
+  }
+
+  const all: { incident: Incident; lines: Cand[] }[] = [];
+  for (const lines of clusters) {
+    const agents = [...new Set(lines.map((l) => l.agent))];
+    if (lines.length < 2 || (agents.length < 2 && lines.length < 3)) continue;
+    // Blocked lines count toward the thread's size and its agent list — they're part of the story — but
+    // can't headline it, since "Needs you" is already showing them verbatim. All-blocked → no thread.
+    const visible = lines.filter((l) => !l.blocked);
+    if (!visible.length) continue;
+    const refs = new Set(lines.flatMap((l) => l.refs));
+    const head = [...visible].sort((a, b) => b.ts - a.ts)[0]; // the latest word on the thread
+    all.push({ lines: visible, incident: { label: labelFor(refs, lines), headline: head.title, outcome: head.outcome, agent: head.agent, agents, updates: lines.length } });
+  }
+  all.sort((a, b) => b.incident.updates - a.incident.updates || a.incident.label.localeCompare(b.incident.label));
+
+  const kept = all.slice(0, MAX_INCIDENTS);
+  const taken = new Set(kept.flatMap((k) => k.lines)); // only KEPT threads consume their lines
+  return { incidents: kept.map((k) => k.incident), rest: cands.filter((c) => !c.blocked && !taken.has(c)) };
+}
+
+const LINE_MAX = 280; // digest lines can breathe — Slack/Discord/KB all handle it (vs the 72-char title)
 const DEDUP_STOP = new Set(['task', 'with', 'this', 'that', 'from', 'into', 'have', 'been', 'were', 'they', 'will', 'just', 'also', 'done', 'made', 'make', 'need', 'some', 'more', 'than', 'only', 'each', 'both', 'over', 'when', 'then', 'sent', 'added', 'set', 'the', 'and', 'for']);
 
 /** Whether a `completed`-card body is the agent's own summary vs a GENERIC end card — the launcher writes
@@ -191,19 +351,23 @@ function dedupeLines(lines: DigestLine[]): DigestLine[] {
   return clusters.map((c) => (c.count > 1 ? { ...c.rep, count: c.count } : c.rep));
 }
 
-/** Compact tally line — "18 sessions · 7 ✓ · 1 partial · 1 ✗ · 9 stopped". */
+/** Compact tally line — "18 sessions · 7 ✓ · 1 partial · 1 ✗ · 9 stopped". Every session is in exactly
+ *  one bucket and every bucket is printed, so the parts always sum back to the total (the old line
+ *  silently omitted `other`, so a 94-session day showed 76). */
 function tally(m: DigestModel): string {
   const b = m.buckets;
   const parts: string[] = [`${m.total} session${m.total === 1 ? '' : 's'}`];
   if (b.success) parts.push(`${b.success} ✓`);
+  if (m.blocked) parts.push(`${m.blocked} ⏳ blocked`);
   if (b.partial) parts.push(`${b.partial} partial`);
   if (b.failure) parts.push(`${b.failure} ✗`);
   if (b.stopped) parts.push(`${b.stopped} stopped`);
   if (b.running) parts.push(`${b.running} running`);
+  if (b.other) parts.push(`${b.other} other`);
   return parts.join(' · ');
 }
 
-const MARK: Record<string, string> = { success: '✓', partial: '◐', failure: '✗', stopped: '·', running: '…' };
+const MARK: Record<string, string> = { success: '✓', partial: '◐', failure: '✗', stopped: '·', running: '…', blocked: '⏳' };
 
 function signalLine(m: DigestModel): string {
   const s = m.signals;
@@ -213,7 +377,35 @@ function signalLine(m: DigestModel): string {
   if (s.rejected) parts.push(`${s.rejected} rejected`);
   if (s.budgetStops) parts.push(`${s.budgetStops} budget stops`);
   if (s.errors) parts.push(`${s.errors} errors`);
+  if (s.costUsd >= 0.01) parts.push(`$${s.costUsd.toFixed(2)}`);
+  // Say what was left out. A body of 60 lines over 94 sessions reads as "everything" unless the gap is named.
+  if (m.hidden) parts.push(`${m.hidden} routine run${m.hidden === 1 ? '' : 's'} not shown`);
   return parts.join(' · ');
+}
+
+/** "⏳ Needs you" — the day's human action list, hoisted above the record so it can't be missed. `b` is
+ *  the platform's bold wrapper (Slack `*x*` vs Discord/markdown `**x**`). */
+function needBlock(m: DigestModel, b: (s: string) => string): string[] {
+  if (!m.needs.length) return [];
+  const out = [b(`⏳ Needs you (${m.needs.length})`)];
+  for (const n of m.needs.slice(0, MAX_NEEDS)) out.push(`• ${b(n.agent)} — ${n.title}`);
+  if (m.needs.length > MAX_NEEDS) out.push(`• _+${m.needs.length - MAX_NEEDS} more_`);
+  out.push('');
+  return out;
+}
+
+/** "🔗 Threads" — one line per cross-agent incident: the latest word on it, plus how much churn there was. */
+function threadBlock(m: DigestModel, b: (s: string) => string): string[] {
+  if (!m.incidents.length) return [];
+  const out = [b('🔗 Threads')];
+  for (const i of m.incidents) {
+    const named = i.agents.slice(0, MAX_THREAD_AGENTS).join(', ');
+    const rest = i.agents.length > MAX_THREAD_AGENTS ? ` +${i.agents.length - MAX_THREAD_AGENTS}` : '';
+    out.push(`• ${b(i.label)} — ${i.headline} ${MARK[i.outcome] ?? ''}`.trimEnd());
+    out.push(`  _${i.updates} updates · ${named}${rest} · latest: ${i.agent}_`);
+  }
+  out.push('');
+  return out;
 }
 
 /** Slack mrkdwn (`*bold*`, `_italic_`, `<url|text>` links). One combined message: 📋 Today + 🧠 Learned.
@@ -222,11 +414,13 @@ function signalLine(m: DigestModel): string {
 export function renderSlack(os: AgentOS, m: DigestModel, origin?: string): string {
   const name = os.tenant.charAt(0).toUpperCase() + os.tenant.slice(1);
   const link = (path: string, text: string) => (origin ? `<${origin}/#/${path}|${text}>` : text);
+  const bold = (s: string) => `*${s}*`;
   const out: string[] = [`*📋 ${link('insights', `${name} — ${m.label}`)}*`, `_${tally(m)}_`];
   const sig = signalLine(m);
   if (sig) out.push(`_${sig}_`);
   out.push('');
-  if (!m.byAgent.length) out.push('_No notable sessions today._');
+  out.push(...needBlock(m, bold), ...threadBlock(m, bold));
+  if (!m.byAgent.length && !m.needs.length && !m.incidents.length) out.push('_No notable sessions today._');
   for (const a of m.byAgent) {
     out.push(`*${link(`agents/${a.agent}`, a.agent)}*`);
     for (const l of a.lines) out.push(`• ${l.title}${l.count ? ` (×${l.count})` : ''} ${MARK[l.outcome] ?? ''}`.trimEnd());
@@ -252,6 +446,17 @@ export function renderMarkdown(os: AgentOS, m: DigestModel): string {
   ];
   const sig = signalLine(m);
   if (sig) out.push(``, `_${sig}_`);
+  if (m.needs.length) {
+    out.push(``, `## ⏳ Needs you (${m.needs.length})`);
+    for (const n of m.needs) out.push(`- **${n.agent}** — ${n.title}`);
+  }
+  if (m.incidents.length) {
+    out.push(``, `## 🔗 Threads`);
+    for (const i of m.incidents) {
+      out.push(`- **${i.label}** ${MARK[i.outcome] ?? ''} ${i.headline}`.replace('  ', ' '));
+      out.push(`  <br>_${i.updates} updates · ${i.agents.join(', ')} · latest: ${i.agent}_`);
+    }
+  }
   out.push(``, `## What got done`);
   if (!m.byAgent.length) out.push(`- (no notable sessions today)`);
   for (const a of m.byAgent) {
@@ -272,11 +477,13 @@ export function renderMarkdown(os: AgentOS, m: DigestModel): string {
 export function renderDiscord(os: AgentOS, m: DigestModel, origin?: string): string {
   const name = os.tenant.charAt(0).toUpperCase() + os.tenant.slice(1);
   const link = (path: string, text: string) => (origin ? `[${text}](${origin}/#/${path})` : text);
+  const bold = (s: string) => `**${s}**`;
   const out: string[] = [`**📋 ${name} — ${m.label}**`, tally(m)];
   const sig = signalLine(m);
   if (sig) out.push(sig);
   out.push('');
-  if (!m.byAgent.length) out.push('_No notable sessions today._');
+  out.push(...needBlock(m, bold), ...threadBlock(m, bold));
+  if (!m.byAgent.length && !m.needs.length && !m.incidents.length) out.push('_No notable sessions today._');
   for (const a of m.byAgent) {
     out.push(`**${link(`agents/${a.agent}`, a.agent)}**`);
     for (const l of a.lines) out.push(`• ${l.title}${l.count ? ` (×${l.count})` : ''} ${MARK[l.outcome] ?? ''}`.trimEnd());

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -27,8 +27,8 @@ export interface DreamResult {
   busy?: boolean; // another pass for this tenant was already running (M1) — this call no-opped
 }
 
-interface Tally { sessions: number; episodes: number; success: number; failure: number; partial: number; stopped: number; unknown: number; rejected: number; budgetStops: number; errors: number }
-interface RecentEntry { day: string; ts: number; sessions: number; success: number; failure: number; stopped: number; rejected: number; budgetStops: number; errors: number; topics: string[] }
+interface Tally { sessions: number; episodes: number; success: number; failure: number; partial: number; stopped: number; unknown: number; approved: number; rejected: number; budgetStops: number; errors: number }
+interface RecentEntry { day: string; ts: number; sessions: number; success: number; failure: number; stopped: number; approved?: number; rejected: number; budgetStops: number; errors: number; topics: string[] }
 interface DreamState {
   firstPass: number;
   passes: number;
@@ -85,6 +85,14 @@ export class DreamingEngine {
     for (const m of this.os.team.listMembers()) {
       for (const w of (m.name || '').toLowerCase().match(/[a-z][a-z0-9-]{3,}/g) ?? []) stop.add(w);
     }
+    // Agent ids are WHO did the work, not WHAT the fleet works on — same reasoning as member names. A
+    // report that names the agent it delegated to ("routed infra-ops…") shouldn't make "infra-ops" a topic.
+    // Only the WHOLE id is stopped, never its parts: "migration-ops" is an agent, "migration" is a topic.
+    try {
+      for (const a of this.os.db.prepare('SELECT DISTINCT agent FROM term_sessions').all<{ agent: string }>()) {
+        if (a.agent) stop.add(a.agent.toLowerCase());
+      }
+    } catch { /* advisory — a missing table just means no agent stop-words */ }
     return stop;
   }
 
@@ -166,7 +174,7 @@ export class DreamingEngine {
     const outcomes = [...bySession.values()];
 
     // ── this window's tallies ──
-    const win: Tally = { sessions: outcomes.length, episodes: episodes.length, success: 0, failure: 0, partial: 0, stopped: 0, unknown: 0, rejected: 0, budgetStops: 0, errors: 0 };
+    const win: Tally = { sessions: outcomes.length, episodes: episodes.length, success: 0, failure: 0, partial: 0, stopped: 0, unknown: 0, approved: 0, rejected: 0, budgetStops: 0, errors: 0 };
     for (const e of outcomes) {
       const o = e.type === 'session.stopped' ? 'stopped' : String(parse(e.data).outcome ?? 'unknown');
       if (o in win) (win as unknown as Record<string, number>)[o]++; else win.unknown++;
@@ -175,6 +183,7 @@ export class DreamingEngine {
       if (f.type === 'budget.exceeded') win.budgetStops++;
       else if (f.type === 'session.error') win.errors++; // L3: real run errors, not memory-store (`episode.error`) failures
       else if (parse(f.data).approved === false) win.rejected++;
+      else win.approved++; // the DENOMINATOR: friction is the rejection RATE, not the raw count (a busy day approves hundreds)
     }
     const winTopics = topicCounts(episodes, this.memberNameStop());
 
@@ -196,7 +205,7 @@ export class DreamingEngine {
     }
     state.topics = pruneTopics(state.topics, until); // M6: bound the map + drop long-unseen topics
     const day = new Date(until).toISOString().slice(0, 10);
-    state.recent.unshift({ day, ts: until, sessions: win.sessions, success: win.success, failure: win.failure, stopped: win.stopped, rejected: win.rejected, budgetStops: win.budgetStops, errors: win.errors, topics: [...winTopics].slice(0, 6).map(([t]) => t) });
+    state.recent.unshift({ day, ts: until, sessions: win.sessions, success: win.success, failure: win.failure, stopped: win.stopped, approved: win.approved, rejected: win.rejected, budgetStops: win.budgetStops, errors: win.errors, topics: [...winTopics].slice(0, 6).map(([t]) => t) });
     state.recent = state.recent.slice(0, MAX_RECENT);
 
     this.os.settings.setDreamingState(state as unknown as Record<string, unknown>, by);
@@ -260,7 +269,7 @@ function normalizeState(raw: Record<string, unknown>): DreamState {
 }
 
 function zeroTally(): Tally {
-  return { sessions: 0, episodes: 0, success: 0, failure: 0, partial: 0, stopped: 0, unknown: 0, rejected: 0, budgetStops: 0, errors: 0 };
+  return { sessions: 0, episodes: 0, success: 0, failure: 0, partial: 0, stopped: 0, unknown: 0, approved: 0, rejected: 0, budgetStops: 0, errors: 0 };
 }
 
 function parse(s: string): Record<string, unknown> {
@@ -271,17 +280,61 @@ function parse(s: string): Record<string, unknown> {
  *  name tokens (built per-pass from the roster) — a person's name describes WHO asked, not WHAT the fleet
  *  works on, so "the fleet frequently works on … vikas, singhal" is noise; drop them alongside STOP. */
 function topicCounts(episodes: EpisodeRow[], nameStop: Set<string> = new Set()): [string, number][] {
+  const proper = properNouns(episodes);
   const counts = new Map<string, number>();
   for (const e of episodes) {
-    const line = (e.content.split('\n').map((l) => l.trim()).find((l) => l) ?? '').replace(/^Task:\s*/i, '');
+    const line = firstLine(e);
     const seen = new Set<string>();
-    for (const w of line.toLowerCase().match(/[a-z][a-z0-9-]{3,}/g) ?? []) {
-      if (STOP.has(w) || nameStop.has(w) || seen.has(w)) continue; // once per episode
-      seen.add(w);
-      counts.set(w, (counts.get(w) ?? 0) + 1);
+    for (const w of line.toLowerCase().match(/[a-z][a-z0-9.-]{3,}/g) ?? []) {
+      const t = w.replace(/[.-]+$/, '');
+      if (t.length < 4 || STOP.has(t) || nameStop.has(t) || seen.has(t)) continue; // once per episode
+      if (!isEntity(t, proper)) continue;
+      seen.add(t);
+      counts.set(t, (counts.get(t) ?? 0) + 1);
     }
   }
   return [...counts].sort((a, b) => b[1] - a[1]);
+}
+
+/** The first meaningful line of an episode, with the `Task:` prefix stripped. */
+function firstLine(e: EpisodeRow): string {
+  return (e.content.split('\n').map((l) => l.trim()).find((l) => l) ?? '').replace(/^Task:\s*/i, '');
+}
+
+const WORD_RE = /[A-Za-z][A-Za-z0-9.-]{3,}/g;
+
+/**
+ * Tokens the corpus itself writes as a **name** — capitalized away from a sentence start, or ALL-CAPS.
+ * Case is the one strong, maintenance-free signal for "this is a thing, not an English word", and the
+ * old lowercase-first tokenizer threw it away before anything could use it.
+ */
+function properNouns(episodes: EpisodeRow[]): Set<string> {
+  const proper = new Set<string>();
+  for (const e of episodes) {
+    const line = firstLine(e);
+    for (const m of line.matchAll(WORD_RE)) {
+      const raw = m[0].replace(/[.-]+$/, '');
+      if (raw.length < 4) continue;
+      const before = line.slice(0, m.index).trimEnd();
+      const sentenceStart = before === '' || /[.!?:;•(\[\-—]$/.test(before);
+      const allCaps = raw === raw.toUpperCase() && /[A-Z]{2,}/.test(raw);
+      if (allCaps || (/^[A-Z]/.test(raw) && !sentenceStart)) proper.add(raw.toLowerCase());
+    }
+  }
+  return proper;
+}
+
+/**
+ * Whether a token is a THING the fleet works on rather than an ordinary English word. The old filter was a
+ * hand-maintained blocklist, which is unwinnable — fleet data produced "the fleet frequently works on:
+ * instawp, handed, client-app, read-only, really", and every such word had to be discovered in production
+ * and then patched in. This inverts it to an ALLOW test on shape: a topic must be written as a name
+ * somewhere (`properNouns`), or carry a digit or a dot (`v3`, `php8`, `instawp.com`). Deliberately
+ * precision-over-recall — an always-lowercase repo name is missed, but nothing embarrassing gets through,
+ * and the guidance line only prints at all when ≥2 topics survive.
+ */
+function isEntity(token: string, proper: Set<string>): boolean {
+  return proper.has(token) || /\d/.test(token) || token.includes('.');
 }
 
 /** A recency-decayed weight for a topic — `count` halved for every `TOPIC_HALFLIFE_MS` since last seen,
@@ -310,16 +363,32 @@ function pruneTopics(topics: Record<string, { count: number; lastSeen: number }>
 
 /** Sum the RECENT window (last `RECENT_PASSES` per-pass tallies) — the honest "recent" signal for
  *  guidance + recommendations, vs. the ever-growing lifetime `totals` (H4). */
-function recentTally(s: DreamState): { sessions: number; success: number; rejected: number; budgetStops: number; errors: number } {
-  const r = { sessions: 0, success: 0, rejected: 0, budgetStops: 0, errors: 0 };
+function recentTally(s: DreamState): { sessions: number; success: number; approved: number; rejected: number; budgetStops: number; errors: number } {
+  const r = { sessions: 0, success: 0, approved: 0, rejected: 0, budgetStops: 0, errors: 0 };
   for (const e of (s.recent ?? []).slice(0, RECENT_PASSES)) {
     r.sessions += e.sessions || 0;
     r.success += e.success || 0;
+    r.approved += e.approved || 0;
     r.rejected += e.rejected || 0;
     r.budgetStops += e.budgetStops || 0;
     r.errors += e.errors || 0;
   }
   return r;
+}
+
+/**
+ * Approval friction is a **rate**, not a count. Gating on "≥3 rejections" fired on tenants whose approvals
+ * are ~100% approved — 3 rejections out of 400 is a healthy gate, and telling the owner their policy is
+ * over-rejecting (and telling every agent to expect rejection) was simply wrong. Both the guidance line
+ * and the recommendation now need the raw count AND this share of human decisions.
+ *
+ * Legacy `recent` entries have no `approved` field → they read as 0, so a stale state can still fire once;
+ * it self-corrects on the next pass, which records the denominator.
+ */
+const REJECTION_RATE = 0.2;
+function rejectionRate(t: { approved: number; rejected: number }): number {
+  const n = t.approved + t.rejected;
+  return n ? t.rejected / n : 0;
 }
 
 // Cadence is OFF (everyHours 0) → learned guidance goes stale after this long unrefreshed. When a cadence
@@ -350,7 +419,7 @@ export function deriveGuidance(s: DreamState): string {
   lines.push('Before non-trivial work, `recall` your memory and `kb_search` the knowledge base — the fleet may have already solved this; build on it rather than redoing it.');
   const topics = topTopicList(s.topics, 5).filter(([, v]) => v.count >= MIN_TOPIC_COUNT).map(([k]) => k);
   if (topics.length >= 2) lines.push(`The fleet frequently works on: ${topics.join(', ')}. For these, read the KB runbook first (kb_read) and update it (kb_write) when you learn something new.`);
-  if (t.rejected >= 2) lines.push('Recent actions were rejected at human approval — `policy_check` before risky effects, and never retry an action a human already rejected.');
+  if (t.rejected >= 2 && rejectionRate(t) >= REJECTION_RATE) lines.push('Recent actions were rejected at human approval — `policy_check` before risky effects, and never retry an action a human already rejected.');
   if (t.budgetStops >= 1) lines.push('Budget limits have been hit — scope work tightly, avoid broad scans / long loops, and `ask` rather than burn budget guessing.');
   if (t.errors >= 2) lines.push('Some sessions ended in errors — verify your work before finishing, and `report` the real outcome (including failures) honestly.');
   const rate = t.sessions ? t.success / t.sessions : 1;
@@ -393,11 +462,11 @@ export function deriveRecommendations(s: DreamState, currentEffort: string | und
       apply: { runtimeDefaults: { effort: 'high' } }, createdAt: now,
     });
   }
-  if (t.rejected >= 3) {
+  if (t.rejected >= 3 && rejectionRate(t) >= REJECTION_RATE) {
     recs.push({
       id: 'policy.review', kind: 'policy',
       title: 'Review your policy — actions are often rejected at approval',
-      rationale: `${t.rejected} actions were rejected at human approval. If a capability is always rejected it may belong on the deny list; if always approved, the gate is just friction. (Advisory — edit in Settings → Policy.)`,
+      rationale: `${t.rejected} of ${t.approved + t.rejected} approvals were rejected (${Math.round(rejectionRate(t) * 100)}%). If a capability is always rejected it may belong on the deny list; if always approved, the gate is just friction. (Advisory — edit in Settings → Policy.)`,
       link: '#/settings', createdAt: now,
     });
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12020,8 +12020,23 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
             <div>
               <div className="mb-1 text-[10px] uppercase tracking-wider text-muted-foreground">Today so far — preview</div>
               <div className="rounded-md border bg-muted/40 p-3 text-xs">
-                <div className="font-medium">📋 {preview.label} · {preview.total} session{preview.total === 1 ? '' : 's'} · {preview.buckets.success} ✓{preview.buckets.failure ? ` · ${preview.buckets.failure} ✗` : ''}{preview.buckets.stopped ? ` · ${preview.buckets.stopped} stopped` : ''}</div>
-                {preview.byAgent.length === 0
+                <div className="font-medium">📋 {preview.label} · {preview.total} session{preview.total === 1 ? '' : 's'} · {preview.buckets.success} ✓{preview.blocked ? ` · ${preview.blocked} ⏳` : ''}{preview.buckets.failure ? ` · ${preview.buckets.failure} ✗` : ''}{preview.buckets.stopped ? ` · ${preview.buckets.stopped} stopped` : ''}{preview.signals?.costUsd >= 0.01 ? ` · $${preview.signals.costUsd.toFixed(2)}` : ''}</div>
+                {/* The two synthesis sections lead, same as the posted digest: what needs a person, then
+                    the day's cross-agent threads. Only then the per-agent record. */}
+                {preview.needs?.length > 0 && (
+                  <div className="mt-2">
+                    <div className="font-medium">⏳ Needs you ({preview.needs.length})</div>
+                    {preview.needs.slice(0, 5).map((n, i) => <div key={i} className="truncate text-muted-foreground">• <span className="font-medium">{n.agent}</span> — {n.title}</div>)}
+                    {preview.needs.length > 5 && <div className="text-muted-foreground">• +{preview.needs.length - 5} more</div>}
+                  </div>
+                )}
+                {preview.incidents?.length > 0 && (
+                  <div className="mt-2">
+                    <div className="font-medium">🔗 Threads</div>
+                    {preview.incidents.map((i) => <div key={i.label} className="truncate text-muted-foreground">• <span className="font-medium">{i.label}</span> — {i.headline} <span className="opacity-70">({i.updates} updates · {i.agents.length} agent{i.agents.length === 1 ? '' : 's'})</span></div>)}
+                  </div>
+                )}
+                {preview.byAgent.length === 0 && !preview.needs?.length && !preview.incidents?.length
                   ? <div className="mt-1 text-muted-foreground">No notable sessions yet today.</div>
                   : preview.byAgent.map((a) => (
                       <div key={a.agent} className="mt-2">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -460,8 +460,12 @@ export interface DigestModel {
   label: string
   total: number
   buckets: { success: number; partial: number; failure: number; stopped: number; running: number; other: number }
+  blocked: number
+  hidden: number
+  needs: { agent: string; title: string }[]
+  incidents: { label: string; headline: string; outcome: string; agent: string; agents: string[]; updates: number }[]
   byAgent: { agent: string; lines: { title: string; outcome: string; importance: number; count?: number }[]; more: number }[]
-  signals: { tasksCreated: number; tasksCompleted: number; approvals: number; rejected: number; errors: number; budgetStops: number }
+  signals: { tasksCreated: number; tasksCompleted: number; approvals: number; rejected: number; errors: number; budgetStops: number; costUsd: number }
   guidance: string[]
   recommendations: string[]
 }


### PR DESCRIPTION
Prompted by reading a real posted digest — instawp, 2026-07-30, 94 sessions. The **lines** were excellent (the `report`-first-sentence source is doing its job); the **artifact around them** was a log grouped by author, and in two places it actively misled.

## The four problems

| # | Symptom in the real digest | Cause |
| --- | --- | --- |
| 1 | `…push is BLOCKED: no token can push… ✓` | `outcome` is whatever the agent passed to `report()` — its grade of its own *effort*, not of the result |
| 2 | One migration bug told **9×** by 4 agents, three lines explicitly correcting each other, all ✓ | `dedupeLines` clusters by Jaccard **within one agent** only |
| 3 | Header `94 sessions · 55 ✓ · 8 partial · 6 stopped · 7 running` — sums to 76 | `tally()` never printed the `other` bucket |
| 4 | `site-doctor • "The backend of … is too slow"`, `triage • "can you please check why this happend?"` | no-report sessions fall back to the **title**, which is derived from the incoming task — so the human's prompt printed as the day's result |

Plus, in the **🧠 Learned** block: `"The fleet frequently works on: instawp, handed, client-app, read-only, really"` and `"⚠ Recommend: Review your policy — actions are often rejected at approval"` on a tenant whose approvals are ~100% approved.

## What changed

**`src/edge/digest.ts`**
- **`⏳ Needs you`** — `BLOCKED_RE` over the line text reclassifies blocked runs out of the outcome buckets and hoists them to the top. The only part of the digest that is a to-do rather than a record.
- **`🔗 Threads`** — `refsOf` (typed ticket/PR/task/ClickUp/host refs, each numeric one also emitting a `num:` alias so `FS#2701` / `FreeScout 2701` / a later bare `#2701` fuse) + `clusterIncidents` (transitive union, **across** agents). Each thread shows the *newest* line — the honest summary of a sequence that corrected itself — plus the update count and the agents involved.
- Blocked lines take part in clustering but never headline a thread. They're frequently what *links* one ("FS#2569: …awaiting human review" is the same thread as "Root-caused FS#2569…"), and hoisting them out of the pool fragmented threads.
- Tally prints every bucket, plus the day's `cost_usd` and `N routine runs not shown`.
- A body line now requires a real `report`; `status === 'done'`/salient-episode were dropped as entry paths. Lines clip at 280 chars (200 was cutting mid-outcome).

**`src/edge/dreaming.ts`**
- Topic extraction inverted from a **blocklist** to an **allow test on shape**: tokenization preserves case, and a topic is admitted only if the corpus writes it as a name (`properNouns` — capitalized away from a sentence start, or ALL-CAPS) or it carries a digit or a dot. A hand-maintained `STOP` list is unwinnable when the output rides in every agent's system prompt. Agent ids join member names as stop-words (whole id only — `migration-ops` is an agent, `migration` is a topic).
- Approval friction gated on the **rate**: the per-pass tally records `approved` alongside `rejected`, and both the guidance line and the `policy.review` recommendation need the count **and** ≥20% of human decisions. The recommendation now states the rate.

Web console preview + `DigestModel` type extended for the two new sections.

## Verification

- Replayed the **real 2026-07-30 instawp digest** (all 58 reports verbatim + 34 no-report runs) through `buildDigest` on an in-memory `AgentOS`: tally reconciles (73 ✓ + 10 ⏳ + 5 ◐ + 3 stopped = 91), **6 threads** formed (`#228093` 6 updates/3 agents, the cert thread 5 updates/4 agents, `FS#2701`, `FS#2648`, `ve-staging.instawp.xyz`, `PR #522`), **10 needs** hoisted, both prompt-as-result lines filtered into `hidden`.
- Full Dreaming passes at **3 rejected / 200 approved** → no nag, no recommendation; **6 / 10** → both fire. Topics resolve to `instawp, clickup, freescout` on episode text that also contains "handed", "read-only" and "really" as ordinary lowercase words.
- `npx tsc --noEmit`, `cd web && npm run build`, `npm run demo`, **130/130 governance conformance**.

## Known limitation

`BLOCKED_RE` is prose matching. A line *describing* blocking as a feature ("downgrades to `blocked` when…") is a false positive — 1 of 10 on the real sample. It reads as obviously-not-a-blocker to a human and the section is short enough to scan; documented in `docs/daily-digest-plan.md` rather than papered over with a more fragile regex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)