### PR TITLE
feat(sessions): summary poll — stop shipping the full list on non-list routes (v0.296.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.296.0] — 2026-08-03
+### Changed
+- **The console's 1.5 s poll stops shipping the full ~950-row session list on most routes**
+  (Sessions-pagination Phase 2; plan in `docs/sessions-pagination-plan.md`). A new
+  **`GET /api/sessions/summary`** returns only what the always-on surfaces need — every LIVE session +
+  the viewer's most-recent **ended** tail (capped 60) + a global **`doneToday`** count — built from
+  `aliveNames()` + a bounded id query + `listSessions(ids)`, all viewer-scoped, **never rebuilding the
+  whole table**. The global poll now switches source by route: the Sessions & Chat *list* views still
+  fetch the full `/api/sessions` (they render it), but **every other route polls the summary** — so
+  navigating the Inbox / Tasks / Overview / Agents / Settings etc. no longer pulls ~950 rows every tick.
+  Measured on a live instawp snapshot (950 rows): the poll payload drops **950 → ~68 rows** off the list
+  routes, and the summary builds **~23–33 % faster** than the full list even before the row-count win.
+  `openNotification` falls back to the Phase-1 by-id fetch for an older session not in the summary;
+  Overview's "Done today" reads the summary count (it's owner-only, so a global count is correct). Badge
+  and per-session bells are unaffected (badge derives from `messages`; bells from `blocked`, which is a
+  subset of live and always present). `src/terminal.ts`, `src/server.ts`, `web/src/lib/api.ts`,
+  `web/src/App.tsx`. Verified with an in-process endpoint test (bounded / viewer-scoped / 304 / doneToday)
+  and a headless-browser smoke test (inbox polls summary with zero full-list calls; the sessions route
+  switches to the full list and renders all 950; Overview KPI renders; no console errors).
 ## [0.295.0] — 2026-08-03
 ### Added
 - **Discord/Slack: `action` requests go to the governed operator, freeform questions to the concierge —

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.295.0",
+  "version": "0.296.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.295.0",
+      "version": "0.296.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.295.0",
+  "version": "0.296.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2528,6 +2528,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       : url.searchParams.get('archived') === '1' ? tm.listArchivedSessions(me, LIST_CLIP) : tm.listSessions(me, LIST_CLIP);
     return sendJson(res, 200, rows.map((s) => (s.task ? { ...s, task: clipText(s.task, LIST_CLIP) } : s)));
   }
+  // The cheap poll payload (Sessions-pagination Phase 2) — live rows + the viewer's recent-ended tail +
+  // a done-today count, instead of the full ~950-row list. The console's 1.5 s poll fetches THIS; the
+  // route-gated full-list views (Sessions, Chat) fetch `/api/sessions` themselves. MUST precede the
+  // `/:id` regex below, or `summary` matches as a session id. ETag/304 rides the shared sendJson.
+  if (method === 'GET' && p === '/api/sessions/summary') {
+    const { rows, doneToday } = tm.sessionsSummary(me, LIST_CLIP);
+    return sendJson(res, 200, { rows: rows.map((s) => (s.task ? { ...s, task: clipText(s.task, LIST_CLIP) } : s)), doneToday });
+  }
   // Single session by id (Sessions-pagination Phase 1) — the by-id fetch the console lacked (every by-id
   // read used to come from the full list array). 404 when the caller can't see it (canViewRow → no row),
   // which doubles as the not-found response — no existence leak. End-anchored so it never shadows the

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -771,6 +771,41 @@ export class TerminalManager {
       return visible.map((r) => ({ ...toSession(r), spawnedByLabel: this.spawnedByLabel(r.spawned_by, r.run_as), sourceKind: this.sourceKind(r.spawned_by), runAsLabel: this.runAsLabel(r.run_as), ratedByLabel: this.runAsLabel(r.rated_by) }));
     });
   }
