### PR TITLE
feat(cockpit): ask tier works with no LLM key — deterministic lookups + ephemeral concierge run (v0.281.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.281.0] — 2026-07-31
+### Changed
+- **Cockpit `ask` tier now works with no LLM key — deterministic lookups + an ephemeral concierge run,
+  not a bolt-on API.** The `ask` path previously needed a separately-configured `router_config.llm`
+  (which the deployment doesn't have), so it was inert. Rebuilt in two bands that use what the workspace
+  already has:
+  - **Band 1 — structured lookups answered from live state**, instant, no LLM/session/key: "which agents
+    are idle?", "what's running?", "how many open tasks?", "list my automations", "what agents do I have?"
+    (`src/edge/ask.ts` `answerFromState`, deterministic over `tm.listSessions`/`os.tasks.counts`/
+    `autos.list`).
+  - **Band 2 — freeform** ("how do automations work?", "why did X fail?"): a fast direct LLM **if one is
+    configured**, else a governed **ephemeral concierge run** — the native LLM in Agent OS is a claude
+    session, so a new System agent (`src/edge/concierge.ts`, `concierge`) answers using the OS tools
+    (`kb_search`/`recall`/`session_history`/…), run-as the asker; Cockpit polls its transcript and renders
+    the reply inline, so it still feels session-free. No API key required.
+  Also: the agent **router now excludes `category:'System'` agents** (concierge/consolidator/strategist/…)
+  — you can never be routed to the machinery for work. `POST /api/router/preview` returns `source`
+  (`state`/`llm`/`concierge`) and, for a concierge answer, `run.sessionId` to poll. `src/edge/ask.ts` +
+  `src/edge/concierge.ts` (new), `src/edge/router.ts`, `src/server.ts`, `web/src/App.tsx`,
+  `web/src/lib/api.ts`.
+
 ## [0.280.0] — 2026-07-31
 ### Changed
 - **The daily digest is now a synthesis, not a log grouped by author.** On a 94-session day the posted

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.280.0",
+  "version": "0.281.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.280.0",
+      "version": "0.281.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.280.0",
+  "version": "0.281.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/ask.ts
+++ b/src/edge/ask.ts
@@ -1,0 +1,57 @@
+/**
+ * Cockpit `ask` tier — Band 1: answer the common structured lookups ("which agents are idle?",
+ * "what's running?", "how many open tasks?") **deterministically from live state** — instant, no LLM,
+ * no session, no API key. A lot of "ask" isn't LLM-shaped at all; it's a query the console already
+ * knows. Returns a markdown answer, or null to fall through to the freeform path (a direct LLM, or the
+ * ephemeral concierge run). System agents (concierge/consolidator/…) are excluded — a member asks
+ * about their teammates, not the machinery.
+ */
+import { isCodingRuntime, Member } from '../types';
+import { AgentOS } from '../kernel';
+import { TerminalManager } from '../terminal';
+import { Automations } from './automations';
+
+export function answerFromState(os: AgentOS, tm: TerminalManager, autos: Automations, me: Member, text: string): string | null {
+  const t = text.toLowerCase();
+  const has = (re: RegExp) => re.test(t);
+  const userAgents = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime) && a.category !== 'System');
+  const sessions = tm.listSessions(me);
+  const live = sessions.filter((s) => s.alive);
+  const fmt = (ids: string[]) => ids.map((x) => `\`${x}\``).join(', ');
+
+  // Idle / inactive agents → those with no live session.
+  if (has(/\bagents?\b/) && has(/\b(idle|inactive|unused|not\s+(running|active|busy)|doing nothing)\b/)) {
+    if (!userAgents.length) return null;
+    const busy = new Set(live.map((s) => s.agent));
+    const idle = userAgents.filter((a) => !busy.has(a.id));
+    return idle.length
+      ? `${idle.length} of ${userAgents.length} agents have no live session right now: ${fmt(idle.map((a) => a.id))}.`
+      : `All ${userAgents.length} agents currently have a live session.`;
+  }
+  // Running / active sessions.
+  if (/what('?s| is)\s+(running|going on|happening)/.test(t) || (has(/\b(running|active|live|in\s?progress)\b/) && has(/\b(session|agent|run|now)\b/))) {
+    if (!live.length) return 'Nothing is running right now — 0 live sessions.';
+    const byAgent: Record<string, number> = {};
+    for (const s of live) byAgent[s.agent] = (byAgent[s.agent] || 0) + 1;
+    const parts = Object.entries(byAgent).map(([a, n]) => `\`${a}\`${n > 1 ? ` ×${n}` : ''}`);
+    return `${live.length} session${live.length > 1 ? 's' : ''} running now: ${parts.join(', ')}.`;
+  }
+  // Tasks.
+  if (has(/\btasks?\b/) && has(/\b(how many|open|list|what|which|status|left|pending|in\s?progress|blocked|to-?do)\b/)) {
+    const c = os.tasks.counts(os.tenant);
+    return `Tasks: ${c.todo} to-do, ${c.doing} in progress, ${c.blocked} blocked, ${c.done} done.`;
+  }
+  // Automations.
+  if (has(/\b(automations?|schedules?|crons?)\b/) && has(/\b(how many|list|what|which|enabled|active|running|do i have)\b/)) {
+    const all = autos.list();
+    if (!all.length) return 'No automations configured yet.';
+    const on = all.filter((a) => a.enabled);
+    return `${all.length} automation${all.length > 1 ? 's' : ''} (${on.length} enabled)${on.length ? `: ${fmt(on.slice(0, 15).map((a) => a.name))}` : ''}.`;
+  }
+  // List agents (generic roster).
+  if ((has(/\b(list|what|which|how many|show)\b/) && has(/\bagents?\b/)) || /\bagents?\b.*\b(do i have|are there|available)\b/.test(t)) {
+    if (!userAgents.length) return 'No agents yet.';
+    return `You have ${userAgents.length} agents: ${fmt(userAgents.map((a) => a.id))}.`;
+  }
+  return null;
+}

