### PR TITLE
feat(agents): a cross-agent edit is worth what the proposer has earned (v0.312.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.312.0] — 2026-08-06
+### Added
+- **A cross-agent edit is now worth what the proposing agent has earned — `agent_propose_update` is
+  tiered by the proposer's maturity.** Any agent could already propose an edit to any other agent's
+  listing/CLAUDE.md, and every proposal landed the same way: an owner card, regardless of whether the
+  proposer had 200 clean runs or was on its first. Both ends of that were wrong — a brand-new agent could
+  fill an owner's queue with prompt rewrites for teammates, and a long-proven one couldn't fix an obvious
+  stale instruction without a human round-trip. The proposer's **maturity score**
+  (`src/state/agent-stats.ts` — autonomy × (1 − denialRate) × volumeConfidence) now routes the call
+  against workspace-configurable tiers (`AgentProposalTrust`, **Settings → Runtime → Cross-agent edits**,
+  `GET`/`PUT /api/settings/agent-proposal-trust`):
+  - **below `minMaturity`** (default 0.40) — refused, with a message telling the agent what earns the
+    right and to raise it with a human instead. No write, and no card either. Audited
+    `agent.update.proposal.blocked`.
+  - **middle band** — unchanged propose-don't-apply: an owner-addressed `agent.update.proposed` card,
+    applied only by an **owner who can run the target**. The card now also carries the proposer's maturity,
+    so the reviewer weighs the proposal against its author's record, not the prose alone.
+  - **at/above `autoApplyAt`** (default 0.80) — **applied immediately, with no human in the loop**; an
+    admin-addressed notice reports it after the fact and names the revision to revert. Audited
+    `agent.update.applied`. This tier is the deliberate trade: it's hard to reach by construction (maturity
+    is damped by `volumeConfidence = runs/(runs+8)`, so 0.80 needs ~32+ runs at near-perfect autonomy with
+    a clean denial record), it's fully revertable, and `autoApply:false` turns it off entirely — which
+    restores exactly the old owner-gated behaviour while keeping the floor.
+  All three lanes were unified onto ONE write path, `applyAgentEdit` in the new `src/state/agent-edit.ts`
+  (extracted verbatim from the owner-approve route: same sanitizers, same `agent.json`/`CLAUDE.md` write,
+  same `os.registerAgent`, same `AgentRevisions.commit`) — so an auto-applied edit is validated and
+  snapshotted exactly like a human-approved one, and shows up in the same Revision history panel.
+  Authorship distinguishes them (`agent:<proposer>` vs the approving owner). `src/types.ts`
+  (`AgentProposalTrust` + `sanitizeAgentProposalTrust`), `src/governance/settings.ts`, `src/terminal.ts`,
+  `src/server.ts`, `src/memory/memory-mcp.ts` (the tool now tells the agent which tier it landed in),
+  `web/src/App.tsx`. Docs: `docs/agent-mcp-tools.md`, CLAUDE.md.
+
 ## [0.311.1] — 2026-08-05
 ### Fixed
 - **A partial agent-config save no longer wipes the tuning knobs it didn't mention.** `PUT

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -279,11 +279,17 @@ Key modules:
   `agent_update`/`agent_history`/`agent_revert` — an agent refines its OWN listing (description, starter
   prompts, tuning) + CLAUDE.md system prompt and can roll back a bad self-edit; every change snapshots a
   reversible revision (`src/state/agent-revisions.ts`, the KB-style rollback backbone). To edit ANOTHER
