### PR TITLE
perf(console): skip the feed-poll re-render on unchanged ticks — client-side 304 (v0.292.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.292.1] — 2026-08-03
+### Changed
+- **The console's global 1.5 s poll now skips the re-render on unchanged ticks (client-side 304).**
+  #530 gave every response a wire-level ETag + gzip, so an idle tab already stops re-*downloading* the
+  ~1.65 MB sessions list. But browser auto-revalidation still hands the *cached* body back to JS, so the
+  console kept re-parsing and re-rendering the whole list every 1.5 s regardless. The global feed poll
+  now sends its last ETag explicitly (`sessionsFeed`/`messagesFeed` → `callFeed`, `cache: 'no-store'`)
+  and, on a **304**, resolves `notModified` so the poll **skips `setState`** — no re-parse, no React
+  re-render. The tag covers the fully-computed response, so a derived change (a run going
+  `blocked`/`crashed`, a cost backfill, a new inbox card) still flips it and the tab-title badge /
+  waiting bells never go stale. Complements #530 (which keeps the transfer + gzip on the ticks that *do*
+  change). `web/src/lib/api.ts`, `web/src/App.tsx`.
+
 ## [0.292.0] — 2026-08-03
 ### Added
 - **Questions in Slack/Discord now get answered inline — no session spawned.** The chat front door

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.292.0",
+  "version": "0.292.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.292.0",
+      "version": "0.292.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.292.0",
+  "version": "0.292.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1059,11 +1059,25 @@ function Console({ me }: { me: Member }) {
     //    tailscale/nginx hop), which read as "notifications only show after a page reload".
     //  • ignore a non-array payload — an error tick returns `{error}`, not a list; don't clobber good
     //    state with garbage.
+    //  • CONDITIONAL fetch (ETag/If-None-Match): each feed carries its last ETag; when nothing changed
+    //    the server 304s and we SKIP setState entirely, so an idle tab stops re-parsing + re-rendering the
+    //    ~1.6 MB sessions list every 1.5 s. (The server already gzips + 304s at the wire; this is the
+    //    client half — browser auto-revalidation alone would still hand JS the cached body and re-render.)
+    //    The ETag covers the fully-computed response, so any derived change (blocked/crashed/cost/new card)
+    //    still flips it — the badge/bells never go stale.
+    let sessEtag: string | null = null
+    let msgEtag: string | null = null
     const poll = async () => {
-      const [s, m] = await Promise.allSettled([api.sessions(), api.messages()])
+      const [s, m] = await Promise.allSettled([api.sessionsFeed(sessEtag), api.messagesFeed(msgEtag)])
       if (!alive) return
-      if (s.status === 'fulfilled' && Array.isArray(s.value)) setSessions(s.value)
-      if (m.status === 'fulfilled' && Array.isArray(m.value)) setMessages(m.value)
+      if (s.status === 'fulfilled') {
+        sessEtag = s.value.etag
+        if ('data' in s.value && Array.isArray(s.value.data)) setSessions(s.value.data)
+      }
+      if (m.status === 'fulfilled') {
+        msgEtag = m.value.etag
+        if ('data' in m.value && Array.isArray(m.value.data)) setMessages(m.value.data)
+      }
     }
     poll()
     const t = setInterval(poll, 1500)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1285,6 +1285,25 @@ async function call<T>(method: string, path: string, body?: unknown): Promise<T>
   return res.json() as Promise<T>
 }
 
