### PR TITLE
feat(connections): mark a Composio app "available to the team" — or just me (v0.303.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.303.0] — 2026-08-04
+### Added
+- **Mark a Composio connection "available to the team" — or take it back to just me.** Connections →
+  Mine now carries a **Share with team / Just me** toggle on each of your Composio apps, and shared apps
+  appear in the Company section attributed to their owner (`shared by alice@…`). Nothing moves on
+  composio.dev in either direction, so the switch is instant and reversible with no re-authorisation.
+  - **Why it isn't a move.** A connected account's `user_id` is immutable (the update endpoint exposes
+    `alias`, credentials and the shared-ACL block — no owner field), and a Tool Router session may only
+    pin accounts belonging to its own `user_id`. Both verified against the live API.
+  - **How it's enforced.** Sharing records a local marker (`composio_shares`); at launch the fleet mints
+    one extra Tool Router session per sharing owner — under **that owner's** entity but allowlisted to
+    the shared toolkits, pinned to the shared account ids, and with connection management disabled. A
+    borrower therefore reaches exactly what was shared, **not** the rest of that person's Composio
+    account, and can neither add nor revoke connections under an entity that isn't theirs. Verified
+    live: asked to "list files in Google Drive", an unrestricted session offers `googledrive` tools
+    while the borrowed one can only offer the shared `gmail`.
+  - **Governance.** Only the owner may grant (the account is verified to be theirs first, so no one can
+    publish a teammate's or the company's connection by guessing an id); owner or admin may revoke.
+    Revoking is local-only and never gated on the Composio key, so a cleared key can't strand a share.
+    A share dies with its connection, dies with its owner (member removal), and is pruned when the
+    account is revoked straight on composio.dev. Audited `connector.shared` / `connector.unshared`, and
+    each borrowed mint records its toolkit allowlist on `connector.minted`.
+  - New: `src/connectors/composio-shares.ts`, the `composio_shares` table, `MintOptions` on
+    `mintToolRouterSession`, `POST /api/connections/share`, `teamShared` on `GET /api/connections`.
+
 ## [0.302.0] — 2026-08-04
 ### Changed
 - **Context-engineering pass on the launch prompt — trim redundant tokens from what every session

