### PR TITLE
fix(router): use the LLM to pick from the full roster on low-confidence routes (v0.292.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.292.5] — 2026-08-03
+### Changed
+- **The router now uses the LLM to pick from the FULL roster when keyword routing isn't confident — not
+  just to re-rank a near-tie shortlist.** Without an embedder the keyword scorer is weak (a task's words
+  rarely match an agent's description verbatim — "build a feature" doesn't lexically hit `engineer`), so it
+  disambiguated to the wrong few or fell through to the whole-fleet list. Now, on any low-confidence
+  keyword result (`disambiguate`/`none`), if an LLM is configured (Anthropic key or an OpenAI-compatible
+  endpoint) it picks the single best-fit agent from *every* agent's description — e.g. "build a feature" /
+  "which agent can help me build a feature" → `engineer`. A confident keyword `route` is left alone (no
+  LLM cost); UNSURE keeps the keyword decision; no LLM configured → unchanged keyword-only behavior. This
+  fixes the wrong list behind Cockpit's "Route to an agent instead" and lifts routing quality across
+  Cockpit, Discord, and Slack (verified with a stubbed model: keyword-weak → full-roster LLM pick;
+  confident keyword → 0 LLM calls). `src/edge/router.ts` (`llmTieBreak` → `llmPick`).
+
 ## [0.292.4] — 2026-08-03
 ### Changed
 - **`GET /api/sessions` clips the `task` prompt IN THE QUERY** instead of `SELECT *`-ing the full text

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.292.4",
+  "version": "0.292.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.292.4",
+      "version": "0.292.5",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.292.4",
+  "version": "0.292.5",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/router.ts
+++ b/src/edge/router.ts
@@ -183,14 +183,18 @@ export async function chooseAgent(os: AgentOS, text: string): Promise<RouteDecis
 
   const decision = decide(scored, cfg);
 
-  // Near-tie → try the LLM tie-break before bothering the human (any resolvable LLM: Anthropic key or an
-  // OpenAI-compatible endpoint). `llmTieBreak` no-ops (returns null) when none is configured. A clear pick
-  // routes; unsure → disambiguate.
-  if (decision.kind === 'disambiguate') {
-    const pick = await llmTieBreak(os, text, decision.candidates, agents);
+  // Low-confidence keyword routing (a near-tie, or nothing clear) → let the LLM pick from the FULL roster.
+  // The keyword scorer is weak without an embedder — a task's words rarely match an agent's description
+  // verbatim ("build a feature" doesn't lexically hit `engineer`), so it disambiguates to the wrong few.
+  // The LLM sees EVERY agent's description and picks the real best fit. A clear pick routes (method
+  // 'llm'); an UNSURE keeps the keyword decision. No-ops when no LLM is configured (Anthropic key or an
+  // OpenAI-compatible endpoint). A confident keyword `route` is left alone (no LLM cost).
+  if (decision.kind !== 'route') {
+    const pick = await llmPick(os, text, agents);
     if (pick) {
-      const c = decision.candidates.find((x) => x.agentId === pick);
-      if (c) return { kind: 'route', agentId: c.agentId, score: c.score, runnerUp: decision.candidates.find((x) => x.agentId !== pick), method: 'llm' };
+      const score = scored.find((s) => s.agentId === pick)?.score ?? 0.6;
+      const runnerUp = decision.kind === 'disambiguate' ? decision.candidates.find((c) => c.agentId !== pick) : undefined;
+      return { kind: 'route', agentId: pick, score, ...(runnerUp ? { runnerUp } : {}), method: 'llm' };
     }
   }
   return decision;
@@ -231,27 +235,19 @@ async function tryEmbeddingBlend(
   }
 }
 
-async function llmTieBreak(
-  os: AgentOS,
-  text: string,
-  candidates: RouterCandidate[],
-  agents: AgentManifest[],
-): Promise<string | null> {
+/** Ask the LLM to pick the single best-fit agent from the FULL roster (id + description). Returns the id
+ *  or null (no LLM configured, UNSURE, malformed, or an id not in the roster). */
+async function llmPick(os: AgentOS, text: string, agents: AgentManifest[]): Promise<string | null> {
   const llm = resolveLlm(os);
   if (!llm) return null;
-  const roster = candidates
-    .map((c) => {
-      const a = agents.find((x) => x.id === c.agentId);
-      return `- ${c.agentId}: ${(a?.description || '').slice(0, 200)}`;
-    })
-    .join('\n');
+  const roster = agents.map((a) => `- ${a.id}: ${(a.description || '').replace(/\s+/g, ' ').slice(0, 220)}`).join('\n');
   const sys =
-    'You route an incoming message to exactly one agent. Reply with ONLY the agent id from the list, ' +
-    'or the single word UNSURE if none clearly fits. No punctuation, no explanation.';
+    'You route an incoming message to exactly one agent — the single best fit for what the person needs ' +
+    'done. Consider what each agent does (from its description), not just word overlap. Reply with ONLY ' +
+    'the agent id from the list, or the single word UNSURE if none clearly fits. No punctuation, no explanation.';
   const user = `Agents:\n${roster}\n\nMessage:\n${text.slice(0, 1500)}\n\nBest agent id:`;
   const out = await chatComplete(llm, [{ role: 'system', content: sys }, { role: 'user', content: user }], { maxTokens: 24, timeoutMs: 8000 });
   if (!out) return null;
   const raw = out.replace(/[^A-Za-z0-9_-]/g, '');
-  const hit = candidates.find((c) => c.agentId === raw);
-  return hit ? hit.agentId : null;
+  return agents.find((a) => a.id === raw)?.id ?? null;
 }


### PR DESCRIPTION
Fixes the "wrong list" behind Cockpit's **"Route to an agent instead"** — and the underlying routing weakness it exposed.

## Root cause
Routing "build a feature" returned `app-packager, marketer, newsletter-writer` — **not** `engineer`. Without an embedder, the keyword scorer matches word overlap, and "build a feature" doesn't lexically hit engineer's description ("writes code, debugs, ships fixes"). So it disambiguated to the wrong few. The LLM step existed but only **re-ranked the near-tie shortlist** — it never reconsidered the full fleet, so it couldn't surface engineer.

## Fix
On **any** low-confidence keyword result (`disambiguate`/`none`), if an LLM is configured, it now picks the single best-fit agent from **every** agent's description (`llmTieBreak` → `llmPick`, over the full roster). A confident keyword `route` is left alone (no LLM cost); `UNSURE` keeps the keyword decision; no LLM configured → unchanged keyword-only behavior.

Result — the reported case and its variants now resolve correctly:
- "build a feature" → **engineer**
- "which agent can help me build a feature" → **engineer**
- "spam and abusive content" → **trust-safety** via keyword, **0 LLM calls** (confident routes skip the LLM)

This lifts routing quality across **Cockpit, Discord, and Slack** (all go through `chooseAgent`), now that a Claude key is configured.

## Verification
- `typecheck` + `build` clean; `test:governance` → **159/159** + tier-A **18/18** + capability **18/18**
- Stubbed-model e2e: keyword-weak → full-roster LLM pick → engineer (1 call); confident keyword → trust-safety (0 calls); no key → keyword-only unchanged

## After merge
Deploy, then in Cockpit hit **"Route to an agent instead"** on that ask answer (or just type "build a feature") → it should route to **engineer**, not the marketing agents.

`src/edge/router.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)