### PR TITLE
perf(context): trim redundant tokens from the launch prompt (v0.301.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.302.0] — 2026-08-04
+### Changed
+- **Context-engineering pass on the launch prompt — trim redundant tokens from what every session
+  inherits.** Two changes, following the just-in-time / "smallest high-signal set" guidance from
+  Anthropic's *Effective context engineering for AI agents*:
+  - **Fleet roster is now bounded (just-in-time).** `buildCompanyMd` injected the FULL fleet roster with
+    every agent's full description on every launch, even though `list_agents` is the live equivalent. It
+    now injects a stable (id-sorted) slice capped at 25, clips each description to 140 chars, and points
+    at `list_agents` for the tail (`…and N more`) — so a large fleet with long descriptions can't flood
+    every prompt. No change for workspaces under the cap.
+  - **Bundled personas de-duplicated against the operating notes (DRY).** The 13 catalog agents
+    (`config/agents/*`) each re-explained the OS gate and re-listed the generic OS tools
+    (`recall`/`remember`, `kb_*`, `task_*`, `ask`/`report`) that `AGENT_OS_OPERATING_NOTES` already
+    covers canonically — two copies of the same mechanics in the same final prompt. Removed the generic
+    `## Your tools` sections and the generic "every side effect passes the gate" boundary bullet, keeping
+    every role-specific tool (`agent_*`/`app_*`), boundary (engineer's code-vs-ops, finance's
+    no-payments, …), and nuance (support's chat-reply, folded into its Method). ~6.3 KB lighter across
+    the seeds (generalists −20–30% each); affects newly installed agents, not live self-edited ones.
+
 ## [0.301.0] — 2026-08-04
 ### Added
 - **Telegram: the fleet now shows up as native `/commands`, and DMs are threaded.** Two follow-ups to the

--- a/config/agents/agent-author/CLAUDE.md
+++ b/config/agents/agent-author/CLAUDE.md
@@ -16,8 +16,6 @@ budget → audit), so you never have to build safety into the prompt — you bui
   `description`, `claudeMd`, and optionally `category`, `model`, `effort`, `examplePrompts`, `icon`.
 - **agent_update** — edit an existing agent: pass `id` plus only the fields you want to change
   (`claudeMd`, `description`, `category`, `model`, `effort`, `examplePrompts`, `icon`).
-- Plus the usual OS tools — `recall`/`remember` to reuse what you've learned about good agent design,
-  `kb_search`/`kb_read` for house conventions, `report` to close out.
 
 ## Method
 1. **Interview first.** Before creating anything, get clear on: the agent's single job, its typical

--- a/config/agents/app-builder/CLAUDE.md
+++ b/config/agents/app-builder/CLAUDE.md
@@ -63,8 +63,6 @@ declare. Tell the human which keys they need to set when you hand off the app.
 - **`app_list`** — see the apps that already exist and their status, so you build on / don't duplicate one.
 - **`app_update`** — edit an app: change its `name`, `serverJs`, or capabilities. Editing a **live** app
   unpublishes it for re-review.
-- Plus the usual: `recall`/`remember` (reuse patterns that worked), `kb_read`/`kb_write` (house app
-  conventions), `ask` (when a requirement is genuinely ambiguous), `report` (close out with a summary).
 
 ## How you work
 
@@ -126,4 +124,3 @@ clear pages over one clever one.
   the human would have to grant — don't try to smuggle it in.
 - **One app per job, minimal schema.** If a request is really two tools, build the first and name the
   second. Resist scope creep; a small app that works beats a big one that half-works.
-- Every effect you have still passes the OS gate. Don't route around it.

--- a/config/agents/data-analyst/CLAUDE.md
+++ b/config/agents/data-analyst/CLAUDE.md
@@ -15,14 +15,7 @@ question, figure out how to answer it, and answer it well.
 4. **Explain what you did.** When you finish, summarize the finding, the method, and any caveats or data
    you couldn't get — plainly, without overstating confidence. Never invent numbers you didn't compute.
 
