### PR TITLE
fix(tasks): wake the caller when a delegate's run ends without closing the task (v0.307.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.307.0] — 2026-08-04
+### Fixed
+- **A delegate that ends its run without closing the task no longer strands the caller forever.** The
+  poke-back that wakes a delegating agent hangs off the TASK reaching `done`/`blocked`, not off the
+  delegate's session ending — so a delegate that finished (or died) without calling `task_update` left
+  the task inert in `doing` **and** the caller waiting with no signal, ever. Nothing re-dispatched it
+  either (`dispatchable()` only selects `todo`). Measured on the instawp tenant: **43 of 307 (14%)** of
+  agent→agent hand-offs over 30 days ended exactly that way — `engineer → qa`, `engineer →
+  release-orchestrator`, `qa → engineer`. The existing Insights reconcile tile could not have rescued
+  one of them: it only auto-closes runs graded `success`, and 15 of the 16 stranded runs ended
+  `outcome = 'unknown'` (the agent closed neither loop), which it parks in a review-only bucket.
+  A new `sweepStrandedTasks` runs each scheduler tick over every non-terminal task whose dispatched
+  session has settled, and splits on what the run actually reported:
+  - **`success`** → close the task `done` (the Insights tile's `apply`, now automatic). The store
+    notifier then fires the ordinary "✅ Really done" poke, so the caller hears the real result through
+    the normal path — one wake-up, not two.
+  - **anything else** → leave the status **alone** and wake the caller with the delegate's last note.
+    Never auto-marks done: a run legitimately ends mid-flight (waiting on CI, a human go/no-go), and
+    calling that "finished" would be a lie.
+
+  Bounded so enabling it can't stampede a backlog: once per dead *run* (marker keyed on the session, so
+  a re-dispatch that strands again is a fresh signal), ≤3 wake-ups per tick sharing the dispatcher's
+  concurrency headroom, nothing older than 3 days ever woken (cold strandings are marked silently), and
+  a row skipped for budget stays unmarked so the next tick still owes it. Replayed over the live instawp
+  backlog: settles in 3 ticks (~60s) — 8 callers woken, 1 task auto-closed, 12 cold ones marked quietly.
+  Audited `task.stranded` / `task.reconciled` / `tasks.reconciled`.
+- **Reconcile settles on when a run ENDED, not when it started.** `planTaskReconcile`/`applyTaskReconcile`
+  gated their 10-minute grace on the session's `created_at`, so a long run that started an hour ago but
+  ended seconds ago counted as settled and could be reconciled out from under an agent about to post its
+  `task_update`. Both now gate on `updated_at` (stamped when the session reaches a terminal state), as
+  does the new sweep; `endedDaysAgo` in the Insights tile is now genuinely the end date.
+
 ## [0.306.0] — 2026-08-04
 ### Changed
 - **Context-engineering pass, part 2 — trim the always-on operating notes.** Follow-up to #554. The

--- a/docs/tasks-plan.md
+++ b/docs/tasks-plan.md
@@ -318,6 +318,36 @@ Agents do **not** get a dispatch MCP tool in v1 (spawning a *new* session is the
 frontier). They participate by `task_claim`-ing work into their *own* running session and by `task_create`
 for sub-tasks. Pool auto-assignment + agent-triggered dispatch are §9 futures.
 
