### PR TITLE
fix(cockpit): recommendation questions no longer dump the whole agent roster (v0.292.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.292.3] — 2026-08-03
+### Fixed
+- **Cockpit `ask`: "which agent can help me build a feature?" dumped the whole roster instead of
+  recommending one.** The band-1 state lookup's agent-list rule fired on any `which/what/list/how many` +
+  "agents", so a *recommendation* question got a raw 16-agent list that ignored the task. It now only
+  fires for genuine **enumeration** ("list my agents", "how many agents", "what agents do I have", "which
+  agents are available"); a "which agent can help with / handles / for <task>" question falls through to
+  the LLM (which sees the agents' descriptions and recommends the right one — e.g. `engineer`). Verified
+  8/8. `src/edge/ask.ts`.
+
 ## [0.292.2] — 2026-08-03
 ### Fixed
 - **`listSessions` re-queried the members and automations tables once per row.** v0.291.6 made the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.292.2",
+  "version": "0.292.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.292.2",
+      "version": "0.292.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.292.2",
+  "version": "0.292.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/ask.ts
+++ b/src/edge/ask.ts
@@ -50,8 +50,11 @@ export function answerFromState(os: AgentOS, tm: TerminalManager, autos: Automat
     const on = all.filter((a) => a.enabled);
     return `${all.length} automation${all.length > 1 ? 's' : ''} (${on.length} enabled)${on.length ? `: ${fmt(on.slice(0, 15).map((a) => a.name))}` : ''}.`;
   }
-  // List agents (generic roster).
-  if ((has(/\b(list|what|which|how many|show)\b/) && has(/\bagents?\b/)) || /\bagents?\b.*\b(do i have|are there|available)\b/.test(t)) {
+  // List agents (roster) — ENUMERATION only ("list my agents", "how many agents", "what agents do I
+  // have"). Deliberately NOT "which agent can help me build a feature" / "which agent handles billing" —
+  // those are recommendation questions; they fall through to the LLM (which sees agent descriptions and
+  // recommends the right one) rather than getting a raw roster dump that ignores the task.
+  if (/\b(list|show)\b.*\bagents?\b/.test(t) || /\bhow many\s+agents?\b/.test(t) || /\bagents?\b.*\b(do i have|are there|(are\s+)?available|exist)\b/.test(t)) {
     if (!userAgents.length) return 'No agents yet.';
     return `You have ${userAgents.length} agents: ${fmt(userAgents.map((a) => a.id))}.`;
   }


### PR DESCRIPTION
**"which agent can help me build a feature?"** was answered with a raw 16-agent list — it ignored "build a feature" entirely.

**Cause:** Cockpit's band-1 (deterministic, no-LLM) state lookup had an agent-list rule that fired on *any* `which/what/list/how many` + "agents". So a **recommendation** question matched the **enumeration** rule and dumped the roster.

**Fix:** the roster dump now only fires for genuine enumeration:
- ✅ "list my agents" / "show me all agents" → roster
- ✅ "how many agents do I have" → roster
- ✅ "what agents do I have" / "which agents are available" → roster
- ✅ "which agent can help me build a feature" / "which agent handles billing" / "who can help with a refund" → **falls through to the LLM**, which sees each agent's description and recommends the right one (e.g. `engineer`)

Verified 8/8 against the exact cases above. Governance 159/159 + tier-A + capability suites pass. `src/edge/ask.ts` (one rule).

## After merge
Deploy, then re-ask in Cockpit: "which agent can help me build a feature?" → should now recommend the `engineer` agent (via Haiku) rather than listing all 16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)