### PR TITLE
fix(slack): enable the app's Messages tab so DM'd questions/approvals can be answered (v0.294.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.294.1] — 2026-08-03
+### Fixed
+- **Slack DMs from the OS were unanswerable — the app manifest never enabled the Messages tab.** Slack
+  ships an app with **App Home → Messages Tab OFF**, which replaces the DM composer with a dead
+  *"Sending messages to this app has been turned off."* banner. Every inbound DM path the OS has arrives
+  as a `message.im`: answering a blocking `ask_human`, approving/denying a gate inline
+  (`decideApprovalFromChat`/`answerQuestionFromChat`), or chatting 1:1 with an agent. So a human could be
+  DM'd a question or an approval and physically could not reply — the scopes and event subscriptions were
+  right, the tab was the missing half. The bundled manifest now sets
+  `features.app_home.messages_tab_enabled: true` (+ `messages_tab_read_only_enabled: false`), and the
+  Settings → Integrations setup guide calls out the toggle for **already-installed apps**, which a
+  manifest change does not reach (`web/src/App.tsx`).
+- **The `notify` tool no longer reads as a way to ask someone a question.** Its description offered
+  itself for "progress/updates/**questions**" to another teammate, but `notify` is strictly one-way (an
+  Inbox `update` card + a DM, with no reply affordance on either) — so an agent that used it to ask for a
+  design decision and then held its work waited forever. It now states the one-way contract explicitly
+  and points at `ask_human` with `to`, which blocks and is answerable from the Inbox or the DM
+  (`src/memory/memory-mcp.ts`). Schema change — a live session picks it up after a relaunch.
+
 ## [0.294.0] — 2026-08-03
 ### Added
 - **By-id session fetch — `GET /api/sessions/:id` and `GET /api/sessions?ids=a,b,c`** (Sessions-pagination

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.294.0",
+  "version": "0.294.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.294.0",
+      "version": "0.294.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.294.0",
+  "version": "0.294.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -513,11 +513,15 @@ const TOOLS = [
     name: 'notify',
     description:
       'Notify a SPECIFIC teammate — the person who should know about something on this run, when that is ' +
-      'someone OTHER than the operator you already report to. By default your progress/updates/questions ' +
-      'go only to the human who owns this session; use `notify` to deliberately loop in someone else: ' +
+      'someone OTHER than the operator you already report to. By default your progress/updates go only to ' +
+      'the human who owns this session; use `notify` to deliberately loop in someone else: ' +
       '"@alex the deploy you asked about is live", "flagging this to the on-call admin". Pass `to` (their ' +
       'name or email) and a one-line `message`. They get an Inbox card + a DM. This does NOT block — keep ' +
-      'working. Use it purposefully for the RIGHT person, not to broadcast; there is no team-wide notify.',
+      'working. Use it purposefully for the RIGHT person, not to broadcast; there is no team-wide notify. ' +
+      'IMPORTANT — `notify` is ONE-WAY: the human CANNOT reply to it. If you need an ANSWER or a decision ' +
+      'from that person, use `ask_human` with `to` set to them instead: it blocks, it is answerable from ' +
+      'their Inbox or straight from the DM, and their reply comes back to you. Never post a question via ' +
+      '`notify` and then wait — nobody can respond, so you will wait forever.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6251,9 +6251,19 @@ function CopyBlock({ text, label = 'Copy' }: { text: string; label?: string }) {
 // bot — without them Slack only delivers explicit `app_mention`s, so a thread follow-up never arrives
 // and thread-continuity can't fire. `channels:read`/`groups:read` back channel-name lookup, `channels:join`
 // lets the bot auto-join a public channel to post, and `im:write` opens DMs.
+//
+// `app_home.messages_tab_enabled` is NOT optional decoration: Slack ships an app with its Messages tab
+// OFF, which renders the DM composer as a dead "Sending messages to this app has been turned off."
+// banner. Every inbound DM path the OS has — answering a blocking `ask_human`, approving/denying a gate
+// from the DM, chatting with an agent 1:1 — arrives as a `message.im`, so with the tab off the human
+// gets pinged and physically cannot reply. The scopes/events above are necessary but not sufficient;
+// this is the other half. (`messages_tab_read_only_enabled: false` is what actually shows the composer.)
 const SLACK_MANIFEST_OBJ = {
   display_information: { name: 'Agent OS' },
-  features: { bot_user: { display_name: 'Agent OS', always_online: true } },
+  features: {
+    bot_user: { display_name: 'Agent OS', always_online: true },
+    app_home: { home_tab_enabled: false, messages_tab_enabled: true, messages_tab_read_only_enabled: false },
+  },
   oauth_config: {
     scopes: {
       bot: [
@@ -6316,8 +6326,15 @@ function SlackSetupGuide() {
             </li>
             <li>The status badge above flips to <strong className="text-emerald-600">connected</strong> within a second or two. Then add a <strong>Slack message</strong> automation on the Automations page.</li>
           </ol>
+          <p className="rounded border border-amber-500/40 bg-amber-500/5 p-2">
+            <strong className="text-foreground">Already have the app installed?</strong> Check <strong>App Home → Show Tabs → Messages Tab</strong> is
+            ON, with <strong>"Allow users to send Slash commands and messages from the messages tab"</strong> ticked. Apps created before this
+            manifest have it OFF, and Slack then shows <em>"Sending messages to this app has been turned off"</em> under every DM — so a
+            question or approval the OS DMs you can be read but not answered. The toggle takes effect immediately; no reinstall needed.
+          </p>
           <p className="border-t pt-2">
-            The manifest already enables <strong>Socket Mode</strong> and subscribes to <code className="text-[11px]">app_mention</code> plus the
+            The manifest already enables <strong>Socket Mode</strong>, the <strong>Messages tab</strong> (so you can reply to a DM'd question or
+            approval right there) and subscribes to <code className="text-[11px]">app_mention</code> plus the
             <code className="text-[11px]"> message.*</code> events — so plain replies inside a thread reach the bot too (not just @mentions),
             which is what lets it keep a conversation going. Remember to <strong>invite the bot to the channel</strong> — <code className="text-[11px]">message.channels</code> only
             fires where it's a member. No request URL or public endpoint is needed; the server dials out to Slack.


### PR DESCRIPTION
Reported from the field: an agent DM'd a design question on Slack and the recipient had **no way to respond** — the DM showed *"Sending messages to this app has been turned off."*

Two independent causes, both fixed here.

### 1. The Slack app manifest never enabled the Messages tab
Slack ships an app with **App Home → Show Tabs → Messages Tab OFF**, which renders the DM composer as a dead banner. Every inbound DM path the OS has arrives as a `message.im`:

- answering a blocking `ask_human` (`answerQuestionFromChat`)
- approving/denying a gate straight from the DM (`decideApprovalFromChat`)
- chatting 1:1 with an agent (the `/agent` router)

The scopes (`im:write`, `im:history`) and events (`message.im`) were already in the manifest — necessary but not sufficient. `features.app_home.messages_tab_enabled: true` (+ `messages_tab_read_only_enabled: false`) is the other half.

A manifest change only reaches **newly created** apps, so the Settings → Integrations setup guide now carries a callout telling an existing workspace to flip the toggle by hand (immediate, no reinstall).

### 2. `notify` invited agents to ask questions it can't carry
Its description offered itself for "progress/updates/**questions**" to another teammate. But `notify` is strictly one-way — an Inbox `update` card plus a DM, neither of which has a reply affordance — so an agent that asked for a design decision through it and then held its PR waited forever. It now states the one-way contract and points at `ask_human` with `to`, which blocks and is answerable from the Inbox *or* the DM.

Schema change → a live session picks it up after a relaunch.

### Verified
`npm run typecheck`, `npm run build`, `cd web && npm run build`, `npm run test:governance` (all green).

### Still open (not in this PR)
A reply to a *one-way* notice (`notify`, session finished/crashed, task events) still has nowhere to go — with the Messages tab on it falls through to the intent router and spawns a **fresh** session rather than reaching the run that pinged you. Binding those DMs back to their session, the way `bindQuestionDm`/`bindApprovalDm` already do, is the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)