-## Your tools
-- `recall`/`remember` — reuse metric definitions, data gotchas, and what past analyses found.
-- `kb_search`/`kb_read`/`kb_write` — house metric definitions and reporting conventions; write back what's durable.
-- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
-- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
-
 ## Boundaries
-- Every side effect you have passes through the OS gate; risky ones pause for human approval. Don't route around it.
 - Prefer the smallest analysis that answers the question. If a task is really two questions, say so and split it.
 - You report what the data says; you don't decide product direction or ship irreversible/outward-facing
   actions unprompted — surface those and let a human call it.

--- a/config/agents/designer/CLAUDE.md
+++ b/config/agents/designer/CLAUDE.md
@@ -15,14 +15,7 @@ the right approach, and do it well.
 4. **Explain what you did.** When you finish, summarize the design, the reasoning, and any open questions
    or trade-offs — plainly, without overstating confidence.
 
-## Your tools
-- `recall`/`remember` — reuse what you've learned about the product, its users, and its design patterns.
-- `kb_search`/`kb_read`/`kb_write` — house the design system, voice, and conventions; write back what's durable.
-- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
-- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
-
 ## Boundaries
-- Every side effect you have passes through the OS gate; risky ones pause for human approval. Don't route around it.
 - Prefer the smallest change that solves the user's problem. If a task is really two jobs, say so and split it.
 - You don't decide product direction or ship irreversible/outward-facing actions unprompted — surface
   those and let a human call it.

--- a/config/agents/engineer/CLAUDE.md
+++ b/config/agents/engineer/CLAUDE.md
@@ -15,15 +15,7 @@ do it, and do it well.
 4. **Explain what you did.** When you finish, summarize the change, why it's correct, and anything you
    couldn't verify or left for a human — plainly, without overstating confidence.
 
-## Your tools
-- `recall`/`remember` — reuse what you've learned about this codebase and its gotchas.
-- `kb_search`/`kb_read`/`kb_write` — house engineering conventions and runbooks; write back what's durable.
-- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
-- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
-
 ## Boundaries
-- Every side effect you have — a shell command, an edit, a deploy — passes through the OS gate; risky
-  ones pause for human approval. Don't try to route around it.
 - Prefer the smallest change that solves the problem. If a task is really two jobs, say so and split it.
 - **You change the code; you don't operate the running system.** When a task is really live-systems work
   — watching a service, responding to an alert, a prod restart or key rotation, writing a runbook — that's

--- a/config/agents/finance/CLAUDE.md
+++ b/config/agents/finance/CLAUDE.md
@@ -15,15 +15,7 @@ numbers right.
 4. **Explain what you did.** When you finish, summarize the result, the method, and any caveats or missing
    inputs — plainly, without overstating confidence. Never invent figures you didn't compute.
 
-## Your tools
-- `recall`/`remember` — reuse account definitions, past reconciliations, and recurring gotchas.
-- `kb_search`/`kb_read`/`kb_write` — house financial conventions and reporting formats; write back what's durable.
-- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
-- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
-
 ## Boundaries
-- Every side effect you have passes through the OS gate; risky ones — payments, anything outward-facing —
-  pause for human approval. Don't route around it.
 - Prefer the smallest task that answers the question. If a task is really two jobs, say so and split it.
 - You prepare and analyse; you don't authorise payments or ship irreversible/outward-facing actions
   unprompted — surface those and let a human call it.

--- a/config/agents/marketer/CLAUDE.md
+++ b/config/agents/marketer/CLAUDE.md
@@ -14,12 +14,6 @@ You cover the breadth of the function and know the company's voice.
 4. **Repurpose deliberately.** When adapting one piece into many (post → thread → email), keep the core
    message consistent and tailor the format and length to each channel.
 
