### PR TITLE
fix(gate): loopback isn't egress; stop mangling IPv6 hosts (v0.291.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.291.5] — 2026-08-03
+### Fixed
+- **Talking to `localhost` no longer raises an owner approval.** Host governance treated loopback as
+  egress, so an agent curling its own dev server — or the Agent OS API — paused for a human at
+  owner/admin tier. It bought nothing: anything listening on loopback is already reachable by the shell
+  the agent is holding, and `shell.exec` governs that. It cost a great deal, though — on live instapods,
+  `127.0.0.1` + `localhost` were **35 of the 49** host approvals ever raised. `computeHostFacts` now
+  reports `netEgress: false` for a pinned loopback target (`localhost`, `127.0.0.0/8`, `::1`), in
+  `allowlist` lockdown as well as `open`. Private, internal and unpinnable hosts are governed exactly as
+  before. Known limit, unchanged: an `ssh -L` tunnel on a loopback port is invisible to a policy layer.
+- **IPv6 hosts were being compared as the single character `:`.** Host normalisation stripped a `:port`
+  suffix with a regex that eats the tail of a bare IPv6 literal (`'::1'` → `':'`), so every v6 address
+  collapsed to the same string — `hostMatches('::1', '::2')` returned **true**, and a granted v6 matcher
+  would have matched any other v6 host. Normalisation is now one shared helper that unwraps `[…]`, keeps
+  a bare v6 literal intact, and strips a port only where there is one. Relatedly, `parseAuthority` failed
+  on a bracketed v6 URL with a path (`https://[::1]:9000/x`) and pinned the host as the literal `[`.
+### Changed
+- Four new conformance cases pin the loopback exemption (localhost, `127.0.0.1`, lockdown mode, and a
+  private non-loopback address that must still be governed) — 159/159.
+
 ## [0.291.4] — 2026-08-03
 ### Fixed
 - **Removing a runtime-account `token` account now deletes its vaulted token** instead of leaving an

--- a/docs/host-connections-plan.md
+++ b/docs/host-connections-plan.md
@@ -103,6 +103,14 @@ already are (the enricher is pure/no-I/O); `gate()` fetches them and threads the
 > **parse conservatively, fail loud.** We do not try to be a shell interpreter — we detect the common
 > forms and, when we *can't* be sure (`hostUnknown`), we escalate rather than wave through (see §3d).
 
