### PR TITLE
fix(sessions): stop provenance leaking into run_as (v0.307.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.307.1] — 2026-08-04
+### Fixed
+- **A session's provenance can no longer leak into its identity column, silently costing the run its
+  human's credentials.** `spawned_by` is provenance (a bare member id OR a prefixed system trigger —
+  `automation:` / `task:` / `chat:` / `poke:` / `ask:` / `goal:`); `run_as` is the accountable human.
+  `createSession` derived the second from the first with a one-entry blocklist — anything not starting
+  `automation:` was taken as the identity — so a chat-routed run or an ownerless task stored
+  `run_as = 'chat:triage'` / `'task:<id>'`: a value no consumer can match. The failure is entirely
+  silent. That run loses the run-as member's GitHub token (its PRs land as the App bot instead of the
+  human), Composio/connector identity, member-scoped secret resolution (`ref.principal ?? actingMember`),
+  granted SSH host keys, and inbox ownership — with no error anywhere. Measured on the instawp tenant:
+  **23 sessions** carrying `chat:docs-bot`, `chat:triage`, `task:tsk_…`, plus a matching
+  `github.token.refresh_failed` logged against `principal: "chat:triage"`.
+  The fallback now resolves against the team (`resolveActingMember` — the single place `run_as` is
+  derived, shared by `createSession`/`forkSession`/`reviveResident`/`chatSend`) instead of blocklisting
+  prefixes, so a future provenance kind can't leak by being forgotten, and an explicit `runAs` is
+  canonicalised (id or email → id). No accountable human now correctly yields NULL — the company
+  identity — rather than a string that impersonates one. A one-time migration NULLs the colon-bearing
+  `run_as` rows already on disk (`spawned_by` untouched); `scripts/run-as-identity-test.cjs` covers it.
+
 ## [0.307.0] — 2026-08-04
 ### Fixed
 - **A delegate that ends its run without closing the task no longer strands the caller forever.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.307.0",
+  "version": "0.307.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.307.0",
+      "version": "0.307.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.307.0",
+  "version": "0.307.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,7 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/deps-freshness-test.cjs",
+    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:deps": "node scripts/deps-freshness-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",

