### PR TITLE
fix(runtime): delete a token account's vaulted secret on removal (v0.291.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.291.4] — 2026-08-03
+### Fixed
+- **Removing a runtime-account `token` account now deletes its vaulted token** instead of leaving an
+  orphaned `runtime-token:<runtime>:<name>` secret behind. `DELETE /api/runtime-accounts/:runtime/:name`
+  drops the value the add-handler sealed (a `token` account OWNS it); an `apikey` account, which only
+  REFERENCES a user-managed vault key, and an `oauth` account, which has none, are left untouched.
+  `src/server.ts`.
+
 ## [0.291.3] — 2026-08-03
 ### Fixed
 - **Console detail pages (task · session · artifact) took seconds to open.** The detail endpoints were

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.291.3",
+  "version": "0.291.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.291.3",
+      "version": "0.291.4",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.291.3",
+  "version": "0.291.4",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4242,7 +4242,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       const name = decodeURIComponent(m[2]);
       if (!isCodingRuntime(runtime)) return sendJson(res, 400, { error: `unknown runtime: ${runtime}` });
       if (method === 'DELETE') {
+        const acct = os.runtimeAccounts.get(runtime, name);
         os.runtimeAccounts.remove(runtime, name);
+        // A 'token' account OWNS the vaulted value the add-handler sealed under this exact key — drop it so a
+        // removed account leaves no orphaned secret. An 'apikey' account only REFERENCES a user-managed vault
+        // key (apiKeyRef), and 'oauth' has none, so neither is touched.
+        if (acct?.kind === 'token') os.secrets.delete(os.tenant, `runtime-token:${runtime}:${name}`, '*');
         os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'runtime.account.removed', data: { runtime, name } });
         return sendJson(res, 200, { ok: true });
       }


### PR DESCRIPTION
## Why
`DELETE /api/runtime-accounts/:runtime/:name` removed the row but left the account's vaulted token behind — deleting the two dead instapods accounts left orphaned `runtime-token:claude-code:{instawp,tools2}` secrets that had to be cleaned up by hand.

## Fix
On delete, if the account is a **`token`** kind, also drop the secret the add-handler sealed under `runtime-token:<runtime>:<name>` (principal `*`) — the account OWNS that value. An **`apikey`** account only *references* a user-managed vault key (`apiKeyRef`), and **`oauth`** has none, so neither is touched.

## Verify (real DELETE route on a scratch server)
- Delete a `token` account → its `runtime-token:…` secret is gone. ✓
- Delete an `apikey` account referencing `my-own-apikey` → that user key **survives**. ✓
- `npm run build` + typecheck + **151/151 governance**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)