### PR TITLE
feat(chat): action→operator, freeform ask→concierge, answered in-thread via chat-mirror (v0.295.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.295.0] — 2026-08-03
+### Added
+- **Discord/Slack: `action` requests go to the governed operator, freeform questions to the concierge —
+  answered IN-THREAD via the chat-mirror ("poke the thread"), not a client poll.** The chat front door
+  (`routeUnmatched`) now runs the full intent layer: `ask` is answered inline (state/direct Claude) or,
+  when there's no fast answer, handed to the **concierge** (a Claude session with the OS tools); `action`
+  ("schedule the churn report every morning", "create a task to …") is handed to the **operator**
+  (`task_create` filed / `automation_propose` a draft an owner approves); `work` routes to the best-fit
+  teammate. The concierge/operator are spawned as THREAD-BOUND chat sessions and reply in-thread through
+  the same chat-mirror primitive every chat agent uses — reusing agent-os's existing comms path instead
+  of the bespoke web spawn-and-poll. Personas updated to call `slack_reply`/`discord_reply` when in a
+  thread. Previously `action`/unanswered-`ask` fell through to a generic work agent. `src/edge/automations.ts`,
+  `src/edge/concierge.ts`.
 ## [0.294.1] — 2026-08-03
 ### Fixed
 - **Slack DMs from the OS were unanswerable — the app manifest never enabled the Messages tab.** Slack

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.294.1",
+  "version": "0.295.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.294.1",
+      "version": "0.295.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.294.1",
+  "version": "0.295.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -20,6 +20,7 @@ import { CodingRuntimeId, isCodingRuntime, Task, TaskTimelineEntry } from '../ty
 import { chooseAgent, RouterCandidate } from './router';
 import { classifyIntent } from './intent';
 import { answerAsk } from './ask';
+import { ensureConcierge, ensureOperator, CONCIERGE_ID, OPERATOR_ID } from './concierge';
 
 // ── minimal cron (5 fields: minute hour day-of-month month day-of-week) ──────────
 // Supports: * , a-b , */n , a-b/n , lists. dow 0-7 (7 ≡ 0 = Sunday).
@@ -797,21 +798,39 @@ export class Automations {
       return { sessions };
     }
 
