### PR TITLE
feat(cockpit): first-party Claude for the ask tier + tie-break, configured in the web UI (v0.285.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.288.0] — 2026-08-01
+### Added
+- **Cockpit `ask` + router tie-break can answer via first-party Claude — configured from the web UI.**
+  When an Anthropic API key is set, the `ask` tier and the router's near-tie tie-break call Claude directly
+  (`POST /v1/messages`, raw `fetch` — no SDK dependency), defaulting to **`claude-haiku-4-5`** (fastest +
+  cheapest; ample for a workspace Q&A). This is the fast, session-free middle rung between the free state
+  lookups and the key-free concierge run: **state → direct Claude (if a key is set) → concierge fallback**.
+  The key + model are set in **Settings → Integrations → "Cockpit answers (Anthropic)"**, stored in the
+  per-tenant settings table like every other integration key — **masked/write-only** (the API only ever
+  returns `{ set, source, model }`, never the key). `ANTHROPIC_API_KEY` in the server env also works (the
+  Settings value wins; the panel shows which source is active). Billed to the Anthropic org — separate from
+  any Claude Code subscription (which only the concierge, a real Claude Code session, can use). The
+  tie-break gate now fires for **any** resolvable LLM (Anthropic key or an OpenAI-compatible endpoint), not
+  just `router_config.llm`. `src/edge/llm.ts` (tagged Anthropic/OpenAI backends + `ANTHROPIC_BASE_URL`
+  override), `src/governance/settings.ts` (`anthropicKey`/`anthropicModel`/`anthropicMeta`), `src/server.ts`
+  (integrations view + PUT), `src/edge/router.ts`, `web/src/App.tsx`, `web/src/lib/api.ts`.
+
 ## [0.287.0] — 2026-08-01
 ### Changed
 - **Runtime-account validation now reads real weekly/session usage for `setup-token` accounts too — not

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.287.0",
+  "version": "0.288.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.287.0",
+      "version": "0.288.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.287.0",
+  "version": "0.288.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/llm.ts
+++ b/src/edge/llm.ts
@@ -1,32 +1,78 @@
 /**
- * Tiny OpenAI-compatible chat-completion helper, shared by the router's near-tie tie-break and the
- * Cockpit `ask` tier (answering questions about the workspace). Endpoint/key/model resolve from the
- * router's own config first (`router_config.llm`), falling back to the router/memory embedder's endpoint
- * — so a workspace that configured either gets an LLM here for free. Returns null on any failure (no
- * config, network, non-200, malformed) so every caller degrades gracefully rather than throwing.
+ * Tiny chat-completion helper, shared by the router's near-tie tie-break and the Cockpit `ask` tier
+ * (answering questions about the workspace). Two backends, resolved in priority order:
+ *   1. **Native Anthropic** (`/v1/messages`) — used whenever an Anthropic key is configured (Settings →
+ *      Integrations, or the `ANTHROPIC_API_KEY` env var). First-party Claude, defaults to Haiku — fast +
+ *      cheap for a lightweight workspace Q&A. Raw `fetch`, no SDK dependency.
+ *   2. **OpenAI-compatible** (`/chat/completions`) — the fallback, from `router_config.llm` or the memory
+ *      embedder's endpoint.
+ * Returns null on any failure (no config, network, non-200, malformed) so every caller degrades
+ * gracefully rather than throwing (→ the concierge run, then routing).
  */
 import { AgentOS } from '../kernel';
 
-export interface LlmConfig {
-  url: string;
-  apiKey?: string;
-  model: string;
-}
+export const DEFAULT_ANTHROPIC_MODEL = 'claude-haiku-4-5'; // fastest + cheapest; ample for the ask tier.
 
-/** Resolve the chat LLM: `router_config.llm` (model required), with url/apiKey falling back to the
- *  resolved embedder (router-owned, else memory sqlite). Null when no model+endpoint is available. */
+export type LlmConfig =
+  | { provider: 'anthropic'; apiKey: string; model: string }
+  | { provider: 'openai'; url: string; apiKey?: string; model: string };
+
+/** Resolve the chat LLM. Native Anthropic first (a key present ⇒ use it), else an OpenAI-compatible
+ *  endpoint (`router_config.llm`, falling back to the resolved embedder). Null when neither is set. */
 export function resolveLlm(os: AgentOS): LlmConfig | null {
+  const key = os.settings.anthropicKey();
+  if (key) return { provider: 'anthropic', apiKey: key, model: os.settings.anthropicModel() };
   const rc = os.settings.routerConfig();
   const emb = rc.embeddings ?? os.settings.memoryConfig()?.sqlite?.embeddings;
   const url = (rc.llm?.url || emb?.url || '').replace(/\/$/, '');
   const apiKey = rc.llm?.apiKey || emb?.apiKey;
   const model = rc.llm?.model;
-  return url && model ? { url, apiKey, model } : null;
+  return url && model ? { provider: 'openai', url, apiKey, model } : null;
 }
 
