### PR TITLE
fix(router): llmPick handles meta-phrased 'which agent for X' questions (v0.292.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.293.1] — 2026-08-03
+### Fixed
+- **Router LLM pick now handles meta-phrased routing questions.** "which agent can help me build a
+  feature?" still disambiguated wrongly because `llmPick` read it as a question ABOUT routing (→ UNSURE)
+  rather than a task to route. Its prompt now tells the model that a message may be a task OR a "which/who
+  agent for X" question, and to route to the agent best suited for the underlying work either way — so
+  "which agent can help me build a feature" → `engineer`, matching the bare "build a feature". This is
+  what Cockpit's "Route to an agent instead" sends. `src/edge/router.ts`.
 ## [0.293.0] — 2026-08-03
 ### Added
 - **A ceiling on how long a session may sit blocked on an unanswered question.** The idle janitor skips a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.293.0",
+  "version": "0.293.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.293.0",
+      "version": "0.293.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.293.0",
+  "version": "0.293.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/router.ts
+++ b/src/edge/router.ts
@@ -243,8 +243,11 @@ async function llmPick(os: AgentOS, text: string, agents: AgentManifest[]): Prom
   const roster = agents.map((a) => `- ${a.id}: ${(a.description || '').replace(/\s+/g, ' ').slice(0, 220)}`).join('\n');
   const sys =
     'You route an incoming message to exactly one agent — the single best fit for what the person needs ' +
-    'done. Consider what each agent does (from its description), not just word overlap. Reply with ONLY ' +
-    'the agent id from the list, or the single word UNSURE if none clearly fits. No punctuation, no explanation.';
+    'done. The message may be a task ("build a feature") OR a question about who to use ("which agent can ' +
+    'help me build a feature?", "who handles billing?") — in either case route to the agent best suited ' +
+    'for the underlying work. Consider what each agent does (from its description), not just word overlap. ' +
+    'Reply with ONLY the agent id from the list, or the single word UNSURE if none clearly fits. No ' +
+    'punctuation, no explanation.';
   const user = `Agents:\n${roster}\n\nMessage:\n${text.slice(0, 1500)}\n\nBest agent id:`;
   const out = await chatComplete(llm, [{ role: 'system', content: sys }, { role: 'user', content: user }], { maxTokens: 24, timeoutMs: 8000 });
   if (!out) return null;


### PR DESCRIPTION
Follow-up to #537. "which agent can help me build a feature?" still disambiguated wrongly — `llmPick` read the meta-phrasing as a question *about* routing (→ UNSURE) rather than a task to route.

Its prompt now states a message may be a task OR a "which/who agent for X" question, and to route to the agent best for the underlying work either way. So it → **engineer**, matching the bare "build a feature" — which is exactly what Cockpit's **"Route to an agent instead"** sends.

typecheck + build clean; governance unaffected (prompt-only change). Verified live after deploy.

`src/edge/router.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)