### PR TITLE
fix(dreaming): do not compute approval friction against a missing denominator (v0.281.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.281.5] — 2026-07-31
+### Fixed
+- **The approval-friction signal no longer divides by a denominator that isn't there.** v0.280.0 started
+  recording the `approved` count so friction could be a rate; per-pass entries written before that carry
+  rejections with **no denominator**, and `recentTally` summed them anyway — so a window of mostly-legacy
+  entries read as ~100% rejection. Live instapods was nagging every agent that "recent actions were
+  rejected at human approval" while its true 7-day rate was **5.4%** (35 approved / 2 rejected). Entries
+  lacking the denominator now contribute to neither side of the ratio (their budget/error signals still
+  count), so the signal stays quiet until real evidence exists rather than inventing it. Verified against
+  both live tenants' actual window shapes: the false instapods nag stops; genuine friction with a real
+  sample still fires.
+
 ## [0.281.4] — 2026-07-31
 ### Fixed
 - **Bump `TOPICS_VERSION` to 3.** v0.281.3 tightened the topic extractor (opaque hex ids) without bumping

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.281.4",
+  "version": "0.281.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.281.4",
+      "version": "0.281.5",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.281.4",
+  "version": "0.281.5",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -464,8 +464,14 @@ function recentTally(s: DreamState): { sessions: number; success: number; approv
   for (const e of (s.recent ?? []).slice(0, RECENT_PASSES)) {
     r.sessions += e.sessions || 0;
     r.success += e.success || 0;
-    r.approved += e.approved || 0;
-    r.rejected += e.rejected || 0;
+    // Approval friction is a RATIO, so an entry that predates the `approved` denominator must contribute
+    // NEITHER side — counting its rejections against a missing denominator reads as 100% rejection. Live
+    // instapods computed 22% (and nagged every agent) while its true rate was 5.4%, because six of seven
+    // window entries were legacy. Skipping them means the signal stays quiet until real evidence exists.
+    if (e.approved !== undefined) {
+      r.approved += e.approved;
+      r.rejected += e.rejected || 0;
+    }
     r.budgetStops += e.budgetStops || 0;
     r.errors += e.errors || 0;
   }


### PR DESCRIPTION
Found by checking whether the approval nag the live tenants are serving is actually **true**. On instapods it is not.

```
instapods, last 7 days (from the audit log):
  approved=35  rejected=2  → true rejection rate 5.4%

instapods guidance, injected into every agent's system prompt:
  • Recent actions were rejected at human approval — `policy_check` before risky effects…
```

## Cause

v0.280.0 (#492) made friction a **rate** and started recording the `approved` count to divide by. Per-pass `recent` entries written before that carry `rejected` with **no `approved` field** — and `recentTally` summed them regardless, so `approved` stayed 0 while rejections accumulated. Six of instapods' seven window entries are legacy, so the computed rate was ~100% against a denominator that doesn't exist.

This was flagged as a known one-pass caveat in #492. It is worse than that in practice: the window holds 7 entries, so a tenant keeps mis-firing until legacy entries roll off — and it fires in the *wrong direction*, telling agents to expect rejection on a workspace that approves ~95% of requests.

## Fix

An entry without the denominator contributes to **neither** side of the ratio. Its budget/error signals still count — only the approval ratio skips it.

## Verified against both tenants' real window shapes

| Window | before | after |
| --- | --- | --- |
| instapods (true 5.4%) | nag **on** | nag off |
| instawp (true 37.1%) | nag on, `policy.review` on | quiet — only 3 decisions carry a denominator |
| genuine friction, good sample | on | **on** |

instawp going quiet is the conservative direction: its true rate *does* warrant the nag, but the recorded evidence is 3 decisions, and it re-fires once enough passes have recorded the denominator. Silence beats confidently wrong advice in every agent's prompt.

137/137 governance + 18/18 tier-A policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)