+### 3.4 When the loop does NOT close itself — the stranded sweep
+
+§3.2's self-closing loop rests on the delegate actually calling `task_update`. When it doesn't, the damage
+is bigger than an untidy board: **the poke-back that wakes a delegating caller hangs off the TASK reaching
+`done`/`blocked`** (`maybePokeCaller`, `tenant-registry.ts`), not off the delegate's session ending. So a
+delegate whose run ends with the task still open strands the task in `doing` *and* leaves the caller
+waiting forever — the delegation silently never completes. Nothing re-dispatches it either:
+`dispatchable()` only selects `status='todo'`, so once a task is `doing` with a dead session it is inert.
+
+Measured on the instawp tenant (30 days): **43 of 307 poke-on-done hand-offs (14%)** ended that way, and
+15 of the 16 stranded runs ended `outcome='unknown'` — the bucket the Insights reconcile tile deliberately
+never touches — so the manual tile could not have rescued one of them.
+
+`sweepStrandedTasks` (`edge/task-reconcile.ts`, run each tick) is the fallback. Over every non-terminal
+task whose dispatched session has settled (`SETTLE_MS` after the session's **end**, not its start):
+
+- **run reported `success`** → close the task `done`. This is the Insights tile's `apply`, now automatic;
+  the store notifier then fires the ordinary "✅ Really done" poke, so the caller hears the real result
+  through the normal path — one wake-up, not two.
+- **anything else** (`unknown` / partial / failure / crashed / stopped) → leave the status **alone** and
+  wake the caller with the delegate's last note. Never auto-marks done: a run legitimately ends mid-flight
+  (waiting on CI, a human go/no-go), and calling that "finished" would be a lie.
+
+Bounded so switching it on can't stampede a backlog: once per dead *run* (`markStranded`, keyed on the
+session id, so a re-dispatch that strands again is a fresh signal), ≤3 wake-ups per tick sharing the
+dispatcher's concurrency headroom, and nothing older than 3 days is ever woken — a cold stranding gets its
+marker silently so it can never fire later. A row skipped for budget stays **unmarked**, so the next tick
+still owes it. Replayed over the live instawp backlog: settles in 3 ticks (~60s), 8 callers woken, 1 task
+auto-closed, 12 cold ones marked silently.
+
 ---
 
 ## 4. Agent-facing MCP tools — `src/memory/memory-mcp.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.306.0",
+  "version": "0.307.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.306.0",
+      "version": "0.307.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.306.0",
+  "version": "0.307.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -21,6 +21,7 @@ import { chooseAgent, RouterCandidate } from './router';
 import { classifyIntent, SOCIAL_REPLY } from './intent';
 import { answerAsk } from './ask';
 import { ensureConcierge, ensureOperator, CONCIERGE_ID, OPERATOR_ID } from './concierge';
+import { sweepStrandedTasks } from './task-reconcile';
 
 // ── minimal cron (5 fields: minute hour day-of-month month day-of-week) ──────────
 // Supports: * , a-b , */n , a-b/n , lists. dow 0-7 (7 ≡ 0 = Sunday).
@@ -1485,6 +1486,7 @@ export class Automations {
       this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'scheduler', type: 'scheduler.deferred', data: { deferred, cap, running } });
     }
     this.sweepOverdue(now);
+    this.sweepStranded(now, cap > 0 ? Math.max(0, cap - running) : Infinity);
     this.sweepStuckGoals(now);
     this.sweepCompletedGoals();
     this.sweepExpiredShares(now);