-  agent, `agent_propose_update` is the **gated** cross-agent path (propose-don't-apply): it writes nothing,
-  posts an owner-addressed `agent.update.proposed` card, and applies only when an **owner who can run the
-  target** approves (`POST /api/agents/proposals/:id/approve` → the same self-edit apply + revision snapshot,
-  author = approver) — an admin can't approve, since rewriting another agent's prompt is a privilege-bearing
-  side effect. Governance (propose, don't apply): `policy_propose` — an agent that spots a weak
+  agent, `agent_propose_update` is the cross-agent path, and what a proposal is worth is decided by the
+  **proposer's maturity** (`src/state/agent-stats.ts`) against the workspace `AgentProposalTrust` tiers
+  (Settings → Runtime → Cross-agent edits): below `minMaturity` (0.4) it's **refused** outright; in the
+  middle band it's propose-don't-apply — writes nothing, posts an owner-addressed `agent.update.proposed`
+  card, applies only when an **owner who can run the target** approves (`POST /api/agents/proposals/:id/approve`)
+  and an admin can't; at/above `autoApplyAt` (0.8, `autoApply:false` disables the tier) it **applies
+  immediately** with the owner notified after the fact. All three lanes share one write path —
+  `applyAgentEdit` in `src/state/agent-edit.ts` — so every outcome snapshots a revertable revision (author
+  `agent:<proposer>` on the auto lane, the approver on the gated one). The top tier is the only place an
+  agent changes another agent with no human in the loop; it's hard to reach by construction (maturity is
+  damped by `volumeConfidence`, so ~32+ clean autonomous runs), and it's revertable, not undoable-only. Governance (propose, don't apply): `policy_propose` — an agent that spots a weak
   guardrail proposes a **TIGHTEN-ONLY** ruleset change (`tighten` a rule stricter, `reorder` a conditional
   rule above the unconditional allows — the first-match ordering fix, or `add` a new `ask`/`never`
   guardrail). `applyProposal` (`src/governance/policy.ts`) refuses any loosening (by construction + an

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -55,7 +55,7 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `goal_propose` | `POST /api/goals/propose` | `GoalStore.create` (status `draft`) + `TerminalManager.postGoalCard` | W | drafts a NOT-YET-ACTIVE goal + posts a `goal.proposed` inbox card to admins; owner = run-as; auto-apply + audited `goal.proposed`. Agents READ + PROPOSE only — activating/editing a goal is a human owner/admin console action (no agent write path) |
 | `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
 | `agent_update` | `POST /api/agents/update` | `AgentOS.registerAgent` + `AgentRevisions.commit` | W | **self-only** (edits the caller's OWN manifest/CLAUDE.md — a body `id` must equal the session's agent); user-home agents only; snapshots a revision; audited `agent.config.updated` |
-| `agent_propose_update` | `POST /api/agent/agent/propose` | `TerminalManager.proposeAgentUpdate` | W(gated) | **cross-agent, propose-don't-apply** — proposes an edit to ANOTHER agent's listing/CLAUDE.md; writes nothing, posts an owner-addressed `agent.update.proposed` review card; applied only when an **owner who can run the target** approves (`POST /api/agents/proposals/:id/approve`, then the self-edit apply + `AgentRevisions.commit`, author = approver); user-home claude-code targets only; 10-open cap + identical-delta dedupe; audited `agent.update.proposed` / `agent.update.proposal.approved`/`rejected` |
+| `agent_propose_update` | `POST /api/agent/agent/propose` | `TerminalManager.proposeAgentUpdate` | W(tiered) | **cross-agent** — proposes an edit to ANOTHER agent's listing/CLAUDE.md, routed by the **proposer's maturity** against the workspace `AgentProposalTrust` (Settings → Runtime): below `minMaturity` (0.4) **refused** (audited `agent.update.proposal.blocked`); middle band = propose-don't-apply, an owner-addressed `agent.update.proposed` card applied only when an **owner who can run the target** approves (`POST /api/agents/proposals/:id/approve`); at/above `autoApplyAt` (0.8, switchable off) **applied immediately** by `applyAgentEdit` with an admin-addressed notice after the fact (audited `agent.update.applied`). All lanes share one write path (`src/state/agent-edit.ts`) + `AgentRevisions.commit`, so every outcome is revertable; user-home claude-code targets only; 10-open cap + identical-delta dedupe |
 | `agent_history` | `POST /api/agents/history` | `AgentRevisions.list` | R | the caller's own listing revisions (rev/author/summary/date), newest first |
 | `agent_revert` | `POST /api/agents/revert` | `AgentRevisions` + `AgentOS.registerAgent` | W | **self-only**; restores a prior revision (description/prompts/tuning/CLAUDE.md), records the revert as a new revision; audited `agent.config.reverted` |
 | `app_create` | `POST /api/apps/create` | `AppStore.scaffold` | W | builds a hosted app (single-file `server.js` for v1) under `<home>/apps/<slug>/`; lands **proposed** (`published:false`, inert until a human publishes); posts an `app.proposed` review card; audited `app.created` |
@@ -229,20 +229,33 @@ revision into `agent_revisions` (`src/state/agent-revisions.ts`), so any change 
 data home (bundled examples can't be edited) and rewrites only the fields the caller supplied. A future
 tightening could classify CLAUDE.md/model self-edits through Policy for workspaces that want sign-off.
 
-`agent_propose_update` is the **cross-agent** counterpart, deliberately kept *gated* rather than an open
-widening of `agent_update`. Rewriting **another** agent's system prompt is a genuine side effect on a
-different principal — a lateral-privilege / prompt-injection vector if left ungated (agents don't share a
-trust level; the target may hold different `shellSecrets`/assignments) — so it follows the **propose-don't-apply**
-pattern of `policy_propose` / `automation_propose`: the agent's loopback call writes **nothing**, it only
-posts an owner-addressed `agent.update.proposed` card carrying the field delta + rationale. Application is
-**owner-only, and the owner must be able to run the target** (`os.team.canRun`; owners run everything, so
-this also future-proofs a narrower run model) — an admin cannot approve. On approval the server runs the
-**same** apply path as the self-edit route (sanitizers + disk write + `AgentRevisions.commit`, author = the
-approving owner, summary naming the proposer), so accountability captures both parties and the result is
-one-click revertable in the same Revision history panel. Same target guards as `agent_update` (user-home
-claude-code agents only, never `id === self`), plus a 10-open queue cap and identical-delta dedupe. The
-console surfaces open proposals on the **agent page → "Proposed edits from other agents"** card (owner-only,
-with a full CLAUDE.md before→after).
+`agent_propose_update` is the **cross-agent** counterpart. Rewriting **another** agent's system prompt is a
+genuine side effect on a different principal — a lateral-privilege / prompt-injection vector if left
+ungated (agents don't share a trust level; the target may hold different `shellSecrets`/assignments). What
+a proposal is *worth* is therefore decided by the **proposer's own track record**: its maturity score
+(`src/state/agent-stats.ts` — autonomy × (1 − denialRate) × volumeConfidence) is compared against the
+workspace `AgentProposalTrust` tiers (`src/types.ts`, stored in settings, edited in **Settings → Runtime →
+Cross-agent edits**, `GET`/`PUT /api/settings/agent-proposal-trust`):
+
+| proposer maturity | outcome |
+| --- | --- |
+| `< minMaturity` (default 0.40) | **refused** at `TerminalManager.proposeAgentUpdate` — no write, and no card either (an unproven agent doesn't get to fill a human's queue). Audited `agent.update.proposal.blocked`. |
+| between | **propose-don't-apply**, the `policy_propose` / `automation_propose` pattern: the loopback call writes **nothing**, it posts an owner-addressed `agent.update.proposed` card carrying the field delta + rationale + the proposer's maturity. Application is **owner-only, and the owner must be able to run the target** (`os.team.canRun`) — an admin cannot approve. |
+| `≥ autoApplyAt` (default 0.80, `autoApply` switchable off) | **applied immediately**, no human in the loop; an admin-addressed `notification` card reports it after the fact and names the revision to revert. Audited `agent.update.applied`. |
+
+The top tier is deliberately expensive to reach: maturity multiplies in `volumeConfidence = runs/(runs+8)`,
+so 0.80 is unreachable below ~32 runs and additionally needs near-perfect autonomy and a clean denial
+record. Operators who want the pre-tier behaviour set `autoApply:false`, which keeps every proposal
+owner-gated while retaining the floor.
+
+All three lanes share ONE write path — `applyAgentEdit` in `src/state/agent-edit.ts` (sanitizers + disk
+write + `os.registerAgent` + `AgentRevisions.commit`) — so an auto-applied edit is validated and
+snapshotted exactly like an owner-approved one, and is equally revertable from the Revision history panel.
+Authorship distinguishes them: `agent:<proposer>` on the auto lane, the approving owner (with a summary
+naming the proposer) on the gated one. Same target guards as `agent_update` (user-home claude-code agents
+only, never `id === self`), plus a 10-open queue cap and identical-delta dedupe. The console surfaces open
+proposals on the **agent page → "Proposed edits from other agents"** card (owner-only, with a full
+CLAUDE.md before→after).
 
 ### `goal_list` / `goal_get` / `goal_propose` — the strategic layer (read + propose only)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.311.1",
+  "version": "0.312.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.311.1",
+      "version": "0.312.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.311.1",
+  "version": "0.312.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -10,7 +10,7 @@
  * so adding more instance-level settings later is just another key.
  */
 import { Db } from '../state/db';
-import { Branding, EnrichPattern, MemoryConfig, Recommendation, RouterConfig, RuntimeTuning, sanitizeBranding, sanitizeRuntimeTuning } from '../types';
+import { AgentProposalTrust, Branding, EnrichPattern, MemoryConfig, Recommendation, RouterConfig, RuntimeTuning, sanitizeAgentProposalTrust, sanitizeBranding, sanitizeRuntimeTuning } from '../types';
 
 const COMPANY_KEY = 'company_md';
 const REVIEW_KEY = 'code_review_md'; // the fleet-wide code-review policy (how agents review a diff/PR)
@@ -39,6 +39,7 @@ const MEMORY_SWITCH_KEY = 'memory_backend_switched_at'; // ts the active externa
 const RUNTIME_DEFAULTS_KEY = 'runtime_defaults'; // workspace-wide model/effort/permission fallback (JSON RuntimeTuning)
 const SUBAGENT_DEFAULT_KEY = 'subagent_default'; // fleet-wide sub-agent posture: 'all' (default) | 'none'
 const SESSION_METRICS_KEY = 'session_metrics'; // sessions-list money column: 'cost' | 'tokens' | 'both'
+const AGENT_PROPOSAL_TRUST_KEY = 'agent_proposal_trust'; // cross-agent edit tiers keyed on proposer maturity (JSON AgentProposalTrust)
 
 /** What the sessions list shows in its money column: dollar cost, token total, or both. */
 export type SessionMetrics = 'cost' | 'tokens' | 'both';
@@ -527,6 +528,28 @@ export class SettingsStore {
   setRuntimeDefaults(tuning: RuntimeTuning, by?: string): RuntimeTuning {
     this.set(RUNTIME_DEFAULTS_KEY, JSON.stringify(tuning), by);
     return this.runtimeDefaults();
+  }
+
+  // ── cross-agent edit trust (agent_propose_update) ──────────────────────────────
+  // How much the cross-agent propose path trusts the PROPOSER, keyed on its maturity score: refuse
+  // below the floor, owner review in the middle band, self-apply at the top (see AgentProposalTrust).
+  // Unset → the shipped defaults, so a tenant that never opens this gets floor 0.4 / auto-apply 0.8.
+
+  /** The live tiers (stored JSON, else the defaults). Always fully populated — never partial. */
+  agentProposalTrust(): AgentProposalTrust {
+    const raw = this.getRow(AGENT_PROPOSAL_TRUST_KEY)?.value;
+    if (!raw) return sanitizeAgentProposalTrust({});
+    try {
+      return sanitizeAgentProposalTrust(JSON.parse(raw) as Record<string, unknown>);
+    } catch {
+      return sanitizeAgentProposalTrust({});
+    }
+  }
+
+  setAgentProposalTrust(cfg: Partial<AgentProposalTrust>, by?: string): AgentProposalTrust {
+    const clean = sanitizeAgentProposalTrust({ ...this.agentProposalTrust(), ...cfg });
+    this.set(AGENT_PROPOSAL_TRUST_KEY, JSON.stringify(clean), by);
+    return this.agentProposalTrust();
   }
 
   /** Fleet-wide sub-agent posture. `'all'` (default): every claude-code agent may spawn every WILLING

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -1214,12 +1214,16 @@ const TOOLS = [
   {
     name: 'agent_propose_update',
     description:
-      "Propose an edit to ANOTHER agent's listing or CLAUDE.md system prompt — the gated counterpart to " +
-      'agent_update (which only edits you). You CANNOT change another agent directly: this posts a review ' +
-      'card to an owner and changes nothing until they approve. Pass only the fields to change, plus a ' +
-      'rationale the owner will read. Use it when you spot a concrete, well-justified improvement to a ' +
-      'teammate agent (a stale instruction, a missing convention, a better description). The target must be ' +
-      'a user-created claude-code agent (not a bundled example), and must not be you.',
+      "Propose an edit to ANOTHER agent's listing or CLAUDE.md system prompt — the cross-agent counterpart " +
+      'to agent_update (which only edits you). Pass only the fields to change, plus a rationale a human ' +
+      'will read. Use it when you spot a concrete, well-justified improvement to a teammate agent (a stale ' +
+      'instruction, a missing convention, a better description). The target must be a user-created ' +
+      'claude-code agent (not a bundled example), and must not be you. What happens next depends on YOUR ' +
+      'maturity score (earned from completed runs that needed few approvals and hit no denials): below the ' +
+      "workspace floor the proposal is refused; in the middle it waits in an owner's inbox and changes " +
+      'nothing until they approve; at the top it applies immediately and the owner is notified after the ' +
+      'fact. Write every proposal as if a human will read it — usually one does, and the reply tells you ' +
+      'which happened.',
     inputSchema: {
       type: 'object',
       additionalProperties: false,
@@ -2499,10 +2503,14 @@ async function agentProposeUpdate(args: Record<string, unknown>): Promise<string
     headers: H({ 'content-type': 'application/json' }),
     body: JSON.stringify(body),
   });
-  const d = (await res.json()) as { ok?: boolean; preview?: string; error?: string };
-  return d.ok
-    ? `Proposed an edit to "${id}"${d.preview ? ` (${d.preview})` : ''} — it's in an owner's inbox for review. NOTHING changes until an owner who can run "${id}" approves it; the target picks it up on its next session once applied.`
-    : `Could not propose the edit: ${d.error ?? 'unknown error'}`;
+  const d = (await res.json()) as { ok?: boolean; preview?: string; applied?: boolean; rev?: number | null; maturity?: number; error?: string };
+  if (!d.ok) return `Could not propose the edit: ${d.error ?? 'unknown error'}`;
+  const what = d.preview ? ` (${d.preview})` : '';
+  // Two very different outcomes — say which one plainly, so the agent doesn't tell a human "it's awaiting
+  // review" when the edit is already live, or go looking for an effect that hasn't happened yet.
+  return d.applied
+    ? `Applied your edit to "${id}"${what} — your maturity (${Math.round((d.maturity ?? 0) * 100)}/100) is at or above this workspace's auto-apply bar, so it took effect without waiting for a human.${d.rev ? ` Saved as rev ${d.rev}.` : ''} An owner has been notified and can revert it. "${id}" picks it up on its next session.`
+    : `Proposed an edit to "${id}"${what} — it's in an owner's inbox for review. NOTHING changes until an owner who can run "${id}" approves it; the target picks it up on its next session once applied.`;
 }
 
 async function agentHistory(): Promise<string> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -68,9 +68,10 @@ import { briefFor, describeBrief } from './governance/briefer';
 import { PRESET_SOURCES, browseRepo, fetchSkill, searchSkillsh } from './governance/skill-registry';
 import { extractSkillsFromZip } from './governance/skill-zip';
 import { parseBundle } from './governance/bundle-import';
