### PR TITLE
fix(runtime): resident chats skip non-refreshable rotation tokens — no mid-session /login (v0.291.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.291.0] — 2026-08-03
+### Fixed
+- **A resident chat no longer hits `/login` mid-session when it launched under a rotation paste-token.**
+  A `token` (setup-token) / `apikey` account is injected as a static `CLAUDE_CODE_OAUTH_TOKEN` with no
+  refresh token in the process, so after its access window (~hours) a long-lived session can't renew it —
+  claude prints "OAuth access token has expired · Please run /login" and wedges. Short unattended runs
+  exit each turn and never live long enough to hit it, but a **resident** Slack/Discord chat (kept warm
+  for days) does. Fix: resident sessions rotate ONLY onto **refresh-capable** `oauth` credential-dir
+  accounts (claude refreshes within `CLAUDE_CONFIG_DIR`); with none available they fall through to the
+  box default, which carries its own refresh token. Unattended/one-off runs still rotate across ALL
+  account kinds (the zombie-during-weekly-limit protection is unchanged). `pick()` gains an optional
+  `kinds` filter; `applyRuntimeAccount` passes the session's `resident` flag. `src/state/runtime-accounts.ts`,
+  `src/terminal.ts`, `web/src/App.tsx` (panel note).
+
 ## [0.290.0] — 2026-08-01
 ### Added
 - **Quick filters on the Tasks board — a status lens and an "Unassigned" chip, both with live counts.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.290.0",
