### PR TITLE
fix(dreaming): bump TOPICS_VERSION for the id-filter change (v0.281.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.281.4] — 2026-07-31
+### Fixed
+- **Bump `TOPICS_VERSION` to 3.** v0.281.3 tightened the topic extractor (opaque hex ids) without bumping
+  the version counter added in v0.281.2, so ids already written into a workspace's cumulative topic map
+  stayed there — the exact failure that counter exists to prevent. Bumped, and the requirement to bump it
+  alongside any extractor change is now stated at the constant.
+
 ## [0.281.3] — 2026-07-31
 ### Fixed
 - **Opaque identifiers are no longer "things the fleet works on".** The digit rule that admits `v3`/`php8`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.281.3",
+  "version": "0.281.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.281.3",
+      "version": "0.281.4",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.281.3",
+  "version": "0.281.4",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -74,8 +74,12 @@ const MIN_TOPIC_COUNT = 3;
  * removed. Bump this whenever the extractor's meaning changes; a state carrying an older version has its
  * map cleared and rebuilt from the current corpus, so every tenant self-heals on its next pass instead of
  * needing a hand-edited DB.
+ *
+ * **Bump this in the same commit as any change to `isEntity`/`properNouns`/`STOP`.** v0.281.3 tightened
+ * `isEntity` (opaque hex ids) without bumping, so the ids already stored stayed in the map — the exact
+ * failure this counter exists to prevent.
  */
-const TOPICS_VERSION = 2;
+const TOPICS_VERSION = 3;
 const STOP = new Set(['task', 'outcome', 'session', 'after', 'then', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'run', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none',
   // Procedural / plumbing words — they describe HOW an agent worked, not WHAT the fleet works on, so they
   // drown the real topics ("slack, check, report, completed, summary" is a useless "frequently works on").


### PR DESCRIPTION
v0.281.3 tightened the topic extractor (opaque hex ids like \`f90fc16d7fb9a19\`) but did not bump \`TOPICS_VERSION\`, the counter added in #501 precisely so that an extractor change invalidates previously-extracted topics. Result: the ids already written into a workspace cumulative map stayed there and would resurface once their counts crossed the display threshold.

Bumped to 3, and the requirement to bump it in the same commit as any \`isEntity\`/\`properNouns\`/\`STOP\` change is now stated at the constant so the next change does not repeat it.

137/137 governance + 18/18 tier-A policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)