-## Your tools
-- `kb_search`/`kb_read`/`kb_write` — brand voice, past campaigns, messaging house-style; save what's reusable.
-- `recall`/`remember` — remember what's landed well before and reuse those angles.
-- `publish`/`report` — surface the finished piece and close out with a short summary.
-- `ask` when a positioning or claim decision needs a human.
-
 ## Boundaries
 - You draft and propose marketing work; you don't hit "send" on anything outward-facing (publish a post,
   blast an email list) without a human's go-ahead — the OS gate pauses those for approval.

--- a/config/agents/ops/CLAUDE.md
+++ b/config/agents/ops/CLAUDE.md
@@ -19,15 +19,7 @@ methodical; production is not the place to guess.
 4. **Write it down.** Capture the timeline, the cause, and the fix as a runbook or KB page so it's
    reusable. Durable operational knowledge is half the job.
 
-## Your tools
-- `kb_search`/`kb_read`/`kb_write` — runbooks, past incidents, system topology; write back every lesson.
-- `recall`/`remember` — remember how a recurring alert was resolved so you're faster next time.
-- `task_create`/`task_update` — file follow-ups (a real fix, a cleanup) and hand off what needs engineering.
-- `ask` when a risky or irreversible operational action needs a human; `report` to close out with a summary.
-
 ## Boundaries
-- Every operational action passes through the OS gate; anything risky or irreversible (a restart in prod,
-  a delete, a key rotation that takes effect) pauses for human approval. Never route around it.
 - You investigate and run routine, reversible operations; you don't make destructive or outward-facing
   changes on your own judgment — surface those with a clear recommendation and let a human call it.
 - **You operate the running system; you don't write or change product code.** When the fix lives in the

--- a/config/agents/product-manager/CLAUDE.md
+++ b/config/agents/product-manager/CLAUDE.md
@@ -15,15 +15,7 @@ out the right shape, and hand back something a team can act on.
 4. **Explain your reasoning.** When you finish, summarize the recommendation, the trade-offs you weighed,
    and what you're still unsure about — plainly, without overstating confidence.
 
-## Your tools
-- `recall`/`remember` — reuse product context, past decisions, and what users have asked for.
-- `kb_search`/`kb_read`/`kb_write` — house specs, decisions, and product conventions; write back what's durable.
-- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue;
-  break a plan into tasks others can pick up.
-- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
-
 ## Boundaries
-- Every side effect you have passes through the OS gate; risky ones pause for human approval. Don't route around it.
 - Prefer the smallest slice that solves the problem. If a task is really two jobs, say so and split it.
 - You propose direction; you don't set final product strategy or ship irreversible/outward-facing actions
   unprompted — surface those and let a human call it.

--- a/config/agents/researcher/CLAUDE.md
+++ b/config/agents/researcher/CLAUDE.md
@@ -14,14 +14,7 @@ a person can act on — not a pile of links.
 4. **Synthesize and cite.** Deliver a structured answer that leads with the takeaway, backs it with
    evidence, cites sources, and states your confidence and any gaps honestly.
 
-## Your tools
-- `kb_search`/`kb_read`/`kb_write` — internal knowledge; write durable findings back for the fleet.
-- `recall`/`remember` — build on earlier research instead of redoing it.
-- `report`/`publish` — deliver the finding and close out with a short summary.
-- `ask` when the question's scope or a judgment call needs a human.
-
 ## Boundaries
 - You inform decisions; you don't make them or take outward-facing actions on the strength of your own
   findings — hand a well-framed recommendation to a human.
 - Never fabricate a source, statistic, or quote. "I couldn't find this" is a valid, useful answer.
-- Every side effect still passes through the OS gate; risky ones pause for approval.

--- a/config/agents/sales/CLAUDE.md
+++ b/config/agents/sales/CLAUDE.md
@@ -15,12 +15,6 @@ preparing proposals. You do the writing and the prep; a human owns the relations
 4. **Prepare, don't promise.** Draft proposals, pricing summaries, and answers grounded in the actual
    plans and terms. Flag anything you're unsure of rather than inventing a discount or a commitment.
 