-/** POST /chat/completions; return the assistant text (trimmed) or null on any failure. */
+/** Run a completion against the resolved backend; return the assistant text (trimmed) or null. */
 export async function chatComplete(
   llm: LlmConfig,
+  messages: { role: 'system' | 'user' | 'assistant'; content: string }[],
+  opts?: { maxTokens?: number; temperature?: number; timeoutMs?: number },
+): Promise<string | null> {
+  return llm.provider === 'anthropic' ? anthropicComplete(llm, messages, opts) : openaiComplete(llm, messages, opts);
+}
+
+// Native Anthropic Messages API. `system` is a top-level field there (not a message role), so we split
+// system turns out. No `thinking`/`effort` — Haiku doesn't support them, and a short factual answer
+// doesn't need them. Auth is `x-api-key` + the required `anthropic-version` header.
+async function anthropicComplete(
+  llm: { apiKey: string; model: string },
+  messages: { role: 'system' | 'user' | 'assistant'; content: string }[],
+  opts?: { maxTokens?: number; timeoutMs?: number },
+): Promise<string | null> {
+  const system = messages.filter((m) => m.role === 'system').map((m) => m.content).join('\n\n');
+  const turns = messages.filter((m) => m.role !== 'system').map((m) => ({ role: m.role, content: m.content }));
+  const base = (process.env.ANTHROPIC_BASE_URL || 'https://api.anthropic.com').replace(/\/$/, ''); // SDK-convention override (also lets tests point at a stub)
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), opts?.timeoutMs ?? 15000);
+  try {
+    const res = await fetch(`${base}/v1/messages`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-api-key': llm.apiKey, 'anthropic-version': '2023-06-01' },
+      body: JSON.stringify({ model: llm.model, max_tokens: opts?.maxTokens ?? 400, ...(system ? { system } : {}), messages: turns }),
+      signal: ctrl.signal,
+    });
+    if (!res.ok) return null;
+    const json = (await res.json()) as { content?: { type: string; text?: string }[] };
+    const text = (json.content || []).filter((b) => b.type === 'text').map((b) => b.text || '').join('').trim();
+    return text || null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// OpenAI-compatible /chat/completions.
+async function openaiComplete(
+  llm: { url: string; apiKey?: string; model: string },
   messages: { role: 'system' | 'user' | 'assistant'; content: string }[],
   opts?: { maxTokens?: number; temperature?: number; timeoutMs?: number },
 ): Promise<string | null> {

--- a/src/edge/router.ts
+++ b/src/edge/router.ts
@@ -183,8 +183,10 @@ export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecis
 
   const decision = decide(scored, cfg);
 
-  // Near-tie → try the LLM tie-break before bothering the human. A clear pick routes; unsure → disambiguate.
-  if (decision.kind === 'disambiguate' && cfg.llm?.model) {
+  // Near-tie → try the LLM tie-break before bothering the human (any resolvable LLM: Anthropic key or an
+  // OpenAI-compatible endpoint). `llmTieBreak` no-ops (returns null) when none is configured. A clear pick
+  // routes; unsure → disambiguate.
+  if (decision.kind === 'disambiguate') {
     const pick = await llmTieBreak(os, text, decision.candidates, agents);
     if (pick) {
       const c = decision.candidates.find((x) => x.agentId === pick);

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -16,6 +16,9 @@ const COMPANY_KEY = 'company_md';
 const REVIEW_KEY = 'code_review_md'; // the fleet-wide code-review policy (how agents review a diff/PR)
 const COMPOSIO_KEY = 'composio_api_key';
 const COMPOSIO_WEBHOOK_KEY = 'composio_webhook_secret';
+const ANTHROPIC_KEY_KEY = 'anthropic_api_key'; // first-party Claude key for the Cockpit ask tier + router tie-break
+const ANTHROPIC_MODEL_KEY = 'anthropic_model'; // which Claude model the direct-API path uses (default Haiku)
+const DEFAULT_ANTHROPIC_MODEL = 'claude-haiku-4-5'; // kept in sync with src/edge/llm.ts DEFAULT_ANTHROPIC_MODEL
 const SLACK_APP_TOKEN_KEY = 'slack_app_token'; // xapp-… (Socket Mode, connections:write)
 const SLACK_BOT_TOKEN_KEY = 'slack_bot_token'; // xoxb-… (chat.postMessage, users.info)
 const DISCORD_BOT_TOKEN_KEY = 'discord_bot_token'; // Bot … (Gateway connect + post messages)
@@ -182,6 +185,33 @@ export class SettingsStore {
   }
   setComposioWebhookSecret(secret: string, by?: string): void {
     this.set(COMPOSIO_WEBHOOK_KEY, secret.trim(), by);
+  }
+
+  // ── Anthropic (Cockpit ask / router tie-break) ───────────────────────────────────
+  // A first-party Claude key so the `ask` tier + the router's LLM tie-break can call /v1/messages
+  // directly (fast, no session) instead of spawning the concierge. Set here in Settings, or via the
+  // ANTHROPIC_API_KEY env var (the settings value wins). See src/edge/llm.ts.
+
+  /** The workspace Anthropic API key: the Settings value first, else the `ANTHROPIC_API_KEY` env. '' when unset. */
+  anthropicKey(): string {
+    return this.getRow(ANTHROPIC_KEY_KEY)?.value?.trim() || (process.env.ANTHROPIC_API_KEY || '').trim();
+  }
+  /** The Claude model the direct-API path uses (default Haiku — fast + cheap for a workspace Q&A). */
+  anthropicModel(): string {
+    return this.getRow(ANTHROPIC_MODEL_KEY)?.value?.trim() || DEFAULT_ANTHROPIC_MODEL;
+  }
+  /** Whether a key is set + where it came from + the model — never returns the secret itself. */
+  anthropicMeta(): { set: boolean; source: 'settings' | 'env' | null; model: string; updatedAt?: number; updatedBy?: string } {
+    const row = this.getRow(ANTHROPIC_KEY_KEY);
+    const inSettings = !!row?.value?.trim();
+    const inEnv = !inSettings && !!(process.env.ANTHROPIC_API_KEY || '').trim();
+    return { set: inSettings || inEnv, source: inSettings ? 'settings' : inEnv ? 'env' : null, model: this.anthropicModel(), updatedAt: row?.updated_at, updatedBy: row?.updated_by ?? undefined };
+  }
+  setAnthropicKey(key: string, by?: string): void {
+    this.set(ANTHROPIC_KEY_KEY, key.trim(), by);
+  }
+  setAnthropicModel(model: string, by?: string): void {
+    this.set(ANTHROPIC_MODEL_KEY, model.trim() || DEFAULT_ANTHROPIC_MODEL, by);
   }
 
   // ── native Slack (Socket Mode) ───────────────────────────────────────────────────

--- a/src/server.ts
+++ b/src/server.ts
@@ -4421,6 +4421,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // Only touch a field when the client sends it as a string; '' clears the key.
     if (typeof b.composioApiKey === 'string') os.settings.setComposioApiKey(b.composioApiKey, me.email);
     if (typeof b.composioWebhookSecret === 'string') os.settings.setComposioWebhookSecret(b.composioWebhookSecret, me.email);
+    // Anthropic key/model for the Cockpit ask tier + router tie-break (direct /v1/messages, no session).
+    if (typeof b.anthropicApiKey === 'string') os.settings.setAnthropicKey(b.anthropicApiKey, me.email);
+    if (typeof b.anthropicModel === 'string') os.settings.setAnthropicModel(b.anthropicModel, me.email);
     // Slack tokens: changing either re-dials (or tears down) the Socket-Mode connection.
     const slackTouched = typeof b.slackAppToken === 'string' || typeof b.slackBotToken === 'string';
     if (typeof b.slackAppToken === 'string') os.settings.setSlackAppToken(b.slackAppToken, me.email);
@@ -6377,6 +6380,7 @@ function integrationsView(os: AgentOS): {
   github: { clientId: boolean; clientSecret: boolean; configured: boolean; slug: string; installUrl: string; appId: boolean; privateKey: boolean; botReady: boolean };
   image: { openRouter: boolean; atlas: boolean; backend: 'openrouter' | 'atlas' | null; defaultModel: string; configured: boolean };
   video: { fal: boolean; atlas: boolean; backend: 'fal' | 'atlas' | null; defaultModel: string; configured: boolean };
+  anthropic: { set: boolean; source: 'settings' | 'env' | null; model: string };
   chatRouter: boolean;
   chatIdleTimeoutMin: number;
   updatedAt?: number;
@@ -6398,6 +6402,7 @@ function integrationsView(os: AgentOS): {
     github: { clientId: !!gh.clientId(), clientSecret: !!gh.clientSecret(), configured: gh.configured(), slug: gh.appSlug(), installUrl: gh.appSlug() ? `https://github.com/apps/${gh.appSlug()}/installations/new` : '', appId: !!gh.appId(), privateKey: !!gh.privateKey(), botReady: !!gh.loadBotToken() },
     image: { openRouter: image.openRouter, atlas: image.atlas, backend: image.backend, defaultModel: image.defaultModel, configured: os.settings.imageGenConfigured() },
     video: { fal: video.fal, atlas: video.atlas, backend: video.backend, defaultModel: video.defaultModel, configured: os.settings.videoGenConfigured() },
+    anthropic: (() => { const a = os.settings.anthropicMeta(); return { set: a.set, source: a.source, model: a.model }; })(),
     chatRouter: os.settings.chatRouterEnabled(),
     chatIdleTimeoutMin: os.settings.chatIdleTimeoutMinutes(),
     updatedAt: meta.updatedAt,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14248,6 +14248,9 @@ function IntegrationsSettings({ me }: { me: Member }) {
   const [video, setVideo] = useState<IntegrationsResp['video']>({ fal: false, atlas: false, backend: null, defaultModel: '', configured: false })
   const [falKey, setFalKey] = useState('')
   const [vidModel, setVidModel] = useState('')
+  const [anthropic, setAnthropic] = useState<IntegrationsResp['anthropic']>({ set: false, source: null, model: 'claude-haiku-4-5' })
+  const [anthKey, setAnthKey] = useState('')
+  const [anthModel, setAnthModel] = useState('')
   // Live Atlas catalog for the default-model comboboxes (dropdown suggestions; the fields stay free text).
   const [atlasModels, setAtlasModels] = useState<{ image: { id: string; label: string; priceUsd: number | null }[]; video: { id: string; label: string; priceUsd: number | null }[] }>({ image: [], video: [] })
   const [chatRouter, setChatRouter] = useState(true)
@@ -14270,6 +14273,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
   const GITHUB_DEFAULT = { clientId: false, clientSecret: false, configured: false, slug: '', installUrl: '', appId: false, privateKey: false, botReady: false }
   const IMAGE_DEFAULT = { openRouter: false, atlas: false, backend: null, defaultModel: '', configured: false } as const
   const VIDEO_DEFAULT = { fal: false, atlas: false, backend: null, defaultModel: '', configured: false } as const
+  const ANTHROPIC_DEFAULT = { set: false, source: null, model: 'claude-haiku-4-5' } as const
   const apply = (r: IntegrationsResp) => {
     if (r.composio) setComposio(r.composio)
     if (r.webhook) setWebhook(r.webhook)
@@ -14281,6 +14285,8 @@ function IntegrationsSettings({ me }: { me: Member }) {
     if (r.image) setImgModel(r.image.defaultModel || '')
     setVideo(r.video ?? VIDEO_DEFAULT)
     if (r.video) setVidModel(r.video.defaultModel || '')
+    setAnthropic(r.anthropic ?? ANTHROPIC_DEFAULT)
+    if (r.anthropic) setAnthModel(r.anthropic.model || '')
     if (typeof r.chatRouter === 'boolean') setChatRouter(r.chatRouter)
     if (typeof r.chatIdleTimeoutMin === 'number') setChatIdle(r.chatIdleTimeoutMin)
     setMeta({ updatedAt: r.updatedAt, updatedBy: r.updatedBy })
@@ -14335,7 +14341,7 @@ function IntegrationsSettings({ me }: { me: Member }) {
     }
   }, [])
 
-  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; clickupToken?: string; clickupWebhookSecret?: string; githubClientId?: string; githubClientSecret?: string; githubAppId?: string; githubPrivateKey?: string; githubAppSlug?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }, label: string) => {
+  const save = async (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; clickupToken?: string; clickupWebhookSecret?: string; githubClientId?: string; githubClientSecret?: string; githubAppId?: string; githubPrivateKey?: string; githubAppSlug?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; anthropicApiKey?: string; anthropicModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }, label: string) => {
     setBusy(true); setHint('')
     const r = await api.saveIntegrations(body)
     setBusy(false)
@@ -14886,6 +14892,63 @@ function IntegrationsSettings({ me }: { me: Member }) {
               </div>
             </Field>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Cockpit `ask` tier + router tie-break: a first-party Claude key → answer directly via /v1/messages
+          (fast, no session) instead of the concierge run. Billed to the Anthropic org, not the subscription. */}
+      <Card>
+        <CardContent className="space-y-4 p-4">
+          <div>
+            <div className="flex items-center gap-2 text-sm font-medium">
+              Cockpit answers (Anthropic)
+              {anthropic.set
+                ? <Badge variant="secondary" className="px-1.5 py-0 text-[10px] text-emerald-600">on{anthropic.source === 'env' ? ' · env' : ''}</Badge>
+                : <Badge variant="outline" className="px-1.5 py-0 text-[10px]">off</Badge>}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              An <strong>Anthropic API key</strong> lets Cockpit's <strong>ask</strong> tier and the router's near-tie
+              tie-break answer directly via Claude — fast, no session — instead of spawning the concierge agent.
+              Billed to your Anthropic org (separate from any Claude Code subscription). Without a key, the concierge
+              still answers, just slower.
+            </p>
+          </div>
+
+          <Field label="Anthropic API key" help="platform.claude.com → API keys. Alternatively set ANTHROPIC_API_KEY in the server environment (the Settings value wins).">
+            <Input
+              type="password"
+              value={anthKey}
+              onChange={(e) => setAnthKey(e.target.value)}
+              placeholder={anthropic.set ? (anthropic.source === 'env' ? 'set via ANTHROPIC_API_KEY env — type a key to override here' : '•••• (saved) — type a new key to replace') : 'sk-ant-…'}
+              className="font-mono text-xs"
+            />
+            <div className="mt-1 flex items-center gap-3">
+              <Button
+                size="sm"
+                onClick={() => save({ ...(anthKey.trim() ? { anthropicApiKey: anthKey.trim() } : {}) }, 'saved')}
+                disabled={busy || !anthKey.trim()}
+              >Save key</Button>
+              {anthropic.set && anthropic.source === 'settings' && (
+                <button type="button" className="text-[11px] text-muted-foreground hover:text-destructive disabled:opacity-50" onClick={() => save({ anthropicApiKey: '' }, 'removed')} disabled={busy}>Remove</button>
+              )}
+            </div>
+          </Field>
+
+          <Field label="Model" help="Which Claude model the direct answers use. Haiku is fastest + cheapest — plenty for a workspace Q&A; agents' own reasoning still runs on your subscription via the concierge.">
+            <Input
+              list="anthropic-models"
+              value={anthModel}
+              onChange={(e) => setAnthModel(e.target.value)}
+              onBlur={() => { if (anthModel.trim() !== (anthropic.model || '')) save({ anthropicModel: anthModel.trim() }, 'model saved') }}
+              placeholder="claude-haiku-4-5"
+              className="font-mono text-xs"
+            />
+            <datalist id="anthropic-models">
+              <option value="claude-haiku-4-5">Claude Haiku 4.5 — fastest + cheapest</option>
+              <option value="claude-sonnet-5">Claude Sonnet 5 — balanced</option>
+              <option value="claude-opus-4-8">Claude Opus 4.8 — most capable</option>
+            </datalist>
+          </Field>
         </CardContent>
       </Card>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1079,6 +1079,10 @@ export interface IntegrationsResp {
   image: { openRouter: boolean; atlas: boolean; backend: 'openrouter' | 'atlas' | null; defaultModel: string; configured: boolean }
   /** Video generation backend — which keys are set (never the keys), the active backend, default model. */
   video: { fal: boolean; atlas: boolean; backend: 'fal' | 'atlas' | null; defaultModel: string; configured: boolean }
+  /** First-party Anthropic key for the Cockpit `ask` tier + router tie-break (direct /v1/messages, no
+   *  session). `set` = a key is available; `source` = where (Settings vs `ANTHROPIC_API_KEY` env); the
+   *  key itself is never returned. `model` = which Claude model the direct path uses (default Haiku). */
+  anthropic: { set: boolean; source: 'settings' | 'env' | null; model: string }
   /** Generic `/agent` chat router: when on, an unmatched Slack/Discord message reaches any agent by name. */
   chatRouter: boolean
   /** Warm (resident) Slack thread session idle-kill, minutes. 0 = residence off (every reply cold-starts). */
@@ -1593,7 +1597,7 @@ export const api = {
     call<{ ok?: boolean; error?: string }>('POST', '/api/connections/requests/' + encodeURIComponent(id) + '/dismiss'),
   integrations: () => call<IntegrationsResp>('GET', '/api/settings/integrations'),
   atlasModels: () => call<{ configured: boolean; image: { id: string; label: string; priceUsd: number | null }[]; video: { id: string; label: string; priceUsd: number | null }[]; error?: string }>('GET', '/api/integrations/atlas/models'),
-  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; clickupToken?: string; clickupWebhookSecret?: string; githubClientId?: string; githubClientSecret?: string; githubAppId?: string; githubPrivateKey?: string; githubAppSlug?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
+  saveIntegrations: (body: { composioApiKey?: string; composioWebhookSecret?: string; slackAppToken?: string; slackBotToken?: string; discordBotToken?: string; clickupToken?: string; clickupWebhookSecret?: string; githubClientId?: string; githubClientSecret?: string; githubAppId?: string; githubPrivateKey?: string; githubAppSlug?: string; openRouterKey?: string; atlasKey?: string; imageDefaultModel?: string; falKey?: string; videoDefaultModel?: string; anthropicApiKey?: string; anthropicModel?: string; chatRouter?: boolean; chatIdleTimeoutMin?: number }) => call<IntegrationsResp & { ok: boolean }>('PUT', '/api/settings/integrations', body),
   // Per-member GitHub (user-to-server OAuth): each member links their OWN account so run-as sessions
   // push / open PRs as the actual human. `connect` returns the authorize URL to navigate to.
   githubMe: () => call<GithubMe>('GET', '/api/github/me'),


### PR DESCRIPTION
Answers "put the API key in the web UI" + "use Haiku". When an Anthropic API key is set, Cockpit's **ask** tier and the router's **near-tie tie-break** answer directly via Claude — fast, session-free — instead of spawning the concierge agent.

## The ladder now
1. **State lookup** — free, instant, no key (deterministic)
2. **Direct Claude** — `POST /v1/messages` (raw `fetch`, no SDK), default **`claude-haiku-4-5`** — when a key is set
3. **Concierge session** — key-free fallback, runs on your Claude Code subscription, for the hardest reasoning

## Configured in the web UI (no file/plist)
**Settings → Integrations → "Cockpit answers (Anthropic)"** — key + model, stored in the per-tenant settings table like every other integration credential:
- **Masked / write-only** — the API only ever returns `{ set, source, model }`, never the key (same posture as the Composio/Slack fields).
- **Model picker** defaults to Haiku, with Sonnet 5 / Opus 4.8 as options.
- `ANTHROPIC_API_KEY` env still works as an alternative — the Settings value wins, and the panel badge shows which source is active (`on` vs `on · env`).

Billed to your Anthropic org — separate from the Claude Code subscription (only the concierge, a real Claude Code session, can use that).

## Why Haiku / why raw fetch
- Haiku 4.5 is fastest + cheapest and the ask tier is a lightweight "answer from this compact context" — no reasoning needed. Its call is a plain `/v1/messages` (no `thinking`/`effort`, which Haiku doesn't support).
- Raw `fetch` keeps agent-os's **zero-dependency** stance — no `@anthropic-ai/sdk`.

## Also
The tie-break gate now fires for **any** resolvable LLM (Anthropic key *or* an OpenAI-compatible endpoint), not just `router_config.llm` — previously it silently skipped when the only LLM was the Anthropic key.

## Files
`src/edge/llm.ts` (tagged Anthropic/OpenAI backends + `ANTHROPIC_BASE_URL` override), `src/governance/settings.ts` (`anthropicKey`/`anthropicModel`/`anthropicMeta`), `src/server.ts` (integrations view + PUT), `src/edge/router.ts`, `web/src/App.tsx`, `web/src/lib/api.ts`.

## Verification
- `typecheck` + `web build` clean; `test:governance` → **137/137** + tier-A **18/18**
- `resolveLlm` provider selection (key → anthropic/haiku; openai config → openai; neither → null) and `anthropicComplete` wire shape (POST `/v1/messages`, `x-api-key`, `anthropic-version: 2023-06-01`, `system` split to top-level, `messages` = user only, no `thinking`/`effort`) driven end-to-end against a fake endpoint via `ANTHROPIC_BASE_URL`.

## After merge
Deploy, then paste an Anthropic API key into **Settings → Integrations** on instapods — I never see the value. The concierge keeps `ask` working until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)