### PR TITLE
perf(console): gzip + ETag + immutable asset caching — 6.5 MB → 1.4 MB per load (v0.291.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.291.6] — 2026-08-03
+### Fixed
+- **The console served every byte uncompressed and uncacheable.** Opening a detail page
+  (`#/tasks/<id>`, a session, an artifact) felt slow, but the detail endpoints were never the problem —
+  `GET /api/tasks/tsk_…` answers in **3 ms / 6.5 KB**. The cost was the shell around it. Measured on the
+  live instawp tenant: the app bundle is **1.13 MB of JavaScript** (plus 592 KB of xterm and 100 KB of
+  CSS) sent with **no `content-encoding` and no `cache-control` at all**, so every reload re-downloaded
+  ~1.8 MB, and the SPA then polls `/api/sessions` (3.07 MB) + `/api/messages` every **1.5 s** forever —
+  twice over on the Tasks page, which polls sessions again on its own 5 s timer. Nothing in front covered
+  it: the Mac Mini tenants run behind `tailscale serve` with no nginx, and the nginx box has `gzip on`
+  but left `gzip_types` commented out, which defaults to `text/html` only.
+  `sendJson`/`sendFile` now funnel through one `sendBody` that:
+  - **gzips** responses over ~1 MTU whose type is worth compressing — app bundle **1115 KB → 299 KB
+    (−73%)**, `/api/sessions` 3.0 MB → 851 KB, `/api/tasks` 1.25 MB → 453 KB;
+  - attaches an **ETag** to cacheable GETs, so the 1.5 s poll answers **304 with an empty body** when
+    nothing changed instead of re-sending a megabyte;
+  - marks Vite's content-hashed `/assets/*` **`immutable` for a year** (they can't change under their own
+    URL) while `index.html` stays `no-cache`, so a deploy is still picked up on the next load;
+  - reads and compresses each static asset **once per build**, keyed by `path:mtime:size`.
+
+  Compression is **opt-in by the client** — we only gzip when the request advertised
+  `accept-encoding: gzip`. The gate hook's loopback calls, the MCP tools and plain `curl` send no such
+  header and keep receiving identity bytes, so nothing on the agent side changes. `no-cache` (not
+  `no-store`) pairs with the ETag: a client may reuse a body only after revalidating, never stale.
+
 ## [0.291.5] — 2026-08-03
 ### Fixed
 - **Talking to `localhost` no longer raises an owner approval.** Host governance treated loopback as

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.291.5",
+  "version": "0.291.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.291.5",
+      "version": "0.291.6",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.291.5",
+  "version": "0.291.6",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -8,6 +8,7 @@ import * as http from 'http';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import * as zlib from 'zlib';
 import * as nodeOs from 'node:os';
 import { AgentOS, loadAgentOS } from './kernel';
 import { VERSION } from './version';
