### PR TITLE
fix(gate): unanswered cards no longer pin panes open, and `ssh` in a grep pattern isn't egress (v0.291.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.291.1] — 2026-08-03
+### Fixed
+- **An unanswered approval no longer pins a finished run's terminal open forever.** Nothing expires an
+  Inbox card, and that was load-bearing in the wrong place: an unattended run whose gate hit the 180s
+  fail-closed deny (or whose `ask` parked) is told to wrap up, calls `report` — the row flips to `done`
+  while the approval stays `pending`. Every teardown path then skipped it as "blocked on a person":
+  `markTurnIdle` bailed, the idle backstop bailed, and neither force-reap could reach it because both
+  require `status = 'running'`. Live instapods was holding **five `done` sessions with a live tmux pane
+  and ~430MB of `claude` each, the oldest three days old** — ~2.1GB pinned by cards nobody could deliver
+  an answer to. A finished run cannot consume an answer, so the done-orphan sweep now reaps it and
+  cancels the card (which is also what makes it dismissable in the Inbox instead of hanging). A
+  still-*running* blocked run is untouched — that wait is real.
+- **The egress parser no longer reads the word `ssh` in a grep pattern as an ssh.** Verbs were matched
+  anywhere in the command line, so `grep -i "cmd\|exec\|ssh\|sprintf"` and `ssh -i ~/.ssh/id_rsa` both
+  registered as egress with an unpinnable host — an owner approval for a local grep. 10 of the last 15
+  host approvals on instapods were this "host could not be identified" shape. `host-match.ts` now splits
+  the line into command invocations (quote-aware, so a `|` inside a quoted pattern is data) and matches
+  the verb against the **head token**, seeing through wrapper prefixes (`sudo -u deploy ssh box`),
+  leading paths (`/usr/bin/ssh`) and one level of quoted assignment / `sh -c` / `find -exec` nesting.
+  Real egress keeps escalating, and `SSH="ssh … root@box"` now *pins* `box` instead of escalating as
+  unknown — so it can be granted in Settings → Connections and stop asking.
+### Changed
+- `npm run test:governance` (what CI runs) now also runs the idle-reaper suite, and that suite's tmux
+  stub reports panes as alive — an empty stub made crash detection claim every row first, which had
+  quietly left 8 of its 12 assertions failing.
+
 ## [0.291.0] — 2026-08-03
 ### Fixed
 - **A resident chat no longer hits `/login` mid-session when it launched under a rotation paste-token.**

--- a/docs/host-connections-plan.md
+++ b/docs/host-connections-plan.md
@@ -103,6 +103,19 @@ already are (the enricher is pure/no-I/O); `gate()` fetches them and threads the
 > **parse conservatively, fail loud.** We do not try to be a shell interpreter — we detect the common
 > forms and, when we *can't* be sure (`hostUnknown`), we escalate rather than wave through (see §3d).
 
+**Verbs are matched in COMMAND POSITION, not anywhere in the line** (v0.290.1). The first cut searched
+the whole command for `\bssh\b`, which fires on `grep -i "cmd\|exec\|ssh\|sprintf"` and on
+`ssh -i ~/.ssh/id_rsa` — the word is there, no host can be pinned, and a local grep becomes an OWNER
+approval. Live instapods: 10 of 15 host approvals in the fortnight to 2026-08-02 were "host could not be
+identified", mostly this shape, and almost all were approved — the false-positive tax the fleet was
+paying. `host-match.ts` now splits the line into invocations (quote-aware, so a separator inside a quoted
+string is data), skips wrapper prefixes and their flag arguments (`sudo -u deploy ssh box`), strips a
+leading path (`/usr/bin/ssh`), and matches the verb against the **head token**. It also descends one
+level into a quoted assignment value (`SSH="ssh -i k root@box"`, then invoked as `$SSH`), a `sh -c '…'`
+payload and a `find -exec` tail — which both preserves the escalation for real egress hidden there and
+*pins* a host that used to read as unknown. Un-pinnable egress still escalates; only the
+never-was-egress cases stop paging a human.
+
 ### 3c. Capability reclassification — in `gate()` (`src/terminal.ts`)
 
 Mirroring the `email.send` rewrite at `terminal.ts:1169`: after enrichment, if `netEgress`, rewrite

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.291.0",
+  "version": "0.291.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.291.0",
+      "version": "0.291.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.291.0",
+  "version": "0.291.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,8 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs",
+    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs",
+    "test:reaper": "node scripts/idle-reaper-test.cjs",
     "test:policy-tier-a": "node scripts/tier-a-policy-test.cjs",
     "test:capabilities": "node scripts/capability-registry-test.cjs",
     "test:enrich": "node scripts/test-enrich-patterns.cjs",

