### PR TITLE
feat(sessions): chain rail + collapse agent-to-agent work into one thread (v0.311.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,37 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.311.0] — 2026-08-05
+### Added
+- **Agent-to-agent work reads as one thread: the chain rail + a collapsed sessions list.** A delegated
+  run was its own session row, so a three-agent delivery scattered across the list — and every
+  poke-back added one more row for a conversation that already existed. Shipping client-app PR #2773
+  on the instawp tenant produced **nine rows across three agents in 70 minutes**, interleaved with
+  unrelated work, four of them the same engineer transcript resumed with machine-written titles
+  (`Poke ← release-orchestrator done: …`). Nobody could see that release-orchestrator had been
+  dispatched **twice** for the same promotion — the second run's own summary reads "PR #2778 was
+  already open from a prior run".
+  Two surfaces, one read model, no new storage — the console simply reads three identities the DB
+  already records: a **run** (`term_sessions.id`), a **conversation** (every run sharing a
+  `claude_session_id` — a poke RESUMES a transcript), and the **chain** (`tasks.caller_claude_id` →
+  the runs dispatched for that task).
+  - **Chain rail** (`GET /api/sessions/:id/chain` → `TerminalManager.sessionChain`): the hand-off tree
+    beside the terminal — each conversation once with its own verdict, cost and run count, a
+    re-dispatch of the same work to the same agent flagged, and **anything waiting on a human**
+    (a delegate's open `ask`, an approval gate) answerable **in place**, instead of being hunted down
+    in the Inbox detached from the work that raised it. Renders nothing for a solo run; collapsible to
+    a spine, persisted per browser. Viewer-scoped by the same rule as the sessions list.
+  - **Sessions list collapse**: rows fold into conversations, and delegates nest under the caller that
+    dispatched them, with an inline chain strip (`qa · release-orch ×2`) so a stalled or duplicated
+    hand-off is visible without opening anything. Grouping runs over the FILTERED set, so a delegate
+    whose caller is filtered out is promoted rather than hidden; a row's checkbox now selects every run
+    behind it.
+  Two folding rules the live data forced: a conversation's cost is the **max** of its runs, not the sum
+  (cost is per-transcript and cumulative, so summing multiplies one bill by the number of resumes), and
+  its verdict + summary come from the **same** reporting run (else a conversation whose last resume
+  ended quietly reads "no report" beside the report it filed). Covered by
+  `scripts/chain-model-test.cjs` (36 assertions, wired into `npm run test:governance`).
+
 ## [0.310.0] — 2026-08-05
 ### Added
 - **Terse output — a verbosity knob on the runtime-tuning chain, with the measurement that can

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -339,6 +339,15 @@ Key modules:
   **episodic↔semantic learning loop** — graded episodes (`episodeSalience` in `terminal.ts`), deliberate
   `report` **lessons**, and **retrieval reinforcement** (`rerank` `weightByUsage` + last-use recency in
   `src/memory/embedding.ts`) — is documented in `docs/memory-encoding-and-consolidation.md`.
+- `src/terminal.ts` also derives the **hand-off chain** (`sessionChain` → `GET /api/sessions/:id/chain`,
+  the console's chain rail): runs fold into CONVERSATIONS by `claude_session_id` (a `poke:` run RESUMES a
+  transcript, so several rows are one conversation), and conversations nest under the caller that
+  delegated them (`tasks.caller_claude_id` → the `task:`/`ask:` runs dispatched for it). Nothing new is
+  stored. Two folding rules the live data forced: a conversation's cost is the **max** of its runs (cost
+  is per-transcript and cumulative — summing multiplies one bill by the number of resumes), and its
+  verdict + summary come from the SAME reporting run. `listSessions` stamps `threadId`/`parentThreadId`/
+  `taskId` on every row (one batched query) so the sessions list can collapse the same way. Tested by
+  `scripts/chain-model-test.cjs`.
 - `src/state/db.ts` — the per-workspace SQLite database + migrations.
 - `src/tenant-registry.ts` — the **multi-tenant registry**: builds + caches one full runtime per tenant
   (`AgentOS` + `TerminalManager` + `Automations` + `SlackSocket` + ttyd) and resolves the request's

