### PR TITLE
feat(sessions): by-id fetch (/:id + ?ids=) + Tasks stops full-list polling (v0.294.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.294.0] — 2026-08-03
+### Added
+- **By-id session fetch — `GET /api/sessions/:id` and `GET /api/sessions?ids=a,b,c`** (Sessions-pagination
+  Phase 1; plan in `docs/sessions-pagination-plan.md`). The console had no way to read a single session —
+  every by-id lookup came from the full ~950-row list the 1.5 s poll ships. These return the same
+  derived-row shape (clipped `task`, `blocked`/`alive`/labels), reuse `listSessions`' `canViewRow` scoping
+  (an id the caller can't see → 404 / omitted, no existence leak), and match by id **regardless of
+  `archived_at`** so a notification-open resolves an archived run too. `listSessions` gained an optional
+  `ids` filter; `src/terminal.ts`, `src/server.ts`, `web/src/lib/api.ts`.
+### Changed
+- **The Tasks board stops re-fetching the whole sessions list every 5 s.** It only needs the sessions its
+  visible tasks point at (`lastSessionId`, to light a card up as live via `liveOf`); it now fetches exactly
+  those ids via `sessionsByIds` instead of all ~950 rows. First step of splitting the session poll from the
+  list — the global 1.5 s poll still ships the full list until Phase 2 (a cheap summary feed). `web/src/App.tsx`.
+
 ## [0.293.1] — 2026-08-03
 ### Fixed
 - **Router LLM pick now handles meta-phrased routing questions.** "which agent can help me build a

--- a/docs/sessions-pagination-plan.md
+++ b/docs/sessions-pagination-plan.md
@@ -1,0 +1,86 @@
+# Sessions pagination plan
+
+`GET /api/sessions` returns **all** non-archived sessions (~950 on instawp) and the console's global
+1.5 s poll re-fetches the whole list every tick — the Tasks page fetches it a second time on its own 5 s
+timer. The console-perf arc so far (#525 clip → #530 gzip+ETag+304 → #532 client render-skip → #533
+per-row cache → #535 in-query task clip) made each tick cheap **when nothing changed**, but on a busy
+tenant the list changes constantly and the server still builds + ships ~950 rows. Pagination is the
+structural fix. See [[console-list-payload-perf]] for the measured baseline.
+
+## Why naive `?limit&offset` on the poll breaks things
+
+The 1.5 s poll's `sessions` array is a **client-wide all-sessions cache**, not just the list view's data.
+Consumers in `web/src/App.tsx`:
+
+- **Counts / tab-title badge** — `runningSessions` (~L1307); Overview's `blocked` / `live` / `doneToday`
+  / per-agent-online tallies (`OverviewPage`, ~L7531-7540).
+- **Sessions list view** — client-side filter over status/agent/source/mode/owner/mine **+ full-text
+  search** on `title·agent·id·task·spawnedByLabel·runAsLabel` (~L3259-3271), facet dropdowns
+  (`agentOptions`/`ownerOptions`) built from the full set (~L3246-3253), multi-key sort, and bulk
+  select "over the filtered view" (~L3285-3304).
+- **Tab management** — live/ended tab strips (~L3385-3386).
+- **By-id / by-tmux lookups** — notification→open, `SessionFacts`, rename (~L1199, L1285, L1487-1493).
+- **Tasks page** — a second full fetch to map `task.lastSessionId → isLive` (~L7912, L7939-7940).
+
+And there is **no `GET /api/sessions/:id`** today — every by-id read is served from that array. So if the
+poll stops carrying all rows, counts, cross-view lookups, and search all break unless we restructure
+first.
+
+## The insight
+
+Almost every consumer needs one of two cheap things, **not** 950 rows:
+- **aggregate counts**, or
+- **the LIVE subset** — small, bounded by the concurrency cap (~20).
+
+Only the **Sessions list view** needs a filtered/sorted page of arbitrary (mostly terminal) rows — and
+it's open only some of the time. So the fix is not "paginate the poll," it's **split the poll from the
+list**.
+
+## Target architecture
+
+1. **`GET /api/sessions/:id`** (+ batch `?ids=a,b,c`) — the missing by-id fetch. Backs notification-open,
+   `SessionFacts`, and the Tasks `lastSessionId` lookups without the full array. Viewer-scoped
+   (`canViewRow`), reuses the same derived-row builder as the list.
+2. **`GET /api/sessions/summary`** — cheap: aggregate counts + the full **live** rows + blocked ids, with
+   the same ETag/304 the poll already uses. The 1.5 s poll fetches **this** instead of ~950 rows. Drives
+   badge, Overview, tab strip, "my live sessions."
+3. **`GET /api/sessions` gains pagination** — `limit` + cursor + **server-side** filter/sort/search +
+   facet lists. The list view fetches pages **on demand** (open + filter/sort/scroll), not on the tick.
+
+## Phasing (each independently shippable, low→high risk)
+
+| Phase | Work | Risk | Win |
+|---|---|---|---|
+| **1** | `GET /api/sessions/:id` + `?ids=`; migrate the Tasks page to fetch only its referenced session ids (drop its 2nd full poll) | S | Removes the 5 s duplicate ~950-row fetch on the Tasks page; lands the by-id infra Phase 2 needs |
+| **2** | `GET /api/sessions/summary` (counts + live rows + blocked ids, ETag); point the 1.5 s poll + badge + Overview + tab strip at it | M | **Core win — the hot poll stops shipping ~950 rows.** Badge/bells are load-bearing; migrate carefully |
+| **3** | Server-side pagination + filter/sort/search + facets on `/api/sessions`; rewrite the list view to fetch pages (debounced search, pager/infinite-scroll); retire client-side filter-over-full-array | L | List view scales past a few thousand sessions |
+
+Order is **1 → 2 → 3**: Phase 1 is the prerequisite (once the poll drops the full list, by-id lookups
+need a home). Phase 2 delivers the measured perf win. Phase 3 is the largest client change and can wait.
+
+## Decisions to make (before Phase 3)
+
+- **Search backend.** `term_sessions` has **no FTS table** (unlike `tasks`/`kb`/`memories`). At ~950–5k
+  rows a `LIKE`-based server filter is fine; a `term_sessions_fts` mirror is only worth it if the corpus
+  grows large. → *Recommend LIKE first, revisit with size.*
+- **Pagination style.** Keyset/**cursor** on `(created_at, id)` (immutable, stable under a live-mutating
+  list) over `offset`.
+- **Bulk select-all across pages.** "Select all matching filter" vs "select visible page" — a product
+  call. Today's select-all operates over the full filtered array; server pagination forces the choice.
+- **Sort on derived columns** (cost/tokens/activeMs). Materialized columns now, so server-side sort is
+  fine.
+
+## Invariants to preserve
+
+- **Viewer scoping** (`TerminalManager.canViewRow`) must hold on every new surface — a member sees only
+  sessions they spawned + automations they created; owner/admin see all. Never widen it.
+- **The badge/bells derive from the poll** — Phase 2's summary must carry everything they read
+  (`blocked`, live rows, counts) or the "waiting on you" nudge goes stale. This is the one load-bearing
+  correctness risk in the whole plan.
+- **ETag/304 + gzip** stay on every new GET (they ride the shared `sendBody`).
+
+## Status
+
+- Phase 1 — in progress (this doc's companion change).
+- Phase 2 — not started.
+- Phase 3 — not started.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.293.1",
+  "version": "0.294.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.293.1",
+      "version": "0.294.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.293.1",
+  "version": "0.294.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2518,8 +2518,25 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   //   per poll, ~33% off the query. `clipText` below is kept as the ellipsis-preserving finisher (it now
   //   operates on the ≤241-char string, so the wire output is byte-identical to before).
   if (method === 'GET' && p === '/api/sessions') {
-    const rows = url.searchParams.get('archived') === '1' ? tm.listArchivedSessions(me, LIST_CLIP) : tm.listSessions(me, LIST_CLIP);
+    // `?ids=a,b,c` → the batch by-id fetch (Sessions-pagination Phase 1): return just those sessions, so a
+    // consumer that only needs a handful (the Tasks board resolving `lastSessionId → isLive`) stops pulling
+    // the whole ~950-row list. Viewer-scoping is unchanged — `listSessions` filters via canViewRow, so an
+    // id the caller can't see simply doesn't come back.
+    const idsParam = url.searchParams.get('ids');
+    const rows = idsParam !== null
+      ? tm.listSessions(me, LIST_CLIP, idsParam ? idsParam.split(',').map((x) => x.trim()).filter(Boolean) : [])
+      : url.searchParams.get('archived') === '1' ? tm.listArchivedSessions(me, LIST_CLIP) : tm.listSessions(me, LIST_CLIP);
     return sendJson(res, 200, rows.map((s) => (s.task ? { ...s, task: clipText(s.task, LIST_CLIP) } : s)));
+  }
+  // Single session by id (Sessions-pagination Phase 1) — the by-id fetch the console lacked (every by-id
+  // read used to come from the full list array). 404 when the caller can't see it (canViewRow → no row),
+  // which doubles as the not-found response — no existence leak. End-anchored so it never shadows the
+  // `/api/sessions/:id/<subresource>` routes above.
+  const sessByIdMatch = p.match(/^\/api\/sessions\/([\w-]+)$/);
+  if (method === 'GET' && sessByIdMatch) {
+    const [row] = tm.listSessions(me, LIST_CLIP, [sessByIdMatch[1]]);
+    if (!row) return sendJson(res, 404, { error: 'unknown session' });
+    return sendJson(res, 200, row.task ? { ...row, task: clipText(row.task, LIST_CLIP) } : row);
   }
   if (method === 'POST' && p === '/api/sessions') {
     const b = await readBody(req);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -705,15 +705,21 @@ export class TerminalManager {
    * regular member sees only sessions they spawned, plus sessions fired by an automation they created.
    * `taskClip` (list endpoint only) fetches `task` pre-truncated to that many chars — see sessionSelectCols.
    */
-  listSessions(viewer?: Member, taskClip?: number): Session[] {
+  listSessions(viewer?: Member, taskClip?: number, ids?: string[]): Session[] {
     // Memoize the member/automation lookups for this call — the per-row helpers below would otherwise
     // re-query them ~2x per row. See withRowCache().
-    return this.withRowCache(() => this.listSessionsUncached(viewer, taskClip));
+    return this.withRowCache(() => this.listSessionsUncached(viewer, taskClip, ids));
   }
-  private listSessionsUncached(viewer?: Member, taskClip?: number): Session[] {
+  private listSessionsUncached(viewer?: Member, taskClip?: number, ids?: string[]): Session[] {
     // Archived sessions are hidden from the list (reversible soft-archive via the Insights declutter tile);
     // their rows survive for every by-id reference (task-reconcile, audit, cost).
-    const rows = this.db.prepare(`SELECT ${this.sessionSelectCols(taskClip)} FROM term_sessions WHERE archived_at IS NULL ORDER BY created_at DESC`).all<SessionRow>();
+    //   `ids` = the by-id / batch fetch (Sessions-pagination Phase 1): return exactly those sessions with
+    //   the same derived fields the list carries, still viewer-scoped below. It intentionally matches by id
+    //   REGARDLESS of archived_at (so a by-id/notification-open resolves an archived session too); an empty
+    //   list short-circuits (`IN ()` is a syntax error). The unfiltered list keeps hiding archived rows.
+    if (ids && ids.length === 0) return [];
+    const where = ids ? `id IN (${ids.map(() => '?').join(',')})` : 'archived_at IS NULL';
+    const rows = this.db.prepare(`SELECT ${this.sessionSelectCols(taskClip)} FROM term_sessions WHERE ${where} ORDER BY created_at DESC`).all<SessionRow>(...(ids ?? []));
     // Lazy liveness: a row stays 'running' until its tmux session is gone. A running row whose pane
     // vanished with NO end signal (no `report`/`markEnded`/`stopSession`) died abruptly — kill/OOM/
     // reboot — so it's a `crashed`, not a clean end. Grace-period new rows (tmux may not have finished

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7909,11 +7909,16 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
   }
 
   const load = async () => {
-    const [r, ss] = await Promise.all([api.tasks(q), api.sessions().catch(() => [] as Session[])])
+    const r = await api.tasks(q)
     setTasks(r.tasks ?? [])
     setDiscussions(r.discussions ?? {})
     if (r.counts) setCounts(r.counts)
-    setSessions(ss)
+    // Only the sessions a visible task points at (its `lastSessionId`) are needed here — to light up a
+    // "doing" card as live via `liveOf`. Fetch exactly those instead of the whole ~950-row list on a 5 s
+    // timer (Sessions-pagination Phase 1). Sequential after tasks (we need their ids), but the payload is
+    // a handful of rows.
+    const ids = [...new Set((r.tasks ?? []).map((t) => t.lastSessionId).filter(Boolean) as string[])]
+    setSessions(await api.sessionsByIds(ids).catch(() => [] as Session[]))
   }
   useEffect(() => { load() }, [q])
   // Live refresh so an agent closing its own loop moves the card without a manual reload. Pause while a

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1329,6 +1329,12 @@ export const api = {
   /** Owner-only: plain restart, no pull/rebuild. The process bounces ~1.5s after the response. */
   restart: () => call<RestartResult>('POST', '/api/restart'),
   sessions: (archived?: boolean) => call<Session[]>('GET', '/api/sessions' + (archived ? '?archived=1' : '')),
+  /** One session by id, with the same derived fields the list carries. 404 → `{error}` when the caller
+   *  can't see it (viewer-scoped server-side). The by-id fetch the console lacked (Sessions-pagination P1). */
+  session: (id: string) => call<Session | { error: string }>('GET', `/api/sessions/${encodeURIComponent(id)}`),
+  /** Batch by-id fetch — just the named sessions (viewer-scoped), so a consumer needing a handful (the
+   *  Tasks board resolving `lastSessionId → isLive`) stops pulling the whole ~950-row list. Empty → []. */
+  sessionsByIds: (ids: string[]) => (ids.length ? call<Session[]>('GET', `/api/sessions?ids=${ids.map(encodeURIComponent).join(',')}`) : Promise.resolve([] as Session[])),
   /** Conditional variant of the live sessions feed for the global 1.5 s poll — resolves `notModified` on a
    *  304 so idle tabs skip the re-parse + re-render. Non-feed callers keep `sessions()` (always full body). */
   sessionsFeed: (etag: string | null) => callFeed<Session[]>('/api/sessions', etag),


### PR DESCRIPTION
**Sessions-pagination Phase 1.** Plan: `docs/sessions-pagination-plan.md` (added here).

## Why
`GET /api/sessions` returns all ~950 sessions and the console had **no single-session read** — every by-id lookup (notification→open, `SessionFacts`, the Tasks board's `lastSessionId → isLive`) came from the full list the 1.5 s poll ships. That's the blocker to ever slimming the poll (Phase 2). This lands the missing by-id surface + removes the first duplicate full fetch.

## Change
- **`GET /api/sessions/:id`** and **`GET /api/sessions?ids=a,b,c`** — same derived-row shape as the list (clipped `task`, `blocked`/`alive`/labels). Reuse `listSessions`' `canViewRow` scoping (an id the caller can't see → 404 / omitted — no existence leak), and match by id **regardless of `archived_at`** so a notification-open resolves an archived run. `listSessions` gained an optional `ids` filter.
- **Tasks board** fetches only the sessions its visible tasks reference (via `sessionsByIds`) instead of re-pulling all ~950 rows on its 5 s timer.

The global 1.5 s poll **still ships the full list** — that's Phase 2 (a cheap `/api/sessions/summary`). This phase is purely additive + the Tasks fetch swap.

## Verification (live instawp snapshot, 950 rows)
- batch `?ids=` / single `/:id` / unknown→404 / empty→`[]` / archived-by-id / plain-list-unaffected / task clipped ≤241 — **9/9**.
- **Viewer-scoping holds**: a plain member (no assignments) sees 0 of 950 in the list and gets **404 / `[]`** for an unowned session id — no leak.
- Typecheck + web build + `npm run test:governance` (29/29) green.

## Next
Phase 2 (the actual perf win — poll stops shipping ~950 rows) and Phase 3 (list-view server pagination). See the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)