+/** Result of a conditional feed GET: either fresh `data`, or `notModified` (the server 304'd because
+ *  nothing changed since our last ETag). Both carry the ETag to thread into the next call. */
+export type FeedResult<T> = { notModified: true; etag: string | null } | { data: T; etag: string | null }
+/** Conditional GET for the hot list feeds (sessions/messages) the global console poll re-fetches every
+ *  1.5 s. The server already tags every response with an ETag (sendBody) and gzips it; here we take the
+ *  extra step of handling the 304 IN THE CLIENT — sending our last ETag explicitly and, on a 304,
+ *  resolving as `notModified` so the poll can skip setState. That's the piece browser auto-revalidation
+ *  can't give us: without it a 304 still serves the cached body to JS and we'd re-parse + re-render the
+ *  full ~1.6 MB list every tick. `cache:'no-store'` keeps the browser cache out of the loop so our
+ *  explicit `If-None-Match` is authoritative (gzip still applies on a 200 — accept-encoding is
+ *  independent of cache mode). An error tick (401/5xx → `{error}`) falls through as `data` with a null
+ *  etag; the caller's array-shape guard drops it and the next poll retries unconditionally. */
+async function callFeed<T>(path: string, etag: string | null): Promise<FeedResult<T>> {
+  const res = await fetch(path, { cache: 'no-store', headers: etag ? { 'if-none-match': etag } : undefined })
+  const next = res.headers.get('etag')
+  if (res.status === 304) return { notModified: true, etag: next ?? etag }
+  return { data: (await res.json()) as T, etag: next }
+}
+
 export const api = {
   /** Current member, or null if not authenticated (401). Drives the login gate. */
   me: async (): Promise<Member | null> => {
@@ -1308,12 +1327,17 @@ export const api = {
   /** Owner-only: plain restart, no pull/rebuild. The process bounces ~1.5s after the response. */
   restart: () => call<RestartResult>('POST', '/api/restart'),
   sessions: (archived?: boolean) => call<Session[]>('GET', '/api/sessions' + (archived ? '?archived=1' : '')),
+  /** Conditional variant of the live sessions feed for the global 1.5 s poll — resolves `notModified` on a
+   *  304 so idle tabs skip the re-parse + re-render. Non-feed callers keep `sessions()` (always full body). */
+  sessionsFeed: (etag: string | null) => callFeed<Session[]>('/api/sessions', etag),
   unarchiveSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/unarchive`),
   sessionTidyPreview: () => call<{ ok: boolean; plan?: SessionTidyPlan; error?: string }>('GET', '/api/insights/sessions/tidy'),
   sessionTidyApply: () => call<{ ok: boolean; archived?: number; error?: string }>('POST', '/api/insights/sessions/tidy'),
   /** Inbox feed. `scope='all'` is the owner/admin oversight view (every session's cards); the default
    *  `mine` is the personal feed — only cards addressed to you, so overseers aren't flooded. */
   messages: (scope: 'mine' | 'all' = 'mine') => call<Msg[]>('GET', `/api/messages${scope === 'all' ? '?scope=all' : ''}`),
+  /** Conditional variant of the inbox feed for the global 1.5 s poll — `notModified` on a 304. */
+  messagesFeed: (etag: string | null, scope: 'mine' | 'all' = 'mine') => callFeed<Msg[]>(`/api/messages${scope === 'all' ? '?scope=all' : ''}`, etag),
   run: (agent: string, task: string) => call<{ id: string; tmux: string; error?: string }>('POST', '/api/sessions', { agent, task }),
   stopSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/stop`),
   /** Restart a session's agent process in place (keeps the transcript, resumes the same claude id) so a


### PR DESCRIPTION
## Context
Follow-on to #530. #530 gave every response a wire-level ETag + gzip, so an idle console tab already stops **re-downloading** the ~1.65 MB `/api/sessions` list. But it relies on browser auto-revalidation, which still hands the **cached body back to JS** — so the console kept re-parsing and re-rendering the whole list every 1.5 s regardless. On a large-list tenant (instawp, ~946 sessions) that's a real recurring main-thread cost.

## Change (client-only)
The global 1.5 s feed poll now sends its last ETag **explicitly** (`sessionsFeed`/`messagesFeed` → `callFeed`, `cache: 'no-store'`) and, on a **304**, resolves `notModified` so the poll **skips `setState`** — no re-parse, no React re-render.

- The tag covers the *fully-computed* response, so any derived change (a run going `blocked`/`crashed`, a cost backfill, a new inbox card) still flips it — the tab-title badge and per-session waiting bells never go stale.
- `cache: 'no-store'` keeps the browser cache out of the loop so our explicit `If-None-Match` is authoritative; gzip still applies on the ticks that *do* change (accept-encoding is independent of cache mode).
- **Server is unchanged** — #530's shared `sendBody` already tags + 304s every response.

## Verification
In-process round-trip against the #530 `sendBody` server: explicit `If-None-Match` → **304 empty**, stale ETag → 200 + body, a new session flips the weak ETag. Byte-stability across unchanged ticks confirmed. Typecheck + web build + `npm run test:governance` green.

## Remaining (separate follow-ups)
Neither #530 nor this cuts the **server-side** query cost — the sessions list is still built every tick (`SELECT *` incl. full task text). The instawp server pain (memory + event-loop) needs: (1) `substr(task,…)` in the query, (2) reap idle resident sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)