+  "version": "0.291.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.290.0",
+      "version": "0.291.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.290.0",
+  "version": "0.291.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/state/runtime-accounts.ts
+++ b/src/state/runtime-accounts.ts
@@ -188,9 +188,14 @@ export class RuntimeAccountStore {
    *  available — and stamp its last_used_at. Returns null when there are NO accounts for the runtime (caller
    *  → box default) or every enabled one is currently limited (caller → box default for a member launch; the
    *  scheduler defers cron). Auto-recovers accounts whose limit has lapsed first. */
-  pick(runtime: CodingRuntimeId, now: number = Date.now()): RuntimeAccount | null {
+  pick(runtime: CodingRuntimeId, now: number = Date.now(), opts?: { kinds?: RuntimeAccountKind[] }): RuntimeAccount | null {
     this.recover(now);
-    const r = this.db.prepare("SELECT * FROM runtime_accounts WHERE runtime = ? AND enabled = 1 AND status = 'available' ORDER BY last_used_at IS NOT NULL, last_used_at ASC LIMIT 1").get<Row>(runtime);
+    // Optional kind filter: a long-lived (resident) session may only rotate onto REFRESH-CAPABLE accounts
+    // (`oauth` credential-dirs), because a static injected `token`/`apikey` can't refresh in-process and
+    // would hit "OAuth access token has expired" → /login after its access window. See applyRuntimeAccount.
+    const kinds = opts?.kinds;
+    const kindClause = kinds && kinds.length ? ` AND kind IN (${kinds.map(() => '?').join(',')})` : '';
+    const r = this.db.prepare(`SELECT * FROM runtime_accounts WHERE runtime = ? AND enabled = 1 AND status = 'available'${kindClause} ORDER BY last_used_at IS NOT NULL, last_used_at ASC LIMIT 1`).get<Row>(runtime, ...(kinds ?? []));
     if (!r) return null;
     this.db.prepare('UPDATE runtime_accounts SET last_used_at = ? WHERE runtime = ? AND name = ?').run(now, runtime, r.name);
     return toAccount({ ...r, last_used_at: now });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1670,7 +1670,7 @@ export class TerminalManager {
     // INERT when the pool is empty — pick() returns null, we set nothing, the CLI uses the box default (i.e.
     // today's behavior). pick() also returns null when every account is limited; a member launch then still
     // proceeds on the default (better than blocking the human), while the scheduler defers cron upstream.
-    this.applyRuntimeAccount(env, o.id, o.agent, runtime);
+    this.applyRuntimeAccount(env, o.id, o.agent, runtime, o.resident);
     if (caps.pinnedSessionId) {
       // A stable claude session id we choose (vs letting claude mint its own), so a stopped session can be
       // resumed in-place with `claude --resume <id>`. `resume` continues that transcript (a thread
@@ -2269,10 +2269,17 @@ export class TerminalManager {
    *  (`term_sessions.runtime_account`) so limit detection at teardown can park the right one. No-op — leaving
    *  the box's default credentials in place — when the pool is empty or exhausted, or when an api-key
    *  account's vault value can't be resolved (fail-open: better to launch on the default than not at all). */
-  private applyRuntimeAccount(env: Record<string, string>, sessionId: string, agent: string, runtime: CodingRuntimeId): void {
+  private applyRuntimeAccount(env: Record<string, string>, sessionId: string, agent: string, runtime: CodingRuntimeId, resident: boolean): void {
     try {
-      const acct = this.os.runtimeAccounts.pick(runtime);
-      if (!acct) return; // empty pool (inert) or all limited → box default
+      // A RESIDENT session is kept warm for hours/days (a Discord/Slack chat), so it outlives the access
+      // window of an injected static credential. A `token` (setup-token) / `apikey` carries no refresh
+      // token into the process, so claude can't renew it in place — it hits "OAuth access token has
+      // expired" → /login mid-chat. So resident sessions rotate ONLY onto refresh-capable `oauth`
+      // credential-dirs (claude refreshes within CLAUDE_CONFIG_DIR); with none available they fall through
+      // to the box default, which has its own refresh token. Short-lived headless/one-off runs exit long
+      // before any expiry, so they keep rotating across ALL account kinds (the zombie-during-limit fix).
+      const acct = this.os.runtimeAccounts.pick(runtime, Date.now(), resident ? { kinds: ['oauth'] } : undefined);
+      if (!acct) return; // empty pool (inert), all limited, or resident with no refresh-capable account → box default
       const { configDirVar, apiKeyVar, tokenVar } = CODING_RUNTIMES[runtime].credentialEnv;
       if (acct.kind === 'oauth') {
         if (!acct.configDir) return;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13812,6 +13812,11 @@ function RuntimeAccountsSettings({ me }: { me: Member }) {
             only when a runtime's whole pool is dry does the scheduler defer. <span className="font-medium">Empty pool = off</span> —
             the box uses its single default login, exactly as before.
           </p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Rotation covers <span className="font-medium">unattended runs</span> (they exit each turn). A <span className="font-medium">resident chat</span>
+            {' '}(Slack/Discord, kept warm for days) skips paste-token accounts — an injected setup-token can't refresh in-process and would
+            hit <span className="font-mono">/login</span> mid-chat — and uses the box default (or a credential-dir account), which refreshes itself.
+          </p>
         </div>
 
         {resp && resp.accounts.length === 0 && (


### PR DESCRIPTION
## Symptom
A resident Discord chat (`engineer`, alive ~25h) hit `/login` mid-session:
```
API Error: 401 OAuth access token has expired. Re-authenticate to continue.
```
…even though the `instawp` setup-token it launched under **still validated fine externally** (`weekly 7% · session 14%`).

## Root cause
A `token` (setup-token) / `apikey` account is injected as a **static** `CLAUDE_CODE_OAUTH_TOKEN` with **no refresh token in the process**. After its access window (~hours) claude can't renew it in place → `/login`. Short unattended runs exit each turn and never live long enough to hit this; a **resident** chat kept warm for days does. The box default doesn't hit it because `~/.claude/.credentials.json` carries a refresh token that claude auto-renews.

## Fix
Resident sessions rotate **only onto refresh-capable `oauth` credential-dir** accounts (claude refreshes within `CLAUDE_CONFIG_DIR`); with none available they fall through to the **box default** (its own refresh token). Unattended/one-off runs keep rotating across **all** account kinds — the zombie-during-weekly-limit protection is unchanged.

- `pick(runtime, now, { kinds })` — optional kind filter.
- `applyRuntimeAccount(…, resident)` — passes the session's `resident` flag; resident ⇒ `{ kinds: ['oauth'] }`.
- Settings → Runtime accounts: a note explaining resident-vs-unattended behavior.

## Verify
- pick filter: token-only pool → resident pick returns `null` (→ box default); add an `oauth` account → resident picks it; unattended rotates across both.
- `npm run build` + web build + typecheck + **138/138 governance**.

## Operator note
To use a *second account* for resident chats too, add it as a **credential-dir** (`claude login`), not a paste-token — only login credentials can refresh in a long-lived session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)