### PR TITLE
feat(goals): goals can finish — derived completion, owner sign-off, and the loop it closes (v0.285.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.285.0] — 2026-08-01
+### Added
+- **Goals can now finish.** `progress()` has always derived 100% from linked tasks and *nothing consumed
+  it* — `achieved` was reachable only by hand-picking it from a dropdown inside the goal drawer, so a
+  completed goal sat `active` indefinitely (on the live instawp tenant, one had been 6/6 done for 19
+  days). Completion is now **derived, announced, and human-confirmed** — never auto-flipped, because "every
+  task I filed is done" is a weaker claim than "the outcome was achieved". New `GoalStore.readyToClose()`
+  (every non-cancelled *leaf* linked task done) drives: a **Ready to close** chip + page banner + drawer
+  sign-off box on the Goals page, offering **Mark achieved** with an optional outcome note (patched
+  alongside the status, so the timeline records *why*) or **Not yet — plan the gap** (hands it back to the
+  strategist). `src/state/goals.ts`, `web/src/App.tsx`, `docs/goals-plan.md` §Slice 4.
+- **A goal whose work completes now reaches its owner.** `GoalStore.setNotifier` existed with **no
+  consumer** — every goal status change was silent. `notifyGoalEvent` (mirroring `notifyTaskEvent`) routes
+  `ready` → the goal's owner (else admins) and `achieved`/`abandoned` → the owner as an inbox card
+  (`goal.ready`) + DM. Driven by a new always-on `sweepCompletedGoals` tick, announced exactly once per
+  completion streak via a `ready` goal_event guard (later work that also completes announces again).
+  `src/tenant-registry.ts`, `src/edge/automations.ts`, `src/terminal.ts`.
+
+### Fixed
+- **The goal auto-planner filed fresh work for goals that were already done.** `GoalStore.stuck()` selected
+  active goals with no *open* task — true both for "never planned" and for "all work finished", so with
+  Auto-plan on the strategist was spawned to invent new tasks for a completed goal. `stuck()` now means
+  **no work filed at all** (never planned, or every task cancelled); the finished case routes to the owner
+  for sign-off instead. The Insights "unstick" list excludes finished goals for the same reason, and the
+  goals tile now separates *ready to close* / *no work planned* / *no progress in 7+ days* rather than
+  calling all three "stuck". `src/state/goals.ts`, `src/server.ts`, `src/edge/improvements.ts`.
+- **A finished goal kept steering the whole fleet.** `buildCompanyMd` injects active goals into every
+  agent's prompt as "the direction your work serves" — including goals whose work was complete but
+  unclosed, indefinitely. Completed-but-unsigned-off goals are now filtered out of that set (they're
+  awaiting a human, not directing work); `goal_list` still returns them live. `src/terminal.ts`.
+
 ## [0.284.0] — 2026-07-31
 ### Added
 - **Runtime-account tokens are validated against the provider before they enter the pool, and their

--- a/docs/goals-plan.md
+++ b/docs/goals-plan.md
@@ -238,6 +238,41 @@ this v1 triggers only on "no open work" (never-planned, or all tasks finished bu
 **Phase 3 (later, separate concern):** if/when Dreaming gains real LLM reasoning, fold stall-judgment into
 it — a Dreaming upgrade tracked against its 🟡 Partial grade, not a blocker for goals.
 
+---
+
+## Slice 4 — completion (shipped, v0.285.0)
+
+Slices 1–3 could plan a goal and measure it, but a goal could never *finish*. `progress()` computed
+100% and **nothing consumed it**: `achieved` was reachable only by hand-picking it from a dropdown
+inside the drawer. On the live instawp tenant a goal sat 6/6 done and `active` for 19 days — still
+injected into every agent's prompt as current direction, and still a re-plan candidate.
+
+**The model: completion is derived, proposed, and human-confirmed.** No auto-flip. "Every task I filed
+is done" ≠ "the outcome was achieved" (the plan may have been incomplete, and `target` is a caption
+nothing verifies), and goal state is human-owned — the same posture as agents proposing but not
+activating goals.
+
+- **`GoalStore.readyToClose(tenant)`** — active goals whose every non-cancelled *leaf* linked task is
+  done (≥1). Derived, no schema change; matches `progress()`'s 100% exactly.
+- **`stuck()` no longer means "no OPEN work".** It meant "never planned" *and* "all work finished",
+  so the auto-planner would file fresh tasks for a completed goal. Now it's "**no work filed at all**"
+  (never planned, or all cancelled); the finished case routes to the human instead.
+- **`announceReady(goalId)`** — appends a `ready` goal_event and fires the notifier, once per
+  *completion streak*: suppressed while a `ready` event sits newer than the newest linked task's
+  `updated_at`, so later work that also completes announces again. The tick's `sweepCompletedGoals`
+  drives it (always on — it spawns nothing).
+- **The notifier is finally wired.** `GoalStore.setNotifier` had **no consumer** — goal state changed
+  silently. `notifyGoalEvent` (tenant-registry, mirroring `notifyTaskEvent`) now routes `ready` →
+  the owner (else admins) and `achieved`/`abandoned` → the owner, as an inbox card + DM.
+- **Prompt injection skips completed goals** — `buildCompanyMd` filters `readyToClose` out of the
+  active set, so a finished goal stops steering the fleet while it waits for sign-off.
+- **Console** — a "Ready to close" chip on the row, a page-level banner, and a drawer sign-off box with
+  **Mark achieved** (+ an optional outcome note, patched with the status so the timeline records *why*)
+  or **Not yet — plan the gap** (reuses the strategist steering box). An active goal with no tasks now
+  reads "No work planned" instead of a bare dash — the two empty states are different asks.
+- **Insights** — the goals tile splits *ready to close* / *no work planned* / *no progress in 7+ days*,
+  and the "unstick" list excludes finished goals.
+
 ## Out of scope (both slices)
 
 - **Agent-authored strategy with real authority.** Humans own goals + acceptance criteria; agents `goal_list`/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.284.0",
