### PR TITLE
fix(insights): alerts must describe the present — stop re-firing about healed problems (v0.297.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.297.1] — 2026-08-03
+### Fixed
+- **Insight alerts kept re-firing about problems that were already fixed.** Both repeat-offender alerts
+  were monotonic counters over a fixed window, so once a condition healed the count stayed above the
+  threshold and the alert re-fired every 3-day cooldown until the rows aged out — training the owner to
+  ignore the channel, and pointing them at healthy agents to "fix".
+  - `agent-crash:<agent>` counted crashes over **30 days**. On the live instapods tenant the consolidator
+    crashed 9× between 2026-07-20 and 07-24 (the `TASK_B64` tmux-overflow bug fixed in v0.265.2), then ran
+    **12/12 green** — and the alert still fired on 07-28, 07-31 and 08-03, with a body telling the owner to
+    scope its tasks smaller. It now reads a 7-day `crashedRecent` count and stands down once the agent has
+    logged 3 clean runs since its last crash (`runsSinceCrash`), so a fixed crash loop goes quiet
+    immediately instead of ~4 weeks later. The 30d `crashed` total stays on the scorecard — that surface
+    is history, and only the alert claims the present tense.
+  - `friction:<capability>` counted rejections over **all time** — no window at all, so it could never
+    stop. `stripe.refund` (30 rejections, all between 2026-06-12 and 07-04) had alerted 7× in the previous
+    30 days and would have kept going forever. Rejections are now windowed to the same 30 days as the
+    scorecard, which also drops stale entries off the Insights **Friction** card.
+  - `agent-low` is deliberately left alone: it's a *rate*, so incoming successes dilute it and it
+    self-heals. New `scripts/alert-staleness-test.cjs` (in `npm run test:governance`) pins all of it —
+    ongoing loops still alert, healed ones don't.
+
 ## [0.297.0] — 2026-08-03
 ### Added
 - **DM continuity — a reply to a DM the OS sent you about a run goes back INTO that run.** `ask_human`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.297.0",
+  "version": "0.297.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.297.0",
+      "version": "0.297.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.297.0",
+  "version": "0.297.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,8 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs",
+    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs",
+    "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",
     "test:reaper": "node scripts/idle-reaper-test.cjs",
     "test:policy-tier-a": "node scripts/tier-a-policy-test.cjs",