+  /**
+   * The cheap poll payload (Sessions-pagination Phase 2). Replaces the full ~950-row list the console's
+   * 1.5 s poll used to ship: returns only the rows the ALWAYS-ON surfaces need — every LIVE session
+   * (running, or with an attachable pane) plus the viewer's most-recent ENDED sessions (bounded, for the
+   * sidebar switcher) — with the same derived fields the list carries, all viewer-scoped. Plus
+   * `doneToday`, a global done-since-server-midnight count: the one always-on aggregate a live+recent set
+   * can't derive, consumed only by the owner-only Overview (so a global count is correct — no per-member
+   * scoping). Bounded by construction (≈ live-count + cap), so it never rebuilds the whole table.
+   */
+  sessionsSummary(viewer?: Member, taskClip?: number): { rows: Session[]; doneToday: number } {
+    const ENDED_CAP = 60;
+    // Live = every running row + every row whose tmux pane is alive (a `done` interactive session can keep
+    // an attachable pane). aliveNames() is null on the launcher backend / a failed poll → status alone
+    // (we never claim liveness we couldn't verify).
+    const alive = this.backend.aliveNames();
+    const aliveList = alive ? [...alive] : [];
+    const liveIds = this.db
+      .prepare(`SELECT id FROM term_sessions WHERE archived_at IS NULL AND (status = 'running'${aliveList.length ? ` OR tmux IN (${aliveList.map(() => '?').join(',')})` : ''})`)
+      .all<{ id: string }>(...aliveList)
+      .map((r) => r.id);
+    // The viewer's most-recent ended sessions — backs the sidebar switcher's "N ended" list. Scoped to the
+    // viewer's OWN runs (spawned_by / run_as); an internal caller (no viewer) gets the global recent tail.
+    const endedIds = (viewer
+      ? this.db.prepare(`SELECT id FROM term_sessions WHERE archived_at IS NULL AND status != 'running' AND (spawned_by = ? OR run_as = ?) ORDER BY COALESCE(updated_at, created_at) DESC LIMIT ?`).all<{ id: string }>(viewer.id, viewer.id, ENDED_CAP)
+      : this.db.prepare(`SELECT id FROM term_sessions WHERE archived_at IS NULL AND status != 'running' ORDER BY COALESCE(updated_at, created_at) DESC LIMIT ?`).all<{ id: string }>(ENDED_CAP)
+    ).map((r) => r.id);
+    const ids = [...new Set([...liveIds, ...endedIds])];
+    const rows = ids.length ? this.listSessions(viewer, taskClip, ids) : [];
+    const t0 = new Date();
+    t0.setHours(0, 0, 0, 0);
+    const doneToday = this.db
+      .prepare(`SELECT COUNT(*) AS c FROM term_sessions WHERE archived_at IS NULL AND status = 'done' AND updated_at >= ?`)
+      .get<{ c: number }>(t0.getTime())!.c;
+    return { rows, doneToday };
+  }
   /** Soft-archive a session — hide it from the list, keep the row + transcript (reversible). */
   archiveSession(id: string, now = Date.now()): boolean {
     return this.db.prepare('UPDATE term_sessions SET archived_at = ? WHERE id = ? AND archived_at IS NULL').run(now, id).changes > 0;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -972,6 +972,10 @@ const DEFAULT_PINNED_NAV: NavKey[] = ['cockpit', 'goals', 'tasks', 'artifacts']
 function Console({ me }: { me: Member }) {
   const [state, setState] = useState<StateResp | null>(null)
   const [sessions, setSessions] = useState<Session[]>([])
+  // Done-since-server-midnight count from the Phase-2 summary poll — the one Overview KPI a live+recent
+  // set can't derive (Overview is owner-only, so a global count is correct). Only refreshed on the routes
+  // that poll the summary (not the full-list Sessions/Chat views), which is fine — Overview is one of them.
+  const [doneToday, setDoneToday] = useState(0)
   // Tabs the user "closed" from the terminal switcher: hidden from the strip, but the session keeps
   // running — reopen it from All sessions. Persisted so a refresh doesn't resurrect closed tabs.
   const [hiddenTabs, setHiddenTabs] = useState<Set<string>>(() => {
@@ -1067,12 +1071,26 @@ function Console({ me }: { me: Member }) {
     //    still flips it — the badge/bells never go stale.
     let sessEtag: string | null = null
     let msgEtag: string | null = null
+    // The sessions half switches SOURCE by route (Sessions-pagination Phase 2): the Sessions + Chat list
+    // views need the FULL list, so they poll `/api/sessions`; every other route polls the cheap
+    // `/api/sessions/summary` — live rows + the viewer's recent-ended tail + a `doneToday` count — so it
+    // stops pulling ~950 rows on the routes that don't render the list (most of them). `route` is in the
+    // deps below, so navigating re-runs this effect with the right endpoint, a fresh ETag, and an immediate
+    // poll (no stale-endpoint 304, no flash of the wrong data).
+    const needFull = route === 'sessions' || route === 'chat'
     const poll = async () => {
-      const [s, m] = await Promise.allSettled([api.sessionsFeed(sessEtag), api.messagesFeed(msgEtag)])
+      const [s, m] = await Promise.allSettled([
+        needFull ? api.sessionsFeed(sessEtag) : api.sessionsSummaryFeed(sessEtag),
+        api.messagesFeed(msgEtag),
+      ])
       if (!alive) return
       if (s.status === 'fulfilled') {
         sessEtag = s.value.etag
-        if ('data' in s.value && Array.isArray(s.value.data)) setSessions(s.value.data)
+        if ('data' in s.value) {
+          const data = s.value.data
+          if (needFull) { if (Array.isArray(data)) setSessions(data) }
+          else if (!Array.isArray(data)) { setSessions(data.rows); setDoneToday(data.doneToday ?? 0) }
+        }
       }
       if (m.status === 'fulfilled') {
         msgEtag = m.value.etag
@@ -1094,7 +1112,7 @@ function Console({ me }: { me: Member }) {
       document.removeEventListener('visibilitychange', wake)
       window.removeEventListener('focus', wake)
     }
-  }, [])
+  }, [route])
 
   // Browser-tab badge: a 🔔 + the bell's unread count (waiting + completions + crashes + approvals +
   // questions, filtered by this member's prefs), so the tab nags even when the console isn't focused.
@@ -1203,11 +1221,18 @@ function Console({ me }: { me: Member }) {
   }
   // Deep-link from an inbox 'artifact' card into the gallery, pre-opening that artifact's preview.
   const openArtifact = (id: string) => nav('artifacts', id)
+  // Reload the sessions array from the endpoint the CURRENT route uses (Phase 2): the full list on the
+  // Sessions/Chat views, else the cheap summary. Mutation handlers call this so a manual refresh matches
+  // whatever the poll feeds — never re-inflating a summary route with the full ~950-row list. Returns the
+  // rows it set so a caller can search them (e.g. for the next live tab to hop to).
+  const reloadSessions = async (): Promise<Session[]> => {
+    if (route === 'sessions' || route === 'chat') { const s = await api.sessions(); setSessions(s); return s }
+    const r = await api.sessionsSummary(); setSessions(r.rows); setDoneToday(r.doneToday); return r.rows
+  }
   const stopSession = async (id: string) => {
     const stopped = sessions.find((s) => s.id === id)
     await api.stopSession(id)
-    const fresh = await api.sessions()
-    setSessions(fresh)
+    const fresh = await reloadSessions()
     // If you stopped the session you're currently viewing, don't sit on a dead terminal:
     // hop to the next open session, or fall back to the all-sessions list when none remain.
     if (stopped && selected?.tmux === stopped.tmux) {
@@ -1220,7 +1245,7 @@ function Console({ me }: { me: Member }) {
   // Human verdict on a finished run — feeds the agent maturity score. Clicking the active thumb clears it.
   const rateSession = async (id: string, rating: 'up' | 'down' | null) => {
     await api.rateSession(id, rating)
-    setSessions(await api.sessions())
+    await reloadSessions()
   }
   // Give a session a human-chosen title (from the header pencil or a double-click on its tab). Optimistic
   // so the header/tab relabel instantly; the poll reconciles with the server's cleaned value.
@@ -1237,19 +1262,19 @@ function Console({ me }: { me: Member }) {
     setSessions((prev) => prev.map((s) => (s.id === id ? { ...s, runAs: to, runAsLabel: members.find((m) => m.id === to)?.name ?? to } : s)))
     const r = await api.transferSession(id, to)
     if (r.error) alert(r.error)
-    setSessions(await api.sessions())
+    await reloadSessions()
   }
   const deleteSession = async (id: string, tmux: string) => {
     if (!confirm('Delete this session? Its inbox messages and transcript files are removed; the audit log is kept.')) return
     await api.deleteSession(id)
     if (selected?.tmux === tmux) nav('sessions')
-    setSessions(await api.sessions())
+    await reloadSessions()
   }
   // Bulk variants for the Sessions list — stop/delete many in one go, single confirm, one refresh.
   const stopSessions = async (ids: string[]) => {
     if (ids.length === 0) return
     await Promise.all(ids.map((id) => api.stopSession(id)))
-    setSessions(await api.sessions())
+    await reloadSessions()
   }
   const deleteSessions = async (ids: string[]) => {
     if (ids.length === 0) return
@@ -1258,14 +1283,14 @@ function Console({ me }: { me: Member }) {
     const tmuxes = new Set(sessions.filter((s) => ids.includes(s.id)).map((s) => s.tmux))
     await Promise.all(ids.map((id) => api.deleteSession(id)))
     if (selected && tmuxes.has(selected.tmux)) nav('sessions')
-    setSessions(await api.sessions())
+    await reloadSessions()
   }
   // Spawn from an agent card on the Agents page; resolves to an error string, or null on success.
   const runAgent = async (agentId: string, task: string): Promise<string | null> => {
     if (!task.trim()) return 'enter a task'
     const r = await api.run(agentId, task)
     if (r.error) return r.error
-    setSessions(await api.sessions())
+    await reloadSessions()
     openTerminal(r.tmux, agentId + ' · ' + r.id)
     return null
   }
@@ -1273,7 +1298,7 @@ function Console({ me }: { me: Member }) {
   // Click a bell item / toast → go to the thing it's about. A session-scoped kind (waiting/finished/
   // crashed) opens that session's terminal (which clears its waiting bell); an approval/question opens
   // the Inbox to act on it. Informational cards (completed/crashed) are marked read on open.
-  const openNotification = (m: Msg) => {
+  const openNotification = async (m: Msg) => {
     if (!m.read && m.type === 'completed') {
       setMessages((ms) => ms.map((x) => (x.id === m.id ? { ...x, read: true } : x)))
       void api.markRead(m.id)
@@ -1282,8 +1307,15 @@ function Console({ me }: { me: Member }) {
     const ins = insightTarget(m)
     if (ins) { nav(ins.route, ins.detail); return }
     const kind = notifyKindOf(m)
-    const sess = sessions.find((s) => s.id === m.sessionId)
-    if ((kind === 'waiting' || kind === 'completed' || kind === 'crashed') && sess) openTerminal(sess.tmux)
+    const opensTerminal = kind === 'waiting' || kind === 'completed' || kind === 'crashed'
+    let sess = sessions.find((s) => s.id === m.sessionId)
+    // The summary poll only carries live + recent-ended rows (Phase 2), so a completed/crashed card for an
+    // OLDER session may not be in `sessions` — resolve it by id (Phase 1) before falling back to the Inbox.
+    if (!sess && opensTerminal && m.sessionId) {
+      const r = await api.session(m.sessionId).catch(() => null)
+      if (r && !('error' in r)) sess = r
+    }
+    if (opensTerminal && sess) openTerminal(sess.tmux)
     else nav('inbox')
   }
   const markAllNotificationsRead = async () => {
@@ -1506,7 +1538,7 @@ function Console({ me }: { me: Member }) {
           {route === 'agents' && <AgentsPage me={me} agents={state?.agents ?? []} selected={detail} onSelect={(id) => nav('agents', id)} run={runAgent} onEdit={openAgent} onNew={() => nav('new-agent')} onDelete={deleteAgent} onDuplicate={duplicateAgent} onRescan={rescanAgents} onImport={importAgent} onRefresh={refreshState} nav={nav} />}
           {route === 'new-agent' && <NewAgentPage me={me} onCreated={async (id) => { await refreshState(); nav('agents', id) }} />}
           {route === 'sessions' && <SessionsPage me={me} members={members} sessions={sessions} waiting={waiting} selected={selected} hiddenTabs={hiddenTabs} metrics={state?.sessionMetrics ?? 'both'} onOpen={openTerminal} onCloseTab={closeTab} onActivity={clearAlerts} onSpawn={() => nav('agents')} onStop={stopSession} onDelete={deleteSession} onRate={rateSession} onRename={renameSession} onTransfer={transferSession} onBulkStop={stopSessions} onBulkDelete={deleteSessions} urlQuery={urlQuery} onFiltersChange={setUrlQuery} />}
-          {route === 'overview' && me.role === 'owner' && <OverviewPage me={me} sessions={sessions} members={members} agents={state?.agents ?? []} maturity={maturity} serverTz={state?.serverTz} onOpen={openTerminal} nav={nav} />}
+          {route === 'overview' && me.role === 'owner' && <OverviewPage me={me} sessions={sessions} doneToday={doneToday} members={members} agents={state?.agents ?? []} maturity={maturity} serverTz={state?.serverTz} onOpen={openTerminal} nav={nav} />}
           {route === 'inbox' && <InboxPage messages={messages} me={me} members={members} onOpen={openTerminal} onOpenArtifact={openArtifact} onOpenTask={(id) => nav('tasks', id)} onOpenGoal={(id) => nav('goals', id)} />}
           {route === 'cockpit' && <CockpitPage onOpenChat={(id) => nav('chat', id)} onOpenTerminal={openTerminal} nav={nav} />}
           {route === 'chat' && <ChatPage agents={state?.agents ?? []} sessions={sessions} messages={messages} selected={detail} onSelect={(id) => nav('chat', id)} onOpenTerminal={openTerminal} />}
@@ -7539,16 +7571,17 @@ const fromDateInput = (v: string): number | null => (v ? new Date(v + 'T00:00:00
 /** Owner-only home. What the fleet is doing right now (live sessions + who's accountable for each) and
  *  which agents are earning trust. Pure-props: it reads the sessions/messages the Console already polls
  *  and the fleet maturity map, so it live-updates on the 1.5s tick with no fetch of its own. */
-function OverviewPage({ me, sessions, members, agents, maturity, serverTz, onOpen, nav }: {
-  me: Member; sessions: Session[]; members: Member[]; agents: AgentInfo[]
+function OverviewPage({ me, sessions, doneToday, members, agents, maturity, serverTz, onOpen, nav }: {
+  me: Member; sessions: Session[]; doneToday: number; members: Member[]; agents: AgentInfo[]
   maturity: Record<string, AgentStats>; serverTz?: string; onOpen: (tmux: string, title: string) => void; nav: (r: Route, detail?: string) => void
 }) {
   // A run is "blocked" when it's waiting on a human (a pending ask/approval). Read straight off the
   // server-authoritative `s.blocked` flag now, rather than re-deriving it from the message feed.
   const blockedRuns = useMemo(() => new Set(sessions.filter((s) => s.blocked).map((s) => s.id)), [sessions])
   const live = useMemo(() => sessions.filter(isLive).sort((a, b) => a.createdAt - b.createdAt), [sessions])
-  const t0 = useMemo(() => { const d = new Date(); d.setHours(0, 0, 0, 0); return d.getTime() }, [])
-  const doneToday = sessions.filter((s) => s.status === 'done' && s.updatedAt >= t0).length
+  // `doneToday` is a global done-since-server-midnight count from the summary poll (Phase 2) — the live+
+  // recent-ended `sessions` array can't derive it. Overview is owner-only, so a global (unscoped) count is
+  // correct here.
   // Agents "online" = at least one live session; count sessions per agent for the chip.
   const liveByAgent = useMemo(() => { const m = new Map<string, number>(); for (const s of live) m.set(s.agent, (m.get(s.agent) ?? 0) + 1); return m }, [live])
   const onlineAgents = useMemo(() => agents.filter((a) => liveByAgent.has(a.id)), [agents, liveByAgent])

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1306,6 +1306,9 @@ async function callFeed<T>(path: string, etag: string | null): Promise<FeedResul
   return { data: (await res.json()) as T, etag: next }
 }
 
+/** The Phase-2 summary poll payload: the always-on rows (live + the viewer's recent-ended tail) plus a
+ *  global done-since-server-midnight count (the one always-on aggregate a live-only set can't derive). */
+export interface SessionsSummary { rows: Session[]; doneToday: number }
 export const api = {
   /** Current member, or null if not authenticated (401). Drives the login gate. */
   me: async (): Promise<Member | null> => {
@@ -1338,6 +1341,12 @@ export const api = {
   /** Conditional variant of the live sessions feed for the global 1.5 s poll — resolves `notModified` on a
    *  304 so idle tabs skip the re-parse + re-render. Non-feed callers keep `sessions()` (always full body). */
   sessionsFeed: (etag: string | null) => callFeed<Session[]>('/api/sessions', etag),
+  /** The cheap poll payload (Sessions-pagination Phase 2): only the LIVE rows + the viewer's recent-ended
+   *  tail + a global `doneToday` count, instead of the full ~950-row list. The global poll fetches this on
+   *  every route EXCEPT the sessions/chat list views (which need the full list). */
+  sessionsSummary: () => call<SessionsSummary>('GET', '/api/sessions/summary'),
+  /** Conditional variant of `sessionsSummary` for the global poll — 304 on no change. */
+  sessionsSummaryFeed: (etag: string | null) => callFeed<SessionsSummary>('/api/sessions/summary', etag),
   unarchiveSession: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/unarchive`),
   sessionTidyPreview: () => call<{ ok: boolean; plan?: SessionTidyPlan; error?: string }>('GET', '/api/insights/sessions/tidy'),
   sessionTidyApply: () => call<{ ok: boolean; archived?: number; error?: string }>('POST', '/api/insights/sessions/tidy'),


### PR DESCRIPTION
**Sessions-pagination Phase 2.** Plan: `docs/sessions-pagination-plan.md`. Builds on Phase 1 (#539).

## Problem
The console's 1.5 s poll shipped **all ~950 sessions every tick, on every route** — even Inbox/Tasks/Overview/Settings, which never render the list. #530/#532 made unchanged ticks cheap on the wire, but the server still rebuilt 950 rows each tick and any change re-shipped them.

## Change
New **`GET /api/sessions/summary`** returns only the always-on rows — every **LIVE** session + the viewer's most-recent **ended** tail (capped 60) + a global **`doneToday`** count — built from `aliveNames()` + a bounded id query + `listSessions(ids)`, viewer-scoped, **never rebuilding the whole table**.

The global poll now **switches source by route**: the Sessions & Chat *list* views still fetch full `/api/sessions` (they render it); **every other route polls the summary**. So most navigation stops pulling ~950 rows per tick.

Kept correct via the reader map (see plan):
- **Badge** derives from `messages` (untouched); **per-session bells** from `blocked` (⊂ live, always in the summary).
- **`openNotification`** falls back to the Phase-1 by-id fetch for an older session not in the summary.
- **Overview** `doneToday` reads the summary count (Overview is owner-only → a global count is correct).
- **Mutation handlers** reload via the route-appropriate endpoint (`reloadSessions`), never re-inflating a summary route with the full list.
- `SessionsPage`/`ChatPage`/`OverviewPage` internals **unchanged** — they still receive a `sessions` array, sourced full on their own routes.

## Measured (live instawp snapshot, 950 rows)
- Poll payload off the list routes: **950 → ~68 rows** (all live + 60 recent-ended, viewer-scoped).
- Summary server build **~23–33 % faster** than the full `listSessions`, before the row-count/​wire win.

## Verification
- **In-process endpoint test**: shape, bounded (68 vs 950), recent-ended cap, `doneToday` matches a direct count, **304** on unchanged tick, **viewer-scoped** (a member sees 0 unowned rows).
- **Headless-browser smoke** (real 950-row DB): inbox route polls `/api/sessions/summary` with **zero** full-list calls; the sessions route switches to the full list and renders **"950 sessions"**; Overview polls summary + renders "Done today"; **no console/page errors**.
- Typecheck + web build + `npm run test:governance` (29/29) green.

## Next
Phase 3 — server-side pagination + filter/sort/search on `/api/sessions` so the *list view itself* scales (it still fetches the full list when open). See the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)