### PR TITLE
fix(tasks): a task's Session tab shows the run's transcript, not tmux's "can't find session" (v0.318.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+### Fixed
+- **A task's Session tab showed tmux's `can't find session: aos-…` instead of the run's transcript.**
+  The room handed `TerminalFrame` a session row only while the run was still ALIVE (`liveOf`), so for a
+  finished run the pane had no row, couldn't tell ended from live, and blind-attached to a tmux session
+  that no longer exists. Task runs are headless by default and leave no resumable pane, so this hit
+  essentially every completed task — 111 of the instapods board's tasks were in that state. The tab now
+  resolves the run's row regardless of liveness (fetching it by id when the board's own
+  `lastSessionId`-scoped fetch doesn't carry it, which is also what makes picking an EARLIER attempt out
+  of the run history work), so an ended run renders its read-only transcript — the same thing the
+  Sessions page and the `#/term/<tmux>` popout already did. Live runs still attach as before.
+
 ### Added
 - **`docs/sops-plan.md`** — plan for SOPs: pre-learned department playbooks (engineering, marketing,
   sales, support, research) with server-enforced stage order, peer review and evidence gates. `SOP.md`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.318.0",
+  "version": "0.318.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.318.0",
+      "version": "0.318.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.318.0",
+  "version": "0.318.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -8410,6 +8410,11 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
   const [hint, setHint] = useState('')
   // Which run from the task's history the room's Session tab is showing ('' = the live/last one).
   const [runSel, setRunSel] = useState('')
+  // Session rows the board's own fetch doesn't carry — `load()` pulls only each task's CURRENT run
+  // (`lastSessionId`), so picking an EARLIER attempt out of the run history has no row to show. Filled
+  // by the by-id fetch below and merged into `sessionById` lookups. See `sessRow` in roomView.
+  // `null` records a miss (deleted/invisible row) so we neither retry it forever nor block the pane.
+  const [extraRuns, setExtraRuns] = useState<Record<string, Session | null>>({})
   // view + filters
   const [view, setView] = useState<'board' | 'list' | 'focus'>(() => { const v = localStorage.getItem('aos_tasks_view'); return v === 'list' || v === 'focus' ? v : 'board' })
   useEffect(() => { localStorage.setItem('aos_tasks_view', view) }, [view])
@@ -8541,6 +8546,20 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
   const sessionById = new Map(sessions.map((s) => [s.id, s]))
   const liveOf = (t: Task): Session | null => { const s = t.lastSessionId ? sessionById.get(t.lastSessionId) : undefined; return s && isLive(s) ? s : null }
   const attach = (t: Task, s: Session) => onOpen(s.tmux || ('aos-' + s.id), 'Task · ' + t.title)
+  // The run the Session tab is showing, whether or not it's still alive.
+  const shownRunId = runSel || detail?.task.lastSessionId || ''
+  // Pull that run's session ROW when the board doesn't already hold it (an earlier attempt from the run
+  // history). Without the row, TerminalFrame can't tell an ENDED run from a live one and blind-attaches
+  // to a dead tmux name — which surfaces as tmux's raw "can't find session: aos-…" instead of the
+  // transcript. Same reason FullTerminalView fetches it. By-id, so one row, and only when missing.
+  useEffect(() => {
+    if (!shownRunId || sessionById.has(shownRunId) || shownRunId in extraRuns) return
+    let alive = true
+    api.sessionsByIds([shownRunId])
+      .then((rows) => { if (alive) setExtraRuns((m) => ({ ...m, [shownRunId]: rows[0] ?? null })) })
+      .catch(() => { if (alive) setExtraRuns((m) => ({ ...m, [shownRunId]: null })) }) // miss → plain attach, as before
+    return () => { alive = false }
+  }, [shownRunId, sessions])
 
   // One predicate for every lens, with `skip` naming a dimension to ignore. That's what lets each quick
   // filter show a count of what picking it would actually yield *given the other filters* — a facet count,
@@ -8862,8 +8881,16 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
     // The Session tab shows the run you picked from the history, defaulting to the live/last one — so a
     // task that crashed twice can be read attempt by attempt without leaving the room.
     const picked = runSel ? detail.runs.find((r) => r.id === runSel) : undefined
