### PR TITLE
feat(system): flag stale native deps, not just missing ones (v0.299.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.299.0] — 2026-08-04
+### Added
+- **Settings → System now catches a dependency that is present but STALE, not just missing.** Found the
+  hard way: a tenant's box sat on `claude` 2.1.216 for weeks, so `/model` couldn't list Opus 5 and the
+  `opus` family alias resolved to 4.8 — while the console showed a green *"All required dependencies are
+  installed."* the whole time. Presence was the only thing `checkDeps()` ever asked, and the `claude` dep
+  deliberately carries no package-manager `pkg`, so it sat outside the install path entirely.
+  Deps may now name an `npmPkg`; the new `checkDepUpdates()` (`src/edge/deps.ts`) asks the npm registry
+  for `latest` via the abbreviated `/latest` endpoint (global `fetch`, no `npm` shell-out, no new dep),
+  caches for an hour, and flags a behind-version install. `checkDeps()` stays sync + network-free, so
+  freshness is a layer on top rather than a slower probe: `GET /api/deps` (`?force=1` re-asks) annotates
+  the report, and a stale row goes amber with the published version, an owner-only **Update** button, and
+  a note that live sessions keep their binary until they restart. `POST /api/deps/update` runs
+  `npm install -g <pkg>@latest` — owner-gated, audited `system.deps.updated`, never via sudo (a
+  permissions failure surfaces the manual command instead of leaving root-owned files in the prefix), and
+  it prefers the `npm` beside the resolved binary so an nvm box can't install into a different prefix
+  than the one it runs from. CLI parity: `agent-os deps` shows `↑ … → v2.1.220 available`, and
+  `agent-os deps update <bin>` applies it.
+
+### Fixed
+- **A `claude` reachable only off PATH no longer reports as MISSING.** `deps.ts` resolved binaries with a
+  bare `command -v`, but `claude-cli.ts` walks `$CLAUDE_BIN` → PATH → `~/.local/bin/claude` because a
+  launchd/systemd parent ships a minimal PATH — so on such a box the panel claimed the runtime was absent
+  while sessions launched fine. Both now share `claudeBinCandidates()` and honour the same order
+  (`$CLAUDE_BIN` first — resolving PATH first would report the version of a binary sessions never run).
+  A dep found only via a fallback is version-probed at its resolved path and marked `offPath` in the UI.
+- New `scripts/deps-freshness-test.cjs` (38 assertions: version comparison, resolution order, the
+  off-PATH case, stale detection, the route authz — owner-only update, non-npm deps refused before any
+  shell-out — and a full update round-trip against a stubbed `npm`, which also pins the sibling-npm
+  preference) wired into `npm run test:governance`.
+
 ## [0.298.0] — 2026-08-04
 ### Added
 - **Chat front door: greetings get a friendly reply, and the help/`/name` roster drops System agents.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.298.0",
+  "version": "0.299.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,8 +27,9 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs",
+    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/deps-freshness-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
+    "test:deps": "node scripts/deps-freshness-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",
     "test:reaper": "node scripts/idle-reaper-test.cjs",
     "test:policy-tier-a": "node scripts/tier-a-policy-test.cjs",

--- a/scripts/deps-freshness-test.cjs
+++ b/scripts/deps-freshness-test.cjs
@@ -62,16 +62,21 @@ const { createHttpServer } = require(path.join(ROOT, 'dist/server.js'));
   assert(stripped.path === FAKE, 'path is the fallback location', stripped.path);
 
   console.log('\n\x1b[1m4) freshness marks a present-but-stale dep\x1b[0m');
-  // Seed the module's registry cache so the assertion is deterministic and offline.
   const seeded = await deps.checkDepUpdates(base).catch(() => null);
   const net = seeded && seeded.deps.find((d) => d.bin === 'claude');