--- a/scripts/alert-staleness-test.cjs
+++ b/scripts/alert-staleness-test.cjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/* Insight-alert staleness test — an alert must describe the PRESENT, not a healed past.
+ *
+ * Both conditions here are monotonic counters that only ever grow inside their window, so before the fix
+ * they kept re-firing (every 3-day cooldown) long after the underlying problem was solved:
+ *   · `agent-crash:<agent>` counted crashes over 30 days → a fixed crash loop re-alerted for ~4 more weeks.
+ *   · `friction:<capability>` counted rejections over ALL TIME → re-alerted forever, unkillable.
+ * Isolated home; rows are synthesized directly so the timing cases are exact. */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-alert-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { detectAlerts } = require(path.join(ROOT, 'dist/edge/alerts.js'));
+const { buildInsights } = require(path.join(ROOT, 'dist/edge/insights.js'));
+
+const aos = loadAgentOS();
+const DAY = 24 * 3600_000;
+const NOW = Date.now();
+
+let n = 0;
+/** One terminated session `ageDays` ago. `crashed` rows carry no terminal audit event, like a real crash. */
+const mkRun = (agent, status, ageDays) => {
+  const id = 'ts_' + (++n), at = NOW - ageDays * DAY;
+  aos.db.prepare("INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,spawned_by,created_at,updated_at) VALUES (?,?,?,?,?,?,1,'m_alice',?,?)")
+    .run(id, agent, 't', 'x', 'aos-' + id, status, at, at + 60_000);
+  if (status === 'done') {
+    aos.db.prepare("INSERT INTO audit_events (ts,tenant,run_id,principal,type,data) VALUES (?,?,?,'agent:x','session.ended',?)")
+      .run(at + 60_000, aos.tenant, id, JSON.stringify({ outcome: 'success' }));
+  }
+  return id;
+};
+const mkRejection = (capability, ageDays) => {
+  const id = 'ap_' + (++n);
+  aos.db.prepare("INSERT INTO approvals (id,run_id,tenant,level,capability,args,reason,status,created_at) VALUES (?,?,?,'owner',?,'{}','because','rejected',?)")
+    .run(id, 'ts_x', aos.tenant, capability, NOW - ageDays * DAY);
+};
+const keys = () => detectAlerts(aos, NOW).map((a) => a.key);
+const scoreFor = (agent) => buildInsights(aos, NOW).agents.find((a) => a.agent === agent);
+const wipeRuns = () => aos.db.exec('DELETE FROM term_sessions; DELETE FROM audit_events');
+
+console.log('\n\x1b[1m1) an ONGOING crash loop still alerts\x1b[0m');
+for (let i = 0; i < 4; i++) mkRun('crasher', 'crashed', i * 0.5);   // 4 crashes inside the last 2 days
+assert(keys().includes('agent-crash:crasher'), 'recent crashes → alert fires');
+assert(scoreFor('crasher').crashedRecent === 4, 'crashedRecent counts the recent burst');
+
+console.log('\n\x1b[1m2) a HEALED crash loop goes quiet (the regression)\x1b[0m');
+wipeRuns();
+for (let i = 0; i < 9; i++) mkRun('healed', 'crashed', 20 + i);      // 9 crashes, 20–28 days ago
+assert(scoreFor('healed').crashed === 9, '30d scorecard still shows the 9 crashes (history is kept)');
+assert(scoreFor('healed').crashedRecent === 0, 'none are recent');
+assert(!keys().includes('agent-crash:healed'), 'crashes older than the recency window → NO alert');
+
+console.log('\n\x1b[1m3) recovery threshold — clean runs since the last crash stand the alert down\x1b[0m');
+wipeRuns();
+for (let i = 0; i < 4; i++) mkRun('flaky', 'crashed', 3 + i * 0.1);  // recent burst, ~3 days ago
+mkRun('flaky', 'done', 1); mkRun('flaky', 'done', 0.9);             // only 2 clean runs since
+assert(scoreFor('flaky').runsSinceCrash === 2, 'runsSinceCrash = 2');
+assert(keys().includes('agent-crash:flaky'), '2 clean runs is not yet recovery → still alerts');
+mkRun('flaky', 'done', 0.8);                                        // the 3rd clean run
+assert(scoreFor('flaky').runsSinceCrash === 3, 'runsSinceCrash = 3');
+assert(!keys().includes('agent-crash:flaky'), '3 clean runs → recovered, alert stands down');
+
+console.log('\n\x1b[1m4) rejection friction is windowed, not all-time\x1b[0m');
+wipeRuns();
+for (let i = 0; i < 30; i++) mkRejection('stripe.refund', 40 + i);  // all 40+ days old
+assert(!keys().includes('friction:stripe.refund'), 'rejections older than the window → NO alert');
+assert(buildInsights(aos, NOW).friction.rejections.length === 0, 'and they leave the Friction card too');
+for (let i = 0; i < 6; i++) mkRejection('slack.send', i);           // 6 in the last week
+assert(keys().includes('friction:slack.send'), 'current rejections still alert');
+
+console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m`);
+fs.rmSync(HOME, { recursive: true, force: true });
+process.exit(fail ? 1 : 0);

--- a/src/edge/alerts.ts
+++ b/src/edge/alerts.ts
@@ -9,10 +9,13 @@
  * the tick posts the card + DMs. See src/edge/insights.ts, docs/inbox-plan.md.
  */
 import type { AgentOS } from '../kernel';
-import { buildInsights } from './insights';
+import { buildInsights, RECENT_DAYS } from './insights';
 import { measureLearning } from './measurement';
 
 const COOLDOWN_MS = 3 * 24 * 3_600_000; // don't re-alert the same key within 3 days
+/** Clean work runs since the last crash that count as "recovered" — enough to not be a lucky single pass,
+ *  small enough that a genuinely flaky agent (crash, pass, crash) never reaches it and keeps alerting. */
+const RECOVERED_RUNS = 3;
 
 export interface InsightAlert {
   key: string;
@@ -58,12 +61,20 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
     }
     // Crashing = the process/pane keeps dying (infra: too heavy / OOM / timeout) — a different fix than
     // "the agent does bad work". Kept distinct so it doesn't read as poor agent quality.
-    else if (a.crashed >= 3) {
+    //
+    // Read the RECENT crash count, not the 30d total, and stand down once the agent has recovered. A crash
+    // count over a fixed window only ever goes up: once a crash loop is FIXED, the 30d total stays over the
+    // threshold for the rest of the window, so the alert re-fires every cooldown for weeks about a problem
+    // that no longer exists — and the body's "scope its tasks smaller" sends the human to re-tune a healthy
+    // agent. (Real case: the consolidator's tmux-overflow crash loop was fixed after 9 crashes and then ran
+    // 12/12 green; the alert fired 3 more times across the next 10 days.) `agent-low` above needs no such
+    // guard — it's a RATE, so incoming successes dilute it and it self-heals.
+    else if (a.crashedRecent >= 3 && a.runsSinceCrash < RECOVERED_RUNS) {
       out.push({
         key: `agent-crash:${a.agent}`,
         severity: 'high',
         title: `${a.agent}'s runs keep crashing`,