--- a/src/edge/concierge.ts
+++ b/src/edge/concierge.ts
@@ -1,0 +1,63 @@
+/**
+ * The **concierge** — a code-provisioned System agent that answers freeform questions ABOUT this
+ * workspace for Cockpit's `ask` tier. It exists so `ask` can answer questions that need reasoning/tools
+ * WITHOUT depending on a separately-configured LLM API key: the native "LLM" in Agent OS is a claude
+ * session (authenticated via the agents' subscription), and every session already gets the OS MCP tools
+ * (recall / kb_search / session_history / task_list / list_capabilities / directory_lookup). So the
+ * concierge answers by querying real state, not a hand-assembled context snapshot.
+ *
+ * It's spawned as an ordinary one-shot chat run (governed, run-as the asker), and Cockpit renders its
+ * reply inline. Category `System` keeps it out of the agent ROUTER (you never get "routed to the
+ * concierge" for work) and out of the fleet picker. Provisioning mirrors the consolidator: idempotent,
+ * writes a manifest + persona under the home's agents dir, registers a live claude-code runtime.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import { AgentManifest } from '../types';
+import { AgentOS } from '../kernel';
+
+export const CONCIERGE_ID = 'concierge';
+
+const MANIFEST: AgentManifest = {
+  id: CONCIERGE_ID,
+  version: '1.0.0',
+  description: 'Workspace concierge — answers questions about this Agent OS workspace using its own tools.',
+  category: 'System',
+  principal: 'svc-concierge',
+  policyContext: 'default@v3',
+  runtime: 'claude-code',
+  budget: { usdCap: 0.5, tokenCap: 150_000, wallClockMs: 300_000 },
+};
+
+const CLAUDE_MD = `# Workspace concierge
+
+You are the **concierge** for this Agent OS workspace. A member asked a question about the workspace
+itself — the agents, sessions, tasks, automations, memory, knowledge base, policy, or how any of it
+works. Answer it, concisely, grounded in **real state**.
+
+## Method
+1. **Ground the answer in tools, not guesses.** Use \`kb_search\`/\`kb_read\` for how-things-work and
+   documented runbooks, \`recall\` for durable facts about this environment, \`session_history\` for what
+   has run, \`task_list\` for work in flight, \`list_capabilities\` for what agents may do, and
+   \`directory_lookup\` for people/agents. Never invent an agent name, a number, or a fact.
+2. **Be brief.** 2–5 sentences, or a short list. This answer is shown inline in the console — no preamble
+   ("Sure!", "Great question"), no sign-off. Lead with the answer.
+3. **If you don't know, say so** and point to the console page that would ("See the Automations page.").
+4. You are **read-only by nature** here: answer the question. Do NOT create tasks, schedule automations,
+   or change anything — if the member wants an action taken, tell them to ask for it directly (that's a
+   different flow). Do not call \`report\`/\`ask\`; your reply text IS the answer.
+
+You act on the member's behalf and only read workspace state — nothing you do needs their connectors.`;
+
+/** Ensure the concierge agent exists on disk + is registered as a live runtime. Idempotent; safe to call
+ *  on every `ask` that needs it. Mirrors the consolidator's self-provisioning. */
+export function ensureConcierge(os: AgentOS): void {
+  if (os.agents.get(CONCIERGE_ID)?.dir) return;
+  const base = os.paths?.userAgents ?? path.join(process.cwd(), 'data', 'agents');
+  const dir = path.join(base, CONCIERGE_ID);
+  fs.mkdirSync(dir, { recursive: true });
+  const manifestPath = path.join(dir, 'agent.json');
+  if (!fs.existsSync(manifestPath)) fs.writeFileSync(manifestPath, JSON.stringify(MANIFEST, null, 2));
+  if (!fs.existsSync(path.join(dir, 'CLAUDE.md'))) fs.writeFileSync(path.join(dir, 'CLAUDE.md'), CLAUDE_MD);
+  os.registerAgent({ ...MANIFEST, dir });
+}

