### PR TITLE
feat(chat): friendly greeting reply + drop System agents from the help/name roster (v0.298.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.298.0] — 2026-08-04
+### Added
+- **Chat front door: greetings get a friendly reply, and the help/`/name` roster drops System agents.**
+  A bare "hey" / "thanks" / "good morning" (a new `social` intent — short, no OS noun, no task) now gets a
+  one-line "👋 Happy to help — ask me a question about your workspace, or tell me what you need done"
+  instead of dumping the whole agent list. A greeting that wraps a real request ("hello, I need help
+  reviewing a PR") still routes as work (length + OS-noun guards). And the addressable/help roster now
+  excludes `category:'System'` machinery (concierge/operator/consolidator) — they were being listed as
+  `/agent`-addressable. Applies to Slack/Discord (`routeUnmatched`/`routeChat`) and Cockpit web
+  (`/api/router/preview` renders the greeting inline like an `ask` answer). `src/edge/intent.ts`,
+  `src/edge/automations.ts`, `src/server.ts`.
+
 ## [0.297.1] — 2026-08-03
 ### Fixed
 - **Insight alerts kept re-firing about problems that were already fixed.** Both repeat-offender alerts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.297.1",
+  "version": "0.298.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.297.1",
+      "version": "0.298.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.297.1",
+  "version": "0.298.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -18,7 +18,7 @@ import { Db } from '../state/db';
 import { TerminalManager } from '../terminal';
 import { CodingRuntimeId, isCodingRuntime, Task, TaskTimelineEntry } from '../types';
 import { chooseAgent, RouterCandidate } from './router';
-import { classifyIntent } from './intent';
+import { classifyIntent, SOCIAL_REPLY } from './intent';
 import { answerAsk } from './ask';
 import { ensureConcierge, ensureOperator, CONCIERGE_ID, OPERATOR_ID } from './concierge';
 
@@ -653,7 +653,9 @@ export class Automations {
   }
 
   private routeChat(text: string): { agentId?: string; help?: string } {
-    const claudeAgents = [...this.os.agents.values()].filter((a) => isCodingRuntime(a.runtime));
+    // Exclude the code-provisioned System machinery (concierge/operator/consolidator/…) — not user-facing
+    // teammates, so never addressable or listed in the help roster.
+    const claudeAgents = [...this.os.agents.values()].filter((a) => isCodingRuntime(a.runtime) && a.category !== 'System');
     // Only agents opted-in to the open chat front door (`chatReachable !== false`) are addressable here.
     const chatAgents = claudeAgents.filter((a) => a.chatReachable !== false).map((a) => a.id);
     const m = this.normalizeChatCommand(text).trim().match(/^\/([A-Za-z0-9][\w-]*)\b\s*([\s\S]*)$/);
@@ -804,6 +806,11 @@ export class Automations {
     //    thread"), not a bespoke client poll. `work` routes to the best-fit teammate. Fails safe.
     if (this.os.settings.autoRouteEnabled()) {
       const intent = classifyIntent(opts.text).intent;
+
+      if (intent === 'social') {
+        // A bare "hey"/"thanks" — reply conversationally instead of routing or dumping the roster.
+        return { sessions, reply: SOCIAL_REPLY };
+      }
 
       if (intent === 'ask') {
         // A question ABOUT the workspace: answer INLINE first (fast, no session) — state lookup → direct

--- a/src/edge/intent.ts
+++ b/src/edge/intent.ts
@@ -12,7 +12,11 @@
  * `ask`/`action`. The `ask` ANSWER needs an LLM, but the CLASSIFICATION here never does.
  */
 
-export type Intent = 'work' | 'ask' | 'action';
+export type Intent = 'work' | 'ask' | 'action' | 'social';
+
+/** The friendly reply to a bare greeting / chit-chat — instead of dumping the agent roster. */
+export const SOCIAL_REPLY =
+  "👋 Happy to help — ask me a question about your workspace, or tell me what you need done and I'll get the right agent on it.";
 
 export interface IntentResult {
   intent: Intent;
@@ -32,6 +36,9 @@ const TASK_RE = /\b(create|add|open|file|make|log)\s+(a\s+|an\s+|the\s+)?(task|t
 const OS_NOUN_RE = /\b(agent|agents|fleet|session|sessions|automation|automations|task|tasks|memory|memories|polic(y|ies)|approval|approvals|budget|spend|cost|costs|audit|team|member|members|skill|skills|connector|connectors|integration|integrations|knowledge\s*base|\bkb\b|agent\s*-?\s*os|this\s+(system|workspace|console)|the\s+(system|fleet|workspace))\b/i;
 // Question-shaped openers (also matched by a trailing '?').
 const QUESTION_RE = /^(how|what|which|why|when|who|whose|where|is|are|am|do|does|did|can|could|should|would|will|list|show|tell\s+me|explain|describe|give\s+me|summar(y|ise|ize)|status)\b/i;
+// A bare greeting / thanks / small-talk — no task, no workspace question. Only `social` when it ALSO has
+// no OS meta-noun ("good morning, how many tasks?" is a real question, not chit-chat — see classifyIntent).
+const GREETING_RE = /^(hi+|hey+|hello|yo|sup|howdy|hiya|gm|gn|good\s+(morning|afternoon|evening|night)|thank(s| you)|thx|ty|cheers)\b|^(how\s+are\s+you|how'?s\s+it\s+going|what'?s\s+up|wass?up|greetings)\b/i;
 
 /** Classify a message. Pure, synchronous, LLM-free. */
 export function classifyIntent(text: string): IntentResult {
@@ -41,6 +48,10 @@ export function classifyIntent(text: string): IntentResult {
   // 1) Action — an explicit request to operate a primitive. Checked first: "schedule …" is unambiguous.
   if (TASK_RE.test(t)) return { intent: 'action', surface: 'tasks' };
   if (SCHEDULE_RE.test(t)) return { intent: 'action', surface: 'automations' };
+
+  // Greeting / chit-chat with no workspace content → a friendly reply, not routing or a roster dump. Only
+  // a SHORT pure greeting counts — "hello, I need help reviewing a PR" is a request wearing a greeting.
+  if (GREETING_RE.test(t) && !OS_NOUN_RE.test(t) && t.split(/\s+/).filter(Boolean).length <= 5) return { intent: 'social' };
 
   // 2) Ask — a question that's ABOUT the workspace (question-shaped or '?'-terminated, AND references an
   //    OS meta-noun). "how do I fix my pod" is question-shaped but about a DOMAIN thing (pod) → stays

--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ import { type ChatArtifactRef, type ChatKbRef, type ChatAppRef } from './edge/co
 import { summarizeConversation } from './edge/summarize';
 import { Automation, Automations, nextCronRun, derivedConcurrencyCap, chatTitle } from './edge/automations';
 import { chooseAgent } from './edge/router';
-import { classifyIntent } from './edge/intent';
+import { classifyIntent, SOCIAL_REPLY } from './edge/intent';
 import { ensureConcierge, CONCIERGE_ID, ensureOperator, OPERATOR_ID } from './edge/concierge';
 import { answerAsk } from './edge/ask';
 import { SlackSocket } from './edge/slack-socket';
@@ -2609,6 +2609,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     };
 
     const intent = b.force === 'work' ? { intent: 'work' as const } : classifyIntent(text);
+
+    // A bare greeting / thanks → a friendly reply, rendered inline like an `ask` answer (no session).
+    if (intent.intent === 'social') {
+      return sendJson(res, 200, { intent: 'ask', answer: SOCIAL_REPLY, source: 'state' });
+    }
 
     if (intent.intent === 'action' && intent.surface) {
       return sendJson(res, 200, { intent: 'action', surface: intent.surface });


### PR DESCRIPTION
Two chat front-door fixes prompted by an instawp Slack reply where "hey how are you" dumped the whole agent list (incl. `consolidator`).

## 1. Greetings get a friendly reply, not a roster dump
A new `social` intent — a **short, pure greeting** (`hi`, `hey how are you`, `thanks`, `good morning`) with no OS-noun and no task — replies:
> 👋 Happy to help — ask me a question about your workspace, or tell me what you need done and I'll get the right agent on it.

instead of listing every agent. Guards keep real requests routing: a greeting that wraps a request ("**hello, I need help reviewing a PR**") stays `work`, and "**good morning, how many tasks are open?**" stays `ask` (OS-noun present). **Verified 10/10.**

Note: this is *not* why instawp misbehaves generally — a bare greeting has nothing to route on any version; this just makes that fallback friendly. Applies to Slack/Discord **and** Cockpit web (rendered inline like an `ask` answer).

## 2. System agents dropped from the addressable/help roster
`routeChat` now excludes `category:'System'` machinery (`concierge`/`operator`/`consolidator`) — they were being listed as `/agent`-addressable and shown in the help list. The router already excluded them; the roster now matches.

## Verification
- `typecheck` + `build` clean; `test:governance` → **159/159** + tier-A **18/18** + capability **18/18** + idle-reaper
- Classifier 10/10 (greetings → social; greeting-prefixed requests + real questions → work/ask/action)

## After merge
Deploy, then in Discord try `hey` (→ friendly reply) and a real request (→ routed), and note the help list no longer shows `consolidator`/`concierge`/`operator`.

`src/edge/intent.ts`, `src/edge/automations.ts`, `src/server.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)