--- a/docs/PILLARS.md
+++ b/docs/PILLARS.md
@@ -40,7 +40,7 @@ Capabilities`), the taxonomy north-star that sits beside [`governance-model.md`]
 
 | # | Pillar | Status | One-liner |
 |---|--------|--------|-----------|
-| 1 | Agents & Sessions | ✅ | Manifest-driven agents, real Claude in tmux, persisted sessions |
+| 1 | Agents & Sessions | ✅ | Manifest-driven agents, real Claude in tmux, persisted sessions. The console reads them at three levels: a **run** (one pane), a **conversation** (every run sharing a claude transcript — a poke-back resumes one rather than starting one), and the **chain** (the hand-off tree over `tasks.caller_claude_id`). The sessions list collapses runs into conversations and nests delegates under their caller; a **chain rail** beside the terminal shows the tree, flags a re-dispatch of work already handed off, and answers a delegate's pending `ask`/approval in place |
 | 2 | Inbox | ✅ | Tasks · updates · approval/question cards, SQLite-backed, role-aware; per-member read/dismiss; out-of-band DMs for approvals **and** questions + chat-thread mirroring. See [`inbox-plan.md`](./inbox-plan.md) |
 | 3 | Connectors | ✅ | MCP catalog → per-session `.mcp.json`, every call still gated |
 | 4 | Team | ✅ | Roles (owner/admin/member), magic-link login, agent assignment, identity map (external accounts → member) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.310.0",
+  "version": "0.311.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.310.0",
+      "version": "0.311.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.310.0",
+  "version": "0.311.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,7 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs",
+    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:deps": "node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",

--- a/scripts/chain-model-test.cjs
+++ b/scripts/chain-model-test.cjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/* Chain read-model test — the tree behind the console's chain rail and the collapsed sessions list
+ * (TerminalManager.sessionChain + the threadId/parentThreadId/taskId stamps on listSessions).
+ *
+ * What it pins down, all of it derived from rows that already exist (no new storage):
+ *   - runs fold into CONVERSATIONS by claude transcript, so a poke-back is a resume, not a new node;
+ *   - conversations nest under the caller that delegated them (tasks.caller_claude_id), from any seed;
+ *   - a conversation's cost is the MAX of its runs (cost is per-transcript and cumulative — summing
+ *     would multiply one bill by the number of resumes);
+ *   - the folded verdict + summary come from the same reporting run;
+ *   - a re-dispatch of the same work to the same agent is flagged, and a DIFFERENT task is not;
+ *   - a delegate's pending ask/approval lands on that delegate's node (what the rail answers in place);
+ *   - viewer scoping matches the sessions list — a member never sees another member's run through it;
+ *   - self-parenting and cycles can't wedge the walk.
+ * Isolated home; no tmux or claude needed (the walk is pure over the DB). */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-chain-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+
+const aos = loadAgentOS();
+const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+
+const mkMember = (email, role) => {
+  const { member } = aos.team.invite({ email, role });
+  aos.db.prepare("UPDATE members SET status='active' WHERE id=?").run(member.id);
+  return aos.team.getMember(member.id);
+};
+const owner = mkMember('owner@testco.dev', 'owner');
+const alice = mkMember('alice@testco.dev', 'member');
+const bob = mkMember('bob@testco.dev', 'member');
+
+const T0 = Date.now() - 3_600_000;
+let n = 0;
+/** One RUN. `claude` is the conversation it belongs to — several runs share it after a poke-back. */
+const mkRun = (o = {}) => {
+  const id = 'ts_' + (++n);
+  const cols = {
+    id, agent: 'engineer', title: 't', task: 'x', tmux: 'aos-' + id, status: 'done',
+    spawned_by: alice.id, run_as: alice.id, claude_session_id: 'cs_eng', archived_at: null,
+    cost_usd: null, outcome: null, report_summary: null,
+    created_at: T0 + n * 60_000, updated_at: T0 + n * 60_000, ...o,
+  };
+  aos.db.prepare(`INSERT INTO term_sessions
+      (id,agent,title,task,tmux,status,spawned_by,run_as,claude_session_id,archived_at,cost_usd,outcome,report_summary,created_at,updated_at)
+      VALUES (@id,@agent,@title,@task,@tmux,@status,@spawned_by,@run_as,@claude_session_id,@archived_at,@cost_usd,@outcome,@report_summary,@created_at,@updated_at)`).run(cols);
+  return id;
+};
+const mkTask = (o) => aos.tasks.create({ tenant: aos.tenant, createdBy: 'agent:engineer', owner: alice.id, pokeOnDone: true, ...o });
+
+// ── the fixture: engineer → qa, then engineer → release-orchestrator twice (the re-dispatch) ──
+// The caller's own conversation: a member spawn plus two poke-back resumes, all one transcript.
+const engRun1 = mkRun({ title: 'ship PR #1', cost_usd: 40, outcome: 'success', report_summary: 'opened PR #1' });
+const tQa = mkTask({ title: 'QA: PR #1', assignee: 'agent:qa', callerAgent: 'agent:engineer', callerClaudeId: 'cs_eng' });
+const tRel1 = mkTask({ title: 'Promote PR #1', assignee: 'agent:release', callerAgent: 'agent:engineer', callerClaudeId: 'cs_eng' });
+const tRel2 = mkTask({ title: 'Promote PR #1', assignee: 'agent:release', callerAgent: 'agent:engineer', callerClaudeId: 'cs_eng' });
+const tOther = mkTask({ title: 'Promote PR #2', assignee: 'agent:release', callerAgent: 'agent:engineer', callerClaudeId: 'cs_eng' });
+
+const engRun2 = mkRun({ spawned_by: `poke:${tQa.id}`, title: 'Poke ← qa done: QA: PR #1', cost_usd: 70, outcome: 'unknown' });
+const engRun3 = mkRun({ spawned_by: `poke:${tRel1.id}`, title: 'Poke ← release done: Promote PR #1', cost_usd: 95, outcome: 'unknown' });
+
+const qaRun = mkRun({ agent: 'qa', claude_session_id: 'cs_qa', spawned_by: `task:${tQa.id}`, title: 'Task: QA: PR #1', cost_usd: 12, outcome: 'success', report_summary: 'QA PASS — 10/10 criteria' });
+const relRun1 = mkRun({ agent: 'release', claude_session_id: 'cs_rel1', spawned_by: `task:${tRel1.id}`, title: 'Task: Promote PR #1', cost_usd: 9, outcome: 'success', report_summary: 'promotion PR opened' });
+const relRun2 = mkRun({ agent: 'release', claude_session_id: 'cs_rel2', spawned_by: `task:${tRel2.id}`, title: 'Task: Promote PR #1', cost_usd: 6, outcome: 'success', report_summary: 'already open from a prior run' });
+const relRun3 = mkRun({ agent: 'release', claude_session_id: 'cs_rel3', spawned_by: `task:${tOther.id}`, title: 'Task: Promote PR #2', cost_usd: 5, outcome: 'success', report_summary: 'PR #2 promoted' });
+// A quick-answer run — an ephemeral delegate that never took the task over.
+const askRun = mkRun({ agent: 'docs', claude_session_id: 'cs_ask', spawned_by: `ask:${tQa.id}`, title: 'Answer · QA: PR #1', cost_usd: 1, outcome: 'success', report_summary: 'answered in the discussion' });
+
+const chain = tm.sessionChain(engRun1);
+const node = (agent, i = 0) => chain.nodes.filter((x) => x.agent === agent)[i];
+
+console.log('\n\x1b[1mchain shape\x1b[0m');
+assert(chain && chain.rootThreadId === 'cs_eng', 'root is the caller conversation');
+// 1 root + qa + 3 release + the quick answer = 6 conversations, NOT the 9 runs behind them.
+assert(chain.nodes.length === 6, 'one node per conversation, not per run', `got ${chain.nodes.length}`);
+assert(node('engineer').runs === 3, 'the caller\'s poke-back resumes fold into its own node', `runs=${node('engineer').runs}`);
+assert(chain.nodes.filter((x) => x.depth === 0).length === 1, 'exactly one root');
+assert(chain.nodes.filter((x) => x.depth === 1).length === 5, 'every delegate hangs off the caller');
+assert(chain.agents === 4, 'distinct agents counted', `agents=${chain.agents}`);
+assert(node('docs').kind === 'answer', 'an `ask:` run reads as a quick answer, not a hand-off');
+assert(node('qa').kind === 'delegate' && node('engineer').kind === 'root', 'kinds resolve');
+assert(node('qa').taskId === tQa.id && node('qa').taskTitle === 'QA: PR #1', 'the delegate carries its task');
+
+console.log('\n\x1b[1mfolded facts\x1b[0m');
+assert(node('engineer').costUsd === 95, 'conversation cost is the MAX of its runs, not the sum', `got ${node('engineer').costUsd}`);
+assert(chain.totalCostUsd === 95 + 12 + 9 + 6 + 5 + 1, 'chain total sums the conversations', `got ${chain.totalCostUsd}`);
+assert(node('engineer').title === 'ship PR #1', 'a poke\'s machine-written title never labels the conversation');
+assert(node('engineer').summary === 'opened PR #1' && node('engineer').outcome === 'success',
+  'verdict + summary come from the same reporting run (not "no report" beside a report)');
+assert(node('engineer').createdAt === chain.startedAt, 'the chain starts when the caller did');
+
+console.log('\n\x1b[1mre-dispatch\x1b[0m');
+assert(node('release', 0).duplicateOf === undefined, 'the first hand-off is not a duplicate');
+assert(node('release', 1).duplicateOf === tRel1.id, 'the same work re-handed to the same agent is flagged');
+assert(node('release', 2).duplicateOf === undefined, 'a DIFFERENT task to the same agent is not a duplicate');
+
+console.log('\n\x1b[1mseeded from anywhere\x1b[0m');
+for (const [label, seed] of [['a delegate', qaRun], ['a poke-back run', engRun3], ['the re-dispatch', relRun2]]) {
+  const c = tm.sessionChain(seed);
+  assert(c && c.rootThreadId === 'cs_eng' && c.nodes.length === 6, `${label} resolves the same chain`, c && `${c.rootThreadId}/${c.nodes.length}`);
+}
+assert(tm.sessionChain('ts_nope') === null, 'an unknown session has no chain');
+
+console.log('\n\x1b[1mwaiting on a human\x1b[0m');
+const q = tm.askQuestion(qaRun, 'qa', 'Which browser matrix?');
+const after = tm.sessionChain(engRun1);
+const qaNode = after.nodes.find((x) => x.agent === 'qa');
+assert(qaNode.pending.length === 1 && qaNode.pending[0].kind === 'question', 'a delegate\'s open ask lands on the delegate\'s node');
+assert(qaNode.pending[0].id === q.id && qaNode.pending[0].text === 'Which browser matrix?', 'it carries the id the answer route takes');
+assert(after.nodes.filter((x) => x.pending.length).length === 1, 'and only on that node');
+tm.answerQuestion(q.id, 'chromium + firefox', owner.email);
+assert(tm.sessionChain(engRun1).nodes.every((x) => !x.pending.length), 'answering clears it');
+
+console.log('\n\x1b[1mvisibility\x1b[0m');
+assert(tm.sessionChain(engRun1, owner).nodes.length === 6, 'owner sees the whole chain');
+assert(tm.sessionChain(engRun1, alice).nodes.length === 6, 'the member who owns the runs sees it');
+assert(tm.sessionChain(engRun1, bob) === null, 'a member who can\'t see the seed gets no chain');
+// A delegate that ran as someone else drops out of alice's view — with its subtree, never leaked.
+aos.db.prepare("UPDATE term_sessions SET run_as=? WHERE id=?").run(bob.id, relRun3);
+assert(tm.sessionChain(engRun1, alice).nodes.length === 5, 'a run she can\'t see is omitted from her chain');
+assert(tm.sessionChain(engRun1, owner).nodes.length === 6, 'and still present for the owner');
+
+console.log('\n\x1b[1mcycle guards\x1b[0m');
+// A task whose caller is its OWN delegate — the shape a cycle would take.
+const tLoop = mkTask({ title: 'loop', assignee: 'agent:qa', callerAgent: 'agent:qa', callerClaudeId: 'cs_loop' });
+const loopRun = mkRun({ agent: 'qa', claude_session_id: 'cs_loop', spawned_by: `task:${tLoop.id}`, title: 'Task: loop' });
+const loop = tm.sessionChain(loopRun);
+assert(loop && loop.nodes.length === 1 && loop.rootThreadId === 'cs_loop', 'a self-parented conversation is its own root, once', loop && `${loop.nodes.length}`);
+
+console.log('\n\x1b[1mlist stamps (the collapse)\x1b[0m');
+const rows = tm.listSessions(owner);
+const row = (id) => rows.find((r) => r.id === id);
+assert(row(engRun2).threadId === 'cs_eng' && row(engRun1).threadId === 'cs_eng', 'runs of one transcript share a threadId');
+assert(new Set(rows.filter((r) => r.agent === 'engineer').map((r) => r.threadId)).size === 1, 'so the caller collapses to one entry');
+assert(row(qaRun).parentThreadId === 'cs_eng' && row(qaRun).taskId === tQa.id, 'a delegate points at its caller + task');
+assert(row(engRun2).parentThreadId === 'cs_eng', 'a poke resolves to its OWN thread (no parent = not a hand-off)');
+assert(row(engRun1).parentThreadId === undefined && row(engRun1).taskId === undefined, 'a member-spawned run has no chain edge');
+
+console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m`);
+fs.rmSync(HOME, { recursive: true, force: true });
+process.exit(fail ? 1 : 0);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2752,6 +2752,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   // Session activity: "which agent-os primitives did this run use?" — the session's audit stream,
   // classified into a chronological timeline + a grouped count summary. Same visibility as the terminal
   // (canViewSession), so a member sees the activity of the runs they can attach to, not just admins.