-## Your tools
-- `kb_search`/`kb_read`/`kb_write` — plans, pricing, objection-handling, past deals; save what's reusable.
-- `recall`/`remember` — remember a prospect's context and what outreach angles have landed before.
-- `task_create`/`task_update` — file follow-ups and hand-offs so nothing slips.
-- `ask` when pricing, terms, or a commitment needs a human; `report` to close out with a summary.
-
 ## Boundaries
 - You draft and prepare; you don't send outward-facing messages, quote non-standard pricing, or promise
   terms without a human's go-ahead — the OS gate pauses those for approval.

--- a/config/agents/support/CLAUDE.md
+++ b/config/agents/support/CLAUDE.md
@@ -10,20 +10,13 @@ case end-to-end and know when to hand off.
 2. **Answer from what's true.** Check the knowledge base and prior threads (`kb_search`, `recall`) rather
    than guessing. If you don't know, say so and find out — never invent a fact or a policy.
 3. **Reply clearly and kindly.** Lead with the answer or the next step, keep it concise, and match a
-   warm, professional tone. Give concrete steps the person can follow.
+   warm, professional tone. Give concrete steps the person can follow. When you're chat-triggered, reply
+   in the channel with your reply tools.
 4. **Triage and route.** Classify severity, tag it, and — if it needs engineering or a human decision —
    file a task (`task_create`, assign it) or escalate rather than sitting on it.
-
-## Your tools
-- `kb_search`/`kb_read` — the source of truth for answers; `kb_write` to capture a new recurring answer.
-- `recall`/`remember` — remember how past issues were resolved so you're faster next time.
-- `task_create`/`task_update` — file bugs or follow-ups and hand them to the right agent/human.
-- `ask` when only a human can decide; `report` to close the loop with a short summary.
-- When chat-triggered, reply in the channel with your reply tools.
 
 ## Boundaries
 - You resolve and route support requests; you don't make product promises, issue refunds, or take
   irreversible/outward-facing actions on your own — escalate those to a human.
-- Every outbound action passes through the OS gate; risky ones pause for approval. Don't route around it.
 - When unsure whether something is safe to say or do, ask first. A careful "let me check" beats a wrong
   confident answer.

--- a/config/agents/writer/CLAUDE.md
+++ b/config/agents/writer/CLAUDE.md
@@ -15,14 +15,7 @@ structure, and make it clear.
 4. **Edit like a reader.** On a finish pass, tighten, fix ambiguity, and match the house voice. When you're
    done, summarize what you wrote or changed and note anything left open — plainly.
 
-## Your tools
-- `recall`/`remember` — reuse the house voice, terminology, and what past pieces established.
-- `kb_search`/`kb_read`/`kb_write` — house the style guide and reference docs; write back what's durable.
-- `task_create`/`task_claim`/`task_update` — file, pick up, and close units of work on the shared queue.
-- `ask` when you're blocked on a decision only a human can make; `report` to close out with a summary.
-
 ## Boundaries
-- Every side effect you have passes through the OS gate; risky ones pause for human approval. Don't route around it.
 - Prefer the smallest change that serves the reader. If a task is really two pieces, say so and split it.
 - You don't publish outward-facing content or ship irreversible actions unprompted — surface those and let
   a human call it.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.301.0",
+  "version": "0.302.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.301.0",
+      "version": "0.302.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.301.0",
+  "version": "0.302.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -2750,19 +2750,31 @@ export class TerminalManager {
       ? this.os.settings.learnedGuidance().trim()
       : '';
     // The fleet roster — WHO this agent can delegate to. Injected so "hand off to the right agent" is
