### PR TITLE
chore(deploy): make-live as a script, with the verification the manual steps skipped (v0.315.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.315.2] — 2026-08-06
+### Added
+- **`scripts/make-live.sh` — the instapods deploy, as a script instead of a retyped sequence.** "Make it
+  live" was five manual steps against the dedicated live checkout (`~/agent-os-live`), and the manual
+  version skipped verification often enough to matter: nothing checked that the running process actually
+  reported the version just built — the difference between "the change is live" and "a long-running
+  server is still holding the old code in memory". The script syncs to `origin/main` (refusing to
+  `reset --hard` over local changes without `--force`), installs dependencies only when a lockfile
+  actually moved, builds both bundles, gates on `npm run test:governance`, restarts with
+  `launchctl kickstart` — never `pkill -f "dist/cli.js serve"`, which is shared by every tenant on the
+  box and took prod down on 2026-08-01 — then polls `/health` until it reports the built version, and
+  prints the exact rollback command if it never does. A build or test failure aborts BEFORE the restart,
+  so a bad commit leaves the running server untouched. `--dry-run` shows what would deploy.
+  Instapods-specific by design (paths/label/port are env-overridable); other tenants have their own
+  service and home.
+
 ## [0.315.1] — 2026-08-06
 ### Fixed
 - **Starting a chat no longer blocks — on the server or on screen.** Sessions and tasks got fast; chat

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,13 @@ running such a script, or you will pollute live data.
   `instapods` tenant runs under launchd as `com.agentos.instapods` (`~/Library/LaunchAgents/com.agentos.instapods.plist`,
   KeepAlive, home `~/agent-os-data/instapods` (kept OUTSIDE the repo checkout so a spawned agent's
   parent-dir CLAUDE.md walk can't pick up this repo's own CLAUDE.md; new tenants go alongside as
-  `~/agent-os-data/<slug>`), on :3010, fronted by `tailscale serve` http→3010): rebuild + bounce with
-  `npm run build && launchctl kickstart -k gui/$(id -u)/com.agentos.instapods`; logs at `~/agent-os-data/instapods/server.log`;
-  load/unload with `launchctl load -w|unload <plist>`.)
+  `~/agent-os-data/<slug>`), on :3010, fronted by `tailscale serve` http→3010): **"make it live" is
+  `scripts/make-live.sh`** — it syncs the dedicated live checkout (`~/agent-os-live`) to `origin/main`,
+  installs only if a lockfile moved, builds both bundles, gates on `npm run test:governance`, restarts
+  via `launchctl kickstart` (never `pkill`), and verifies `/health` reports the version it just built,
+  printing the rollback command if it doesn't. `--dry-run` shows what would deploy. The manual
+  equivalent is `npm run build && launchctl kickstart -k gui/$(id -u)/com.agentos.instapods`; logs at
+  `~/agent-os-data/instapods/server.log`; load/unload with `launchctl load -w|unload <plist>`.)
 - **Agent-facing MCP tools (`src/memory/memory-mcp.ts` — `recall`/`remember`/`revise`/`forget`, the
   `kb_*` tools, `ask`/`check_inbox`/`report`/`update`/`publish`/`library_list`, `schedule`/`unschedule`,
   …; full list in `docs/agent-mcp-tools.md`):** changing a tool's SCHEMA needs `npm run build` **+ relaunch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.315.1",
