### PR TITLE
fix(tasks): a running delegate is reachable — HOLD stops the work, not just the row (v0.315.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.315.0] — 2026-08-06
+### Fixed
+- **A running delegate was unreachable, so "stand down" spawned a second agent instead of stopping the
+  first.** Caught live on instapods (`tsk_67de2dfe`, 2026-08-06): `marketing-manager` auto-dispatched a
+  build it hadn't meant to, put the task on **HOLD** 35 s later — and the hold reached a *newly spawned*
+  `marketing-site` run, which stood down, while the run actually building kept going for 25+ minutes.
+  Root cause: `deliverToResident` refused any session with `resident = 0`, so every unattended
+  (task/automation) run was unreachable even though those are attachable TUIs now, not `claude -p`. The
+  task-discussion path then fell through to spawning a rival worker and re-pointed the task's
+  `last_session_id` at it, orphaning the live run from its own task. Now:
+  - any LIVE claude pane can be delivered into, unattended or not;
+  - a turn-end teardown is deferred while a message delivered in the last 90 s is still unread
+    (`DELIVERY_GRACE_MS`), so a HOLD typed a second before the Stop hook isn't swallowed;
+  - a task moved to `blocked`/`cancelled` by anyone other than the executing agent now **injects the
+    reason into the live run** (`task.hold.delivered`), so the row and the work stop together;
+  - the discussion path reports an undeliverable live run instead of spawning a rival onto the same task.
+- **A caller no longer pokes itself.** The poke-back fires when a task reaches `done`/`blocked`; the code
+  assumed the delegate is always the actor ("so this can't self-wake"), which a caller parking its own
+  hand-off falsifies — 14 spurious wake-up sessions across the fleet in 30 days. The actor decides now.
+- **A parked task can no longer be re-dispatched by a guarded path.** `dispatchTask` refused
+  `done`/`cancelled` but not `blocked`, so `task_dispatch`, `task_wait`'s polling kick and app dispatch
+  all sailed past a deliberate stop (45 tasks dispatched 2+ times in 30 days, 23 of them within 60 s). A
+  human forcing it from the console is still allowed — that is the un-park.
+### Added
+- **Message a delegate from the chain rail.** Any live node gets a composer that types straight into that
+  agent's session (`POST /api/sessions/:id/inject`) — steering a run you aren't attached to, without
+  opening its terminal or filing a task comment that reaches the wrong run.
+
 ## [0.314.0] — 2026-08-06
 ### Added
 - **A task's full run history — every session that worked it, not just the last one.** The task↔session

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.314.0",
+  "version": "0.315.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.314.0",
+      "version": "0.315.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.314.0",
+  "version": "0.315.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/chain-model-test.cjs
+++ b/scripts/chain-model-test.cjs
@@ -162,6 +162,56 @@ assert(row(qaRun).parentThreadId === 'cs_eng' && row(qaRun).taskId === tQa.id, '
 assert(row(engRun2).parentThreadId === 'cs_eng', 'a poke resolves to its OWN thread (no parent = not a hand-off)');
 assert(row(engRun1).parentThreadId === undefined && row(engRun1).taskId === undefined, 'a member-spawned run has no chain edge');
 
+// ── steering a live hand-off: the instapods 2026-08-06 incident (tsk_67de2dfe) ──
+// A manager put its own delegated task on HOLD. The stand-down reached a NEWLY SPAWNED run while the
+// agent actually executing kept going for 25+ minutes, and the manager poked itself for the transition.
+console.log('\n\x1b[1msteering a live delegate\x1b[0m');
+{
+  const { Automations } = require(path.join(ROOT, 'dist/edge/automations.js'));
+  const autos = new Automations(aos, tm);
+  const injected = [];
+  tm.backend.injectText = (space, tmuxName, body) => { injected.push({ tmux: tmuxName, body }); return true; };
+  tm.isAlive = (id) => id === liveDelegate;
+
+  const held = mkTask({ title: 'ship batch 1', assignee: 'agent:builder', callerAgent: 'agent:manager', callerClaudeId: 'cs_mgr' });
+  var liveDelegate = mkRun({ agent: 'builder', claude_session_id: 'cs_build', spawned_by: `task:${held.id}`, status: 'running', title: 'Task: ship batch 1' });
+  aos.db.prepare('UPDATE term_sessions SET headless = 1, resident = 0 WHERE id = ?').run(liveDelegate);   // unattended: the case that was unreachable
+  aos.tasks.markDispatched(held.id, liveDelegate);
+
+  // An unattended run is an attachable TUI — delivery must reach it (this is what was broken).
+  assert(tm.deliverToResident(liveDelegate, 'stand down') === true, 'a live UNATTENDED run can be messaged');
+  assert(tm.deliverToResident(mkRun({ status: 'done' }), 'x') === false, 'a finished run cannot');
+
+  // A HOLD by the caller reaches the run that is doing the work.
+  injected.length = 0;
+  const notices = [];
+  aos.tasks.setNotifier((n) => notices.push(n));
+  aos.tasks.update(held.id, { status: 'blocked', note: 'HOLD - auto-dispatch was unintended', by: 'agent:manager' });
+  const notice = notices.find((n) => n.kind === 'status');
+  assert(!!notice && notice.by === 'agent:manager', 'the notice names the actor');
+  // (the tenant-registry wiring is what calls maybeHoldDelegate; assert the pieces it depends on)
+  assert(aos.tasks.get(held.id).lastSessionId === liveDelegate, 'the task still points at the RUNNING delegate');
+  assert(aos.tasks.latestNote(held.id).startsWith('HOLD'), 'the reason is available to forward');
+
+  // A parked task is not re-dispatchable by any guarded path.
+  const blocked = autos.dispatchTask(held.id, { guard: true, by: 'test' });
+  assert(blocked.ok === false && /blocked/.test(blocked.reason), 'a blocked task refuses a guarded dispatch', blocked.reason);
+  // …but a human forcing it from the console still gets PAST the park (it stops on this scratch home's
+  // missing agent manifest, not on the block — spawning a real one would start a real tmux session).
+  tm.isAlive = () => false;
+  const forced = autos.dispatchTask(held.id, { guard: false, by: 'human' });
+  assert(!/blocked/.test(forced.reason || ''), 'a human forcing it is not refused for being blocked', forced.reason);
+
+  // And a still-working delegate is never given a rival by the discussion path.
+  tm.isAlive = (id) => id === liveDelegate;
+  tm.deliverToResident = () => false;   // simulate an undeliverable pane
+  tm.reviveResident = () => false;
+  const before = aos.db.prepare('SELECT COUNT(*) AS c FROM term_sessions').get().c;
+  const r = autos.continueTaskThread(held.id, 'manager', 'stand down', 'builder');
+  assert(r.status === 'none', 'an undeliverable LIVE run is reported, not duplicated', r.status);
+  assert(aos.db.prepare('SELECT COUNT(*) AS c FROM term_sessions').get().c === before, 'no rival session was spawned');
+}
+
 console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m`);
 fs.rmSync(HOME, { recursive: true, force: true });
 process.exit(fail ? 1 : 0);

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -601,6 +601,11 @@ export class Automations {
     const t = this.os.tasks.get(id);
     if (!t) return { ok: false, reason: 'task not found' };
     if (t.status === 'done' || t.status === 'cancelled') return { ok: false, reason: `task is ${t.status}` };
+    // `blocked` means someone parked this deliberately. The tick never selects it (dispatchable() is
+    // todo-only), but every DIRECT path — task_dispatch, task_wait's polling kick, an app dispatch —
+    // used to sail past, re-spawning work a human or a caller had just stopped. A human forcing it from
+    // the console (guard:false) is still allowed: that IS the un-park.
+    if (guard && t.status === 'blocked') return { ok: false, reason: 'task is blocked — unblock it before dispatching' };
     const agentId = (t.assignee || '').startsWith('agent:') ? t.assignee!.slice('agent:'.length) : '';
     if (!agentId) return { ok: false, reason: 'task has no agent assignee' };
     if (!this.os.agents.has(agentId)) return { ok: false, reason: `unknown agent: ${agentId}` };
@@ -1026,6 +1031,10 @@ export class Automations {
     if (boundId && boundAgent === agentId) {
       if (this.tm.deliverToResident(boundId, liveMsg)) { emit('delivered', boundId); return { status: 'delivered', sessionId: boundId }; }
       if (this.tm.reviveResident(boundId, liveMsg, runAs)) { emit('revived', boundId); return { status: 'revived', sessionId: boundId }; }
+      // Delivery failed but the run is STILL WORKING: spawning a second agent onto the same task is how a
+      // "stand down" ends up executed by a fresh run while the original keeps building (instapods
+      // 2026-08-06). Report the failure instead of duplicating the worker.
+      if (this.tm.isAlive(boundId)) { emit('undeliverable', boundId); return { status: 'none', sessionId: boundId }; }
     }
     const seed = buildTaskPrompt({ id: t.id, title: t.title, body: t.body, criteria: t.criteria }) +
       `\n\nA teammate pulled you into the discussion:\n${authorLabel}: ${text}\n\nReply in the discussion with task_say({ id: "${t.id}", message: "…" }).`;

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -291,6 +291,8 @@ export class TenantRegistry {
       // Async poke-back: a delegate that closed a `poke_on_done` hand-off resumes the CALLER agent's
       // transcript with the outcome, so a fire-and-forget delegation wakes the caller (no polling).
       maybePokeCaller(autos, os, notice);
+      // A HOLD/cancel has to reach the agent DOING the work, not just the task row.
+      maybeHoldDelegate(tm, os, notice);
     });
     // Goal lifecycle → Inbox. Same sink shape as Tasks, one rung up the ladder: a goal whose work all
     // finished (the tick's completion sweep) or that someone closed reaches the human accountable for it.
@@ -560,6 +562,31 @@ async function notifyGoalEvent(os: AgentOS, tm: Pick<TerminalManager, 'postGoalC
 }
 
 /**
+ * Park the RUN, not just the row. A task moved to `blocked`/`cancelled` by anyone other than the agent
+ * executing it (a manager calling HOLD, a human hitting stop) has to reach the live dispatched session —
+ * otherwise the row reads "blocked" while the agent keeps building. Delivered into the pane by the same
+ * send-keys channel a thread follow-up uses; a dead/finished run is simply skipped.
+ */
+function maybeHoldDelegate(tm: TerminalManager, os: AgentOS, notice: TaskNotice): void {
+  if (notice.kind !== 'status') return;
+  const t = notice.task;
+  if (t.status !== 'blocked' && t.status !== 'cancelled') return;
+  if (!t.lastSessionId) return;
+  if (notice.by === t.assignee) return;               // the delegate parked itself — it already knows
+  if (!tm.isAlive(t.lastSessionId)) return;           // nothing running to interrupt
+  const note = os.tasks.latestNote(t.id) || '(no reason given)';
+  const who = notice.by.startsWith('agent:') ? notice.by.slice('agent:'.length) : (os.team.getMember(notice.by)?.name ?? 'a teammate');
+  const verb = t.status === 'cancelled' ? 'CANCELLED' : 'put on HOLD';
+  const ok = tm.deliverToResident(t.lastSessionId,
+    `⛔ ${who} ${verb} the task you are working (${t.id}). Reason: ${note} — stop what you are doing, do not deploy or publish anything, and confirm you have stood down.`);
+  os.audit.append({
+    ts: Date.now(), runId: t.lastSessionId, tenant: os.tenant,
+    principal: notice.by.startsWith('agent:') ? notice.by : `member:${notice.by}`,
+    type: 'task.hold.delivered', data: { task: t.id, status: t.status, delivered: ok },
+  });
+}
+
+/**
  * Async poke-back. When a delegate closes a `poke_on_done` hand-off — the task reaches a terminal-for-now
  * state (done, or blocked and handed back) — resume the CALLER agent's transcript with the outcome, so a
  * fire-and-forget delegation wakes the caller instead of making it poll. No-op unless the task carries a
@@ -572,6 +599,10 @@ function maybePokeCaller(autos: Automations, os: AgentOS, notice: TaskNotice): v
   const t = notice.task;
   if (!t.pokeOnDone || !t.callerAgent || !t.callerClaudeId) return;
   if (t.status !== 'done' && t.status !== 'blocked') return;
+  // The delegate is USUALLY the actor — but not always: a caller that parks or closes its own hand-off
+  // (a manager blocking work it just delegated) would otherwise wake ITSELF with news it authored. 14 of
+  // these self-pokes across the fleet in 30 days, each one a spurious session. The actor decides.
+  if (notice.by === t.callerAgent) return;
   const delegate = t.assignee?.startsWith('agent:') ? t.assignee.slice('agent:'.length) : (t.assignee ?? 'the delegate');
   const note = os.tasks.latestNote(t.id) || '(no note left)';
   const goal = t.criteria ? ` — goal "${t.criteria}"` : '';

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -42,6 +42,9 @@ import { readConversation, Conversation } from './edge/conversation';
 
 // Video render tuning: a submitted job renders async. The in-call path polls briefly for the fast case;
 // the tick poller finishes the rest, bounded by a TTL + a poll ceiling so a stuck render can't linger.
+/** How long a just-delivered message keeps an unattended run's pane alive at turn-end, so a HOLD or a
+ *  correction typed in seconds before the Stop hook fired still gets read instead of dying with the pane. */
+const DELIVERY_GRACE_MS = 90_000;
 const VIDEO_MAX_DURATION_SEC = 60;         // clamp the requested clip length
 const VIDEO_JOB_TTL_MS = 20 * 60_000;      // give up on a render after 20 minutes
 const VIDEO_MAX_POLLS = 200;               // poll-attempt ceiling (belt-and-suspenders with the TTL)
@@ -2320,7 +2323,12 @@ export class TerminalManager {
   deliverToResident(sessionId: string, text: string): boolean {
     const row = this.db.prepare('SELECT tmux, status, resident, run_as, spawned_by FROM term_sessions WHERE id = ?')
       .get<{ tmux: string; status: string; resident: number; run_as: string | null; spawned_by: string | null }>(sessionId);
-    if (!row || !row.resident || row.status !== 'running') return false;
+    // Any LIVE claude pane can be typed into — `resident` marks a warm chat session, not "reachable".
+    // Gating on it made every unattended (task/automation) run unreachable: a task-discussion HOLD could
+    // not reach the agent executing the task, and `continueTaskThread` fell through to spawning a SECOND
+    // agent on the same task while the first kept working. Observed live on instapods 2026-08-06
+    // (tsk_67de2dfe): the stand-down went to a fresh run, the real one ran on for 25+ minutes.
+    if (!row || row.status !== 'running') return false;
     if (!this.isAlive(sessionId)) return false;
     const body = (text || '').replace(/\r?\n+/g, ' ').trim(); // one-line: a stray newline would submit early
     if (!body) return false;
@@ -2752,11 +2760,24 @@ export class TerminalManager {
     this.db.prepare('UPDATE term_sessions SET last_activity = ? WHERE id = ?').run(Date.now(), sessionId);
     if (r.claimed_by) return;                       // taken over → sticky, the human owns its lifecycle
     if (this.hasPendingHumanBlock(sessionId)) return; // waiting on an answer/approval → keep the pane alive
+    // A message was typed in moments ago (a HOLD, a correction, a thread follow-up) — tearing the pane
+    // down now would silently swallow it. Give it one grace window to start the turn that reads it.
+    if (this.deliveredWithin(sessionId, DELIVERY_GRACE_MS)) return;
     const space = this.spaceFor(r.run_as ?? r.spawned_by);
     const alive = this.backend.aliveNames();
     if (alive && !alive.has(r.tmux)) return;         // pane already gone (already reaped) — nothing to do
     if (this.backend.hasClient(space, r.tmux) === true) return; // a human is watching live → don't close on them
     this.teardownUnattended(sessionId, space, r.tmux, 'turn-end');
+  }
+
+  /** Was text delivered into this session within `ms`? Reads the `chat.delivered` / `session.inject`
+   *  audit rows the two delivery paths already write, so nothing new is stored. Guards the turn-end
+   *  teardown against swallowing a message that arrived a second before the Stop hook fired. */
+  private deliveredWithin(sessionId: string, ms: number): boolean {
+    const row = this.db
+      .prepare("SELECT 1 AS hit FROM audit_events WHERE run_id = ? AND type IN ('chat.delivered','session.inject') AND ts > ? LIMIT 1")
+      .get<{ hit: number }>(sessionId, Date.now() - ms);
+    return !!row;
   }
 
   /** Close a finished unattended run: snapshot its pane for the console transcript view, mark it done

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3329,6 +3329,34 @@ function ChainAction({ item, onDone }: { item: ChainPending; onDone: () => void 
   )
 }
 
+/** Steer a delegate you are not attached to: type into its live pane from the caller's rail. The lever a
+ *  chain was missing — until now the only way to stop a running delegate was to open its terminal (or
+ *  file a task comment, which reached a NEW run rather than the working one). */
+function ChainSay({ node, onSent }: { node: ChainNode; onSent: () => void }) {
+  const [text, setText] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const send = async () => {
+    const body = text.trim()
+    if (!body) return
+    setBusy(true); setErr('')
+    const r = await api.injectToSession(node.sessionId, body)
+    setBusy(false)
+    if (r.error) setErr(r.error)
+    else { setText(''); onSent() }
+  }
+  return (
+    <form className="mt-1.5 flex gap-1" onClick={(e) => e.stopPropagation()} onSubmit={(e) => { e.preventDefault(); void send() }}>
+      <Input value={text} onChange={(e) => setText(e.target.value)} disabled={busy}
+        placeholder={`Message ${node.agent}…`} className="h-6 text-[11px]" />
+      <Button size="xs" type="submit" disabled={busy || !text.trim()} title={`type this into ${node.agent}'s live session`}>
+        <Send className="h-3 w-3" />
+      </Button>
+      {err && <span className="text-[10px] text-red-600">{err}</span>}
+    </form>
+  )
+}
+
 /**
  * The hand-off tree beside the terminal — "where is this piece of work, and who is blocked?".
  *
@@ -3419,6 +3447,7 @@ function ChainRail({ chain, session, open, onToggle, onReload, onOpen }: {
                 </p>
               )}
             </button>
+            {st.live && !here && <div className="px-2.5 pb-2"><ChainSay node={n} onSent={load} /></div>}
             </div>
           )
         })}


### PR DESCRIPTION
Found by reading a chain that was failing **while I was looking at it** — `tsk_67de2dfe` on instapods, 2026-08-06.

## The incident

| time | event |
|---|---|
| 14:58:05 | `marketing-manager` files pSEO batch-1 → auto-dispatches `marketing-site` (`ses_5732879a`) |
| 14:58:40 | manager sets the task **blocked** + comments *"HOLD — do not build or deploy yet"* |
| 14:58:40 | the poke-back fires **at marketing-manager**, which caused the transition itself |
| 14:58:47 | the HOLD comment **spawns a second** `marketing-site` run |
| 14:59:03 | the second run stands down — "no work performed" |
| +25 min | **the first run is still building.** It never saw the HOLD. |

**Root cause:** `deliverToResident` refused any session with `resident = 0`. Unattended runs are attachable TUIs now (not `claude -p`), but the message channel still treated them as unreachable — so `continueTaskThread` fell through to spawning a rival worker, and `markDispatched` re-pointed `last_session_id` at it, orphaning the run that was actually executing.

## Fixes

- **Any LIVE pane can be delivered into**, unattended or not.
- **Turn-end teardown defers** while a message delivered in the last 90 s is unread (`DELIVERY_GRACE_MS`), so a HOLD typed a second before the Stop hook fires isn't swallowed with the pane.
- **`blocked`/`cancelled` by anyone but the executing agent injects the reason into the live run** (`task.hold.delivered`) — the row and the work stop together.
- **The discussion path reports an undeliverable live run** instead of duplicating the worker.
- **No self-pokes** — the poke assumed the delegate is always the actor; a caller parking its own hand-off falsifies that. **14** spurious wake-up sessions across the fleet in 30 days.
- **`dispatchTask` refuses a `blocked` task on guarded paths** — it refused `done`/`cancelled` but not `blocked`, so `task_dispatch`, `task_wait`'s polling kick and app dispatch all sailed past a deliberate stop. **45** tasks dispatched 2+ times in 30 days, **23 within 60 s**. A human forcing it from the console still works — that *is* the un-park.
- **Chain rail gains a composer on every live node** — steer a delegate you aren't attached to (`POST /api/sessions/:id/inject`).

## Verification

- `chain-model-test.cjs` → **50 assertions**, adding a replay of this incident: an unattended run is deliverable, a finished one isn't, a blocked task refuses a guarded dispatch but not a forced one, and an undeliverable live run is reported rather than duplicated (asserting no rival row is created).
- Full `npm run test:governance`, `npm run typecheck`, both builds, `npm run demo` — clean.
- Fleet numbers above measured directly against the instapods and instawp databases (30-day windows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)