--- a/src/edge/router.ts
+++ b/src/edge/router.ts
@@ -168,7 +168,9 @@ function profileHash(s: string): string {
  */
 export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecision> {
   const cfg = os.settings.routerConfig();
-  const agents = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime));
+  // Route only to user-facing teammates — never to the code-provisioned System machinery (consolidator,
+  // concierge, strategist, …); those aren't work agents a person should be handed off to.
+  const agents = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime) && a.category !== 'System');
   if (agents.length === 0) return { kind: 'none' };
 
   let scored = scoreAgents(text, agents);

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,6 +23,8 @@ import { Automation, Automations, nextCronRun, derivedConcurrencyCap, chatTitle 
 import { chooseAgent } from './edge/router';
 import { classifyIntent } from './edge/intent';
 import { resolveLlm, chatComplete } from './edge/llm';
+import { ensureConcierge, CONCIERGE_ID } from './edge/concierge';
+import { answerFromState } from './edge/ask';
 import { SlackSocket } from './edge/slack-socket';
 import { ClickupIngress } from './edge/clickup-ingress';
 import { DiscordSocket } from './edge/discord-socket';
@@ -2556,7 +2558,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return { id, description: a?.description || '', category: a?.category, icon: a?.icon, score };
     };
     const fleet = () =>
-      [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime) && runnable(a.id)).map((a) => card(a.id));
+      [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime) && a.category !== 'System' && runnable(a.id)).map((a) => card(a.id));
     // The `work` responder: the agent-routing decision, filtered to what this member can run.
     const respondWork = async (askFallback?: boolean) => {
       const decision = await chooseAgent(os, text);
@@ -2580,14 +2582,30 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     }
 
     if (intent.intent === 'ask') {
+      // Band 1: structured lookups answered deterministically from state — instant, no LLM, no session.
+      const stateAnswer = answerFromState(os, tm, autos, me, text);
+      if (stateAnswer) return sendJson(res, 200, { intent: 'ask', answer: stateAnswer, source: 'state' });
+
+      // Band 2a: freeform, and a fast direct LLM IS configured → answer inline from a compact context.
       const llm = resolveLlm(os);
-      if (!llm) return respondWork(true); // no LLM → route to an agent, but flag why (Settings hint)
-      const answer = await chatComplete(llm, [
-        { role: 'system', content: 'You are the assistant for this Agent OS workspace. Answer the question ONLY from the CONTEXT below — the live state of this workspace. Be concise (2–5 sentences). If the answer is not in the context, say you do not have that information and suggest the relevant console page. Never invent agents, numbers, or names.' },
-        { role: 'user', content: `CONTEXT:\n${cockpitWorkspaceContext(os, tm, autos, me)}\n\nQUESTION: ${text}` },
-      ], { maxTokens: 500, timeoutMs: 15000 });
-      if (!answer) return respondWork(true); // LLM failed → don't dead-end; route instead
-      return sendJson(res, 200, { intent: 'ask', answer });
+      if (llm) {
+        const answer = await chatComplete(llm, [
+          { role: 'system', content: 'You are the assistant for this Agent OS workspace. Answer the question ONLY from the CONTEXT below — the live state of this workspace. Be concise (2–5 sentences). If the answer is not in the context, say you do not have that information and suggest the relevant console page. Never invent agents, numbers, or names.' },
+          { role: 'user', content: `CONTEXT:\n${cockpitWorkspaceContext(os, tm, autos, me)}\n\nQUESTION: ${text}` },
+        ], { maxTokens: 500, timeoutMs: 15000 });
+        if (answer) return sendJson(res, 200, { intent: 'ask', answer, source: 'llm' });
+      }
+
+      // Band 2b: no direct LLM → answer via a governed, ephemeral CLAUDE run (the concierge). This is the
+      // native LLM in Agent OS — no separate API key needed, and it can use the OS tools to ground the
+      // answer. Spawned run-as the asker (read-only persona, System agent so it's never a route target);
+      // the client polls the run's transcript and renders the reply inline. See src/edge/concierge.ts.
+      ensureConcierge(os);
+      if (os.agents.get(CONCIERGE_ID)?.dir) {
+        const s = tm.createSession(CONCIERGE_ID, chatTitle(text, CONCIERGE_ID), text, `chat:${me.id}`, true, undefined, undefined, me.id, undefined, false);
+        return sendJson(res, 200, { intent: 'ask', run: { sessionId: s.id }, source: 'concierge' });
+      }
+      return respondWork(true); // last resort — couldn't provision the concierge
     }
 
     return respondWork();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3940,6 +3940,35 @@ function CockpitPage({ onOpenChat, onOpenTerminal, nav }: {
     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); runPreview() }
   }
 