-    const sessTmux = picked ? 'aos-' + picked.id : live?.tmux || (t.lastSessionId ? 'aos-' + t.lastSessionId : '')
-    const sessLive = picked ? (picked.alive ? sessionById.get(picked.id) : undefined) : live ?? undefined
+    const sessId = picked?.id || live?.id || t.lastSessionId || ''
+    // Hand TerminalFrame the session ROW even for a finished run — that's what lets it show the captured
+    // transcript instead of attaching to a tmux session that no longer exists. A headless task run (the
+    // common case here) leaves no resumable pane, so without the row every ended task run rendered
+    // tmux's "can't find session: aos-…".
+    const sessRow = (sessId ? sessionById.get(sessId) ?? extraRuns[sessId] : undefined) ?? undefined
+    const sessTmux = sessRow?.tmux || (sessId ? 'aos-' + sessId : '')
+    // Row still in flight — hold the pane rather than attach without it, or an ended run would flash the
+    // dead-terminal error for a beat before the transcript replaced it.
+    const sessPending = Boolean(sessId) && !sessionById.has(sessId) && !(sessId in extraRuns)
     const activeTab: 'discussion' | 'description' | 'session' = roomTab === 'session' && !sessTmux ? 'discussion' : roomTab
     const roomTab_btn = (id: 'discussion' | 'description' | 'session', label: ReactNode) => (
       <a href={navHref('tasks', id === 'discussion' ? t.id : `${t.id}/${id}`)} onClick={onNavClick(() => openTaskTab(t.id, id))} className={`-mb-px flex items-center gap-1.5 border-b-2 px-3 py-2 text-[13px] font-medium no-underline transition-colors ${activeTab === id ? 'border-primary text-foreground' : 'border-transparent text-muted-foreground hover:text-foreground'}`}>{label}</a>
@@ -8912,7 +8939,13 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
                     : <div className="flex h-full flex-col items-center justify-center gap-2 text-center text-sm text-muted-foreground"><FileText className="h-6 w-6 opacity-40" />No description. <button className="text-primary underline" onClick={() => setEditing(true)}>Add one</button></div>}
                 </div>
               )}
-              {activeTab === 'session' && sessTmux && <div className="flex h-full min-h-0 flex-col"><TerminalFrame session={sessLive} tmux={sessTmux} standalone /></div>}
+              {activeTab === 'session' && sessTmux && (
+                <div className="flex h-full min-h-0 flex-col">
+                  {sessPending
+                    ? <div className="flex flex-1 items-center justify-center bg-black text-sm text-neutral-500">opening session…</div>
+                    : <TerminalFrame key={sessTmux} session={sessRow} tmux={sessTmux} standalone />}
+                </div>
+              )}
             </div>
           </div>
           <div className="overflow-y-auto bg-muted/20 p-4">


### PR DESCRIPTION
## The bug

Opening a task's Session tab — e.g. `#/tasks/tsk_0042a26b7a86018a/session` — showed a black pane with
tmux's raw error:

```
can't find session: aos-ses_618b21c089b4467f
```

## Root cause

The room only handed `TerminalFrame` a session row while the run was still **alive**:

```ts
const sessLive = picked ? (picked.alive ? sessionById.get(picked.id) : undefined) : live ?? undefined
```

`TerminalFrame` already has the right behaviour — an ended, non-resumable session renders its captured
transcript instead of attaching — but that check keys off the session **row**. With no row it fell to
the `!session?.id` branch and blind-attached by tmux name. Task runs are headless by default, so they
leave no resumable pane and their tmux session is long gone → tmux's error, every time. 111 of the
instapods board's tasks are in that state, which matches the "most of the time" report.

The same gap made picking an **earlier attempt** out of the run history useless: those rows were never
fetched (the board fetches only each task's `lastSessionId`), so any non-current run showed a dead pane too.

## The fix

Resolve the shown run's row regardless of liveness, fetching it by id when the board doesn't already
carry it, and hold the pane while that's in flight so an ended run can't flash the dead terminal first.
This is the same thing `FullTerminalView` (the `#/term/<tmux>` popout) already does, and for the same
stated reason.

## Verification

Against **live instapods data**, on the reported URL, with a control run on the current bundle:

| | current bundle | with this fix |
|---|---|---|
| `tsk_0042a26b7a86018a` | opens a ttyd socket for a dead tmux name → tmux error | read-only transcript (5,150 chars) |

Swept 5 task rooms: the 4 ended headless runs all flipped from dead-attach to transcript; the 5th
(`ses_511d7fe32bae1a67`, an interactive run that's still `resumable`) keeps the untouched attach/resume
path. No sessions were spawned by the test — the tmux socket and `term_sessions` were unchanged.

`npm run typecheck`, `web` build, and `npm run test:governance` (23 passed) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)