+  // The hand-off chain this session belongs to — the tree behind the console's chain rail: who delegated
+  // to whom, what came back, and what is still waiting on a person. Derived, not stored (see
+  // TerminalManager.sessionChain); viewer-scoped by the same rule as the sessions list.
+  const chainMatch = p.match(/^\/api\/sessions\/([\w-]+)\/chain$/);
+  if (method === 'GET' && chainMatch) {
+    const chain = tm.sessionChain(chainMatch[1], me);
+    if (!chain) return sendJson(res, 404, { error: 'unknown session' });
+    return sendJson(res, 200, chain);
+  }
+
   const activityMatch = p.match(/^\/api\/sessions\/([\w-]+)\/activity$/);
   if (method === 'GET' && activityMatch) {
     const id = activityMatch[1];

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -15,7 +15,7 @@ import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { containedPath, mimeOf } from './state/artifacts';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId, type MintOptions } from './connectors/composio';
-import { isCodingRuntime, runtimeSupports, CODING_RUNTIMES, CodingRuntimeId, ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskTimelineEntry, TaskDiscussionSummary, Verbosity, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
+import { isCodingRuntime, runtimeSupports, CODING_RUNTIMES, CodingRuntimeId, ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskStatus, TaskTimelineEntry, TaskDiscussionSummary, Verbosity, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval, redactSecrets } from './governance/enricher';
 import { resolveCapability } from './capabilities/normalize';
 import { briefFor } from './governance/briefer';
@@ -233,6 +233,18 @@ export interface Session {
    *  Sessions lists to keep them uncluttered; the row still exists for by-id opens (Cockpit's "Open full
    *  session") + Audit. */
   system?: boolean;
+  /** CONVERSATION key — the claude transcript this run belongs to, falling back to the session id when
+   *  there is none. A poke-back / thread continuation RESUMES a transcript, so several session rows share
+   *  one `threadId`: it is the identity the console groups the list by, so a resumed conversation reads as
+   *  one entry with N runs instead of N unrelated entries. */
+  threadId?: string;
+  /** The `threadId` of the CALLER that delegated this run — set when the run was dispatched by a task
+   *  (`task:` / `ask:` / `poke:` provenance) whose `caller_claude_id` is known. Equal to `threadId` for a
+   *  poke (a caller waking itself), which the console reads as "no parent". The one edge that turns the
+   *  flat session list into the hand-off tree. */
+  parentThreadId?: string;
+  /** The task this run works (`task:`/`poke:`/`ask:` provenance) — the hand-off it belongs to. */
+  taskId?: string;
   /** True when the run launched unattended (an automation/cron/task run). These now run as an attachable
    *  interactive TUI (not `claude -p`) that a human can take over live; the console badges them as
    *  unattended vs. a member's own interactive session. */
@@ -305,6 +317,93 @@ export interface Session {
   blockedMs?: number;
   /** How many deliverables the run published to the Library (`artifacts` rows). Undefined until stamped. */
   artifacts?: number;
+}
+
+/** Something in a chain node that can't proceed without a person: an unanswered `ask`, or an approval
+ *  gate holding a run open. Carries the id its resolve route takes, so the rail answers in place. */
+export interface ChainPending {
+  kind: 'question' | 'approval';
+  /** The question / approval id — `POST /api/questions/:id` or `POST /api/approvals/:id`. */
+  id: string;
+  sessionId: string;
+  agent: string;
+  /** The question text, or the policy's reason this action needs sign-off. */
+  text: string;
+  capability?: string;
+  level?: ApprovalLevel;
+  createdAt: number;
+}
+
+/** One CONVERSATION in a hand-off chain — every run sharing a claude transcript folded into a single
+ *  entry (`runs` of them), positioned in the delegation tree by `parentThreadId` + `depth`. */
+export interface ChainNode {
+  threadId: string;
+  /** The conversation that delegated this one. Absent on the root. */
+  parentThreadId?: string;
+  depth: number;
+  /** The newest run of the conversation — what "open this node" attaches to. */
+  sessionId: string;
+  tmux: string;
+  agent: string;
+  title: string;
+  summary?: string;
+  status: SessionStatus;
+  alive?: boolean;
+  outcome?: string;
+  /** How many session rows this conversation spans (>1 = it was resumed by pokes/continuations). */
+  runs: number;
+  /** Cost summed across every run of the conversation. */
+  costUsd?: number;
+  createdAt: number;
+  updatedAt: number;
+  /** `root` = the conversation the chain starts at; `delegate` = dispatched for a task; `answer` = an
+   *  ephemeral quick-answer run (`ask:` provenance) that never took the task over. */
+  kind: 'root' | 'delegate' | 'answer';
+  taskId?: string;
+  taskTitle?: string;
+  taskStatus?: TaskStatus;
+  /** Set when an earlier sibling already handed the SAME work to the SAME agent — the duplicate
+   *  re-dispatch a flat list hides. Holds the task id it repeats. */
+  duplicateOf?: string;
+  pending: ChainPending[];
+}
+
+/** The hand-off tree a session belongs to — see {@link TerminalManager.sessionChain}. */
+export interface SessionChain {
+  rootThreadId: string;
+  /** Flat, in walk order (parents before children); render as a tree via `parentThreadId`/`depth`. */
+  nodes: ChainNode[];
+  /** Distinct agents taking part — the chain's headline "3 agents". */
+  agents: number;
+  totalCostUsd?: number;
+  startedAt: number;
+  updatedAt: number;
+}
+
+/** Chain-walk bounds. Deep enough for any real hand-off (the deepest observed in the fleet is 3), tight
+ *  enough that a cyclic or pathological graph can't turn one request into an unbounded crawl. */
+const CHAIN_MAX_DEPTH = 8;
+const CHAIN_MAX_NODES = 60;
+
+/** The task id behind a dispatched run's provenance — `task:<id>` (working it), `ask:<id>` (quick answer
+ *  on it), or `poke:<id>` (the caller woken because it finished). Undefined for every other origin. */
+function taskOfProvenance(spawnedBy: string | null | undefined): string | undefined {
+  const m = spawnedBy ? /^(?:task|poke|ask):(.+)$/.exec(spawnedBy) : null;
+  return m ? m[1] : undefined;
+}
+
+/** Flag re-dispatches: among siblings of one caller, a delegate to the same agent for the same task
+ *  title is the SECOND (or third) attempt at work already handed off. First one wins; the rest carry
+ *  `duplicateOf`. Mutates in place — the nodes are already in walk (chronological) order. */
+function markDuplicateDispatches(nodes: ChainNode[]): void {
+  const firstSeen = new Map<string, string>();
+  for (const n of nodes) {
+    if (!n.taskId || !n.parentThreadId || n.kind === 'root') continue;
+    const key = `${n.parentThreadId}|${n.agent}|${(n.taskTitle ?? n.title).trim().toLowerCase().replace(/\s+/g, ' ')}`;
+    const first = firstSeen.get(key);
+    if (first && first !== n.taskId) n.duplicateOf = first;
+    else if (!first) firstSeen.set(key, n.taskId);
+  }
 }
 
 export interface FeedMessage {
@@ -772,8 +871,10 @@ export class TerminalManager {
     // One query resolves the whole list's blocked-on-human state (a pending ask/approval), instead of a
     // per-row check — so the console gets an authoritative `blocked` without re-deriving it from the feed.
     const blocked = this.blockedSessionIds();
+    const links = this.chainLinks(visible);
     return visible.map((r) => ({
       ...toSession(r),
+      ...links.get(r.id),
       alive: alive ? alive.has(r.tmux) : undefined,
       blocked: r.status === 'running' && blocked.has(r.id),
       resumable: resumable.has(r.id),
@@ -1090,6 +1191,181 @@ export class TerminalManager {
     for (const q of this.db.prepare("SELECT DISTINCT run_id FROM questions WHERE status = 'pending'").all<{ run_id: string }>()) ids.add(q.run_id);
     for (const a of this.os.approvals.pending(this.os.tenant)) ids.add(a.runId);
     return ids;
+  }
+
+  /**
+   * The delegation edge for a page of rows: session → the task that dispatched it, and that task's CALLER
+   * conversation. Resolved in ONE batched query over `tasks` (chunked under SQLite's variable cap) rather
+   * than per row — the sessions list is a hot poll path, and an N+1 here would cost a query per delegated
+   * run. Rows with no `task:`/`poke:`/`ask:` provenance simply aren't in the map.
+   */
+  private chainLinks(rows: SessionRow[]): Map<string, { taskId: string; parentThreadId?: string }> {
+    const out = new Map<string, { taskId: string; parentThreadId?: string }>();
+    for (const r of rows) {
+      const taskId = taskOfProvenance(r.spawned_by);
+      if (taskId) out.set(r.id, { taskId });
+    }
+    if (!out.size) return out;
+    const ids = [...new Set([...out.values()].map((v) => v.taskId))];
+    const callers = new Map<string, string>();
+    for (let i = 0; i < ids.length; i += 400) {
+      const page = ids.slice(i, i + 400);
+      for (const c of this.db
+        .prepare(`SELECT id, caller_claude_id FROM tasks WHERE id IN (${page.map(() => '?').join(',')})`)
+        .all<{ id: string; caller_claude_id: string | null }>(...page)) {
+        if (c.caller_claude_id) callers.set(c.id, c.caller_claude_id);
+      }
+    }
+    for (const link of out.values()) link.parentThreadId = callers.get(link.taskId);
+    return out;
+  }
+
+  /**
+   * The HAND-OFF CHAIN a session belongs to — the tree the console's chain rail renders, and the answer
+   * to "where is this piece of work right now?" that a flat session list can't give.
+   *
+   * Three identities are collapsed into one view here, all of them already recorded:
+   *   - a **run** is a `term_sessions` row (one pane);
+   *   - a **conversation** is every run sharing a `claude_session_id` — a poke-back RESUMES a transcript,
+   *     so one conversation routinely spans several rows;
+   *   - the **chain** is the delegation tree over conversations: `tasks.caller_claude_id` (the caller)
+   *     → the runs dispatched for that task (`task:` / `ask:` provenance).
+   *
+   * We walk UP from `sessionId` to the chain root, then DOWN over every descendant, folding each
+   * conversation into a single node (runs counted, cost summed, newest run representative). Sibling
+   * delegates to the same agent with the same task title are flagged `duplicate` — the re-dispatch that
+   * is invisible in a flat list. Depth and breadth are capped so a pathological graph can't wedge the
+   * request. Viewer-scoped by the same `canViewRow` rule as the list: a node the viewer can't see is
+   * omitted (its subtree with it), never leaked.
+   */
+  sessionChain(sessionId: string, viewer?: Member): SessionChain | null {
+    const seed = this.db.prepare('SELECT * FROM term_sessions WHERE id = ?').get<SessionRow>(sessionId);
+    if (!seed) return null;
+    if (viewer && !this.canViewRow(seed.spawned_by, seed.run_as, viewer)) return null;
+
+    const threadOf = (r: SessionRow): string => r.claude_session_id ?? r.id;
+    const rowsOfThread = (threadId: string): SessionRow[] => {
+      const rows = this.db
+        .prepare('SELECT * FROM term_sessions WHERE claude_session_id = ? OR (claude_session_id IS NULL AND id = ?) ORDER BY created_at ASC')
+        .all<SessionRow>(threadId, threadId);
+      return viewer ? rows.filter((r) => this.canViewRow(r.spawned_by, r.run_as, viewer)) : rows;
+    };
+    // The task a conversation was dispatched FOR (its first `task:`/`ask:` run), and from it the caller
+    // conversation one level up.
+    const dispatchOf = (rows: SessionRow[]): { taskId: string; callerThreadId?: string } | undefined => {
+      for (const r of rows) {
+        const taskId = taskOfProvenance(r.spawned_by);
+        if (!taskId || r.spawned_by?.startsWith('poke:')) continue; // a poke resumes the CALLER, not a delegate
+        const t = this.db.prepare('SELECT caller_claude_id FROM tasks WHERE id = ?').get<{ caller_claude_id: string | null }>(taskId);
+        return { taskId, callerThreadId: t?.caller_claude_id ?? undefined };
+      }
+      return undefined;
+    };
+
+    // ── walk up to the root conversation ──
+    let rootThread = threadOf(seed);
+    const climbed = new Set<string>([rootThread]);
+    for (let hop = 0; hop < CHAIN_MAX_DEPTH; hop++) {
+      const up = dispatchOf(rowsOfThread(rootThread))?.callerThreadId;
+      if (!up || up === rootThread || climbed.has(up)) break;
+      if (!rowsOfThread(up).length) break; // caller invisible to this viewer / pruned → stop here
+      rootThread = up;
+      climbed.add(up);
+    }
+
+    // ── walk down over every descendant ──
+    const nodes: ChainNode[] = [];
+    const seen = new Set<string>();
+    const alive = this.backend.aliveNames(); // one tmux poll for the whole walk, not one per node
+    const visit = (threadId: string, depth: number, parentThreadId?: string): void => {
+      if (seen.has(threadId) || nodes.length >= CHAIN_MAX_NODES || depth > CHAIN_MAX_DEPTH) return;
+      const rows = rowsOfThread(threadId);
+      if (!rows.length) return;
+      seen.add(threadId);
+      const latest = rows[rows.length - 1];
+      const dispatch = dispatchOf(rows);
+      const task = dispatch ? this.os.tasks.get(dispatch.taskId) : undefined;
+      // Cost is per-TRANSCRIPT and cumulative: every resumed row re-parses the same conversation and
+      // stores the running total, so the conversation's cost is the largest of them — summing would
+      // multiply one bill by the number of resumes.
+      const cost = rows.reduce((n, r) => Math.max(n, r.cost_usd ?? 0), 0);
+      // A resumed row's title is machine-written ("Poke ← … done: …") and its summary usually empty, so
+      // the newest row is the wrong label for the conversation. Prefer the freshest real verdict — and
+      // take the outcome from the SAME run as the summary, or a conversation whose last resume ended
+      // quietly reads "no report" right beside the report it filed.
+      const voice = [...rows].reverse();
+      const reported = voice.find((r) => r.report_summary?.trim());
+      const summary = reported?.report_summary ?? undefined;
+      const title = voice.find((r) => !r.spawned_by?.startsWith('poke:'))?.title ?? latest.title;
+      nodes.push({
+        threadId,
+        parentThreadId,
+        depth,
+        sessionId: latest.id,
+        tmux: latest.tmux,
+        agent: latest.agent,
+        title,
+        summary,
+        status: latest.status,
+        alive: alive ? alive.has(latest.tmux) : undefined,
+        outcome: reported?.outcome ?? latest.outcome ?? undefined,
+        runs: rows.length,
+        costUsd: cost || undefined,
+        createdAt: rows[0].created_at,
+        updatedAt: latest.updated_at ?? latest.created_at,
+        kind: depth === 0 ? 'root' : rows.some((r) => r.spawned_by?.startsWith('ask:')) ? 'answer' : 'delegate',
+        taskId: dispatch?.taskId,
+        taskTitle: task?.title,
+        taskStatus: task?.status,
+        pending: this.chainPending(rows),
+      });
+      // Children: every task this conversation delegated, and the runs dispatched for it.
+      const tasks = this.db
+        .prepare('SELECT id FROM tasks WHERE caller_claude_id = ? ORDER BY created_at ASC')
+        .all<{ id: string }>(threadId);
+      for (const t of tasks) {
+        const runs = this.db
+          .prepare("SELECT * FROM term_sessions WHERE spawned_by = ? OR spawned_by = ? ORDER BY created_at ASC")
+          .all<SessionRow>(`task:${t.id}`, `ask:${t.id}`);
+        for (const child of runs) {
+          const childThread = threadOf(child);
+          if (childThread === threadId) continue; // defensive: never nest a conversation under itself
+          visit(childThread, depth + 1, threadId);
+        }
+      }
+    };
+    visit(rootThread, 0);
+    markDuplicateDispatches(nodes);
+
+    return {
+      rootThreadId: rootThread,
+      nodes,
+      agents: new Set(nodes.map((n) => n.agent)).size,
+      totalCostUsd: nodes.reduce((n, x) => n + (x.costUsd ?? 0), 0) || undefined,
+      startedAt: Math.min(...nodes.map((n) => n.createdAt)),
+      updatedAt: Math.max(...nodes.map((n) => n.updatedAt)),
+    };
+  }
+
+  /** What a chain node is waiting on a human for: its unanswered `ask` questions and unresolved approval
+   *  gates, over every run of the conversation. This is what makes the rail actionable — a delegate's
+   *  question is answered from the CALLER's pane, instead of being hunted down in the Inbox. */
+  private chainPending(rows: SessionRow[]): ChainPending[] {
+    const ids = rows.map((r) => r.id);
+    if (!ids.length) return [];
+    const out: ChainPending[] = [];
+    const marks = ids.map(() => '?').join(',');
+    for (const q of this.db
+      .prepare(`SELECT id, run_id, agent, prompt, created_at FROM questions WHERE status = 'pending' AND run_id IN (${marks}) ORDER BY created_at ASC`)
+      .all<{ id: string; run_id: string; agent: string; prompt: string; created_at: number }>(...ids)) {
+      out.push({ kind: 'question', id: q.id, sessionId: q.run_id, agent: q.agent, text: q.prompt, createdAt: q.created_at });
+    }
+    const own = new Set(ids);
+    for (const a of this.os.approvals.pending(this.os.tenant)) {
+      if (!own.has(a.runId)) continue;
+      out.push({ kind: 'approval', id: a.id, sessionId: a.runId, agent: rows.find((r) => r.id === a.runId)?.agent ?? '', text: a.reason || a.attempt.capabilityId, capability: a.attempt.capabilityId, level: a.level, createdAt: a.createdAt });
+    }
+    return out.sort((a, b) => a.createdAt - b.createdAt);
   }
 
   /**
@@ -5914,7 +6190,7 @@ function buildAskAgentPrompt(id: string, callerAgent: string, question: string, 
 }
 
 function toSession(r: SessionRow): Session {
-  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined, costUsd: r.cost_usd ?? undefined, tokens: r.cost_usd != null ? { input: r.input_tokens ?? 0, output: r.output_tokens ?? 0, cacheRead: r.cache_read_tokens ?? 0, cacheWrite: r.cache_write_tokens ?? 0 } : undefined, outcome: r.outcome ?? undefined, summary: r.report_summary ?? undefined, activeMs: r.active_ms ?? undefined, turns: r.turns ?? undefined, toolCalls: r.tool_calls ?? undefined, insights: r.gov_approvals != null ? { actions: r.gov_actions ?? 0, approvals: r.gov_approvals, denied: r.gov_denied ?? 0, errors: r.gov_errors ?? 0 } : undefined, model: r.model ?? undefined, effort: r.effort ?? undefined, verbosity: r.verbosity ?? undefined, blockedMs: r.blocked_ms ?? undefined, artifacts: r.artifacts ?? undefined };
+  return { id: r.id, agent: r.agent, title: r.title, task: r.task, tmux: r.tmux, status: r.status, threadId: r.claude_session_id ?? r.id, spawnedBy: r.spawned_by ?? undefined, runAs: r.run_as ?? undefined, headless: !!r.headless, claimedBy: r.claimed_by ?? undefined, createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at, rating: r.rating === 'up' || r.rating === 'down' ? r.rating : undefined, ratedBy: r.rated_by ?? undefined, ratedAt: r.rated_at ?? undefined, costUsd: r.cost_usd ?? undefined, tokens: r.cost_usd != null ? { input: r.input_tokens ?? 0, output: r.output_tokens ?? 0, cacheRead: r.cache_read_tokens ?? 0, cacheWrite: r.cache_write_tokens ?? 0 } : undefined, outcome: r.outcome ?? undefined, summary: r.report_summary ?? undefined, activeMs: r.active_ms ?? undefined, turns: r.turns ?? undefined, toolCalls: r.tool_calls ?? undefined, insights: r.gov_approvals != null ? { actions: r.gov_actions ?? 0, approvals: r.gov_approvals, denied: r.gov_denied ?? 0, errors: r.gov_errors ?? 0 } : undefined, model: r.model ?? undefined, effort: r.effort ?? undefined, verbosity: r.verbosity ?? undefined, blockedMs: r.blocked_ms ?? undefined, artifacts: r.artifacts ?? undefined };
 }
 
 function toMessage(r: MessageRow): FeedMessage {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type KeyboardEvent as ReactKeyboardEvent, type ChangeEvent as ReactChangeEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type KeyboardEvent as ReactKeyboardEvent, type ChangeEvent as ReactChangeEvent } from 'react'
 import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, FileCode, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Lightbulb, Moon, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink, Paperclip, KeyRound, Blocks, FilePlus, Maximize2, Minimize2, Filter, Share2, Lock, Gauge } from 'lucide-react'
 import { Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, Pin, PinOff, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -3143,6 +3143,268 @@ function OperationsMenu({ session, ops, onReload }: { session: Session; ops: Ses
   )
 }
 
+// ── Chain collapse ─────────────────────────────────────────────────────────────
+/** A CONVERSATION in the sessions list — every run sharing a claude transcript (`runs`), shown as one
+ *  entry, with the conversations it delegated to nested beneath it. */
+interface SessionGroup {
+  /** The row the entry renders as: the newest run, relabelled with the conversation's best title +
+   *  freshest verdict (a poke-back's own title is machine-written and its summary usually empty). */
+  rep: Session
+  /** Every run of this conversation, oldest first. `runs.length > 1` = it was resumed. */
+  runs: Session[]
+  children: SessionGroup[]
+}
+
+const threadOf = (s: Session): string => s.threadId ?? s.id
+/** The caller conversation that delegated this run, if any. A poke carries its own thread as the parent
+ *  (a caller waking itself) — that's not a hand-off, so it reads as no parent. */
+const parentOf = (s: Session): string | undefined =>
+  s.parentThreadId && s.parentThreadId !== threadOf(s) ? s.parentThreadId : undefined
+
+/**
+ * Fold a sorted, filtered session list into hand-off chains: runs → conversations → tree.
+ *
+ * Roots keep the incoming order (so the page's sort still drives the list); children are chronological.
+ * A conversation whose caller isn't in this list — filtered out, or not visible to this viewer — is
+ * promoted to a root, so nothing is ever hidden by grouping. Cycles are impossible by construction
+ * (a node is attached only to an EARLIER-seen parent), and a self-parent is dropped.
+ */
+function buildChainGroups(rows: Session[]): SessionGroup[] {
+  const byThread = new Map<string, Session[]>()
+  const order: string[] = []
+  for (const s of rows) {
+    const t = threadOf(s)
+    if (!byThread.has(t)) { byThread.set(t, []); order.push(t) }
+    byThread.get(t)!.push(s)
+  }
+  const groups = new Map<string, SessionGroup>()
+  for (const t of order) {
+    const runs = [...byThread.get(t)!].sort((a, b) => a.createdAt - b.createdAt)
+    const newest = runs.reduce((a, b) => (b.updatedAt > a.updatedAt ? b : a))
+    // Prefer the freshest REAL verdict + a human-written title over a resume's machine label.
+    const back = [...runs].reverse()
+    const title = back.find((r) => !r.spawnedBy?.startsWith('poke:'))?.title ?? newest.title
+    // Verdict and summary come from the SAME run — the freshest one that actually reported. Taking the
+    // outcome off the newest row instead would label a conversation "no report" whenever its last resume
+    // ended quietly, contradicting the summary printed beside it.
+    const reported = back.find((r) => r.summary?.trim())
+    groups.set(t, { rep: { ...newest, title, summary: reported?.summary, outcome: reported?.outcome ?? newest.outcome }, runs, children: [] })
+  }
+  const roots: SessionGroup[] = []
+  for (const t of order) {
+    const g = groups.get(t)!
+    const parent = g.runs.map(parentOf).find(Boolean)
+    const under = parent && parent !== t ? groups.get(parent) : undefined
+    if (under) under.children.push(g)
+    else roots.push(g)
+  }
+  const sortKids = (g: SessionGroup): void => {
+    g.children.sort((a, b) => a.rep.createdAt - b.rep.createdAt)
+    g.children.forEach(sortKids)
+  }
+  roots.forEach(sortKids)
+  return roots
+}
+
+/** The chain a list entry heads, as inline chips: who it handed off to and how each came out, plus a
+ *  marker when the conversation itself spans several runs. This is what makes a re-dispatch or a stalled
+ *  delegate visible from the list, instead of only after opening the session. */
+const MAX_CHAIN_CHIPS = 3
+function ChainStrip({ group, runs, onOpen, className = '' }: {
+  group: SessionGroup; runs: number; onOpen: (tmux: string, title: string) => void; className?: string
+}) {
+  const kids = group.children
+  if (!kids.length && runs < 2) return null
+  return (
+    <div className={`flex flex-wrap items-center gap-1 ${className}`}>
+      {runs > 1 && (
+        <span className="rounded-full border px-1.5 text-[10px] text-muted-foreground" title={`${runs} runs — this conversation was resumed (poke-backs / continuations)`}>
+          {runs} runs
+        </span>
+      )}
+      {kids.slice(0, MAX_CHAIN_CHIPS).map((k, i) => (
+        <span key={k.rep.id} className="flex items-center gap-1">
+          {i > 0 && <span className="text-[10px] text-muted-foreground/50">·</span>}
+          <button
+            onClick={(e) => { e.stopPropagation(); onOpen(k.rep.tmux, `${k.rep.agent} · ${k.rep.id}`) }}
+            title={k.rep.summary || k.rep.title}
+            className="flex items-center gap-1 rounded-full border px-1.5 text-[10px] text-muted-foreground hover:bg-background hover:text-foreground">
+            <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${statusDot(k.rep)}`} />
+            <span className="max-w-[9rem] truncate">{k.rep.agent}</span>
+          </button>
+        </span>
+      ))}
+      {kids.length > MAX_CHAIN_CHIPS && (
+        <span className="text-[10px] text-muted-foreground" title={kids.slice(MAX_CHAIN_CHIPS).map((k) => k.rep.agent).join(', ')}>
+          +{kids.length - MAX_CHAIN_CHIPS}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/** Flatten a group for rendering: the root, then (when expanded) its descendants with a depth. */
+function flattenGroup(g: SessionGroup, expanded: Set<string>, depth = 0): Array<{ g: SessionGroup; depth: number }> {
+  const out = [{ g, depth }]
+  if (expanded.has(threadOf(g.rep))) for (const c of g.children) out.push(...flattenGroup(c, expanded, depth + 1))
+  return out
+}
+
+/** Total conversations a chain contains below its root — the "+N" the collapsed row advertises. */
+const countDescendants = (g: SessionGroup): number =>
+  g.children.reduce((n, c) => n + 1 + countDescendants(c), 0)
+
+// ── Chain rail ─────────────────────────────────────────────────────────────────
+/** Is this conversation working right now? (Same rule as `isLive` for a session row.) */
+const nodeLive = (n: ChainNode): boolean => Boolean(n.alive) || n.status === 'running'
+
+/** The chain node's state word + tone, priority-ordered by what needs a human: waiting first, then a
+ *  duplicate re-dispatch, then live, then the agent's own verdict, then how the process ended. */
+const nodeState = (n: ChainNode): { label: string; tone: string; dot: string } => {
+  if (n.pending.length) return { label: 'waiting on you', tone: 'text-amber-600', dot: 'bg-amber-400 animate-pulse' }
+  if (n.duplicateOf) return { label: 'duplicate', tone: 'text-amber-600', dot: 'bg-amber-500' }
+  if (nodeLive(n)) return { label: 'live', tone: 'text-emerald-600', dot: 'bg-emerald-500' }
+  if (n.status === 'crashed') return { label: 'crashed', tone: 'text-red-600', dot: 'bg-red-500' }
+  if (n.outcome === 'success') return { label: 'pass', tone: 'text-emerald-600', dot: 'bg-emerald-500/60' }
+  if (n.outcome === 'failure' || n.outcome === 'error') return { label: 'failed', tone: 'text-red-600', dot: 'bg-red-500' }
+  if (n.outcome === 'partial') return { label: 'partial', tone: 'text-amber-600', dot: 'bg-amber-500' }
+  if (n.status === 'stopped') return { label: 'stopped', tone: 'text-amber-600', dot: 'bg-amber-500' }
+  return { label: n.outcome === 'unknown' ? 'no report' : n.status, tone: 'text-muted-foreground', dot: 'bg-muted-foreground/40' }
+}
+
+/** One pending item — a delegate's unanswered `ask`, or an approval gate — resolved WITHOUT leaving the
+ *  pane you're watching. This is the rail's reason to exist: today a question raised three hand-offs deep
+ *  surfaces only in the Inbox, detached from the work that raised it. */
+function ChainAction({ item, onDone }: { item: ChainPending; onDone: () => void }) {
+  const [answer, setAnswer] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const run = async (fn: () => Promise<{ ok?: boolean; error?: string }>) => {
+    setBusy(true); setErr('')
+    const r = await fn()
+    setBusy(false)
+    if (r.error) setErr(r.error)
+    else { setAnswer(''); onDone() }
+  }
+  return (
+    <div className="rounded-md border border-amber-500/40 bg-amber-500/5 p-2.5">
+      <div className="flex items-center gap-1.5 text-[11px] font-medium text-amber-600">
+        <Bot className="h-3 w-3 shrink-0" />
+        <span className="truncate">{item.agent}</span>
+        <span className="opacity-60">{item.kind === 'approval' ? 'needs approval' : 'asked you'}</span>
+      </div>
+      <p className="mt-1 whitespace-pre-wrap break-words text-xs text-foreground">{item.text}</p>
+      {item.capability && <p className="mt-0.5 font-mono text-[10px] text-muted-foreground">{item.capability}</p>}
+      {item.kind === 'approval' ? (
+        <div className="mt-2 flex gap-1.5">
+          <Button size="xs" disabled={busy} onClick={() => run(() => api.resolve(item.id, true))}>Approve</Button>
+          <Button size="xs" variant="outline" disabled={busy} onClick={() => run(() => api.resolve(item.id, false))}>Reject</Button>
+        </div>
+      ) : (
+        <form className="mt-2 flex gap-1.5" onSubmit={(e) => { e.preventDefault(); if (answer.trim()) run(() => api.answerQuestion(item.id, answer.trim())) }}>
+          <Input value={answer} onChange={(e) => setAnswer(e.target.value)} placeholder="Answer…" className="h-7 text-xs" disabled={busy} />
+          <Button size="xs" type="submit" disabled={busy || !answer.trim()}><Send className="h-3 w-3" /></Button>
+        </form>
+      )}
+      {err && <p className="mt-1 text-[11px] text-red-600">{err}</p>}
+    </div>
+  )
+}
+
+/**
+ * The hand-off tree beside the terminal — "where is this piece of work, and who is blocked?".
+ *
+ * A delegated run is its own session row, so a three-agent delivery reads as a handful of unrelated
+ * entries scattered through the list (plus one more per poke-back). The rail puts the whole chain in the
+ * pane the human is already watching: each CONVERSATION once (its resumes folded in), the agent's own
+ * verdict, a duplicate re-dispatch called out, and anything waiting on a person answerable in place.
+ *
+ * Renders nothing when the open session has no hand-offs — a solo run keeps the full-width terminal it
+ * has today. Collapsed state persists per browser.
+ */
+function ChainRail({ session, onOpen }: { session?: Session; onOpen: (tmux: string, title: string) => void }) {
+  const [chain, setChain] = useState<SessionChain | null>(null)
+  const [open, setOpen] = useState(() => localStorage.getItem('aos_chain_rail') !== '0')
+  const id = session?.id
+  const load = useCallback(() => {
+    if (!id) { setChain(null); return }
+    api.sessionChain(id).then((r) => setChain(r && 'nodes' in r ? r : null)).catch(() => {})
+  }, [id])
+  useEffect(() => {
+    load()
+    // The chain is derived per request (~15 ms), so a slow poll is enough to keep a live hand-off and a
+    // freshly-raised question current without adding load to the 1.5 s session poll.
+    const t = setInterval(load, 6000)
+    return () => clearInterval(t)
+  }, [load])
+
+  const nodes = chain?.nodes ?? []
+  // A single node isn't a chain — nothing was handed off, so there's nothing to show.
+  if (nodes.length < 2) return null
+  const pending = nodes.flatMap((n) => n.pending)
+  const toggle = () => setOpen((v) => { localStorage.setItem('aos_chain_rail', v ? '0' : '1'); return !v })
+
+  if (!open) {
+    return (
+      <button onClick={toggle} title="show the hand-off chain"
+        className="flex w-8 shrink-0 flex-col items-center gap-2 border-l bg-muted/30 py-3 text-muted-foreground hover:bg-muted hover:text-foreground">
+        <GitBranch className="h-4 w-4 shrink-0" />
+        <span className="text-[10px] tabular-nums">{nodes.length}</span>
+        {pending.length > 0 && <span className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-400 motion-safe:animate-pulse" />}
+      </button>
+    )
+  }
+
+  return (
+    <aside className="flex w-[19rem] shrink-0 flex-col overflow-hidden border-l bg-muted/20">
+      <div className="flex shrink-0 items-center gap-2 border-b px-3 py-2">
+        <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        <span className="text-[13px] font-semibold">Chain</span>
+        <span className="ml-auto truncate font-mono text-[10px] text-muted-foreground" title="agents in this chain · total cost">
+          {chain!.agents} agent{chain!.agents === 1 ? '' : 's'}
+          {chain!.totalCostUsd ? ` · $${chain!.totalCostUsd.toFixed(2)}` : ''}
+        </span>
+        <button onClick={toggle} title="hide the chain" className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground">
+          <ChevronRight className="h-3.5 w-3.5" />
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 space-y-2 overflow-y-auto p-2.5">
+        {pending.map((p) => <ChainAction key={p.id} item={p} onDone={load} />)}
+        {nodes.map((n) => {
+          const st = nodeState(n)
+          const here = n.threadId === (session?.threadId ?? session?.id)
+          return (
+            <div key={n.threadId} className={n.depth ? 'border-l pl-1.5' : ''} style={{ marginLeft: `${Math.min(n.depth, 3) * 8}px` }}>
+            <button onClick={() => onOpen(n.tmux, `${n.agent} · ${n.sessionId}`)}
+              title={n.taskTitle ?? n.title}
+              className={`block w-full rounded-md border px-2.5 py-2 text-left transition-colors ${here ? 'border-primary/40 bg-background' : 'border-transparent hover:border-border hover:bg-background'}`}>
+              <div className="flex items-center gap-1.5">
+                <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${st.dot}`} />
+                <span className="truncate text-[13px] font-medium">{n.agent}</span>
+                <span className={`ml-auto shrink-0 text-[10px] ${st.tone}`}>{st.label}</span>
+              </div>
+              <p className="mt-0.5 line-clamp-3 text-[11.5px] leading-snug text-muted-foreground">{n.summary || n.taskTitle || n.title}</p>
+              <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 font-mono text-[10px] text-muted-foreground/80">
+                <span title={new Date(n.createdAt).toLocaleString()}>{timeAgo(n.createdAt)} ago</span>
+                {n.runs > 1 && <span title={`${n.runs} runs — this conversation was resumed (poke-backs / continuations)`}>{n.runs} runs</span>}
+                {n.costUsd != null && <span>${n.costUsd.toFixed(2)}</span>}
+                {n.taskId && <span className="truncate" title={n.taskTitle}>{n.taskId}</span>}
+              </div>
+              {n.duplicateOf && (
+                <p className="mt-1 flex items-start gap-1 text-[10px] text-amber-600">
+                  <AlertTriangle className="mt-px h-3 w-3 shrink-0" />
+                  <span>re-dispatch of work already handed to {n.agent}</span>
+                </p>
+              )}
+            </button>
+            </div>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}
+
 function SessionsPage({
   me, members, sessions, waiting, selected, hiddenTabs, metrics, onOpen, onCloseTab, onActivity, onSpawn, onStop, onDelete, onRate, onRename, onTransfer, onBulkStop, onBulkDelete, urlQuery, onFiltersChange,
 }: {
@@ -3324,6 +3586,21 @@ function SessionsPage({
     })
   }, [filtered, sortKey, sortDir])
 
+  // ── Collapse: runs → conversations → chains ──────────────────────────────────
+  // The list used to show one row per RUN, which double-counts two ways: a resumed conversation (every
+  // poke-back adds a row to the same claude transcript) and a hand-off (each delegate is its own row,
+  // stranded among unrelated work). So we fold rows into conversations (`threadId`), then nest each
+  // conversation under the caller that delegated it (`parentThreadId`). Grouping runs over the FILTERED
+  // set, so filters keep their meaning: a delegate whose caller was filtered out is promoted to a root
+  // rather than disappearing with it.
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  const toggleExpand = (threadId: string) =>
+    setExpanded((p) => { const n = new Set(p); n.has(threadId) ? n.delete(threadId) : n.add(threadId); return n })
+  const groups = useMemo(() => buildChainGroups(shown), [shown])
+  // Every run behind a group (its own conversation + all descendants) — what the row's checkbox selects
+  // and what "N runs" counts, since the row now stands for more than one session.
+  const groupRuns = (g: SessionGroup): Session[] => [...g.runs, ...g.children.flatMap(groupRuns)]
+
   // Multi-select for bulk stop/delete. Kept in sync with the live list: ids that vanish (deleted
   // elsewhere, or by our own bulk delete) are pruned so the toolbar count never lies. Select-all and
   // the header count operate over the FILTERED view, so bulk actions never touch hidden rows.
@@ -3335,8 +3612,10 @@ function SessionsPage({
       return next.size === prev.size ? prev : next
     })
   }, [sessions])
-  const toggle = (id: string) =>
-    setSel((p) => { const n = new Set(p); n.has(id) ? n.delete(id) : n.add(id); return n })
+  /** A row now stands for a whole conversation (and, at the root, its chain) — so its checkbox selects
+   *  every run behind it, and a bulk stop/delete acts on all of them rather than the newest alone. */
+  const toggleRuns = (runs: Session[], checked: boolean) =>
+    setSel((p) => { const n = new Set(p); runs.forEach((r) => (checked ? n.delete(r.id) : n.add(r.id))); return n })
   const allSelected = filtered.length > 0 && filtered.every((s) => sel.has(s.id))
   const toggleAll = () => setSel((prev) => {
     const n = new Set(prev)
@@ -3460,8 +3739,13 @@ function SessionsPage({
             )}
           </div>
         </div>
-        <TerminalFrame key={selected.tmux} session={sessions.find((s) => s.tmux === selected.tmux)} tmux={selected.tmux} onActivity={onActivity}
-          ops={{ members, me, onOpen, onStop, onDelete, onTransfer, onActivity: setInspect }} />
+        {/* Terminal + the hand-off chain, side by side: the pane keeps its height, the rail takes width
+            only when this session actually delegated (it renders nothing for a solo run). */}
+        <div className="flex min-h-0 flex-1">
+          <TerminalFrame key={selected.tmux} session={sessions.find((s) => s.tmux === selected.tmux)} tmux={selected.tmux} onActivity={onActivity}
+            ops={{ members, me, onOpen, onStop, onDelete, onTransfer, onActivity: setInspect }} />
+          <ChainRail session={sessions.find((s) => s.tmux === selected.tmux)} onOpen={onOpen} />
+        </div>
         {/* Activity side panel — mounted here too so the Operations→Activity shortcut works from the
             terminal-tabs view, not just the list view (this branch early-returns before the list's copy). */}
         {inspect && <SessionActivity session={inspect} onClose={() => setInspect(null)} />}
@@ -3503,11 +3787,12 @@ function SessionsPage({
         <div className="flex items-center gap-3">
           <label className="flex cursor-pointer items-center gap-2 text-sm text-muted-foreground" title={allSelected ? 'clear selection' : 'select all'}>
             <input type="checkbox" checked={allSelected} onChange={toggleAll} className="h-3.5 w-3.5 cursor-pointer accent-primary" />
+            {/* Counts the ENTRIES on screen, with the underlying runs alongside whenever grouping folded
+                any (resumes + hand-offs) — so the number never contradicts what's rendered. */}
             {sel.size > 0
               ? `${sel.size} selected`
-              : filtersActive
-                ? `${filtered.length} of ${sessions.length} session${sessions.length === 1 ? '' : 's'}`
-                : `${sessions.length} session${sessions.length === 1 ? '' : 's'}`}
+              : `${filtersActive ? `${filtered.length} of ${sessions.length}` : sessions.length} session${sessions.length === 1 ? '' : 's'}`
+                + (groups.length !== filtered.length ? ` · ${groups.length} conversations` : '')}
           </label>
           {sel.size > 0 && (
             <div className="flex items-center gap-1">
@@ -3603,14 +3888,18 @@ function SessionsPage({
         </div>
       ) : view === 'grid' ? (
         <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
-          {shown.map((s) => (
-            <div key={s.id} className={`group relative flex flex-col rounded-lg border p-3 hover:bg-muted ${sel.has(s.id) ? 'ring-1 ring-primary' : ''}`}>
+          {groups.map((g) => {
+          const s = g.rep
+          const runs = groupRuns(g)
+          const checked = runs.every((r) => sel.has(r.id))
+          return (
+            <div key={s.id} className={`group relative flex flex-col rounded-lg border p-3 hover:bg-muted ${checked ? 'ring-1 ring-primary' : ''}`}>
               <input
                 type="checkbox"
-                checked={sel.has(s.id)}
-                onChange={() => toggle(s.id)}
-                title="select"
-                className={`absolute right-2 top-2 h-3.5 w-3.5 cursor-pointer accent-primary transition-opacity ${sel.has(s.id) ? '' : 'opacity-0 group-hover:opacity-100'}`}
+                checked={checked}
+                onChange={() => toggleRuns(runs, checked)}
+                title={runs.length > 1 ? `select all ${runs.length} runs in this chain` : 'select'}
+                className={`absolute right-2 top-2 h-3.5 w-3.5 cursor-pointer accent-primary transition-opacity ${checked ? '' : 'opacity-0 group-hover:opacity-100'}`}
               />
               <a href={navHref('sessions', s.tmux)} onClick={onNavClick(() => onOpen(s.tmux, s.agent + ' · ' + s.id))} className="block pr-6 text-left text-foreground no-underline">
                 <div className="flex items-center gap-2">
@@ -3638,6 +3927,7 @@ function SessionsPage({
                   <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground" title={new Date(s.updatedAt).toLocaleString()}>{timeAgo(s.updatedAt)} ago</span>
                 </div>
               </a>
+              <ChainStrip group={g} runs={g.runs.length} onOpen={onOpen} />
               {/* Human verdict — only for finished runs; stays visible once rated, faint-until-hover otherwise. */}
               {!isLive(s) && (
                 <div className={`mt-1.5 transition-opacity ${s.rating ? '' : 'opacity-40 group-hover:opacity-100'}`}>
@@ -3660,7 +3950,7 @@ function SessionsPage({
                 <RowActionsMenu session={s} members={members} me={me} onOpen={onOpen} onStop={onStop} onDelete={onDelete} onTransfer={onTransfer} onActivity={setInspect} />
               </div>
             </div>
-          ))}
+          )})}
         </div>
       ) : (
         <div className="divide-y overflow-hidden rounded-lg border">
@@ -3686,18 +3976,41 @@ function SessionsPage({
             </div>
             <span className="w-20 shrink-0" aria-hidden />
           </div>
-          {shown.map((s) => (
-            <div key={s.id} className={`group relative flex items-center gap-3 px-3 py-2 hover:bg-muted ${sel.has(s.id) ? 'bg-muted' : ''}`}>
+          {groups.flatMap((g) => flattenGroup(g, expanded)).map(({ g, depth }) => {
+          const s = g.rep
+          const runs = groupRuns(g)
+          const checked = runs.every((r) => sel.has(r.id))
+          const kids = countDescendants(g)
+          const isOpen = expanded.has(threadOf(s))
+          return (
+            <div key={s.id} className={`group relative flex items-center gap-3 px-3 py-2 hover:bg-muted ${checked ? 'bg-muted' : ''} ${depth ? 'bg-muted/20' : ''}`}>
               <input
                 type="checkbox"
-                checked={sel.has(s.id)}
-                onChange={() => toggle(s.id)}
-                title="select"
+                checked={checked}
+                onChange={() => toggleRuns(runs, checked)}
+                title={runs.length > 1 ? `select all ${runs.length} runs in this chain` : 'select'}
                 className="h-3.5 w-3.5 shrink-0 cursor-pointer accent-primary"
               />
               <button onClick={() => onOpen(s.tmux, s.agent + ' · ' + s.id)} className="flex min-w-0 flex-1 items-center gap-3 text-left">
+                {depth > 0 && <span className="shrink-0" style={{ width: `${Math.min(depth, 3) * 14}px` }} aria-hidden />}
+                {/* Chain expander — only on an entry that actually delegated. Stops propagation so
+                    expanding never opens the terminal by accident. */}
+                {kids > 0 ? (
+                  <span
+                    role="button"
+                    tabIndex={0}
+                    onClick={(e) => { e.stopPropagation(); toggleExpand(threadOf(s)) }}
+                    onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); e.stopPropagation(); toggleExpand(threadOf(s)) } }}
+                    title={isOpen ? 'collapse the chain' : `show ${kids} hand-off${kids === 1 ? '' : 's'}`}
+                    className="-ml-1 shrink-0 rounded p-0.5 text-muted-foreground hover:bg-background hover:text-foreground">
+                    <ChevronDown className={`h-3.5 w-3.5 transition-transform ${isOpen ? '' : '-rotate-90'}`} />
+                  </span>
+                ) : (
+                  <span className="w-[1.125rem] shrink-0" aria-hidden />
+                )}
                 <span className={`h-2 w-2 shrink-0 rounded-full ${statusDot(s)}`} />
                 <span className="min-w-[7rem] flex-1 truncate text-sm font-medium">{s.title}</span>
+                {!isOpen && <ChainStrip group={g} runs={g.runs.length} onOpen={onOpen} className="hidden shrink-0 lg:flex" />}
                 {waiting.has(s.id) && <WaitingBell className="h-3.5 w-3.5 shrink-0" />}
                 <span className="hidden w-28 shrink-0 truncate text-xs text-muted-foreground xl:block">{s.agent}</span>
                 <span className="hidden w-20 shrink-0 truncate font-mono text-xs text-muted-foreground 2xl:block" title={s.id}>{s.id}</span>
@@ -3726,7 +4039,7 @@ function SessionsPage({
                 <RowActionsMenu session={s} members={members} me={me} onOpen={onOpen} onStop={onStop} onDelete={onDelete} onTransfer={onTransfer} onActivity={setInspect} className="opacity-0 group-hover:opacity-100 data-[state=open]:opacity-100" />
               </div>
             </div>
-          ))}
+          )})}
         </div>
       )}
       {inspect && <SessionActivity session={inspect} onClose={() => setInspect(null)} />}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -299,6 +299,15 @@ export interface Session {
   /** True for a `category:'System'` machinery agent (the Cockpit concierge/operator, consolidator, …).
    *  Hidden from the Chat + Sessions lists to reduce clutter; still openable by id + in Audit. */
   system?: boolean
+  /** CONVERSATION key — the claude transcript this run belongs to (its own id when there is none). A
+   *  poke-back RESUMES a transcript, so several rows share one `threadId`; the list groups by it so a
+   *  resumed conversation reads as ONE entry with N runs instead of N unrelated ones. */
+  threadId?: string
+  /** The `threadId` of the caller that delegated this run — the edge that turns the flat list into the
+   *  hand-off tree. Equal to `threadId` for a poke (a caller waking itself) = treat as no parent. */
+  parentThreadId?: string
+  /** The task this run works (`task:`/`poke:`/`ask:` provenance) — the hand-off it belongs to. */
+  taskId?: string
   /** True when the run launched unattended (an automation/cron/task run). These now run as an attachable
    *  interactive TUI a human can take over live; the list badges them as unattended vs. a member session. */
   headless?: boolean
@@ -1387,6 +1396,63 @@ async function callFeed<T>(path: string, etag: string | null): Promise<FeedResul
 /** The Phase-2 summary poll payload: the always-on rows (live + the viewer's recent-ended tail) plus a
  *  global done-since-server-midnight count (the one always-on aggregate a live-only set can't derive). */
 export interface SessionsSummary { rows: Session[]; doneToday: number }
+
+/** Something in a chain node that can't move without a person: an unanswered `ask`, or an approval gate
+ *  holding a run open. The rail resolves it in place via the same routes the Inbox uses. */
+export interface ChainPending {
+  kind: 'question' | 'approval'
+  /** Question / approval id — `api.answerQuestion(id, …)` or `api.resolve(id, approved)`. */
+  id: string
+  sessionId: string
+  agent: string
+  /** The question text, or the policy's reason this action needs sign-off. */
+  text: string
+  capability?: string
+  level?: string
+  createdAt: number
+}
+
+/** One CONVERSATION in a hand-off chain: every run sharing a claude transcript folded into one entry
+ *  (`runs` of them), placed in the delegation tree by `parentThreadId` + `depth`. */
+export interface ChainNode {
+  threadId: string
+  parentThreadId?: string
+  depth: number
+  /** Newest run of the conversation — what opening this node attaches to. */
+  sessionId: string
+  tmux: string
+  agent: string
+  title: string
+  summary?: string
+  status: Session['status']
+  alive?: boolean
+  outcome?: string
+  /** Session rows this conversation spans (>1 = it was resumed by pokes/continuations). */
+  runs: number
+  costUsd?: number
+  createdAt: number
+  updatedAt: number
+  /** `root` = where the chain starts; `delegate` = dispatched for a task; `answer` = an ephemeral
+   *  quick-answer run that never took the task over. */
+  kind: 'root' | 'delegate' | 'answer'
+  taskId?: string
+  taskTitle?: string
+  taskStatus?: TaskStatus
+  /** Set when an earlier sibling already handed the SAME work to the SAME agent — holds that task id. */
+  duplicateOf?: string
+  pending: ChainPending[]
+}
+
+/** The hand-off tree a session belongs to. `nodes` is flat and in walk order (parents before children). */
+export interface SessionChain {
+  rootThreadId: string
+  nodes: ChainNode[]
+  agents: number
+  totalCostUsd?: number
+  startedAt: number
+  updatedAt: number
+}
+
 export const api = {
   /** Current member, or null if not authenticated (401). Drives the login gate. */
   me: async (): Promise<Member | null> => {
@@ -1410,6 +1476,9 @@ export const api = {
   /** Owner-only: plain restart, no pull/rebuild. The process bounces ~1.5s after the response. */
   restart: () => call<RestartResult>('POST', '/api/restart'),
   sessions: (archived?: boolean) => call<Session[]>('GET', '/api/sessions' + (archived ? '?archived=1' : '')),
+  /** The hand-off chain this session belongs to — the tree the chain rail renders (who delegated to whom,
+   *  what came back, what's still waiting on a person). Derived server-side; viewer-scoped like the list. */
+  sessionChain: (id: string) => call<SessionChain | { error: string }>('GET', `/api/sessions/${encodeURIComponent(id)}/chain`),
   /** One session by id, with the same derived fields the list carries. 404 → `{error}` when the caller
    *  can't see it (viewer-scoped server-side). The by-id fetch the console lacked (Sessions-pagination P1). */
   session: (id: string) => call<Session | { error: string }>('GET', `/api/sessions/${encodeURIComponent(id)}`),


### PR DESCRIPTION
Agent→agent work reads as one thread instead of scattered rows.

## Why

A delegated run is its own session row, and every poke-back adds another row for a conversation that already exists. Shipping client-app **PR #2773** on the instawp tenant produced **9 rows across 3 agents in 70 minutes**, interleaved with unrelated work — four of them the same engineer transcript resumed under machine-written titles (`Poke ← release-orchestrator done: …`). Nobody could see that release-orchestrator had been dispatched **twice** for the same promotion; the second run's own summary reads *"PR #2778 was already open from a prior run."*

## What

Two surfaces over one read model, **storing nothing new** — the console reads three identities the DB already records:

| identity | already recorded as |
|---|---|
| **run** — one pane | `term_sessions.id` |
| **conversation** — every run sharing a transcript (a poke *resumes* one) | `term_sessions.claude_session_id` |
| **chain** — the hand-off tree | `tasks.caller_claude_id` → the `task:`/`ask:` runs dispatched for it |

- **Chain rail** (`GET /api/sessions/:id/chain` → `TerminalManager.sessionChain`) beside the terminal: each conversation once with its own verdict, cost and run count; a re-dispatch of the same work to the same agent flagged; and **anything waiting on a human** — a delegate's open `ask`, an approval gate — answerable **in place**, instead of being hunted down in the Inbox detached from the work that raised it. Renders nothing for a solo run; collapsible to a spine, persisted per browser. Viewer-scoped by the same rule as the sessions list.
- **Sessions list collapse**: runs fold into conversations, delegates nest under their caller, with an inline chain strip (`qa · release-orch ×2`) so a stalled or duplicated hand-off is visible without opening anything. Grouping runs over the **filtered** set, so a delegate whose caller was filtered out is promoted rather than hidden; a row's checkbox selects every run behind it.

Two folding rules the live data forced:
- a conversation's cost is the **max** of its runs, not the sum — cost is per-transcript and cumulative, so summing multiplied one engineer conversation's bill from $277 to $748;
- verdict + summary come from the **same** reporting run, else a conversation whose last resume ended quietly reads "no report" beside the report it filed.

## Verification

- `npm run typecheck`, `cd web && npm run build`, `npm run demo` — clean.
- `npm run test:governance` — now includes **`scripts/chain-model-test.cjs`** (36 assertions): conversation folding, nesting from any seed, cost-max, paired verdict, duplicate detection (and that a *different* task to the same agent isn't one), pending ask/approval placement, per-viewer scoping, self-parent/cycle guards, and the list stamps.
- Driven end-to-end in a browser against a **read-only snapshot of the live instawp DB** in an isolated scratch home (automations + auto-dispatch neutralized first): the #2773 chain resolves from any seed — 7 nodes, 3 agents, the duplicate flagged — the list shows `1062 sessions · 719 conversations`, the rail collapses and restores, and a solo run keeps its full-width terminal.
- `listSessions` over 1 079 real rows: **21 ms** (one extra batched query for the chain edges); a chain walk: **~16 ms**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)