### PR TITLE
fix(test): make the governance conformance suite home-independent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+### Fixed
+- **Governance conformance passes off the author's Mac again.** Three `file-guard` fixtures hardcoded
+  `/Users/vmini/.ssh/…` as "the service user's home", but `sensitiveWriteRoots` resolves the home with
+  `os.homedir()` at call time — so those cases only ever exercised the guard on one machine and asserted
+  `allow`-shaped nonsense everywhere else. CI (Linux) had been red on exactly these 3 for weeks, which
+  meant the governance gate was giving **no signal on merges**. Fixtures now write `${HOME}` and the
+  runner expands it per platform. The guard itself was never wrong — verified on a Linux host that
+  `$HOME/.ssh/authorized_keys` and `$HOME/.codex/auth.json` are denied.
 
 ## [0.281.0] — 2026-07-31
 ### Changed

--- a/scripts/governance-conformance.cjs
+++ b/scripts/governance-conformance.cjs
@@ -13,6 +13,7 @@
  */
 const path = require('path');
 const fs = require('fs');
+const os = require('os');
 
 const ROOT = path.resolve(__dirname, '..');
 
@@ -51,7 +52,20 @@ const { JsonPolicyEngine } = require(path.join(ROOT, 'dist/governance/policy'));
 const { fileGovernanceDecision } = require(path.join(ROOT, 'dist/governance/file-guard.js'));
 const { hostGovernanceDecision, stricterDecision } = require(path.join(ROOT, 'dist/governance/host-match'));
 
-const fixture = JSON.parse(fs.readFileSync(path.join(ROOT, 'test/governance/conformance.json'), 'utf8'));
+/**
+ * The file-guard cases assert that a write under the SERVICE USER's home is denied, and
+ * `sensitiveWriteRoots` resolves that home with `os.homedir()` at call time. A fixture can therefore
+ * not hardcode a home path: three cases baked in `/Users/vmini/…`, so they passed on the author's Mac
+ * and failed on every Linux box — CI included, which went red for weeks while the guard itself was
+ * working correctly (verified on a Linux host: `$HOME/.ssh/authorized_keys` → deny). Fixtures write
+ * `${HOME}` and it is expanded here, per platform, before enrichment.
+ */
+const expandHome = (v) => (typeof v === 'string' ? v.split('${HOME}').join(os.homedir())
+  : Array.isArray(v) ? v.map(expandHome)
+  : v && typeof v === 'object' ? Object.fromEntries(Object.entries(v).map(([k, x]) => [k, expandHome(x)]))
+  : v);
+
+const fixture = expandHome(JSON.parse(fs.readFileSync(path.join(ROOT, 'test/governance/conformance.json'), 'utf8')));
 const policyDoc = JSON.parse(fs.readFileSync(path.join(ROOT, 'config/policy/default.policy.json'), 'utf8'));
 
 /** Map a Decision to the fixture's compact expectation string. */

--- a/test/governance/conformance.json
+++ b/test/governance/conformance.json
@@ -1430,7 +1430,7 @@
       "args": {
         "tool": "Write",
         "input": {
-          "file_path": "/Users/vmini/.ssh/authorized_keys",
+          "file_path": "${HOME}/.ssh/authorized_keys",
           "content": "x"
         }
       },
@@ -1444,7 +1444,7 @@
       "args": {
         "tool": "Write",
         "input": {
-          "file_path": "/Users/vmini/.codex/auth.json",
+          "file_path": "${HOME}/.codex/auth.json",
           "content": "x"
         }
       },
@@ -1514,7 +1514,7 @@
       "args": {
         "tool": "apply_patch",
         "input": {
-          "command": "*** Begin Patch\n*** Update File: /Users/vmini/.ssh/id_rsa\n+x\n*** End Patch"
+          "command": "*** Begin Patch\n*** Update File: ${HOME}/.ssh/id_rsa\n+x\n*** End Patch"
         }
       },
       "workdir": "/srv/aos-data/agents/writer",


### PR DESCRIPTION
Found while deploying v0.281.0 to the instawp box: `npm run test:governance` fails 3 cases on Linux and passes on macOS.

## Cause

Three `file-guard` fixtures hardcode the author's macOS home:

```json
{ "name": "file-guard: ~/.ssh is never writable",
  "args": { "input": { "file_path": "/Users/vmini/.ssh/authorized_keys" } },
  "expect": "never" }
```

`sensitiveWriteRoots` builds its crown-jewel list from `os.homedir()` **at call time**. On any host that isn't the author's Mac, `/Users/vmini/.ssh/…` simply isn't under the home, the guard correctly returns `allow`, and the fixture reports a failure.

**The guard is not broken.** Verified on the instawp Linux box against the built `dist/`:

```
deny   /home/ubuntu/.ssh/authorized_keys
deny   /home/ubuntu/.codex/auth.json
allow  /Users/vmini/.ssh/authorized_keys     ← correct: not this host's home
```

## Why it matters beyond the red X

CI runs on Linux and has been failing these 3 for weeks — the last several merges to `main` all landed with the governance gate red, so it was giving **no signal**. A real conformance regression would have been indistinguishable from the standing noise.

## Fix

Fixtures write `${HOME}`; the runner expands it per platform before enrichment.

Verified: 130/130 on macOS, and with `HOME` forced to `/home/runner` and `/root`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)