--- a/docs/connectors-and-triggers.md
+++ b/docs/connectors-and-triggers.md
@@ -219,6 +219,38 @@ minted to its own identity (P3). **Personal connectors should prefer Composio** 
 lands on disk — only a short-lived minted URL — which keeps the pre-Tier-A privacy gap small (see
 scoping doc Decision #5).
 
+### Sharing a single Composio app with the team (`composio_shares`)
+
+The P3 `shared` flag above is per *connector row*. A **Composio** app isn't a connector row — it's a
+connected account living on composio.dev under a `user_id` — so "make my Gmail available to the team"
+needed its own mechanism. Two constraints, both verified against the live API:
+
+- a connected account's **`user_id` is immutable** (`PATCH /api/v3/connected_accounts/{id}` exposes
+  `alias`, credentials and the shared-ACL block — no owner field), so sharing **cannot be a move**;
+- a Tool Router session may **only pin accounts belonging to its own `user_id`** ("Could not find
+  connected account(s) … belonging to user …"), so a teammate's app can't be pulled into your session.
+
+Hence sharing is a **local marker** (`composio_shares`: connection id, toolkit, owning entity) that the
+launcher enforces. `ComposioShareStore.mintsFor(actingMember)` groups every OTHER member's shares by
+owner, and `buildMcpConfigJson` mints one extra Tool Router session per owner — under **that owner's**
+entity, but `{toolkits:{enable:[…]}, connected_accounts:{…}, manage_connections:{enable:false}}`. So a
+borrower reaches exactly the shared connections, nothing else of that person's Composio account, and
+cannot add or revoke connections under an entity that isn't theirs. Confirmed live: asked to "list files
+in Google Drive", an unrestricted session offers `googledrive` tools while the borrowed one can only
+offer the shared `gmail`.
+
+Consequences worth keeping:
+- **Nothing changes on composio.dev in either direction** — sharing and un-sharing are reversible and
+  need no re-authorisation. `POST /api/connections/share {id, shared}`.
+- **Sharing is owner-only and verified remotely** (the account must appear under the caller's own
+  entity), so nobody publishes a teammate's — or the company's — connection by guessing an id.
+- **Revoking is local-only and never gated on the key**, so a cleared/broken Composio key can't leave
+  the team stuck with a share they can't take back. Owner or admin may revoke; only the owner may grant.
+- A share dies with its connection (disconnect), with its owner (member removal), and is pruned when
+  the account is revoked straight on composio.dev.
+- An automation/system spawn (no run-as member) **does** get shared apps — same rule as a
+  `personal + shared` connector: the owner opted in explicitly.
+
 ---
 
 ## The five use cases

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.302.0",
+  "version": "0.303.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.302.0",
+      "version": "0.303.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.302.0",
+  "version": "0.303.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/connectors/composio-shares.ts
+++ b/src/connectors/composio-shares.ts
@@ -1,0 +1,152 @@
+/**
+ * Composio connection sharing — "is this app available to the team, or just me?"
+ *
+ * A Composio connected account lives under a `user_id` (a member's email for a personal app, the
+ * service entity for a company one) and that owner is IMMUTABLE — Composio has no transfer API, and a
+ * Tool Router session may only pin accounts belonging to its own `user_id`. So "make my Gmail
+ * available to the team" cannot be a move; it has to be a marker Agent OS enforces at mint time.
+ *
+ * That's this table. Marking a connection shared records `(connection id, toolkit, owning entity)`.
+ * At launch `TerminalManager` mints ONE extra Tool Router session per sharing owner, under that
+ * owner's `user_id` but **allowlisted to the shared toolkits and pinned to the shared connection ids**
+ * — so a borrower reaches exactly the apps their teammate shared and none of the rest of that
+ * teammate's Composio account. Connection management is disabled on those borrowed sessions, so a
+ * borrower can't add or revoke connections under someone else's entity either.
+ *
+ * Unsharing deletes the row; the next session mints without it. Nothing on composio.dev changes in
+ * either direction, so sharing is reversible and needs no re-authorisation.
+ */
+import { Db } from '../state/db';
+
+/** One connection its owner has marked available to the whole team. */
+export interface ComposioShare {
+  /** The Composio connected-account id (`ca_…`) — the thing that gets pinned into a borrowed session. */
+  id: string;
+  /** Toolkit slug (gmail, linkedin, …) — the allowlist entry that goes with the pin. */
+  toolkit: string;
+  /** The Composio entity that owns the account (the owner's email). Sessions mint under THIS id. */
+  userId: string;
+  /** Our member id for that owner — so removing the member prunes their shares. */
+  ownerMemberId: string;
+  /** The connection's distinguishing handle/alias at share time, for display without a live fetch. */
+  name: string;
+  /** Email of whoever flipped the switch (the owner, or an admin unsharing). */
+  sharedBy: string;
+  createdAt: number;
+}
+
+interface ShareRow {
+  id: string;
+  toolkit: string;
+  user_id: string;
+  owner_member_id: string;
+  name: string;
+  shared_by: string;
+  created_at: number;
+}
+
+function toShare(r: ShareRow): ComposioShare {
+  return {
+    id: r.id,
+    toolkit: r.toolkit,
+    userId: r.user_id,
+    ownerMemberId: r.owner_member_id,
+    name: r.name || '',
+    sharedBy: r.shared_by,
+    createdAt: r.created_at,
+  };
+}
+
+/** What one borrowed Tool Router session needs: whose entity to mint under, and what to expose from it. */
+export interface SharedMint {
+  /** The owning member's id — used to name the MCP server entry and to skip the owner's own session. */
+  ownerMemberId: string;
+  /** The Composio entity to mint under (the owner's email). */
+  userId: string;
+  /** Toolkit allowlist — every shared toolkit of this owner. */
+  toolkits: string[];
+  /** Per-toolkit connected-account pins, so only the SHARED accounts are reachable. */
+  connectedAccounts: Record<string, string[]>;
+}
+
+export class ComposioShareStore {
+  constructor(private readonly db: Db) {}
+
+  list(): ComposioShare[] {
+    return this.db
+      .prepare('SELECT * FROM composio_shares ORDER BY created_at')
+      .all<ShareRow>()
+      .map(toShare);
+  }
+
+  /** The shared connection ids belonging to one Composio entity (used to flag a member's own rows). */
+  sharedIdsFor(userId: string): Set<string> {
+    const rows = this.db
+      .prepare('SELECT id FROM composio_shares WHERE user_id = ?')
+      .all<{ id: string }>(userId);
+    return new Set(rows.map((r) => r.id));
+  }
+
+  get(id: string): ComposioShare | undefined {
+    const r = this.db.prepare('SELECT * FROM composio_shares WHERE id = ?').get<ShareRow>(id);
+    return r ? toShare(r) : undefined;
+  }
+
+  /** Mark a connection available to the team. Idempotent — re-sharing refreshes the display fields. */
+  share(s: Omit<ComposioShare, 'createdAt'>): ComposioShare {
+    const existing = this.get(s.id);
+    this.db
+      .prepare(
+        `INSERT INTO composio_shares (id, toolkit, user_id, owner_member_id, name, shared_by, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET toolkit = excluded.toolkit, user_id = excluded.user_id,
+           owner_member_id = excluded.owner_member_id, name = excluded.name, shared_by = excluded.shared_by`,
+      )
+      .run(s.id, s.toolkit, s.userId, s.ownerMemberId, s.name, s.sharedBy, existing?.createdAt ?? Date.now());
+    return this.get(s.id)!;
+  }
+
+  /** Back to "just me". Returns whether a share existed. */
+  unshare(id: string): boolean {
+    return this.db.prepare('DELETE FROM composio_shares WHERE id = ?').run(id).changes > 0;
+  }
+
+  /** Drop this entity's shares whose connection no longer exists on Composio (revoked outside the
+   *  console) — otherwise every launch would keep trying to pin a dead account id. */
+  pruneEntity(userId: string, liveIds: Set<string>): string[] {
+    const gone = this.list().filter((s) => s.userId === userId && !liveIds.has(s.id)).map((s) => s.id);
+    for (const id of gone) this.unshare(id);
+    return gone;
+  }
+
+  /** A removed member's shares go with them — their credentials must not outlive the account. */
+  removeByOwner(memberId: string): string[] {
+    const rows = this.db
+      .prepare('SELECT id FROM composio_shares WHERE owner_member_id = ?')
+      .all<{ id: string }>(memberId);
+    this.db.prepare('DELETE FROM composio_shares WHERE owner_member_id = ?').run(memberId);
+    return rows.map((r) => r.id);
+  }
+
+  /**
+   * The borrowed sessions to mint for a run acting as `actingMemberId` — one per OTHER member who has
+   * shared something. The acting member is skipped: they already get an unrestricted session under
+   * their own entity, so re-minting a pinned subset of it would only narrow what they can already
+   * reach. An automation/system spawn (no acting member) borrows from everyone, exactly like a
+   * `personal + shared` MCP connector: the owner opted in explicitly.
+   */
+  mintsFor(actingMemberId?: string): SharedMint[] {
+    const byOwner = new Map<string, SharedMint>();
+    for (const s of this.list()) {
+      if (s.ownerMemberId === actingMemberId) continue;
+      let m = byOwner.get(s.ownerMemberId);
+      if (!m) {
+        m = { ownerMemberId: s.ownerMemberId, userId: s.userId, toolkits: [], connectedAccounts: {} };
+        byOwner.set(s.ownerMemberId, m);
+      }
+      if (!m.toolkits.includes(s.toolkit)) m.toolkits.push(s.toolkit);
+      (m.connectedAccounts[s.toolkit] ??= []).push(s.id);
+    }
+    return [...byOwner.values()];
+  }
+}

--- a/src/connectors/composio.ts
+++ b/src/connectors/composio.ts
@@ -192,15 +192,39 @@ export async function initiateConnection(
 }
 
 /**
+ * Narrowing options for a minted session. Used for a BORROWED session — one minted under a teammate's
+ * entity because they shared a connection — so the borrower reaches exactly what was shared:
+ *   - `toolkits`          → the session's toolkit allowlist (`toolkits.enable`).
+ *   - `connectedAccounts` → per-toolkit account pins. Composio only accepts pins that belong to the
+ *     session's OWN `user_id` (verified against the live API), which is precisely why sharing mints
+ *     under the owner's entity rather than pulling their account into someone else's session.
+ *   - `manageConnections: false` → drops COMPOSIO_MANAGE_CONNECTIONS, so a borrower can neither add
+ *     nor revoke connections under an entity that isn't theirs.
+ * Omit all three for the normal, unrestricted mint.
+ */
+export interface MintOptions {
+  toolkits?: string[];
+  connectedAccounts?: Record<string, string[]>;
+  manageConnections?: boolean;
+}
+
+/**
  * Mint a Tool Router session for `userId` and return its MCP endpoint URL. The session is scoped to
  * that user, so the agent only sees the apps that user has connected on composio.dev — and Tool
  * Router auto-selects the relevant tools from them. Returns `{ error }` (never throws) so a flaky
  * network or a bad key degrades to "this connector is skipped this launch", not a dead session.
  */
-export function mintToolRouterSession(apiKey: string, userId: string): MintResult {
+export function mintToolRouterSession(apiKey: string, userId: string, opts: MintOptions = {}): MintResult {
   if (!apiKey) return { error: 'no Composio API key' };
   const url = `${apiBase()}/api/v3.1/tool_router/session`;
-  const body = JSON.stringify({ user_id: userId });
+  const body = JSON.stringify({
+    user_id: userId,
+    ...(opts.toolkits?.length ? { toolkits: { enable: opts.toolkits } } : {}),
+    ...(opts.connectedAccounts && Object.keys(opts.connectedAccounts).length
+      ? { connected_accounts: opts.connectedAccounts }
+      : {}),
+    ...(opts.manageConnections === false ? { manage_connections: { enable: false } } : {}),
+  });
   const res = spawnSync(
     'curl',
     ['-sS', '--max-time', '20', '-X', 'POST', url,

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -24,6 +24,7 @@ import {
 import { createMemoryProvider } from './memory';
 import { CapabilityRegistry } from './capabilities/registry';
 import { ConnectorStore } from './connectors/connectors';
+import { ComposioShareStore } from './connectors/composio-shares';
 import { HostStore } from './hosts/hosts';
 import { AutoApprovalStore } from './state/auto-approvals';
 import { Gateway } from './gateway/gateway';
@@ -116,6 +117,8 @@ export class AgentOS {
   private readonly warnedPolicyContexts = new Set<string>();
   /** User-registered connectors (MCP servers) the claude-code runtime exposes to agents. */
   readonly connectors: ConnectorStore;
+  /** Composio connections their owner marked available to the whole team (composio-shares.ts). */
+  readonly composioShares: ComposioShareStore;
   /** Host connections — governed reachable destinations (SSH / internal HTTP / DB). See host-connections-plan.md. */
   readonly hosts: HostStore;
   /** "Always approve THIS action" list, keyed on the decision-brief signature (auto-approvals.ts). */
@@ -140,6 +143,7 @@ export class AgentOS {
     this.db = openDb(opts.paths?.db ?? ':memory:');
     this.secrets = new SqliteSecretsVault(this.db, resolveMasterKey(opts.paths?.home), new EnvSecretsVault());
     this.connectors = new ConnectorStore(this.db);
+    this.composioShares = new ComposioShareStore(this.db);
     this.hosts = new HostStore(this.db);
     this.autoApprovals = new AutoApprovalStore(this.db);
     this.approvals = new SqliteApprovals(this.db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2305,8 +2305,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // not outlive the account. Sessions, invites and assignment grants were cleared in removeMember.
     const connectorsRemoved = os.connectors.removeByOwner(teamMember[1]).length;
     const hostsRemoved = os.hosts.removeByOwner(teamMember[1]).length;
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'member.removed', data: { member: teamMember[1], connectorsRemoved, hostsRemoved } });
-    return sendJson(res, 200, { ...out, connectorsRemoved, hostsRemoved });
+    // Same rule for their shared Composio apps: the team borrowed those through THEIR entity, so the
+    // grant dies with the account rather than leaving the fleet minting under a departed member.
+    const sharesRemoved = os.composioShares.removeByOwner(teamMember[1]).length;
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'member.removed', data: { member: teamMember[1], connectorsRemoved, hostsRemoved, sharesRemoved } });
+    return sendJson(res, 200, { ...out, connectorsRemoved, hostsRemoved, sharesRemoved });
   }
   const teamAssign = p.match(/^\/api\/team\/assignments\/([\w.-]+)$/);
   if (method === 'PUT' && teamAssign) {
@@ -5506,12 +5509,72 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   // Live Composio connections (read from composio.dev): the member's own apps + the company entity's.
   if (method === 'GET' && p === '/api/connections') {
     const key = os.settings.composioApiKey();
-    if (!key) return sendJson(res, 200, { keySet: false, company: [], mine: [] });
-    const [company, mine] = await Promise.all([
+    if (!key) return sendJson(res, 200, { keySet: false, company: [], mine: [], teamShared: [] });
+    // Plus every connection a TEAMMATE marked available to the team: one live read per sharing owner
+    // (normally none or one) so the row carries a real status, not a stale one cached at share time.
+    const shares = os.composioShares.list().filter((s) => s.userId !== me.email);
+    const owners = [...new Set(shares.map((s) => s.userId))];
+    const [company, mine, ...borrowed] = await Promise.all([
       listConnectedAccounts(key, serviceUserId(os.tenant)),
       listConnectedAccounts(key, me.email),
+      ...owners.map((u) => listConnectedAccounts(key, u)),
     ]);
-    return sendJson(res, 200, { keySet: true, company, mine, me: me.email, companyEntity: serviceUserId(os.tenant) });
+    const live = new Map(borrowed.flat().map((a) => [a.id, a]));
+    const teamShared = shares.map((s) => {
+      const a = live.get(s.id);
+      return {
+        id: s.id,
+        toolkit: s.toolkit,
+        // A share whose account was revoked straight on composio.dev shows as gone rather than
+        // silently pretending to work; the row is pruned on the owner's next share toggle.
+        status: a?.status ?? 'REVOKED',
+        name: a?.name ?? s.name,
+        ownerEmail: s.userId,
+        ownerMemberId: s.ownerMemberId,
+      };
+    });
+    // `mine` rows carry their own share state so the row can render Share / Unshare directly.
+    const sharedIds = os.composioShares.sharedIdsFor(me.email);
+    return sendJson(res, 200, {
+      keySet: true,
+      company,
+      mine: mine.map((a) => ({ ...a, shared: sharedIds.has(a.id) })),
+      teamShared,
+      me: me.email,
+      companyEntity: serviceUserId(os.tenant),
+    });
+  }
+  // Mark one of MY Composio connections available to the whole team — or take it back to just me.
+  // Composio can't move an account between entities (its `user_id` is immutable and a session may only
+  // pin accounts of its own user), so this is a marker the launcher enforces: a shared connection is
+  // minted into other members' sessions under MY entity, allowlisted to its toolkit and pinned to its
+  // id. Only the owner may share; an owner/admin may also UNSHARE anyone's (governance override).
+  if (method === 'POST' && p === '/api/connections/share') {
+    const b = await readBody(req);
+    const id = String(b.id || '').trim();
+    const shared = b.shared !== false;
+    if (!id) return sendJson(res, 400, { error: 'id is required' });
+    // Revoking is purely local and must ALWAYS be possible — it talks to no remote, so a cleared or
+    // broken Composio key can never leave the team stuck with a share they can't take back.
+    if (!shared) {
+      const existing = os.composioShares.get(id);
+      if (!existing) return sendJson(res, 404, { error: 'that connection is not shared' });
+      if (existing.userId !== me.email && !isAdmin(me)) return sendJson(res, 403, { error: 'only the owner or an admin can unshare a connection' });
+      os.composioShares.unshare(id);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'connector.unshared', data: { id, toolkit: existing.toolkit, owner: existing.userId } });
+      return sendJson(res, 200, { ok: true, shared: false });
+    }
+    // Sharing is owner-only, and verified against Composio: you can only share an account that really
+    // is yours, so no one can publish a teammate's (or the company's) connection by guessing an id.
+    const key = os.settings.composioApiKey();
+    if (!key) return sendJson(res, 400, { error: 'no Composio API key' });
+    const owned = await listConnectedAccounts(key, me.email);
+    const app = owned.find((a) => a.id === id);
+    if (!app) return sendJson(res, 404, { error: 'that connection is not one of yours' });
+    os.composioShares.pruneEntity(me.email, new Set(owned.map((a) => a.id)));
+    os.composioShares.share({ id, toolkit: app.toolkit, userId: me.email, ownerMemberId: me.id, name: app.name, sharedBy: me.email });
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'connector.shared', data: { id, toolkit: app.toolkit, owner: me.email } });
+    return sendJson(res, 200, { ok: true, shared: true });
   }
   // Read-only company-integration overview (any member): what's wired at the COMPANY level —
   // Composio company apps, the native Slack app, and org-scoped custom MCP servers. No secrets, just
@@ -5585,6 +5648,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!owned.some((a) => a.id === id)) return sendJson(res, 404, { error: 'connection not found for this scope' });
     const r = await deleteConnectedAccount(key, id);
     if ('error' in r) return sendJson(res, 502, { error: r.error });
+    // Disconnecting also revokes any team share of it — the account it pinned no longer exists.
+    os.composioShares.unshare(id);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'connector.disconnect', data: { id, scope, entity } });
     return sendJson(res, 200, { ok: true });
   }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -95,6 +95,21 @@ function migrate(db: Db): void {
       created_at  INTEGER NOT NULL
     );
 
