### PR TITLE
perf(context): trim mechanical prose from the always-on operating notes (v0.306.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.306.0] — 2026-08-04
+### Changed
+- **Context-engineering pass, part 2 — trim the always-on operating notes.** Follow-up to #554. The
+  `AGENT_OS_OPERATING_NOTES` block rides in every session's system prompt (~2k tokens); this relocates
+  the mechanical file-plumbing out of it. The `publish`/scratchpad rule (a ~150-word paragraph) is
+  shortened to the one instruction that matters and its mechanics moved into the `publish` tool's own
+  description — where the model reads them at call time, not on every launch (MCP tool descriptions load
+  with the tool, so nothing is lost). The PR-linkback section is tightened to the instruction. No
+  guidance removed; ~8% (~160 tokens) off every session, fleet-wide on next launch.
+
 ## [0.305.0] — 2026-08-04
 ### Added
 - **Telegram helper commands: `/help`, `/agents`, `/whoami`.** The bot is now self-explanatory — all

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.305.0",
+  "version": "0.306.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.305.0",
+      "version": "0.306.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.305.0",
+  "version": "0.306.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -559,6 +559,11 @@ const TOOLS = [
       'folder, e.g. "report.pdf"), a short `title`, and an optional one-line `description`. The file is ' +
       'snapshotted on publish, so you can keep editing your working copy freely. An inbox notification ' +
       'is posted automatically. Use this for real outputs the human should see — NOT for scratch files. ' +
+      'A file left in the scratchpad CANNOT be published (it is outside your working folder, and is ' +
+      'deleted when the session ends), so write deliverables into your working folder — and when a skill ' +
+      'or tool renders an image/PDF/chart into the scratchpad by default, move it into your working folder ' +
+      'first, then publish. (Images from `image_generate` are auto-published; this is for media you write ' +
+      'yourself.) ' +
       'Re-publishing the SAME filename into the SAME folder UPDATES that deliverable in place (its id and ' +
       'shareable link are preserved) instead of creating a duplicate — so you can refresh a living ' +
       'deliverable by just publishing it again.',

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -110,22 +110,16 @@ Your terminal output may not be read. The operator lives in the Inbox:
 - \`report\` exactly once when you finish, with the outcome and a one-line summary, so the result is
   visible without anyone reading the terminal. If the task taught you something durable, pass it in
   \`lessons\` — it's saved to your memory as a note to your future self.
-- \`publish\` real deliverables (a document, PDF, image, chart, generated media) to the Library. Two
-  rules that override the harness's "put ALL temporary files in the scratchpad" instruction: (1) the
-  scratchpad is ONLY for throwaway intermediates — anything a human should see or download is a
-  deliverable, so **write it into your working folder (your cwd)**, never the scratchpad; (2) then
-  \`publish\` it (\`path\` is relative to your working folder). A file left in the scratchpad **cannot be
-  published** — it's outside your working folder, so \`publish\` can't reach it — and it's deleted when
-  the session ends, so the operator never sees it. When a skill or tool renders an image/PDF/chart to
-  the scratchpad by default, move it into your working folder first, then publish. (Images you make
-  with \`image_generate\` are auto-published — this is about media you write yourself.)
+- \`publish\` real deliverables (a document, PDF, image, chart, generated media) to the Library. The one
+  rule that matters — overriding the harness's "put ALL temporary files in the scratchpad" instruction —
+  is that a deliverable must live in **your working folder (your cwd)**, never the scratchpad, or
+  \`publish\` can't reach it (see the tool's own notes for the details).
 
 ## Opening a pull request — always link back to this session
-When you raise a pull request (or any similar external deliverable that carries a description), add a
-link back to this Agent OS session so a reviewer can trace the change to the audited run that produced
-it. The link is in the \`AOS_SESSION_URL\` environment variable — read it with \`echo "$AOS_SESSION_URL"\`
-(or \`printenv AOS_SESSION_URL\`) and drop it into the PR body, e.g. a line like
-\`Agent OS session: <AOS_SESSION_URL>\`. Print it as a plain URL (links aren't clickable here).
+When you open a pull request (or any deliverable that carries a description), add a line linking back to
+this run so a reviewer can trace the change to the audited session that produced it — the URL is in the
+\`AOS_SESSION_URL\` env var (\`echo "$AOS_SESSION_URL"\`), e.g. \`Agent OS session: <url>\`. Print it as a
+plain URL (links aren't clickable here).
 
 ## You are one agent in a fleet — don't work alone
 Other agents run in this workspace and you share state with them. You are a node, not a silo:


### PR DESCRIPTION
## What
Part 2 of the context-engineering pass (follows #554). `AGENT_OS_OPERATING_NOTES` rides in **every** session's system prompt (~8 KB / ~2k tokens). This relocates the mechanical file-plumbing out of it, per the *"keep instruction in the prompt, mechanics in the tool"* altitude guidance:

- **`publish`/scratchpad rule** (a ~150-word paragraph) → shortened to the one instruction that matters (deliverables live in your cwd, not the scratchpad), with the mechanics moved into the **`publish` tool's own description**. MCP tool descriptions load with the tool, so the agent still sees the full guidance when it publishes — nothing lost.
- **PR-linkback section** → tightened to the instruction.

**No guidance removed; ~8% (~160 tokens) off every session**, fleet-wide on next launch. (Conservative pass — this is the ceiling for purely-mechanical prose; the instructional bulk was left intact.)

## Verification — real session launches in an isolated scratch tenant
- Rendered the **actual launched `company.md`** (written by the serve backend): trimmed publish bullet ✓, tightened PR-linkback ✓, fleet capped at 25 + `…and N more — list_agents` ✓.
- Confirmed the compiled MCP server the session spawns carries the **relocated publish description**.
- **End-to-end behavior:** a real `reporter` run (launched with the trimmed prompt + relocated tool description) wrote `report.md` to its **cwd** (not the scratchpad) and published it — deliverable landed in the Library via the loopback (`artifact.updated` audit + `/api/artifacts`).
- `npm run typecheck` clean · `npm run test:governance` 38/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)