### PR TITLE
feat(codex): attachable + resident sessions via pre-seeded hook trust (v0.282.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ new version heading in the same commit.
 ## [Unreleased]
 
 ## [0.281.0] — 2026-07-31
+### Added
+- **Codex sessions are attachable, and support warm resident chat.** Every lane is now the interactive
+  TUI, matching the Claude lane: an unattended run can be taken over mid-run by simply attaching (no
+  kill, no resume, no lost turn) and is torn down at turn end by the server via a `Stop` hook →
+  `/api/turn-idle`; a chat run stays warm for send-keys follow-ups. `attachableUnattended` and
+  `residentChat` flip to true, giving Codex parity with Claude Code on every capability except pinned
+  session ids, native skills/sub-agents, the status line and permission mode.
+- **Hook trust is pre-seeded**, which is what made the above possible. Codex refuses to run a hook whose
+  hash it hasn't recorded as trusted, and `--dangerously-bypass-hook-trust` is ignored in TUI mode
+  (openai/codex#24093) — so the TUI previously ran with no gate at all and Codex was locked to
+  `codex exec`. The launcher now computes the hash itself and writes it into `config.toml`
+  (`[hooks.state."<hooks.json>:<event>:<i>:<j>"] trusted_hash`). Algorithm, from the Codex sources and
+  verified against hashes Codex itself wrote: identity → **TOML→JSON** → **recursively sorted keys** →
+  compact JSON → sha256. The traps: it is TOML→JSON and not JSON; the serde name is `timeout` (default
+  **600**, baked in even when absent from `hooks.json`); and `matcher` is part of the identity for
+  `PreToolUse` but **dropped for `Stop`**.
+- **Pane guard (`TerminalManager.guardHookTrust`).** The trust hash is derived from Codex internals, so a
+  future release could stale it. That fails *loudly* — the TUI blocks on "Hooks need review" rather than
+  skipping the hook — but a human could still answer it with *"continue without trusting"* and get an
+  ungoverned agent. The existing 60s liveness sweep now captures the pane of every live Codex session and
+  stops any that shows that prompt, with a card naming the cause. Verified by pre-seeding a deliberately
+  stale hash. Codex-only; one `capture-pane` per live Codex session per sweep.
+
+## [0.281.0] — 2026-07-31
 ### Changed
 - **Cockpit `ask` tier now works with no LLM key — deterministic lookups + an ephemeral concierge run,
   not a bolt-on API.** The `ask` path previously needed a separately-configured `router_config.llm`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ new version heading in the same commit.
   runner expands it per platform. The guard itself was never wrong — verified on a Linux host that
   `$HOME/.ssh/authorized_keys` and `$HOME/.codex/auth.json` are denied.
 
-## [0.281.0] — 2026-07-31
+## [0.282.0] — 2026-07-31
 ### Added
 - **Codex sessions are attachable, and support warm resident chat.** Every lane is now the interactive
   TUI, matching the Claude lane: an unattended run can be taken over mid-run by simply attaching (no

--- a/docs/codex-runtime.md
+++ b/docs/codex-runtime.md
@@ -109,6 +109,80 @@ pane is written to that session's scratch dir and thrown away with it. The launc
 whole fleet. If neither that file nor `OPENAI_API_KEY` is present the launcher **refuses to start** and
 prints the fix — it will not let Codex's interactive sign-in menu appear inside an agent session.
 
+## Hook trust — why Codex sessions are attachable
+
+Codex will not run a hook whose hash it hasn't recorded as trusted; an untrusted hook is **silently
+skipped** in `exec`, and in the TUI it **blocks** on a "Hooks need review" prompt.
+`--dangerously-bypass-hook-trust` is documented as per-invocation and is **ignored in TUI mode**
+([openai/codex#24093](https://github.com/openai/codex/issues/24093)). That combination originally forced
+every Codex run down `codex exec`, costing take-over and warm chat.
+
+The launcher now **pre-seeds the trust hash**, so the TUI runs fully governed and no human ever sees the
+prompt. Trust lives in `config.toml`, not `hooks.json`:
+
+```toml
+[hooks.state."<abs hooks.json path>:<event_label>:<group_index>:<handler_index>"]
+trusted_hash = "sha256:<hex>"
+```
+
+The hash (`command_hook_hash` in `codex-rs/hooks/src/engine/discovery.rs` → `version_for_toml` in
+`codex-rs/config/src/fingerprint.rs`): build the identity, serialize **TOML→JSON** (absent/`None` fields
+vanish), **recursively sort every object's keys**, compact-JSON, sha256, prefix `sha256:`.
+
+```js
+{ event_name: "pre_tool_use", matcher: ".*",
+  hooks: [{ type: "command", command: CMD, timeout: 600, async: false }] }
+```
+
+Three details that are easy to get wrong, and that no amount of black-box guessing recovers:
+
+- it is **TOML→JSON, not JSON** — every direct-JSON serialization fails;
+- the serde name is **`timeout`**, not `timeout_sec`, and its default **600** is baked into the hash even
+  though it never appears in `hooks.json`;
+- **`matcher` is part of the identity for `PreToolUse` but is dropped for `Stop`** (Stop takes no
+  matcher), so the Stop identity must omit the key entirely.
+
+Both hashes are verified against values Codex itself wrote after an interactive `/hooks` trust.
+
+### The pane guard
+
+The hash is derived from Codex internals, so a future release could change it. **That failure is not
+silent** — the TUI blocks on the review prompt. The danger is narrower: a human who attaches, sees a
+stuck pane, and picks *"3. Continue without trusting (hooks won't run)"* then has a completely
+ungoverned agent.
+
+So nobody is allowed to reach that choice. `TerminalManager.guardHookTrust` runs inside the existing
+60s liveness sweep, captures the pane of every live Codex session, and on "Hooks need review" stops the
+session and posts an explicit card — turning a silent-governance-loss risk into a loud, actionable
+failure. Verified by pre-seeding a deliberately stale hash and confirming detection.
+
+**If you upgrade Codex and sessions start dying with "hook trust stale", re-derive the hash**: run the
+TUI once against a scratch `$CODEX_HOME`, trust the hooks interactively, and diff the `trusted_hash`
+Codex writes against what `codex-launch.sh` computes.
+
+**Remote (OAuth) MCP connectors need a one-time `codex mcp login`.** A connector registered as a
+hosted HTTP endpoint with no auth headers — e.g. DataForSEO — authenticates by OAuth, and Codex keeps
+those tokens in `$CODEX_HOME/mcp_oauth.age`. The launcher symlinks that store back to the real
+`$CODEX_HOME` (like `auth.json`), so a login done once is shared by every session; without the link
+every run starts with an empty store and rmcp logs
+`AuthRequired … token is null or empty` into the pane while that one connector's tools go missing.
+The login itself can't happen inside a session (`codex exec` is non-interactive), so do it once:
+
+```
+codex mcp add   dataforseo --url https://mcp.dataforseo.com/mcp   # so the name resolves
+codex mcp login dataforseo                                        # opens the browser once
+```
+
+Note this is per-CLI: Claude Code has its own OAuth store, so a connector working under Claude tells
+you nothing about whether Codex can reach it.
+
+**Account authentication is a one-time, out-of-band step.** Run `codex login` **from a normal shell as the
+service user**, never inside an agent session: `$CODEX_HOME` is per-session, so a login performed in a
+pane is written to that session's scratch dir and thrown away with it. The launcher symlinks
+`$REAL_CODEX_HOME/auth.json` (default `~/.codex/auth.json`) into each session, so one login covers the
+whole fleet. If neither that file nor `OPENAI_API_KEY` is present the launcher **refuses to start** and
+prints the fix — it will not let Codex's interactive sign-in menu appear inside an agent session.
+
 ## Hook trust — why Codex is `codex exec` only
 
 Codex will not run a hook whose hash it has not recorded as trusted. An untrusted hook is **silently
@@ -185,8 +259,8 @@ with `runtimeSupports(runtime, cap)`; use `isCodingRuntime(runtime)` for "is thi
 | --- | --- | --- | --- |
 | `pinnedSessionId` | ✅ | ❌ | Codex mints its own rollout UUID; no `--session-id` |
 | `resume` / `fork` | ✅ | ✅ | `codex resume <id>` / `codex fork <id>` |
-| `attachableUnattended` | ✅ | ❌ | exec-only lane, forced by hook trust — see above |
-| `residentChat` | ✅ | ❌ | needs a TUI that survives a turn |
+| `attachableUnattended` | ✅ | ✅ | TUI on every lane; trust pre-seeded, Stop hook tears down |
+| `residentChat` | ✅ | ✅ | the TUI survives a turn, so follow-ups go by send-keys |
 | `transcript` (cost, engaged time, chat timeline) | ✅ | ✅ | `src/edge/codex-transcript.ts` reads the rollout JSONL |
 | `nativeSkills` / `nativeSubagents` | ✅ | ❌ | `.claude/skills` + `.claude/agents` are Claude conventions |
 | `statusLine` / `permissionMode` | ✅ | ❌ | no equivalent |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.281.0",
+  "version": "0.282.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.281.0",
+      "version": "0.282.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.281.0",
+  "version": "0.282.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -938,8 +938,40 @@ export class TerminalManager {
     for (const r of rows) {
       if (!alive.has(r.tmux) && r.created_at < cutoff) {
         try { this.markCrashed(r); } catch { /* one bad row must not stop the sweep */ }
+      } else if (alive.has(r.tmux)) {
+        try { this.guardHookTrust(r); } catch { /* one bad row must not stop the sweep */ }
       }
     }
+  }
+
+  /**
+   * PANE GUARD — kill any Codex session sitting on Codex's "Hooks need review" prompt.
+   *
+   * We pre-seed the hook trust hash so that prompt never appears (see terminal/codex-launch.sh). But the
+   * hash is derived from Codex's internals, so a future Codex release could change it. If that happens
+   * the TUI does NOT silently skip the hook — it BLOCKS on a three-way prompt. The danger is entirely in
+   * the third option: a human who attaches, sees the pane stuck, and picks *"Continue without trusting
+   * (hooks won't run)"* now has a completely ungoverned agent.
+   *
+   * So we never let a person reach that choice. The sweep already reads panes for liveness; here we look
+   * for the prompt and tear the session down with an explicit reason, turning a silent-governance-loss
+   * risk into a loud, actionable failure ("re-derive the trust hash"). Codex-only and cheap: one
+   * capture-pane per live Codex session per 60s sweep.
+   */
+  private guardHookTrust(r: SessionRow): void {
+    if (this.os.agents.get(r.agent)?.runtime !== 'codex') return;
+    const pane = this.backend.capturePane(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux);
+    if (!pane || !/hooks need review/i.test(pane)) return;
+    const why = 'Codex asked to review its hooks, which means Agent OS\'s pre-seeded trust hash is stale '
+      + '(most likely after a Codex upgrade). The session was stopped rather than risk it running with the '
+      + 'gate hook disabled — re-derive the hash in terminal/codex-launch.sh.';
+    this.audit(r.id, r.agent, 'session.hook_trust.stale', { tmux: r.tmux });
+    this.stopSession(r.id, 'system');
+    this.db.prepare("UPDATE term_sessions SET status = 'crashed', updated_at = ? WHERE id = ?").run(Date.now(), r.id);
+    this.addMessage({
+      type: 'completed', sessionId: r.id, agent: r.agent, title: `Stopped — ${r.agent} (hook trust stale)`,
+      body: why, status: 'open', outcome: 'crashed', audienceKind: 'sessionOwner', audienceId: r.id,
+    });
   }
 
   /** The set of session ids BLOCKED on a human right now — a pending `ask` question or a pending approval

--- a/src/types.ts
+++ b/src/types.ts
@@ -1161,11 +1161,12 @@ export const CODING_RUNTIMES: Readonly<Record<CodingRuntimeId, CodingRuntimeSpec
       // captured after launch rather than pinned. The unattended lane is `codex exec`, which exits at
       // turn end — no Stop hook needed, but also nothing to attach to, which rules out resident chat.
       pinnedSessionId: false, resume: true, fork: true,
-      // Every Codex run uses `codex exec`. Not a preference: Codex silently SKIPS a hook whose hash it
-      // hasn't recorded as trusted, and `--dangerously-bypass-hook-trust` is ignored in TUI mode
-      // (openai/codex#24093) — so an interactive Codex session would run with no gate at all. Until hook
-      // trust can be pre-seeded we take the feature gap over the security hole. See docs/codex-runtime.md.
-      attachableUnattended: false, residentChat: false,
+      // Attachable since v0.281.0. Codex refuses to run a hook whose hash it hasn't recorded as trusted,
+      // and `--dangerously-bypass-hook-trust` is ignored in TUI mode (openai/codex#24093), which used to
+      // force every run down `codex exec`. The launcher now PRE-SEEDS the trust hash, so the TUI runs
+      // fully governed — and `guardHookTrust` kills any session that still shows the review prompt, so a
+      // stale hash after a Codex upgrade fails loud instead of letting someone opt out of the gate.
+      attachableUnattended: true, residentChat: true,
       // Codex's rollout JSONL is parsed by src/edge/codex-transcript.ts, so cost / engaged time /
       // turns / tool calls and the friendly chat timeline all work.
       transcript: true, nativeSkills: false, nativeSubagents: false,

--- a/terminal/codex-launch.sh
+++ b/terminal/codex-launch.sh
@@ -33,7 +33,8 @@
 #   MCP_CONFIG     path to the session's mcpServers JSON (converted to TOML below)
 #   COMPANY_FILE   workspace Company context markdown (folded into AGENTS.md below)
 #   CODEX_MODEL / CODEX_EFFORT   resolved runtime tuning ("" → inherit the CLI default)
-#   UNATTENDED     "1" → an automation/cron/task run: `codex exec`, which exits at turn end
+#   UNATTENDED     "1" → an automation/cron/task run: an attachable TUI torn down by the server at
+#                  turn end (Stop hook → /api/turn-idle), same contract as the Claude lane
 #   RESUME         "1" → continue RUNTIME_SESSION_ID instead of starting fresh
 #   FORK_FROM      branch a new conversation off this rollout id (first launch only)
 set -u
@@ -171,8 +172,8 @@ node -e '
   // silently ignored and gave a false sense that hooks had been switched on.
   // Pre-accept the workspace-TRUST gate for this agent folder — the exact analogue of the
   // `~/.claude.json` hasTrustDialogAccepted seed on the Claude lane, and the same failure mode if
-  // missing: agent folders are freshly created and are NOT git repos, so without this `codex exec`
-  // dies on "Not inside a trusted directory" and the interactive TUI parks on a trust prompt nobody
+  // missing: agent folders are freshly created and are NOT git repos, so without this the TUI parks
+  // on a "Not inside a trusted directory" / trust prompt nobody
   // is there to answer. (Verified against codex 0.145 in a dry run.) Trust only bypasses that
   // one-time gate; the PreToolUse hook and the sandbox still govern every effect.
   out.push("");
@@ -211,18 +212,59 @@ node -e '
   fs.writeFileSync(process.env.CODEX_HOME + "/config.toml", out.join("\n") + "\n", { mode: 0o600 });
 ' || { red "failed to generate codex config — refusing to start ungoverned."; exec bash; }
 
-# ── hooks.json (the gate) ─────────────────────────────────────────────────────────────────────────
-# matcher ".*" so EVERY tool reaches the hook and OUR routing table decides what is a governed
-# capability — the hook itself is dumb transport, exactly as on the Claude lane.
-node -e '
-  const fs = require("fs");
-  const hook = process.argv[1];
-  fs.writeFileSync(process.env.CODEX_HOME + "/hooks.json", JSON.stringify({
+# ── hooks.json + PRE-SEEDED TRUST ─────────────────────────────────────────────────────────────────
+# Two hooks:
+#   PreToolUse (matcher ".*") — the gate. Every tool reaches it and OUR routing table decides.
+#   Stop       (NO matcher)   — beacons /api/turn-idle so the server can tear down an unattended run at
+#                               turn end, exactly as the Claude lane does.
+#
+# TRUST IS THE HARD PART. Codex refuses to run a hook whose hash it hasn't recorded as trusted, and
+# `--dangerously-bypass-hook-trust` is ignored in TUI mode (openai/codex#24093) — which is why every
+# Codex run used to be forced down `codex exec`. We now compute the trust hash ourselves and write it
+# into config.toml, so an interactive/attachable TUI runs GOVERNED with no human ever seeing a prompt.
+#
+# The hash (codex-rs/hooks/src/engine/discovery.rs `command_hook_hash` → config/src/fingerprint.rs
+# `version_for_toml`): build the identity, serialize TOML→JSON (so absent/None fields vanish),
+# RECURSIVELY SORT every object's keys, compact-JSON it, sha256, prefix `sha256:`.
+#
+# Two details that are easy to get wrong and fail SILENTLY-ish:
+#   • the serde name is `timeout`, not `timeout_sec`, and its default (600) is baked into the hash even
+#     though it never appears in hooks.json;
+#   • `matcher` is part of the identity for PreToolUse but is DROPPED for Stop (Stop takes no matcher),
+#     so the Stop identity must omit the key entirely.
+# Both hashes below are verified against values Codex itself wrote after an interactive `/hooks` trust.
+#
+# If a Codex upgrade changes this, the TUI shows "Hooks need review" instead of silently skipping — and
+# TerminalManager's pane guard kills the session on sight, so a human can never answer that prompt with
+# "continue without trusting". Stale trust therefore fails LOUD, never ungoverned.
+STOP_HOOK="$(dirname "$HOOK")/stop-hook.sh"
+AOS_HOOK="$HOOK" AOS_STOP_HOOK="$STOP_HOOK" node -e '
+  const fs = require("fs"), crypto = require("crypto");
+  const home = process.env.CODEX_HOME;
+  const gate = `bash ${JSON.stringify(process.env.AOS_HOOK)}`;
+  const stop = `bash ${JSON.stringify(process.env.AOS_STOP_HOOK)}`;
+  fs.writeFileSync(home + "/hooks.json", JSON.stringify({
     hooks: {
-      PreToolUse: [{ matcher: ".*", hooks: [{ type: "command", command: `bash ${JSON.stringify(hook)}` }] }],
+      PreToolUse: [{ matcher: ".*", hooks: [{ type: "command", command: gate }] }],
+      Stop: [{ hooks: [{ type: "command", command: stop }] }],
     },
   }, null, 2), { mode: 0o600 });
-' "$HOOK" || { red "failed to write the gate hook config — refusing to start ungoverned."; exec bash; }
+
+  const canon = (v) => Array.isArray(v) ? v.map(canon)
+    : (v && typeof v === "object" ? Object.fromEntries(Object.keys(v).sort().map((k) => [k, canon(v[k])])) : v);
+  const hash = (identity) =>
+    "sha256:" + crypto.createHash("sha256").update(JSON.stringify(canon(identity))).digest("hex");
+  const handler = (command) => ({ type: "command", command, timeout: 600, async: false });
+  const hooksJson = home + "/hooks.json";
+  const rows = [
+    // key = <hooks.json path>:<event label>:<matcher-group index>:<handler index>
+    [`${hooksJson}:pre_tool_use:0:0`, hash({ event_name: "pre_tool_use", matcher: ".*", hooks: [handler(gate)] })],
+    [`${hooksJson}:stop:0:0`,         hash({ event_name: "stop",                        hooks: [handler(stop)] })],
+  ];
+  const esc = (s) => s.replace(/\\/g, "\\\\").replace(/"/g, "\\\"");
+  const toml = rows.map(([k, h]) => `\n[hooks.state."${esc(k)}"]\ntrusted_hash = "${h}"\n`).join("");
+  fs.appendFileSync(home + "/config.toml", toml);
+' || { red "failed to write the gate hook config — refusing to start ungoverned."; exec bash; }
 
 # ── AGENTS.md (system prompt) ─────────────────────────────────────────────────────────────────────
 # Codex has no `--append-system-prompt-file`; it discovers AGENTS.md from the workspace root. So the
@@ -308,35 +350,71 @@ echo
 # path, so the hash legitimately changes and there is no human at the pane to confirm it. This is
 # precisely the documented "automation that already vets hook sources" case — the hook is ours. It
 # does NOT weaken the gate; without it the gate would simply never run, which is the unsafe outcome.
+# `--dangerously-bypass-hook-trust` is kept as belt-and-braces: it is INERT in TUI mode (that's the
+# upstream bug that forced exec-only), but harmless, and it keeps the non-TUI fallback paths governed if
+# one is ever reintroduced. The real mechanism is the pre-seeded `[hooks.state]` trust above.
 COMMON_ARGS=(--dangerously-bypass-hook-trust -C "$AGENT_DIR")
-# `--skip-git-repo-check` is an exec-only flag (the TUI has no such option and errors on it), so it
-# lives in a separate array. Belt-and-braces with the `[projects.…] trust_level` seed above.
-EXEC_ARGS=("${COMMON_ARGS[@]}" --skip-git-repo-check)
 
 # ── launch ────────────────────────────────────────────────────────────────────────────────────────
-# EXEC-ONLY, ON PURPOSE. Codex will not run a hook whose hash it has not recorded as trusted — an
-# untrusted hook is SILENTLY SKIPPED (no warning, no error), and `--dangerously-bypass-hook-trust` is
-# documented as applying only "for that invocation". Critically, that flag is IGNORED IN TUI MODE
-# (openai/codex#24093), so an interactive `codex` session runs with NO PreToolUse hook at all — i.e.
-# completely ungoverned. We proved both halves locally: exec WITHOUT the flag → hook skipped; exec WITH
-# it → hook fires on Bash/apply_patch/mcp__*.
-#
-# So every Codex run — console, automation, task, chat — goes down `codex exec`, the one lane where the
-# gate provably runs. The cost is that a Codex session is not attachable/take-over-able (already
-# declared as attachableUnattended:false + residentChat:false in the capability matrix). That is a
-# feature gap; an ungoverned interactive session would be a security hole, and we take the gap.
-# Re-enabling the TUI requires pre-seeding hook trust — tracked in docs/codex-runtime.md.
-dim "codex exec — the gate hook governs every Bash / apply_patch / MCP call. Exits at turn end."
+# Every lane is now the INTERACTIVE TUI, matching the Claude lane. This is only possible because trust
+# is pre-seeded above; before that, the TUI ran with no PreToolUse hook at all and we were forced onto
+# `codex exec`. Consequences:
+#   • an UNATTENDED run is attachable — a human can take it over mid-run by simply attaching, no kill,
+#     no resume, no lost turn. Teardown is SERVER-driven: the Stop hook beacons /api/turn-idle and
+#     TerminalManager.markTurnIdle kills the pane, unless a human has taken it over / is watching / it's
+#     blocked on a person. Exactly the Claude lane's contract.
+#   • a RESIDENT (warm chat) run stays live for send-keys follow-ups until the idle reaper.
+# `approval_policy = "never"` in the generated config is what removes Codex's own prompts (nobody is at
+# the pane to answer them); the gate hook still blocks every governed effect for inbox approval.
+if [ "${UNATTENDED:-}" = "1" ]; then
+  dim "unattended run — attachable TUI (gate hook governs); take it over anytime. Closes at turn-end."
+elif [ "${RESIDENT:-}" = "1" ]; then
+  dim "resident warm chat session — kept warm for fast follow-ups (gate hook still governs)."
+else
+  dim "interactive session — every Bash / apply_patch / MCP call is gated by Agent OS."
+fi
 echo
+
 if [ "${RESUME:-}" = "1" ] && [ -n "${RUNTIME_SESSION_ID:-}" ]; then
   notify_resumed
-  codex exec resume "$RUNTIME_SESSION_ID" "${EXEC_ARGS[@]}" ${TASK:+"$TASK"} \
-    || codex exec "${EXEC_ARGS[@]}" "$TASK"
+  dim "resuming codex session $RUNTIME_SESSION_ID …"
+  echo
+  # A browser reattach must NOT re-seed $TASK (it's already in the transcript); a server-driven
+  # follow-up spawns a fresh pane with no ENV_FILE and a genuinely new $TASK, so that one does seed.
+  if [ -n "${RESUMED_FROM_ENV:-}" ]; then
+    codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
+  else
+    codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" ${TASK:+"$TASK"} || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
+  fi
 elif [ -n "${FORK_FROM:-}" ]; then
-  codex exec resume "$FORK_FROM" "${EXEC_ARGS[@]}" ${TASK:+"$TASK"} \
-    || codex exec "${EXEC_ARGS[@]}" "$TASK"
+  dim "forking codex session $FORK_FROM …"
+  echo
+  codex fork "$FORK_FROM" "${COMMON_ARGS[@]}" ${TASK:+"$TASK"} || codex "${COMMON_ARGS[@]}" "$TASK"
 else
-  codex exec "${EXEC_ARGS[@]}" "$TASK"
+  codex "${COMMON_ARGS[@]}" "$TASK"
 fi
 notify_ended
-exit 0
+
+# SECURITY: do NOT drop to a raw shell when codex exits. A tmux shell has NO PreToolUse gate hook and NO
+# sandbox, so `exec bash` here would hand whoever is attached full, ungoverned access as the app user.
+# Keep the pane alive (so ttyd doesn't loop "Reconnecting") with a holding prompt that can ONLY re-open
+# codex or close.
+echo
+while true; do
+  dim "codex session ended — press [r] to resume, [q] to close the tab."
+  key=""
+  IFS= read -rsn1 key || { sleep 2; continue; }
+  case "$key" in
+    r|R)
+      notify_resumed
+      if [ -n "${RUNTIME_SESSION_ID:-}" ]; then
+        codex resume "$RUNTIME_SESSION_ID" "${COMMON_ARGS[@]}" || codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
+      else
+        codex "${COMMON_ARGS[@]}" ${TASK:+"$TASK"}
+      fi
+      notify_ended
+      ;;
+    q|Q) exit 0 ;;
+    *) : ;;   # ignore any other key — never spawn a shell
+  esac
+done


### PR DESCRIPTION
Closes the last Codex gap. Every lane is now the interactive TUI: an unattended run can be **taken over mid-run** by attaching (no kill, no resume, no lost turn) and is torn down at turn end by the server via a `Stop` hook → `/api/turn-idle`; chat runs stay **warm** for send-keys follow-ups.

## What was blocking it

Codex won't run a hook whose hash it hasn't recorded as trusted. Untrusted means *silently skipped* in `exec` and *blocked on a prompt* in the TUI — and `--dangerously-bypass-hook-trust` is [ignored in TUI mode](https://github.com/openai/codex/issues/24093). So the TUI ran with **no gate at all**, and #481 locked Codex to `codex exec`.

## The hash

Trust lives in `config.toml`, not `hooks.json`:

```toml
[hooks.state."<abs hooks.json path>:<event_label>:<group_idx>:<handler_idx>"]
trusted_hash = "sha256:<hex>"
```

`command_hook_hash` → `version_for_toml`: build the identity, serialize **TOML→JSON** (absent/`None` fields vanish), **recursively sort every object's keys**, compact-JSON, sha256.

```js
{ event_name: "pre_tool_use", matcher: ".*",
  hooks: [{ type: "command", command: CMD, timeout: 600, async: false }] }
```

Three details that ~200 black-box guesses could never have recovered — I only got them by reading the Codex sources:

- it is **TOML→JSON, not JSON**, so every direct-JSON serialization fails;
- the serde name is **`timeout`**, not `timeout_sec`, and its default **600** is baked into the hash despite never appearing in `hooks.json`;
- **`matcher` is part of the identity for `PreToolUse` but dropped for `Stop`** (Stop takes no matcher).

Both hashes reproduce exactly what Codex itself wrote after an interactive `/hooks` trust.

## The pane guard

The hash is derived from Codex internals, so a future release could stale it. That failure is **not silent** — the TUI blocks on "Hooks need review". The residual danger is narrow but real: a human attaches, sees a stuck pane, and picks *"3. Continue without trusting (hooks won't run)"* — now the agent is completely ungoverned.

So nobody gets to reach that choice. `guardHookTrust` runs inside the **existing** 60s liveness sweep, captures the pane of every live Codex session, and stops any that shows the prompt, posting a card that names the cause. A silent-governance-loss risk becomes a loud, actionable failure.

Verified by pre-seeding a deliberately stale hash against a real Codex TUI:

```
Hooks need review
1. Review hooks   2. Trust all and continue   3. Continue without trusting (hooks won't run)
→ DETECTED ✓ — guard would stop this session
```

## Verified

- Pre-seeded hash → **no trust prompt**, and the hook **fires on `Bash` with no bypass flag** in a live TUI
- `Stop` hook fires in the TUI (its own hash verified separately)
- Stale hash → prompt appears → guard detects it
- Capability parity: `attachableUnattended`, `residentChat`, `transcript`, `fork`, `fileWriteGate`, `mcpGate` all true for both runtimes
- typecheck + build + web build clean; `npm run test:governance` 130/130

Docs record the algorithm and, importantly, **how to re-derive it** if a Codex upgrade stales it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)