-        body: `${a.crashed} of ${a.agent}'s runs crashed in the last ${ins.windowDays} days — the process died mid-run (usually too-heavy work, OOM, or a timeout), not a task failure. Scope its tasks smaller, or give it more headroom.`,
+        body: `${a.crashedRecent} of ${a.agent}'s runs crashed in the last ${RECENT_DAYS} days — the process died mid-run (usually too-heavy work, OOM, or a timeout), not a task failure. Scope its tasks smaller, or give it more headroom.`,
         route: 'insights',
       });
     }

--- a/src/edge/insights.ts
+++ b/src/edge/insights.ts
@@ -18,14 +18,28 @@ type Db = AgentOS['db'];
 
 const DAY = 24 * 3_600_000;
 const WINDOW_DAYS = 30;
+/** Recency sub-window inside the 30d scorecard. The scorecard is *history* ("how has this agent done
+ *  lately?"), but an ALERT must describe the PRESENT — a monotonic count over 30 days keeps firing for
+ *  weeks after the cause is fixed. `crashedRecent` / `runsSinceCrash` are the "is this still happening?"
+ *  companions the alert branch reads instead of the window totals. */
+export const RECENT_DAYS = 7;
 const STOP = new Set(['task', 'outcome', 'session', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none', 'then', 'call', 'test', 'once', 'stop', 'tool', 'tools', 'exactly', 'nothing', 'else']);
 
-export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
+export interface AgentScore {
+  agent: string; runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number;
+  rate: number | null; focus: string[];
+  /** Crashes within the last RECENT_DAYS — "is it crashing NOW", vs `crashed`'s 30d history. */
+  crashedRecent: number;
+  /** Work runs that have completed SINCE the most recent crash — the recovery signal (a healed agent
+   *  piles these up). `Infinity`-free: no crash in the window ⇒ all of `runs`. */
+  runsSinceCrash: number;
+  diagnosis?: { at: number; slug: string };
+}
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }
 
-interface OutRow { run_id: string; agent: string; spawned_by: string | null; status: string; outcome: string | null }
+interface OutRow { run_id: string; agent: string; spawned_by: string | null; status: string; outcome: string | null; created_at: number }
 interface EpRow { agent_id: string; content: string }
 
 /** Top few focus keywords for one agent's episode first-lines (what it actually spends runs on). */
@@ -53,27 +67,40 @@ export function buildInsights(os: AgentOS, now = Date.now()): Insights {
   // still-running sessions.
   const rows = db
     .prepare(
-      "SELECT s.id AS run_id, s.agent, s.spawned_by, s.status, " +
+      "SELECT s.id AS run_id, s.agent, s.spawned_by, s.status, s.created_at, " +
         "(SELECT CASE WHEN a.type = 'session.stopped' THEN 'stopped' ELSE COALESCE(json_extract(a.data,'$.outcome'),'unknown') END " +
         "   FROM audit_events a WHERE a.run_id = s.id AND a.type IN ('session.reported','session.ended','session.stopped','run.completed') " +
         "   ORDER BY CASE a.type WHEN 'session.reported' THEN 3 WHEN 'run.completed' THEN 2 WHEN 'session.ended' THEN 1 ELSE 0 END DESC LIMIT 1) AS outcome " +
         "FROM term_sessions s WHERE s.created_at >= ? AND s.status != 'running'",
     )
     .all<OutRow>(since);
-  const tally = new Map<string, { runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number }>();
+  const recentSince = now - RECENT_DAYS * DAY;
+  const tally = new Map<string, { runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number; crashedRecent: number; lastCrashAt: number }>();
   for (const r of rows) {
-    const t = tally.get(r.agent) ?? { runs: 0, success: 0, failed: 0, stopped: 0, crashed: 0, chats: 0 };
+    const t = tally.get(r.agent) ?? { runs: 0, success: 0, failed: 0, stopped: 0, crashed: 0, chats: 0, crashedRecent: 0, lastCrashAt: 0 };
     // Chat-triggered sessions are conversational Q&A — they don't call `report`, so counting them in the
     // success rate unfairly penalises chat-heavy agents (they'd all look like they're "failing"). Track
     // them separately and keep them OUT of the rate denominator.
     if ((r.spawned_by ?? '').startsWith('chat:')) { t.chats++; tally.set(r.agent, t); continue; }
     const outcome = r.outcome ?? 'unknown';
     t.runs++;
-    if (r.status === 'crashed') t.crashed++;          // crash = infra died, surfaced distinctly from a `failure`
+    if (r.status === 'crashed') {                     // crash = infra died, surfaced distinctly from a `failure`
+      t.crashed++;
+      if (r.created_at >= recentSince) t.crashedRecent++;
+      if (r.created_at > t.lastCrashAt) t.lastCrashAt = r.created_at;
+    }
     else if (outcome === 'success') t.success++;
     else if (outcome === 'failure') t.failed++;
     else if (outcome === 'stopped') t.stopped++;
     tally.set(r.agent, t);
+  }
+  // Second pass: work runs that landed AFTER each agent's most recent crash. A fixed crash loop shows up
+  // here as a growing streak, which is what lets the alert shut up as soon as the agent recovers.
+  const sinceCrash = new Map<string, number>();
+  for (const r of rows) {
+    if ((r.spawned_by ?? '').startsWith('chat:')) continue;
+    const last = tally.get(r.agent)?.lastCrashAt ?? 0;
+    if (r.created_at > last) sinceCrash.set(r.agent, (sinceCrash.get(r.agent) ?? 0) + 1);
   }
 
   // Per-agent focus from this window's episodes.
@@ -84,16 +111,19 @@ export function buildInsights(os: AgentOS, now = Date.now()): Insights {
   const agents: AgentScore[] = [...tally.entries()]
     .map(([agent, t]) => {
       const dx = os.kb.read(os.tenant, 'operations', diagnosisSlug(agent)); // existing root-cause diagnosis, if any
-      return { agent, runs: t.runs, success: t.success, failed: t.failed, stopped: t.stopped, crashed: t.crashed, chats: t.chats, rate: t.runs ? Math.round((t.success / t.runs) * 100) : null, focus: focusFor(epByAgent.get(agent) ?? []), diagnosis: dx ? { at: dx.updatedAt, slug: dx.slug } : undefined };
+      return { agent, runs: t.runs, success: t.success, failed: t.failed, stopped: t.stopped, crashed: t.crashed, chats: t.chats, crashedRecent: t.crashedRecent, runsSinceCrash: sinceCrash.get(agent) ?? 0, rate: t.runs ? Math.round((t.success / t.runs) * 100) : null, focus: focusFor(epByAgent.get(agent) ?? []), diagnosis: dx ? { at: dx.updatedAt, slug: dx.slug } : undefined };
     })
     // Rank by activity — work runs, then chats — so a chat-only agent still appears.
     .sort((a, b) => (b.runs + b.chats) - (a.runs + a.chats))
     .slice(0, 12);
 
   // Friction: capabilities rejected at approval (deny or auto-allow?), + approvals waiting on a human.
+  // Windowed to the SAME 30 days as the scorecard: unbounded, this counts rejections from the beginning of
+  // time, so a capability someone sorted out months ago stays on the card (and re-alerts every cooldown)
+  // forever. "Keeps getting rejected" is a claim about the present tense.
   const rejections = db
-    .prepare("SELECT capability, count(*) AS count FROM approvals WHERE status = 'rejected' GROUP BY capability ORDER BY count DESC LIMIT 8")
-    .all<RejectedCapability>();
+    .prepare("SELECT capability, count(*) AS count FROM approvals WHERE status = 'rejected' AND created_at >= ? GROUP BY capability ORDER BY count DESC LIMIT 8")
+    .all<RejectedCapability>(since);
   const pending = db.prepare("SELECT count(*) AS n, MIN(created_at) AS oldest FROM approvals WHERE status = 'pending'").get<{ n: number; oldest: number | null }>();
   const friction: FrictionMap = {
     rejections,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -429,7 +429,7 @@ export interface DreamingState {
   totals?: { sessions: number; success: number; failure: number; partial: number; stopped: number; unknown: number; rejected: number; budgetStops: number; errors: number }
   recent?: DreamingReview[]
 }
-export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
+export interface AgentScore { agent: string; runs: number; success: number; failed: number; stopped: number; crashed: number; chats: number; crashedRecent: number; runsSinceCrash: number; rate: number | null; focus: string[]; diagnosis?: { at: number; slug: string } }
 export interface RejectedCapability { capability: string; count: number }
 export interface FrictionMap { rejections: RejectedCapability[]; pendingApprovals: number; oldestPendingAgeMs: number | null }
 export interface Insights { windowDays: number; agents: AgentScore[]; friction: FrictionMap }


### PR DESCRIPTION
## The report

> 9 of consolidator's runs crashed in the last 30 days — the process died mid-run … Scope its tasks smaller, or give it more headroom.

Getting this repeatedly. It's a false positive, and the advice is actively wrong.

## What the live data says

All 9 consolidator crashes are in one dead 5-day window:

| | |
|---|---|
| Crashes | 2026-07-20 → **2026-07-24 16:35** (9 runs, each dead in ~10s) |
| First success | **2026-07-24 16:42** — 7 minutes later |
| Since then | **12 runs, 12 done, 0 crashed** |

That gap is v0.265.2 (#463) shipping — the `TASK_B64` tmux command-line overflow. The crash loop was diagnosed and fixed 10 days ago. But `agent-crash:consolidator` fired on **07-22, 07-25, 07-28, 07-31, 08-03** — every 3 days, exactly the cooldown — and **the last three fired after the fix, against a 12/12-green agent**. It would keep going until 2026-08-23.

Same bug, worse, in the friction branch: the rejections query has **no time window at all**.

```sql
SELECT capability, count(*) FROM approvals WHERE status = 'rejected' GROUP BY capability
```

`stripe.refund` — 30 rejections, all between 2026-06-12 and **2026-07-04** — has alerted 7× in the last 30 days and would have alerted forever. The only `stripe.refund` events in the audit log for the past month *are the alerts about it*.

## Root cause

Both are monotonic counters over a fixed window being asked to answer a present-tense question. A crash count only goes up; once a loop is fixed the total stays over the threshold for the rest of the window. A scorecard can be history — an **alert** cannot, because it's an interrupt that costs a human attention and sends them to "fix" something healthy.

## The fix

- **`agent-crash`** reads a new 7-day `crashedRecent` instead of the 30d total, and stands down once the agent logs 3 clean runs since its last crash (`runsSinceCrash`). A fixed crash loop goes quiet immediately rather than ~4 weeks later. The 30d `crashed` total stays on the scorecard — that surface *is* history.
- **`friction`** is windowed to the same 30 days as the scorecard. This also drops stale rows off the Insights **Friction** card, which was showing an all-time count next to a 30-day scorecard.
- **`agent-low` deliberately unchanged** — it's a *rate*, so incoming successes dilute it and it self-heals. No guard needed.

## Verification

A/B on a `VACUUM INTO` snapshot of the live instapods DB (isolated `AGENT_OS_HOME`), same build otherwise:

```
CONTROL (main)                          FIXED
─────────────────────────────────       ─────────────────────────────────
[high]   success-drop                   [high] success-drop
[high]   agent-crash:consolidator   →   (gone — crashedRecent=0, sinceCrash=11)
[medium] friction:stripe.refund     →   (gone — rejections=[])
```

`success-drop` survives in both — it's week-over-week, already recency-correct. Proof this narrows the noise rather than muting the channel.

Negative control — same DB with the crashes shifted into the last 3 days: alert fires again, now reading `9 … in the last 7 days`. Boundary: 2 clean runs since the crash → still fires; 3 → stands down.

New `scripts/alert-staleness-test.cjs` (12 assertions, wired into `npm run test:governance`) pins both directions.

`npm run typecheck` · `web` build · `test:governance` **265/265** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)