-    // 2.5) A question ABOUT the workspace is answered INLINE — fast, no session — the same way Cockpit
-    //      does (`answerAsk`: state lookup → direct Claude). So "how do automations work?" in Discord/Slack
-    //      comes back as a threaded reply in ~1–2s instead of spawning an agent. `action`/`work` — and an
-    //      `ask` with no inline answer available (no LLM configured) — fall through to routing below.
-    if (this.os.settings.autoRouteEnabled() && classifyIntent(opts.text).intent === 'ask') {
-      const me = opts.runAs ? this.os.team.getMember(opts.runAs) : undefined;
-      const inline = await answerAsk(this.os, this.tm, this, me, opts.text);
-      if (inline) {
-        this.os.audit.append({ ts: Date.now(), runId: opts.key, tenant: this.os.tenant, principal: opts.runAs ? `member:${opts.runAs}` : 'chat', type: 'chat.answered', data: { source: inline.source, chars: inline.answer.length, runAs: opts.runAs ?? null } });
-        return { sessions, reply: inline.answer };
-      }
-    }
-
-    // 3) Auto-route (when enabled). Fails safe: confident → route; uncertain → ask; nothing → help list.
+    // 3) Auto-route (when enabled) — the intent layer, mirrored from Cockpit. For `ask`/`action` we hand
+    //    off to the read-only concierge / action operator as THREAD-BOUND chat sessions: they do the work
+    //    and reply IN-THREAD via the same chat-mirror primitive every chat agent uses (the "poke the
+    //    thread"), not a bespoke client poll. `work` routes to the best-fit teammate. Fails safe.
     if (this.os.settings.autoRouteEnabled()) {
+      const intent = classifyIntent(opts.text).intent;
+
+      if (intent === 'ask') {
+        // A question ABOUT the workspace: answer INLINE first (fast, no session) — state lookup → direct
+        // Claude. Only when there's no fast inline answer do we spawn the concierge to answer in-thread.
+        const me = opts.runAs ? this.os.team.getMember(opts.runAs) : undefined;
+        const inline = await answerAsk(this.os, this.tm, this, me, opts.text);
+        if (inline) {
+          this.os.audit.append({ ts: Date.now(), runId: opts.key, tenant: this.os.tenant, principal: opts.runAs ? `member:${opts.runAs}` : 'chat', type: 'chat.answered', data: { source: inline.source, chars: inline.answer.length, runAs: opts.runAs ?? null } });
+          return { sessions, reply: inline.answer };
+        }
+        ensureConcierge(this.os);
+        if (this.os.agents.get(CONCIERGE_ID)?.dir) {
+          spawn(CONCIERGE_ID, opts.extra, { by: 'auto' }, opts.text, opts.runAs);
+          return { sessions };
+        }
+        // Concierge unavailable → fall through to work routing (an agent can still answer conversationally).
+      } else if (intent === 'action') {
+        // "schedule … / create a task …" → the governed operator: task_create (filed) / automation_propose
+        // (a draft an owner approves). Bound to the thread; it confirms in-thread. Falls back to routing.
+        ensureOperator(this.os);
+        if (this.os.agents.get(OPERATOR_ID)?.dir) {
+          spawn(OPERATOR_ID, opts.extra, { by: 'auto' }, opts.text, opts.runAs);
+          return { sessions };
+        }
+      }
+
+      // `work` (or a concierge/operator that couldn't be provisioned) → route to the best-fit teammate.
       const decision = await chooseAgent(this.os, opts.text);
       if (decision.kind === 'route') {
         spawn(decision.agentId, opts.extra, { by: decision.method === 'llm' ? 'auto-llm' : 'auto', score: decision.score, runnerUp: decision.runnerUp?.agentId }, opts.text, opts.runAs);

--- a/src/edge/concierge.ts
+++ b/src/edge/concierge.ts
@@ -59,6 +59,8 @@ works. Answer it, concisely, grounded in **real state**.
 4. You are **read-only by nature** here: answer the question. Do NOT create tasks, schedule automations,
    or change anything — if the member wants an action taken, tell them to ask for it directly (that's a
    different flow). Do not call \`report\`/\`ask\`; your reply text IS the answer.
+5. **If a \`slack_reply\`/\`discord_reply\` tool is available you're answering in a chat thread — call it
+   with your final answer** so it posts back to the thread. (Otherwise your reply text is read directly.)
 
 You act on the member's behalf and only read workspace state — nothing you do needs their connectors.`;
 
@@ -97,7 +99,8 @@ using the governed tools, then confirm in one line what happened. You act on the
   is genuinely ambiguous (which agent should run it, and you can't tell), pick the closest fit and say so
   in your confirmation rather than stalling.
 - Your reply text IS the confirmation shown inline — no preamble, no sign-off, lead with the "✓" line.
-  Do not call \`report\`/\`ask\`.`;
+  Do not call \`report\`/\`ask\`. **If a \`slack_reply\`/\`discord_reply\` tool is available you're in a chat
+  thread — call it with the "✓ …" confirmation** so it posts back to the thread.`;
 
 /** Ensure the read-only concierge exists. */
 export function ensureConcierge(os: AgentOS): void {


### PR DESCRIPTION
Uses the existing agent-comms primitive (the chat-mirror "poke the thread") for the Cockpit concierge/operator in Slack/Discord, instead of the bespoke web spawn-and-poll — per the design discussion.

## What changed
The chat front door (`routeUnmatched`, behind `fireSlack`/`fireDiscord`/`fireClickup`) now runs the **full intent layer**:

| Intent | Behavior in Discord/Slack |
|---|---|
| **ask** | answered **inline** (state lookup → direct Claude); if there's no fast inline answer, the **concierge** (a Claude session with the OS tools) answers **in-thread** |
| **action** ("schedule the churn report every morning", "create a task to…") | the governed **operator** does it — `task_create` (filed) / `automation_propose` (a draft an owner approves) — and confirms **in-thread** |
| **work** | routes to the best-fit teammate (unchanged) |

The concierge/operator are spawned as **thread-bound chat sessions** and reply through the **same chat-mirror primitive every chat agent already uses** — the "poke the thread." No new polling mechanism; it reuses agent-os's existing comms path. Previously `action` and an unanswered `ask` just fell through to a generic work agent.

Personas updated to call `slack_reply`/`discord_reply` when a reply tool is present (i.e. they're in a thread), so the in-thread confirmation is reliable.

## Verification
- `typecheck` + `build` clean; `test:governance` → **159/159** + tier-A **18/18** + capability **18/18**
- The engines are already verified end-to-end earlier: `answerAsk` (state/LLM), the operator creating a task via `task_create`, and `chooseAgent` routing. This wires them into the chat front door via the existing thread-bound spawn.

## Testing note
I can't inject a Discord/Slack message myself (the bot ignores its own posts; I can't impersonate a user). After deploy I'll watch the live audit while you send a few Discord messages to the instapods bot — the one part only a real thread exercises is the operator/concierge's `discord_reply` post-back.

`src/edge/automations.ts`, `src/edge/concierge.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)