+**Loopback is not egress** (v0.291.3). `localhost`, `127.0.0.0/8` and `::1` never leave the box, and
+anything listening there is already reachable by the shell the agent is holding — `shell.exec` governs
+that. Governing it bought no safety and cost most of the noise: on live instapods, `127.0.0.1` +
+`localhost` were **35 of the 49** host approvals ever raised, typically an agent curling its own dev
+server at owner/admin tier. `computeHostFacts` now reports `netEgress: false` for a pinned loopback
+target, in `allowlist` mode as well as `open`. (An `ssh -L` tunnel on a loopback port is invisible to
+this — same honest constraint as the rest of §2.)
+
 **Verbs are matched in COMMAND POSITION, not anywhere in the line** (v0.290.1). The first cut searched
 the whole command for `\bssh\b`, which fires on `grep -i "cmd\|exec\|ssh\|sprintf"` and on
 `ssh -i ~/.ssh/id_rsa` — the word is there, no host can be pinned, and a local grep becomes an OWNER

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.291.4",
+  "version": "0.291.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.291.4",
+      "version": "0.291.5",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.291.4",
+  "version": "0.291.5",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/host-match.ts
+++ b/src/governance/host-match.ts
@@ -75,6 +75,11 @@ function parseAuthority(authority: string): { host: string; port?: number } {
   let a = authority.trim();
   const at = a.lastIndexOf('@');
   if (at >= 0) a = a.slice(at + 1); // drop user[:pass]@
+  // The caller's URL match runs to the end of the token, so trim the path/query/fragment first. The
+  // IPv4 branch below stops at `/` on its own, but the bracketed-IPv6 pattern is anchored — without
+  // this, `https://[::1]:9000/x` failed it and fell through to the IPv4 branch, which pinned the host
+  // as the literal `[`.
+  a = a.split(/[/?#]/)[0];
   // Bracketed IPv6 [::1]:port
   const v6 = a.match(/^\[([^\]]+)\](?::(\d+))?$/);
   if (v6) return { host: v6[1].toLowerCase(), port: v6[2] ? Number(v6[2]) : undefined };
@@ -263,14 +268,28 @@ function cidrMatch(host: string, cidr: string): boolean {
   return (hostInt & mask) === (netInt & mask);
 }
 
+/**
+ * Normalise a host for comparison: lowercase, drop a trailing root dot, unwrap `[ipv6]`, and strip a
+ * `:port` — but NEVER from a bare IPv6 literal, where the colons are the address. `'::1'.replace(/:\d+$/)`
+ * yields `':'`, which made every IPv6 host collapse to the same string: `hostMatches('::1', '::2')` was
+ * true, and the loopback/internal checks were matching on the wreckage rather than the address.
+ */
+function normalizeHost(host: string): string {
+  const h = (host || '').trim().toLowerCase().replace(/\.$/, '');
+  const bracketed = h.match(/^\[([^\]]+)\](?::\d+)?$/);
+  if (bracketed) return bracketed[1];
+  if ((h.match(/:/g) || []).length > 1) return h; // bare IPv6 — there is no port to strip
+  return h.replace(/:\d+$/, '');
+}
+
 /** Does `host` match a granted host matcher — an exact host, a `*.wildcard`, a CIDR, or `host:port`?
  *  Port in the matcher is ignored for host comparison in v1 (the host is the blast-radius unit). */
 export function hostMatches(host: string, matcher: string): boolean {
-  const h = (host || '').toLowerCase().replace(/\.$/, '').replace(/:\d+$/, '');
+  const h = normalizeHost(host);
   const m = (matcher || '').trim().toLowerCase();
   if (!h || !m) return false;
   if (m.includes('/') && ipv4ToInt(h) !== null) return cidrMatch(h, m);
-  const mHost = m.replace(/:\d+$/, '');
+  const mHost = normalizeHost(m);
   if (mHost.includes('*')) {
     const re = new RegExp('^' + mHost.split('*').map(escapeRe).join('.*') + '$');
     return re.test(h);
@@ -278,13 +297,34 @@ export function hostMatches(host: string, matcher: string): boolean {
   return h === mHost;
 }
 
+/**
+ * True if `host` is THIS machine — loopback (`127.0.0.0/8`, `::1`) or `localhost`.
+ *
+ * Such a "reach" never leaves the box, so it isn't egress and there is nothing for host governance to
+ * protect: anything listening on loopback is already reachable by the shell the agent is holding, and
+ * `shell.exec` governs that. Treating it as egress bought no safety and cost a great deal of noise —
+ * on live instapods, `127.0.0.1` + `localhost` accounted for **35 of the 49** host approvals ever
+ * raised (an agent curling its own dev server, or the Agent OS API, at owner/admin tier).
+ *
+ * Deliberate limit: a loopback port that is an `ssh -L` tunnel to somewhere else is invisible to us.
+ * That's the same honest constraint as the rest of this module (§2 of the plan) — a policy layer, not
+ * a firewall.
+ */
+export function isLoopbackHost(host: string): boolean {
+  const h = normalizeHost(host);
+  if (!h) return false;
+  if (h === 'localhost' || h === 'localhost.localdomain' || h === '::1' || h.startsWith('[::1')) return true;
+  return ipv4ToInt(h) !== null && cidrMatch(h, '127.0.0.0/8');
+}
+
 /** True if `host` looks internal/sensitive: private/loopback/link-local IPs, localhost, a bare
  *  single-label hostname, or an internal TLD (.internal/.local/.lan/.corp/.home/.intranet). Public
  *  FQDNs (api.stripe.com) are NOT internal — they stay ungoverned under netMode 'open'. */
 export function isInternalHost(host: string): boolean {
-  const h = (host || '').toLowerCase().replace(/\.$/, '').replace(/:\d+$/, '');
+  const h = normalizeHost(host);
   if (!h) return false;
-  if (h === 'localhost' || h === '::1' || h.startsWith('[::1')) return true;
+  if (isLoopbackHost(h)) return true;
+  if (h.includes(':')) return true; // any other IPv6 literal — treat as internal (fail toward escalation)
   const ip = ipv4ToInt(h);
   if (ip !== null) {
     return cidrMatch(h, '10.0.0.0/8') || cidrMatch(h, '172.16.0.0/12') || cidrMatch(h, '192.168.0.0/16')
@@ -328,6 +368,10 @@ export function computeHostFacts(command: string, grants: HostGrant[]): HostFact
   if (!e.egress) return { netEgress: false };
   const facts: HostFacts = { netEgress: true, netProtocol: e.protocol };
   if (e.unknown || !e.host) { facts.hostUnknown = true; facts.hostAllowed = false; return facts; }
+  // A pinned LOOPBACK target isn't a reach at all — it never leaves the box (see isLoopbackHost). Report
+  // no egress, so the gate leaves the call as plain `shell.exec` and the ordinary policy governs it.
+  // Only a PINNED host can be loopback; an unpinnable one is still unknown → escalated above.
+  if (isLoopbackHost(e.host)) return { netEgress: false };
   facts.host = e.host;
   facts.hostInternal = isInternalHost(e.host);
   const wire = e.protocol ?? 'any';

--- a/test/governance/conformance.json
+++ b/test/governance/conformance.json
@@ -969,6 +969,62 @@
       "expect": "ask:head"
     },
     {
+      "name": "open: loopback (localhost) is not egress — never leaves the box",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl -s http://localhost:3010/api/state"
+        }
+      },
+      "hostGrants": [],
+      "netMode": "open",
+      "expect": "allow",
+      "expectFacts": { "netEgress": false }
+    },
+    {
+      "name": "open: loopback (127.0.0.1) is not egress",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "psql -h 127.0.0.1 -U app -c \"select 1\""
+        }
+      },
+      "hostGrants": [],
+      "netMode": "open",
+      "expect": "allow",
+      "expectFacts": { "netEgress": false }
+    },
+    {
+      "name": "allowlist: loopback is exempt in lockdown too",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl -s http://127.0.0.1:8080/health"
+        }
+      },
+      "hostGrants": [],
+      "netMode": "allowlist",
+      "expect": "allow",
+      "expectFacts": { "netEgress": false }
+    },
+    {
+      "name": "open: a PRIVATE (non-loopback) address is still governed",
+      "capability": "shell.exec",
+      "args": {
+        "tool": "Bash",
+        "input": {
+          "command": "curl http://192.168.1.9/x"
+        }
+      },
+      "hostGrants": [],
+      "netMode": "open",
+      "expect": "ask:head",
+      "expectFacts": { "netEgress": true }
+    },
+    {
       "name": "open: the word ssh inside a grep PATTERN is not egress",
       "capability": "shell.exec",
       "args": {


### PR DESCRIPTION
Follow-up to #521. With the false-positive verbs gone, I looked at what host governance has *actually* pinned on live instapods since it was enabled on 2026-07-10 — every `gate.net.reclassified` event:

| pinned | events | |
|---|---|---|
| *(empty — "could not be identified")* | 62 | mostly the FP shapes fixed in #521 |
| `127.0.0.1` + `localhost` | **35** | **this PR** |
| `key`, `alias`, `config`, `the`, `or`, `is`, `py`, `[^\` | 10 | junk tokens from the same FP verbs |
| `pod-db-0{1,2,3,99}.internal`, `10.0.0.5`, `192.168.1.110`, `github-vikasprogrammer` | 8 | real (4 of them from the day it was switched on) |

## Loopback is not egress

`localhost`, `127.0.0.0/8` and `::1` never leave the box. Governing them buys nothing — anything listening on loopback is already reachable by the shell the agent is holding, and `shell.exec` governs that — while costing an owner/admin approval every time an agent curls its own dev server or the Agent OS API.

`computeHostFacts` now returns `netEgress: false` for a pinned loopback target, so the gate leaves the call as plain `shell.exec`. Applies in `allowlist` lockdown too, on the same reasoning. Private (`192.168/16`, `10/8`), internal-TLD and unpinnable hosts are governed **exactly** as before — there's a fixture pinning that.

Known limit, unchanged and stated in the plan: an `ssh -L` tunnel on a loopback port is invisible to a policy layer. This is §2's honest constraint, not a firewall.

## IPv6 hosts were all comparing equal

Found while writing the loopback check. Host normalisation stripped `:port` with `/:\d+$/`, which eats the tail of a bare IPv6 literal — `'::1'` normalises to `':'`. Every v6 address therefore collapsed to the same string:

```js
hostMatches('::1', '::2')   // → true   (!)
```

So a granted v6 matcher would have matched **any** other v6 host — a quiet over-grant in the allowlist. One shared `normalizeHost()` now unwraps `[…]`, leaves a bare v6 intact, and strips a port only where there is one. Separately, `parseAuthority` couldn't handle a bracketed v6 URL carrying a path (`https://[::1]:9000/x` pinned the host as the literal `[`) — its anchored v6 pattern never matched, so it fell through to the IPv4 branch.

## Tests

159/159 conformance (4 new: localhost, `127.0.0.1`, lockdown mode, and a private non-loopback that must still ask), 18/18 tier-A, 18/18 capability registry, 18/18 idle reaper. `typecheck` and both builds clean.

## Fleet note

Host governance is enabled on **instapods only** — `personal`, `instawp`, `expresstech` and `insta-ai` all have it unset (the default), 0 granted hosts, 0 host approvals. So this changes behaviour on one tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)