+    -- Composio connections a member has marked "available to the team" (composio-shares.ts). A
+    -- connected account's owning entity is immutable on Composio's side, so sharing can't be a move —
+    -- it's this marker, enforced at launch by minting an extra Tool Router session under the OWNER's
+    -- entity that is allowlisted to its toolkit and pinned to its id. One row = one shared connection.
+    CREATE TABLE IF NOT EXISTS composio_shares (
+      id              TEXT PRIMARY KEY,       -- the Composio connected-account id (ca_…)
+      toolkit         TEXT NOT NULL,          -- toolkit slug (gmail, linkedin, …) — the allowlist entry
+      user_id         TEXT NOT NULL,          -- the Composio entity that owns it (the owner's email)
+      owner_member_id TEXT NOT NULL,          -- our member id for that owner (prunes with the member)
+      name            TEXT NOT NULL DEFAULT '', -- handle/alias at share time, for display
+      shared_by       TEXT NOT NULL,          -- email of whoever flipped the switch
+      created_at      INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_composio_shares_owner ON composio_shares (owner_member_id);
+
     -- Host connections — reachable destinations (SSH box / internal HTTP / DB) an agent may talk to,
     -- as a first-class governed thing (docs/host-connections-plan.md). Phase 2a stores them; the
     -- governance that reads them (net.connect/ssh.exec + allow-list) is Phase 2b. Mirrors connectors'

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -14,7 +14,7 @@ import { newId } from './id';
 import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { containedPath, mimeOf } from './state/artifacts';
-import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId } from './connectors/composio';
+import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId, type MintOptions } from './connectors/composio';
 import { isCodingRuntime, runtimeSupports, CODING_RUNTIMES, CodingRuntimeId, ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskTimelineEntry, TaskDiscussionSummary, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval, redactSecrets } from './governance/enricher';
 import { resolveCapability } from './capabilities/normalize';