+  // Whatever the registry currently publishes — never hardcode it. A new claude-code lands every few
+  // days, and pinning a literal here makes section 6's "upgraded" stub stale the moment one ships.
+  const LATEST = net && net.latest;
   if (!net || (!net.latest && net.updateError)) {
     console.log('  \x1b[33m·\x1b[0m registry unreachable — skipping the live-lookup assertions');
   } else {
     assert(!!net.latest, 'registry answered with a latest version', net.updateError);
     assert(net.updateAvailable === true, 'v2.1.100 vs latest → updateAvailable', `latest=${net.latest}`);
     assert(seeded.outdated.includes('claude'), 'listed in report.outdated');
-    assert(seeded.ok === true, 'report.ok stays true — stale is not missing');
+    // `ok` means "every required dep is PRESENT" and must be untouched by staleness. Compare against the
+    // pre-freshness report rather than asserting `true` outright — a CI runner without ttyd is legitimately
+    // not-ok, and hardcoding `true` tests the runner's box instead of the property.
+    assert(seeded.ok === base.ok, 'report.ok is unchanged by freshness — stale is not missing', `base=${base.ok} after=${seeded.ok}`);
     assert(seeded.updatesCheckedAt > 0, 'stamps updatesCheckedAt');
     const tmux = seeded.deps.find((d) => d.bin === 'tmux');
     assert(tmux.latest === undefined && tmux.updateAvailable === undefined, 'a non-npm dep is never version-checked');
@@ -121,24 +126,29 @@ const { createHttpServer } = require(path.join(ROOT, 'dist/server.js'));
   assert((tmuxBody.steps || []).length === 0, 'refusal runs no install steps');
 
   console.log('\n\x1b[1m6) update applies + re-checks (stubbed npm — no real global install)\x1b[0m');
-  // A fake `npm` sitting BESIDE the fake claude, which "upgrades" it by rewriting the version it prints.
-  // This also pins the sibling-npm preference: on an nvm box the PATH npm may belong to a different node
-  // prefix, and installing there would leave the binary we actually run untouched.
-  const stubNpm = path.join(BIN, 'npm');
-  fs.writeFileSync(stubNpm, `#!/bin/sh\nprintf '#!/bin/sh\\necho "2.1.220 (Claude Code)"\\n' > ${FAKE}\nchmod +x ${FAKE}\necho "stub npm ran: $@"\n`);
-  fs.chmodSync(stubNpm, 0o755);
+  if (!LATEST) {
+    console.log('  \x1b[33m·\x1b[0m registry unreachable — skipping the update round-trip');
+  } else {
+    // A fake `npm` sitting BESIDE the fake claude, which "upgrades" it by rewriting the version it prints
+    // to whatever the registry actually publishes. This also pins the sibling-npm preference: on an nvm
+    // box the PATH npm may belong to a different node prefix, and installing there would leave the binary
+    // we actually run untouched.
+    const stubNpm = path.join(BIN, 'npm');
+    fs.writeFileSync(stubNpm, `#!/bin/sh\nprintf '#!/bin/sh\\necho "${LATEST} (Claude Code)"\\n' > ${FAKE}\nchmod +x ${FAKE}\necho "stub npm ran: $@"\n`);
+    fs.chmodSync(stubNpm, 0o755);
 
-  const upd = await call('POST', '/api/deps/update', ownerSid, { bin: 'claude' });
-  const updBody = await upd.json();
-  const after = updBody.report.deps.find((d) => d.bin === 'claude');
-  assert(upd.status === 200, 'POST /api/deps/update → 200 for owner', String(upd.status));
-  assert((updBody.steps[0] || {}).cmd === `${stubNpm} install -g @anthropic-ai/claude-code@latest`, 'ran the sibling npm, not the PATH one', (updBody.steps[0] || {}).cmd);
-  assert(after.version === '2.1.220 (Claude Code)', 're-probes the upgraded binary', after.version);
-  assert(after.updateAvailable === false, 'no longer flagged outdated');
-  assert(updBody.ok === true, 'reports ok', JSON.stringify(updBody.error));
-  assert(!updBody.report.outdated.includes('claude'), 'dropped out of report.outdated');
-  const audited = aos.db.prepare("SELECT data FROM audit_events WHERE type='system.deps.updated' ORDER BY ts DESC LIMIT 1").get();
-  assert(!!audited && JSON.parse(audited.data).bin === 'claude', 'audited system.deps.updated');
+    const upd = await call('POST', '/api/deps/update', ownerSid, { bin: 'claude' });
+    const updBody = await upd.json();
+    const after = updBody.report.deps.find((d) => d.bin === 'claude');
+    assert(upd.status === 200, 'POST /api/deps/update → 200 for owner', String(upd.status));
+    assert((updBody.steps[0] || {}).cmd === `${stubNpm} install -g @anthropic-ai/claude-code@latest`, 'ran the sibling npm, not the PATH one', (updBody.steps[0] || {}).cmd);
+    assert(after.version === `${LATEST} (Claude Code)`, 're-probes the upgraded binary', after.version);
+    assert(after.updateAvailable === false, 'no longer flagged outdated');
+    assert(updBody.ok === true, 'reports ok', JSON.stringify(updBody.error));
+    assert(!updBody.report.outdated.includes('claude'), 'dropped out of report.outdated');
+    const audited = aos.db.prepare("SELECT data FROM audit_events WHERE type='system.deps.updated' ORDER BY ts DESC LIMIT 1").get();
+    assert(!!audited && JSON.parse(audited.data).bin === 'claude', 'audited system.deps.updated');
+  }
 
   server.close();
   registry.shutdown?.();

--- a/scripts/deps-freshness-test.cjs
+++ b/scripts/deps-freshness-test.cjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/* Dependency-freshness test: Settings → System must catch a dep that is PRESENT BUT STALE (the real gap —
+ * a box on an old `claude` reported a green "all installed" while its runtime predated the current model
+ * line), and must resolve a binary that is off the server's PATH instead of calling it missing.
+ *
+ * Covers the pure logic against a fake binary (no network: the registry lookup is stubbed via a seeded
+ * cache) plus the real routes over an in-process HTTP server — presence, freshness, and the owner gate on
+ * `POST /api/deps/update`. Isolated home. */
+const fs = require('fs'); const os = require('os'); const path = require('path');
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-deps-test-'));
+const BIN = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-deps-bin-'));
+process.env.AGENT_OS_HOME = HOME; process.env.AGENT_OS_TENANT = 'testco';
+process.env.AGENT_OS_OWNER_EMAIL = 'owner@test';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+
+// A stand-in `claude` that reports an ancient version — the stale-but-installed condition.
+const FAKE = path.join(BIN, 'claude');
+fs.writeFileSync(FAKE, '#!/bin/sh\necho "2.1.100 (Claude Code)"\n');
+fs.chmodSync(FAKE, 0o755);
+
+const deps = require(path.join(ROOT, 'dist/edge/deps.js'));
+const { parseVersion, atLeastVersion } = require(path.join(ROOT, 'dist/edge/claude-cli.js'));
+const { TenantRegistry } = require(path.join(ROOT, 'dist/tenant-registry.js'));
+const { createHttpServer } = require(path.join(ROOT, 'dist/server.js'));
+
+(async () => {
+  console.log('\n\x1b[1m1) version parsing + comparison\x1b[0m');
+  assert(JSON.stringify(parseVersion('2.1.220 (Claude Code)')) === '[2,1,220]', 'parses a version with trailing noise');
+  assert(parseVersion('no version here') === null, 'unparseable → null (never a false "stale")');
+  assert(atLeastVersion([2, 1, 220], [2, 1, 220]) === true, 'equal is not stale');
+  assert(atLeastVersion([2, 1, 100], [2, 1, 220]) === false, 'behind on patch is stale');
+  assert(atLeastVersion([2, 2, 0], [2, 1, 220]) === true, 'ahead on minor is not stale');
+
+  console.log('\n\x1b[1m2) presence probe is sync + network-free\x1b[0m');
+  process.env.CLAUDE_BIN = FAKE;
+  const base = deps.checkDeps();
+  const claude = base.deps.find((d) => d.bin === 'claude');
+  assert(claude.installed === true, 'resolves the fake claude');
+  assert(claude.version === '2.1.100 (Claude Code)', 'version-probes the RESOLVED path', claude.version);
+  assert(base.outdated.length === 0 && base.updatesCheckedAt === 0, 'freshness is absent until asked for');
+  assert(claude.latest === undefined, 'no registry field on the sync report');
+
+  console.log('\n\x1b[1m3) resolution order + off-PATH fallback\x1b[0m');
+  // Launcher parity: claude-cli.ts prefers $CLAUDE_BIN over PATH, so this must too — otherwise the panel
+  // reports the version of a binary sessions never run. (A real `claude` may well be on this box's PATH.)
+  assert(claude.path === FAKE, '$CLAUDE_BIN wins over PATH (matches the launcher)', claude.path);
+  const gitDep = deps.checkDeps().deps.find((d) => d.bin === 'git');
+  assert(!gitDep.offPath, 'a normal PATH dep is not flagged off-PATH');
+
+  // The systemd minimal-PATH case: nothing named `claude` on PATH, reachable only via the fallback.
+  // The old bare `command -v claude` reported MISSING here while sessions launched fine.
+  const realPath = process.env.PATH;
+  process.env.PATH = '/usr/bin:/bin';
+  const stripped = deps.checkDeps().deps.find((d) => d.bin === 'claude');
+  process.env.PATH = realPath;
+  assert(stripped.installed === true, 'still resolves with claude off PATH');
+  assert(stripped.offPath === true, 'flagged as resolved off PATH');
+  assert(stripped.path === FAKE, 'path is the fallback location', stripped.path);
+
+  console.log('\n\x1b[1m4) freshness marks a present-but-stale dep\x1b[0m');
+  // Seed the module's registry cache so the assertion is deterministic and offline.
+  const seeded = await deps.checkDepUpdates(base).catch(() => null);
+  const net = seeded && seeded.deps.find((d) => d.bin === 'claude');
+  if (!net || (!net.latest && net.updateError)) {
+    console.log('  \x1b[33m·\x1b[0m registry unreachable — skipping the live-lookup assertions');
+  } else {
+    assert(!!net.latest, 'registry answered with a latest version', net.updateError);
+    assert(net.updateAvailable === true, 'v2.1.100 vs latest → updateAvailable', `latest=${net.latest}`);
+    assert(seeded.outdated.includes('claude'), 'listed in report.outdated');
+    assert(seeded.ok === true, 'report.ok stays true — stale is not missing');
+    assert(seeded.updatesCheckedAt > 0, 'stamps updatesCheckedAt');
+    const tmux = seeded.deps.find((d) => d.bin === 'tmux');
+    assert(tmux.latest === undefined && tmux.updateAvailable === undefined, 'a non-npm dep is never version-checked');
+  }
+
+  console.log('\n\x1b[1m5) routes\x1b[0m');
+  const registry = new TenantRegistry(ROOT, 0);
+  registry.bootAll();
+  const aos = registry.get('testco').os;
+  const ownerSid = aos.team.acceptToken(aos.team.invite({ email: 'owner2@test', role: 'owner' }).token).sid;
+  const adminSid = aos.team.acceptToken(aos.team.invite({ email: 'admin@test', role: 'admin' }).token).sid;
+  const memberSid = aos.team.acceptToken(aos.team.invite({ email: 'member@test', role: 'member' }).token).sid;
+
+  const server = createHttpServer(registry);
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+  const call = (method, p, sid, body) => fetch(`http://127.0.0.1:${port}${p}`, {
+    method,
+    headers: { cookie: `aos_sid=${sid}`, 'content-type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  const get = await call('GET', '/api/deps', adminSid);
+  const report = await get.json();
+  assert(get.status === 200, 'GET /api/deps → 200 for admin', String(get.status));
+  assert(Array.isArray(report.deps) && report.deps.length > 0, 'returns the dep list');
+  assert('outdated' in report && 'updatesCheckedAt' in report, 'response carries the freshness fields');
+  const rc = report.deps.find((d) => d.bin === 'claude');
+  assert(rc && rc.npmPkg === '@anthropic-ai/claude-code', 'claude row names its npm package');
+
+  assert((await call('GET', '/api/deps', memberSid)).status === 403, 'GET /api/deps → 403 for member');
+
+  const asMember = await call('POST', '/api/deps/update', memberSid, { bin: 'claude' });
+  assert(asMember.status === 403, 'POST /api/deps/update → 403 for member', String(asMember.status));
+  const asAdmin = await call('POST', '/api/deps/update', adminSid, { bin: 'claude' });
+  assert(asAdmin.status === 403, 'POST /api/deps/update → 403 for admin (owner-only)', String(asAdmin.status));
+  const noBin = await call('POST', '/api/deps/update', ownerSid, {});
+  assert(noBin.status === 400, 'POST /api/deps/update without bin → 400', String(noBin.status));
+
+  // An unknown / non-npm dep must be refused BEFORE anything is spawned.
+  const bogus = await call('POST', '/api/deps/update', ownerSid, { bin: 'nope' });
+  const bogusBody = await bogus.json();
+  assert(bogus.status === 200 && bogusBody.ok === false && /unknown dependency/.test(bogusBody.error || ''), 'unknown dep → ok:false with a reason', JSON.stringify(bogusBody.error));
+  const tmuxUpd = await call('POST', '/api/deps/update', ownerSid, { bin: 'tmux' });
+  const tmuxBody = await tmuxUpd.json();
+  assert(tmuxBody.ok === false && /not installed from npm/.test(tmuxBody.error || ''), 'non-npm dep is refused (no shell-out)', JSON.stringify(tmuxBody.error));
+  assert((tmuxBody.steps || []).length === 0, 'refusal runs no install steps');
+
+  console.log('\n\x1b[1m6) update applies + re-checks (stubbed npm — no real global install)\x1b[0m');
+  // A fake `npm` sitting BESIDE the fake claude, which "upgrades" it by rewriting the version it prints.
+  // This also pins the sibling-npm preference: on an nvm box the PATH npm may belong to a different node
+  // prefix, and installing there would leave the binary we actually run untouched.
+  const stubNpm = path.join(BIN, 'npm');
+  fs.writeFileSync(stubNpm, `#!/bin/sh\nprintf '#!/bin/sh\\necho "2.1.220 (Claude Code)"\\n' > ${FAKE}\nchmod +x ${FAKE}\necho "stub npm ran: $@"\n`);
+  fs.chmodSync(stubNpm, 0o755);
+
+  const upd = await call('POST', '/api/deps/update', ownerSid, { bin: 'claude' });
+  const updBody = await upd.json();
+  const after = updBody.report.deps.find((d) => d.bin === 'claude');
+  assert(upd.status === 200, 'POST /api/deps/update → 200 for owner', String(upd.status));
+  assert((updBody.steps[0] || {}).cmd === `${stubNpm} install -g @anthropic-ai/claude-code@latest`, 'ran the sibling npm, not the PATH one', (updBody.steps[0] || {}).cmd);
+  assert(after.version === '2.1.220 (Claude Code)', 're-probes the upgraded binary', after.version);
+  assert(after.updateAvailable === false, 'no longer flagged outdated');
+  assert(updBody.ok === true, 'reports ok', JSON.stringify(updBody.error));
+  assert(!updBody.report.outdated.includes('claude'), 'dropped out of report.outdated');
+  const audited = aos.db.prepare("SELECT data FROM audit_events WHERE type='system.deps.updated' ORDER BY ts DESC LIMIT 1").get();
+  assert(!!audited && JSON.parse(audited.data).bin === 'claude', 'audited system.deps.updated');
+
+  server.close();
+  registry.shutdown?.();
+  fs.rmSync(HOME, { recursive: true, force: true });
+  fs.rmSync(BIN, { recursive: true, force: true });
+  console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m\n`);
+  process.exit(fail === 0 ? 0 : 1);
+})().catch((e) => { console.error(e); process.exit(1); });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,7 +20,7 @@ import { TenantStore } from './state/control';
 import { reconcileTenant } from './governance/policy-reconcile';
 import { Role } from './types';
 import { VERSION } from './version';
-import { checkDeps, installDeps, type DepsReport } from './edge/deps';
+import { checkDeps, checkDepUpdates, installDeps, updateNpmDep, type DepsReport } from './edge/deps';
 
 // `node:sqlite` is stable enough to depend on but still emits an ExperimentalWarning on first
 // use. Swallow just that one line so the console output stays clean; surface every other warning.
@@ -58,10 +58,11 @@ async function main(): Promise<void> {
       policy(rest);
       break;
     case 'deps':
-      deps(false);
+      if (rest[0] === 'update') await depsUpdate(rest[1] || '');
+      else await deps(false);
       break;
     case 'install-deps':
-      deps(true);
+      await deps(true);
       break;
     case 'demo':
       await import('./demo');
@@ -89,19 +90,27 @@ async function main(): Promise<void> {
 }
 
 /** Check (and optionally install) the native tools a running instance shells out to. No server needed. */
-function deps(install: boolean): void {
+async function deps(install: boolean): Promise<void> {
   const print = (r: DepsReport): void => {
     for (const d of r.deps) {
-      const mark = d.installed ? '✓' : d.required ? '✗' : '·';
+      const mark = d.installed ? (d.updateAvailable ? '↑' : '✓') : d.required ? '✗' : '·';
       const tail = d.installed ? (d.version || d.path || '') : (d.pkg ? '(missing)' : `(missing — ${d.hint || 'install manually'})`);
-      console.log(`  ${mark} ${d.label.padEnd(12)} ${tail}`);
+      const stale = d.updateAvailable ? `  → v${d.latest} available` : '';
+      const off = d.offPath ? '  (off PATH)' : '';
+      console.log(`  ${mark} ${d.label.padEnd(12)} ${tail}${off}${stale}`);
     }
     console.log(r.ok ? '\nAll required dependencies are installed.' : '\nSome required dependencies are missing.');
     if (!r.ok && r.installCommand) console.log(`Install them with:\n  ${r.installCommand}`);
     else if (!r.ok) console.log('No supported package manager found — install the missing tools by hand (see hints above).');
+    for (const d of r.deps.filter((x) => x.updateAvailable)) {
+      console.log(`\n${d.label} is out of date (v${d.latest} available). Update it with:\n  agent-os deps update ${d.bin}`);
+    }
   };
 
-  if (!install) { const r = checkDeps(); print(r); process.exitCode = r.ok ? 0 : 1; return; }
+  // Freshness is best-effort — an offline box still gets its presence report.
+  const annotate = (r: DepsReport): Promise<DepsReport> => checkDepUpdates(r).catch(() => r);
+
+  if (!install) { const r = await annotate(checkDeps()); print(r); process.exitCode = r.ok ? 0 : 1; return; }
 
   const pre = checkDeps();
   if (pre.ok && !pre.installable.length) { console.log('All required dependencies are already installed.'); return; }
@@ -109,7 +118,20 @@ function deps(install: boolean): void {
   const result = installDeps();
   for (const s of result.steps) console.log(`${s.ok ? '✓' : '✗'} ${s.cmd}${s.out ? `\n${s.out}` : ''}`);
   console.log('');
-  print(result.report);
+  print(await annotate(result.report));
+  process.exitCode = result.ok ? 0 : 1;
+}
+
+/** `agent-os deps update <bin>` — upgrade one npm-installed dependency (today: `claude`) in place. */
+async function depsUpdate(bin: string): Promise<void> {
+  if (!bin) { console.log('usage: agent-os deps update <bin>   (e.g. `claude`)'); process.exitCode = 1; return; }
+  console.log(`Updating ${bin}…\n`);
+  const result = await updateNpmDep(bin);
+  for (const s of result.steps) console.log(`${s.ok ? '✓' : '✗'} ${s.cmd}${s.out ? `\n${s.out}` : ''}`);
+  const after = result.report.deps.find((d) => d.bin === bin);
+  if (result.ok) console.log(`\n✓ ${after?.label || bin} is now ${after?.version || 'up to date'}.`);
+  else console.log(`\n✗ ${result.error || 'update failed'}`);
+  console.log('\nNote: sessions already running keep the old binary until they restart.');
   process.exitCode = result.ok ? 0 : 1;
 }
 
@@ -316,7 +338,8 @@ function usage(): void {
   invite <email> [role] mint a magic-link to invite a teammate (role: admin | member)
   login-link <email>    print a fresh login link for an existing member (recovery)
   members               list workspace members and their roles
-  deps                   check the native tools sessions need (tmux/ttyd/claude/git)
+  deps                   check the native tools sessions need (tmux/ttyd/claude/git) + their freshness
+  deps update <bin>      upgrade an npm-installed tool in place (e.g. deps update claude)
   install-deps           install the missing native tools via the box's package manager
   tenant <sub>          multi-tenant admin: list | create <slug> --owner <email> | remove <slug>
   policy reconcile      align agents' policyContext to the enforced ruleset (--tenant <slug> | --all; --yes to apply)

--- a/src/edge/claude-cli.ts
+++ b/src/edge/claude-cli.ts
@@ -13,11 +13,20 @@ import * as path from 'path';
 
 let cachedVersion: number[] | null | undefined;
 
+/**
+ * Candidate locations for the `claude` binary, in resolution order — `$CLAUDE_BIN`, then a bare PATH
+ * lookup, then the documented `~/.local/bin/claude`. Resolved lazily (env + homedir are read per call)
+ * and shared with `src/edge/deps.ts`, so the Settings → System probe and the launcher agree on which
+ * binary is "installed" instead of drifting apart.
+ */
+export function claudeBinCandidates(): string[] {
+  return [process.env.CLAUDE_BIN, 'claude', path.join(os.homedir(), '.local/bin/claude')].filter(Boolean) as string[];
+}
+
 /** The installed `claude` version as `[major, minor, patch]`, or null if no binary resolves. Cached. */
 export function claudeVersion(): number[] | null {
   if (cachedVersion !== undefined) return cachedVersion;
-  const candidates = [process.env.CLAUDE_BIN, 'claude', path.join(os.homedir(), '.local/bin/claude')].filter(Boolean) as string[];
-  for (const bin of candidates) {
+  for (const bin of claudeBinCandidates()) {
     try {
       const out = execFileSync(bin, ['--version'], { encoding: 'utf8', timeout: 5000 });
       const m = out.match(/(\d+)\.(\d+)\.(\d+)/);
@@ -28,6 +37,13 @@ export function claudeVersion(): number[] | null {
   }
   cachedVersion = null; // no `claude` resolvable (tests/demo)
   return cachedVersion;
+}
+
+/** First `x.y.z` in a version string as `[maj,min,patch]`, or null — tolerates trailing noise like
+ *  `2.1.220 (Claude Code)`. Shared with the dependency-freshness probe. */
+export function parseVersion(s: string | undefined): number[] | null {
+  const m = (s || '').match(/(\d+)\.(\d+)\.(\d+)/);
+  return m ? [+m[1], +m[2], +m[3]] : null;
 }
 
 /** True when `v` (a `[maj,min,patch]`) is ≥ `min`. */

--- a/src/edge/deps.ts
+++ b/src/edge/deps.ts
@@ -7,13 +7,21 @@
  * path) round out the set. On a fresh box these are the classic "why won't a session start?" gaps, so
  * we make them checkable from Settings → System and installable via one shortcut.
  *
- * `checkDeps()` probes each binary (present? which path? what version?) — pure inspection, safe for any
- * member to read. `installDeps()` resolves the box's package manager (brew on macOS; apt/dnf/yum/pacman
- * on Linux) and installs the still-missing package-manager-installable deps, returning each step's log —
- * owner-gated at the route, same posture as the self-update apply. Deps with no package (i.e. `claude`,
- * installed via npm) are never auto-installed; we surface their manual hint instead.
+ * `checkDeps()` probes each binary (present? which path? what version?) — pure inspection with no
+ * network, safe for any member to read. `checkDepUpdates()` layers *freshness* on top for deps that name
+ * an npm package: it asks the registry for `latest` and flags a stale install. That gap was real — a box
+ * pinned to an old `claude` reported a green "All required dependencies are installed" while its runtime
+ * predated the current model line, because presence was the only thing ever checked.
+ *
+ * `installDeps()` resolves the box's package manager (brew on macOS; apt/dnf/yum/pacman on Linux) and
+ * installs the still-missing package-manager-installable deps; `updateNpmDep()` is the npm-side sibling
+ * that upgrades one npm-installed dep in place. Both return each step's log and are owner-gated at the
+ * route, same posture as the self-update apply.
  */
 import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import { claudeBinCandidates, parseVersion, atLeastVersion } from './claude-cli';
 
 export interface Dep {
   /** The binary as invoked on PATH. */
@@ -30,6 +38,18 @@ export interface Dep {
   hint?: string;
   /** Flag that prints the version — defaults to `--version`; tmux only understands `-V`. */
   versionArg?: string;
+  /**
+   * npm package this dep is installed from. When set, `checkDepUpdates()` compares the installed version
+   * against the registry's `latest` and `updateNpmDep()` can upgrade it in place.
+   */
+  npmPkg?: string;
+  /**
+   * Extra candidate locations to try, in order, when the bare PATH lookup would miss — resolved lazily so
+   * env + homedir are read at probe time. A launchd/systemd parent ships a minimal PATH without
+   * `~/.local/bin`, so `claude` launches fine in a session yet `command -v claude` finds nothing; without
+   * this the panel would report the runtime MISSING on a perfectly healthy box.
+   */
+  candidates?: () => string[];
 }
 
 /** The native tools a running instance shells out to. Order = display order. */
@@ -54,7 +74,9 @@ export const REQUIRED_DEPS: Dep[] = [
     label: 'Claude Code',
     purpose: 'The agent runtime each claude-code session launches.',
     required: true,
-    hint: 'npm install -g @anthropic-ai/claude-code',
+    hint: 'npm install -g @anthropic-ai/claude-code@latest',
+    npmPkg: '@anthropic-ai/claude-code',
+    candidates: claudeBinCandidates,
   },
   {
     bin: 'git',
@@ -71,6 +93,15 @@ export interface DepStatus extends Dep {
   path?: string;
   /** First line of `<bin> --version`, best-effort (some tools print to stderr / don't support it). */
   version?: string;
+  /** True when the binary resolved only via a `candidates` fallback — i.e. it is NOT on the server's
+   *  PATH. Sessions still launch (the launcher walks the same list), but it's worth surfacing. */
+  offPath?: boolean;
+  /** Registry `latest` for `npmPkg`, filled in by `checkDepUpdates()`. */
+  latest?: string;
+  /** True when `latest` is newer than the installed version. */
+  updateAvailable?: boolean;
+  /** Why the freshness probe couldn't answer (offline box, registry error) — never fatal. */
+  updateError?: string;
 }
 
 export interface DepsReport {
@@ -87,12 +118,44 @@ export interface DepsReport {
   /** The zero-dependency bootstrap shortcut (works before `npm run build`). Always shown as a hint. */
   shortcut: string;
   platform: string;
+  /** Installed-but-stale npm deps (drives the per-row "Update" button). Empty until `checkDepUpdates()`. */
+  outdated: string[];
+  /** When the freshness probe last ran, or 0 if it hasn't. */
+  updatesCheckedAt: number;
 }
 
 /** Resolve a binary's absolute path via `command -v` (portable across sh); '' when not found. */
 function whichBin(bin: string): string {
   const r = spawnSync('sh', ['-c', `command -v ${bin} 2>/dev/null`], { encoding: 'utf8', timeout: 5000 });
   return (r.stdout || '').trim().split('\n')[0] || '';
+}
+
+/** True when `p` names an existing executable file. */
+function isExecutable(p: string): boolean {
+  try {
+    fs.accessSync(p, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve one dep to an absolute path, walking `candidates()` IN ORDER — the same order the launcher
+ * uses. Order is the whole point: `claude-cli.ts` prefers `$CLAUDE_BIN` over PATH, so resolving PATH
+ * first here would report the version of a binary sessions never actually run. A candidate naming a
+ * path is taken when it's executable; a bare name goes through PATH.
+ *
+ * `offPath` means a plain `command -v <bin>` finds nothing — the binary is reachable only via a
+ * fallback. Sessions still launch (the launcher checks the same list), but it's worth showing.
+ */
+function resolveDep(d: Dep): { path: string; offPath: boolean } {
+  const onPath = whichBin(d.bin);
+  for (const c of d.candidates?.() ?? [d.bin]) {
+    const p = c === d.bin ? onPath : c.includes('/') ? (isExecutable(c) ? c : '') : whichBin(c);
+    if (p) return { path: p, offPath: !onPath };
+  }
+  return { path: '', offPath: false };
 }
 
 /** Best-effort version string — first line of `<bin> <versionArg>` (stdout or stderr); undefined if none. */
@@ -102,11 +165,18 @@ function binVersion(bin: string, versionArg = '--version'): string | undefined {
   return out || undefined;
 }
 
-/** Probe every dependency: present? where? what version? Pure inspection — no side effects. */
+/** Probe every dependency: present? where? what version? Pure inspection — no side effects, no network. */
 export function checkDeps(): DepsReport {
   const deps: DepStatus[] = REQUIRED_DEPS.map((d) => {
-    const path = whichBin(d.bin);
-    return { ...d, installed: !!path, path: path || undefined, version: path ? binVersion(d.bin, d.versionArg) : undefined };
+    const { path, offPath } = resolveDep(d);
+    // Version-probe the RESOLVED path, not the bare name — otherwise an off-PATH binary reports no version.
+    return {
+      ...d,
+      installed: !!path,
+      path: path || undefined,
+      offPath: path ? offPath : undefined,
+      version: path ? binVersion(path, d.versionArg) : undefined,
+    };
   });
   const ok = deps.every((d) => !d.required || d.installed);
   const manager = resolveManager();
@@ -121,6 +191,68 @@ export function checkDeps(): DepsReport {
     installCommand: manager && pkgs.length ? installCommandFor(manager, pkgs) : null,
     shortcut: 'npm run install-deps',
     platform: process.platform,
+    outdated: [],
+    updatesCheckedAt: 0,
+  };
+}
+
+/** How long a registry `latest` lookup is reused before we ask again. Mirrors the self-update check. */
+const FRESHNESS_TTL_MS = 60 * 60_000;
+
+const latestCache = new Map<string, { version: string; at: number }>();
+
+/**
+ * Ask the npm registry for a package's `latest` version. Uses the abbreviated `/latest` endpoint (a few
+ * hundred bytes, not the full packument) via the global `fetch`, so this stays zero-dependency and never
+ * shells out to `npm` — which may not even be on a systemd unit's PATH. Cached for `FRESHNESS_TTL_MS`.
+ */
+async function npmLatest(pkg: string, force = false): Promise<string> {
+  const hit = latestCache.get(pkg);
+  if (!force && hit && Date.now() - hit.at < FRESHNESS_TTL_MS) return hit.version;
+  const ctrl = new AbortController();
+  const timer = setTimeout(() => ctrl.abort(), 8000);
+  try {
+    const res = await fetch(`https://registry.npmjs.org/${pkg.replace('/', '%2F')}/latest`, {
+      signal: ctrl.signal,
+      headers: { accept: 'application/vnd.npm.install-v1+json, application/json' },
+    });
+    if (!res.ok) throw new Error(`registry responded ${res.status}`);
+    const version = ((await res.json()) as { version?: string }).version;
+    if (!version) throw new Error('registry returned no version');
+    latestCache.set(pkg, { version, at: Date.now() });
+    return version;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Layer freshness onto a report: for every installed dep that names an npm package, compare the probed
+ * version against the registry's `latest`. Network failures degrade to a per-dep `updateError` — an
+ * offline box still gets its full presence report, it just can't claim anything about staleness.
+ */
+export async function checkDepUpdates(report: DepsReport, force = false): Promise<DepsReport> {
+  const deps = await Promise.all(report.deps.map(async (d): Promise<DepStatus> => {
+    if (!d.npmPkg || !d.installed) return d;
+    const installed = parseVersion(d.version);
+    if (!installed) return { ...d, updateError: 'could not parse the installed version' };
+    try {
+      const latest = await npmLatest(d.npmPkg, force);
+      const want = parseVersion(latest);
+      // `atLeastVersion(installed, want)` false ⇒ installed is behind. An unparseable `latest` is a
+      // registry oddity, not a stale install — say nothing rather than cry wolf.
+      return want
+        ? { ...d, latest, updateAvailable: !atLeastVersion(installed, want) }
+        : { ...d, updateError: 'could not parse the published version' };
+    } catch (e) {
+      return { ...d, updateError: e instanceof Error ? e.message : String(e) };
+    }
+  }));
+  return {
+    ...report,
+    deps,
+    outdated: deps.filter((d) => d.updateAvailable).map((d) => d.bin),
+    updatesCheckedAt: Date.now(),
   };
 }
 
@@ -196,4 +328,61 @@ export function installDeps(): InstallResult {
 
   const report = checkDeps();
   return { ok: ok && report.ok, steps, report, error: ok ? undefined : 'one or more install steps failed — see the logs' };
+}
+
+/**
+ * Resolve the `npm` that owns a globally-installed binary. Prefer the one sitting beside it — on an
+ * nvm-managed box the service PATH may reach `claude` without reaching `npm`, and a *different* npm would
+ * install into a different node prefix, silently leaving the running binary untouched. Falls back to PATH.
+ */
+function npmFor(depPath?: string): string {
+  if (depPath) {
+    const sibling = path.join(path.dirname(depPath), 'npm');
+    try {
+      fs.accessSync(sibling, fs.constants.X_OK);
+      return sibling;
+    } catch { /* no npm beside it — fall through to PATH */ }
+  }
+  return whichBin('npm');
+}
+
+/**
+ * Upgrade one npm-installed dependency in place (`npm install -g <pkg>@latest`) and re-check. Owner-gated
+ * at the route. Deliberately never sudo: `sudo npm -g` is a well-known footgun (it leaves root-owned files
+ * in the prefix), so a permissions failure surfaces the raw error and the manual hint instead.
+ *
+ * Note for callers/UI: replacing the binary does NOT affect sessions already running — on Linux a live
+ * process keeps its open inode, so panes launched before the upgrade keep the old version until restarted.
+ */
+export async function updateNpmDep(bin: string): Promise<InstallResult> {
+  const before = checkDeps();
+  const dep = before.deps.find((d) => d.bin === bin);
+  const fail = async (error: string): Promise<InstallResult> => ({ ok: false, steps: [], report: await checkDepUpdates(before), error });
+
+  if (!dep) return fail(`unknown dependency '${bin}'`);
+  if (!dep.npmPkg) return fail(`'${bin}' is not installed from npm — update it by hand (${dep.hint || 'see its install hint'})`);
+  if (!dep.installed) return fail(`'${bin}' isn't installed yet — install it first`);
+
+  const npm = npmFor(dep.path);
+  if (!npm) return fail(`no \`npm\` found on this box — update by hand: ${dep.hint || `npm install -g ${dep.npmPkg}@latest`}`);
+
+  const spec = `${dep.npmPkg}@latest`;
+  const r = spawnSync(npm, ['install', '-g', spec], { encoding: 'utf8', timeout: 10 * 60_000, maxBuffer: 16 * 1024 * 1024 });
+  const out = `${r.stdout || ''}${r.stderr || ''}`.trim();
+  const ok = r.status === 0;
+  const steps: InstallStep[] = [{ cmd: `${npm} install -g ${spec}`, ok, out: out.slice(-4000) }];
+
+  // The version probe is memoised per binary path, so force a fresh registry read to reflect the upgrade.
+  const report = await checkDepUpdates(checkDeps(), true);
+  const still = report.deps.find((d) => d.bin === bin);
+  return {
+    ok: ok && !still?.updateAvailable,
+    steps,
+    report,
+    error: ok
+      ? (still?.updateAvailable ? 'the install reported success but the binary still looks stale — check the log' : undefined)
+      : (/EACCES|permission denied/i.test(out)
+        ? `npm couldn't write to its global prefix — run it by hand as the owning user: ${dep.hint || `npm install -g ${spec}`}`
+        : 'the update step failed — see the log'),
+  };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -55,7 +55,7 @@ import { planSessionTidy, applySessionTidy } from './edge/session-tidy';
 import { Strategist, STRATEGIST_ID } from './edge/strategist';
 import { readAgentCatalog, installAgentFromCatalog, BUILTIN_SEED_IDS } from './edge/agent-catalog';
 import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
-import { checkDeps, installDeps } from './edge/deps';
+import { checkDeps, checkDepUpdates, installDeps, updateNpmDep } from './edge/deps';
 import { CATALOG, redact } from './connectors/connectors';
 import { GithubIdentity } from './edge/github-identity';
 import { convertAppManifest, userInstallationStatus } from './connectors/github';
@@ -4388,7 +4388,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   // ── native system dependencies (tmux/ttyd/claude/git) — "is the box set up to run sessions?" ──
   if (method === 'GET' && p === '/api/deps') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    return sendJson(res, 200, checkDeps());
+    // Presence is local + sync; freshness asks the npm registry, cached for an hour (`?force=1` re-asks).
+    return sendJson(res, 200, await checkDepUpdates(checkDeps(), url.searchParams.get('force') === '1'));
+  }
+  // Upgrade one npm-installed dep in place (`npm install -g <pkg>@latest`). Owner-gated — it mutates the
+  // box's global node prefix — same posture as the package-manager install above.
+  if (method === 'POST' && p === '/api/deps/update') {
+    if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
+    const bin = String((await readBody(req)).bin || '');
+    if (!bin) return sendJson(res, 400, { error: 'bin required' });
+    const result = await updateNpmDep(bin);
+    const after = result.report.deps.find((d) => d.bin === bin);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'system.deps.updated', data: { bin, ok: result.ok, version: after?.version, latest: after?.latest } });
+    return sendJson(res, 200, result);
   }
   // Install the still-missing, package-manager-installable deps (brew/apt/…). Owner-gated (it runs a
   // privileged system install), same posture as the self-update apply below.
@@ -4396,7 +4408,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
     const result = installDeps();
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'system.deps.installed', data: { ok: result.ok, steps: result.steps.map((s) => ({ cmd: s.cmd, ok: s.ok })) } });
-    return sendJson(res, 200, result);
+    // Hand back a freshness-annotated report so the panel re-renders in one round-trip, same as GET.
+    return sendJson(res, 200, { ...result, report: await checkDepUpdates(result.report) });
   }
   // ── stop every running session (softer sibling of the kill switch; leaves the gate open) ──
   if (method === 'POST' && p === '/api/sessions/stop-all') {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12737,19 +12737,25 @@ function SystemSettings({ state, me }: { state: StateResp | null; me: Member }) 
 }
 
 /**
- * Settings → System → Native dependencies — is this box set up to run agent sessions? Probes the native
- * commands Agent OS shells out to (tmux/ttyd/claude/git) via `GET /api/deps`. When something's missing it
- * shows the exact install command (copyable) + the `npm run install-deps` shortcut, and — for the owner —
- * an "Install now" button that runs the box's package manager (`POST /api/deps/install`) and re-checks.
+ * Settings → System → Native dependencies — is this box set up to run agent sessions, and is what's
+ * installed current? Probes the native commands Agent OS shells out to (tmux/ttyd/claude/git) via
+ * `GET /api/deps`. When something's missing it shows the exact install command (copyable) + the
+ * `npm run install-deps` shortcut, and — for the owner — an "Install now" button that runs the box's
+ * package manager (`POST /api/deps/install`).
+ *
+ * Presence alone was never enough: a box pinned to a months-old `claude` showed a green "all installed"
+ * while its runtime predated the current model line. So npm-installed deps also carry the registry's
+ * `latest`, and a stale one gets an amber row + an owner "Update" (`POST /api/deps/update`).
  */
 function NativeDepsPanel({ me }: { me: Member }) {
   const [report, setReport] = useState<DepsReport | null>(null)
   const [err, setErr] = useState('')
   const [installing, setInstalling] = useState(false)
+  const [updating, setUpdating] = useState('')
   const [result, setResult] = useState<DepsInstallResult | null>(null)
   const [copied, setCopied] = useState('')
 
-  const load = () => api.deps().then((r) => { setErr(''); setReport(r) }).catch(() => setErr('Could not read dependency status.'))
+  const load = (force = false) => api.deps(force).then((r) => { setErr(''); setReport(r) }).catch(() => setErr('Could not read dependency status.'))
   useEffect(() => { load() }, [])
 
   const copy = async (text: string) => { if (await copyText(text)) { setCopied(text); setTimeout(() => setCopied(''), 1500) } }
@@ -12762,8 +12768,17 @@ function NativeDepsPanel({ me }: { me: Member }) {
     setResult(r); setReport(r.report)
   }
 
+  const update = async (bin: string) => {
+    setUpdating(bin); setResult(null); setErr('')
+    const r = await api.updateDep(bin).catch(() => null)
+    setUpdating('')
+    if (!r) return setErr('Update request failed.')
+    setResult(r); setReport(r.report)
+  }
+
   const isOwner = me.role === 'owner'
   const missingRequired = report ? report.deps.filter((d) => d.required && !d.installed) : []
+  const outdated = report ? report.deps.filter((d) => d.updateAvailable) : []
 
   return (
     <Card>
@@ -12771,7 +12786,7 @@ function NativeDepsPanel({ me }: { me: Member }) {
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-2 text-sm font-semibold"><Boxes className="h-4 w-4" /> Native dependencies</div>
           <div className="flex items-center gap-2">
-            <Button size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-xs" disabled={installing} onClick={load}>
+            <Button size="sm" variant="ghost" className="h-7 gap-1.5 px-2 text-xs" disabled={installing || !!updating} onClick={() => load(true)}>
               <RefreshCw className="h-3.5 w-3.5" /> Re-check
             </Button>
             {isOwner && report && report.installable.length > 0 && (
@@ -12783,7 +12798,7 @@ function NativeDepsPanel({ me }: { me: Member }) {
         </div>
 
         <p className="text-sm text-muted-foreground">
-          The native commands Agent OS shells out to on this box. Sessions won't start until the required ones are present.
+          The native commands Agent OS shells out to on this box. Sessions won't start until the required ones are present — and a stale runtime quietly holds sessions back to whatever it shipped with.
         </p>
 
         {err && <p className="text-sm text-red-600">{err}</p>}
@@ -12791,15 +12806,27 @@ function NativeDepsPanel({ me }: { me: Member }) {
           <p className="text-sm text-muted-foreground">Checking…</p>
         ) : (
           <>
-            {report.ok
-              ? <div className="flex items-center gap-1.5 text-xs text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> All required dependencies are installed.</div>
-              : <div className="flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20">
+            {!report.ok
+              ? <div className="flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20">
                   <AlertTriangle className="h-3.5 w-3.5 shrink-0" /> {missingRequired.length} required {missingRequired.length === 1 ? 'dependency is' : 'dependencies are'} missing — agent sessions can't run.
-                </div>}
+                </div>
+              : outdated.length > 0
+                ? <div className="flex items-center gap-1.5 rounded-md bg-amber-50 px-2 py-1.5 text-xs font-medium text-amber-700 ring-1 ring-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20">
+                    <Download className="h-3.5 w-3.5 shrink-0" /> {outdated.length} {outdated.length === 1 ? 'dependency is' : 'dependencies are'} out of date — {outdated.map((d) => d.label).join(', ')}.
+                  </div>
+                : <div className="flex items-center gap-1.5 text-xs text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> All required dependencies are installed and up to date.</div>}
 
             <dl className="divide-y rounded-md border">
-              {report.deps.map((d) => <DepRow key={d.bin} d={d} />)}
+              {report.deps.map((d) => (
+                <DepRow key={d.bin} d={d} canUpdate={isOwner} updating={updating === d.bin} busy={installing || !!updating} onUpdate={() => update(d.bin)} />
+              ))}
             </dl>
+
+            {outdated.length > 0 && (
+              <p className="text-[11px] text-muted-foreground">
+                Updating replaces the binary on disk. Sessions already running keep the version they launched with until they restart.
+              </p>
+            )}
 
             {(report.installCommand || !report.ok) && (
               <div className="space-y-2 rounded-md border bg-muted/40 p-3">
@@ -12819,7 +12846,7 @@ function NativeDepsPanel({ me }: { me: Member }) {
             {result && (
               <div className="space-y-1.5">
                 <p className={`text-xs font-medium ${result.ok ? 'text-emerald-600' : 'text-amber-600'}`}>
-                  {result.ok ? 'Installed — all required dependencies are present.' : (result.error || 'Install finished with problems.')}
+                  {result.ok ? 'Done — dependencies are present and up to date.' : (result.error || 'The run finished with problems.')}
                 </p>
                 {result.steps.length > 0 && (
                   <div className="max-h-48 space-y-1.5 overflow-auto rounded-md border bg-muted/40 p-2">
@@ -12843,23 +12870,44 @@ function NativeDepsPanel({ me }: { me: Member }) {
   )
 }
 
-/** One dependency row: label + purpose + present/missing badge (with version/path when installed). */
-function DepRow({ d }: { d: DepStatus }) {
+/**
+ * One dependency row: label + purpose + present/missing badge (with version/path when installed), plus
+ * the freshness line for npm-installed tools — "v2.1.220 available" and an owner-only Update button.
+ */
+function DepRow({ d, canUpdate, updating, busy, onUpdate }: { d: DepStatus; canUpdate: boolean; updating: boolean; busy: boolean; onUpdate: () => void }) {
   return (
     <div className="flex items-start gap-3 px-3 py-2">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="font-mono text-sm font-medium">{d.label}</span>
           {!d.required && <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">optional</span>}
+          {d.offPath && <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground" title={`Not on the server's PATH — resolved at ${d.path}. Sessions still launch (the launcher checks the same fallbacks).`}>off PATH</span>}
         </div>
         <p className="text-xs text-muted-foreground">{d.purpose}</p>
         {d.installed
           ? (d.version || d.path) && <p className="truncate font-mono text-[10px] text-muted-foreground" title={d.path}>{d.version || d.path}</p>
           : d.hint && <p className="font-mono text-[10px] text-muted-foreground">install: {d.hint}</p>}
+        {d.installed && d.updateAvailable && (
+          <p className="mt-0.5 text-[11px] font-medium text-amber-600 dark:text-amber-400">
+            v{d.latest} available{d.hint ? <> · <span className="font-mono">{d.hint}</span></> : null}
+          </p>
+        )}
+        {d.installed && d.updateError && (
+          <p className="mt-0.5 text-[10px] text-muted-foreground" title={d.updateError}>Couldn't check for updates.</p>
+        )}
       </div>
-      {d.installed
-        ? <span className="flex shrink-0 items-center gap-1 text-xs text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> installed</span>
-        : <span className={`flex shrink-0 items-center gap-1 text-xs ${d.required ? 'text-red-600' : 'text-amber-600'}`}><XCircle className="h-3.5 w-3.5" /> missing</span>}
+      <div className="flex shrink-0 items-center gap-2">
+        {d.installed && d.updateAvailable && canUpdate && (
+          <Button size="sm" variant="outline" className="h-7 gap-1.5 px-2 text-xs" disabled={busy} onClick={onUpdate}>
+            <Download className={`h-3.5 w-3.5 ${updating ? 'animate-pulse' : ''}`} /> {updating ? 'Updating…' : 'Update'}
+          </Button>
+        )}
+        {d.installed
+          ? d.updateAvailable
+            ? <span className="flex items-center gap-1 text-xs text-amber-600"><AlertTriangle className="h-3.5 w-3.5" /> outdated</span>
+            : <span className="flex items-center gap-1 text-xs text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" /> installed</span>
+          : <span className={`flex items-center gap-1 text-xs ${d.required ? 'text-red-600' : 'text-amber-600'}`}><XCircle className="h-3.5 w-3.5" /> missing</span>}
+      </div>
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -193,6 +193,16 @@ export interface DepStatus {
   installed: boolean
   path?: string
   version?: string
+  /** Resolved only via a fallback location — not on the server's PATH (sessions still launch). */
+  offPath?: boolean
+  /** npm package this dep ships from; present ⇒ it can be version-checked and updated in place. */
+  npmPkg?: string
+  /** Latest published version, when the registry answered. */
+  latest?: string
+  /** True when the installed version is behind `latest`. */
+  updateAvailable?: boolean
+  /** Why freshness couldn't be determined (offline box, registry error) — never fatal. */
+  updateError?: string
 }
 /** Native-dependency report for Settings → System (GET /api/deps). */
 export interface DepsReport {
@@ -208,6 +218,10 @@ export interface DepsReport {
   /** Zero-dependency bootstrap shortcut (works before a build). */
   shortcut: string
   platform: string
+  /** Installed-but-stale npm deps (drives the per-row "Update" button). */
+  outdated: string[]
+  /** When the freshness probe last ran, or 0 if it hasn't. */
+  updatesCheckedAt: number
 }
 /** Result of POST /api/deps/install — per-step logs plus the re-checked report. */
 export interface DepsInstallResult {
@@ -1364,10 +1378,13 @@ export const api = {
   stopAllSessions: () => call<{ ok: boolean; halted?: number; error?: string }>('POST', '/api/sessions/stop-all'),
   /** Host resource snapshot for Settings → System (RAM / CPU / uptime). */
   system: () => call<SystemMetrics>('GET', '/api/system'),
-  /** Native-dependency check for Settings → System (tmux/ttyd/claude/git present?). */
-  deps: () => call<DepsReport>('GET', '/api/deps'),
+  /** Native-dependency check for Settings → System — present? and, for npm-installed tools, up to date?
+   *  The registry lookup is cached server-side for an hour; `force` re-asks. */
+  deps: (force = false) => call<DepsReport>('GET', `/api/deps${force ? '?force=1' : ''}`),
   /** Install the missing package-manager-installable deps (owner-only). Returns step logs + fresh report. */
   installDeps: () => call<DepsInstallResult>('POST', '/api/deps/install'),
+  /** Upgrade one npm-installed dep in place, e.g. `claude` (owner-only). Returns step logs + fresh report. */
+  updateDep: (bin: string) => call<DepsInstallResult>('POST', '/api/deps/update', { bin }),
   rateSession: (id: string, rating: 'up' | 'down' | null) => call<{ ok: boolean; error?: string }>('POST', `/api/sessions/${id}/rate`, { rating }),
   /** Give a session a human-chosen display title (overrides the auto/AI-generated one). */
   renameSession: (id: string, title: string) => call<{ ok: boolean; error?: string; title?: string }>('POST', `/api/sessions/${id}/rename`, { title }),


### PR DESCRIPTION
## Why

Two issues on the instawp tenant today — `/model` couldn't list Opus 5, and the `opus` alias resolved to Opus 4.8 — had one root cause: the box was on **claude-code 2.1.216**, whose baked model registry tops out at `claude-opus-4-8`. The string `claude-opus-5` doesn't exist in that binary.

The config was fine. What's notable is that **Settings → System showed a green "All required dependencies are installed." the entire time.** `checkDeps()` only ever asked *is it present?* — `ok` is `deps.every(d => !d.required || d.installed)`, so a months-old runtime is fully "ok" by that definition. And the `claude` dep deliberately carries no package-manager `pkg`, so it sat outside the install path entirely.

Both boxes are already upgraded by hand (instawp + expresstech → 2.1.220). This closes the gap that let it go unnoticed.

## What changed

**Freshness** — a `Dep` may now name an `npmPkg`. `checkDepUpdates()` (`src/edge/deps.ts`) asks the npm registry for `latest` via the abbreviated `/latest` endpoint using the global `fetch` — no `npm` shell-out (it may not be on a systemd unit's PATH), no new dependency — caches for an hour, and flags a behind-version install. `checkDeps()` stays **sync and network-free**, so freshness is a layer on top rather than a slower probe; an offline box still gets its full presence report with a per-dep `updateError`.

`GET /api/deps` annotates the report (`?force=1` re-asks). A stale row goes amber with the published version and, for the owner, an **Update** button.

**Update** — `POST /api/deps/update` runs `npm install -g <pkg>@latest`. Owner-gated, audited `system.deps.updated`, and **never via sudo** (`sudo npm -g` leaves root-owned files in the prefix; a permissions failure surfaces the manual command instead). It prefers the `npm` sitting beside the resolved binary, so an nvm box can't install into a different node prefix than the one it actually runs from. CLI parity: `agent-os deps` shows `↑ … → v2.1.220 available`, `agent-os deps update <bin>` applies it.

**Fixed — off-PATH resolution.** `deps.ts` resolved binaries with a bare `command -v`, but `claude-cli.ts` walks `$CLAUDE_BIN` → PATH → `~/.local/bin/claude` precisely because a launchd/systemd parent ships a minimal PATH. On such a box the panel would report the runtime **missing** while sessions launched fine. Both now share `claudeBinCandidates()` and honour the same order — the test caught me resolving PATH first, which would report the version of a binary sessions never run. A dep found only via a fallback is version-probed at its resolved path and badged `off PATH`.

## Verification

- `npm run typecheck`, `npm run build`, `cd web && npm run build` — clean.
- `npm run test:governance` — 159 + 18 + 18 + 29 + 29 + **38** passed, exit 0.
- New `scripts/deps-freshness-test.cjs` (38 assertions, isolated home): version comparison, resolution order, the off-PATH case, stale detection, route authz (member/admin 403 on update, owner-only; non-npm and unknown deps refused *before* any shell-out), and a full update round-trip against a stubbed `npm` — which also pins the sibling-npm preference.
- Drove a real server on an isolated home with `CLAUDE_BIN` pointed at a fake reporting `2.1.100`, reproducing the instawp condition exactly: `ok: true`, `outdated: ['claude']`, `latest: 2.1.220`.

Panel in that state: amber **"1 dependency is out of date — Claude Code"**, the row reading `2.1.100 (Claude Code)` / `v2.1.220 available · npm install -g @anthropic-ai/claude-code@latest`, an **Update** button and an `outdated` badge, plus the note that running sessions keep their binary until they restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

