### PR TITLE
feat(goals): maturity-tiered goal_update — agents can edit an existing goal (v0.318.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.318.0] — 2026-08-07
+### Added
+- **`goal_update` — agents can now edit an EXISTING goal, on a maturity tier.** Until now the agent goal
+  surface was read + propose-a-draft only (`goal_list`/`goal_get`/`goal_propose`); there was no way for an
+  agent to change a live goal's status or fields. `goal_update` adds that on the **same three-lane trust
+  model as `agent_propose_update`** (the shared `agentProposalTrust` config): below `minMaturity` → refused;
+  middle band → a `goal.update.proposed` review card that applies nothing until an owner/admin approves
+  (`POST /api/goals/proposals/:id/approve`); at/above `autoApplyAt` → applied immediately via
+  `GoalStore.update`, owner notified after. A **"shape beats score"** rule (mirroring the agent path's
+  destructive-rewrite demotion) keeps the steering-wheel transitions — **activating, abandoning, or
+  reopening a goal, or claiming an unfinished one is `achieved`** — in the human-review lane at *every*
+  tier; the only status change a top-tier agent auto-applies is marking a goal `achieved` whose linked work
+  is already 100% done. Every applied edit (auto or approved) is event-logged in `goal_events` (author =
+  the agent on the auto lane, the approving human on the gated one), so it's revertable; `dryRun` names the
+  lane without writing. Console: an owner/admin review card in the Goal room sidebar + a `goal.update.proposed`
+  inbox card. Pinned by `scripts/goal-update-guard-test.cjs` (wired into `test:governance`).
+- **Goal console deep-links in the agent tools.** `goal_get`, `goal_propose`, and `goal_update` now return
+  the `…/#/goals/<id>` console link, so an agent can hand a human a clickable pointer to the goal it read,
+  proposed, or edited.
+
 ## [0.317.0] — 2026-08-06
 ### Added
 - **`agent_get` — agents can finally READ a prompt before replacing it.** `agent_update` /

--- a/docs/agent-mcp-tools.md
+++ b/docs/agent-mcp-tools.md
@@ -52,7 +52,8 @@ can only ever act as its own session; the namespace/tenant/policy are enforced s
 | `task_dispatch` | `POST /api/tasks/dispatch` | `Automations.dispatchTask` | W | spawns a governed session NOW for an agent-assigned task (async hand-off, distinct from `task_claim`); `guard:true` (no pile-up) + `TASK_MAX_ATTEMPTS` ceiling; run-as = task owner; audited `task.dispatched` (`by:agent:<id>`) |
 | `goal_list` | `GET /api/goals/list` | `GoalStore.list` | R | the strategic layer (company goals); filter by `status`/`query`; read-only |
 | `goal_get` | `GET /api/goals/get` | `GoalStore.withEvents` + `.progress` + `TaskStore.tasksForGoal` | R | one goal + its full activity timeline + **derived progress** (% from linked tasks) + the linked tasks |
-| `goal_propose` | `POST /api/goals/propose` | `GoalStore.create` (status `draft`) + `TerminalManager.postGoalCard` | W | drafts a NOT-YET-ACTIVE goal + posts a `goal.proposed` inbox card to admins; owner = run-as; auto-apply + audited `goal.proposed`. Agents READ + PROPOSE only — activating/editing a goal is a human owner/admin console action (no agent write path) |
+| `goal_propose` | `POST /api/goals/propose` | `GoalStore.create` (status `draft`) + `TerminalManager.postGoalCard` | W | drafts a NOT-YET-ACTIVE goal + posts a `goal.proposed` inbox card to admins; owner = run-as; auto-apply + audited `goal.proposed` |
+| `goal_update` | `POST /api/goals/update` | `TerminalManager.proposeGoalUpdate` → `GoalStore.update` | W | edit an EXISTING goal (status/title/body/target/labels/dueAt/note) with a required `rationale`, **maturity-tiered** on the shared `agentProposalTrust` (like `agent_propose_update`): below `minMaturity` → refused; middle band → a `goal.update.proposed` review card (nothing applied); ≥ `autoApplyAt` → applied immediately, owner notified. **Shape beats score:** activating / abandoning / reopening a goal, or a premature `achieved`, ALWAYS demote to human review whatever the tier; only ordinary edits + `achieved`-at-100% auto-apply. Owner/admin approve at `POST /api/goals/proposals/:id/approve`. Revertable via the `goal_events` log. `dryRun` names the lane without writing |
 | `agent_create` | `POST /api/agents/create` | `AgentOS.registerAgent` | W | writes `<home>/agents/<id>/{agent.json,CLAUDE.md}` + registers live; author `agent:<id>`; audited `agent.created` |
 | `agent_get` | `POST /api/agents/get` | `readAgentSnapshot` | R | reads an agent's current editable config **including the full CLAUDE.md** + a `baseHash`; defaults to self, any user-home claude-code agent is readable (the same set `agent_propose_update` can target); a cross-agent read is audited `agent.config.read` |
 | `agent_update` | `POST /api/agents/update` | `applyAgentEdit` + `AgentRevisions.commit` | W | **self-only** (edits the caller's OWN manifest/CLAUDE.md — a body `id` must equal the session's agent); user-home agents only; accepts `claudeMdEdits`/`claudeMdAppend` (anchored patch) as well as a full `claudeMd`; `baseHash` precondition, `dryRun`, and a destructive-rewrite guard needing `confirmRewrite`; snapshots a revision; audited `agent.config.updated` |
@@ -301,13 +302,14 @@ only, never `id === self`), plus a 10-open queue cap and identical-delta dedupe.
 proposals on the **agent page → "Proposed edits from other agents"** card (owner-only, with a full
 CLAUDE.md before→after).
 
-### `goal_list` / `goal_get` / `goal_propose` — the strategic layer (read + propose only)
+### `goal_list` / `goal_get` / `goal_propose` / `goal_update` — the strategic layer
 
 Goals are the tier **above** the task board — the tenant-wide, human-owned *direction* the whole fleet
-orients to: **Goal → Task → session**. The agent surface is deliberately **read + propose only**, mirroring
-the propose-not-apply posture of `policy_propose` / `skill_propose`, because activating or editing a goal
-steers the entire fleet — a steering-wheel decision reserved for a human owner/admin (there is **no agent
-write path** to activate, edit, achieve, or abandon a goal, only to *suggest* one).
+orients to: **Goal → Task → session**. Agents **read** freely (`goal_list`/`goal_get`, which also carry the
+console deep-link `…/#/goals/<id>` so an agent can hand a human a clickable link), **propose new** directions
+(`goal_propose`, always a `draft`), and **edit existing** goals under a maturity tier (`goal_update`). The
+load-bearing steering-wheel acts — activating, abandoning, or reopening a goal, or claiming an unfinished one
+is done — stay human decisions even for the most trusted agent.
 
 - **Read** — `goal_list` (filter by `status`/`query`) surfaces the active direction so an agent can orient
   its work toward a goal; `goal_get` returns one goal + its full activity timeline + **derived progress**
@@ -320,7 +322,19 @@ write path** to activate, edit, achieve, or abandon a goal, only to *suggest* on
   planner trigger — inert until a human activates it) and posts a `goal.proposed` inbox card to admins;
   `owner` = the run-as human (delegation passthrough). Like `kb_write` / `task_create` it's **auto-apply +
   audited** (`goal.proposed`), not gate-suspended — the draft is harmless until promoted, and the append-only
