### PR TITLE
feat(tasks): re-dispatch knows about earlier attempts, "Run again" on a doing task, report fallback with no transcript (v0.319.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+### Added
+- **`docs/sops-plan.md`** — plan for SOPs: pre-learned department playbooks (engineering, marketing,
+  sales, support, research) with server-enforced stage order, peer review and evidence gates. `SOP.md`
+  frontmatter + prose (not YAML), stages compiled to child tasks over the `blocked_by` dependency edge
+  (no new run engine), and an `advisory → enforced` adoption ramp measured by stage-skip rate.
+
+## [0.319.0] — 2026-08-07
+### Added
+- **A re-dispatched task tells the next run it isn't the first.** A task is the unit of work and a
+  session is one ATTEMPT at it, but every attempt got a prompt byte-identical to the first one's — no
+  signal that anyone had been here, which invites redoing work that already landed or re-hitting a wall
+  a predecessor already documented. `buildTaskPrompt` now takes the task's prior runs and opens with
+  `This is attempt N — M earlier sessions already worked this task`, one line each (agent, reported
+  outcome, its one-line summary), plus a pointer to `task_get` for the notes and discussion the
+  summaries can't hold. The last three attempts are named and the rest collapse to a count, so a
+  much-retried task doesn't turn its prompt into a wall of history. It sits inside the text the `/goal`
+  length gate measures, so a converging task can't ship a payload the CLI rejects.
+- **"Run again" on a task that's already `doing`.** Dispatch was offered only for `todo`/`blocked`, but a
+  `doing` task whose run has ENDED — the normal shape, since headless runs exit at turn-end — is exactly
+  the one that needs another go, and the server has always allowed it (`dispatchTask` refuses only
+  done/cancelled plus a live-session pile-up guard). The button now appears for any non-terminal task
+  with no live run, labelled with the attempt number it will start.
+
+### Fixed
+- **A finished run with no transcript now shows what it REPORTED instead of a bare error.** A pane log is
+  best-effort — an older session may never have written one — but the verdict, summary, cost, duration
+  and turn count live on the session row, so the pane can still answer "what came of it" even when it
+  can't answer "what happened". Replaces the `⚠ no transcript for this session` dead end, on every
+  surface that shows a finished run.
+
+## [0.318.1] — 2026-08-07
 ### Fixed
 - **A task's Session tab showed tmux's `can't find session: aos-…` instead of the run's transcript.**
   The room handed `TerminalFrame` a session row only while the run was still ALIVE (`liveOf`), so for a
@@ -17,12 +48,6 @@ new version heading in the same commit.
   `lastSessionId`-scoped fetch doesn't carry it, which is also what makes picking an EARLIER attempt out
   of the run history work), so an ended run renders its read-only transcript — the same thing the
   Sessions page and the `#/term/<tmux>` popout already did. Live runs still attach as before.
-
-### Added
-- **`docs/sops-plan.md`** — plan for SOPs: pre-learned department playbooks (engineering, marketing,
-  sales, support, research) with server-enforced stage order, peer review and evidence gates. `SOP.md`
-  frontmatter + prose (not YAML), stages compiled to child tasks over the `blocked_by` dependency edge
-  (no new run engine), and an `advisory → enforced` adoption ramp measured by stage-skip rate.
 
 ## [0.318.0] — 2026-08-07
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.318.1",
+  "version": "0.319.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.318.1",
+      "version": "0.319.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.318.1",
+  "version": "0.319.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/task-runs-test.cjs
+++ b/scripts/task-runs-test.cjs
@@ -90,6 +90,32 @@ tm.backend.aliveNames = () => null;   // launcher backend / failed poll → live
 assert(tm.taskRuns(t1.id).find((r) => r.id === r3).alive === true, 'a running row stays alive when the poll cannot run');
 assert(tm.taskRuns(t1.id).find((r) => r.id === r2).alive === false, 'a terminal row is never claimed alive');
 