+  "version": "0.315.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.315.1",
+      "version": "0.315.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.315.1",
+  "version": "0.315.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/make-live.sh
+++ b/scripts/make-live.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# "Make it live" — deploy origin/main to the instapods tenant on this Mac Mini.
+#
+# The live service runs from a DEDICATED checkout (/Users/vmini/agent-os-live), decoupled from the
+# shared primary checkout that several sessions edit concurrently, and is supervised by launchd
+# (com.agentos.instapods → scripts/run-tenant.sh instapods … :3010). Deploying is always the same
+# five steps — sync, install if deps moved, build both bundles, restart, verify — so they live here
+# instead of being retyped.
+#
+#   scripts/make-live.sh                 # deploy origin/main
+#   scripts/make-live.sh --dry-run       # show what WOULD deploy, change nothing
+#   scripts/make-live.sh --skip-tests    # skip the governance suite gate
+#   scripts/make-live.sh --force         # discard local changes in the live checkout
+#
+# Deliberately instapods-only: every other tenant on this box (and every Linux box) has its own
+# service, home and port. Override via env if that ever changes:
+#   AOS_LIVE_CHECKOUT  AOS_LIVE_LABEL  AOS_LIVE_PORT  AOS_LIVE_LOG  AOS_LIVE_REF
+#
+# Safety properties worth keeping:
+#  - Nothing is restarted until the build AND the tests pass, so a broken commit leaves the running
+#    server untouched (it holds the old code in memory).
+#  - The restart is `launchctl kickstart`, never `pkill -f "dist/cli.js serve"` — that command line is
+#    shared by every tenant process on this box and killing it took prod down on 2026-08-01.
+#  - A failed health check prints the exact rollback command rather than guessing.
+set -euo pipefail
+
+CHECKOUT="${AOS_LIVE_CHECKOUT:-$HOME/agent-os-live}"
+LABEL="${AOS_LIVE_LABEL:-com.agentos.instapods}"
+PORT="${AOS_LIVE_PORT:-3010}"
+LOG="${AOS_LIVE_LOG:-$HOME/agent-os-data/instapods/server.log}"
+REF="${AOS_LIVE_REF:-origin/main}"
+
+DRY=0; SKIP_TESTS=0; FORCE=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run)    DRY=1 ;;
+    --skip-tests) SKIP_TESTS=1 ;;
+    --force)      FORCE=1 ;;
+    -h|--help)    sed -n '2,20p' "$0"; exit 0 ;;
+    *)            echo "unknown option: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+say()  { printf '\033[36m%s\033[0m\n' "$*"; }
+fail() { printf '\033[31m%s\033[0m\n' "$*" >&2; exit 1; }
+
+[ -d "$CHECKOUT/.git" ] || fail "no live checkout at $CHECKOUT (set AOS_LIVE_CHECKOUT)"
+command -v launchctl >/dev/null || fail "launchctl not found — this script is for the macOS box"
+launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || fail "launchd job $LABEL is not loaded (launchctl load -w ~/Library/LaunchAgents/$LABEL.plist)"
+
+cd "$CHECKOUT"
+git fetch -q origin
+OLD="$(git rev-parse HEAD)"
+NEW="$(git rev-parse "$REF")"
+
+# What's about to land — the operator should see this before anything restarts.
+if [ "$OLD" = "$NEW" ]; then
+  say "already at $(git rev-parse --short "$NEW") — rebuilding + restarting anyway"
+else
+  say "deploying $(git rev-parse --short "$OLD") → $(git rev-parse --short "$NEW")"
+  git --no-pager log --oneline "$OLD..$NEW" | sed 's/^/  /'
+fi
+
+# A dedicated checkout should never be dirty; if it is, someone edited the live tree by hand and a
+# reset would silently destroy that work. Show it and stop.
+DIRTY="$(git status --porcelain)"
+if [ -n "$DIRTY" ] && [ "$FORCE" -ne 1 ]; then
+  echo "$DIRTY" | sed 's/^/  /'
+  fail "live checkout has local changes (above) — rerun with --force to discard them"
+fi
+
+if [ "$DRY" -eq 1 ]; then say "dry run — nothing changed"; exit 0; fi
+
+START=$(date +%s)
+git reset --hard -q "$NEW"
+
+# Dependencies only when the lockfiles actually moved (a full install on every deploy is ~30s of
+# nothing). `git diff --quiet` between the two commits is the honest test.
+if [ "$OLD" != "$NEW" ]; then
+  if ! git diff --quiet "$OLD" "$NEW" -- package-lock.json package.json; then
+    say "root deps changed → npm install"
+    npm install --no-audit --no-fund >/dev/null
+  fi
+  if ! git diff --quiet "$OLD" "$NEW" -- web/package-lock.json web/package.json; then
+    say "web deps changed → npm install"
+    (cd web && npm install --no-audit --no-fund >/dev/null)
+  fi
+fi
+
+# Build output is captured, not streamed: tsc says nothing on success and vite writes its chunk-size
+# advice to stderr on every run. On failure the log is printed, so nothing is actually hidden.
+BUILD_LOG=/tmp/aos-make-live-build.log
+say "building server"
+npm run build >"$BUILD_LOG" 2>&1 \
+  || { tail -30 "$BUILD_LOG" >&2; fail "server build failed — live server untouched, still on $(git rev-parse --short "$OLD")"; }
+say "building console"
+(cd web && npm run build >"$BUILD_LOG" 2>&1) \
+  || { tail -30 "$BUILD_LOG" >&2; fail "web build failed — live server untouched, still on $(git rev-parse --short "$OLD")"; }
+
+if [ "$SKIP_TESTS" -eq 1 ]; then
+  say "skipping governance suite (--skip-tests)"
+else
+  say "running governance suite"
+  npm run test:governance >/tmp/aos-make-live-tests.log 2>&1 \
+    || { tail -20 /tmp/aos-make-live-tests.log >&2; fail "governance suite failed — NOT restarting (still serving $(git rev-parse --short "$OLD"))"; }
+  tail -1 /tmp/aos-make-live-tests.log
+fi
+
+VERSION="$(node -p "require('$CHECKOUT/package.json').version")"
+say "restarting $LABEL"
+launchctl kickstart -k "gui/$(id -u)/$LABEL"
+
+# Verify the running process actually reports the version we just built — the single check that tells
+# "the change took effect" apart from "a long-running server is still holding the old code".
+LIVE=""
+for _ in $(seq 1 30); do
+  sleep 1
+  LIVE="$(curl -fsS --max-time 2 "http://127.0.0.1:$PORT/health" 2>/dev/null || true)"
+  case "$LIVE" in *"\"version\":\"$VERSION\""*) break ;; esac
+done
+
+case "$LIVE" in
+  *"\"version\":\"$VERSION\""*)
+    say "live: $LIVE"
+    say "done in $(( $(date +%s) - START ))s — $(git rev-parse --short "$NEW") @ v$VERSION"
+    ;;
+  *)
+    echo "--- last 30 lines of $LOG ---" >&2
+    tail -30 "$LOG" >&2 || true
+    fail "health check never reported v$VERSION (last response: ${LIVE:-none}).
+Roll back with:
+  git -C $CHECKOUT reset --hard $OLD && (cd $CHECKOUT && npm run build && cd web && npm run build) && launchctl kickstart -k gui/$(id -u)/$LABEL"
+    ;;
+esac