@@ -6675,7 +6676,9 @@ function redirect(res: http.ServerResponse, location: string): void {
   res.end();
 }
 function sendHtml(res: http.ServerResponse, status: number, html: string): void {
-  res.writeHead(status, { 'content-type': 'text/html; charset=utf-8' });
+  // The one caller is the magic-link interstitial, whose URL carries a one-time token — never let it
+  // sit in a cache. Small enough that compression is pointless, so it skips `sendBody`.
+  res.writeHead(status, { 'content-type': 'text/html; charset=utf-8', 'cache-control': 'no-store' });
   res.end(html);
 }
 function escapeHtml(s: string): string {
@@ -6771,15 +6774,100 @@ function relOf(root: string, abs: string): string {
 }
 
 // ── http helpers ─────────────────────────────────────────────────────────────
+//
+// TRANSPORT: every in-memory response body funnels through `sendBody`, which adds the two things this
+// server shipped without for its whole life — compression and revalidation. Measured on the live
+// instawp tenant (949 sessions / 473 tasks), one console load moved ~4.7 MB of JSON plus 1.82 MB of
+// uncompressed app bundle, and the SPA re-polls sessions+messages every 1.5s forever. Nothing in front
+// covers it either: the Mac Mini tenants run behind `tailscale serve` with no nginx at all, and the
+// nginx box has `gzip on` but the default `gzip_types` (text/html only), so JS/CSS/JSON went out raw.
+// Fixing it here means it holds on every deployment shape.
+
+/** Below ~1 MTU, compressing costs more (CPU + headers) than the bytes it saves. */
+const COMPRESS_MIN = 1400;
+/** Worth compressing. Everything else we serve (woff2, png, ico) is already compressed. */
+const COMPRESSIBLE = /^(?:text\/|application\/(?:json|javascript|xml)|image\/svg)/;
+/**
+ * Compressed bytes keyed by the body's ETag (its content hash), so identical payloads compress once.
+ * The console polls from every open tab; without this a multi-tab session would re-gzip the same
+ * ~1 MB sessions payload per tab per tick. Bounded FIFO — a hot-path cache, not a store.
+ */
+const GZIP_CACHE = new Map<string, Buffer>();
+const GZIP_CACHE_MAX = 64;
+function gzipFor(key: string, raw: Buffer): Buffer {
+  const hit = GZIP_CACHE.get(key);
+  if (hit) return hit;
+  const out = zlib.gzipSync(raw, { level: 6 });
+  if (GZIP_CACHE.size >= GZIP_CACHE_MAX) GZIP_CACHE.delete(GZIP_CACHE.keys().next().value as string);
+  GZIP_CACHE.set(key, out);
+  return out;
+}
+/**
+ * Write a complete in-memory body, negotiating `content-encoding` and (for a cacheable GET) an ETag.
+ *
+ * Compression is strictly opt-in by the CLIENT: we only gzip when the request advertised
+ * `accept-encoding: gzip`. A plain `curl`, the gate hook's loopback calls and the MCP tools send no
+ * such header, so they keep receiving identity bytes and are unaffected by this whole path.
+ *
+ * The ETag is paired with `cache-control: no-cache`, which means "you may reuse this, but ALWAYS
+ * revalidate first" — never "serve it stale". So a 304 can only follow a fresh round-trip, and the
+ * 1.5s poll degrades from a megabyte to a bodyless header when nothing changed.
+ */
+function sendBody(res: http.ServerResponse, status: number, raw: Buffer, contentType: string, cacheControl: string): void {
+  const req: http.IncomingMessage | undefined = res.req;
+  const headers: Record<string, string> = { 'content-type': contentType, 'cache-control': cacheControl, vary: 'accept-encoding' };
+  // Revalidation only makes sense for a successful GET; a 304 carries validators and no body.
+  let etag = '';
+  if (status === 200 && req?.method === 'GET') {
+    etag = `W/"${crypto.createHash('sha1').update(raw).digest('base64url')}"`;
+    headers.etag = etag;
+    if (req.headers['if-none-match'] === etag) {
+      res.writeHead(304, { etag, 'cache-control': cacheControl, vary: 'accept-encoding' });
+      return void res.end();
+    }
+  }
+  let body = raw;
+  if (raw.length >= COMPRESS_MIN && COMPRESSIBLE.test(contentType) && /\bgzip\b/.test(String(req?.headers['accept-encoding'] || ''))) {
+    // Only cache keyed by a content hash; without an ETag (a POST reply, an error) compress one-off.
+    body = etag ? gzipFor(etag, raw) : zlib.gzipSync(raw, { level: 6 });
+    headers['content-encoding'] = 'gzip';
+  }
+  headers['content-length'] = String(body.length);
+  res.writeHead(status, headers);
+  res.end(req?.method === 'HEAD' ? undefined : body);
+}
 function sendJson(res: http.ServerResponse, status: number, body: unknown): void {
-  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
-  res.end(JSON.stringify(body));
+  sendBody(res, status, Buffer.from(JSON.stringify(body) ?? 'null', 'utf8'), 'application/json; charset=utf-8', 'no-cache, private');
+}
+/**
+ * Static console assets, read + compressed ONCE per build and served from memory thereafter.
+ *
+ * `web/dist` is immutable between deploys, so the cache is keyed by `path:mtime:size` — a rebuild
+ * changes the mtime and invalidates it with no restart needed. Vite content-hashes asset filenames
+ * (`main-OWHvPakq.js`), so those can be marked `immutable` for a year: today the browser re-downloads
+ * the full 1.13 MB bundle on every single reload because nothing sends a caching header at all.
+ */
+const FILE_CACHE = new Map<string, Buffer>();
+const FILE_CACHE_MAX_BYTES = 8 * 1024 * 1024;
+/** A content-hashed build artifact (`name-8dGk2xQ1.js`) can never change under its own URL. */
+function isFingerprinted(file: string): boolean {
+  return /-[A-Za-z0-9_-]{8,}\.[a-z0-9]+$/.test(path.basename(file));
 }
 function sendFile(res: http.ServerResponse, file: string, contentType: string): void {
-  fs.readFile(file, (err, data) => {
-    if (err) return sendJson(res, 404, { error: `file not found: ${path.basename(file)}` });
-    res.writeHead(200, { 'content-type': contentType });
-    res.end(data);
+  fs.stat(file, (statErr, st) => {
+    if (statErr || !st.isFile()) return sendJson(res, 404, { error: `file not found: ${path.basename(file)}` });
+    const cacheControl = isFingerprinted(file) ? 'public, max-age=31536000, immutable' : 'no-cache';
+    const key = `${file}:${st.mtimeMs}:${st.size}`;
+    const hit = FILE_CACHE.get(key);
+    if (hit) return sendBody(res, 200, hit, contentType, cacheControl);
+    fs.readFile(file, (err, data) => {
+      if (err) return sendJson(res, 404, { error: `file not found: ${path.basename(file)}` });
+      if (st.size <= FILE_CACHE_MAX_BYTES) {
+        if (FILE_CACHE.size >= 64) FILE_CACHE.delete(FILE_CACHE.keys().next().value as string);
+        FILE_CACHE.set(key, data);
+      }
+      sendBody(res, 200, data, contentType, cacheControl);
+    });
   });
 }
 function end(res: http.ServerResponse, status: number): void {


### PR DESCRIPTION
## The measurement

Detail pages felt slow, so I measured the live **instawp** tenant (949 sessions / 473 tasks) before changing anything. The detail endpoints were never the problem:

| Endpoint | Time | Size |
|---|---|---|
| `GET /api/tasks/tsk_aeb1c5579b6589c4` | **3 ms** | **6.5 KB** |

The cost is the shell loaded around it, and the server shipped all of it raw:

| Asset / endpoint | Wire size | Notes |
|---|---|---|
| `main-*.js` | 1.13 MB | no `content-encoding`, **no `cache-control` at all** |
| `Xterm-*.js` | 592 KB | ” |
| `Xterm-*.css` | 100 KB | ” |
| `GET /api/sessions` | 3.07 MB | re-polled **every 1.5 s** |
| `GET /api/messages` | 124 KB | ” |
| `GET /api/tasks` | 1.28 MB | + a **second** `/api/sessions` poll on a 5 s timer |

Two compounding effects: ~1.8 MB of bundle is re-downloaded on **every reload** (nothing sends a caching header), and on `#/tasks/<id>` the sessions list is polled by two independent timers at once — which is why that page felt worst.

Nothing in front covers this. The Mac Mini tenants run behind `tailscale serve` with **no nginx**, and the nginx box has `gzip on` but left `gzip_types` commented out — which defaults to `text/html` only, so JS/CSS/JSON went out uncompressed. The fix therefore belongs in the Node server, where it holds on every deployment shape.

## The change

`sendJson` / `sendFile` now funnel through one `sendBody`:

- **gzip** for bodies over ~1 MTU whose content type is worth it
- **ETag** on cacheable GETs → the 1.5 s poll answers **304 with an empty body** when nothing changed
- Vite's content-hashed `/assets/*` marked **`immutable`, 1 year** (they cannot change under their own URL); `index.html` stays `no-cache` so deploys are still picked up
- each static asset is read + compressed **once per build**, keyed by `path:mtime:size`
- compressed bytes cached by ETag, so multiple tabs don't re-gzip an identical payload

### Result

| | before | after |
|---|---|---|
| app bundle | 1115 KB | **299 KB** (−73%) |
| `/api/sessions` | 3.0 MB | **851 KB** (−72%), then **0 B** while idle |
| `/api/tasks` | 1.25 MB | **453 KB** (−64%) |
| reload (warm cache) | ~1.8 MB re-downloaded | **0 B** — immutable |

Roughly **6.5 MB → 1.4 MB** on a cold load, and a warm reload stops re-fetching the bundle entirely.

## Safety

- **Compression is opt-in by the client.** We gzip only when the request advertised `accept-encoding: gzip`. The gate hook's loopback calls, the MCP tools and plain `curl` send no such header and keep receiving identity bytes — the agent side is untouched.
- **`no-cache`, not `no-store`.** Paired with the ETag this means "reuse only after revalidating" — a client can never serve a stale body, it just skips the download when the validator matches.
- `no-store` added to the magic-link interstitial, whose URL carries a one-time token.
- Already-compressed types (woff2/png/ico) and sub-MTU bodies are left alone.

## Verification

A raw-`http.request` harness on a scratch `AGENT_OS_HOME` — Node's `fetch` hides both properties under test, since undici always sends `accept-encoding` and silently gunzips:

```
1. Compression is opt-in by the client
  no accept-encoding (curl / gate hook) 200 enc=identity wire=9589b
  accept-encoding: gzip (browser)       200 enc=gzip    wire=4471b
2. ETag → 304 on the repeat poll
  first GET /api/sessions               200 cc=no-cache, private
  repeat with if-none-match             304 wire=0b
  stale validator → full body           200
3. Static assets
  GET /assets/main-WgKzGIMX.js          1115KB → 299KB (-73%)
    cache-control                       public, max-age=31536000, immutable
    gunzip(gzip) === identity bytes     YES
  GET / (index.html)                    cc=no-cache
4. Small payloads stay uncompressed     /health 71b identity
✅ all transport checks passed
```

Governance 159/159 · tier-A policy 18/18 · capability registry 18/18 · idle reaper 18/18 · `tsc` clean · web build clean.

## Still open (not in this PR)

- `/api/sessions` is **unbounded** (949 rows and growing) and `listSessions` costs ~128 ms of *synchronous* SQLite per call — the ETag saves the bandwidth but the server still rebuilds the list on every 1.5 s tick, blocking the event loop for every other request. Wants a cheap change-stamp or a cap.
- The Tasks page's duplicate `/api/sessions` poll could share the shell's.
- `main.js` is one 15.7k-line `App.tsx` with no code splitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)