-import { isCodingRuntime, CODING_RUNTIMES, RuntimeId, AgentManifest, AppManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, isValidAppSlug, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeAppDomains, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, runtimeTuningPatch, sanitizeRuntimeTuning, sanitizeShellSecrets, sanitizeUsableSubagents, TaskStatus, GoalStatus, riskClassForLevel } from './types';
+import { isCodingRuntime, CODING_RUNTIMES, RuntimeId, AgentManifest, AppManifest, ApprovalRequest, Branding, EmbeddingsConfig, ENV_NAME, IDENTITY_PROVIDERS, IdentityProvider, isValidAppSlug, Member, MemoryConfig, MemoryMaintenance, MemoryPreload, MemoryRanking, MemoryType, Role, Run, sanitizeAgentProposalTrust, sanitizeAppDomains, sanitizeBranding, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, runtimeTuningPatch, sanitizeRuntimeTuning, sanitizeShellSecrets, sanitizeUsableSubagents, TaskStatus, GoalStatus, riskClassForLevel } from './types';
 import { AgentConfigSnapshot } from './state/agent-revisions';
 import { computeAgentStats, computeAgentStat } from './state/agent-stats';
+import { agentEditable, applyAgentEdit, manifestToSnapshot, readAgentSnapshot } from './state/agent-edit';
 
 /** Sum busy + idle CPU tick counters across all cores (for a sampled utilization %). */
 function cpuTicks(): { idle: number; total: number } {
@@ -146,16 +147,6 @@ const BUILT_IN_AGENT_IDS = new Set<string>([
   SCOUT_ID, STRATEGIST_ID, IMPROVER_ID, ANALYST_ID,
 ]);
 
-/** The full editable state of an agent, from its manifest + on-disk CLAUDE.md — the unit revisions snapshot. */
-function manifestToSnapshot(ag: AgentManifest, claudeMd: string): AgentConfigSnapshot {
-  return {
-    description: ag.description ?? '',
-    category: ag.category, icon: ag.icon,
-    model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, verbosity: ag.verbosity,
-    examplePrompts: ag.examplePrompts ?? [], shellSecrets: ag.shellSecrets ?? [],
-    claudeMd,
-  };
-}
 
 /** Agent ids that currently have an improver-drafted CLAUDE.md proposal awaiting review (Apply/Dismiss).
  *  Derived from the KB proposal pages — no extra table. NB: the KB store normSeg's a slug's `/` to `-`, so
@@ -211,12 +202,6 @@ function troubledAutomations(os: AgentOS, now = Date.now()): Array<{ id: string;
   return out;
 }
 
-/** Read the agent's current on-disk snapshot (manifest fields + CLAUDE.md), to record as the "before". */
-function readAgentSnapshot(ag: AgentManifest): AgentConfigSnapshot {
-  const file = ag.dir ? path.join(ag.dir, 'CLAUDE.md') : '';
-  const claudeMd = file && fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
-  return manifestToSnapshot(ag, claudeMd);
-}
 
 /** Re-apply a full snapshot to disk (agent.json + CLAUDE.md) and re-register — the shared revert primitive. */
 function applyAgentSnapshot(os: AgentOS, ag: AgentManifest, snap: AgentConfigSnapshot): AgentManifest {
@@ -2426,27 +2411,18 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!card) return sendJson(res, 404, { error: 'no such agent-edit proposal' });
     if (card.status !== 'open') return sendJson(res, 409, { error: 'this proposal was already resolved' });
     if (!os.team.canRun(me, card.target)) return sendJson(res, 403, { error: `you cannot run "${card.target}", so you cannot approve edits to it` });
-    const ag = os.agents.get(card.target);
-    if (!ag?.dir) { tm.setAgentUpdateProposalStatus(card.id, 'rejected'); return sendJson(res, 200, { ok: false, error: `target agent "${card.target}" no longer exists` }); }
-    if (!isCodingRuntime(ag.runtime)) return sendJson(res, 200, { ok: false, error: 'only CLI-backed agents can be edited' });
-    const userRoot = path.resolve(os.paths.userAgents) + path.sep;
-    if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return sendJson(res, 200, { ok: false, error: 'built-in agents cannot be edited' });
+    const editable = agentEditable(os, card.target);
+    if (!editable.ok) {
+      // A target that vanished can never be approved — close the card rather than leaving it open forever.
+      if (!os.agents.get(card.target)) { tm.setAgentUpdateProposalStatus(card.id, 'rejected'); return sendJson(res, 200, { ok: false, error: `target agent "${card.target}" no longer exists` }); }
+      return sendJson(res, 200, { ok: false, error: editable.error });
+    }
     const f = card.fields; // the proposed field delta (only present keys are applied — same shape as the self-edit body)
-    const { tuning, error: tErr } = sanitizeRuntimeTuning(runtimeTuningPatch(f, ag, { fields: ['model', 'effort', 'verbosity'] }));
-    if (tErr) return sendJson(res, 200, { ok: false, error: tErr });
-    const before = readAgentSnapshot(ag);
-    const description = 'description' in f ? String(f.description ?? '').trim() : ag.description;
-    const category = 'category' in f ? sanitizeCategory(f.category) : ag.category;
-    const icon = 'icon' in f ? sanitizeIcon(f.icon) : ag.icon;
-    const examplePrompts = 'examplePrompts' in f ? sanitizeExamplePrompts(f.examplePrompts) : ag.examplePrompts;
-    const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, verbosity: tuning.verbosity, category, icon, examplePrompts };
-    const { dir: _dir, ...onDisk } = next;
-    fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
-    if ('claudeMd' in f) fs.writeFileSync(path.join(ag.dir, 'CLAUDE.md'), String(f.claudeMd ?? ''));
-    os.registerAgent(next);
-    const after = manifestToSnapshot(next, 'claudeMd' in f ? String(f.claudeMd ?? '') : before.claudeMd);
-    // Author = the approving owner; the summary preserves who proposed it, so the revision log names both parties.
-    const rev = os.agentRevisions.commit(os.tenant, card.target, before, after, `proposed by ${card.agent}, approved by ${me.email}`, me.email);
+    // Author = the approving owner; the summary preserves who proposed it, so the revision log names both
+    // parties. Shares one write path with the auto-apply tier (see src/state/agent-edit.ts).
+    const applied = applyAgentEdit(os, editable.ag, f, { summary: `proposed by ${card.agent}, approved by ${me.email}`, author: me.email });
+    if (!applied.ok) return sendJson(res, 200, { ok: false, error: applied.error });
+    const rev = applied.rev;
     tm.setAgentUpdateProposalStatus(card.id, 'approved');
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.update.proposal.approved', data: { target: card.target, proposer: card.agent, by: me.email, fields: Object.keys(f), claudeMd: 'claudeMd' in f, rev } });
     return sendJson(res, 200, { ok: true, target: card.target, rev });