@@ -1567,6 +1569,25 @@ export class Automations {
    * lives in the DB (`markOverdueNotified`), so a restart never re-alarms. Wrapped so a bad row never
    * kills the scheduler; a no-op when no overdue notifier is wired.
    */
+  /**
+   * Close the delegation loop when a delegate's RUN ends but its TASK doesn't. The poke-back that wakes a
+   * delegating caller hangs off the task reaching done/blocked, so a delegate that finishes (or dies)
+   * without calling `task_update` strands the task AND leaves the caller waiting forever — 14% of
+   * agent→agent hand-offs on a busy tenant. This is the fallback: reconcile a run that reported success,
+   * and wake the caller for everything else. Shares the tick's concurrency headroom, since a poke to a
+   * caller with no live session resumes it in a fresh run. See {@link sweepStrandedTasks}.
+   */
+  private sweepStranded(now: Date, budget: number): void {
+    try {
+      const r = sweepStrandedTasks(this.os, this, { now: now.getTime(), budget });
+      if (r.poked || r.closed) {
+        this.os.audit.append({ ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'scheduler', type: 'tasks.reconciled', data: { closed: r.closed, poked: r.poked, marked: r.marked } });
+      }
+    } catch {
+      // never let the stranded-task sweep take down the automation scheduler
+    }
+  }
+
   private sweepOverdue(now: Date): void {
     if (!this.overdueNotifier) return;
     try {

--- a/src/edge/task-reconcile.ts
+++ b/src/edge/task-reconcile.ts
@@ -17,13 +17,24 @@
  * `apply` only closes the `finished` set; `stalled` is informational. Pure over `tasks` ⋈ `term_sessions`;
  * no LLM (like Memory cleanup / KB tidy). Goals are already covered by the stuck-goal detector, so this
  * is the tasks half of "reconcile the plan against reality".
+ *
+ * {@link sweepStrandedTasks} runs the same reconciliation AUTOMATICALLY off the scheduler tick, because
+ * the drift above isn't only a tidiness problem — it silently breaks agent→agent delegation. The
+ * poke-back that wakes a delegating caller is wired to the TASK reaching done/blocked
+ * (`maybePokeCaller`), not to the delegate's session ending, so a delegate that finishes its run without
+ * calling `task_update` strands the task in `doing` AND leaves the caller waiting forever. Measured on the
+ * instawp tenant: 43 of 307 (14%) poke-on-done hand-offs over 30 days ended exactly that way, and 15 of 16
+ * of those runs ended `outcome = 'unknown'` — the bucket `apply` deliberately never touches — so the
+ * manual tile could not have rescued a single one.
  */
 import type { AgentOS } from '../kernel';
 
 const DAY = 86_400_000;
 const SAMPLE = 8;
-// Only reconcile a task whose run ended at least this long ago — a grace so a just-finished run whose
-// agent is about to post its `task_update(done)` isn't reconciled out from under it.
+// Only reconcile a task whose run ENDED at least this long ago — a grace so a just-finished run whose
+// agent is about to post its `task_update(done)` isn't reconciled out from under it. Measured off the
+// session's `updated_at` (stamped when it reaches a terminal state), not `created_at`: a long run that
+// STARTED an hour ago but ended seconds ago has not settled, and gating on start time would sweep it.
 const SETTLE_MS = 10 * 60_000;
 
 export interface TaskDriftItem {
@@ -44,14 +55,13 @@ export interface TaskReconcilePlan {
 interface Row {
   id: string; title: string; assignee: string | null; owner: string | null;
   status: string; updated_at: number;
-  s_id: string; s_status: string; s_outcome: string | null; s_created: number;
+  s_id: string; s_status: string; s_outcome: string | null; s_created: number; s_updated: number;
 }
 
 /** A dispatched task's run has ENDED (not running). `finished` = succeeded; `stalled` = failed/died. */
 function classify(r: Row): 'finished' | 'stalled' | null {
   if (r.s_status === 'running') return null; // still working — not drift
-  const outcome = (r.s_outcome || (r.s_status === 'done' ? 'success' : r.s_status) || 'unknown').toLowerCase();
-  if (outcome === 'success') return 'finished';
+  if (outcomeOf(r) === 'success') return 'finished';
   return 'stalled'; // failure | partial | unknown | crashed | stopped
 }
 
@@ -59,9 +69,15 @@ function toItem(r: Row, now: number): TaskDriftItem {
   return {
     id: r.id, title: r.title, assignee: r.assignee, owner: r.owner,
     sessionId: r.s_id, sessionStatus: r.s_status,
-    outcome: (r.s_outcome || (r.s_status === 'done' ? 'success' : r.s_status) || 'unknown').toLowerCase(),
-    endedDaysAgo: Math.floor((now - r.s_created) / DAY),
+    outcome: outcomeOf(r),
+    endedDaysAgo: Math.floor((now - r.s_updated) / DAY),
   };
+}
+
+/** The run's effective outcome: its self-reported grade, else derived from how the row ended. A finished
+ *  run that never called `report` reads `unknown` — "nobody closed the loop", not "it failed". */
+function outcomeOf(r: Row): string {
+  return (r.s_outcome || (r.s_status === 'done' ? 'success' : r.s_status) || 'unknown').toLowerCase();
 }
 
 /** Compute the finished (auto-closable) + stalled (review) drift lists WITHOUT mutating anything. */
@@ -69,12 +85,12 @@ export function planTaskReconcile(os: AgentOS, now = Date.now()): TaskReconcileP
   const rows = os.db
     .prepare(
       `SELECT t.id, t.title, t.assignee, t.owner, t.status, t.updated_at,
-              s.id AS s_id, s.status AS s_status, s.outcome AS s_outcome, s.created_at AS s_created
+              s.id AS s_id, s.status AS s_status, s.outcome AS s_outcome, s.created_at AS s_created, s.updated_at AS s_updated
          FROM tasks t
          JOIN term_sessions s ON s.id = t.last_session_id
         WHERE t.tenant = ? AND t.status = 'doing' AND t.last_session_id IS NOT NULL
-          AND s.status != 'running' AND s.created_at < ?
-        ORDER BY s.created_at`,
+          AND s.status != 'running' AND s.updated_at < ?
+        ORDER BY s.updated_at`,
     )
     .all<Row>(os.tenant, now - SETTLE_MS);
   const finished: TaskDriftItem[] = [];
@@ -110,12 +126,134 @@ function allFinished(os: AgentOS, now: number): TaskDriftItem[] {
   const rows = os.db
     .prepare(
       `SELECT t.id, t.title, t.assignee, t.owner, t.status, t.updated_at,
-              s.id AS s_id, s.status AS s_status, s.outcome AS s_outcome, s.created_at AS s_created
+              s.id AS s_id, s.status AS s_status, s.outcome AS s_outcome, s.created_at AS s_created, s.updated_at AS s_updated
          FROM tasks t
          JOIN term_sessions s ON s.id = t.last_session_id
         WHERE t.tenant = ? AND t.status = 'doing' AND t.last_session_id IS NOT NULL
-          AND s.status != 'running' AND s.created_at < ?`,
+          AND s.status != 'running' AND s.updated_at < ?`,
     )
     .all<Row>(os.tenant, now - SETTLE_MS);
   return rows.filter((r) => classify(r) === 'finished').map((r) => toItem(r, now));
+}
+
+// ── Automatic reconciliation (scheduler tick) ─────────────────────────────────────────────────────
+
+/**
+ * The wake-up hook the sweep reaches a delegating caller through — structurally {@link
+ * Automations.pokeCaller}, passed IN rather than imported so this module keeps its pure-over-the-DB shape
+ * and the edge keeps one owner of session spawning.
+ */
+export interface PokeHook {
+  pokeCaller(input: {
+    callerAgent: string; callerClaudeId: string; runAs?: string;
+    message: string; source: string; title?: string;
+  }): { ok: boolean };
+}
+
+/** Only wake a caller about a run that ended within this window. An older stranding still gets its marker
+ *  (so it can never fire later) but stays SILENT: switching this sweep on must not stampede a backlog of
+ *  month-old hand-offs into a burst of resumed caller sessions. */
+const POKE_MAX_AGE_MS = 3 * DAY;
+/** Wake-ups per tick. A poke to a caller that no longer has a live session RESUMES its transcript in a
+ *  fresh run, so this is real load — drain the backlog a few at a time rather than all at once. */
+const POKE_PER_TICK = 3;
+/** Cap on the delegate's quoted note. The poke is TYPED INTO a live caller's pane (or becomes a resumed
+ *  run's prompt), and a delegate's sign-off can run to thousands of characters. The message tells the
+ *  caller to `task_get` for the rest, so the quote only has to be enough to orient it. */
+const NOTE_MAX = 800;
+
+export interface StrandedSweep {
+  closed: number;   // run reported success, task left open → closed for it (normal done-poke follows)
+  poked: number;    // caller woken: "your delegate's run ended without closing this"
+  marked: number;   // strandings recorded this pass (poked + those with nobody to wake / too old)
+}
+
+interface StrandedRow extends Row {
+  poke_on_done: number; caller_agent: string | null; caller_claude_id: string | null;
+}
+
+/**
+ * Close the delegation loop when the DELEGATE'S RUN ends but the TASK doesn't — the gap that leaves a
+ * caller waiting forever (see the module header). Runs off the scheduler tick over every non-terminal task
+ * whose dispatched session has settled, and splits by what the run actually reported:
+ *
+ *  · **success** → close the task `done` (what the Insights tile does by hand, now automatic). The store
+ *    notifier then fires the ORDINARY "✅ Really done" poke, so the caller hears the real result through
+ *    the normal path instead of a second "it stalled" message — one wake-up, not two.
+ *  · **anything else** (`unknown` — the common case, the agent closed neither loop — plus partial /
+ *    failure / crashed / stopped) → leave the status ALONE and wake the caller with what the delegate last
+ *    said, so a human or the caller decides. Never auto-marks done: a run can end mid-flight for good
+ *    reasons (waiting on CI, a human go/no-go), and calling that "finished" would be a lie.
+ *
+ * Once per dead run (`markStranded`, keyed on the session), bounded by {@link POKE_PER_TICK} and
+ * {@link POKE_MAX_AGE_MS}. A row that is over budget is left UNMARKED so the next tick still owes it.
+ */
+export function sweepStrandedTasks(
+  os: AgentOS,
+  poker: PokeHook,
+  opts: { budget?: number; now?: number } = {},
+): StrandedSweep {
+  const now = opts.now ?? Date.now();
+  const out: StrandedSweep = { closed: 0, poked: 0, marked: 0 };
+  let budget = Math.max(0, Math.min(opts.budget ?? POKE_PER_TICK, POKE_PER_TICK));
+  const rows = os.db
+    .prepare(
+      `SELECT t.id, t.title, t.assignee, t.owner, t.status, t.updated_at,
+              t.poke_on_done, t.caller_agent, t.caller_claude_id,
+              s.id AS s_id, s.status AS s_status, s.outcome AS s_outcome, s.created_at AS s_created, s.updated_at AS s_updated
+         FROM tasks t
+         JOIN term_sessions s ON s.id = t.last_session_id
+        WHERE t.tenant = ? AND t.status IN ('todo','doing') AND t.last_session_id IS NOT NULL
+          AND s.status != 'running' AND s.updated_at < ?
+        ORDER BY s.updated_at DESC`,
+    )
+    .all<StrandedRow>(os.tenant, now - SETTLE_MS);
+
+  for (const r of rows) {
+    if (classify(r) === 'finished') {
+      const closed = os.tasks.update(r.id, {
+        status: 'done',
+        note: `Auto-reconciled: dispatched run ${r.s_id} reported success but the task was left open.`,
+        by: 'system',
+      });
+      if (closed) {
+        out.closed++;
+        os.audit.append({ ts: now, runId: r.s_id, tenant: os.tenant, principal: 'system', type: 'task.reconciled', data: { closed: 1, id: r.id, via: 'sweep' } });
+      }
+      continue;
+    }
+    // Stalled: the run is over and the work was NOT reported done. Decide whether anyone is owed a
+    // wake-up BEFORE burning the one-time marker — a poke we skip for budget must stay owed next tick.
+    const waiting = r.poke_on_done === 1 && !!r.caller_agent && !!r.caller_claude_id;
+    const fresh = now - r.s_updated <= POKE_MAX_AGE_MS;
+    if (waiting && fresh && budget <= 0) continue;
+    if (!os.tasks.markStranded(r.id, r.s_id)) continue; // this dead run was already handled
+    out.marked++;
+    os.audit.append({
+      ts: now, runId: r.s_id, tenant: os.tenant, principal: 'system', type: 'task.stranded',
+      data: { id: r.id, status: r.status, outcome: outcomeOf(r), caller: r.caller_agent ?? null, poked: waiting && fresh },
+    });
+    if (!waiting || !fresh) continue; // nobody delegated this, or it went cold — marked, not woken
+    budget--;
+    const delegate = r.assignee?.startsWith('agent:') ? r.assignee.slice('agent:'.length) : (r.assignee ?? 'the delegate');
+    const full = os.tasks.latestNote(r.id) || '(it left no note)';
+    const note = full.length > NOTE_MAX ? `${full.slice(0, NOTE_MAX)}… (truncated — task_get for the rest)` : full;
+    const shortTitle = r.title.length > 48 ? `${r.title.slice(0, 47)}…` : r.title;
+    poker.pokeCaller({
+      callerAgent: r.caller_agent!,
+      callerClaudeId: r.caller_claude_id!,
+      runAs: r.owner ?? undefined,
+      source: r.id,
+      title: `Poke ← ${delegate} ran out: ${shortTitle}`,
+      message:
+        `⚠️ Ran out: ${delegate}'s run on the task you handed off (${r.id}: "${r.title}") ENDED without closing it — ` +
+        `the task is still "${r.status}" and its run finished ${outcomeOf(r)}.\n\n` +
+        `The last thing it said on the task: ${note}\n\n` +
+        `It may have done the work and forgotten to close the loop, or stopped partway. Read the task ` +
+        `(task_get) before you assume either way, then decide: accept it and move on, hand it back with ` +
+        `task_update, or pick the remaining work up yourself.`,
+    });
+    out.poked++;
+  }
+  return out;
 }

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -46,6 +46,9 @@ const TERMINAL: ReadonlySet<TaskStatus> = new Set<TaskStatus>(['done', 'cancelle
 const STATUSES: readonly TaskStatus[] = ['todo', 'doing', 'blocked', 'done', 'cancelled'];
 /** Sentinel body for the one-time "went overdue" event that dedupes the overdue notification. */
 const OVERDUE_MARK = '⏰ went overdue';
+/** Sentinel body for the one-time "its run ended without closing this" event, per stranding SESSION — so a
+ *  task stranded twice (re-dispatched, stranded again) wakes its caller once per dead run, not once ever. */
+const strandedMark = (sessionId: string): string => `⚠️ run ended without closing this (${sessionId})`;
 
 /**
  * What the {@link TaskStore} notifier sink receives on a meaningful task change. The store stays
@@ -301,6 +304,22 @@ export class TaskStore {
       .get<{ 1: number }>(id, OVERDUE_MARK);
     if (existing) return false;
     this.addEvent(id, 'status', OVERDUE_MARK, 'system');
+    return true;
+  }
+
+  /**
+   * Record a one-time "the dispatched run ended with this task still open" marker for `sessionId`; returns
+   * true only the FIRST time, so the stranded sweep wakes the delegating caller exactly once per dead run
+   * (not every tick). Keyed on the SESSION, not the task, so a re-dispatch that strands again is a fresh
+   * signal. The marker also reads in the task timeline as the reason the board stopped moving.
+   */
+  markStranded(id: string, sessionId: string): boolean {
+    const mark = strandedMark(sessionId);
+    const existing = this.db
+      .prepare(`SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'status' AND body = ? LIMIT 1`)
+      .get<{ 1: number }>(id, mark);
+    if (existing) return false;
+    this.addEvent(id, 'status', mark, 'system', sessionId);
     return true;
   }
 


### PR DESCRIPTION
## The bug

Agent→agent delegation goes silent ~14% of the time. Reported symptom: *"engineer launches qa/release-orchestrator, but it doesn't reply back when it finishes."*

The poke-back that wakes a delegating caller is wired to the **task** reaching `done`/`blocked` (`maybePokeCaller`, `tenant-registry.ts:570`), not to the **delegate's session** ending. The delegate is expected to close its own loop with `task_update` (`buildTaskPrompt`). When it doesn't, nothing else notices:

- no session-lifecycle hook touches tasks (`markTurnIdle`, the crash sweep),
- `dispatchable()` only selects `status = 'todo'` (`state/tasks.ts:312`), so a task already in `doing` with a dead session is never re-dispatched,
- so the task rots in `doing` **and** the caller waits forever.

## Measured, not assumed

instawp tenant, last 30 days, 307 `poke_on_done` hand-offs:

| | n |
|---|---|
| terminal → caller poked | 264 |
| **open, delegate session already ended → caller never poked** | **43 (14%)** |

The stuck pairs are exactly the reported ones: `engineer → release-orchestrator`, `engineer → qa`, `qa → engineer`, `engineer → infra-ops`. instapods, with far less delegation traffic, has 1 of 40.

Concrete case (`tsk_92aec22d395b045e`): release-orchestrator did the whole job, posted a detailed task comment ("Gates verified… promotion PR #2770 opened… now watching CI"), then its headless run hit turn-end and was torn down. Task still `doing`. Engineer never heard a word.

**The existing safety net could not have caught any of these.** `task-reconcile.ts` only auto-closes sessions graded `outcome = 'success'` — but 15 of the 16 stranded runs ended `unknown` (the agent called neither `report` nor `task_update`), which it classifies as `stalled` = review-only. It is also a manual Insights tile nobody clicks.

## The fix

`sweepStrandedTasks` (`edge/task-reconcile.ts`) runs each scheduler tick over every non-terminal task whose dispatched session has settled, and splits on what the run actually reported:

- **`success`** → close the task `done`. This is the Insights tile's `apply`, now automatic; the store notifier then fires the ordinary "✅ Really done" poke, so the caller hears the real result through the normal path — one wake-up, not two.
- **anything else** (`unknown`, partial, failure, crashed, stopped) → leave the status **alone** and wake the caller with the delegate's last note. It never auto-marks done: a run legitimately ends mid-flight (waiting on CI, a human go/no-go), and calling that "finished" would be a lie.

Bounded so switching it on can't stampede a backlog:

- once per dead **run** (`markStranded`, keyed on the session id — a re-dispatch that strands again is a fresh signal),
- ≤3 wake-ups per tick, sharing the dispatcher's concurrency headroom (a poke usually resumes a dead caller in a new session — real load),
- nothing older than 3 days is ever woken; a cold stranding gets its marker silently so it can never fire later,
- a row skipped for budget stays **unmarked**, so the next tick still owes it.

Also fixes reconcile's settle grace to gate on when a run **ended** (`updated_at`) rather than when it **started** (`created_at`) — a long run that started an hour ago but ended seconds ago counted as settled and could be reconciled out from under an agent about to close it.

## Verification

**Replayed over a snapshot of the live instawp DB** — settles in 3 ticks (~60s of scheduler time): 8 callers woken, 1 task auto-closed, 12 cold strandings marked quietly. First wake-up is the reported case:

```
⚠️ Ran out: release-orchestrator's run on the task you handed off
(tsk_92aec22d395b045e: "Promote client-app #2769 …") ENDED without closing it —
the task is still "doing" and its run finished unknown.

The last thing it said on the task: Gates verified (QA PASS @32f205d6 …)
Draft promotion PR opened: …/client-app/pull/2770 … Now watching CI.

It may have done the work and forgotten to close the loop, or stopped partway.
Read the task (task_get) before you assume either way, then decide: accept it
and move on, hand it back with task_update, or pick the remaining work up yourself.
```

**8 in-process assertions** on an isolated scratch home: stranded-unknown pokes without touching status · second tick is a no-op · `success` auto-closes with no stall poke · the settle grace holds · a 6-day-old stranding is marked but silent · a task with no caller is marked, not poked · the per-tick budget defers rather than drops (all 3 eventually woken) · a second dead run on the same task is a fresh signal.

`npm run typecheck` · `npm run build` · `cd web && npm run build` · `npm run test:governance` → **38 passed, 0 failed**.

## Not covered (deliberate)

- 13 stranded tasks whose `last_session_id` points at a purged session row — unclassifiable, skipped.
- Poking on `cancelled` (16 cases where a hand-off was killed and the caller never told) — considered and left out of this PR.
- One `todo` task with `attempts = 0` that was never dispatched at all — a separate bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)