### PR TITLE
feat(chat): answer questions inline in Slack/Discord + fix the automation-noun classifier bug (v0.292.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.292.0] — 2026-08-03
+### Added
+- **Questions in Slack/Discord now get answered inline — no session spawned.** The chat front door
+  (`Automations.routeUnmatched`, behind fireSlack/fireDiscord/fireClickup) now runs the Cockpit **intent
+  layer**: a message classified `ask` ("how do automations work?", "which agents are idle?") is answered
+  in-thread via the *same* backend Cockpit uses — a deterministic state lookup, else a direct Claude call
+  (Haiku by default) — and posted back as a threaded reply in ~1–2s, instead of routing the question to an
+  agent (a whole session). `action`/`work` messages, and an `ask` when no LLM is configured, still route to
+  an agent as before (graceful fallback). Audited `chat.answered` (source `state`/`llm`, no session row).
+  The `ask` engine is now a shared `answerAsk` in `src/edge/ask.ts` (with `cockpitWorkspaceContext` moved
+  there from `src/server.ts`), used by BOTH `/api/router/preview` and the chat front door so they answer
+  identically. `src/edge/ask.ts`, `src/edge/automations.ts`, `src/server.ts`.
+### Fixed
+- **The intent classifier mis-read questions about automations as create-requests.** "what's the
+  difference between a task and an automation" classified as **action** (→ Automations) because the bare
+  noun "automation" tripped the schedule regex. It now requires a scheduling **verb** or recurrence
+  (`schedule …`, `automate …`, `every morning`, `daily`), or an explicit "create/set up an automation/cron"
+  — so the noun alone in a question stays an **ask**. Legit action requests ("schedule the churn report
+  every morning", "create a cron job") are unaffected (verified 11/11). `src/edge/intent.ts`.
+
 ## [0.291.6] — 2026-08-03
 ### Fixed
 - **The console served every byte uncompressed and uncacheable.** Opening a detail page

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.291.6",
+  "version": "0.292.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.291.6",
+      "version": "0.292.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.291.6",
+  "version": "0.292.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/ask.ts
+++ b/src/edge/ask.ts
@@ -6,12 +6,14 @@
  * ephemeral concierge run). System agents (concierge/consolidator/…) are excluded — a member asks
  * about their teammates, not the machinery.
  */
-import { isCodingRuntime, Member } from '../types';
-import { AgentOS } from '../kernel';
-import { TerminalManager } from '../terminal';
-import { Automations } from './automations';
+import { isCodingRuntime } from '../types';
+import type { Member } from '../types';
+import type { AgentOS } from '../kernel';
+import type { TerminalManager } from '../terminal';
+import type { Automations } from './automations';
+import { resolveLlm, chatComplete } from './llm';
 
-export function answerFromState(os: AgentOS, tm: TerminalManager, autos: Automations, me: Member, text: string): string | null {
+export function answerFromState(os: AgentOS, tm: TerminalManager, autos: Automations, me: Member | undefined, text: string): string | null {
   const t = text.toLowerCase();
   const has = (re: RegExp) => re.test(t);
   const userAgents = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime) && a.category !== 'System');