@@ -4150,6 +4126,20 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     os.settings.setSubagentDefault(mode, me.email);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.subagentDefault.updated', data: { mode } });
     return sendJson(res, 200, { ok: true, mode });
+  }
+
+  // ── cross-agent edit trust: what a proposing agent's maturity earns it (agent_propose_update) ──
+  //    Three tiers — refuse below `minMaturity`, owner review in the middle, self-apply at/above
+  //    `autoApplyAt` (when `autoApply` is on). Read on every propose call; owner/admin may retune.
+  if (method === 'GET' && p === '/api/settings/agent-proposal-trust') {
+    return sendJson(res, 200, { trust: os.settings.agentProposalTrust() });
+  }
+  if (method === 'PUT' && p === '/api/settings/agent-proposal-trust') {
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
+    const b = await readBody(req) as Partial<Record<'minMaturity' | 'autoApplyAt' | 'autoApply', unknown>>;
+    const trust = os.settings.setAgentProposalTrust(sanitizeAgentProposalTrust({ ...os.settings.agentProposalTrust(), ...b }), me.email);
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.agentProposalTrust.updated', data: { ...trust } });
+    return sendJson(res, 200, { ok: true, trust });
   }
 
   // ── sessions-list money column (cost / tokens / both) — a workspace-wide viewing preference ──