--- a/scripts/idle-reaper-test.cjs
+++ b/scripts/idle-reaper-test.cjs
@@ -25,7 +25,10 @@ let attached = new Set();               // tmux names with a "client" attached
 const killed = [];
 tm.backend.hasClient = (_space, tmux) => attached.has(tmux);
 tm.backend.kill = (_space, tmux) => { killed.push(tmux); };
-tm.backend.aliveNames = () => new Set(); // sweeps 1/2 no-op; we're testing sweep 3
+// Every session's pane reports ALIVE by default. `reapIdleSessions` runs crash detection first (sweep 0),
+// so a stub returning an empty set marks every row `crashed` before the idle sweeps ever look at it — the
+// whole file went red that way when that sweep was folded in. Sections that care override this.
+tm.backend.aliveNames = () => new Set(aos.db.prepare('SELECT tmux FROM term_sessions').all().map((r) => r.tmux));
 
 const H = 3600_000;
 let n = 0;
@@ -47,6 +50,10 @@ assert(aos.settings.setInteractiveIdleTimeoutHours(99999) === 24 * 30, 'clamps t
 
 console.log('\n\x1b[1m2) reaper sweep (timeout = 48h)\x1b[0m');
 aos.settings.setInteractiveIdleTimeoutHours(48);
+// Isolate sweep 3: the unattended backstops (24h hard ceiling, 30m no-progress) would otherwise claim
+// this section's 96h-old headless control row themselves, which is sweep 2's job, not what we assert here.
+aos.settings.setUnattendedMaxHours(0);
+aos.settings.setUnattendedNoProgressMinutes(0);
 
 const stale = mkSession({ created_at: Date.now() - 96 * H });                 // 4 days idle → reap
 const recent = mkSession({ created_at: Date.now() - 2 * H });                 // 2h → keep
@@ -70,6 +77,43 @@ aos.settings.setInteractiveIdleTimeoutHours(0);
 const stale2 = mkSession({ created_at: Date.now() - 200 * H });
 tm.reapIdleSessions();
 assert(statusOf(stale2) === 'running', 'timeout 0 → even a 200h-idle session is left alone');
+
+/* Sweep 2 — the done-orphan pane leak. An unattended run whose gate hit the fail-closed deny (or whose
+ * `ask` parked) wraps up with `report`: the row goes 'done' while the approval/question stays pending
+ * forever, because nothing expires an unanswered card. The block-skip used to fire on that finished run
+ * and pin its tmux pane + `claude` process open indefinitely. A done run cannot consume an answer, so it
+ * is reaped and its card cancelled; a still-RUNNING blocked run is untouched. */
+console.log('\n\x1b[1m4) sweep 2: a done orphan blocked on an unanswered card\x1b[0m');
+aos.settings.setInteractiveIdleTimeoutHours(48);
+const pendingApprovalFor = (id) => {
+  const { req } = aos.approvals.request({ runId: id, tenant: aos.tenant, level: 'owner', reason: 'test',
+    attempt: { capabilityId: 'ssh.exec', args: {}, reasoning: '' } });
+  return req.id;
+};
+const pendingQuestionFor = (id) => {
+  const qid = 'qst_' + id;
+  aos.db.prepare('INSERT INTO questions (id, run_id, tenant, agent, prompt, status, created_at) VALUES (?,?,?,?,?,?,?)')
+    .run(qid, id, aos.tenant, 'website-bot', 'which one?', 'pending', Date.now());
+  return qid;
+};
+const qStatus = (qid) => aos.db.prepare('SELECT status s FROM questions WHERE id=?').get(qid).s;
+
+const doneOrphan = mkSession({ headless: 1, status: 'done', spawned_by: 'automation:a1', last_activity: Date.now() - 5 * H });
+const apr = pendingApprovalFor(doneOrphan);
+const runningBlocked = mkSession({ headless: 1, status: 'running', spawned_by: 'automation:a1', last_activity: Date.now() - 5 * H });
+const qst = pendingQuestionFor(runningBlocked);
+// Sweep 2 only reaps a done orphan whose pane is genuinely still alive, so report both as live.
+tm.backend.aliveNames = () => new Set(['aos-' + doneOrphan, 'aos-' + runningBlocked]);
+killed.length = 0;
+
+tm.reapIdleSessions();
+
+assert(killed.includes('aos-' + doneOrphan), 'done orphan with a pending approval → pane killed');
+assert(statusOf(doneOrphan) === 'done', 'its outcome is preserved (stays done)');
+assert(aos.approvals.statusOf(apr) === 'cancelled', 'the undeliverable approval is cancelled, not left hanging');
+assert(!killed.includes('aos-' + runningBlocked), 'a still-running run blocked on a question → left alone');
+assert(statusOf(runningBlocked) === 'running', '…and still running');
+assert(qStatus(qst) === 'pending', '…with its question still open for an answer');
 
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}IDLE REAPER: ${pass}/${pass + fail} passed\x1b[0m`);
 try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}

--- a/src/governance/host-match.ts
+++ b/src/governance/host-match.ts
@@ -30,23 +30,41 @@ export interface Egress {
   unknown: boolean;
 }
 
-// Outbound-connection verbs → the protocol they imply. Word-boundary matched so `sync`≠`nc`, `func`≠`nc`.
-const EGRESS_VERBS: { re: RegExp; protocol: EgressProtocol }[] = [
-  { re: /\bssh\b/i, protocol: 'ssh' },
-  { re: /\bscp\b/i, protocol: 'ssh' },
-  { re: /\bsftp\b/i, protocol: 'ssh' },
-  { re: /\brsync\b/i, protocol: 'ssh' },
-  { re: /\bcurl\b/i, protocol: 'http' },
-  { re: /\bwget\b/i, protocol: 'http' },
-  { re: /\bpsql\b/i, protocol: 'postgres' },
-  { re: /\bpg_dump\b/i, protocol: 'postgres' },
-  { re: /\bmysql\b/i, protocol: 'any' },
-  { re: /\bmongosh?\b/i, protocol: 'any' },
-  { re: /\bredis-cli\b/i, protocol: 'any' },
-  { re: /\bncat\b/i, protocol: 'any' },
-  { re: /\bnc\b/i, protocol: 'any' },
-  { re: /\btelnet\b/i, protocol: 'any' },
+/**
+ * Outbound-connection verbs → the protocol they imply, matched against the EXECUTABLE NAME of a
+ * command invocation (see {@link egressHead}) — never as a bare substring of the whole line.
+ *
+ * That distinction is the whole point. A `\bssh\b` search over the command text fires on
+ * `grep -i "cmd\|exec\|ssh\|sprintf"` and on `ssh -i ~/.ssh/id_rsa` twice over: the word appears, no
+ * host can be pinned, and a purely local grep is escalated to an OWNER approval. Live instapods data
+ * (2026-08): 10 of the last 15 host approvals were "host could not be identified", most of them this
+ * shape. Matching the head token instead keeps the same governance reach (every real invocation still
+ * has its verb in command position) while the word-in-a-string cases stop paging a human.
+ *
+ * `positional` marks the verbs whose destination is a bare token rather than a URL or -h flag
+ * (`ssh box`, `nc host 22`, `telnet host`) — rule 4 below.
+ */
+interface EgressVerb { name: RegExp; protocol: EgressProtocol; positional?: boolean }
+const EGRESS_VERBS: EgressVerb[] = [
+  { name: /^ssh$/i, protocol: 'ssh', positional: true },
+  { name: /^scp$/i, protocol: 'ssh', positional: true },
+  { name: /^sftp$/i, protocol: 'ssh', positional: true },
+  { name: /^rsync$/i, protocol: 'ssh', positional: true },
+  { name: /^curl$/i, protocol: 'http' },
+  { name: /^wget$/i, protocol: 'http' },
+  { name: /^psql$/i, protocol: 'postgres' },
+  { name: /^pg_dump$/i, protocol: 'postgres' },
+  { name: /^mysql$/i, protocol: 'any' },
+  { name: /^mongosh?$/i, protocol: 'any' },
+  { name: /^redis-cli$/i, protocol: 'any' },
+  { name: /^ncat$/i, protocol: 'any', positional: true },
+  { name: /^nc$/i, protocol: 'any', positional: true },
+  { name: /^telnet$/i, protocol: 'any', positional: true },
 ];
+
+/** Shell words that PREFIX a command without being it — the token after them (and after their flag
+ *  arguments) is still in command position, so `sudo -u deploy ssh box` is still an ssh. */
+const COMMAND_PREFIX = /^(sudo|doas|env|time|timeout|nohup|exec|command|builtin|nice|ionice|stdbuf|xargs|if|then|else|elif|do|while|until|not|!)$/i;
 
 const SCHEME_PROTOCOL: Record<string, EgressProtocol> = {
   http: 'http', https: 'http', postgres: 'postgres', postgresql: 'postgres',
@@ -75,15 +93,102 @@ function looksLikeHost(tok: string): boolean {
 }
 
 /**
+ * Split a command line into candidate INVOCATIONS — the pieces whose first token sits in the
+ * executable slot. Splits on the shell's command separators (`| ; & && || newline` and the
+ * subshell/group punctuation `( ) { } $( \``), but is QUOTE-AWARE: a separator inside a quoted string
+ * is data, not a separator. That matters — `grep -i "cmd|exec|ssh|sprintf"` must stay ONE invocation
+ * headed by `grep`, or the split alone would manufacture a segment that looks like an `ssh` command.
+ *
+ * Not a shell parser, and deliberately not trying to be: an approximation that keeps every real
+ * invocation's verb in head position (see the module note on parsing conservatively).
+ */
+function splitSegments(command: string): string[] {
+  const out: string[] = [];
+  let cur = '';
+  let quote: string | null = null;
+  const flush = (): void => { if (cur.trim()) out.push(cur.trim()); cur = ''; };
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i];
+    if (quote) {
+      cur += ch;
+      // A backslash escape only suppresses the closing quote inside double quotes; in single quotes
+      // the shell takes it literally.
+      if (ch === '\\' && quote === '"' && i + 1 < command.length) { cur += command[++i]; continue; }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") { quote = ch; cur += ch; continue; }
+    if (ch === '\\' && i + 1 < command.length) { cur += ch + command[++i]; continue; }
+    if (ch === '|' || ch === ';' || ch === '&' || ch === '\n' || ch === '(' || ch === ')' || ch === '{' || ch === '}' || ch === '`') { flush(); continue; }
+    cur += ch;
+  }
+  flush();
+  return out;
+}
+
+/** Sub-command lines hidden one level DOWN inside a segment: the quoted value of a variable assignment
+ *  (`SSH="ssh -i k root@box"` — then invoked as `$SSH`), a `sh -c '…'` payload, and a `find -exec` tail.
+ *  Each is its own command line, so we recurse into it rather than lose the egress it performs. */
+function descend(segment: string): string[] {
+  const inner: string[] = [];
+  for (const m of segment.matchAll(/(?:^|\s)(?:[A-Za-z_][A-Za-z0-9_]*=|-c[=\s]+)(["'])([\s\S]*?)\1/g)) inner.push(m[2]);
+  const exec = segment.match(/(?:^|\s)-exec(?:dir)?\s+([\s\S]+)$/);
+  if (exec) inner.push(exec[1]);
+  return inner;
+}
+
+/** The egress verb this segment INVOKES, plus the segment text from that verb onward (what the host
+ *  rules below parse). Skips wrapper/keyword prefixes, their flags and flag arguments, and inline
+ *  `VAR=value` prefixes. Returns null the moment a non-egress executable owns the head slot — that's
+ *  what stops `grep … "ssh"` from reading as an ssh. */
+function egressHead(segment: string): { verb: EgressVerb; text: string } | null {
+  const tokens = segment.split(/\s+/).filter(Boolean);
+  let sawPrefix = false;
+  let prevWasFlag = false;
+  for (let i = 0; i < tokens.length; i++) {
+    // Strip surrounding quotes (`bash -c "ssh box"` leaves a leading `"`) and any leading path, so
+    // `/usr/bin/ssh` is still ssh.
+    const t = tokens[i].replace(/^['"]+/, '').replace(/['"]+$/, '').replace(/^.*\//, '');
+    if (!t) continue;
+    const verb = EGRESS_VERBS.find((v) => v.name.test(t));
+    if (verb) return { verb, text: tokens.slice(i).join(' ') };
+    if (COMMAND_PREFIX.test(t)) { sawPrefix = true; prevWasFlag = false; continue; }
+    if (t.startsWith('-')) { prevWasFlag = !t.includes('='); continue; }
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(t)) { prevWasFlag = false; continue; } // inline env assignment
+    if (/^\d+[smhd]?$/i.test(t)) { prevWasFlag = false; continue; }            // `timeout 30 ssh …`
+    if (sawPrefix && prevWasFlag) { prevWasFlag = false; continue; }           // a wrapper flag's argument
+    return null; // a real command, and it isn't an egress verb
+  }
+  return null;
+}
+
+/**
  * Does this Bash command reach out to a host, and which one? Best-effort; `unknown:true` when egress
- * is clear but the host isn't pinnable. Only the FIRST target is extracted (v1).
+ * is clear but the host isn't pinnable. Only the FIRST invocation that reaches out is extracted (v1) —
+ * first, not best, so a later pinnable-but-public target can never mask an earlier unpinnable one.
  */
 export function extractEgress(command: string): Egress {
   const cmd = (command || '').trim();
   if (!cmd) return { egress: false, unknown: false };
-  const verb = EGRESS_VERBS.find((v) => v.re.test(cmd));
-  if (!verb) return { egress: false, unknown: false };
+  return findEgress(cmd, 0) ?? { egress: false, unknown: false };
+}
 
+function findEgress(command: string, depth: number): Egress | null {
+  for (const seg of splitSegments(command)) {
+    const head = egressHead(seg);
+    if (head) return extractTarget(head.text, head.verb);
+    if (depth < 3) {
+      for (const inner of descend(seg)) {
+        const found = findEgress(inner, depth + 1);
+        if (found) return found;
+      }
+    }
+  }
+  return null;
+}
+
+/** Pin the destination of ONE invocation (`cmd` starts at the verb). */
+function extractTarget(cmd: string, verb: EgressVerb): Egress {
   // 1. URL form (curl/wget/psql/redis/mongo): scheme://[user:pass@]host[:port]/…
   const url = cmd.match(/\b([a-z][a-z0-9+.-]*):\/\/([^\s'"`|;&<>]+)/i);
   if (url) {
@@ -108,15 +213,14 @@ export function extractEgress(command: string): Egress {
     return { egress: true, host: userAt[2].toLowerCase(), port: userAt[3] ? Number(userAt[3]) : undefined, protocol: 'ssh', unknown: false };
   }
 
-  // 4. ssh/telnet positional host: the first non-flag, non-verb token that looks like a host.
-  if (verb.protocol === 'ssh' || verb.re.source.includes('telnet') || verb.re.source.includes('\\bnc')) {
-    const tokens = cmd.split(/\s+/);
-    let seenVerb = false;
+  // 4. ssh/telnet/nc positional host: the first non-flag token after the verb that looks like a host.
+  if (verb.positional) {
+    const tokens = cmd.split(/\s+/).slice(1); // `cmd` starts at the verb
     for (const raw of tokens) {
       const t = raw.replace(/^['"]|['"]$/g, '');
-      if (!seenVerb) { if (EGRESS_VERBS.some((v) => v.re.test(t))) seenVerb = true; continue; }
       if (t.startsWith('-')) continue; // an option
       if (/^\d+$/.test(t)) continue;   // a bare port (nc host port) handled by the token before it
+      if (/^[.~/]/.test(t)) continue;  // a local path — `scp ./file box:/tmp/` puts the source first
       if (looksLikeHost(t)) {
         const host = t.replace(/:\d+$/, '').replace(/:.*/, '').toLowerCase();
         const portM = t.match(/:(\d+)$/);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2148,7 +2148,17 @@ export class TerminalManager {
         // anyway — teardownUnattended cancels its dangling question/approval so nothing is left waiting. A
         // no-progress run CAN legitimately be blocked (it may have called `ask` — an MCP tool, no gate.attempt),
         // so it keeps the block-skip; only overMaxAge overrides it.
-        if (!overMaxAge && this.hasPendingHumanBlock(r.id)) continue;
+        //
+        // A `done` ORPHAN is the third override, and the one that leaked. An unattended run whose gate hit
+        // the 180s fail-closed deny (or whose `ask` parked) is TOLD to wrap up: it calls `report`, the row
+        // flips to 'done' — while the approval/question row stays `pending` forever, because nothing expires
+        // an unanswered card. So the block-skip fired on a run whose turn was already OVER, markTurnIdle had
+        // already bailed on the same check, and neither force-reap could reach it (both require
+        // status='running'). Net effect on live instapods (2026-08): five `done` rows still holding a live
+        // tmux pane + ~430MB of `claude` each, the oldest 3 days old, pinned open by cards nobody could
+        // deliver an answer to. A finished run cannot consume one — reap it and let teardownUnattended cancel
+        // the card, which is what makes it dismissable in the Inbox instead of hanging there.
+        if (!overMaxAge && r.status !== 'done' && this.hasPendingHumanBlock(r.id)) continue;
         this.teardownUnattended(r.id, space, r.tmux, overMaxAge ? 'max-runtime' : noProgress ? 'stuck-no-progress' : r.status === 'done' ? 'done-orphan' : 'idle-backstop');
       } catch { /* one bad row must not stop the sweep */ }
     }

--- a/test/governance/conformance.json
+++ b/test/governance/conformance.json
@@ -969,6 +969,82 @@
       "expect": "ask:head"
     },
     {
+      "name": "open: the word ssh inside a grep PATTERN is not egress",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "grep -rn certbot --include=*.go internal/ | grep -i \"cmd\\|exec\\|ssh\\|sprintf\" | head -20"
+        }
+      },
+      "hostGrants": [],
+      "netMode": "open",
+      "expect": "allow",
+      "expectFacts": { "netEgress": false }
+    },
+    {
+      "name": "open: reading ~/.ssh locally is not egress",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "ls -la ~/.ssh"
+        }
+      },
+      "hostGrants": [],
+      "netMode": "open",
+      "expect": "allow",
+      "expectFacts": { "netEgress": false }
+    },
+    {
+      "name": "open: ssh in a quoted var assignment still pins its host",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "SSH=\"ssh -i ~/.ssh/id_rsa -o ConnectTimeout=15 deploy@web.prod.internal\"\n$SSH uptime"
+        }
+      },
+      "hostGrants": [
+        { "match": "*.prod.internal", "protocol": "ssh", "posture": "ask" }
+      ],
+      "netMode": "open",
+      "expect": "ask:owner",
+      "expectFacts": { "netEgress": true, "hostListed": true }
+    },
+    {
+      "name": "open: a wrapper (sudo -u) does not hide the ssh",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "sudo -u deploy ssh web.prod.internal uptime"
+        }
+      },
+      "hostGrants": [
+        { "match": "*.prod.internal", "protocol": "ssh", "posture": "ask" }
+      ],
+      "netMode": "open",
+      "expect": "ask:owner",
+      "expectFacts": { "netEgress": true, "hostListed": true }
+    },
+    {
+      "name": "open: egress inside a subshell is still found",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "CODE=$(curl -s -o /tmp/f -w \"%{http_code}\" http://10.0.4.4/status)"
+        }
+      },
+      "hostGrants": [
+        { "match": "10.0.0.0/8", "protocol": "any", "posture": "ask" }
+      ],
+      "netMode": "open",
+      "expect": "ask:head",
+      "expectFacts": { "netEgress": true, "hostListed": true }
+    },
+    {
       "name": "rm -rf /tmp scratch is allowed (not destructive)",
       "capability": "shell.exec",
       "args": {


### PR DESCRIPTION
Two findings from the live **instapods** tenant, one root theme: **nothing expires an Inbox card**, so anything a pending card gates has to be able to survive it forever — and two things couldn't.

## 1. A `done` run pinned open by a card nobody could answer

An unattended run whose gate hits the 180s fail-closed deny (or whose `ask` parks) is told to wrap up. It calls `report`, the row flips to `done` — **and the approval stays `pending`.** Every teardown path then skipped it as "blocked on a person":

- `markTurnIdle` bails on `hasPendingHumanBlock`
- the idle backstop bails on the same check
- neither force-reap can reach it — `overMaxAge` and `noProgress` both require `status = 'running'`
- sweep 3 only takes `headless = 0`

Live, right now: **5 `done` sessions still holding a live tmux pane and ~430MB of `claude` each, the oldest 3 days old** — ~2.1GB pinned by cards that can never be delivered to anyone.

A finished run cannot consume an answer, so the done-orphan sweep now reaps it and cancels the card (which is also what makes the card dismissable instead of hanging in the Inbox). A still-**running** blocked run is untouched — that wait is real. `markTurnIdle` is deliberately left alone; the sweep bounds the leak to one 60s tick with no risk of cutting a live run.

## 2. The word `ssh` in a grep pattern was being read as an ssh

Egress verbs were matched anywhere in the command line, so both of these registered as egress with an unpinnable host — an **owner** approval, for a local grep:

```
grep -rn certbot --include=*.go internal/ | grep -i "cmd\|exec\|ssh\|sprintf"
ssh -i ~/.ssh/id_rsa …          # the ~/.ssh path alone was enough
```

10 of the last 15 host approvals on instapods were this `host could not be identified` shape, and nearly all were approved — pure false-positive tax.

`host-match.ts` now splits the line into command invocations (**quote-aware**, so a `|` inside a quoted pattern is data, not a separator) and matches the verb against the **head token**, seeing through wrapper prefixes (`sudo -u deploy ssh box`), leading paths (`/usr/bin/ssh`), and one level of nesting — a quoted assignment value, a `sh -c '…'` payload, a `find -exec` tail. That last part cuts both ways on purpose: real egress hidden one level down still escalates, and `SSH="ssh … root@95.217.4.240"` now **pins** the host instead of escalating as unknown, so it can be granted in Settings → Connections and stop asking.

Un-pinnable egress still escalates. Only the never-was-egress cases stop paging a human.

> Not changed: `hostUnknown` still asks at **owner** for `ssh.exec`. With the false positives gone, a genuinely unpinnable remote shell is worth the interrupt.

## Tests

- 5 new conformance cases (grep-pattern, `ls ~/.ssh`, quoted-assignment ssh, `sudo -u` wrapper, subshell curl) — **151/151**.
- New idle-reaper section: a done orphan with a pending approval is reaped and its card cancelled; a running blocked run with a pending question is left alone — **18/18**.
- That reaper suite was silently **8-of-12 red** on `main`: its tmux stub reported no pane alive, so crash detection claimed every row before the idle sweeps ever looked. Stub fixed, and the suite is now part of `npm run test:governance`, which is what CI runs.
- `npm run typecheck`, `npm run build`, `cd web && npm run build` all clean.

## Deploy note

Once this is live on instapods, the 5 leaked panes are reaped on the next 60s sweep and their approvals move from pending to cancelled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)