### PR TITLE
feat(chat): Telegram /new — end a conversation and start fresh (v0.304.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.304.0] — 2026-08-04
+### Added
+- **Telegram `/new` — end the current conversation and start a fresh one.** Now that a Telegram DM is
+  threaded (a follow-up continues the last run), there was no way to reset it — a console Stop even got
+  *revived* on the next message. `/new` (aliases `/reset`, `/newchat`) stops the live run bound to the
+  chat and detaches its reply bindings, so the next message starts a brand-new session
+  (`Automations.resetTelegramChat` + `TerminalManager.clearTelegramBinding`). `/new` alone acks and
+  waits; `/new <request>` resets and immediately starts the new thing. Registered in the bot's `/command`
+  menu (first entry) so it's discoverable. Audited `telegram.chat.reset`. `src/edge/telegram-socket.ts`,
+  `src/edge/automations.ts`, `src/terminal.ts`.
+
 ## [0.303.0] — 2026-08-04
 ### Added
 - **Mark a Composio connection "available to the team" — or take it back to just me.** Connections →

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.303.0",
+  "version": "0.304.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.303.0",
+      "version": "0.304.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.303.0",
+  "version": "0.304.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -1385,6 +1385,20 @@ export class Automations {
     return { status: 'none' };
   }
 
+  /**
+   * End the conversation bound to a Telegram chat (+ forum topic) — the `/new` reset. Stops any live run
+   * and detaches every reply binding for the chat, so the caller's NEXT message starts a FRESH session
+   * instead of continuing/reviving the last one. Returns whether a session was actually closed (for the ack).
+   */
+  resetTelegramChat(chat: string, messageThreadId: string): { closed: boolean; agent?: string } {
+    const bound = this.tm.sessionForTelegramThread(chat, messageThreadId || '');
+    if (bound) {
+      try { this.tm.stopSession(bound.sessionId, 'telegram', 'user started a new conversation'); } catch { /* going away regardless */ }
+    }
+    this.tm.clearTelegramBinding(chat, messageThreadId || '');
+    return { closed: !!bound, agent: bound?.agent };
+  }
+
   // ── scheduler ──────────────────────────────────────────────────────────────────
   /** Check every ~20s; fire each due cron automation at most once per matching minute. */
   start(intervalMs = 20_000): void {

--- a/src/edge/telegram-socket.ts
+++ b/src/edge/telegram-socket.ts
@@ -154,7 +154,29 @@ export class TelegramSocket {
     // Strip a leading @botusername (and the `@bot` appended to a `/cmd@bot` command) so the message — and
     // the `/agent` router prefix — starts clean, then map a registered Telegram command name back to its
     // real (possibly hyphenated) agent id so a tapped `/agent_author` reaches `agent-author`.
-    const text = this.resolveCommand(this.stripMention(ev.text));
+    let text = this.resolveCommand(this.stripMention(ev.text));
+
+    // `/new` (or `/reset`) — end the current conversation in this chat and start fresh. Detected before
+    // continuity so the command itself never gets delivered into the live session. `/new` alone acks and
+    // returns; `/new <request>` resets then falls through with the request as a fresh spawn. Skipped if an
+    // agent is literally named `new`/`reset` (resolveCommand would already have rewritten a tapped one).
+    const reset = text.match(/^\/(new|reset|newchat)(?:@\w+)?\b\s*/i);
+    if (reset && !this.os.agents.has(reset[1].toLowerCase())) {
+      const r = this.autos.resetTelegramChat(ev.chatId, ev.messageThreadId);
+      this.os.audit.append({
+        ts: Date.now(), runId: '-', tenant: this.os.tenant,
+        principal: runAsMember ? `member:${runAsMember}` : 'telegram',
+        type: 'telegram.chat.reset', data: { chat: ev.chatId, closed: r.closed, agent: r.agent ?? null },
+      });
+      text = text.slice(reset[0].length).trim();
+      if (!text) {
+        void this.dmUser(ev.chatId, r.closed
+          ? `🆕 Ended the conversation with ${r.agent}. Send your next request, or tap /command to pick an agent.`
+          : `🆕 Fresh start — send your next request, or tap /command to pick an agent.`);
+        return;
+      }
+      // else: fall through with the remaining text as a brand-new request.
+    }
 
     // Inline approve/deny: a private-chat reply from someone with a pending approval we sent them resolves
     // the gate directly (no trip to the web Inbox). Only for private chats (where the ping was sent).
@@ -327,7 +349,10 @@ export class TelegramSocket {
     const token = this.os.settings.telegramBotToken();
     if (!token) return;
     const seen = new Set<string>();
-    const commands: { command: string; description: string }[] = [];
+    // `/new` first — the reset gesture, always available (see the `/new` branch in dispatch).
+    const commands: { command: string; description: string }[] = [
+      { command: 'new', description: 'End this conversation and start a fresh one' },
+    ];
     for (const a of this.chatAgents()) {
       const command = telegramCommandName(a.id);
       if (!command || seen.has(command)) continue;

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1485,6 +1485,12 @@ export class TerminalManager {
     if (!row) return undefined;
     return { sessionId: row.id, agent: row.agent, runAs: row.runAs ?? undefined, claudeSessionId: row.claudeSessionId ?? undefined };
   }
+  /** Detach every session bound to a Telegram chat (+ forum topic), so the NEXT message in that chat
+   *  starts a FRESH run instead of continuing/reviving the last one — the `/new` reset. Removes only the
+   *  reply bindings; the session rows themselves stay for history (the caller stops the live one first). */
+  clearTelegramBinding(chatId: string, messageThreadId: string): void {
+    this.db.prepare('DELETE FROM telegram_threads WHERE chat_id = ? AND message_thread_id = ?').run(chatId, messageThreadId || '');
+  }
   listMessages(viewer?: Member, scope: 'mine' | 'all' = 'mine'): FeedMessage[] {
     // Approval messages take their live status from the approvals table, so the inbox stays
     // correct even after a restart (when the in-memory resolution waiter is gone). We also pull each


### PR DESCRIPTION
From live dogfooding: now that Telegram DMs are threaded (#553), there was **no way to reset** a conversation — a follow-up always continued the last run, and even a console **Stop** got *revived* on the next message.

## `/new`
Ends the conversation bound to the current chat and starts fresh:
- Stops the live run + detaches the chat's reply bindings (`Automations.resetTelegramChat` → `stopSession` + `TerminalManager.clearTelegramBinding`), so `sessionForTelegramThread` finds nothing and the next message spawns a brand-new session.
- `/new` alone → acks ("🆕 Ended the conversation with X…") and waits.
- `/new <request>` → resets, then falls through with the request as a fresh spawn.
- Aliases `/reset`, `/newchat`. Registered as the **first entry** in the bot's `/command` menu so it's discoverable. Audited `telegram.chat.reset`.

Detected before the continuity check, so the command itself is never delivered into the live session.

## Verification
typecheck + build clean; `npm run test:governance` 38/38.

Files: `src/edge/telegram-socket.ts`, `src/edge/automations.ts`, `src/terminal.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)