@@ -2954,13 +2954,32 @@ export class TerminalManager {
       // `composio` → the running member's OWN connected apps (their email as user_id); `composio-company`
       // → apps connected under the shared service entity, usable by every agent. Automation/system spawns
       // get only the company entity (no person's personal credentials).
-      const sessions = [{ id: 'composio-company', userId: serviceUserId(this.os.tenant), scope: 'company' }];
+      const sessions: Array<{ id: string; userId: string; scope: string; opts?: MintOptions }> = [
+        { id: 'composio-company', userId: serviceUserId(this.os.tenant), scope: 'company' },
+      ];
       if (memberId) sessions.unshift({ id: 'composio', userId: this.composioUserId(memberId, agent), scope: 'personal' });
+      // Connections a TEAMMATE marked "available to the team". A connected account's owning entity is
+      // immutable on Composio's side, so sharing is a marker we enforce here: one extra session per
+      // sharing owner, minted under THEIR entity but allowlisted to the shared toolkits and pinned to
+      // the shared account ids — so the borrower reaches exactly what was shared and nothing else of
+      // that person's Composio account. Connection management is off: a borrower must not be able to
+      // add or revoke connections under an entity that isn't theirs.
+      for (const m of this.os.composioShares.mintsFor(memberId)) {
+        sessions.push({
+          id: `composio-shared-${m.ownerMemberId}`,
+          userId: m.userId,
+          scope: 'shared',
+          opts: { toolkits: m.toolkits, connectedAccounts: m.connectedAccounts, manageConnections: false },
+        });
+      }
       for (const s of sessions) {
-        const res = mintToolRouterSession(apiKey, s.userId);
+        const res = mintToolRouterSession(apiKey, s.userId, s.opts);
         if ('url' in res) {
           config.mcpServers[s.id] = { type: 'http', url: res.url, headers: { [COMPOSIO_KEY_HEADER]: apiKey } };
-          this.audit(sessionId, agent, 'connector.minted', { connector: s.id, scope: s.scope, userId: s.userId });
+          this.audit(sessionId, agent, 'connector.minted', {
+            connector: s.id, scope: s.scope, userId: s.userId,
+            ...(s.opts?.toolkits ? { toolkits: s.opts.toolkits } : {}),
+          });
         } else {
           this.audit(sessionId, agent, 'connector.mint.failed', { connector: s.id, scope: s.scope, error: res.error });
         }

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -373,26 +373,48 @@ function ConnectorRow({ c, me, busy, onToggle, onRemove, onShare }: {
 }
 
 /** A live Composio-connected app row (company or personal). Shows the connection's distinguishing
- *  handle/alias so multiple accounts of the same app (e.g. two Gmails) are told apart. */
-function ComposioRow({ app, canRemove, busy, onRemove }: {
-  app: { id: string; toolkit: string; status: string; name?: string }
-  canRemove: boolean; busy: boolean; onRemove: () => void
+ *  handle/alias so multiple accounts of the same app (e.g. two Gmails) are told apart.
+ *  `onShare` is passed for a row the viewer owns — the "available to the team / just me" toggle. */
+function ComposioRow({ app, canRemove, busy, onRemove, onShare, sharedBy }: {
+  app: { id: string; toolkit: string; status: string; name?: string; shared?: boolean }
+  canRemove: boolean; busy: boolean; onRemove?: () => void
+  onShare?: (shared: boolean) => void
+  /** Set on a BORROWED row (a teammate shared it) — shown instead of the share control. */
+  sharedBy?: string
 }) {
   // The auto handle is like `gmail_comma-hugh`; drop the redundant toolkit prefix for display. A
   // user-set alias (which won't carry the prefix) is shown as-is.
   const handle = app.name && app.name !== app.toolkit
     ? app.name.replace(new RegExp(`^${app.toolkit}[_-]`, 'i'), '')
     : ''
+  const detail = [handle, sharedBy ? `shared by ${sharedBy}` : '', 'via Composio'].filter(Boolean).join(' · ')
   return (
     <Row
       name={app.toolkit}
       title={app.toolkit}
-      subtitle={handle ? `${handle} · via Composio` : 'via Composio'}
-      badges={statusBadge(app.status.toLowerCase(), app.status === 'ACTIVE' ? 'ok' : 'warn')}
-      right={canRemove ? (
-        <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" disabled={busy} onClick={onRemove} title="disconnect">
-          <X className="h-4 w-4" />
-        </Button>
+      subtitle={detail}
+      badges={
+        <>
+          {statusBadge(app.status.toLowerCase(), app.status === 'ACTIVE' ? 'ok' : 'warn')}
+          {app.shared && statusBadge('shared with team', 'ok')}
+        </>
+      }
+      right={(onShare || onRemove) ? (
+        <>
+          {onShare && (
+            <Button size="sm" variant="outline" disabled={busy} onClick={() => onShare(!app.shared)}
+              title={app.shared
+                ? 'Take it back: only sessions you start will load it'
+                : 'Let every agent use this app — they get only this connection, not the rest of your Composio account'}>
+              {app.shared ? 'Just me' : 'Share with team'}
+            </Button>
+          )}
+          {canRemove && onRemove && (
+            <Button size="icon" variant="ghost" className="h-8 w-8 text-destructive" disabled={busy} onClick={onRemove} title="disconnect">
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </>
       ) : undefined}
     />
   )
@@ -566,7 +588,7 @@ export function GithubMineCard() {
   )
 }
 
-function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRemove, onShare, onDisconnectComposio, onToggleHost, onRemoveHost, onShareHost, onEditHost, onPublishHost }: {
+function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRemove, onShare, onDisconnectComposio, onShareComposio, onToggleHost, onRemoveHost, onShareHost, onEditHost, onPublishHost }: {
   me: Member | null
   connectors: Connector[]
   hosts: Host[]
@@ -577,6 +599,7 @@ function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRem
   onRemove: (id: string) => void
   onShare: (id: string, shared: boolean) => void
   onDisconnectComposio: (id: string, scope: 'company' | 'personal', label: string) => void
+  onShareComposio: (id: string, shared: boolean, label: string) => void
   onToggleHost: (id: string, enabled: boolean) => void
   onRemoveHost: (id: string) => void
   onShareHost: (id: string, shared: boolean) => void
@@ -590,6 +613,9 @@ function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRem
   // apps come from /api/connections (carries each connection's distinguishing name), not the overview.
   const orgConnectors = connectors.filter((c) => c.scope === 'org' || (c.scope === 'personal' && c.shared))
   const companyApps = conns?.company ?? []
+  // Apps a teammate marked available to the team. They still live under that person's Composio
+  // entity — the launcher lends only the shared connection, pinned, into everyone else's sessions.
+  const sharedApps = (conns?.teamShared ?? []).filter((a) => a.ownerEmail !== conns?.me)
   const orgHosts = hosts.filter((h) => !h.proposed && (h.scope === 'org' || (h.scope === 'personal' && h.shared)))
   // Mine = the viewer's own personal connectors + their own Composio apps + their own hosts.
   const myConnectors = connectors.filter((c) => c.scope === 'personal' && c.ownerMemberId === me?.id)
@@ -598,7 +624,7 @@ function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRem
   // Agent-proposed hosts awaiting review (admin-only action).
   const proposedHosts = isAdmin ? hosts.filter((h) => h.proposed) : []
 
-  const companyCount = orgConnectors.length + companyApps.length + orgHosts.length + 2 // +2 for the native bot rows
+  const companyCount = orgConnectors.length + companyApps.length + sharedApps.length + orgHosts.length + 2 // +2 for the native bot rows
   const mineCount = myConnectors.length + myApps.length + myHosts.length
   const showCompany = filter === 'all' || filter === 'company'
   const showMine = filter === 'all' || filter === 'mine'
@@ -641,6 +667,17 @@ function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRem
           {companyApps.map((a) => (
             <ComposioRow key={a.id} app={a} canRemove={isAdmin} busy={busy === a.id} onRemove={() => onDisconnectComposio(a.id, 'company', a.toolkit)} />
           ))}
+          {sharedApps.map((a) => (
+            <ComposioRow
+              key={a.id}
+              app={a}
+              canRemove={false}
+              busy={busy === a.id}
+              sharedBy={a.ownerEmail}
+              // An admin can revoke a share for governance; the owner does it from their own Mine row.
+              onShare={isAdmin ? () => onShareComposio(a.id, false, a.toolkit) : undefined}
+            />
+          ))}
           {orgConnectors.map((c) => <ConnectorRow key={c.id} c={c} {...cardProps} />)}
           {orgHosts.map((h) => <HostRow key={h.id} h={h} {...hostProps} />)}
         </div>
@@ -660,7 +697,14 @@ function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRem
             <p className="text-xs text-muted-foreground">You haven’t connected any personal apps or servers yet.</p>
           )}
           {myApps.map((a) => (
-            <ComposioRow key={a.id} app={a} canRemove busy={busy === a.id} onRemove={() => onDisconnectComposio(a.id, 'personal', a.toolkit)} />
+            <ComposioRow
+              key={a.id}
+              app={a}
+              canRemove
+              busy={busy === a.id}
+              onRemove={() => onDisconnectComposio(a.id, 'personal', a.toolkit)}
+              onShare={(shared) => onShareComposio(a.id, shared, a.toolkit)}
+            />
           ))}
           {myConnectors.map((c) => <ConnectorRow key={c.id} c={c} {...cardProps} />)}
           {myHosts.map((h) => <HostRow key={h.id} h={h} {...hostProps} />)}
@@ -1015,6 +1059,20 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
     setBusy('')
     if (r.error) return window.alert('Could not disconnect: ' + r.error)
     scope === 'company' ? loadOverview() : loadConnections()
+    loadConnections()
+  }
+
+  // "Available to the team" / "just me". Nothing moves on Composio (an account's owner is immutable
+  // there) — the flag makes the launcher lend THIS connection, pinned, into everyone else's sessions.
+  const shareComposio = async (id: string, shared: boolean, label: string) => {
+    if (shared && !window.confirm(
+      `Let every agent use your ${label}?\n\nThey act as you on that account. Only this connection is lent out — the rest of your Composio apps stay private.`,
+    )) return
+    setBusy(id)
+    const r = await api.shareConnection({ id, shared })
+    setBusy('')
+    if (r.error) return window.alert('Could not update sharing: ' + r.error)
+    loadConnections()
   }
 
   const keySet = !!(ov?.composio.keySet || conns?.keySet)
@@ -1058,6 +1116,7 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
         onRemove={remove}
         onShare={share}
         onDisconnectComposio={disconnectComposio}
+        onShareComposio={shareComposio}
         onToggleHost={toggleHost}
         onRemoveHost={removeHost}
         onPublishHost={publishHost}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1148,11 +1148,25 @@ export interface ComposioConnection {
   userId: string
   /** Distinguishing label for this connection (user alias, else Composio's auto handle). */
   name: string
+  /** Mine only: the owner marked it available to the whole team (composio_shares). */
+  shared?: boolean
+}
+/** A teammate's connection they marked available to the team — borrowed, not owned. */
+export interface SharedConnection {
+  id: string
+  toolkit: string
+  status: string
+  name: string
+  /** The Composio entity it lives under = the sharing member's email. */
+  ownerEmail: string
+  ownerMemberId: string
 }
 export interface ConnectionsResp {
   keySet: boolean
   company: ComposioConnection[]
   mine: ComposioConnection[]
+  /** Connections other members shared with the team (empty when nobody has shared). */
+  teamShared?: SharedConnection[]
   me?: string
   companyEntity?: string
   error?: string
@@ -1654,6 +1668,10 @@ export const api = {
     call<{ redirectUrl?: string; error?: string }>('POST', '/api/connections/connect', body),
   disconnectApp: (body: { id: string; scope: 'company' | 'personal' }) =>
     call<{ ok?: boolean; error?: string }>('POST', '/api/connections/disconnect', body),
+  // Mark one of MY Composio apps available to the team (or take it back). Nothing moves on Composio —
+  // the launcher mints a toolkit-allowlisted, account-pinned session under my entity for teammates.
+  shareConnection: (body: { id: string; shared: boolean }) =>
+    call<{ ok?: boolean; shared?: boolean; error?: string }>('POST', '/api/connections/share', body),
   // Agent connection requests (`connection_request`). List: admin sees all open; a member sees their own
   // personal ones. Fulfilling initiates the Composio OAuth and returns the hosted link to finish.
   connectionRequests: () => call<ConnectionRequestsResp>('GET', '/api/connections/requests'),


### PR DESCRIPTION
Each of your Composio connections in **Connections → Mine** now carries a **Share with team / Just me** toggle. Shared apps appear in the **Company** section attributed to their owner (`shared by alice@…`).

## Why it isn't a move

Two constraints, both verified against the live Composio API:

- A connected account's **`user_id` is immutable** — `PATCH /api/v3/connected_accounts/{id}` exposes `alias`, credentials and the shared-ACL block, but no owner field.
- A Tool Router session may **only pin accounts belonging to its own `user_id`** — pinning `owner@localhost`'s Gmail into a `service:instapods` session is rejected outright.

So "available to the team" can't be an account transfer without a re-OAuth. It's a **local marker** instead.

## How it's enforced

Sharing records a row in the new `composio_shares` table. At launch, `buildMcpConfigJson` mints one **extra** Tool Router session per sharing owner — under *that owner's* entity, but:

```json
{ "toolkits": { "enable": ["gmail"] },
  "connected_accounts": { "gmail": ["ca_…"] },
  "manage_connections": { "enable": false } }
```

A borrower therefore reaches exactly the shared connections, **not** the rest of that person's Composio account, and can neither add nor revoke connections under an entity that isn't theirs.

Verified live — same question ("list files in Google Drive") to both sessions:

| session | toolkits it can offer |
| --- | --- |
| unrestricted (owner's own) | `googledrive` |
| borrowed (gmail shared) | `gmail` |

`COMPOSIO_MANAGE_CONNECTIONS` is absent from the borrowed session's meta-tools.

Nothing changes on composio.dev in either direction, so both directions are instant and need no re-authorisation.

## Governance

- **Granting is owner-only and remotely verified** — the account must appear under the caller's own entity, so nobody publishes a teammate's or the company's connection by guessing an id.
- **Revoking is local-only and never gated on the Composio key.** Caught during testing: the first cut refused to unshare when no key was set, i.e. you could grant but not revoke. A cleared or broken key must never strand a share.
- Owner or admin may revoke; only the owner may grant.
- A share dies with its connection (disconnect), dies with its owner (member removal → `sharesRemoved`), and is pruned when the account is revoked straight on composio.dev.
- An automation/system spawn (no run-as member) does get shared apps — same rule as a `personal + shared` connector: the owner opted in explicitly.
- Audited `connector.shared` / `connector.unshared`; each borrowed mint records its toolkit allowlist on `connector.minted`.

## Changes

- New `src/connectors/composio-shares.ts` (`ComposioShareStore`) + the `composio_shares` table.
- `MintOptions` on `mintToolRouterSession` (toolkit allowlist / account pins / manage-connections off).
- `POST /api/connections/share`; `teamShared` + per-row `shared` on `GET /api/connections`.
- Console: share toggle on owned rows, borrowed rows in the Company section.
- `docs/connectors-and-triggers.md` → new "Sharing a single Composio app with the team" section.

## Verification

- `npm run typecheck`, `cd web && npm run build`, `npm run test:governance` (38 passed).
- A 20-assertion in-process HTTP harness on an isolated `AGENT_OS_HOME` covering the mint plan, both authz directions, the no-key revoke path, stale-share pruning, member-removal cascade, and the owner-vs-borrower views (share path driven against a stub Composio).
- The two live-API probes above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)