-  `goal_events` log is the safety net. Humans activate/edit/close a goal only from the console Goals page.
+  `goal_events` log is the safety net.
+- **Edit** — `goal_update` changes an EXISTING goal, keyed on the proposer's **maturity** against the shared
+  `agentProposalTrust` tiers (the same config that governs `agent_propose_update` — Settings → Runtime →
+  Cross-agent edits): below `minMaturity` (0.4) → **refused**; middle band → a `goal.update.proposed` review
+  card, **nothing applied**, an owner/admin approves at `POST /api/goals/proposals/:id/approve`; at/above
+  `autoApplyAt` (0.8) → **applied immediately** via `GoalStore.update`, owner notified after. A **"shape beats
+  score"** rule (mirroring the agent path's destructive-rewrite demotion) forces the steering transitions —
+  **activate / abandon / reopen-to-draft / claim-`achieved`-while-unfinished** — to the human-review lane
+  *whatever* the tier; the only status change a top-tier agent auto-applies is marking a goal `achieved` whose
+  linked work is already 100% done (the console's "Mark achieved" affordance). Every applied edit — auto or
+  approved — is event-logged in `goal_events` (author = the agent on the auto lane, the approving human on the
+  gated one), so it's revertable, and `dryRun` names the lane without writing. Pinned by
+  `scripts/goal-update-guard-test.cjs`.
 
 Linkage flows the other way through the **Tasks** tools, not a goal write: an agent connects work to a goal
 with `task_create({ goalId })` / `task_update({ goalId })` (a sub-task inherits its parent's `goalId`), and

--- a/docs/goals-plan.md
+++ b/docs/goals-plan.md
@@ -275,8 +275,14 @@ activating goals.
 
 ## Out of scope (both slices)
 
-- **Agent-authored strategy with real authority.** Humans own goals + acceptance criteria; agents `goal_list`/
-  `goal_get`/`goal_propose` only. No `goal_update`/activation by agents.
+- ~~**Agent-authored strategy with real authority.** Humans own goals + acceptance criteria; agents `goal_list`/
+  `goal_get`/`goal_propose` only. No `goal_update`/activation by agents.~~ **Superseded (v0.317.0):** agents
+  now have a **maturity-tiered** `goal_update` — the same three-lane trust model as `agent_propose_update`
+  (`agentProposalTrust`). It is NOT open write: below the maturity floor it's refused, and a **"shape beats
+  score"** rule keeps the steering-wheel transitions (activate / abandon / reopen / premature-`achieve`) in the
+  human-review lane at *every* tier. Only ordinary edits and rubber-stamping an already-100%-done goal as
+  `achieved` auto-apply for a proven agent (owner notified, revertable via `goal_events`). Acceptance criteria
+  (`criteria`/`/goal`) remain a per-task field, not goal state. See `docs/agent-mcp-tools.md`.
 - **Structured numeric metrics.** v1 uses task-completion-derived progress + a free-text `target` caption.
   Real metrics (a number an automation writes, dashboards) come later, once we know what's worth measuring.
 - **Per-agent missions.** If direction turns out to be role-specific rather than company-wide, that's the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.317.0",
+  "version": "0.318.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.317.0",
+      "version": "0.318.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.317.0",
+  "version": "0.318.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,7 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/warm-chat-test.cjs && node scripts/agent-edit-guard-test.cjs",
+    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/warm-chat-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:deps": "node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",

--- a/scripts/goal-update-guard-test.cjs
+++ b/scripts/goal-update-guard-test.cjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/* goal_update — the maturity-tiered agent write path over EXISTING goals.
+ *
+ * Goals are human-owned strategy: agents could only read (goal_list/goal_get) and draft new ones
+ * (goal_propose). goal_update lets a proven agent edit an existing goal, on the same three-lane trust
+ * model as agent_propose_update — but with a "shape beats score" rule tuned to strategy: the
+ * steering-wheel transitions (activate / abandon / reopen-to-draft / claim-achieved-while-unfinished)
+ * ALWAYS go to a human, whatever the proposer's maturity. Only ordinary edits and rubber-stamping an
+ * already-100%-done goal as achieved auto-apply at the top tier.
+ *
+ * This pins those lanes end to end: the refusal below the floor, the always-gated steering transitions
+ * even at a forced top tier, the auto-apply of a safe edit, the achieved-at-100% exception, the approve
+ * route that applies a gated proposal, and dryRun writing nothing.
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-goal-update-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d !== undefined ? ' — ' + JSON.stringify(d).slice(0, 400) : ''}`));
+
+(async () => {
+  const { createHttpServer } = require(path.join(ROOT, 'dist/server.js'));
+  const { TenantRegistry } = require(path.join(ROOT, 'dist/tenant-registry.js'));
+  const registry = new TenantRegistry(ROOT, 0, path.join(ROOT, 'config/agent-os.config.json'));
+  registry.bootAll();
+  const { os: aos, tm } = registry.default();
+  const server = createHttpServer(registry);
+  await new Promise((r) => server.listen(0, '127.0.0.1', r));
+  const base = `http://127.0.0.1:${server.address().port}`;
+
+  // A claude-code agent to act as the proposer.
+  const dir = path.join(aos.paths.userAgents, 'planner-bot');
+  fs.mkdirSync(dir, { recursive: true });
+  const manifest = { id: 'planner-bot', version: '1.0.0', description: 'planner', principal: 'svc-planner-bot', policyContext: 'default@v3', runtime: 'claude-code' };
+  fs.writeFileSync(path.join(dir, 'agent.json'), JSON.stringify(manifest, null, 2) + '\n');
+  fs.writeFileSync(path.join(dir, 'CLAUDE.md'), '# Planner\n\nPlan the work.\n');
+  aos.registerAgent({ ...manifest, dir });
+  const AGENT = 'planner-bot';
+
+  const session = tm.createSession(AGENT, 'goal edit test', 'task');
+  const secret = aos.db.prepare('SELECT secret FROM term_sessions WHERE id = ?').get(session.id).secret;
+  const call = async (p, body) => {
+    const res = await fetch(base + p, { method: 'POST', headers: { 'content-type': 'application/json', 'x-aos-secret': secret }, body: JSON.stringify({ session: session.id, ...body }) });
+    return res.json();
+  };
+  const statusOf = (id) => aos.goals.get(id).status;
+
+  const draft = aos.goals.create({ tenant: aos.tenant, title: 'Grow signups', body: 'why', status: 'draft', createdBy: 'owner-seed' });
+  const active = aos.goals.create({ tenant: aos.tenant, title: 'Ship the console', body: 'why', status: 'active', createdBy: 'owner-seed' });
+
+  console.log('\n\x1b[1m1) below the trust floor — an unproven agent is refused\x1b[0m');
+  {
+    // Default trust floor is 0.4; a brand-new agent has maturity 0.
+    const r = await call('/api/goals/update', { id: active.id, rationale: 'tweak the target', target: 'x' });
+    assert(r.ok === false && r.outcome === 'refused' && /maturity/i.test(r.error || ''), 'refused, and the error explains maturity', r);
+    assert(aos.goals.get(active.id).target === undefined, 'nothing was written', { target: aos.goals.get(active.id).target });
+  }
+
+  // Force the top tier so ONLY the shape rule can gate a change.
+  aos.settings.setAgentProposalTrust({ minMaturity: 0, autoApplyAt: 0, autoApply: true }, 'test');
+
+  console.log('\n\x1b[1m2) the steering-wheel transitions always wait for a human — even at the top tier\x1b[0m');
+  {
+    const r = await call('/api/goals/update', { id: draft.id, rationale: 'this is ready to steer the fleet', status: 'active' });
+    assert(r.ok && r.outcome === 'pending_approval', 'activating a draft goal is held for review', r);
+    assert(statusOf(draft.id) === 'draft', 'the goal is still a draft — nothing applied', { status: statusOf(draft.id) });
+    assert(/NOTHING has changed yet/.test(r.message || ''), 'and the reply says so plainly', r.message);
+  }
+  {
+    const r = await call('/api/goals/update', { id: active.id, rationale: 'we are dropping this bet', status: 'abandoned' });
+    assert(r.ok && r.outcome === 'pending_approval', 'abandoning a goal is held for review', r);
+    assert(statusOf(active.id) === 'active', 'still active — nothing applied');
+  }
+  {
+    // active goal with no completed linked work → claiming "achieved" is premature → gated.
+    const r = await call('/api/goals/update', { id: active.id, rationale: 'call it done', status: 'achieved' });
+    assert(r.ok && r.outcome === 'pending_approval', 'a premature achieved is held for review', r);
+    assert(statusOf(active.id) === 'active', 'still active — nothing applied');
+  }
+
+  console.log('\n\x1b[1m3) an ordinary edit from a trusted agent applies immediately\x1b[0m');
+  {
+    const r = await call('/api/goals/update', { id: active.id, rationale: 'sharpen the target', target: '20% MoM' });
+    assert(r.ok && r.applied && r.outcome === 'applied', 'a non-status edit auto-applies', r);
+    assert(aos.goals.get(active.id).target === '20% MoM', 'and the goal is actually updated', { target: aos.goals.get(active.id).target });
+    assert(/APPLIED/.test(r.message) && /#\/goals\//.test(r.message), 'the reply is unambiguous it is LIVE and carries the goal URL', r.message);
+  }
+
+  console.log('\n\x1b[1m4) achieved auto-applies ONLY when the linked work is already 100% done\x1b[0m');
+  {
+    const done = aos.goals.create({ tenant: aos.tenant, title: 'Finish the migration', status: 'active', createdBy: 'owner-seed' });
+    const t = aos.tasks.create({ tenant: aos.tenant, title: 'do it', goalId: done.id, createdBy: 'owner-seed' });
+    aos.tasks.update(t.id, { status: 'done', by: 'owner-seed' });
+    assert(aos.goals.progress(done.id).percent === 100, 'the goal is 100% done by its linked tasks', aos.goals.progress(done.id));
+    const r = await call('/api/goals/update', { id: done.id, rationale: 'all filed work is complete', status: 'achieved' });
+    assert(r.ok && r.outcome === 'applied', 'marking an already-complete goal achieved auto-applies', r);
+    assert(statusOf(done.id) === 'achieved', 'and the goal is achieved');
+  }
+
+  console.log('\n\x1b[1m5) the approve route applies a gated proposal (owner sign-off)\x1b[0m');
+  {
+    const owner = aos.team.listMembers().find((m) => m.role === 'owner');
+    const cookie = `aos_sid=${aos.team.createSession(owner.id)}`;
+    const cards = await fetch(base + '/api/goals/proposals', { headers: { cookie } }).then((r) => r.json());
+    const card = cards.proposals.find((c) => c.goalId === draft.id && c.fields && c.fields.status === 'active');
+    assert(!!card, 'the activation proposal is in the owner review queue', { n: cards.proposals?.length });
+    const approved = await fetch(base + `/api/goals/proposals/${card.id}/approve`, { method: 'POST', headers: { cookie } }).then((r) => r.json());
+    assert(approved.ok && approved.status === 'active', 'approving it activates the goal', approved);
+    assert(statusOf(draft.id) === 'active', 'and the goal is now active');
+    // The event log records the human as the applying author, preserving the proposer in the note.
+    const ev = aos.goals.withEvents(draft.id).events.find((e) => e.kind === 'status' && /→active/.test(e.body || ''));
+    assert(!!ev && ev.author === owner.email, 'the applying author is the approving human, not the agent', ev);
+  }
+
+  console.log('\n\x1b[1m6) dryRun names the lane and writes nothing\x1b[0m');
+  {
+    const before = aos.goals.get(active.id).body;
+    const openBefore = tm.openGoalUpdateProposals().length;
+    const r = await call('/api/goals/update', { id: active.id, rationale: 'just checking', body: 'a rewritten body', dryRun: true });
+    assert(r.ok && r.outcome === 'dry_run', 'dryRun reports the lane', r);
+    assert(aos.goals.get(active.id).body === before, 'and writes absolutely nothing');
+    assert(tm.openGoalUpdateProposals().length === openBefore, 'and queues no card');
+  }
+
+  console.log('\n\x1b[1m7) a no-op edit is refused, not silently "applied"\x1b[0m');
+  {
+    const r = await call('/api/goals/update', { id: active.id, rationale: 'no change', target: '20% MoM' });
+    assert(r.ok === false && /nothing to change/i.test(r.error || ''), 'passing the goal\'s current values changes nothing', r);
+  }
+
+  server.close();
+  console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m`);
+  fs.rmSync(HOME, { recursive: true, force: true });
+  process.exit(fail ? 1 : 0);
+})().catch((e) => { console.error(e); fs.rmSync(HOME, { recursive: true, force: true }); process.exit(1); });

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -1118,8 +1118,8 @@ const TOOLS = [
     description:
       'List the company GOALS — the strategic direction the whole fleet works toward, above the task ' +
       'board. Check this to orient your work: prefer tasks that advance an active goal. Filter by `status` ' +
-      "(default shows all) or a free-text `query`. You cannot change a goal here — that's a human decision " +
-      '(use `goal_propose` to suggest a new one). Read-only.',
+      "(default shows all) or a free-text `query`. Propose a new direction with `goal_propose`, or suggest " +
+      'a change to an existing goal with `goal_update`. Read-only.',
     annotations: { readOnlyHint: true },
     inputSchema: {
       type: 'object',
@@ -1160,6 +1160,35 @@ const TOOLS = [
         labels: { type: 'array', items: { type: 'string' }, description: 'Optional freeform labels.' },
       },
       required: ['title'],
+    },
+  },
+  {
+    name: 'goal_update',
+    description:
+      "Suggest a change to an EXISTING goal's state — its status, title, description, target, labels, or due " +
+      'date — with a required `rationale`. What happens depends on your track record (maturity) and on WHAT ' +
+      'you change: an unproven agent is refused; the steering-wheel transitions — **activating, abandoning, ' +
+      'or reopening a goal, or marking one `achieved` while its linked work is unfinished** — ALWAYS go to a ' +
+      'human owner to approve (nothing changes until they do); ordinary edits and rubber-stamping an ' +
+      'already-100%-done goal as `achieved` apply immediately once you are trusted enough, with an owner ' +
+      'notified. To CREATE a new goal use `goal_propose`; to file work under one use `task_create({ goalId })`. ' +
+      'Pass `dryRun:true` to see which lane your edit would take without writing anything.',
+    inputSchema: {
+      type: 'object',
+      additionalProperties: false,
+      properties: {
+        id: { type: 'string', description: 'The goal id to edit (see goal_list / goal_get).' },
+        rationale: { type: 'string', description: 'Why — the human reviewing (or auditing) the change reads this. Required.' },
+        status: { type: 'string', enum: ['draft', 'active', 'achieved', 'abandoned'], description: 'New status. active/abandoned/draft and a premature achieved always require human approval.' },
+        title: { type: 'string', description: 'New title.' },
+        body: { type: 'string', description: 'New description (the what/why).' },
+        target: { type: 'string', description: 'New free-text target caption ("" clears it).' },
+        labels: { type: 'array', items: { type: 'string' }, description: 'Replace the goal\'s labels.' },
+        dueAt: { type: ['number', 'null'], description: 'New soft deadline (epoch ms), or null to clear it.' },
+        note: { type: 'string', description: 'A comment to append to the goal\'s activity timeline.' },
+        dryRun: { type: 'boolean', description: 'Preview the lane (apply now vs wait for approval) without writing anything.' },
+      },
+      required: ['id', 'rationale'],
     },
   },
   // ── Agents: author new agents (the agent-author's build tools) ──
@@ -2470,7 +2499,7 @@ async function goalGet(args: Record<string, unknown>): Promise<string> {
   const progressLine = p && p.total ? `\nProgress: ${p.percent}% (${p.done}/${p.total} linked tasks done)` : '\nProgress: no tasks linked yet — link work with task_create/task_update({ goalId: "' + g.id + '" }).';
   const taskLines = (d.tasks ?? []).map((t) => `  · [${t.status}] ${t.id} — ${t.title}`).join('\n');
   const tasksSection = d.tasks?.length ? `\n\nLinked tasks:\n${taskLines}` : '';
-  return `${g.id} · [${g.status}]${g.target ? ` · target: ${g.target}` : ''}${progressLine}\n# ${g.title}\n${g.body ?? ''}\n\nActivity:\n${timeline || '  (none)'}${tasksSection}`;
+  return `${g.id} · [${g.status}]${g.target ? ` · target: ${g.target}` : ''}${progressLine}\n${consoleLink('goals', g.id)}\n# ${g.title}\n${g.body ?? ''}\n\nActivity:\n${timeline || '  (none)'}${tasksSection}`;
 }
 
 async function goalPropose(args: Record<string, unknown>): Promise<string> {
@@ -2488,8 +2517,31 @@ async function goalPropose(args: Record<string, unknown>): Promise<string> {
   });
   const d = (await res.json()) as { ok?: boolean; id?: string; error?: string };
   return d.ok
-    ? `Proposed goal ${d.id}: "${title}" — it's a draft in the inbox for an owner/admin to review and activate. It won't steer the fleet until then.`
+    ? `Proposed goal ${d.id}: "${title}" — it's a draft in the inbox for an owner/admin to review and activate. It won't steer the fleet until then.\n${consoleLink('goals', d.id!)}`
     : `Could not propose goal: ${d.error ?? 'unknown error'}`;
+}
+
+async function goalUpdate(args: Record<string, unknown>): Promise<string> {
+  if (!String(args.id ?? '').trim()) return 'goal_update needs the id of the goal to edit (see goal_list).';
+  if (!String(args.rationale ?? '').trim()) return 'goal_update needs a rationale — the human reviewing the change reads it.';
+  const res = await fetch(AOS_URL + '/api/goals/update', {
+    method: 'POST',
+    headers: H({ 'content-type': 'application/json' }),
+    body: JSON.stringify({
+      session: SESSION,
+      id: String(args.id), rationale: String(args.rationale),
+      ...(args.status !== undefined ? { status: String(args.status) } : {}),
+      ...(args.title !== undefined ? { title: String(args.title) } : {}),
+      ...(args.body !== undefined ? { body: String(args.body) } : {}),
+      ...(args.target !== undefined ? { target: String(args.target) } : {}),
+      ...(Array.isArray(args.labels) ? { labels: args.labels.map(String) } : {}),
+      ...('dueAt' in args ? { dueAt: args.dueAt === null ? null : Number(args.dueAt) } : {}),
+      ...(args.note !== undefined ? { note: String(args.note) } : {}),
+      ...(args.dryRun === true ? { dryRun: true } : {}),
+    }),
+  });
+  const d = (await res.json()) as { ok?: boolean; message?: string; error?: string };
+  return d.ok ? (d.message ?? 'Done.') : `Could not update goal: ${d.error ?? 'unknown error'}`;
 }
 
 // ── Agents: author new agents ─────────────────────────────────────────────────
@@ -3132,6 +3184,7 @@ async function handle(req: JsonRpc): Promise<void> {
         : name === 'goal_list' ? await goalList(args)
         : name === 'goal_get' ? await goalGet(args)
         : name === 'goal_propose' ? await goalPropose(args)
+        : name === 'goal_update' ? await goalUpdate(args)
         : name === 'agent_create' ? await agentCreate(args)
         : name === 'agent_get' ? await agentGet(args)
         : name === 'agent_update' ? await agentUpdate(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -1786,6 +1786,19 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       return sendJson(res, 200, { ok: false, error: e instanceof Error ? e.message : String(e) });
     }
   }
+  // Agent proposes an edit to an EXISTING goal's state (`goal_update`) — the maturity-tiered sibling of
+  // goal_propose. Below the trust floor → refused; middle band → a 'goal.update.proposed' review card,
+  // nothing applied; at/above the auto-apply bar → applied immediately (owner notified). The steering-wheel
+  // transitions (activate / abandon / reopen / premature-achieve) always demote to a human. Pre-auth
+  // loopback, session-secret gated (proposer resolved from the session row, not the body).
+  if (method === 'POST' && p === '/api/goals/update') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    const agent = tm.sessionAgent(session);
+    if (!agent) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    return sendJson(res, 200, tm.proposeGoalUpdate(session, agent, b));
+  }
 
   // ── Agents (agent loopback) ──────────────────────────────────────────────────
   // The agent-author (and any agent, as the delegation surface) creates/refines agents AS ITSELF. Like
@@ -2498,6 +2511,50 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const b = await readBody(req);
     tm.setAgentUpdateProposalStatus(card.id, 'rejected');
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.update.proposal.rejected', data: { by: me.email, agent: card.agent, target: card.target, note: b.note ? String(b.note) : undefined } });
+    return sendJson(res, 200, { ok: true });
+  }
+
+  // Agent-proposed edits to EXISTING goals, awaiting human sign-off (the goals twin of /api/agents/proposals).
+  // Editing strategy is an owner/admin act (same gate as activating a goal on the console). Nothing is
+  // applied until approve; the goal_events log makes an approved (or auto-applied) edit revertable.
+  if (method === 'GET' && p === '/api/goals/proposals') {
+    if (me.role !== 'owner' && me.role !== 'admin') return sendJson(res, 403, { error: 'owner or admin required' });
+    const goalId = url.searchParams.get('goal') || undefined;
+    return sendJson(res, 200, { proposals: tm.openGoalUpdateProposals(goalId), canApprove: true });
+  }
+  const goalUpdApprove = p.match(/^\/api\/goals\/proposals\/([\w.-]+)\/approve$/);
+  if (method === 'POST' && goalUpdApprove) {
+    if (me.role !== 'owner' && me.role !== 'admin') return sendJson(res, 403, { error: 'owner or admin required — editing a goal is a steering act' });
+    const card = tm.goalUpdateProposalCard(goalUpdApprove[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such goal-edit proposal' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this proposal was already resolved' });
+    if (!os.goals.get(card.goalId)) { tm.setGoalUpdateProposalStatus(card.id, 'rejected'); return sendJson(res, 200, { ok: false, error: 'the goal no longer exists' }); }
+    // Author = the approving human; the note preserves who proposed it, so the goal_events log names both.
+    const f = card.fields;
+    const updated = os.goals.update(card.goalId, {
+      title: f.title !== undefined ? String(f.title) : undefined,
+      body: f.body !== undefined ? String(f.body) : undefined,
+      status: f.status !== undefined ? (String(f.status) as GoalStatus) : undefined,
+      target: 'target' in f ? (f.target === null ? null : String(f.target)) : undefined,
+      labels: Array.isArray(f.labels) ? f.labels.map(String) : undefined,
+      dueAt: 'dueAt' in f ? (f.dueAt === null ? null : Number(f.dueAt)) : undefined,
+      note: card.note ? `${card.note} (proposed by ${card.agent}, approved by ${me.email})` : `proposed by ${card.agent}, approved by ${me.email}`,
+      by: me.email,
+    });
+    if (!updated) return sendJson(res, 200, { ok: false, error: 'the goal could not be updated' });
+    tm.setGoalUpdateProposalStatus(card.id, 'approved');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'goal.update.proposal.approved', data: { goal: card.goalId, proposer: card.agent, by: me.email, fields: Object.keys(f) } });
+    return sendJson(res, 200, { ok: true, goalId: card.goalId, status: updated.status });
+  }
+  const goalUpdReject = p.match(/^\/api\/goals\/proposals\/([\w.-]+)\/reject$/);
+  if (method === 'POST' && goalUpdReject) {
+    if (me.role !== 'owner' && me.role !== 'admin') return sendJson(res, 403, { error: 'owner or admin required' });
+    const card = tm.goalUpdateProposalCard(goalUpdReject[1]);
+    if (!card) return sendJson(res, 404, { error: 'no such goal-edit proposal' });
+    if (card.status !== 'open') return sendJson(res, 409, { error: 'this proposal was already resolved' });
+    const b = await readBody(req);
+    tm.setGoalUpdateProposalStatus(card.id, 'rejected');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'goal.update.proposal.rejected', data: { by: me.email, agent: card.agent, goal: card.goalId, note: b.note ? String(b.note) : undefined } });
     return sendJson(res, 200, { ok: true });
   }
   const autoRun = p.match(/^\/api\/automations\/([\w-]+)\/run$/);

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -659,6 +659,7 @@ const REVIEW_PRESENTATION: Record<ReviewNotice['kind'], { icon: string; page: st
   'policy.proposal': { icon: '🛡️', page: 'settings/policy' },
   'automation.proposed': { icon: '⚡', page: 'automations' },
   'agent.update.proposed': { icon: '✏️', page: 'agents' },
+  'goal.update.proposed': { icon: '🎯', page: 'goals' },
   'connection.request': { icon: '🔌', page: 'connectors' },
 };
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -440,7 +440,7 @@ function markDuplicateDispatches(nodes: ChainNode[]): void {
 
 export interface FeedMessage {
   id: string;
-  type: 'task' | 'task.chat' | 'task.mention' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'goal.ready' | 'skill.request' | 'secret.request' | 'host.proposed' | 'app.proposed' | 'policy.proposal' | 'automation.proposed' | 'agent.update.proposed' | 'connection.request';
+  type: 'task' | 'task.chat' | 'task.mention' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'goal.ready' | 'goal.update.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'app.proposed' | 'policy.proposal' | 'automation.proposed' | 'agent.update.proposed' | 'connection.request';
   sessionId: string;
   agent: string;
   title: string;
@@ -636,7 +636,7 @@ export interface MemberNotice {
 export interface ReviewNotice {
   sessionId: string;
   agent: string;
-  kind: 'secret.request' | 'skill.proposed' | 'skill.request' | 'host.proposed' | 'policy.proposal' | 'automation.proposed' | 'agent.update.proposed' | 'connection.request';
+  kind: 'secret.request' | 'skill.proposed' | 'skill.request' | 'host.proposed' | 'policy.proposal' | 'automation.proposed' | 'agent.update.proposed' | 'goal.update.proposed' | 'connection.request';
   title: string;
   summary: string;
   /** Whom to DM. Defaults (in the registry's `notifyReview`) to the `admins` tier — the audience nearly
@@ -5363,6 +5363,157 @@ export class TerminalManager {
       .filter((p) => p.target && (!target || p.target === target.trim().toLowerCase()));
   }
 
+  /**
+   * Agent proposes an edit to an EXISTING goal's state (`goal_update`) — the maturity-tiered sibling of the
+   * read-only `goal_list`/`goal_get` and the create-a-draft `goal_propose`. Same three lanes as
+   * {@link proposeAgentUpdate}, keyed on the proposer's maturity against the shared `agentProposalTrust`
+   * tiers: below the floor → refused; middle band → a `goal.update.proposed` review card, nothing applied;
+   * at/above the auto-apply bar → applied immediately via {@link GoalStore.update}, owner notified after.
+   *
+   * "Shape beats score" (mirrors the agent path's destructive-rewrite demotion): the load-bearing
+   * steering-wheel transitions — **activating, abandoning, or reopening a goal, or claiming an unfinished
+   * goal is `achieved`** — ALWAYS demote to human review, whatever the maturity tier. The only status change
+   * a top-tier agent auto-applies is marking a goal `achieved` whose linked work is already 100% done (the
+   * console's "Mark achieved" affordance). Non-status edits (title/body/target/labels/dueAt/note) auto-apply
+   * at the top tier. Owner/parent are NOT agent-editable — re-owning or re-parenting strategy stays a console
+   * act. Every applied edit is event-logged in `goal_events` (the append-only safety net), so it's revertable.
+   */
+  proposeGoalUpdate(sessionId: string, proposer: string, body: Record<string, unknown>): { ok: boolean; applied?: boolean; maturity?: number; outcome?: string; message?: string; error?: string; preview?: string; url?: string } {
+    const target = String(body.id ?? '').trim();
+    if (!target) return { ok: false, outcome: 'refused', error: 'id (the goal to edit) is required — see goal_list for ids' };
+    if (!String(body.rationale ?? '').trim()) return { ok: false, outcome: 'refused', error: 'a rationale is required — the approver sees it on the card' };
+    const goal = this.os.goals.get(target);
+    if (!goal) return { ok: false, outcome: 'refused', error: `no goal "${target}" — check goal_list for ids` };
+
+    // ── build the field delta from the fields actually present (only these are agent-editable) ──
+    const STATUSES = ['draft', 'active', 'achieved', 'abandoned'];
+    const delta: Record<string, unknown> = {};
+    if ('status' in body && body.status !== undefined) {
+      const s = String(body.status);
+      if (!STATUSES.includes(s)) return { ok: false, outcome: 'refused', error: `status must be one of ${STATUSES.join(', ')}` };
+      if (s !== goal.status) delta.status = s;
+    }
+    if ('title' in body && String(body.title ?? '').trim() && String(body.title).trim() !== goal.title) delta.title = String(body.title).trim();
+    if ('body' in body && body.body !== undefined && String(body.body) !== goal.body) delta.body = String(body.body);
+    if ('target' in body && body.target !== undefined) { const t = String(body.target); if (t !== (goal.target ?? '')) delta.target = t || null; }
+    if ('labels' in body && Array.isArray(body.labels)) delta.labels = body.labels.map(String);
+    if ('dueAt' in body && body.dueAt !== undefined) { const d = body.dueAt === null ? null : Number(body.dueAt); if ((d ?? null) !== (goal.dueAt ?? null)) delta.dueAt = d; }
+    const note = 'note' in body && String(body.note ?? '').trim() ? String(body.note).trim() : undefined;
+    if (!Object.keys(delta).length && !note) {
+      return { ok: false, outcome: 'refused', error: 'nothing to change — pass at least one of status, title, body, target, labels, dueAt, or note (with values different from the goal\'s current ones)' };
+    }
+
+    // ── the trust tier: what this proposer's track record earns it ──
+    const trust = this.os.settings.agentProposalTrust();
+    const maturity = computeAgentStat(this.db, proposer).maturity;
+    const pct = Math.round(maturity * 100);
+    if (maturity < trust.minMaturity) {
+      this.audit(sessionId, proposer, 'goal.update.blocked', { goal: target, maturity, floor: trust.minMaturity, fields: Object.keys(delta) });
+      return {
+        ok: false, outcome: 'refused', maturity,
+        error: `your maturity is ${pct}/100 and this workspace requires ${Math.round(trust.minMaturity * 100)}/100 to edit a goal directly. Maturity comes from completed runs that needed few approvals and hit no denials — until then, propose a NEW direction with goal_propose or tell a human what "${goal.title}" needs.`,
+      };
+    }
+
+    // ── shape beats score: the steering-wheel transitions always go to a human ──
+    const progress = this.os.goals.progress(target);
+    const newStatus = typeof delta.status === 'string' ? delta.status : undefined;
+    const achievedComplete = newStatus === 'achieved' && progress.total > 0 && progress.percent >= 100;
+    const forceGate = !!newStatus && !achievedComplete;
+    const forceReason =
+      newStatus === 'active' ? 'activating a goal steers the whole fleet — that\'s a human decision'
+      : newStatus === 'abandoned' ? 'abandoning a strategic direction is a human decision'
+      : newStatus === 'achieved' ? `its linked work isn't complete yet (${progress.percent}% done) — claiming the outcome needs a human`
+      : newStatus === 'draft' ? 'pulling a goal back to draft de-activates live strategy — a human decides that'
+      : 'a status change is a human decision';
+
+    const previewText = describeGoalDelta(delta, note, goal);
+    const url = this.consoleGoalUrl(target);
+
+    // ── dry run: name the lane, write nothing ──
+    if (body.dryRun === true) {
+      const lane = trust.autoApply && maturity >= trust.autoApplyAt && !forceGate ? 'apply immediately' : 'wait for an owner to approve';
+      return {
+        ok: true, outcome: 'dry_run', maturity, preview: previewText, url,
+        message: `Dry run — nothing was written. This would change ${previewText} on "${goal.title}" and would ${lane}${forceGate && trust.autoApply && maturity >= trust.autoApplyAt ? ` (held for review because ${forceReason})` : ''}.`,
+      };
+    }
+
+    const rationaleText = String(body.rationale).trim();
+
+    if (trust.autoApply && maturity >= trust.autoApplyAt && !forceGate) {
+      // Top tier + a non-steering edit: apply now, tell the owner afterwards. The goal_events log makes it revertable.
+      const updated = this.os.goals.update(target, { ...delta, note, by: `agent:${proposer}` });
+      if (!updated) return { ok: false, outcome: 'refused', error: 'the goal disappeared before the edit could apply' };
+      this.addMessage({
+        type: 'notification', sessionId, agent: proposer,
+        title: `${proposer} edited goal "${goal.title}"`,
+        body: `${rationaleText}\n\nChanges: ${previewText}\n\nApplied automatically — ${proposer} is at maturity ${pct}/100, at or above this workspace's ${Math.round(trust.autoApplyAt * 100)}/100 auto-apply bar. See the goal's activity log to review or reverse it.`,
+        status: 'open',
+        args: { goalId: target, fields: delta, note, rationale: rationaleText, preview: previewText, maturity, autoApplied: true },
+        audienceKind: 'admins',
+      });
+      this.audit(sessionId, proposer, 'goal.update.applied', { goal: target, fields: Object.keys(delta), note: !!note, maturity, bar: trust.autoApplyAt, auto: true });
+      return {
+        ok: true, applied: true, maturity, outcome: 'applied', preview: previewText, url,
+        message: `APPLIED your edit to "${goal.title}" (${previewText}) — your maturity (${pct}/100) is at or above this workspace's auto-apply bar, so it took effect immediately WITHOUT a human approving it. An owner has been notified and can reverse it from the goal's activity log. Do NOT tell anyone this is awaiting review — it is already live.\n${url}`,
+      };
+    }
+
+    // Cap the queue + dedupe an identical open proposal from this agent for this goal.
+    const open = this.db.prepare(`SELECT args FROM messages WHERE type = 'goal.update.proposed' AND status = 'open' AND agent = ?`).all<{ args: string | null }>(proposer);
+    if (open.length >= 10) return { ok: false, outcome: 'refused', error: 'you already have 10 open goal-edit proposals awaiting review — wait for a human to act on them first' };
+    const deltaKey = JSON.stringify({ goalId: target, fields: delta, note });
+    if (open.some((o) => { try { const a = JSON.parse(o.args || '{}') as { goalId?: string; fields?: unknown; note?: unknown }; return JSON.stringify({ goalId: a.goalId, fields: a.fields, note: a.note }) === deltaKey; } catch { return false; } })) {
+      return { ok: false, outcome: 'refused', error: 'an identical goal-edit proposal from you is already awaiting review' };
+    }
+    // Middle band (or a demoted top-tier steering change) — the owner decides. Proposer maturity rides the card.
+    const demoted = forceGate && trust.autoApply && maturity >= trust.autoApplyAt;
+    this.postReviewCard({
+      type: 'goal.update.proposed', sessionId, agent: proposer,
+      title: `Goal edit proposed — ${goal.title}`,
+      body: `${rationaleText}\n\nChanges to goal "${goal.title}": ${previewText}\n\nProposed by ${proposer} — maturity ${pct}/100.${demoted ? ` Above the auto-apply bar but held for review because ${forceReason}.` : ''}`,
+      args: { goalId: target, fields: delta, note, rationale: rationaleText, preview: previewText, maturity, demoted },
+      summary: `${proposer} (maturity ${pct}/100) proposes editing goal "${goal.title}" (${previewText})`,
+    });
+    this.audit(sessionId, proposer, 'goal.update.proposed', { goal: target, fields: Object.keys(delta), note: !!note, maturity, demoted });
+    return {
+      ok: true, applied: false, maturity, outcome: 'pending_approval', preview: previewText, url,
+      message: `Proposed an edit to "${goal.title}" (${previewText}) — it is in an owner's inbox for review. NOTHING has changed yet; an owner/admin must approve it first.${demoted ? ` (Your maturity is above the auto-apply bar, but this one is held for review because ${forceReason}.)` : ''}\n${url}`,
+    };
+  }
+
+  /** The proposed goal-edit review card by id (its goal + field delta + status) — for the approve/reject routes. */
+  goalUpdateProposalCard(id: string): { id: string; agent: string; goalId: string; fields: Record<string, unknown>; note?: string; rationale?: string; preview?: string; status: string } | undefined {
+    const row = this.db.prepare(`SELECT agent, args, status FROM messages WHERE id = ? AND type = 'goal.update.proposed'`).get<{ agent: string; args: string | null; status: string }>(id);
+    if (!row) return undefined;
+    let a: Record<string, unknown> = {};
+    try { a = row.args ? JSON.parse(row.args) : {}; } catch { /* tolerate a corrupt payload */ }
+    if (!a.goalId || !a.fields) return undefined;
+    return { id, agent: row.agent, goalId: String(a.goalId), fields: a.fields as Record<string, unknown>, note: a.note ? String(a.note) : undefined, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, status: row.status };
+  }
+  setGoalUpdateProposalStatus(id: string, status: 'approved' | 'rejected'): void {
+    this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'goal.update.proposed'`).run(status, id);
+  }
+  /** Open goal-edit proposals (all goals, or just one when `goalId` is given) — for the console review list. */
+  openGoalUpdateProposals(goalId?: string): { id: string; agent: string; goalId: string; fields: Record<string, unknown>; note?: string; rationale?: string; preview?: string; createdAt: number }[] {
+    return this.db
+      .prepare(`SELECT id, agent, args, created_at FROM messages WHERE type = 'goal.update.proposed' AND status = 'open' ORDER BY created_at DESC`)
+      .all<{ id: string; agent: string; args: string | null; created_at: number }>()
+      .map((r) => {
+        let a: Record<string, unknown> = {};
+        try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate corrupt payload */ }
+        return { id: r.id, agent: r.agent, goalId: String(a.goalId ?? ''), fields: (a.fields ?? {}) as Record<string, unknown>, note: a.note ? String(a.note) : undefined, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, createdAt: r.created_at };
+      })
+      .filter((pr) => pr.goalId && (!goalId || pr.goalId === goalId.trim()));
+  }
+
+  /** Absolute console deep-link to a goal — the tenant's real external origin when known, else the loopback
+   *  base (dev/demo), mirroring how AOS_SESSION_URL is built for the launcher. */
+  private consoleGoalUrl(goalId: string): string {
+    return `${(this.publicOrigin || this.baseUrl).replace(/\/$/, '')}/#/goals/${encodeURIComponent(goalId)}`;
+  }
+
   /** Agent posts a mid-task progress update to the Inbox feed. Unlike the (now removed) spawn/stop/exit
    *  lifecycle cards, this is an agent-authored signal: a short note on what it just did or is about to
    *  do. Flagging it `important` highlights it in the feed — a milestone or heads-up worth the operator's
@@ -6638,3 +6789,17 @@ function audienceIdOf(a: Audience): string | undefined {
   }
 }
 
+
+/** Human-readable one-line summary of a goal-edit delta, for the review card + return message. Renders a
+ *  status transition as "status draft→active", other fields by name, and a trailing note if present. */
+function describeGoalDelta(delta: Record<string, unknown>, note: string | undefined, goal: { status: string }): string {
+  const parts: string[] = [];
+  if (typeof delta.status === 'string') parts.push(`status ${goal.status}→${delta.status}`);
+  if ('title' in delta) parts.push('title');
+  if ('body' in delta) parts.push('description');
+  if ('target' in delta) parts.push(delta.target ? 'target' : 'clear target');
+  if ('labels' in delta) parts.push('labels');
+  if ('dueAt' in delta) parts.push(delta.dueAt == null ? 'clear due date' : 'due date');
+  if (note) parts.push('a note');
+  return parts.length ? parts.join(', ') : 'no fields';
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12,7 +12,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskRun, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type AgentProposalTrust, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
+import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskRun, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type AgentProposalTrust, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type GoalUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -5260,9 +5260,10 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
   const goArtifact = m.type === 'artifact' && meta.artifactId && onOpenArtifact ? () => onOpenArtifact(meta.artifactId!) : null
   // A 'task' card has no session — it deep-links to the board (its taskId), not a terminal.
   const goTask = m.type === 'task' && meta.taskId && onOpenTask ? () => onOpenTask(meta.taskId!) : null
-  // A goal card ('goal.proposed' — an agent's draft; 'goal.ready' — its work all finished) deep-links to
-  // the Goals page for that goal (no session backs a goal).
-  const goGoal = (m.type === 'goal.proposed' || m.type === 'goal.ready') && meta.goalId && onOpenGoal ? () => onOpenGoal(meta.goalId!) : null
+  // A goal card ('goal.proposed' — an agent's draft; 'goal.ready' — its work all finished;
+  // 'goal.update.proposed' — an agent's proposed edit awaiting review) deep-links to the Goals page for
+  // that goal (no session backs a goal), where the owner review card lives.
+  const goGoal = (m.type === 'goal.proposed' || m.type === 'goal.ready' || m.type === 'goal.update.proposed') && meta.goalId && onOpenGoal ? () => onOpenGoal(meta.goalId!) : null
   // An 'agent.update.proposed' card deep-links to the TARGET agent's page, where the owner review
   // card lives — not the proposer's session terminal. Hash routing, so setting the hash routes in place.
   const goAgentEdit = m.type === 'agent.update.proposed' && meta.target ? () => { window.location.hash = navHref('agent', meta.target!) } : null
@@ -5336,6 +5337,11 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
     Icon = Target; iconCls = 'text-emerald-600'; highlight = m.status === 'open'
     verb = m.title; detail = m.body
     badge = <Badge variant="outline" className="border-emerald-300 px-1.5 py-0 text-[10px] font-normal text-emerald-700">Ready to close</Badge>
+  } else if (m.type === 'goal.update.proposed') {
+    Icon = Target; iconCls = 'text-indigo-600'; highlight = m.status === 'open'
+    const resolved = m.status === 'approved' ? 'applied' : m.status === 'rejected' ? 'rejected' : ''
+    verb = 'proposed a goal edit'; detail = m.body
+    badge = <Badge variant="outline" className="border-indigo-300 px-1.5 py-0 text-[10px] font-normal text-indigo-700">{resolved || 'review in Goals'}</Badge>
   } else if (m.type === 'skill.request') {
     Icon = Sparkles; iconCls = 'text-violet-600'; highlight = m.status === 'open'
     const resolved = m.status === 'approved' ? 'installed' : m.status === 'rejected' ? 'dismissed' : ''
@@ -7458,6 +7464,60 @@ function GoalProgressBar({ p, className = '' }: { p?: GoalProgress; className?: 
 
 type GoalTab = 'tasks' | 'description' | 'activity'
 
+/** Owner/admin review queue for agent-proposed edits to THIS goal (goal_update, middle-band / demoted
+ *  lane). Non-admins get a 403 → renders nothing. Approving applies the field delta via GoalStore.update
+ *  (event-logged, revertable from the activity timeline); rejecting discards it. Mirrors AgentUpdateProposalsCard. */
+function GoalUpdateProposalsCard({ goalId, members, onResolved }: { goalId: string; members: Member[]; onResolved: () => void }) {
+  const [props, setProps] = useState<GoalUpdateProposal[] | null>(null)
+  const [busy, setBusy] = useState('')
+  const [hint, setHint] = useState('')
+  const load = () => api.goalUpdateProposals(goalId).then((r) => setProps(r.error ? [] : (r.proposals ?? []))).catch(() => setProps([]))
+  useEffect(() => { setProps(null); setHint(''); load() }, [goalId]) // eslint-disable-line react-hooks/exhaustive-deps
+  const act = async (id: string, approve: boolean) => {
+    setBusy(id); setHint('')
+    const r = approve ? await api.approveGoalUpdateProposal(id) : await api.rejectGoalUpdateProposal(id)
+    setBusy('')
+    if (r.error || !r.ok) return setHint('⚠ ' + (r.error ?? 'failed'))
+    setHint(approve ? 'applied' : 'rejected')
+    load(); if (approve) onResolved()
+    setTimeout(() => setHint(''), 3000)
+  }
+  if (!props || props.length === 0) return null // silent for non-admins and when nothing is pending
+  const describe = (f: GoalUpdateProposal['fields']): string => {
+    const parts: string[] = []
+    if (f.status) parts.push(`status → ${f.status}`)
+    if (f.title !== undefined) parts.push(`title → "${f.title}"`)
+    if (f.body !== undefined) parts.push('description')
+    if (f.target !== undefined) parts.push(f.target ? `target → "${f.target}"` : 'clear target')
+    if (f.labels !== undefined) parts.push('labels')
+    if (f.dueAt !== undefined) parts.push(f.dueAt == null ? 'clear due date' : 'due date')
+    return parts.join(' · ') || 'no fields'
+  }
+  return (
+    <div className="space-y-2 rounded-md border border-indigo-400/50 bg-indigo-500/10 p-3">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1.5 text-xs font-medium text-indigo-800 dark:text-indigo-300"><Target className="h-3.5 w-3.5" /> Proposed edits from agents ({props.length})</div>
+        {hint && <span className="font-mono text-[11px] text-muted-foreground">{hint}</span>}
+      </div>
+      {props.map((pr) => (
+        <div key={pr.id} className="space-y-2 rounded border border-indigo-300/60 bg-background p-2.5">
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <Bot className="h-3 w-3 shrink-0" /><span className="font-medium text-foreground">{principalLabel(`agent:${pr.agent}`, members)}</span>
+            <span>· {new Date(pr.createdAt).toLocaleString()}</span>
+          </div>
+          {pr.rationale && <div className="text-sm">{pr.rationale}</div>}
+          <div className="text-xs"><span className="text-muted-foreground">Change: </span><span className="font-mono">{describe(pr.fields)}</span></div>
+          {pr.note && <div className="text-xs text-muted-foreground">Note: {pr.note}</div>}
+          <div className="flex items-center gap-2 pt-0.5">
+            <Button size="sm" className="h-7" disabled={!!busy} onClick={() => act(pr.id, true)}>Approve & apply</Button>
+            <Button size="sm" variant="outline" className="h-7" disabled={!!busy} onClick={() => act(pr.id, false)}>Reject</Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: Route, detail?: string) => void }) {
   const [members, setMembers] = useState<Member[]>([])
   useEffect(() => { api.team().then((r) => setMembers(r.members ?? [])).catch(() => {}) }, [])
@@ -7629,6 +7689,7 @@ function GoalsPage({ me, goalId, nav }: { me: Member; goalId: string; nav: (r: R
    *  progress) plus the destructive action, mirroring the task room's sidebar. */
   const goalSidebar = () => detail && (
     <div className="space-y-3.5">
+      {isAdmin && <GoalUpdateProposalsCard goalId={detail.goal.id} members={members} onResolved={() => { load(); refreshDetail(detail.goal.id) }} />}
       {signOffBox()}
       <Field label="Status">
         {isAdmin ? (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -774,7 +774,7 @@ export interface AutoApproval {
 
 export interface Msg {
   id: string
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'goal.ready' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed' | 'agent.update.proposed'
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'goal.ready' | 'goal.update.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed' | 'agent.update.proposed'
   sessionId: string
   agent: string
   title: string
@@ -865,6 +865,16 @@ export interface AgentUpdateProposal {
   agent: string          // the proposing agent
   target: string         // the agent to be edited
   fields: { description?: string; claudeMd?: string; category?: string; model?: string; effort?: string; icon?: string; examplePrompts?: string[] }
+  rationale?: string
+  preview?: string
+  createdAt: number
+}
+export interface GoalUpdateProposal {
+  id: string
+  agent: string          // the proposing agent
+  goalId: string         // the goal to be edited
+  fields: { status?: GoalStatus; title?: string; body?: string; target?: string | null; labels?: string[]; dueAt?: number | null }
+  note?: string
   rationale?: string
   preview?: string
   createdAt: number
@@ -1675,6 +1685,9 @@ export const api = {
   agentUpdateProposals: (target?: string) => call<{ proposals: AgentUpdateProposal[]; canApprove?: boolean; error?: string }>('GET', '/api/agents/proposals' + (target ? '?target=' + encodeURIComponent(target) : '')),
   approveAgentUpdateProposal: (id: string) => call<{ ok: boolean; target?: string; rev?: number; error?: string }>('POST', `/api/agents/proposals/${id}/approve`),
   rejectAgentUpdateProposal: (id: string, note?: string) => call<{ ok: boolean; error?: string }>('POST', `/api/agents/proposals/${id}/reject`, { note }),
+  goalUpdateProposals: (goal?: string) => call<{ proposals: GoalUpdateProposal[]; canApprove?: boolean; error?: string }>('GET', '/api/goals/proposals' + (goal ? '?goal=' + encodeURIComponent(goal) : '')),
+  approveGoalUpdateProposal: (id: string) => call<{ ok: boolean; goalId?: string; status?: GoalStatus; error?: string }>('POST', `/api/goals/proposals/${id}/approve`),
+  rejectGoalUpdateProposal: (id: string, note?: string) => call<{ ok: boolean; error?: string }>('POST', `/api/goals/proposals/${id}/reject`, { note }),
   automationRuns: (id: string) => call<{ runs: Session[]; error?: string }>('GET', `/api/automations/${id}/runs`),
 
   memory: (agent: string, q = '', limit = 50, scope: 'all' | 'agent' | 'tenant' = 'all') =>


### PR DESCRIPTION
## What

Adds **`goal_update`**, the maturity-tiered agent write path over EXISTING goals, plus goal console deep-links in the read/propose tools.

Until now the agent goal surface was **read + propose-a-draft only** (`goal_list`/`goal_get`/`goal_propose`) — a trusted agent had no way to change a live goal's status or fields, and the tools returned no clickable URL for the goal.

## How — same trust model as `agent_propose_update`

`goal_update(id, {status?, title?, body?, target?, labels?, dueAt?, note?}, rationale, dryRun?)`, keyed on the proposer's **maturity** against the shared `agentProposalTrust` tiers:

- `< minMaturity` (0.4) → **refused**
- middle band → a `goal.update.proposed` **review card**, nothing applied, owner/admin approves at `POST /api/goals/proposals/:id/approve`
- `≥ autoApplyAt` (0.8) → **applied immediately** via `GoalStore.update`, owner notified after

### Shape beats score
Mirroring the agent path's destructive-rewrite demotion, the steering-wheel transitions — **activating, abandoning, or reopening a goal, or claiming an unfinished one is `achieved`** — ALWAYS demote to human review *whatever* the tier. The only status change a top-tier agent auto-applies is marking a goal `achieved` whose linked work is already **100% done** (the console's "Mark achieved" affordance). Ordinary edits (title/body/target/labels/dueAt/note) auto-apply for a proven agent.

Every applied edit — auto or approved — is event-logged in `goal_events` (author = the agent on the auto lane, the approving human on the gated one), so it's **revertable**. `dryRun` names the lane without writing. Owner/parent are **not** agent-editable.

## Surfaces
- **MCP**: `goal_update` tool + handler; `goal_get`/`goal_propose`/`goal_update` now return the `…/#/goals/<id>` deep-link
- **Server**: `POST /api/goals/update` (agent loopback) + owner/admin `GET/POST /api/goals/proposals[/:id/approve|reject]`
- **TerminalManager**: `proposeGoalUpdate` + card helpers; new `goal.update.proposed` card kind (inbox + DM)
- **Console**: owner/admin review card in the Goal room sidebar; `goal.update.proposed` inbox card renderer
- **Docs**: `agent-mcp-tools.md` matrix + prose; `goals-plan.md` out-of-scope note superseded

## Verification
- `scripts/goal-update-guard-test.cjs` (wired into `test:governance`) — 23 assertions, all lanes end-to-end: refusal below floor, always-gated steering transitions, auto-apply of ordinary edits + achieved-at-100%, the approve route applying with the human as author, dryRun writing nothing, no-op refusal
- `npm run build` + `cd web && npm run build` + full `npm run test:governance` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)