### PR TITLE
fix(codex): suppress the in-pane update banner; verify hash against 0.146 (v0.284.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.284.1] — 2026-08-01
+### Fixed
+- **Codex's "Update available" banner is now suppressed** (`check_for_update_on_startup = false` in the
+  generated config). It is an INTERACTIVE prompt drawn at TUI startup that waits on a keypress — on an
+  unattended run nobody answers it, which is the same permanent-hang class as the folder-trust and
+  hook-review prompts already pre-empted. It also silently swallows the first keystroke sent to a fresh
+  pane, which is how it was spotted. Agent OS pins the CLI deliberately, so an in-pane self-update was
+  never wanted.
+
+### Changed
+- Hook-trust hash **verified compatible with Codex 0.146.0** (derived against 0.145.0): the computed hash
+  is still accepted with no review prompt, the hook still fires, `tool_name` is still `Bash`, an allow is
+  still correctly expressed as silence, and a deny still blocks. Documented as a per-upgrade check.
+
 ## [0.284.0] — 2026-07-31
 ### Added
 - **Runtime-account tokens are validated against the provider before they enter the pool, and their

--- a/docs/codex-runtime.md
+++ b/docs/codex-runtime.md
@@ -166,6 +166,12 @@ Three details that are easy to get wrong, and that no amount of black-box guessi
 
 Both hashes are verified against values Codex itself wrote after an interactive `/hooks` trust.
 
+**Version compatibility.** The hash is derived from Codex internals, so it is pinned to a CLI version
+in principle. Verified compatible across **0.145.0 → 0.146.0**: the same computed hash is accepted (no
+review prompt), the hook still fires, `tool_name` is still `Bash`, an allow is still expressed as
+silence, and a deny still blocks. Re-run that check on each Codex upgrade — it takes minutes and the
+pane guard turns a miss into a stopped session rather than an ungoverned one.
+
 ### The pane guard
 
 The hash is derived from Codex internals, so a future release could change it. **That failure is not
@@ -232,6 +238,11 @@ sessions.
 > Do **not** write `[features] codex_hooks = true`. There is no such key — `codex features list` names
 > the flag `hooks`, and it is already stage=stable and enabled by default. The bogus key was silently
 > ignored and gave a false impression that hooks had been switched on.
+
+**Three interactive startup prompts must be pre-empted**, or a session hangs waiting for a keypress
+nobody will press. Two are trust gates; the third is the update banner, suppressed with
+`check_for_update_on_startup = false` (Agent OS pins the CLI deliberately, so an in-pane self-update is
+never wanted — and the banner also swallows the first keystroke sent to a fresh pane).
 
 Two trust gates have to be pre-accepted or every session hangs or dies — the same class of bug as the
 Claude lane's `~/.claude.json` seed:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.284.0",
+  "version": "0.284.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.284.0",
+      "version": "0.284.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.284.0",
+  "version": "0.284.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/terminal/codex-launch.sh
+++ b/terminal/codex-launch.sh
@@ -159,6 +159,13 @@ node -e '
   // Agent OS is the sole authority (see header note 4); the gate hook still blocks for approval.
   out.push(`approval_policy = "never"`);
   out.push(`sandbox_mode = "workspace-write"`);
+  // Suppress the "Update available / 1. Update now  2. Skip  3. Skip until next version" banner. It is
+  // an INTERACTIVE prompt drawn at TUI startup that waits on a keypress — on an unattended run nobody is
+  // there to answer it, which is the same permanent-hang class as the folder-trust and hook-review
+  // prompts we already pre-empt. (It also silently swallows the first keystroke sent to a fresh pane,
+  // which is how it was noticed.) Agent OS pins the CLI deliberately, so an in-pane self-update is
+  // something we never want anyway.
+  out.push("check_for_update_on_startup = false");
   out.push("");
   out.push("[sandbox_workspace_write]");
   // Structural containment for any write that does not pass through the shell tool. The workdir is


### PR DESCRIPTION
Two outcomes from checking whether a Codex upgrade would break us.

## 1. The 0.146 upgrade is safe

The hook-trust hash was derived against **0.145.0**, so a Codex release could stale it and start tripping the pane guard. Tested 0.146.0 side-by-side:

| Check | Result |
| --- | --- |
| Our computed hash accepted (no review prompt) | ✓ |
| Hook fires | ✓ |
| `tool_name` still `Bash` | ✓ |
| Allow still correctly expressed as silence (no `hook (failed)`) | ✓ |
| **Deny still blocks** — `PreToolUse hook (blocked)`, command never ran | ✓ |

Now documented as a short per-upgrade check. The pane guard means a future miss stops a session rather than running one ungoverned.

## 2. A third startup prompt was waiting to hang us

Codex draws this at TUI startup and **waits on a keypress**:

```
✨ Update available! 0.145.0 -> 0.146.0
› 1. Update now   2. Skip   3. Skip until next version
  Press enter to continue
```

On an unattended run nobody answers it — the same permanent-hang class as the folder-trust dialog and the hook-review prompt we already pre-empt. It also **silently swallows the first keystroke sent to a fresh pane**, which is exactly how it was noticed: it ate a `2` during hook-trust testing and sent the next Enter to the wrong prompt.

Agent OS pins the CLI deliberately, so an in-pane self-update was never something we wanted. Suppressed with `check_for_update_on_startup = false` in the generated config (verified to parse under `--strict-config`).

Docs now list **three** interactive startup prompts that must be pre-empted, not two.

`npm run test:governance` 137/137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)