@@ -52,6 +54,66 @@ export function answerFromState(os: AgentOS, tm: TerminalManager, autos: Automat
   if ((has(/\b(list|what|which|how many|show)\b/) && has(/\bagents?\b/)) || /\bagents?\b.*\b(do i have|are there|available)\b/.test(t)) {
     if (!userAgents.length) return 'No agents yet.';
     return `You have ${userAgents.length} agents: ${fmt(userAgents.map((a) => a.id))}.`;
+  }
+  return null;
+}
+
+const ASK_SYSTEM =
+  'You are the assistant for this Agent OS workspace. Answer the question ONLY from the CONTEXT below — ' +
+  'the live state of this workspace. Be concise (2–5 sentences). If the answer is not in the context, say ' +
+  'you do not have that information and suggest the relevant console page. Never invent agents, numbers, or names.';
+
+/** A compact, factual snapshot of the workspace — the ONLY ground the `ask` LLM may answer from. Kept
+ *  small (agents + live counts + KB sections) and derived live, so answers reflect the real fleet, not a
+ *  hallucination. Member-scoped where it matters (sessions the viewer can see). */
+export function cockpitWorkspaceContext(os: AgentOS, tm: TerminalManager, autos: Automations, me: Member | undefined): string {
+  const agents = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime));
+  const agentLines = agents.map((a) => `  - ${a.id}: ${(a.description || '').replace(/\s+/g, ' ').slice(0, 140)}`).join('\n');
+  const sessions = tm.listSessions(me);
+  const live = sessions.filter((s) => s.alive).length;
+  const waiting = sessions.filter((s) => s.blocked).length;
+  const tc = os.tasks.counts(os.tenant);
+  const autoList = autos.list();
+  const autoOn = autoList.filter((a) => a.enabled);
+  const autoNames = autoOn.slice(0, 20).map((a) => a.name).join(', ');
+  const sections = os.kb.sections(os.tenant);
+  return [
+    `Workspace: ${os.tenantName} (tenant ${os.tenant}).`,
+    `Agents (${agents.length}):\n${agentLines || '  (none)'}`,
+    `Sessions: ${sessions.length} total, ${live} running, ${waiting} blocked/waiting on a human.`,
+    `Tasks: ${tc.todo} todo, ${tc.doing} in progress, ${tc.blocked} blocked, ${tc.done} done.`,
+    `Automations: ${autoList.length} total, ${autoOn.length} enabled${autoNames ? ` (${autoNames})` : ''}.`,
+    `Knowledge Base sections: ${sections.join(', ') || '(none)'}.`,
+  ].join('\n');
+}
+
+/**
+ * The Cockpit `ask` answer, session-free: Band 1 structured lookups (from live state), else Band 2a a
+ * direct LLM over a compact workspace context. Returns null when no inline answer is possible (no state
+ * match + no LLM configured) — the caller then falls back (the web route → an ephemeral concierge run;
+ * the Slack/Discord front door → route the question to an agent). Shared by `/api/router/preview` and
+ * `Automations.routeUnmatched` so both answer questions the exact same way.
+ */
+export async function answerAsk(
+  os: AgentOS,
+  tm: TerminalManager,
+  autos: Automations,
+  me: Member | undefined,
+  text: string,
+): Promise<{ answer: string; source: 'state' | 'llm' } | null> {
+  const state = answerFromState(os, tm, autos, me, text);
+  if (state) return { answer: state, source: 'state' };
+  const llm = resolveLlm(os);
+  if (llm) {
+    const answer = await chatComplete(
+      llm,
+      [
+        { role: 'system', content: ASK_SYSTEM },
+        { role: 'user', content: `CONTEXT:\n${cockpitWorkspaceContext(os, tm, autos, me)}\n\nQUESTION: ${text}` },
+      ],
+      { maxTokens: 500, timeoutMs: 15000 },
+    );
+    if (answer) return { answer, source: 'llm' };
   }
   return null;
 }

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -18,6 +18,8 @@ import { Db } from '../state/db';
 import { TerminalManager } from '../terminal';
 import { CodingRuntimeId, isCodingRuntime, Task, TaskTimelineEntry } from '../types';
 import { chooseAgent, RouterCandidate } from './router';
+import { classifyIntent } from './intent';
+import { answerAsk } from './ask';
 
 // ── minimal cron (5 fields: minute hour day-of-month month day-of-week) ──────────
 // Supports: * , a-b , */n , a-b/n , lists. dow 0-7 (7 ≡ 0 = Sunday).
