### PR TITLE
fix(sessions): canonicalise email-shaped run_as in the cleanup (v0.307.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.307.2] — 2026-08-04
+### Fixed
+- **The `run_as` cleanup now also catches the email-shaped rows.** v0.307.1 swept provenance strings out
+  of the identity column, but a second shape survives it: an **email** (a caller handed `createSession`
+  an email as provenance). It has no colon, so the sweep missed it, and it matches no member id — the
+  same silent identity loss. Found while verifying the 0.307.1 deploy: 2 rows on instapods
+  (`owner@localhost`), 1 on personal. The human is recoverable here, so the migration canonicalises
+  rather than NULLs — email → member id, lowercased to match `TeamStore.getMemberByEmail`. An email
+  resolving to nobody is left alone: it may be the only trace of a since-removed member, and unlike a
+  provenance string it isn't structurally impossible for a human to have owned that run. New rows were
+  already prevented by `resolveActingMember`, which canonicalises an id-or-email `runAs`.
+
 ## [0.307.1] — 2026-08-04
 ### Fixed
 - **A session's provenance can no longer leak into its identity column, silently costing the run its

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.307.1",
+  "version": "0.307.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.307.1",
+      "version": "0.307.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.307.1",
+  "version": "0.307.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/run-as-identity-test.cjs
+++ b/scripts/run-as-identity-test.cjs
@@ -95,6 +95,9 @@ async function main() {
   row('s_task', 'task:tsk_1', 'task:tsk_1');
   row('s_ok', memberId, memberId);
   row('s_null', 'automation:a1', null);
+  row('s_email', 'owner@test', 'owner@test');       // the second shape: an email, no colon
+  row('s_EMAIL', 'Owner@Test', 'Owner@Test');       // …and mixed case (members store lowercased)
+  row('s_gone', 'ex-staff@test', 'ex-staff@test');  // resolves to nobody — recoverable info, left as-is
 
   const { openDb } = require(path.join(ROOT, 'dist/state/db.js'));
   openDb(path.join(HOME, 'agent-os.db')); // re-runs migrate() over the same file
@@ -104,6 +107,9 @@ async function main() {
   assert(runAsOf('s_task') === null, 'migration NULLs a `task:` run_as');
   assert(runAsOf('s_ok') === memberId, 'migration LEAVES a real member id alone');
   assert(runAsOf('s_null') === null, 'an already-NULL run_as stays NULL');
+  assert(runAsOf('s_email') === memberId, 'migration CANONICALISES an email run_as to the member id');
+  assert(runAsOf('s_EMAIL') === memberId, 'email canonicalisation is case-insensitive');
+  assert(runAsOf('s_gone') === 'ex-staff@test', 'an email matching no member is left alone (not discarded)');
   assert(db.prepare('SELECT spawned_by FROM term_sessions WHERE id = ?').get('s_chat').spawned_by === 'chat:triage',
     'provenance (spawned_by) is untouched — only the identity column is cleaned');
 

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -1028,6 +1028,15 @@ function migrate(db: Db): void {
   // said all along. Scoped to colon-bearing values so a legitimate id can never be caught by it (a
   // member id never contains ':'), and so the sweep is a no-op on every already-clean workspace.
   db.exec("UPDATE term_sessions SET run_as = NULL WHERE run_as IS NOT NULL AND instr(run_as, ':') > 0");
+  // Second shape of the same bug: an EMAIL in the identity column (a caller handed `createSession` an
+  // email as provenance). It has no colon, so the sweep above misses it, and it matches no member id —
+  // the same silent identity loss. Here the human IS recoverable, so canonicalise rather than NULL:
+  // resolve the email to its member id (lowercased, matching TeamStore.getMemberByEmail). An email that
+  // resolves to nobody is left alone — it may be the only trace of a since-removed member, and unlike a
+  // provenance string it isn't structurally impossible for a human to have owned that run.
+  db.exec(`UPDATE term_sessions SET run_as = (SELECT m.id FROM members m WHERE m.email = lower(term_sessions.run_as))
+             WHERE run_as IS NOT NULL AND instr(run_as, '@') > 0
+               AND EXISTS (SELECT 1 FROM members m WHERE m.email = lower(term_sessions.run_as))`);
 }
 
 /** Add a column only if it isn't already present (SQLite has no ADD COLUMN IF NOT EXISTS). */


### PR DESCRIPTION
Follow-up to #562, found while verifying that deploy on the live boxes.

v0.307.1 swept prefixed provenance (`chat:`, `task:`, …) out of `term_sessions.run_as`. A **second shape** survives it: an **email** in the identity column, from a caller that handed `createSession` an email as provenance. It has no colon so the sweep misses it, and it matches no member id — the same silent identity loss (GitHub token, connectors, member-scoped secrets, inbox ownership).

Fleet scan: **2 rows on instapods** (`owner@localhost`), **1 on personal**, 0 on instawp.

Unlike a provenance string, the human here is *recoverable* — so the migration canonicalises instead of NULLing: email → member id, lowercased to match `TeamStore.getMemberByEmail`. An email that resolves to nobody is deliberately left alone; it may be the only trace of a since-removed member, and it isn't structurally impossible for a human to have owned that run.

New rows were already prevented by #562's `resolveActingMember`, which canonicalises an id-or-email `runAs`. This is purely the backfill catching up with it.

Three new assertions in `scripts/run-as-identity-test.cjs` (25 total): canonicalises an email, case-insensitively, and leaves an unresolvable one alone. Full governance suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)