+console.log('\n\x1b[1m5) a re-dispatched run is told it is not the first (buildTaskPrompt priorRuns)\x1b[0m');
+// The run history is only worth recovering if it reaches the next ATTEMPT. A re-dispatch used to get a
+// prompt byte-identical to the first run's, which invites redoing work that already landed.
+const { buildTaskPrompt } = require(path.join(ROOT, 'dist/edge/automations.js'));
+const pt = { id: 'tsk_x', title: 'Ship the thing', body: 'Do the work.' };
+const first = buildTaskPrompt(pt);
+assert(!/attempt/i.test(first), 'a first dispatch carries no history preamble');
+const prior = [
+  { agent: 'engineer', outcome: 'crashed' },
+  { agent: 'engineer', outcome: 'partial', summary: 'Shipped phase 1 as PR #419' },
+];
+const again = buildTaskPrompt(pt, { priorRuns: prior });
+assert(again.includes('This is attempt 3 — 2 earlier sessions already worked this task'), 'the re-dispatch is numbered off the prior count');
+assert(again.includes('1. engineer — crashed'), 'a prior run with no summary still reports its verdict');
+assert(again.includes('2. engineer — partial: Shipped phase 1 as PR #419'), 'and one with a summary carries the one-liner');
+assert(again.includes('task_get({ id: "tsk_x" })'), 'and points at the notes/discussion the summaries cannot hold');
+assert(again.indexOf('This is attempt') < again.indexOf('When finished'), 'history precedes the closing instructions, which still land');
+// A much-retried task must not turn its prompt into a wall of history.
+const many = buildTaskPrompt(pt, { priorRuns: Array.from({ length: 6 }, (_, i) => ({ agent: 'engineer', outcome: 'failure', summary: 'try ' + (i + 1) })) });
+assert(many.includes('(3 older ones not listed)'), 'a long history collapses to the last three');
+assert(many.includes('4. engineer — failure: try 4') && !many.includes('3. engineer'), 'and the survivors keep their ABSOLUTE attempt numbers');
+// The `/goal` CLI counts the whole emitted payload against its cap, so the preamble must sit INSIDE the
+// text that gate measures — otherwise a re-dispatch could ship a payload the CLI rejects and never run.
+const goalish = buildTaskPrompt({ ...pt, criteria: 'tests green' }, { goalMode: true, priorRuns: prior });
+assert(!goalish.startsWith('/goal ') || goalish.includes('This is attempt 3'), 'goal mode carries the history inside the measured payload');
+
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);
 fs.rmSync(HOME, { recursive: true, force: true });
 process.exit(fail === 0 ? 0 : 1);

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -282,7 +282,41 @@ const GOAL_AUTOPLAN_MAX_PER_TICK = Number(process.env.AOS_GOAL_AUTOPLAN_MAX_PER_
  * full payload won't fit, we fall back to plain mode with the acceptance condition embedded in the body —
  * the run still knows what "done" means, it just isn't evaluator-driven.
  */
-export function buildTaskPrompt(t: { id: string; title: string; body: string; criteria?: string }, opts: { goalMode?: boolean } = {}): string {
+/** One earlier session that already worked this task — the slice of `TaskRun` the prompt needs. */
+export type PriorRun = { agent: string; outcome?: string; summary?: string };
+
+/** How many earlier attempts we name individually before collapsing the rest to a count. Keeps a
+ *  much-retried task's prompt from turning into a wall of history. */
+const PRIOR_RUNS_SHOWN = 3;
+
+/**
+ * The "you are not the first" preamble for a re-dispatched task.
+ *
+ * A task is the unit of work and a session is one ATTEMPT at it, so a re-dispatch used to hand the next
+ * agent a prompt identical to the first one's — no signal that anyone had been here, which invites
+ * redoing work that already landed (or re-hitting a wall a predecessor already documented). Each prior
+ * run is one line: who ran it, what it reported, and the one-liner it left behind. The pointer to
+ * `task_get` matters as much as the lines — the notes and discussion hold the detail this can't.
+ */
+function priorRunsBlock(taskId: string, runs?: PriorRun[]): string {
+  if (!runs?.length) return '';
+  const shown = runs.slice(-PRIOR_RUNS_SHOWN);
+  const earlier = runs.length - shown.length;
+  const line = (r: PriorRun, i: number) =>
+    `  ${earlier + i + 1}. ${r.agent} — ${r.outcome || 'no report'}${r.summary ? `: ${r.summary}` : ''}`;
+  return (
+    `This is attempt ${runs.length + 1} — ${runs.length} earlier session${runs.length === 1 ? '' : 's'} already worked this task` +
+    `${earlier > 0 ? ` (${earlier} older one${earlier === 1 ? '' : 's'} not listed)` : ''}:\n` +
+    shown.map(line).join('\n') + '\n' +
+    `Pick up where they left off rather than starting over — call task_get({ id: "${taskId}" }) for the full notes and discussion first.\n\n`
+  );
+}
+
+export function buildTaskPrompt(
+  t: { id: string; title: string; body: string; criteria?: string },
+  opts: { goalMode?: boolean; priorRuns?: PriorRun[] } = {},
+): string {
+  const history = priorRunsBlock(t.id, opts.priorRuns);
   const buildBase = (converging: boolean) => {
     // Criteria we want to honour but can't route through `/goal` still belongs in the prompt.
     const embedCriteria = !!t.criteria && !converging;
@@ -293,6 +327,7 @@ export function buildTaskPrompt(t: { id: string; title: string; body: string; cr
       `You are working task ${t.id}: ${t.title}\n\n` +
       `${t.body || '(no description provided)'}\n\n` +
       (embedCriteria ? `Acceptance criteria (the definition of done): ${t.criteria}\n\n` : '') +
+      history +
       close +
       `If you cannot proceed, call task_update({ id: "${t.id}", status: "blocked", note: "<why>" }).\n` +
       `Break large work into sub-tasks with task_create({ parentId: "${t.id}", ... }).`
@@ -634,7 +669,11 @@ export class Automations {
     // A delegator can pin the dispatched session's model / reasoning effort (e.g. a cheap background
     // sweep, or max effort for a hard task); undefined fields fall back to the agent + workspace default.
     const tuning = (t.model || t.effort) ? { model: t.model, effort: t.effort } : undefined;
-    const s = this.tm.createSession(agentId, `Task: ${t.title}`, buildTaskPrompt(t, { goalMode }), `task:${t.id}`, t.mode !== 'interactive', undefined, undefined, t.owner, undefined, false, tuning);
+    // Tell a re-dispatched run that it isn't the first — see priorRunsBlock. Only sessions that actually
+    // finished carry a verdict worth reporting; a still-alive one can't be a predecessor anyway (the
+    // pile-up guard above already refused that case).
+    const priorRuns = this.tm.taskRuns(t.id).filter((r) => !r.alive).map((r) => ({ agent: r.agent, outcome: r.outcome, summary: r.summary }));
+    const s = this.tm.createSession(agentId, `Task: ${t.title}`, buildTaskPrompt(t, { goalMode, priorRuns }), `task:${t.id}`, t.mode !== 'interactive', undefined, undefined, t.owner, undefined, false, tuning);
     this.os.tasks.markDispatched(t.id, s.id);
     this.os.audit.append({
       ts: Date.now(),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2694,6 +2694,10 @@ function TerminalFrame({ session, tmux, onActivity, ops, standalone }: { session
       <pre className="min-h-0 flex-1 overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-xs leading-relaxed text-neutral-300">{transcript || '(no output captured)'}</pre>
     </div>
   )
+  // No transcript for a finished run (an older session whose pane log was never written, or one whose
+  // log has since been cleaned up). We still know what the run REPORTED — fall back to that rather than
+  // a bare error, so the pane answers "what came of it" even when it can't answer "what happened".
+  if (ended && err && session) return <RunReport session={session} note={err} />
   if (err) return <div className="flex flex-1 items-center justify-center bg-black text-sm text-red-400">⚠ {err}</div>
   if (!wsUrl) return <div className="flex flex-1 items-center justify-center bg-black text-sm text-neutral-500">opening terminal…</div>
   return (
@@ -2714,6 +2718,55 @@ function TerminalFrame({ session, tmux, onActivity, ops, standalone }: { session
       </ImageDropZone>
     </div>
   )
+}
+
+/**
+ * What a finished run REPORTED, shown when its transcript can't be. A pane log is best-effort — an older
+ * session may never have written one, and a cleaned-up home loses them — but the verdict and the
+ * one-line summary live on the session row, so "what came of it" survives even when "what happened"
+ * doesn't. Strictly better than the bare error this replaced, which told the reader nothing at all.
+ */
+function RunReport({ session: s, note }: { session: Session; note: string }) {
+  const v = OUTCOME_TONE[s.outcome ?? 'unknown'] ?? OUTCOME_TONE.unknown
+  const facts = [
+    s.agent,
+    s.activeMs != null ? formatDuration(s.activeMs) : null,
+    s.costUsd != null ? fmtCost(s.costUsd) : null,
+    s.turns ? `${s.turns} turn${s.turns === 1 ? '' : 's'}` : null,
+    `${timeAgo(s.updatedAt)} ago`,
+  ].filter(Boolean) as string[]
+  return (
+    <div className="flex min-h-0 flex-1 flex-col bg-black">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-neutral-800 px-3 py-1.5 text-xs text-neutral-500">
+        <span>Session ended · report</span>
+      </div>
+      <div className="min-h-0 flex-1 overflow-auto px-4 py-4">
+        <div className="mx-auto max-w-2xl space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className={`rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide ${v}`}>{s.outcome === 'unknown' || !s.outcome ? 'no report' : s.outcome}</span>
+            <span className="font-mono text-[11px] text-neutral-500">{facts.join(' · ')}</span>
+          </div>
+          {s.summary
+            ? <p className="text-sm leading-relaxed text-neutral-300">{s.summary}</p>
+            : <p className="text-sm italic text-neutral-500">The run left no summary — nobody closed the loop with a report.</p>}
+          {/* The usual `note` is just "no transcript", which would read as a stutter — only show it when
+              it says something the sentence doesn't (a permission error, say). */}
+          <p className="border-t border-neutral-800 pt-3 font-mono text-[11px] text-neutral-600">
+            No transcript was captured for this run{/^no transcript/i.test(note) ? '' : ` — ${note}`}.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Outcome → pill tone, for the dark terminal pane (OUTCOME_STYLE's light-mode 700s are unreadable here). */
+const OUTCOME_TONE: Record<string, string> = {
+  success: 'border-emerald-800 text-emerald-400',
+  failure: 'border-red-900 text-red-400',
+  error: 'border-red-900 text-red-400',
+  partial: 'border-amber-900 text-amber-400',
+  unknown: 'border-neutral-700 text-neutral-400',
 }
 
 /** Wraps the first-party terminal (<Xterm>) with the console chrome: the font stepper, the "how to use"
@@ -8813,9 +8866,15 @@ function TasksPage({ me, agents, taskId, onOpen, nav }: { me: Member; agents: Ag
           </Field>
         )}
 
-        {(detail.task.assignee || '').startsWith('agent:') && (detail.task.status === 'todo' || detail.task.status === 'blocked') && (
+        {/* Dispatch is offered for `doing` too, not just todo/blocked. A task is the unit of work and a
+            session is one ATTEMPT at it, so a `doing` task whose run has ENDED (headless runs exit at
+            turn-end, which is the common shape) is precisely the case that needs another go — and the
+            server has always allowed it (dispatchTask refuses only done/cancelled, plus a live-session
+            pile-up guard). Hiding the button here was the only thing standing in the way. While a run
+            IS alive we still hide it: that's the pile-up the guard would reject anyway. */}
+        {(detail.task.assignee || '').startsWith('agent:') && detail.task.status !== 'done' && detail.task.status !== 'cancelled' && !liveOf(detail.task) && (
           <Button size="sm" className="w-full" disabled={busy} onClick={() => dispatch(detail.task)}>
-            <Play className="mr-1 h-3.5 w-3.5" />{detail.task.status === 'blocked' ? 'Re-dispatch' : 'Dispatch now'}
+            <Play className="mr-1 h-3.5 w-3.5" />{detail.runs.length > 0 ? `Run again · attempt ${detail.runs.length + 1}` : 'Dispatch now'}
           </Button>
         )}
         {detail.runs.length > 0 && (


### PR DESCRIPTION
Three gaps around **re-running a task**, all surfaced working a live board.

### 1. A re-dispatched run is told it isn't the first

A task is the unit of work and a session is one **attempt** at it — but every attempt got a prompt
byte-identical to the first one's. Nothing said two sessions had already been here, which invites redoing
work that already landed or re-hitting a wall a predecessor documented.

```
You are working task tsk_0042…: Diagnose failed deploys from the build log

Ship the deploy doctor.

This is attempt 3 — 2 earlier sessions already worked this task:
  1. engineer — crashed
  2. engineer — partial: Shipped phases 0+1 as PR #419; blocked on two Phase-3 decisions.
Pick up where they left off rather than starting over — call task_get({ id: "tsk_0042…" }) for the full notes and discussion first.

When finished, call task_update(…)
```

Last three attempts named, the rest collapse to a count (`(2 older ones not listed)`) with absolute
numbering preserved. The block sits **inside** the text the `/goal` length gate measures, so a converging
task can't ship a payload the CLI rejects. Nine new assertions in `scripts/task-runs-test.cjs`.

### 2. "Run again" on a task that's already `doing`

Dispatch was offered only for `todo`/`blocked`. But a `doing` task whose run has **ended** — the normal
shape, since headless runs exit at turn-end — is exactly the one that needs another go, and the server
always allowed it (`dispatchTask` refuses only done/cancelled, plus the live-session pile-up guard). The
hidden button was the entire obstacle. It now shows for any non-terminal task with no live run, labelled
with the attempt it will start; while a run IS alive it stays hidden, which is the pile-up the guard
would reject anyway.

### 3. A finished run with no transcript shows its report

A pane log is best-effort and some older sessions never wrote one. The verdict, summary, cost, duration
and turn count live on the session row, so the pane now answers "what came of it" even when it can't
answer "what happened" — replacing the `⚠ no transcript for this session` dead end on every surface that
shows a finished run.

## Verification

Against **live instapods data**, new bundle served over the live API:

- `tsk_0042a26b7a86018a` (the `doing` task that prompted this) → **"Run again · attempt 2"** above its
  run history, transcript in the pane.
- `tsk_fd1772d4b5eb21cd` (a real no-transcript run) → **SUCCESS · marketing-site · 18m · $17.52 ·
  9 turns**, its summary, and a footnote that no transcript was captured — instead of the bare error.
- Prompt output inspected for 0, 2 and 5 prior runs; `npm run test:governance` green (task-runs 28/28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)