@@ -793,6 +795,19 @@ export class Automations {
     if (explicit.agentId) {
       spawn(explicit.agentId, opts.extra, { by: 'explicit' }, opts.text, opts.runAs);
       return { sessions };
+    }
+
+    // 2.5) A question ABOUT the workspace is answered INLINE — fast, no session — the same way Cockpit
+    //      does (`answerAsk`: state lookup → direct Claude). So "how do automations work?" in Discord/Slack
+    //      comes back as a threaded reply in ~1–2s instead of spawning an agent. `action`/`work` — and an
+    //      `ask` with no inline answer available (no LLM configured) — fall through to routing below.
+    if (this.os.settings.autoRouteEnabled() && classifyIntent(opts.text).intent === 'ask') {
+      const me = opts.runAs ? this.os.team.getMember(opts.runAs) : undefined;
+      const inline = await answerAsk(this.os, this.tm, this, me, opts.text);
+      if (inline) {
+        this.os.audit.append({ ts: Date.now(), runId: opts.key, tenant: this.os.tenant, principal: opts.runAs ? `member:${opts.runAs}` : 'chat', type: 'chat.answered', data: { source: inline.source, chars: inline.answer.length, runAs: opts.runAs ?? null } });
+        return { sessions, reply: inline.answer };
+      }
     }
 
     // 3) Auto-route (when enabled). Fails safe: confident → route; uncertain → ask; nothing → help list.

--- a/src/edge/intent.ts
+++ b/src/edge/intent.ts
@@ -21,7 +21,11 @@ export interface IntentResult {
 }
 
 // A request to stand up a recurring/scheduled run, or an explicit "create a task" → an OS primitive.
-const SCHEDULE_RE = /\b(schedul(e|ing)|automat(e|ion)|recurring|every\s+(morning|day|night|week|hour|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|daily|weekly|hourly|nightly|each\s+(day|morning|week)|set\s+up\s+a?\s*(cron|automation|schedule)|remind\s+me)\b/i;
+// A scheduling VERB or recurrence, or an explicit "create/set up an automation/cron". Deliberately does
+// NOT match the bare noun "automation(s)" — "what's an automation?" / "how do automations work?" are
+// questions (→ ask), not requests to build one (which need a verb: "schedule …", "automate …",
+// "set up an automation", or a recurrence like "every morning").
+const SCHEDULE_RE = /\b(schedul(e|ing)|automate|recurring|every\s+(morning|day|night|week|hour|monday|tuesday|wednesday|thursday|friday|saturday|sunday)|daily|weekly|hourly|nightly|each\s+(day|morning|week)|remind\s+me)\b|\b(create|set\s*up|add|make|configure)\s+(a\s+|an\s+|the\s+)?(automation|cron(\s*job)?|schedule)\b/i;
 const TASK_RE = /\b(create|add|open|file|make|log)\s+(a\s+|an\s+|the\s+)?(task|to-?do|ticket|work\s*item)\b/i;
 
 // Meta-nouns that mean "about the agent-os / this workspace" rather than a domain topic an agent works on.

--- a/src/server.ts
+++ b/src/server.ts
@@ -31,9 +31,8 @@ import { summarizeConversation } from './edge/summarize';
 import { Automation, Automations, nextCronRun, derivedConcurrencyCap, chatTitle } from './edge/automations';
 import { chooseAgent } from './edge/router';
 import { classifyIntent } from './edge/intent';
-import { resolveLlm, chatComplete } from './edge/llm';
 import { ensureConcierge, CONCIERGE_ID, ensureOperator, OPERATOR_ID } from './edge/concierge';
-import { answerFromState } from './edge/ask';
+import { answerAsk } from './edge/ask';
 import { SlackSocket } from './edge/slack-socket';
 import { checkClaudeToken, readConfigDirToken, RuntimeCheckResult } from './edge/runtime-account-check';
 import { ClickupIngress } from './edge/clickup-ingress';
@@ -237,30 +236,6 @@ function applyAgentSnapshot(os: AgentOS, ag: AgentManifest, snap: AgentConfigSna
  *  `deletable` = lives under the data home (user-created), so it can be removed; the bundled
  *  examples that ship with the software are read-only. `builtIn` = one of the agents Agent OS
  *  provisions itself, so the console can label it as shipped-with-the-software vs. user-authored. */
-/** A compact, factual snapshot of the workspace for the Cockpit `ask` tier — the ONLY ground the LLM
- *  may answer from. Kept small (agents + live counts + KB sections) and derived live, so answers reflect
- *  the real fleet, not a hallucination. Member-scoped where it matters (sessions the viewer can see). */
-function cockpitWorkspaceContext(os: AgentOS, tm: TerminalManager, autos: Automations, me: Member): string {
-  const agents = [...os.agents.values()].filter((a) => isCodingRuntime(a.runtime));
-  const agentLines = agents.map((a) => `  - ${a.id}: ${(a.description || '').replace(/\s+/g, ' ').slice(0, 140)}`).join('\n');
-  const sessions = tm.listSessions(me);
-  const live = sessions.filter((s) => s.alive).length;
-  const waiting = sessions.filter((s) => s.blocked).length;
-  const tc = os.tasks.counts(os.tenant);
-  const autoList = autos.list();
-  const autoOn = autoList.filter((a) => a.enabled);
-  const autoNames = autoOn.slice(0, 20).map((a) => a.name).join(', ');
-  const sections = os.kb.sections(os.tenant);
-  return [
-    `Workspace: ${os.tenantName} (tenant ${os.tenant}).`,
-    `Agents (${agents.length}):\n${agentLines || '  (none)'}`,
-    `Sessions: ${sessions.length} total, ${live} running, ${waiting} blocked/waiting on a human.`,
-    `Tasks: ${tc.todo} todo, ${tc.doing} in progress, ${tc.blocked} blocked, ${tc.done} done.`,
-    `Automations: ${autoList.length} total, ${autoOn.length} enabled${autoNames ? ` (${autoNames})` : ''}.`,
-    `Knowledge Base sections: ${sections.join(', ') || '(none)'}.`,
-  ].join('\n');
-}
-
 function terminalAgents(os: AgentOS): { id: string; description: string; category?: string; runtime: string; deletable: boolean; builtIn: boolean; model?: string; effort?: string; examplePrompts?: string[]; icon?: string }[] {
   const userRoot = os.paths ? path.resolve(os.paths.userAgents) + path.sep : null;
   return [...os.agents.values()].map((a) => ({
@@ -2611,19 +2586,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     }
 
     if (intent.intent === 'ask') {
-      // Band 1: structured lookups answered deterministically from state — instant, no LLM, no session.
-      const stateAnswer = answerFromState(os, tm, autos, me, text);
-      if (stateAnswer) return sendJson(res, 200, { intent: 'ask', answer: stateAnswer, source: 'state' });
-
-      // Band 2a: freeform, and a fast direct LLM IS configured → answer inline from a compact context.
-      const llm = resolveLlm(os);
-      if (llm) {
-        const answer = await chatComplete(llm, [
-          { role: 'system', content: 'You are the assistant for this Agent OS workspace. Answer the question ONLY from the CONTEXT below — the live state of this workspace. Be concise (2–5 sentences). If the answer is not in the context, say you do not have that information and suggest the relevant console page. Never invent agents, numbers, or names.' },
-          { role: 'user', content: `CONTEXT:\n${cockpitWorkspaceContext(os, tm, autos, me)}\n\nQUESTION: ${text}` },
-        ], { maxTokens: 500, timeoutMs: 15000 });
-        if (answer) return sendJson(res, 200, { intent: 'ask', answer, source: 'llm' });
-      }
+      // Band 1 (state lookup) + Band 2a (direct LLM), shared with the Slack/Discord front door.
+      const inline = await answerAsk(os, tm, autos, me, text);
+      if (inline) return sendJson(res, 200, { intent: 'ask', answer: inline.answer, source: inline.source });
 
       // Band 2b: no direct LLM → answer via a governed, ephemeral CLAUDE run (the concierge). This is the
       // native LLM in Agent OS — no separate API key needed, and it can use the OS tools to ground the


### PR DESCRIPTION
Makes "test it with a Discord message" actually meaningful, and fixes the classifier bug I flagged.

## Questions answered inline in Slack/Discord (no session)

The chat front door (`Automations.routeUnmatched`, behind `fireSlack`/`fireDiscord`/`fireClickup`) now runs the Cockpit **intent layer**. A message classified `ask` — "how do automations work?", "which agents are idle?" — is answered **in-thread** via the *same* backend Cockpit uses:

1. **State lookup** (deterministic, instant, 0 LLM calls), else
2. **Direct Claude** (Haiku by default, via your Anthropic key — ~1-2s)

…and posted back as a threaded reply, instead of routing the question to an agent (a whole session). `action`/`work` messages — and an `ask` when **no** LLM is configured — still route to an agent exactly as before (graceful fallback). Audited `chat.answered` (source `state`/`llm`, no session row).

**Shared engine:** the ask logic is now `answerAsk` in `src/edge/ask.ts` (with `cockpitWorkspaceContext` moved there from `server.ts`), used by **both** `/api/router/preview` and the chat front door — so the console and Discord answer identically.

## Classifier fix

"what's the difference between a task and an automation" was classifying as **action** (→ Automations) because the bare noun "automation" tripped the schedule regex. It now requires a scheduling **verb** or recurrence (`schedule …`, `automate …`, `every morning`, `daily`) or an explicit "create/set up an automation/cron" — so the noun alone in a question stays an **ask**. Legit action requests are unaffected.

## Verification
- `typecheck` + `build` clean; `test:governance` → **159/159** + tier-A **18/18** + capability **18/18**
- **Classifier: 11/11** — incl. the bug case (→ ask) and all action cases (`schedule … every morning`, `automate …`, `create a cron job`, `remind me … daily`, `create a task …` → still action)
- **`answerAsk` end-to-end** against a fake Anthropic endpoint (`ANTHROPIC_BASE_URL`): state question = 0 LLM calls (source `state`); freeform = 1 Haiku call (source `llm`); no key = `null` → falls through to routing

## After merge
Deploy, then in Discord ask the instapods bot **"how do automations work?"** (or "which agents are idle?") — it should reply in-thread in ~1-2s via Haiku, no session spawned. A work request ("why is my pod down") still routes to an agent.

Files: `src/edge/ask.ts`, `src/edge/automations.ts`, `src/edge/intent.ts`, `src/server.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)