### PR TITLE
fix(runtime): never inherit the box account's identity into a credential dir (v0.309.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.309.2] — 2026-08-04
+### Fixed
+- **First-run inheritance no longer copies the box account's identity.** v0.309.1 gap-fills a credential
+  dir's `.claude.json` from the box's so a rotated session inherits every "seen/dismissed" flag. A dir
+  written by `claude login` carries its own `oauthAccount`/`userID`, so those were already left alone — but
+  a dir holding only a `.credentials.json` has none, and would have taken the box's identity while
+  authenticating as a different account, labelling the session with the wrong account and keying its
+  per-account caches off the wrong uuid. Both are now never inherited; claude repopulates them from the
+  token, so absent beats guessed. Caught by probing the deployed seeder against a bare dir.
+
+
 ## [0.309.1] — 2026-08-04
 ### Fixed
 - **A rotated session no longer parks on claude's first-run prompts.** Claude keeps its UI state in

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.309.1",
+  "version": "0.309.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.309.1",
+      "version": "0.309.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.309.1",
+  "version": "0.309.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/claude-config-seed-test.cjs
+++ b/scripts/claude-config-seed-test.cjs
@@ -56,6 +56,18 @@ console.log('\n\x1b[1m2) Inheriting never overwrites the account\x1b[0m');
 assert(seeded.userID === 'pool-user' && seeded.oauthAccount.accountUuid === 'pool-account',
   'the account\'s own identity keys win over the box\'s', JSON.stringify({ u: seeded.userID, a: seeded.oauthAccount }));
 assert(seeded.mcpServers === undefined, 'box-level mcpServers is not copied into an account dir');
+// The identity keys must not be inherited even when the target has none — a credential dir holding only
+// a .credentials.json (no .claude.json yet) would otherwise authenticate as one account while claiming
+// the box's identity, and key its per-account caches off the wrong uuid.
+const bare = path.join(TMP, 'bare-credentials');
+fs.mkdirSync(bare, { recursive: true });
+const bareR = seedClaudeConfig({ home, configDir: bare, projectDir: agentDir });
+const bareCfg = read(path.join(bare, '.claude.json'));
+assert(bareCfg.oauthAccount === undefined && bareCfg.userID === undefined,
+  'a dir with no config of its own does NOT inherit the box account\'s identity', JSON.stringify({ o: bareCfg.oauthAccount, u: bareCfg.userID }));
+assert(bareCfg.fullscreenUpsellSeenCount === 3 && bareCfg.hasCompletedOnboarding === true,
+  'while still inheriting the first-run flags that keep it from prompting');
+assert(bareR.inherited > 0, 'and it reports what it inherited');
 assert(seeded.projects['/somewhere/else'] === undefined, 'nor are the box\'s other project entries');
 
 console.log('\n\x1b[1m3) Idempotent — several sessions can launch at once\x1b[0m');

--- a/terminal/seed-config.js
+++ b/terminal/seed-config.js
@@ -32,8 +32,13 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
-/** Per-directory and server configuration — not first-run UI state, and not ours to copy between accounts. */
-const SKIP_INHERIT = new Set(['projects', 'mcpServers']);
+/** Never inherited. `projects`/`mcpServers` are per-directory and server configuration rather than UI
+ *  state. `oauthAccount`/`userID` are WHO THE ACCOUNT IS: a dir written by `claude login` carries its own
+ *  (so gap-fill leaves them alone anyway), but a dir holding only a credentials file would otherwise take
+ *  the box's identity while authenticating as a different account — claude would label the session with
+ *  the wrong account and key its per-account caches off the wrong uuid. It repopulates both from the
+ *  token, so leaving them absent is strictly better than guessing. */
+const SKIP_INHERIT = new Set(['projects', 'mcpServers', 'oauthAccount', 'userID']);
 
 const readJson = (p) => {
   try {


### PR DESCRIPTION
Follow-up to #567, found by probing the deployed seeder against a bare directory.

v0.309.1 gap-fills a credential dir's `.claude.json` from the box's, so a rotated session inherits every
"seen/dismissed" flag and never meets a first-run prompt. A dir written by `claude login` carries its own
`oauthAccount`/`userID`, so gap-fill already left those alone — but a dir holding **only** a
`.credentials.json` has none, and would have taken the box's identity while authenticating as a different
account: the session would be labelled with the wrong account and key its per-account caches off the wrong
uuid.

Both are now in `SKIP_INHERIT`. Claude repopulates them from the token, so absent beats guessed.

The live instawp dirs were never affected — they came from `claude login` and carry their own identity —
so this is closing the latent case, not repairing one.

Test: `scripts/claude-config-seed-test.cjs` grows a bare-dir case asserting identity is not inherited while
the first-run flags still are. 21 assertions; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)