-    // answerable straight from the prompt without a discovery round-trip (`list_agents` is the live
-    // equivalent). Excludes self and mock agents, so it only lists peers this agent can actually dispatch.
-    const roster = [...this.os.agents.values()]
+    // answerable straight from the prompt without a discovery round-trip. But `list_agents` is the live
+    // equivalent, so we don't pay to embed an unbounded roster on every launch: cap the list, clip each
+    // description, and point at the tool for the tail (the just-in-time contract — a high-value slice in
+    // the prompt, the rest one tool-call away). Sorted by id so the injected slice is STABLE across
+    // launches (predictable prompt → better caching). Excludes self and mock agents.
+    const FLEET_CAP = 25;
+    const peers = [...this.os.agents.values()]
       .filter((a) => isCodingRuntime(a.runtime) && a.id !== selfAgent)
-      .map((a) => `- \`agent:${a.id}\`${a.category ? ` (${a.category})` : ''} — ${a.description}`)
+      .sort((a, b) => a.id.localeCompare(b.id));
+    const roster = peers
+      .slice(0, FLEET_CAP)
+      .map((a) => {
+        const desc = a.description.replace(/\s+/g, ' ').trim();
+        return `- \`agent:${a.id}\`${a.category ? ` (${a.category})` : ''} — ${desc.length > 140 ? desc.slice(0, 139) + '…' : desc}`;
+      })
       .join('\n');
-    const fleet = roster
+    const overflow = peers.length - FLEET_CAP;
+    const fleet = peers.length
       ? '# Your fleet — who you can delegate to\n\n' +
         'These are the other agents in this workspace. To hand work to one, `task_create({ title, ' +
         'assignee: "agent:<id>", autoDispatch: true })` — it spawns that agent as a governed run under ' +
         'the same accountable human. Assign specialised work to the right agent rather than doing it ' +
         'poorly yourself or filing an unassigned task (which nobody picks up).\n\n' +
-        roster
+        roster +
+        (overflow > 0 ? `\n- …and ${overflow} more — \`list_agents\` for the full roster.` : '')
       : '';
     // The team roster — WHO this agent works for and with. Injected so an agent can loop in the right
     // person (roles set who can approve what) without a `directory_lookup` round-trip. Capped: past a


### PR DESCRIPTION
## What

A context-engineering pass on the per-session launch prompt (`buildCompanyMd` + the bundled personas), applying the just-in-time / *"smallest set of high-signal tokens"* guidance from Anthropic's [Effective context engineering for AI agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents).

### 1. Fleet roster → just-in-time (bounded)
`buildCompanyMd` injected the **full** fleet roster — every agent, full description — on **every** launch, even though `list_agents` is the live equivalent. Now it injects a stable (id-sorted) slice **capped at 25**, clips each description to 140 chars, and points at `list_agents` for the tail (`…and N more`). A large fleet with long descriptions can no longer flood every prompt. No change for workspaces under the cap.

### 2. Bundled personas de-duplicated against the operating notes (DRY)
The 13 catalog agents (`config/agents/*`) each re-explained the OS gate and re-listed the generic OS tools (`recall`/`remember`, `kb_*`, `task_*`, `ask`/`report`) that `AGENT_OS_OPERATING_NOTES` already covers canonically — two copies of the same mechanics in the same final prompt. Removed the generic `## Your tools` sections and the generic "every side effect passes the gate" boundary bullet, **keeping every role-specific** tool (`agent_*`/`app_*`), boundary (engineer's code-vs-ops, finance's no-payments, ops' operate-vs-code, …), and nuance (support's chat-reply, folded into its Method).

**~6.3 KB lighter across the 13 seeds** (generalists −20–30% each). Note: personas are the install-on-demand catalog, so this affects **newly installed** agents, not live self-edited ones.

## Verification
- `npm run typecheck` — clean
- `npm run test:governance` — 38 passed, 0 failed
- Rendered `buildCompanyMd` against a synthesized 30-agent fleet in an **isolated scratch home**: fleet section renders 25 capped lines + the `…and N more — list_agents` pointer, self excluded, stable-sorted.

## Not in this PR
The fattest always-on block is `AGENT_OS_OPERATING_NOTES` (~8 KB / ~2k tokens, every session). Tightening it is the higher-leverage lever but hits the **live** fleet immediately (it's code, not a seed) — proposing that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)