+  // `ask` band 2b: the server started an ephemeral concierge run — poll its transcript and surface the
+  // reply inline (so a claude-backed answer still feels session-free). Stops once the reply stabilises.
+  const runSession = preview?.intent === 'ask' ? preview.run?.sessionId : undefined
+  const [askAnswer, setAskAnswer] = useState('')
+  const [askThinking, setAskThinking] = useState(false)
+  const prevAnswer = useRef('')
+  useEffect(() => {
+    setAskAnswer(''); prevAnswer.current = ''
+    if (!runSession) { setAskThinking(false); return }
+    setAskThinking(true)
+    let stop = false
+    const poll = async () => {
+      const r = await api.conversation(runSession)
+      if (stop) return
+      const assistant = (r.turns || []).filter((t) => t.kind !== 'user')
+      const last = assistant[assistant.length - 1]
+      const text = (last && 'text' in last ? last.text : '') || ''
+      if (text) {
+        setAskAnswer(text)
+        if (text === prevAnswer.current) { setAskThinking(false); stop = true; clearInterval(timer); clearTimeout(to) } // stable → done
+        prevAnswer.current = text
+      }
+    }
+    poll()
+    const timer = setInterval(poll, 1500)
+    const to = setTimeout(() => { stop = true; clearInterval(timer); setAskThinking(false) }, 60000)
+    return () => { stop = true; clearInterval(timer); clearTimeout(to) }
+  }, [runSession])
+
   const isWork = !preview?.intent || preview.intent === 'work'
 
   const card = (c: RouterCard, opts?: { primary?: boolean }) => (
@@ -3990,12 +4019,26 @@ function CockpitPage({ onOpenChat, onOpenTerminal, nav }: {
 
       {preview && (
         <div className="flex flex-col gap-3">
-          {/* ASK — answered inline from the workspace context; no session spawned. */}
-          {preview.intent === 'ask' && preview.answer && (
+          {/* ASK — answered inline (band 1 from live state / a direct LLM), or via an ephemeral concierge
+              run (band 2b) whose reply we poll in. Either way: no session the user has to babysit. */}
+          {preview.intent === 'ask' && (preview.answer || preview.run) && (
             <div className="rounded-xl border bg-card p-4">
-              <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground"><Sparkles className="h-3.5 w-3.5 text-primary" /><span>Answered from your workspace</span></div>
-              <div className="prose prose-sm max-w-none dark:prose-invert prose-p:my-1.5"><ReactMarkdown remarkPlugins={[remarkGfm]}>{preview.answer}</ReactMarkdown></div>
-              <button onClick={() => runPreview('work')} className="mt-3 text-xs text-muted-foreground underline-offset-2 hover:underline">Not what you meant? Route to an agent instead →</button>
+              <div className="mb-2 flex items-center gap-2 text-xs text-muted-foreground">
+                <Sparkles className="h-3.5 w-3.5 text-primary" />
+                <span>{preview.source === 'state' ? 'Answered from your workspace' : preview.run ? 'Concierge · looked it up for you' : 'Answered'}</span>
+              </div>
+              {preview.answer && (
+                <div className="prose prose-sm max-w-none dark:prose-invert prose-p:my-1.5"><ReactMarkdown remarkPlugins={[remarkGfm]}>{preview.answer}</ReactMarkdown></div>
+              )}
+              {preview.run && (
+                askAnswer
+                  ? <div className="prose prose-sm max-w-none dark:prose-invert prose-p:my-1.5"><ReactMarkdown remarkPlugins={[remarkGfm]}>{askAnswer}</ReactMarkdown></div>
+                  : <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground"><RefreshCw className="h-3.5 w-3.5 animate-spin" />Looking into it…</div>
+              )}
+              <div className="mt-3 flex items-center gap-3 text-xs">
+                <button onClick={() => runPreview('work')} className="text-muted-foreground underline-offset-2 hover:underline">Not what you meant? Route to an agent instead →</button>
+                {preview.run && !askThinking && askAnswer && <button onClick={() => onOpenChat(preview.run!.sessionId)} className="text-muted-foreground underline-offset-2 hover:underline">Open full session →</button>}
+              </div>
             </div>
           )}
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1246,8 +1246,15 @@ export interface RouterPreviewResp {
   method?: 'keyword' | 'embedding' | 'llm'
   suggested?: RouterCard
   candidates: RouterCard[]
-  /** ask only: the inline answer composed from the workspace context. */
+  /** ask only: an inline answer that's ready immediately (band 1 = from live state, or a configured
+   *  direct LLM). Rendered as-is. */
   answer?: string
+  /** ask only: no instant answer was available, so a governed ephemeral concierge run was started —
+   *  poll its conversation and render the reply inline. */
+  run?: { sessionId: string }
+  /** ask only: where the answer came from — `state` (deterministic lookup), `llm` (direct model),
+   *  `concierge` (ephemeral claude run via `run`). */
+  source?: 'state' | 'llm' | 'concierge'
   /** action only: the primitive surface this request maps to. */
   surface?: 'automations' | 'tasks'
   /** work only: this was classified `ask` but no LLM is configured, so it fell back to routing (show a


### PR DESCRIPTION
Answers your question — "why can't we use the same Chat primitive for `ask`?" You were right. The native LLM in Agent OS **is** a claude session, so the `ask` tier no longer depends on a bolt-on `router_config.llm` key (which the deployment doesn't have, so `ask` was inert). Rebuilt in two bands using what the workspace already has.

## Band 1 — structured lookups, answered from live state

A lot of `ask` isn't LLM-shaped — it's a query the console already knows. Answered **deterministically, instant, no LLM / no session / no key** (`src/edge/ask.ts`):

| Question | Answer |
|---|---|
| "which agents are idle?" | `1 of 2 agents have no live session right now: researcher.` |
| "what's running right now?" | `2 sessions running now: pod-troubleshooter ×2.` |
| "how many open tasks?" | `Tasks: 4 to-do, 2 in progress, 1 blocked, 12 done.` |
| "list my automations" | `3 automations (2 enabled): daily churn, weekly digest.` |
| "what agents do I have?" | `You have 2 agents: …` |

## Band 2 — freeform, via the Chat primitive

For questions that need reasoning/tools ("how do automations work?", "why did X fail?"):
- a **fast direct LLM** if one is configured (kept as an optional fast-path), else
- a governed **ephemeral concierge run** — a new System agent (`src/edge/concierge.ts`) that answers using the OS tools (`kb_search`/`recall`/`session_history`/`list_capabilities`), **run-as the asker**. Cockpit **polls its transcript and renders the reply inline**, so a claude-backed answer still feels session-free. **No API key required — works on instapods today.**

The concierge is read-only by persona (it answers, never acts), and `category:'System'` so it's never a route target.

## Bonus fix

The agent **router now excludes `category:'System'` agents** (concierge, consolidator, strategist, improver, analyst) — you can never be routed to the machinery for a work request. Verified no leak across 6 probes.

## Flow

`POST /api/router/preview` for an `ask`: Band 1 → returns `{answer, source:'state'}`; else direct LLM → `{answer, source:'llm'}`; else spawns the concierge → `{run:{sessionId}, source:'concierge'}` which the client polls.

## Verification

- `typecheck` + `web build` clean; `test:governance` → **130/130** ✓
- Band-1 answers over stubbed state (table above); "how do automations work" correctly falls through to the concierge
- Router excludes System agents — **no leak** across 6 probes
- Concierge provisioning mirrors the consolidator (idempotent); the spawn + inline polling reuse the proven chat-session + `/conversation` machinery

## Note / follow-ups

- On live instapods the concierge answers via the subscription claude — first answer has claude cold-start latency (shown as "Looking into it…"). A direct LLM, if configured, is faster; still optional.
- The concierge run appears as a chat session in the member's Chat list — a follow-up could hide System-agent chats.
- Phase 3 (still open): let `action` **execute** via a governed meta-agent (create the automation / task directly), same concierge pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)