--- a/scripts/run-as-identity-test.cjs
+++ b/scripts/run-as-identity-test.cjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/*
+ * Run-as identity conformance test — `term_sessions.run_as` holds a MEMBER id, never provenance.
+ *
+ * `spawned_by` is PROVENANCE (a bare member id OR a prefixed system trigger: `automation:` / `task:` /
+ * `chat:` / `poke:` / `ask:` / `goal:`); `run_as` is IDENTITY (the accountable human). The old
+ * createSession fallback took ANY non-`automation:` provenance as the identity, so a chat-routed or
+ * ownerless-task run stored `run_as = 'chat:triage'` / `'task:<id>'` — a value no consumer can match.
+ * Measured on the live instawp tenant (2026-08-04): 23 such rows. The cost is silent: that run loses the
+ * member's GitHub token (its PRs land as the App bot), Composio/connector identity, member-scoped secret
+ * resolution, and inbox ownership — with no error anywhere.
+ *
+ * Covers, fully isolated (scratch AGENT_OS_HOME — see the CLAUDE.md warning about polluting ./data):
+ *   1. resolveActingMember: every provenance prefix falls back to NO identity; a bare member id (or an
+ *      email) resolves to the canonical member id; an explicit runAs wins over provenance.
+ *   2. The consequence at launch: a prefixed-provenance run gets the company-bot GH_TOKEN untouched
+ *      rather than a garbage principal — and the same run with a real run-as member gets THEIR token.
+ *   3. The one-time migration NULLs colon-bearing run_as rows already on disk, and leaves member ids.
+ *
+ * Usage:  npm run build && node scripts/run-as-identity-test.cjs
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-runas-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY; // keep the vault master key inside the scratch home
+
+let pass = 0, fail = 0;
+const ok = (n) => { pass++; console.log(`  \x1b[32m✓\x1b[0m ${n}`); };
+const bad = (n, d) => { fail++; console.log(`  \x1b[31m✗ ${n}\x1b[0m${d ? `\n      ${d}` : ''}`); };
+const assert = (c, n, d) => (c ? ok(n) : bad(n, d));
+
+async function main() {
+  const { TenantRegistry } = require(path.join(ROOT, 'dist/tenant-registry.js'));
+  const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+  const { GithubIdentity } = require(path.join(ROOT, 'dist/edge/github-identity.js'));
+
+  const registry = new TenantRegistry(ROOT, 0);
+  registry.bootAll();
+  const osx = registry.get('testco').os;
+  const tm = new TerminalManager(osx, 'http://127.0.0.1:1', path.join(HOME, 'tmux.sock'));
+
+  const inv = osx.team.invite({ email: 'owner@test', role: 'owner' });
+  const memberId = osx.team.acceptToken(inv.token).member.id;
+
+  // ─── 1) resolveActingMember ────────────────────────────────────────────────
+  console.log('\n\x1b[1m1) resolveActingMember (provenance never becomes identity)\x1b[0m');
+  const R = (runAs, spawnedBy) => tm.resolveActingMember(runAs, spawnedBy);
+
+  // Every prefixed provenance kind — the blocklist this replaces only excluded `automation:`.
+  for (const prov of ['automation:a1', 'task:tsk_abc', 'chat:triage', 'poke:tsk_x', 'ask:coder', 'goal:g1']) {
+    assert(R(undefined, prov) === undefined, `provenance "${prov}" → no run-as identity`);
+  }
+  assert(R(undefined, memberId) === memberId, 'bare member-id provenance → that member (console spawn)');
+  assert(R(undefined, 'm_deleted_or_typo') === undefined, 'a member id that no longer exists → no identity');
+  assert(R(undefined, undefined) === undefined, 'no provenance at all → no identity');
+
+  // Explicit runAs wins, and is canonicalised.
+  assert(R(memberId, 'task:tsk_abc') === memberId, 'explicit runAs wins over prefixed provenance');
+  assert(R('owner@test', 'chat:triage') === memberId, 'an email runAs is canonicalised to the member id');
+  assert(R('  ' + memberId + '  ', undefined) === memberId, 'runAs is trimmed before resolving');
+  assert(R('nobody@nowhere', memberId) === memberId, 'an unresolvable runAs falls back to a real provenance member');
+  assert(R('nobody@nowhere', 'chat:triage') === undefined, 'neither resolvable → no identity (company run)');
+
+  // ─── 2) What that costs at launch ──────────────────────────────────────────
+  console.log('\n\x1b[1m2) Launch consequence (GH_TOKEN authorship)\x1b[0m');
+  const gid = new GithubIdentity(osx);
+  gid.save(memberId, { token: 'gho_member', login: 'octocat', connectedAt: Date.now() });
+
+  const envChat = { GH_TOKEN: 'ghs_BOT' };
+  tm.injectMemberGithub(envChat, 'triage', R(undefined, 'chat:triage'), 'sessChat');
+  assert(envChat.GH_TOKEN === 'ghs_BOT', 'chat-provenance run keeps the company-bot token (no garbage principal)');
+
+  const envMember = { GH_TOKEN: 'ghs_BOT' };
+  tm.injectMemberGithub(envMember, 'triage', R(memberId, 'chat:triage'), 'sessMember');
+  assert(envMember.GH_TOKEN === 'gho_member', 'same run WITH a resolved run-as member is authored as the human');
+
+  // The pre-fix value would have been the provenance string itself — assert it resolves to nothing.
+  const envBug = { GH_TOKEN: 'ghs_BOT' };
+  tm.injectMemberGithub(envBug, 'triage', 'chat:triage', 'sessBug');
+  assert(envBug.GH_TOKEN === 'ghs_BOT', 'a raw provenance string as run-as matches no member (the silent old cost)');
+  gid.clear(memberId);
+
+  // ─── 3) Migration cleans rows already on disk ──────────────────────────────
+  console.log('\n\x1b[1m3) Migration (existing polluted rows)\x1b[0m');
+  const db = osx.db;
+  const row = (id, spawnedBy, runAs) => db.prepare(
+    'INSERT INTO term_sessions (id, agent, title, task, tmux, status, spawned_by, run_as, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?,?)',
+  ).run(id, 'triage', 't', 't', 'x-' + id, 'done', spawnedBy, runAs, Date.now(), Date.now());
+  row('s_chat', 'chat:triage', 'chat:triage');
+  row('s_task', 'task:tsk_1', 'task:tsk_1');
+  row('s_ok', memberId, memberId);
+  row('s_null', 'automation:a1', null);
+
+  const { openDb } = require(path.join(ROOT, 'dist/state/db.js'));
+  openDb(path.join(HOME, 'agent-os.db')); // re-runs migrate() over the same file
+
+  const runAsOf = (id) => db.prepare('SELECT run_as FROM term_sessions WHERE id = ?').get(id).run_as;
+  assert(runAsOf('s_chat') === null, 'migration NULLs a `chat:` run_as');
+  assert(runAsOf('s_task') === null, 'migration NULLs a `task:` run_as');
+  assert(runAsOf('s_ok') === memberId, 'migration LEAVES a real member id alone');
+  assert(runAsOf('s_null') === null, 'an already-NULL run_as stays NULL');
+  assert(db.prepare('SELECT spawned_by FROM term_sessions WHERE id = ?').get('s_chat').spawned_by === 'chat:triage',
+    'provenance (spawned_by) is untouched — only the identity column is cleaned');
+
+  console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m`);
+  fs.rmSync(HOME, { recursive: true, force: true });
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch((e) => { console.error(e); fs.rmSync(HOME, { recursive: true, force: true }); process.exit(1); });

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -1020,6 +1020,14 @@ function migrate(db: Db): void {
   // Private-to-owners agents: when 1, ONLY the owner role runs/sees the agent (admins excluded, the
   // role/member grants void) — the tightest tier below the owner+admin default. NULL/0 = default floor.
   addColumn(db, 'assignments', 'owner_only', 'INTEGER');       // 1 = owner-role-only
+
+  // One-time cleanup: `term_sessions.run_as` must hold a MEMBER id, but the old createSession fallback
+  // took any non-`automation:` provenance, so prefixed system triggers (`chat:<agent>`, `task:<id>`, …)
+  // were written into the identity column — a value no consumer can match. `resolveActingMember` now
+  // prevents new ones; this NULLs the ones already stored, which is what an ownerless run should have
+  // said all along. Scoped to colon-bearing values so a legitimate id can never be caught by it (a
+  // member id never contains ':'), and so the sweep is a no-op on every already-clean workspace.
+  db.exec("UPDATE term_sessions SET run_as = NULL WHERE run_as IS NOT NULL AND instr(run_as, ':') > 0");
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1156,6 +1156,32 @@ export class TerminalManager {
   }
 
   /**
+   * Resolve a session's **run-as identity** — the ONE place `term_sessions.run_as` is derived, and the
+   * guarantee that the column only ever holds a real member id.
+   *
+   * `spawnedBy` is PROVENANCE and may be a bare member id OR a prefixed system trigger
+   * (`automation:` / `task:` / `chat:` / `poke:` / `ask:` / `goal:`). Only the bare-member case is a
+   * human to act as, so the fallback resolves against the team rather than blocklisting prefixes — a
+   * new provenance kind can't leak into the identity column by being forgotten here. An explicit
+   * `runAs` is canonicalised the same way (id or email → id), so a caller that hands over an email or
+   * a stale member never writes a value the rest of the system silently fails to match.
+   *
+   * Returning undefined (→ NULL) is the correct answer for a run with no accountable human: it degrades
+   * to the company identity, which is exactly what an ownerless automation/task run should use. The old
+   * behavior instead stored the provenance string itself, so `run_as = 'chat:triage'` looked like an
+   * identity to every consumer and matched none — silently costing that run the member's GitHub token,
+   * connectors, member-scoped secrets and inbox ownership.
+   */
+  private resolveActingMember(runAs?: string, spawnedBy?: string): string | undefined {
+    const asMember = (v?: string): string | undefined => {
+      const raw = (v ?? '').trim();
+      if (!raw) return undefined;
+      return (this.os.team.getMember(raw) ?? this.os.team.getMemberByEmail(raw))?.id;
+    };
+    return asMember(runAs) ?? asMember(spawnedBy);
+  }
+
+  /**
    * Is a message ADDRESSED to `viewer` (vs merely visible via an oversight role)? This is the `mine`
    * inbox scope — the fix for owner/admin being flooded by every session's cards. An explicit audience
    * routes by REAL membership: a named `member`/`sessionOwner` by id, an `approvers`/`admins` card to
@@ -1649,7 +1675,7 @@ export class TerminalManager {
     //   `actingMember`  = whose IDENTITY the agent acts under (connectors / Composio / inbox / uid).
     //                     `runAs` when a trigger resolved a member, else the console member who spawned.
     // When no runAs is given this collapses to today's behavior (identity = the spawning member).
-    const actingMember = runAs ?? (spawnedBy && !spawnedBy.startsWith('automation:') ? spawnedBy : undefined);
+    const actingMember = this.resolveActingMember(runAs, spawnedBy);
     // Per-session bearer (0d): exported into the session env and required on the loopback agent
     // endpoints, so one session's runtime can't gate/recall/report AS another by forging its id.
     const secret = randomBytes(24).toString('hex');
@@ -1738,7 +1764,7 @@ export class TerminalManager {
     const claudeSessionId = runtimeSupports(manifest.runtime, 'pinnedSessionId') ? randomUUID() : null;
     // Inherit the branch identity (connectors/Composio/uid follow run_as); fall back to the forker when
     // the parent had none. Provenance (`spawned_by`) is the forking member — this fork was console-driven.
-    const actingMember = src.run_as ?? (by || undefined);
+    const actingMember = this.resolveActingMember(src.run_as ?? undefined, by);
     const secret = randomBytes(24).toString('hex');
     const seed = (task || '').trim();
     const title = `fork of ${sourceId}${seed ? ' · ' + (seed.length > 48 ? seed.slice(0, 47) + '…' : seed) : ''}`;
@@ -2025,13 +2051,13 @@ export class TerminalManager {
     if (this.isAlive(sessionId)) return false; // caller should have delivered instead
     const body = (text || '').trim();
     if (!body) return false;
-    const actingMember = runAs ?? row.run_as ?? undefined;
+    const actingMember = this.resolveActingMember(runAs ?? row.run_as ?? undefined);
     const hasSlack = !!this.db.prepare('SELECT 1 FROM slack_threads WHERE session_id = ?').get(sessionId);
     const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
     const hasClickup = !!this.db.prepare('SELECT 1 FROM clickup_threads WHERE session_id = ?').get(sessionId);
     const hasTelegram = !!this.db.prepare('SELECT 1 FROM telegram_threads WHERE session_id = ?').get(sessionId);
     this.db.prepare("UPDATE term_sessions SET status = 'running', resident = 1, task = ?, run_as = ?, last_activity = ?, updated_at = ? WHERE id = ?")
-      .run(body, actingMember ?? row.run_as ?? null, Date.now(), Date.now(), sessionId);
+      .run(body, actingMember ?? null, Date.now(), Date.now(), sessionId);
     this.audit(sessionId, row.agent, 'chat.revived', { runAs: actingMember ?? null });
     this.launchAgentRuntime({
       id: sessionId, agent: row.agent, task: body, secret: row.secret ?? randomBytes(24).toString('hex'),
@@ -2061,13 +2087,13 @@ export class TerminalManager {
     const body = (message || '').trim();
     if (!body) return 'error';
     if (this.isAlive(sessionId)) return 'busy'; // a turn is still generating — don't launch a competing run
-    const actingMember = runAs ?? row.run_as ?? undefined;
+    const actingMember = this.resolveActingMember(runAs ?? row.run_as ?? undefined);
     const hasSlack = !!this.db.prepare('SELECT 1 FROM slack_threads WHERE session_id = ?').get(sessionId);
     const hasDiscord = !!this.db.prepare('SELECT 1 FROM discord_threads WHERE session_id = ?').get(sessionId);
     const hasClickup = !!this.db.prepare('SELECT 1 FROM clickup_threads WHERE session_id = ?').get(sessionId);
     const hasTelegram = !!this.db.prepare('SELECT 1 FROM telegram_threads WHERE session_id = ?').get(sessionId);
     this.db.prepare("UPDATE term_sessions SET status = 'running', headless = 1, resident = 0, task = ?, run_as = ?, last_activity = ?, updated_at = ? WHERE id = ?")
-      .run(body, actingMember ?? row.run_as ?? null, Date.now(), Date.now(), sessionId);
+      .run(body, actingMember ?? null, Date.now(), Date.now(), sessionId);
     this.audit(sessionId, row.agent, 'chat.turn', { runAs: actingMember ?? null });
     this.launchAgentRuntime({
       id: sessionId, agent: row.agent, task: body, secret: row.secret ?? randomBytes(24).toString('hex'),


### PR DESCRIPTION
## The bug

`term_sessions` separates **`spawned_by`** (provenance — what triggered the run) from **`run_as`** (identity — the accountable human). Provenance is either a bare member id *or* a prefixed system trigger: `automation:` / `task:` / `chat:` / `poke:` / `ask:` / `goal:`.

`createSession` derived identity from provenance with a **one-entry blocklist**:

```ts
const actingMember = runAs ?? (spawnedBy && !spawnedBy.startsWith('automation:') ? spawnedBy : undefined);
```

So every *other* prefix fell through into the identity column. A chat-routed run whose sender wasn't in the identity map, or an ownerless auto-dispatched task, stored `run_as = 'chat:triage'` / `'task:tsk_…'` — a value no consumer can ever match.

**Nothing errors.** That run silently loses:
- the run-as member's **GitHub token** — its PRs are authored by the App bot instead of the human (`injectMemberGithub` → `gh.load('chat:triage')` → nothing)
- Composio / connector identity (`buildMcpConfigJson` memberId)
- member-scoped secret resolution (`ref.principal ?? actingMember ?? '*'`)
- granted SSH host credentials (`sshCredsFor`)
- inbox/session ownership (`ownsSession`, the `mine` scope)

Not a privilege issue — a bogus principal always resolves to *less*, never more. It's a silent-degradation bug.

## Measured on the live instawp tenant (2026-08-04)

23 sessions carry a polluted `run_as`: `chat:docs-bot` (10), `chat:triage` (7), `task:tsk_23b1a04c1b37f74e` (3), plus three more `task:` ids. There's a matching `github.token.refresh_failed` audit row logged against `principal: "chat:triage"` — the agent trying, and failing, to refresh a token belonging to nobody.

## The fix

`resolveActingMember` becomes the single place `run_as` is derived (shared by `createSession`, `forkSession`, `reviveResident`, `chatSend`). It resolves **against the team** rather than blocklisting prefixes, so a future provenance kind can't leak in by being forgotten here:

- explicit `runAs` is canonicalised (member id **or** email → member id)
- the provenance fallback applies only when it names a real member
- otherwise **NULL** — which is the correct answer for a run with no accountable human, and degrades to the company identity exactly as an ownerless automation already does

`reviveResident`/`chatSend` also stopped re-writing the old value through their `?? row.run_as` second fallback, which would have undone the cleaning.

A one-time migration NULLs the colon-bearing rows already on disk. It's scoped to values containing `:` so a legitimate member id can never be caught by it, and it's a no-op on an already-clean workspace. `spawned_by` is untouched — the record of what triggered the run doesn't change.

## Verification

New `scripts/run-as-identity-test.cjs` (wired into `npm run test:governance`), 22 assertions on a scratch `AGENT_OS_HOME`:
- every provenance prefix → no identity; bare member id → that member; email → canonical id; explicit `runAs` wins; neither resolvable → NULL
- the launch consequence: a chat-provenance run keeps the company-bot `GH_TOKEN`, the same run with a resolved member is authored as the human, and a raw provenance string matches no member
- the migration NULLs `chat:`/`task:` rows, leaves real member ids, and doesn't touch `spawned_by`

`npm run typecheck` clean; full governance suite green (159 + 18 + 18 + 29 + 29 + 12 + 22 + 38).

🤖 Generated with [Claude Code](https://claude.com/claude-code)