+  "version": "0.285.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.284.0",
+      "version": "0.285.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.284.0",
+  "version": "0.285.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -1302,6 +1302,7 @@ export class Automations {
     }
     this.sweepOverdue(now);
     this.sweepStuckGoals(now);
+    this.sweepCompletedGoals();
     this.sweepExpiredShares(now);
     // Re-nudge stale human-in-the-loop prompts (approvals/questions blocking an agent) so a missed ask
     // doesn't strand the run forever. Wrapped so a bad row can't take down the scheduler.
@@ -1354,6 +1355,26 @@ export class Automations {
       }
     } catch {
       // never let the goal sweep take down the automation scheduler
+    }
+  }
+
+  /**
+   * The completion half of the goal sweep: a goal whose every linked task has finished is DONE-in-fact but
+   * still says `active`, because only a human closes a goal. Announce it exactly once (the once-guard lives
+   * in `goal_events`, so a restart never re-alarms) so the owner gets an inbox card + DM rather than having
+   * to notice a full progress bar on a page nobody visits daily.
+   *
+   * Always on and cheap — unlike {@link sweepStuckGoals} this spawns nothing, it just tells a human their
+   * goal is finished. Wrapped so a bad row never kills the scheduler.
+   */
+  private sweepCompletedGoals(): void {
+    try {
+      for (const g of this.os.goals.readyToClose(this.os.tenant)) {
+        if (!this.os.goals.announceReady(g.id)) continue; // already announced this completion streak
+        this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'system', type: 'goal.ready', data: { goalId: g.id, title: g.title } });
+      }
+    } catch {
+      // never let the completion sweep take down the automation scheduler
     }
   }
 

--- a/src/edge/improvements.ts
+++ b/src/edge/improvements.ts
@@ -65,14 +65,32 @@ export function buildImprovements(os: AgentOS, insights: Insights, now = Date.no
     actionLabel: 'Open Knowledge', href: '#/kb',
   });
 
-  // 3) Goals — active goals with no progress recently (stuck) that a human/strategist should nudge.
+  // 3) Goals — two different asks, deliberately not lumped together. A goal whose work is all DONE needs a
+  // human DECISION (close it, or plan what's missing); a goal with no recent progress needs a NUDGE. Both
+  // used to read as "stuck", which sent an owner to re-plan goals that were actually finished.
+  const goalsReady = num(db, `SELECT count(*) AS n FROM goals g WHERE g.status = 'active'
+      AND EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status != 'cancelled'
+                   AND NOT EXISTS (SELECT 1 FROM tasks c WHERE c.parent_id = t.id))
+      AND NOT EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status NOT IN ('done','cancelled')
+                   AND NOT EXISTS (SELECT 1 FROM tasks c WHERE c.parent_id = t.id))`);
   const stuck = num(db,
-    "SELECT count(*) AS n FROM goals g WHERE g.status = 'active' AND COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) < ?",
+    `SELECT count(*) AS n FROM goals g WHERE g.status = 'active'
+       AND COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) < ?
+       AND EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status NOT IN ('done','cancelled'))`,
     now - 7 * DAY);