--- a/src/state/agent-edit.ts
+++ b/src/state/agent-edit.ts
@@ -1,0 +1,83 @@
+/**
+ * The ONE place an agent's editable config (manifest fields + CLAUDE.md) is written to disk from a
+ * field delta, plus the snapshot helpers around it.
+ *
+ * This used to live inline in the owner-approve route in `src/server.ts`. It moved here when the
+ * cross-agent proposal path grew a trust tier: a proposal from a HIGH-maturity agent applies without a
+ * human (see `TerminalManager.proposeAgentUpdate`), so the same write has two callers — the owner's
+ * approve route and the auto-apply lane. Sharing the primitive is what keeps the two identical: same
+ * validation (claude-code + user-home only), same tuning sanitiser, same `agent.json`/`CLAUDE.md`
+ * write, same re-register, and — critically — the same revision snapshot, so an auto-applied edit is
+ * as revertable as a human-approved one.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AgentOS } from '../kernel';
+import { AgentManifest, isCodingRuntime, runtimeTuningPatch, sanitizeCategory, sanitizeExamplePrompts, sanitizeIcon, sanitizeRuntimeTuning } from '../types';
+import { AgentConfigSnapshot } from './agent-revisions';
+
+/** The full editable state of an agent, from its manifest + on-disk CLAUDE.md — the unit revisions snapshot. */
+export function manifestToSnapshot(ag: AgentManifest, claudeMd: string): AgentConfigSnapshot {
+  return {
+    description: ag.description ?? '',
+    category: ag.category, icon: ag.icon,
+    model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, verbosity: ag.verbosity,
+    examplePrompts: ag.examplePrompts ?? [], shellSecrets: ag.shellSecrets ?? [],
+    claudeMd,
+  };
+}
+
+/** Read the agent's current on-disk snapshot (manifest fields + CLAUDE.md), to record as the "before". */
+export function readAgentSnapshot(ag: AgentManifest): AgentConfigSnapshot {
+  const file = ag.dir ? path.join(ag.dir, 'CLAUDE.md') : '';
+  const claudeMd = file && fs.existsSync(file) ? fs.readFileSync(file, 'utf8') : '';
+  return manifestToSnapshot(ag, claudeMd);
+}
+
+/**
+ * Is this agent editable at all? The same check the human self-edit route makes, so no proposal lane
+ * can reach a target a person couldn't edit either: a CLI-backed agent living under the user-agents
+ * root (never a bundled example shipped with the software).
+ */
+export function agentEditable(os: AgentOS, id: string): { ok: true; ag: AgentManifest } | { ok: false; error: string } {
+  if (!os.paths) return { ok: false, error: 'editing agents requires a data home' };
+  const ag = os.agents.get(id);
+  if (!ag?.dir) return { ok: false, error: `unknown agent "${id}"` };
+  if (!isCodingRuntime(ag.runtime)) return { ok: false, error: 'only CLI-backed agents can be edited' };
+  const userRoot = path.resolve(os.paths.userAgents) + path.sep;
+  if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return { ok: false, error: 'built-in agents cannot be edited' };
+  return { ok: true, ag };
+}
+
+/**
+ * Apply a proposed field delta to an agent and snapshot the change as a revision.
+ *
+ * `fields` is the propose-time delta: only keys actually present are applied, everything else keeps its
+ * current value (so a proposal that touches only `description` can't blank a CLAUDE.md). `author` is who
+ * the revision is attributed to — the approving owner's email on the gated lane, `agent:<proposer>` when
+ * a trusted agent applied it itself — and `summary` records both parties either way.
+ */
+export function applyAgentEdit(
+  os: AgentOS,
+  ag: AgentManifest,
+  fields: Record<string, unknown>,
+  opts: { summary: string; author: string },
+): { ok: true; rev: number | null; target: string } | { ok: false; error: string } {
+  // NB: no `runtime` arg — same as the self-edit and approve routes this shares. An agent-proposed model
+  // is validated by the CLI at launch, not here, so the three lanes stay behaviourally identical.
+  const { tuning, error } = sanitizeRuntimeTuning(runtimeTuningPatch(fields, ag, { fields: ['model', 'effort', 'verbosity'] }));
+  if (error) return { ok: false, error };
+  const before = readAgentSnapshot(ag);
+  const description = 'description' in fields ? String(fields.description ?? '').trim() : ag.description;
+  const category = 'category' in fields ? sanitizeCategory(fields.category) : ag.category;
+  const icon = 'icon' in fields ? sanitizeIcon(fields.icon) : ag.icon;
+  const examplePrompts = 'examplePrompts' in fields ? sanitizeExamplePrompts(fields.examplePrompts) : ag.examplePrompts;
+  const next: AgentManifest = { ...ag, description, model: tuning.model, effort: tuning.effort, verbosity: tuning.verbosity, category, icon, examplePrompts };
+  const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
+  fs.writeFileSync(path.join(ag.dir!, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
+  if ('claudeMd' in fields) fs.writeFileSync(path.join(ag.dir!, 'CLAUDE.md'), String(fields.claudeMd ?? ''));
+  os.registerAgent(next);
+  const after = manifestToSnapshot(next, 'claudeMd' in fields ? String(fields.claudeMd ?? '') : before.claudeMd);
+  const rev = os.agentRevisions.commit(os.tenant, ag.id, before, after, opts.summary, opts.author);
+  return { ok: true, rev, target: ag.id };
+}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -14,6 +14,8 @@ import { newId } from './id';
 import { AgentOS } from './kernel';
 import { Db } from './state/db';
 import { containedPath, mimeOf } from './state/artifacts';
+import { computeAgentStat } from './state/agent-stats';
+import { agentEditable, applyAgentEdit } from './state/agent-edit';
 import { mintToolRouterSession, COMPOSIO_KEY_HEADER, serviceUserId, type MintOptions } from './connectors/composio';
 import { isCodingRuntime, runtimeSupports, CODING_RUNTIMES, CodingRuntimeId, ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskStatus, TaskTimelineEntry, TaskDiscussionSummary, Verbosity, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval, redactSecrets } from './governance/enricher';
@@ -4918,25 +4920,34 @@ export class TerminalManager {
   }
 
   /**
-   * An agent PROPOSES an edit to ANOTHER agent's listing / CLAUDE.md — the cross-agent, gated sibling of
-   * the self-only `agent_update`. Nothing is written here (an unapproved prompt edit must not take effect):
-   * the field delta lives in the review card's args, and the approve route applies it only once an OWNER
-   * who can run the target signs off. Validates the target the SAME way the self-edit route does
-   * (claude-code only, under the user-agents root, not a bundled example), so an agent can't propose edits
-   * to something a human couldn't edit either. Same queue-cap + identical-delta dedupe as the other propose
+   * An agent PROPOSES an edit to ANOTHER agent's listing / CLAUDE.md — the cross-agent sibling of the
+   * self-only `agent_update`. Validates the target the SAME way the self-edit route does (claude-code
+   * only, under the user-agents root, not a bundled example), so an agent can't propose edits to
+   * something a human couldn't edit either. Same queue-cap + identical-delta dedupe as the other propose
    * lanes; `id === proposer` is refused (that's what `agent_update` is for).
+   *
+   * What happens to a VALID proposal is decided by the PROPOSER's maturity score against the workspace
+   * {@link AgentProposalTrust} tiers (Settings → Agents):
+   *   below `minMaturity`  → refused here. An unproven agent doesn't get to rewrite a teammate's prompt,
+   *                          and doesn't get to fill a human's queue asking to.
+   *   middle band          → the original behaviour: nothing is written, the field delta rides in an
+   *                          owner-addressed review card, and only the approve route applies it.
+   *   ≥ `autoApplyAt`      → APPLIED NOW by {@link applyAgentEdit}, with the owner notified after the
+   *                          fact. This is the one path where an agent changes another agent with no
+   *                          human in the loop, so it is deliberately expensive to reach (maturity
+   *                          multiplies in volumeConfidence — ~32+ clean, autonomous runs) and it
+   *                          snapshots a revision like every other edit, so an owner can revert it.
+   * Maturity is computed per call from the audit/session history — a full-history scan, but this is a
+   * rare, human-speed tool call, not a hot path.
    */
-  proposeAgentUpdate(sessionId: string, proposer: string, body: Record<string, unknown>): { ok: boolean; preview?: string; error?: string } {
+  proposeAgentUpdate(sessionId: string, proposer: string, body: Record<string, unknown>): { ok: boolean; preview?: string; applied?: boolean; rev?: number | null; maturity?: number; error?: string } {
     const target = String(body.id ?? '').trim().toLowerCase();
     if (!target) return { ok: false, error: 'id (the agent to edit) is required' };
     if (target === proposer) return { ok: false, error: 'use agent_update to edit your own listing' };
     if (!String(body.rationale ?? '').trim()) return { ok: false, error: 'a rationale is required — the approver sees it on the card' };
-    if (!this.os.paths) return { ok: false, error: 'editing agents requires a data home' };
-    const ag = this.os.agents.get(target);
-    if (!ag?.dir) return { ok: false, error: `unknown agent "${target}"` };
-    if (!isCodingRuntime(ag.runtime)) return { ok: false, error: 'only CLI-backed agents can be edited' };
-    const userRoot = path.resolve(this.os.paths.userAgents) + path.sep;
-    if (!(path.resolve(ag.dir) + path.sep).startsWith(userRoot)) return { ok: false, error: 'built-in agents cannot be edited' };
+    const editable = agentEditable(this.os, target);
+    if (!editable.ok) return { ok: false, error: editable.error };
+    const ag = editable.ag;
     // Only the fields actually present become the delta; store them verbatim on the card for the approve route.
     const fields: Record<string, unknown> = {};
     for (const k of ['description', 'claudeMd', 'category', 'model', 'effort', 'icon'] as const) {
@@ -4944,6 +4955,38 @@ export class TerminalManager {
     }
     if ('examplePrompts' in body && Array.isArray(body.examplePrompts)) fields.examplePrompts = body.examplePrompts.map(String);
     if (!Object.keys(fields).length) return { ok: false, error: 'nothing to change — pass at least one field (description, claudeMd, category, model, effort, icon, examplePrompts)' };
+    // ── the trust tier: what this proposer's track record earns it ──────────────────────────────
+    const trust = this.os.settings.agentProposalTrust();
+    const maturity = computeAgentStat(this.db, proposer).maturity;
+    const pct = Math.round(maturity * 100);
+    if (maturity < trust.minMaturity) {
+      this.audit(sessionId, proposer, 'agent.update.proposal.blocked', { target, maturity, floor: trust.minMaturity, fields: Object.keys(fields) });
+      return {
+        ok: false, maturity,
+        error: `your maturity is ${pct}/100 and this workspace requires ${Math.round(trust.minMaturity * 100)}/100 to propose edits to another agent. Maturity comes from completed runs that needed few approvals and hit no denials — keep doing your own work well, and tell a human directly if "${target}" needs changing.`,
+      };
+    }
+    const rationaleText = String(body.rationale).trim();
+    const previewText = Object.keys(fields).map((k) => (k === 'claudeMd' ? 'CLAUDE.md (system prompt)' : k)).join(', ');
+    if (trust.autoApply && maturity >= trust.autoApplyAt) {
+      // Top tier: apply now, tell the owner afterwards. The revision snapshot is what makes this safe to
+      // undo — the notification card names the rev so an owner can revert it in one step.
+      const applied = applyAgentEdit(this.os, ag, fields, {
+        summary: `auto-applied from ${proposer} (maturity ${pct}/100): ${rationaleText}`,
+        author: `agent:${proposer}`,
+      });
+      if (!applied.ok) return { ok: false, error: applied.error };
+      this.addMessage({
+        type: 'notification', sessionId, agent: proposer,
+        title: `${proposer} edited ${target}`,
+        body: `${rationaleText}\n\nChanges to \`${target}\`: ${previewText}\n\nApplied automatically — ${proposer} is at maturity ${pct}/100, at or above this workspace's ${Math.round(trust.autoApplyAt * 100)}/100 auto-apply bar.${applied.rev ? ` Saved as rev ${applied.rev}; revert it from the agent's History if it's wrong.` : ''}`,
+        status: 'open',
+        args: { target, fields, rationale: rationaleText, preview: previewText, maturity, rev: applied.rev, autoApplied: true },
+        audienceKind: 'admins',
+      });
+      this.audit(sessionId, proposer, 'agent.update.applied', { target, fields: Object.keys(fields), maturity, bar: trust.autoApplyAt, rev: applied.rev, auto: true });
+      return { ok: true, preview: previewText, applied: true, rev: applied.rev, maturity };
+    }
     // Cap the queue + dedupe an identical open proposal from this agent for this target (mirrors proposeAutomation).
     const open = this.db.prepare(`SELECT args FROM messages WHERE type = 'agent.update.proposed' AND status = 'open' AND agent = ?`).all<{ args: string | null }>(proposer);
     if (open.length >= 10) return { ok: false, error: 'you already have 10 open edit proposals awaiting review — wait for a human to act on them first' };
@@ -4951,17 +4994,17 @@ export class TerminalManager {
     if (open.some((o) => { try { const a = JSON.parse(o.args || '{}') as { target?: string; fields?: unknown }; return JSON.stringify({ target: a.target, fields: a.fields }) === deltaKey; } catch { return false; } })) {
       return { ok: false, error: 'an identical edit proposal from you is already awaiting review' };
     }
-    const rationale = String(body.rationale).trim();
-    const preview = Object.keys(fields).map((k) => (k === 'claudeMd' ? 'CLAUDE.md (system prompt)' : k)).join(', ');
+    // Middle band — the owner decides. The proposer's maturity rides on the card so the reviewer weighs
+    // the proposal against its author's track record instead of on prose alone.
     this.postReviewCard({
       type: 'agent.update.proposed', sessionId, agent: proposer,
       title: `Edit proposed for ${target}`,
-      body: `${rationale}\n\nChanges to \`${target}\`: ${preview}`,
-      args: { target, fields, rationale, preview },
-      summary: `${proposer} proposes editing ${target} (${preview})`,
+      body: `${rationaleText}\n\nChanges to \`${target}\`: ${previewText}\n\nProposed by ${proposer} — maturity ${pct}/100.`,
+      args: { target, fields, rationale: rationaleText, preview: previewText, maturity },
+      summary: `${proposer} (maturity ${pct}/100) proposes editing ${target} (${previewText})`,
     });
-    this.audit(sessionId, proposer, 'agent.update.proposed', { target, fields: Object.keys(fields) });
-    return { ok: true, preview };
+    this.audit(sessionId, proposer, 'agent.update.proposed', { target, fields: Object.keys(fields), maturity });
+    return { ok: true, preview: previewText, applied: false, maturity };
   }
 
   /** The proposed agent-edit review card by id (its target + field delta + status) — for the approve/reject routes. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1595,6 +1595,48 @@ export function sanitizeUsableSubagents(input: unknown): string[] | undefined {
   return out.length ? out : undefined;
 }
 
+/**
+ * How much the CROSS-AGENT edit path (`agent_propose_update`) trusts the PROPOSING agent, keyed off its
+ * maturity score (`src/state/agent-stats.ts`: autonomy × (1 − denialRate) × volumeConfidence).
+ *
+ * Three tiers, low to high:
+ *   maturity < `minMaturity`   → the proposal is REFUSED outright (an unproven agent doesn't get to
+ *                                rewrite a teammate's system prompt, not even into a human's queue).
+ *   in between                 → today's behaviour: an owner-addressed review card, applied only on
+ *                                owner approval.
+ *   ≥ `autoApplyAt` (+ `autoApply`) → applied IMMEDIATELY, owner notified after the fact, revertable
+ *                                from the revision it snapshots.
+ *
+ * The top tier deliberately removes the human from the loop, so note what makes it hard to reach:
+ * maturity multiplies in `volumeConfidence = runs/(runs+8)`, so 0.8 is unreachable below ~32 runs and
+ * needs near-perfect autonomy and a clean denial record on top. Set `autoApply:false` to keep every
+ * proposal owner-gated (the two lower tiers still apply).
+ */
+export interface AgentProposalTrust {
+  /** Floor to propose at all (0..1). Default 0.4. 0 lets any agent propose. */
+  minMaturity: number;
+  /** Maturity at/above which a proposal self-applies (0..1). Default 0.8. Ignored when `autoApply` is off. */
+  autoApplyAt: number;
+  /** Master switch for the auto-apply tier. Default true. */
+  autoApply: boolean;
+}
+
+export const DEFAULT_AGENT_PROPOSAL_TRUST: AgentProposalTrust = { minMaturity: 0.4, autoApplyAt: 0.8, autoApply: true };
+
+/** Normalize a stored/API `AgentProposalTrust`: clamp both thresholds to 0..1, and keep the floor at or
+ *  below the auto-apply bar (an inverted pair would make a band that refuses and self-applies at once —
+ *  raise the auto-apply bar to the floor rather than silently reordering the tiers). */
+export function sanitizeAgentProposalTrust(input: unknown): AgentProposalTrust {
+  const b = (input ?? {}) as Partial<Record<keyof AgentProposalTrust, unknown>>;
+  const num = (v: unknown, fallback: number): number => {
+    const n = Number(v);
+    return Number.isFinite(n) ? Math.min(1, Math.max(0, n)) : fallback;
+  };
+  const minMaturity = num(b.minMaturity, DEFAULT_AGENT_PROPOSAL_TRUST.minMaturity);
+  const autoApplyAt = Math.max(minMaturity, num(b.autoApplyAt, DEFAULT_AGENT_PROPOSAL_TRUST.autoApplyAt));
+  return { minMaturity, autoApplyAt, autoApply: b.autoApply === undefined ? DEFAULT_AGENT_PROPOSAL_TRUST.autoApply : !!b.autoApply };
+}
+
 /** Normalize an agent category label (from an API body or config file): trim, collapse internal
  *  whitespace, cap at 40 chars. Returns undefined when empty so an uncategorised agent's manifest
  *  carries no `category` key at all. */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type AgentProposalTrust, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -14149,8 +14149,64 @@ function RuntimeDefaultsSettings({ me }: { me: Member }) {
             {subHint && <span className="font-mono text-xs text-muted-foreground">{subHint}</span>}
           </div>
         </div>
+        <AgentProposalTrustSettings canEdit={canEdit} />
       </CardContent>
     </Card>
+  )
+}
+
+/** Settings → Runtime → what an agent's track record earns it on the CROSS-AGENT edit path
+ *  (`agent_propose_update`). Three tiers keyed on the PROPOSER's maturity score: refused below the floor,
+ *  owner review in the middle, self-applied at the top. The top tier is the only path where one agent
+ *  rewrites another with no human in the loop, so the copy says so plainly and the switch turns it off. */
+function AgentProposalTrustSettings({ canEdit }: { canEdit: boolean }) {
+  const [trust, setTrust] = useState<AgentProposalTrust | null>(null)
+  const [hint, setHint] = useState('')
+
+  useEffect(() => { api.agentProposalTrust().then((r) => { if (!r.error) setTrust(r.trust) }).catch(() => {}) }, [])
+
+  const save = async (patch: Partial<AgentProposalTrust>) => {
+    const next = { ...(trust ?? { minMaturity: 0.4, autoApplyAt: 0.8, autoApply: true }), ...patch }
+    setTrust(next); setHint('')
+    const r = await api.saveAgentProposalTrust(patch)
+    if (r.error) return setHint('⚠ ' + r.error)
+    if (r.trust) setTrust(r.trust)  // the server clamps + keeps the floor ≤ the bar; show what it stored
+    setHint('saved'); setTimeout(() => setHint(''), 2000)
+  }
+
+  if (!trust) return null
+  const pct = (n: number) => String(Math.round(n * 100))
+  return (
+    <div className="space-y-1 border-t pt-4">
+      <label className="text-sm font-medium">Cross-agent edits</label>
+      <p className="text-sm text-muted-foreground">
+        An agent can propose an edit to <em>another</em> agent's description or system prompt. What its proposal is worth depends on its{' '}
+        <span className="font-medium">maturity</span> score — earned from completed runs that needed few approvals and hit no denials.
+      </p>
+      <div className="flex flex-wrap items-center gap-3 pt-2">
+        <label className="text-sm text-muted-foreground">Refuse below</label>
+        <input type="number" min={0} max={100} step={5} value={pct(trust.minMaturity)} disabled={!canEdit}
+          onChange={(e) => save({ minMaturity: Math.min(100, Math.max(0, Number(e.target.value) || 0)) / 100 })}
+          className="w-20 rounded-md border bg-background px-2 py-1.5 text-sm" />
+        <span className="text-sm text-muted-foreground">/100 — under this, the agent can't propose at all.</span>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 pt-2">
+        <label className="flex items-center gap-2 text-sm">
+          <input type="checkbox" checked={trust.autoApply} disabled={!canEdit} onChange={(e) => save({ autoApply: e.target.checked })} />
+          Let a highly mature agent apply its edit immediately, at or above
+        </label>
+        <input type="number" min={0} max={100} step={5} value={pct(trust.autoApplyAt)} disabled={!canEdit || !trust.autoApply}
+          onChange={(e) => save({ autoApplyAt: Math.min(100, Math.max(0, Number(e.target.value) || 0)) / 100 })}
+          className="w-20 rounded-md border bg-background px-2 py-1.5 text-sm" />
+        <span className="text-sm text-muted-foreground">/100</span>
+        {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
+      </div>
+      <p className="pt-1 text-[11px] text-muted-foreground">
+        {trust.autoApply
+          ? <>Above the bar, one agent rewrites another <strong>with no human in the loop</strong> — you're notified after the fact and every edit is a revertable revision. Maturity is hard to reach by design (it's damped by run volume, so it takes ~30+ clean, autonomous runs). Turn the checkbox off to keep every proposal owner-approved.</>
+          : <>Every proposal between the floor and 100 waits for an owner who can run the target agent. Nothing is written until they approve.</>}
+      </p>
+    </div>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -603,6 +603,15 @@ export interface AgentStats {
   confidence: 'none' | 'low' | 'medium' | 'high'
 }
 
+/** What a PROPOSING agent's maturity earns it on the cross-agent edit path (`agent_propose_update`) —
+ *  mirror of src/types.ts AgentProposalTrust. Below `minMaturity` the proposal is refused; in between an
+ *  owner reviews it; at/above `autoApplyAt` (when `autoApply`) it applies with no human in the loop. */
+export interface AgentProposalTrust {
+  minMaturity: number
+  autoApplyAt: number
+  autoApply: boolean
+}
+
 export type TaskStatus = 'todo' | 'doing' | 'blocked' | 'done' | 'cancelled'
 export interface Task {
   id: string
@@ -1747,6 +1756,8 @@ export const api = {
   verbositySavings: (days = 30) => call<VerbositySavings>('GET', `/api/settings/verbosity-savings?days=${days}`),
   subagentDefault: () => call<{ mode: 'all' | 'none'; error?: string }>('GET', '/api/settings/subagent-default'),
   saveSubagentDefault: (mode: 'all' | 'none') => call<{ ok: boolean; mode?: 'all' | 'none'; error?: string }>('PUT', '/api/settings/subagent-default', { mode }),
+  agentProposalTrust: () => call<{ trust: AgentProposalTrust; error?: string }>('GET', '/api/settings/agent-proposal-trust'),
+  saveAgentProposalTrust: (patch: Partial<AgentProposalTrust>) => call<{ ok: boolean; trust?: AgentProposalTrust; error?: string }>('PUT', '/api/settings/agent-proposal-trust', patch),
   saveSessionMetrics: (value: SessionMetrics) => call<{ ok: boolean; sessionMetrics?: SessionMetrics; error?: string }>('PUT', '/api/settings/session-metrics', { value }),
   concurrency: () => call<Concurrency & { error?: string }>('GET', '/api/settings/concurrency'),
   saveConcurrency: (body: { value?: number | null; idleHours?: number; unattendedMaxHours?: number; unattendedNoProgressMinutes?: number; blockedMaxHours?: number }) => call<{ ok: boolean; error?: string; value?: number | null; resolved?: number; derived?: number; idleHours?: number; unattendedMaxHours?: number; unattendedNoProgressMinutes?: number; blockedMaxHours?: number }>('PUT', '/api/settings/concurrency', body),


### PR DESCRIPTION
## What

`agent_propose_update` already let any agent propose an edit to any *other* agent's listing/CLAUDE.md — that half was never self-only. What was missing: every proposal landed identically whether the proposer had 200 clean runs or was on its first. Both ends of that were wrong. A brand-new agent could fill an owner's queue with prompt rewrites for teammates; a long-proven one couldn't fix an obvious stale instruction without a human round-trip.

The **proposer's maturity score** (`src/state/agent-stats.ts` — autonomy × (1 − denialRate) × volumeConfidence) now routes the call against workspace-configurable tiers (`AgentProposalTrust`, **Settings → Runtime → Cross-agent edits**, `GET`/`PUT /api/settings/agent-proposal-trust`):

| proposer maturity | outcome |
| --- | --- |
| `< minMaturity` (0.40) | **refused** — no write, and no card either. The error tells the agent what earns the right and to raise it with a human instead. Audited `agent.update.proposal.blocked`. |
| middle band | unchanged **propose-don't-apply**: owner-addressed card, applied only by an owner who can run the target. The card now also carries the proposer's maturity, so the reviewer weighs the author's record, not the prose alone. |
| `≥ autoApplyAt` (0.80) | **applied immediately, no human in the loop**; admin-addressed notice after the fact naming the revision to revert. Audited `agent.update.applied`. |

## The top tier, stated plainly

It removes the human from the loop for a privilege-bearing act. What makes that a defensible trade:

- **Hard to reach by construction** — maturity multiplies in `volumeConfidence = runs/(runs+8)`, so 0.80 is unreachable below ~32 runs and additionally needs near-perfect autonomy and a clean denial record.
- **Revertable, not just auditable** — it commits a normal revision (author `agent:<proposer>`), so it shows up in the same Revision history panel as every other edit.
- **Switchable** — `autoApply:false` disables the tier entirely, restoring exactly the previous owner-gated behaviour while keeping the new floor.

## One write path

All three lanes now share `applyAgentEdit` in the new `src/state/agent-edit.ts`, extracted verbatim from the owner-approve route (same sanitizers, same `agent.json`/`CLAUDE.md` write, same `os.registerAgent`, same `AgentRevisions.commit`). An auto-applied edit is validated and snapshotted exactly like a human-approved one; only authorship differs.

## Verification

An isolated-home harness (`AGENT_OS_HOME` scratch dir — never the live `./data`) drives `proposeAgentUpdate` at each band and asserts against disk + DB, not just return values:

- refused tier: nothing written, no card, blocked event audited
- middle tier: card posted with maturity, `agent.json` and CLAUDE.md untouched, identical-delta dedupe still holds
- top tier: description + CLAUDE.md written, revision committed and authored `agent:proposer`, admin notice posted
- `autoApply:false` at the same maturity falls back to a card
- settings sanitiser clamps to 0..1 and never leaves the floor above the bar

**27/27 pass**, alongside `npm run typecheck`, `cd web && npm run build`, and `npm run test:governance` (20/20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)