### PR DESCRIPTION
"Make it live" on this Mac Mini was five retyped steps against the dedicated live checkout (`~/agent-os-live` → launchd `com.agentos.instapods` → `:3010`). The step that kept getting skipped is the one that matters: **confirming the running process reports the version just built** — the difference between "the change is live" and "a long-running server is still holding the old code in memory".

`scripts/make-live.sh`:

1. `git fetch` + show the commits about to land; **refuses** to `reset --hard` over local changes in the live checkout without `--force` (it prints them first).
2. `npm install` only when a lockfile actually moved between the two commits — root and `web/` independently.
3. Builds both bundles (output captured; printed only on failure, since `tsc` says nothing on success and vite writes chunk advice to stderr every run).
4. Gates on `npm run test:governance`.
5. Restarts with `launchctl kickstart -k` — **never** `pkill -f "dist/cli.js serve"`, which is shared by every tenant process on this box and took prod down on 2026-08-01.
6. Polls `/health` until it reports the built version; on failure tails `server.log` and prints the exact rollback command.

A build or test failure aborts **before** the restart, so a bad commit leaves the running server untouched.

```
scripts/make-live.sh              # deploy origin/main
scripts/make-live.sh --dry-run    # show what would deploy, change nothing
scripts/make-live.sh --skip-tests
scripts/make-live.sh --force      # discard local changes in the live checkout
```

Instapods-specific by design — every other tenant here (and every Linux box) has its own service, home and port. `AOS_LIVE_CHECKOUT` / `AOS_LIVE_LABEL` / `AOS_LIVE_PORT` / `AOS_LIVE_LOG` / `AOS_LIVE_REF` override if that changes.

## Verification

Exercised against the real instapods service:

```
building server / building console
running governance suite
19 passed, 0 failed
restarting com.agentos.instapods
live: {"ok":true,"tenant":"instapods","name":"Instapods","version":"0.315.1"}
done in 12s — 8891bec @ v0.315.1
```

Guards checked individually: dirty checkout (lists the files, aborts), unknown option, missing launchd job, `--dry-run` (changes nothing).

`CLAUDE.md`'s deploy note now points at the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)