+  const noPlan = num(db, `SELECT count(*) AS n FROM goals g WHERE g.status = 'active'
+      AND NOT EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status != 'cancelled')`);
+  const goalWork = goalsReady + stuck + noPlan;
+  const parts = [
+    goalsReady ? `${goalsReady} finished and waiting to be closed` : '',
+    noPlan ? `${noPlan} with no work planned yet` : '',
+    stuck ? `${stuck} with no progress in 7+ days` : '',
+  ].filter(Boolean);
   tiles.push({
-    domain: 'goals', count: stuck,
-    title: stuck ? `${stuck} goal${stuck === 1 ? '' : 's'} stuck` : 'Goals are moving',
-    detail: stuck ? `${stuck} active goal${stuck === 1 ? '' : 's'} with no progress in 7+ days — plan the next tasks or re-scope.` : 'Every active goal has recent progress.',
+    domain: 'goals', count: goalWork,
+    title: goalsReady ? `${goalsReady} goal${goalsReady === 1 ? '' : 's'} ready to close`
+      : goalWork ? `${goalWork} goal${goalWork === 1 ? '' : 's'} need you` : 'Goals are moving',
+    detail: goalWork ? `${parts.join(', ')} — sign off what's done, plan the rest.` : 'Every active goal has open work and recent progress.',
     actionLabel: 'Open Goals', href: '#/goals',
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -163,7 +163,17 @@ function pendingProposals(os: AgentOS): string[] {
 function stuckGoals(os: AgentOS, now = Date.now()): Array<{ id: string; title: string; days: number }> {
   const cutoff = now - 7 * 86_400_000;
   return os.db
-    .prepare("SELECT g.id, g.title, COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) AS last FROM goals g WHERE g.tenant = ? AND g.status = 'active' AND COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) < ? ORDER BY last")
+    // A goal whose filed work is ALL DONE is excluded: it isn't stuck, it's finished and waiting on a
+    // human to close it (the Goals page flags that separately). Offering to re-plan it would file fresh
+    // work for a completed goal.
+    .prepare(`SELECT g.id, g.title, COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) AS last
+                FROM goals g WHERE g.tenant = ? AND g.status = 'active'
+                 AND COALESCE((SELECT MAX(created_at) FROM goal_events e WHERE e.goal_id = g.id), g.created_at) < ?
+                 AND NOT (EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status != 'cancelled'
+                                   AND NOT EXISTS (SELECT 1 FROM tasks c WHERE c.parent_id = t.id))
+                      AND NOT EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status NOT IN ('done','cancelled')
+                                   AND NOT EXISTS (SELECT 1 FROM tasks c WHERE c.parent_id = t.id)))
+               ORDER BY last`)
     .all<{ id: string; title: string; last: number }>(os.tenant, cutoff)
     .map((g) => ({ id: g.id, title: g.title, days: Math.floor((now - g.last) / 86_400_000) }));
 }

--- a/src/state/goals.ts
+++ b/src/state/goals.ts
@@ -36,7 +36,7 @@ const STATUSES: readonly GoalStatus[] = ['draft', 'active', 'achieved', 'abandon
  */
 export interface GoalNotice {
   goal: Goal;
-  kind: 'created' | 'status' | 'proposed';
+  kind: 'created' | 'status' | 'proposed' | 'ready';
   by: string;
   detail?: string;
 }
@@ -126,19 +126,66 @@ export class GoalStore {
   }
 
   /**
-   * The auto-planner's trigger set: active goals that need (re)planning — they have **no OPEN**
-   * (non-terminal) linked task (never planned, or all their work finished but the goal isn't achieved) and
-   * haven't been edited within `graceMs` (so a goal you're still writing isn't grabbed). Oldest-idle first.
+   * The auto-planner's trigger set: active goals with **no work filed at all** (never planned, or every
+   * linked task cancelled) that haven't been edited within `graceMs` — so a goal you're still writing
+   * isn't grabbed. Oldest-idle first.
+   *
+   * Deliberately EXCLUDES a goal whose filed work is all *done*: that isn't stalled, it's finished and
+   * waiting on a human to sign it off ({@link readyToClose}). Planning it would invent fresh work for a
+   * completed goal, which is what the old "no OPEN task" predicate did.
    */
   stuck(tenant: string, graceMs: number, now: number): Goal[] {
     return this.db
       .prepare(
         `SELECT * FROM goals g WHERE g.tenant = ? AND g.status = 'active' AND g.updated_at < ?
-           AND NOT EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status NOT IN ('done','cancelled'))
+           AND NOT EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status != 'cancelled')
          ORDER BY g.updated_at ASC`,
       )
       .all<GoalRow>(tenant, now - graceMs)
       .map(toGoal);
+  }
+
+  /**
+   * Goals whose work is COMPLETE but whose status still says `active` — every leaf task linked to them is
+   * done (and there's at least one), matching {@link progress}'s 100%. Completion is *derived*; the goal
+   * does NOT self-close, because "all the filed tasks are done" is not the same claim as "the outcome was
+   * achieved" — the plan may simply have been incomplete. So this is a proposal set: the console flags it
+   * and the owner confirms (or plans the gap). Oldest-idle first.
+   */
+  readyToClose(tenant: string): Goal[] {
+    return this.db
+      .prepare(
+        `SELECT * FROM goals g WHERE g.tenant = ? AND g.status = 'active'
+           AND EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status != 'cancelled'
+                        AND NOT EXISTS (SELECT 1 FROM tasks c WHERE c.parent_id = t.id))
+           AND NOT EXISTS (SELECT 1 FROM tasks t WHERE t.goal_id = g.id AND t.status NOT IN ('done','cancelled')
+                        AND NOT EXISTS (SELECT 1 FROM tasks c WHERE c.parent_id = t.id))
+         ORDER BY g.updated_at ASC`,
+      )
+      .all<GoalRow>(tenant)
+      .map(toGoal);
+  }
+
+  /**
+   * Announce that a goal's work is complete — append the `ready` timeline event and fire the notifier, so
+   * the owner learns their goal finished instead of having to notice a full progress bar. Idempotent per
+   * *completion streak*: returns false when a `ready` event already sits newer than the most recently
+   * touched linked task. If more work is later filed under the goal and finished, that task's `updated_at`
+   * moves past the old event and the goal announces again — one notice per time it actually completes.
+   */
+  announceReady(goalId: string, by = 'system'): boolean {
+    const goal = this.get(goalId);
+    if (!goal) return false;
+    const last = this.db
+      .prepare(
+        `SELECT (SELECT MAX(created_at) FROM goal_events WHERE goal_id = ? AND kind = 'ready') AS announced,
+                (SELECT MAX(updated_at) FROM tasks WHERE goal_id = ?) AS worked`,
+      )
+      .get<{ announced: number | null; worked: number | null }>(goalId, goalId);
+    if (last?.announced && last.announced >= (last.worked ?? 0)) return false; // already announced this streak
+    this.addEvent(goalId, 'ready', 'all linked work is done — ready to close', by);
+    this.notify({ goal, kind: 'ready', by });
+    return true;
   }
 
   /**

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -23,6 +23,7 @@ import { ClickupIngress } from './edge/clickup-ingress';
 import { DiscordSocket } from './edge/discord-socket';
 import { Member, Task } from './types';
 import { TaskNotice } from './state/tasks';
+import { GoalNotice } from './state/goals';
 import { Audience, approvalAudience, resolveRecipients } from './governance/recipients';
 import { ChatPlatform, chatLink, consolePage } from './governance/chat-links';
 import { controlHome, resolvePaths, resolveTenantPaths } from './home';
@@ -282,6 +283,10 @@ export class TenantRegistry {
       // transcript with the outcome, so a fire-and-forget delegation wakes the caller (no polling).
       maybePokeCaller(autos, os, notice);
     });
+    // Goal lifecycle → Inbox. Same sink shape as Tasks, one rung up the ladder: a goal whose work all
+    // finished (the tick's completion sweep) or that someone closed reaches the human accountable for it.
+    // Until this was wired the store's notifier had no consumer, so goal state changed silently.
+    os.goals.setNotifier((notice) => { void notifyGoalEvent(os, tm, slack, discord, consoleOrigin, notice); });
     // Agent → teammate: when an agent uses the `notify` tool, the inbox card is written inline (addressed
     // to the target member); this sink DMs that member on their linked Slack/Discord too.
     tm.setMemberNotifier((notice) => { void notifyMember(os, slack, discord, notice); });
@@ -497,6 +502,45 @@ export async function notifyTaskEvent(os: AgentOS, tm: Pick<TerminalManager, 'po
   const text = (p: ChatPlatform) => `📋 ${card.title} — \`${t.title}\` (${t.id}).\nOpen it in the ${chatLink(p, url, 'Agent OS console')}.`;
   const dms = await deliverDM(slack, discord, os, recipients, text);
   os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'task.notified', data: { id: t.id, event: card.event, recipients: recipients.length, dms } });
+}
+
+/**
+ * Goal lifecycle → Inbox. The strategic twin of {@link notifyTaskEvent}: writes an audience-addressed card
+ * for the human a goal change concerns and DMs them.
+ *
+ * Only two kinds are routed, and both are things a human must ACT on:
+ * - **ready** → the goal's every linked task finished, so its owner (else the admin tier, since an
+ *   unowned goal still needs closing) is asked to sign it off or plan the gap. This is the notice that
+ *   makes derived completion real — without it a finished goal just sits `active` forever.
+ * - **status → achieved | abandoned** → the owner, so a close someone else performed doesn't go unseen.
+ *
+ * `created`/`proposed` are deliberately silent here: a goal an admin just typed needs no card back, and
+ * the agent `goal_propose` route already posts its own review card inline.
+ */
+async function notifyGoalEvent(os: AgentOS, tm: Pick<TerminalManager, 'postGoalCard'>, slack: Pick<SlackSocket, 'dmUser' | 'userIdForEmail'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: GoalNotice): Promise<void> {
+  const g = notice.goal;
+  const owned: Audience = isHumanMember(g.owner) ? { kind: 'member', id: g.owner } : { kind: 'admins' };
+  let card: { audience: Audience; title: string; line: string; type: 'goal.ready' | 'goal.proposed' } | null = null;
+  if (notice.kind === 'ready') {
+    card = {
+      audience: owned, type: 'goal.ready', title: 'Goal complete — ready to close',
+      line: `🎯 Every task under **${g.title}** is done. Close it out (or plan what's still missing).`,
+    };
+  } else if (notice.kind === 'status' && isHumanMember(g.owner) && (g.status === 'achieved' || g.status === 'abandoned')) {
+    card = {
+      audience: { kind: 'member', id: g.owner }, type: 'goal.proposed',
+      title: g.status === 'achieved' ? 'Goal achieved' : 'Goal abandoned',
+      line: `🎯 Goal **${g.title}** was marked ${g.status}.`,
+    };
+  }
+  if (!card) return;
+  const recipients = resolveRecipients(os, card.audience).filter((m) => m.id !== notice.by);
+  if (!recipients.length) return;
+  tm.postGoalCard({ goalId: g.id, agent: 'goals', title: card.title, body: g.target ? `${g.title} — target: ${g.target}` : g.title, audience: card.audience, type: card.type });
+  const url = consolePage(consoleOrigin, 'goals', g.id);
+  const text = (p: ChatPlatform) => `${card!.line}\nOpen it in the ${chatLink(p, url, 'Agent OS console')}.`;
+  const dms = await deliverDM(slack, discord, os, recipients, text);
+  os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: 'system', type: 'goal.notified', data: { id: g.id, kind: notice.kind, status: g.status, recipients: recipients.length, dms } });
 }
 
 /**

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -299,7 +299,7 @@ export interface Session {
 
 export interface FeedMessage {
   id: string;
-  type: 'task' | 'task.chat' | 'task.mention' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'app.proposed' | 'policy.proposal' | 'automation.proposed' | 'agent.update.proposed' | 'connection.request';
+  type: 'task' | 'task.chat' | 'task.mention' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'goal.ready' | 'skill.request' | 'secret.request' | 'host.proposed' | 'app.proposed' | 'policy.proposal' | 'automation.proposed' | 'agent.update.proposed' | 'connection.request';
   sessionId: string;
   agent: string;
   title: string;
@@ -2647,7 +2647,11 @@ export class TerminalManager {
     // Human-owned; toggleable in Settings. Capped so a long goal list can't dominate every prompt.
     let goalsSection = '';
     if (this.os.settings.injectGoals()) {
-      const active = this.os.goals.active(this.os.tenant).slice(0, 12);
+      // Drop goals whose work is all done but that nobody has closed yet — they're awaiting a human's
+      // sign-off, not direction for the fleet. Left in, a finished goal keeps steering every agent's work
+      // indefinitely (it stays `active` until someone flips it). `goal_list` still shows them live.
+      const complete = new Set(this.os.goals.readyToClose(this.os.tenant).map((g) => g.id));
+      const active = this.os.goals.active(this.os.tenant).filter((g) => !complete.has(g.id)).slice(0, 12);
       if (active.length) {
         goalsSection =
           '# Company goals — the direction your work serves\n\n' +
@@ -3435,14 +3439,15 @@ export class TerminalManager {
   }
 
   /**
-   * Post an inbox card for an agent's goal PROPOSAL (a draft goal an owner/admin must review + activate),
-   * addressed to an explicit {@link Audience} (admins). Like {@link postTaskCard} it uses the `goal:<id>`
+   * Post an inbox card about a goal — an agent's PROPOSAL (a draft an owner/admin reviews + activates) or,
+   * with `type: 'goal.ready'`, a goal whose linked work has all finished and now needs its owner to sign it
+   * off. Addressed to an explicit {@link Audience}. Like {@link postTaskCard} it uses the `goal:<id>`
    * sentinel for `session_id` (no session backs a goal) so visibility is governed by the audience, and
    * `args.goalId` deep-links the card to the Goals page. Public so the loopback propose route can call it.
    */
-  postGoalCard(input: { goalId: string; agent: string; title: string; body: string; audience: Audience }): void {
+  postGoalCard(input: { goalId: string; agent: string; title: string; body: string; audience: Audience; type?: 'goal.proposed' | 'goal.ready' }): void {
     this.addMessage({
-      type: 'goal.proposed', sessionId: `goal:${input.goalId}`, agent: input.agent, title: input.title,
+      type: input.type ?? 'goal.proposed', sessionId: `goal:${input.goalId}`, agent: input.agent, title: input.title,
       body: input.body, status: 'open', args: { goalId: input.goalId },
       audienceKind: input.audience.kind, audienceId: audienceIdOf(input.audience),
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -936,7 +936,8 @@ export interface Goal {
 export interface GoalEvent {
   id: string;
   goalId: string;
-  kind: 'status' | 'comment' | 'edit' | 'link';
+  // `ready` = every linked task finished; the derived completion signal, and the once-guard for its notice.
+  kind: 'status' | 'comment' | 'edit' | 'link' | 'ready';
   body?: string;
   author: string; // member id | 'agent:<id>' | 'system'
   createdAt: number;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4774,8 +4774,9 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
   const goArtifact = m.type === 'artifact' && meta.artifactId && onOpenArtifact ? () => onOpenArtifact(meta.artifactId!) : null
   // A 'task' card has no session — it deep-links to the board (its taskId), not a terminal.
   const goTask = m.type === 'task' && meta.taskId && onOpenTask ? () => onOpenTask(meta.taskId!) : null
-  // A 'goal.proposed' card deep-links to the Goals page for that goal (no session).
-  const goGoal = m.type === 'goal.proposed' && meta.goalId && onOpenGoal ? () => onOpenGoal(meta.goalId!) : null
+  // A goal card ('goal.proposed' — an agent's draft; 'goal.ready' — its work all finished) deep-links to
+  // the Goals page for that goal (no session backs a goal).
+  const goGoal = (m.type === 'goal.proposed' || m.type === 'goal.ready') && meta.goalId && onOpenGoal ? () => onOpenGoal(meta.goalId!) : null
   // An 'agent.update.proposed' card deep-links to the TARGET agent's page, where the owner review
   // card lives — not the proposer's session terminal. Hash routing, so setting the hash routes in place.
   const goAgentEdit = m.type === 'agent.update.proposed' && meta.target ? () => { window.location.hash = navHref('agent', meta.target!) } : null
@@ -4844,6 +4845,11 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
     Icon = Target; iconCls = 'text-indigo-600'; highlight = true
     verb = 'proposed a goal'; detail = m.body
     badge = <Badge variant="outline" className="border-indigo-300 px-1.5 py-0 text-[10px] font-normal text-indigo-700">Goal proposed</Badge>
+  } else if (m.type === 'goal.ready') {
+    // Every task under a goal finished — the human still owns the close, so this asks rather than reports.
+    Icon = Target; iconCls = 'text-emerald-600'; highlight = m.status === 'open'
+    verb = m.title; detail = m.body
+    badge = <Badge variant="outline" className="border-emerald-300 px-1.5 py-0 text-[10px] font-normal text-emerald-700">Ready to close</Badge>
   } else if (m.type === 'skill.request') {
     Icon = Sparkles; iconCls = 'text-violet-600'; highlight = m.status === 'open'
     const resolved = m.status === 'approved' ? 'installed' : m.status === 'rejected' ? 'dismissed' : ''
@@ -6872,6 +6878,12 @@ const goalStatusBorder = (s: GoalStatus): string => ({
   achieved: 'border-l-emerald-500',
   abandoned: 'border-l-red-500',
 }[s])
+// A goal is COMPLETE-in-fact when every task filed under it has finished — derived from linked-task
+// status, never stored. It stays `active` until a human signs it off: "all the filed work is done" is a
+// weaker claim than "the outcome was achieved" (the plan may simply have been incomplete), and goal state
+// is human-owned. So the UI proposes the close; the owner confirms it or plans the gap.
+const goalComplete = (g: Goal, p?: GoalProgress): boolean =>
+  g.status === 'active' && !!p && p.counted > 0 && p.done === p.counted
 // Derived-progress meter for a goal (share of its linked tasks that are done). A thin emerald bar +
 // a "done/total tasks" caption; renders nothing when the goal has no linked tasks.
 function GoalProgressBar({ p, className = '' }: { p?: GoalProgress; className?: string }) {
@@ -6920,6 +6932,9 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
   const [showPlan, setShowPlan] = useState(false)
   const [planGuidance, setPlanGuidance] = useState('')
   const [planMax, setPlanMax] = useState('')
+  // Sign-off step for a goal whose work is complete — an optional outcome note lands on the timeline.
+  const [signingOff, setSigningOff] = useState(false)
+  const [outcome, setOutcome] = useState('')
 
   const isAdmin = me.role === 'owner' || me.role === 'admin'
   const nameOf = (id?: string) => principalLabel(id, members)
@@ -6955,9 +6970,12 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
     if (editing) return // don't overwrite an in-progress edit on a background refresh
     api.goal(selId).then((r) => { if (r.goal) setDetail({ goal: r.goal, events: r.events ?? [], tasks: r.tasks ?? [], progress: r.progress }) })
   }, [selId, goals, editing])
-  useEffect(() => { setEditing(false); setConfirmDel(false); setPlanNote(''); setPlanSession(''); setShowPlan(false); setPlanGuidance(''); setPlanMax('') }, [selId]) // fresh drawer per selection
+  useEffect(() => { setEditing(false); setConfirmDel(false); setPlanNote(''); setPlanSession(''); setShowPlan(false); setPlanGuidance(''); setPlanMax(''); setSigningOff(false); setOutcome('') }, [selId]) // fresh drawer per selection
 
   const visible = goals ?? []
+  // Goals finished in fact but still open — the banner's subject. Derived from the list in view (the
+  // default "All" filter shows every one; a narrowed filter scopes the call-to-action to what you're on).
+  const ready = visible.filter((g) => goalComplete(g, progress[g.id]))
 
   const create = async () => {
     setHint('')
@@ -6982,6 +7000,16 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
     setPlanSession(r.sessionId ?? '')
     setTimeout(() => refreshDetail(id), 6000)
   }
+  // Close a completed goal. Status + the outcome note go in ONE patch so the timeline reads
+  // "achieved" alongside *why* — that note is the goal's lasting record, and what `goal_get` shows later.
+  const achieve = async () => {
+    if (!detail) return
+    setBusy(true)
+    await api.patchGoal(detail.goal.id, { status: 'achieved', note: outcome.trim() || undefined })
+    setSigningOff(false); setOutcome(''); setBusy(false)
+    await load()
+    await refreshDetail(detail.goal.id)
+  }
   const startEdit = () => { if (!detail) return; setETitle(detail.goal.title); setEBody(detail.goal.body); setEditing(true) }
   const saveEdit = async () => {
     if (!detail) return
@@ -6997,12 +7025,19 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
 
   const row = (g: Goal) => {
     const dm = dueMeta(g.dueAt, g.status === 'achieved' || g.status === 'abandoned' ? 'done' : 'todo')
+    const p = progress[g.id]
+    const done = goalComplete(g, p)
+    // An active goal nobody has filed work under isn't "0%" — it's unplanned. Say so, so the two very
+    // different empty states (nothing planned vs. planned-and-finished) don't both read as a bare dash.
+    const unplanned = g.status === 'active' && (!p || p.total === 0)
     return (
-      <tr key={g.id} onClick={() => openGoal(g.id)} className={`cursor-pointer border-b border-l-[3px] last:border-b-0 hover:bg-muted ${goalStatusBorder(g.status)} ${selId === g.id ? 'bg-muted' : ''}`}>
+      <tr key={g.id} onClick={() => openGoal(g.id)} className={`cursor-pointer border-b border-l-[3px] last:border-b-0 hover:bg-muted ${done ? 'border-l-emerald-500' : goalStatusBorder(g.status)} ${selId === g.id ? 'bg-muted' : ''}`}>
         <td className="px-3 py-2"><a href={navHref('goals', g.id)} onClick={(e) => { e.stopPropagation(); onNavClick(() => openGoal(g.id))(e) }} className={`text-foreground no-underline hover:underline ${g.status === 'abandoned' ? 'line-through opacity-60' : ''}`}>{g.title}</a> {g.labels.map((l) => <Badge key={l} variant="outline" className="ml-1 px-1 py-0 text-[10px]">{l}</Badge>)}</td>
-        <td className={`px-3 py-2 text-xs capitalize ${goalStatusTone(g.status)}`}>{g.status}</td>
+        <td className={`px-3 py-2 text-xs capitalize ${goalStatusTone(g.status)}`}>
+          {done ? <span className="inline-flex items-center gap-1 rounded bg-emerald-500/15 px-1.5 py-0.5 text-[10px] font-medium normal-case text-emerald-700 dark:text-emerald-400" title="Every task under this goal is done — close it out or plan what's missing"><Check className="h-3 w-3" />Ready to close</span> : g.status}
+        </td>
         <td className="px-3 py-2 text-xs text-muted-foreground">{g.target || '—'}</td>
-        <td className="px-3 py-2">{progress[g.id]?.total ? <GoalProgressBar p={progress[g.id]} className="w-28" /> : <span className="text-xs text-muted-foreground">—</span>}</td>
+        <td className="px-3 py-2">{p?.total ? <GoalProgressBar p={p} className="w-28" /> : <span className="text-xs text-muted-foreground">{unplanned ? 'No work planned' : '—'}</span>}</td>
         <td className="px-3 py-2 text-muted-foreground">{g.owner ? ownerChip(g.owner) : '—'}</td>
         <td className="px-3 py-2 text-xs">{dm ? <span className={dm.overdue ? 'text-red-600' : dm.soon ? 'text-amber-600' : 'text-muted-foreground'}>{dm.label}</span> : <span className="text-muted-foreground">—</span>}</td>
         <td className="px-3 py-2 text-xs text-muted-foreground">{new Date(g.updatedAt).toLocaleDateString()}</td>
@@ -7072,6 +7107,22 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
         </Card>
       )}
 
+      {/* Completion, surfaced where you land rather than left to be noticed as a full progress bar. The
+          goals it names are finished in fact but still `active` — the OS never closes one for you. */}
+      {ready.length > 0 && (
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-xs text-emerald-800 dark:text-emerald-300">
+          <Check className="h-4 w-4 shrink-0" />
+          <span className="font-medium">{ready.length === 1 ? 'A goal has finished all its work' : `${ready.length} goals have finished all their work`}</span>
+          <span className="text-emerald-700/80 dark:text-emerald-400/80">— sign it off, or plan what's still missing.</span>
+          <span className="flex flex-wrap gap-1.5">
+            {ready.slice(0, 4).map((g) => (
+              <button key={g.id} onClick={() => openGoal(g.id)} className="rounded border border-emerald-500/40 bg-background/60 px-1.5 py-0.5 font-medium hover:bg-background">{g.title.length > 40 ? g.title.slice(0, 39) + '…' : g.title}</button>
+            ))}
+            {ready.length > 4 && <span className="self-center">+{ready.length - 4} more</span>}
+          </span>
+        </div>
+      )}
+
       <div className="overflow-x-auto rounded-md border">
         <table className="w-full text-sm">
           <thead className="border-b bg-muted/40 text-[11px] uppercase tracking-wider text-muted-foreground">
@@ -7118,6 +7169,40 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
             ) : (
               <div className="space-y-3.5">
                 <div className="font-mono text-xs text-muted-foreground">{detail.goal.id}{detail.goal.createdBy ? ` · by ${nameOf(detail.goal.createdBy)}` : ''}</div>
+
+                {/* The sign-off prompt: this goal's work is all done, so put the decision in front of the
+                    person instead of leaving them to find `achieved` in the status dropdown. Both outcomes
+                    are one click — it's finished, or the plan missed something and needs more work. */}
+                {isAdmin && goalComplete(detail.goal, detail.progress) && (
+                  <div className="space-y-2 rounded-md border border-emerald-500/40 bg-emerald-500/10 p-3">
+                    <div className="flex items-start gap-2 text-sm text-emerald-800 dark:text-emerald-300">
+                      <Check className="mt-0.5 h-4 w-4 shrink-0" />
+                      <span>All {detail.progress?.counted} task{detail.progress?.counted === 1 ? '' : 's'} under this goal are done. Was the outcome achieved?</span>
+                    </div>
+                    {signingOff ? (
+                      <div className="space-y-2">
+                        <textarea
+                          value={outcome}
+                          onChange={(e) => setOutcome(e.target.value)}
+                          placeholder="What actually changed? (optional — kept on the goal's timeline, and what agents read later)"
+                          rows={3}
+                          className="w-full resize-y rounded-md border bg-background px-2 py-1.5 text-xs outline-none focus:ring-1 focus:ring-ring"
+                        />
+                        <div className="flex items-center gap-2">
+                          <Button size="sm" className="h-7" disabled={busy} onClick={achieve}>Confirm achieved</Button>
+                          <Button size="sm" variant="ghost" className="h-7" onClick={() => { setSigningOff(false); setOutcome('') }}>Cancel</Button>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="flex flex-wrap items-center gap-2">
+                        <Button size="sm" className="h-7" disabled={busy} onClick={() => setSigningOff(true)}><Check className="mr-1 h-3.5 w-3.5" />Mark achieved</Button>
+                        <Button size="sm" variant="outline" className="h-7" disabled={busy} onClick={() => { setPlanNote(''); setHint(''); setShowPlan(true) }}>
+                          <Wand2 className="mr-1 h-3.5 w-3.5" />Not yet — plan the gap
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                )}
                 {detail.goal.body && <div className="max-h-56 overflow-y-auto break-words rounded-md border bg-muted/30 p-3 text-sm [&_pre]:whitespace-pre-wrap [&_pre]:break-words"><ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks]} components={mdComponents}>{detail.goal.body}</ReactMarkdown></div>}
 
                 <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">

--- a/web/src/docs/goals.md
+++ b/web/src/docs/goals.md
@@ -34,9 +34,9 @@ outcome decomposes instead of turning into fifty loose tasks.
 ## Auto-planning (opt-in)
 
 Turn on **Auto-plan stuck goals** (owner/admin, top of the Goals page) and you don't even click Plan.
-The scheduler notices an **active goal with no open work** — never planned, or all its tasks finished
-but the goal isn't achieved — that's sat idle past a short grace window, and runs the strategist for
-you. Same as clicking Plan: it drafts tasks for review and never auto-dispatches.
+The scheduler notices an **active goal with no work filed against it** — never planned, or every task
+cancelled — that's sat idle past a short grace window, and runs the strategist for you. Same as
+clicking Plan: it drafts tasks for review and never auto-dispatches.
 
 It's **off by default** (it spawns agent sessions) and deliberately boring — a plain check on the
 goal's own data, rate-limited per goal and per tick so it can't burst runs or grab a goal you're
@@ -51,6 +51,24 @@ spawns a governed session, the agent closes its own loop, and the goal's progres
 
 Deleting a goal **detaches** its tasks rather than deleting them — real work survives on the board,
 just unlinked.
+
+## When the work is done
+
+Once **every task under a goal has finished**, the goal is marked **Ready to close** — on its row, in
+a banner at the top of the Goals page, and as an inbox card + DM to whoever owns it. You don't have to
+be watching the page to find out your goal landed.
+
+Agent OS does **not** close the goal for you. "All the tasks I filed are done" is a weaker claim than
+"the outcome was achieved" — the plan may simply have missed something — and goal status is yours to
+set. So the goal's page offers the two real answers:
+
+- **Mark achieved** — with an optional note on *what actually changed*. That note stays on the goal's
+  timeline and is what agents read later when they ask what came of it.
+- **Not yet — plan the gap** — hands it back to the strategist to file the work that's still missing.
+
+Until you pick one, a finished goal stops being injected into agents' prompts as current direction
+(it's awaiting your sign-off, not steering work), and the auto-planner leaves it alone rather than
+inventing fresh tasks for something that's already done.
 
 ## Rule of thumb
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -669,7 +669,7 @@ export interface AutoApproval {
 
 export interface Msg {
   id: string
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed' | 'agent.update.proposed'
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'goal.ready' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed' | 'agent.update.proposed'
   sessionId: string
   agent: string
   title: string


### PR DESCRIPTION
## The gap

`GoalStore.progress()` has always derived 100% from linked tasks — and **nothing consumed it**. `achieved` was reachable only by hand-picking it from a dropdown inside the goal drawer, so a finished goal just sat `active`. On the live **instawp** tenant, *"Remove all blank links from marketing site"* had been **6/6 done and `active` for 19 days**.

Three consequences, two of them defects rather than missing UX:

1. It was still injected into every agent's prompt by `buildCompanyMd` as *"the direction your work serves"* — the whole fleet steered toward finished work, indefinitely.
2. `GoalStore.stuck()` selected active goals with no **open** task — true for *"never planned"* **and** *"all work finished"*. With Auto-plan on, the strategist was spawned to invent new tasks for a completed goal.
3. Nobody was told. `GoalStore.setNotifier` existed with **no consumer** — every goal status change was silent.

## The model

**Derived, announced, human-confirmed — never auto-flipped.** "Every task I filed is done" is a weaker claim than "the outcome was achieved" (the plan may have been incomplete; `target` is a caption nothing verifies), and goal state is human-owned — the same posture as agents proposing but not activating goals.

- **`GoalStore.readyToClose(tenant)`** — active goals whose every non-cancelled *leaf* linked task is done. Derived, no schema change; matches `progress()`'s 100% exactly.
- **`announceReady()`** + an always-on `sweepCompletedGoals` tick — fires once per *completion streak*, guarded by a `ready` goal_event newer than the newest linked task, so later work that also completes announces again.
- **The notifier is wired** — `notifyGoalEvent` (mirroring `notifyTaskEvent`) routes `ready` → the owner (else admins) and `achieved`/`abandoned` → the owner, as a `goal.ready` inbox card + DM.
- **Console** — a "Ready to close" chip, a page banner, and a drawer sign-off box: **Mark achieved** with an optional outcome note (patched *alongside* the status, so the timeline records what changed and agents read it later) or **Not yet — plan the gap** (reuses the strategist steering box). An active goal with no tasks now reads **"No work planned"** instead of a bare dash — the two empty states are different asks.
- **`stuck()` now means "no work filed at all"**; the Insights goals tile splits *ready to close* / *no work planned* / *no progress in 7+ days*, and the unstick list excludes finished goals.
- **Prompt injection skips completed goals** — `goal_list` still returns them live.

## Verification

- **Store predicates against a copy of the live instawp DB** — `readyToClose` = the one 6/6 goal; new `stuck` = the two never-planned goals; the old predicate returned all three (the bug, reproduced).
- **Isolated store test** — partial / cancelled-only / umbrella-parent goals correctly excluded (leaf counting), announce dedupes within a streak and re-fires after new work completes, achieving leaves the set.
- **Full loop on a scratch instance** — tick → `ready` event + `goal.ready` card + audit within 20s; `PATCH {status, note}` → `status` + `comment` on one timeline; counts move. All three UI surfaces screenshotted.
- **`buildCompanyMd`** — a finished goal is absent from the injected prompt, an open one present.
- `npm run typecheck`, `cd web && npm run build`, governance **137/137** + tier-A **18/18**.

## Deploy note

Server + store + web changes → `npm run build` **+ restart** (plus `cd web && npm run build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)