### PR TITLE
fix(insights): retire the fleet-wide "success rate" from all four channels that broadcast it (v0.319.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+
+## [0.319.1] — 2026-08-08
+### Removed
+- **The fleet-wide "success rate" is gone from every channel that broadcast it** (`docs/insights-revisit.md`
+  Step 0). `success / sessions` divided *self-reported* successes by ALL sessions, so its complement was
+  dominated by runs that simply never called `report`: live instapods logged 334 `session.ended` with no
+  outcome against 302 `session.reported` in 30 days, and **one** reported failure in 329 reports lifetime
+  (instawp: 6 in 1830). Both tenants computed ~55% and broadcast it four ways — retired all four:
+  - the `deriveGuidance` line telling **every agent, in every system prompt, permanently** to "slow down"
+    about a failure rate that isn't in the data;
+  - the `runtime.effort.high` recommendation, which stood ready to raise the whole workspace's reasoning
+    effort (and cost) on the same evidence — `recommendationResolved` now retires any persisted one at read
+    time rather than waiting for the next pass;
+  - the tenant-shared memory Insight agents `recall`, which now reports raw counts including how many runs
+    **never reported an outcome**;
+  - the `success-drop` alert, which DM'd a human whenever reporting discipline dipped (it fired twice on
+    instapods); dropping it also drops a full 8-week `measureLearning` scan per alert tick.
+  `agent-low` is kept — it gates on real reported failures (`failed >= 2`), which `success-drop` never had.
+  The KB fleet-learnings page keeps its counts, derives no percentage from them, and now says outcome is
+  self-reported. Pinned by `scripts/insights-signal-test.cjs` (19 assertions, in `npm run test:governance`),
+  verified to fail 10 of them against the pre-fix build. A rate returns only when Step 1 derives an outcome
+  from observable facts.
+
 ### Added
 - **`docs/insights-revisit.md`** — audit of the Insights surface against live instapods + instawp data,
   and a from-scratch rebuild sequenced one step at a time. Findings: the stack rests on a self-graded

--- a/docs/insights-revisit.md
+++ b/docs/insights-revisit.md
@@ -152,14 +152,29 @@ Principles for the rebuild, each a direct inversion of a root cause:
 - **One step at a time.** A step ships, then is measured on live data, then the next begins. Steps do
   not run in parallel.
 
-### Step 0 — stop the harm (no new capability)
+### Step 0 — stop the harm (no new capability) ✅ shipped v0.319.1
 
-Remove the success-rate line from `deriveGuidance` and the `runtime.effort.high` recommendation that
-shares its denominator. Both are wrong on both live tenants today.
+Retire every channel that broadcasts `success / sessions`. Scoping this by *channel* rather than by
+call site turned up **four**, not the two originally listed — the same number was also reaching agents
+through the tenant-shared memory Insight they `recall`, and reaching humans as a DM'd alert:
 
-- **Exit:** live `learned_guidance` on instapods + instawp no longer asserts a success rate; the
-  remaining `recall`/`kb_search` line is left alone for now.
-- **Falsifier:** none needed — this is a deletion.
+| Channel | Reaches | Action |
+|---|---|---|
+| `deriveGuidance` success-rate line | every agent's system prompt, always | deleted |
+| `deriveRecommendations` → `runtime.effort.high` | owner, as an applyable config change | deleted; `recommendationResolved` now retires persisted ones at read time |
+| Tenant-shared memory Insight summary | any agent that calls `recall` | rate replaced with raw counts incl. "never reported an outcome" |
+| `alerts.ts` → `success-drop` | a DM to a human | deleted (also drops a full `measureLearning` scan per alert tick) |
+
+`agent-low` is deliberately **kept**: it gates on `a.failed >= 2`, i.e. real reported failures, so it
+has evidence behind it that `success-drop` never had. The KB fleet-learnings page keeps its counts but
+no longer derives a percentage from them, and states that outcome is self-reported.
+
+- **Exit:** live `learned_guidance` on instapods + instawp no longer asserts a success rate. Regenerates
+  on the next reflect pass after deploy (≤2h instapods, ≤24h instawp) — no migration needed.
+- **Pin:** `scripts/insights-signal-test.cjs` (in `npm run test:governance`) — 19 assertions across all
+  four channels, verified to fail 10 of them against the pre-fix build. Its `noRateWithoutFailures`
+  case is the fixture Step 1 must satisfy: two states differing **only** in how many runs reported,
+  with identical real failures, must produce identical guidance.
 
 ### Step 1 — an outcome that isn't self-graded
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.320.0",
+  "version": "0.319.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.320.0",
+      "version": "0.319.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.320.0",
+  "version": "0.319.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,7 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs",
+    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:deps": "node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",

--- a/scripts/insights-signal-test.cjs
+++ b/scripts/insights-signal-test.cjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/* Insights signal test (docs/insights-revisit.md, Step 0) — a number that rides in EVERY agent's system
+ * prompt, or DMs a human, must not be derived from `success / sessions`.
+ *
+ * That ratio divides SELF-REPORTED successes by ALL sessions, so its complement is dominated by runs that
+ * never called `report` at all. On live data (2026-08-08): instapods logged 334 `session.ended` with no
+ * outcome against 302 `session.reported` in 30 days, and ONE reported failure in 329 reports lifetime
+ * (instawp: 6 in 1830). Both tenants computed ~55% "success" and broadcast it four ways — the injected
+ * guidance line, a config recommendation, the tenant-shared memory Insight, and a `success-drop` DM.
+ *
+ * These cases pin all four shut. They're the fixture for Step 1: when an outcome derived from observable
+ * facts lands, a rate may return — but it must fail `noRateWithoutFailures` below, i.e. it must move when
+ * real failures move, not when reporting discipline does. */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-insights-signal-'));
+process.env.AGENT_OS_HOME = HOME;          // ⚠ never let loadAgentOS() resolve to the live ./data home
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+
+const { deriveGuidance, deriveRecommendations, recommendationResolved } = require(path.join(ROOT, 'dist/edge/dreaming.js'));
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { detectAlerts } = require(path.join(ROOT, 'dist/edge/alerts.js'));
+
+const NOW = Date.now();
+const DAY = 24 * 3600_000;
+
+/** A state shaped like real live data: plenty of runs, a middling "success" share, and ZERO reported
+ *  failures — every non-success is a run that stopped or never reported. */
+const realistic = (over = {}) => ({
+  firstPass: NOW - 30 * DAY, passes: 12, topics: {}, watermark: NOW,
+  totals: { sessions: 635, episodes: 464, success: 291, failure: 0, partial: 44, stopped: 147, unknown: 153, approved: 24, rejected: 0, budgetStops: 0, errors: 0 },
+  recent: [
+    { day: 'd1', ts: NOW - 1 * DAY, sessions: 40, success: 22, failure: 0, stopped: 8, approved: 0, rejected: 0, budgetStops: 0, errors: 0, topics: [] },
+    { day: 'd2', ts: NOW - 2 * DAY, sessions: 28, success: 17, failure: 0, stopped: 1, approved: 0, rejected: 0, budgetStops: 0, errors: 0, topics: [] },
+    { day: 'd3', ts: NOW - 3 * DAY, sessions: 24, success: 17, failure: 0, stopped: 0, approved: 2, rejected: 0, budgetStops: 0, errors: 0, topics: [] },
+  ],
+  ...over,
+});
+
+console.log('\n\x1b[1mInsights signal — no prompt-injected or DM\'d number off `success / sessions`\x1b[0m');
+
+// ── 1. The guidance line ───────────────────────────────────────────────────────────────────────────
+{
+  const s = realistic();
+  const recentSessions = s.recent.reduce((n, r) => n + r.sessions, 0);
+  const recentSuccess = s.recent.reduce((n, r) => n + r.success, 0);
+  const bogusRate = Math.round((recentSuccess / recentSessions) * 100);
+  const g = deriveGuidance(s);
+
+  assert(bogusRate < 70 && recentSessions >= 5, 'fixture would have tripped the old gate', `rate ${bogusRate}% over ${recentSessions} sessions`);
+  assert(!/success rate/i.test(g), 'guidance asserts no success rate', g);
+  assert(!/slow down/i.test(g), 'guidance does not tell every agent to slow down');
+  assert(!new RegExp(`${bogusRate}\\s*%`).test(g), `guidance does not contain the ${bogusRate}% figure`);
+  assert(/recall/.test(g) && /kb_search/.test(g), 'the baseline recall/KB nudge still ships', g);
+}
+
+// ── 2. The config recommendation ───────────────────────────────────────────────────────────────────
+{
+  const recs = deriveRecommendations(realistic(), 'medium', NOW);
+  assert(!recs.some((r) => r.id === 'runtime.effort.high'), 'no runtime.effort.high proposed', JSON.stringify(recs.map((r) => r.id)));
+  assert(!recs.some((r) => r.apply), 'nothing auto-applyable is proposed off this state');
+
+  // A persisted one from before the retirement must vanish at READ time, not wait for the next pass.
+  assert(recommendationResolved({ id: 'runtime.effort.high' }, 'medium') === true, 'a legacy runtime.effort.high reads as resolved');
+  assert(recommendationResolved({ id: 'policy.review' }, 'medium') === false, 'unrelated recommendations are untouched');
+}
+
+// ── 3. Friction signals that DO have a denominator still fire ──────────────────────────────────────
+{
+  // Not a blanket "no guidance ever": real, sampled, denominated friction must still reach agents.
+  const s = realistic({ recent: [{ day: 'd1', ts: NOW - DAY, sessions: 40, success: 5, failure: 0, stopped: 8, approved: 2, rejected: 10, budgetStops: 3, errors: 4, topics: [] }] });
+  const g = deriveGuidance(s);
+  assert(/rejected at human approval/i.test(g), 'approval friction still fires (10 of 12 decisions rejected)');
+  assert(/[Bb]udget/.test(g), 'budget friction still fires');
+  assert(/errors/i.test(g), 'error friction still fires');
+  assert(!/success rate/i.test(g), 'still no success rate, even alongside real friction');
+
+  const recs = deriveRecommendations(s, 'medium', NOW);
+  assert(recs.some((r) => r.id === 'policy.review'), 'policy.review still proposed on a real rejection rate');
+  assert(recs.some((r) => r.id === 'budget.review'), 'budget.review still proposed');
+}
+
+// ── 4. The success-drop alert ──────────────────────────────────────────────────────────────────────
+{
+  const aos = loadAgentOS();
+  let n = 0;
+  /** One terminated run. `reported` false ⇒ it ended WITHOUT an outcome — the live majority case. */
+  const mkRun = (ageDays, reported) => {
+    const id = 'ts_' + (++n), at = NOW - ageDays * DAY;
+    aos.db.prepare("INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,spawned_by,created_at,updated_at) VALUES (?,?,'t','x',?,'done',1,'m_alice',?,?)")
+      .run(id, 'worker', 'aos-' + id, at, at + 60_000);
+    aos.db.prepare("INSERT INTO audit_events (ts,tenant,run_id,principal,type,data) VALUES (?,?,?,'agent:worker','session.ended',?)")
+      .run(at + 60_000, aos.tenant, id, JSON.stringify(reported ? { outcome: 'success' } : {}));
+  };
+  // Prior week: 20 runs, 18 reported success (90%). This week: 20 runs, 4 reported (20%) — a 70-point
+  // "collapse" in which NOTHING failed; 16 runs merely exited without calling `report`.
+  for (let i = 0; i < 20; i++) mkRun(9, i < 18);
+  for (let i = 0; i < 20; i++) mkRun(2, i < 4);
+
+  const alerts = detectAlerts(aos, NOW);
+  assert(!alerts.some((a) => a.key === 'success-drop'), 'no success-drop alert on a 70-point reporting swing with zero failures', JSON.stringify(alerts.map((a) => a.key)));
+  assert(!alerts.some((a) => a.key === 'agent-low:worker'), 'no agent-low either — that gate needs real reported failures');
+}
+
+// ── 5. The regression guard for Step 1 ─────────────────────────────────────────────────────────────
+{
+  // noRateWithoutFailures: whatever metric Step 1 introduces, two states that differ ONLY in how many runs
+  // reported (identical real failures: none) must produce identical guidance. A metric that moves here is
+  // measuring reporting discipline, not quality — the exact defect Step 0 removed.
+  const quiet = realistic({ recent: [{ day: 'd1', ts: NOW - DAY, sessions: 40, success: 4, failure: 0, stopped: 0, approved: 0, rejected: 0, budgetStops: 0, errors: 0, topics: [] }] });
+  const chatty = realistic({ recent: [{ day: 'd1', ts: NOW - DAY, sessions: 40, success: 38, failure: 0, stopped: 0, approved: 0, rejected: 0, budgetStops: 0, errors: 0, topics: [] }] });
+  assert(deriveGuidance(quiet) === deriveGuidance(chatty), 'guidance is identical whether 10% or 95% of runs reported', `\n${deriveGuidance(quiet)}\n---\n${deriveGuidance(chatty)}`);
+  assert(JSON.stringify(deriveRecommendations(quiet, 'medium', NOW)) === JSON.stringify(deriveRecommendations(chatty, 'medium', NOW)), 'recommendations are identical too');
+}
+
+fs.rmSync(HOME, { recursive: true, force: true });
+console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m\n`);
+process.exit(fail ? 1 : 0);

--- a/src/edge/alerts.ts
+++ b/src/edge/alerts.ts
@@ -10,7 +10,6 @@
  */
 import type { AgentOS } from '../kernel';
 import { buildInsights, RECENT_DAYS } from './insights';
-import { measureLearning } from './measurement';
 
 const COOLDOWN_MS = 3 * 24 * 3_600_000; // don't re-alert the same key within 3 days
 /** Clean work runs since the last crash that count as "recovered" — enough to not be a lucky single pass,
@@ -32,19 +31,16 @@ export interface InsightAlert {
 /** Detect the conditions worth a human's attention right now (pure — no dedup, no side effects). */
 export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
   const ins = buildInsights(os, now);
-  const m = measureLearning(os, now);
   const out: InsightAlert[] = [];
 
-  // Fleet success rate fell sharply week-over-week (enough runs to be real).
-  if (m.deltaPp != null && m.deltaPp <= -15 && m.recent.n >= 10) {
-    out.push({
-      key: 'success-drop',
-      severity: 'high',
-      title: `Fleet success rate dropped ${Math.abs(m.deltaPp)} points`,
-      body: `Success fell to ${m.recent.rate}% this week (${m.recent.n} runs) from ${m.prior.rate}% the week before. Check the Insights page for which agents regressed.`,
-      route: 'insights',
-    });
-  }
+  // ⛔ RETIRED (2026-08-08, docs/insights-revisit.md Step 0) — the `success-drop` alert. It was the fourth
+  // and loudest broadcast of the same broken metric: `measureLearning` counts a run as successful only if it
+  // self-reported `outcome: success`, so a week where more runs simply exited without calling `report` reads
+  // as a "fleet success rate dropped N points" DM to a human. It fired twice on instapods, where agents have
+  // reported failure exactly once in their entire history. Unlike `agent-low` below — which requires
+  // `a.failed >= 2`, i.e. real reported failures — this one had no failure evidence at all behind it.
+  // Restore it in Step 4, over an outcome derived from observable facts. (Dropping it also drops the
+  // `measureLearning` call this tick made — a multi-query scan over 8 weeks of audit, run for one alert.)
 
   // An individual agent is failing badly.
   for (const a of ins.agents) {

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -263,9 +263,11 @@ export class DreamingEngine {
     let insightId: string | undefined;
     try {
       const t = state.totals;
-      const rate = t.sessions ? Math.round((t.success / t.sessions) * 100) : 0;
+      // No derived "N% success" here either — this Insight is tenant-shared and agents `recall` it, so it's
+      // a THIRD broadcast channel for the same broken rate (Step 0). Report the raw counts instead: they say
+      // what was actually observed, including how much of it was never reported at all.
       const topTopics = topTopicList(state.topics, 6).filter(([, v]) => v.count >= MIN_TOPIC_COUNT).map(([k]) => k).join(', ') || '—';
-      const summary = `Fleet self-learning (pass ${state.passes}, since ${new Date(state.firstPass).toISOString().slice(0, 10)}): ${t.sessions} sessions, ${rate}% success. Recurring topics: ${topTopics}. Friction so far: ${t.rejected} approvals rejected, ${t.budgetStops} budget stops, ${t.errors} errors. Details: [[${DREAM_SECTION}/${DREAM_SLUG}]].`;
+      const summary = `Fleet self-learning (pass ${state.passes}, since ${new Date(state.firstPass).toISOString().slice(0, 10)}): ${t.sessions} sessions — ${t.success} reported success, ${t.unknown} never reported an outcome. Recurring topics: ${topTopics}. Friction so far: ${t.rejected} approvals rejected, ${t.budgetStops} budget stops, ${t.errors} errors. Details: [[${DREAM_SECTION}/${DREAM_SLUG}]].`;
       const rec = await this.os.memory.store({ tenant: this.os.tenant, agentId: 'dreamer', content: summary, tags: ['dreaming', 'learned'], type: 'Insight', importance: 0.6, scope: 'tenant', metadata: { passes: state.passes, window, sessions: win.sessions } });
       insightId = rec.id;
     } catch { /* best-effort */ }
@@ -528,8 +530,15 @@ export function deriveGuidance(s: DreamState): string {
   if (t.rejected >= 2 && rejectionRate(t) >= REJECTION_RATE) lines.push('Recent actions were rejected at human approval — `policy_check` before risky effects, and never retry an action a human already rejected.');
   if (t.budgetStops >= 1) lines.push('Budget limits have been hit — scope work tightly, avoid broad scans / long loops, and `ask` rather than burn budget guessing.');
   if (t.errors >= 2) lines.push('Some sessions ended in errors — verify your work before finishing, and `report` the real outcome (including failures) honestly.');
-  const rate = t.sessions ? t.success / t.sessions : 1;
-  if (t.sessions >= 5 && rate < 0.7) lines.push(`Recent success rate is ${Math.round(rate * 100)}% — slow down, confirm assumptions, and prefer asking over guessing on anything ambiguous.`);
+  // ⛔ RETIRED (2026-08-08, docs/insights-revisit.md Step 0) — the "Recent success rate is N% — slow down"
+  // line. `t.success / t.sessions` divides *self-reported* successes by ALL sessions, so its complement is
+  // dominated by runs that simply never called `report`: live instapods had 334 `session.ended` with no
+  // outcome against 302 `session.reported` in 30 days, and exactly ONE reported failure in 329 reports
+  // lifetime (instawp: 6 in 1830). Both tenants therefore computed ~55% and told EVERY agent, in EVERY
+  // system prompt, permanently, to slow down about a failure rate that does not exist in the data. This is
+  // the same defect the 2026-07-31 correction fixed for approval friction (a rate needs a denominator and a
+  // sample) — missed here because this metric's denominator looked like one. It returns only when Step 1
+  // lands an outcome derived from observable facts rather than the agent's own grade of its own homework.
   const top = lines.slice(0, 6);
   if (!top.length) return '';
   return [
@@ -547,7 +556,11 @@ export function deriveGuidance(s: DreamState): string {
  * ones (policy/budget) clear on the next pass.
  */
 export function recommendationResolved(rec: Recommendation, currentEffort: string | undefined): boolean {
-  if (rec.id === 'runtime.effort.high') return currentEffort === 'high' || currentEffort === 'xhigh' || currentEffort === 'max';
+  // `runtime.effort.high` is RETIRED (Step 0) — it proposed a fleet-wide config change off the same broken
+  // success rate as the guidance line above. It can no longer be derived, but a tenant that hasn't run a
+  // pass since the upgrade still has one persisted in `learned_recommendations.open`; treating it as always
+  // resolved retires those at read time instead of waiting for the next pass to recompute `open`.
+  if (rec.id === 'runtime.effort.high') return true;
   return false;
 }
 
@@ -558,16 +571,11 @@ export function recommendationResolved(rec: Recommendation, currentEffort: strin
 export function deriveRecommendations(s: DreamState, currentEffort: string | undefined, now: number): Recommendation[] {
   const t = recentTally(s); // H4: propose from RECENT friction, not lifetime — a subsided problem stops re-proposing
   const recs: Recommendation[] = [];
-  const rate = t.sessions ? t.success / t.sessions : 1;
-  const effortAlreadyHigh = currentEffort === 'high' || currentEffort === 'xhigh' || currentEffort === 'max';
-  if (t.sessions >= 5 && rate < 0.7 && !effortAlreadyHigh) {
-    recs.push({
-      id: 'runtime.effort.high', kind: 'runtime',
-      title: 'Raise the workspace default reasoning effort to “high”',
-      rationale: `Recent success rate is ${Math.round(rate * 100)}% over ${t.sessions} sessions${t.errors ? `, with ${t.errors} errored` : ''}. More reasoning effort often helps agents get it right the first time. Reversible in Settings → Runtime defaults.`,
-      apply: { runtimeDefaults: { effort: 'high' } }, createdAt: now,
-    });
-  }
+  // ⛔ RETIRED (Step 0): `runtime.effort.high`. It fired on `success / sessions` — the same self-reported,
+  // 40%-missing metric the guidance line did — so it stood ready to raise the whole workspace's reasoning
+  // effort (and its cost) on evidence of nothing. `currentEffort` is kept in the signature for
+  // `recommendationResolved` and the next recommendation that legitimately needs it.
+  void currentEffort;
   if (t.rejected >= 3 && rejectionRate(t) >= REJECTION_RATE) {
     recs.push({
       id: 'policy.review', kind: 'policy',
@@ -589,7 +597,6 @@ export function deriveRecommendations(s: DreamState, currentEffort: string | und
 
 function renderPage(s: DreamState): string {
   const t = s.totals;
-  const rate = t.sessions ? Math.round((t.success / t.sessions) * 100) : 0;
   const top = topTopicList(s.topics, TOP_TOPICS);
   return [
     `_Auto-maintained and **compounding** — each self-learning pass folds new activity into this page (a pure render of the OS's cumulative state; it rebuilds even if deleted). Edit it and the next pass will overwrite._`,
@@ -597,7 +604,8 @@ function renderPage(s: DreamState): string {
     `**Pass ${s.passes}** · learning since ${new Date(s.firstPass).toISOString().slice(0, 10)}`,
     ``,
     `## Cumulative totals`,
-    `- Sessions/runs: **${t.sessions}** — ${t.success} succeeded, ${t.failure} failed, ${t.partial} partial, ${t.stopped} stopped, ${t.unknown} unknown · **${rate}% success**.`,
+    `- Sessions/runs: **${t.sessions}** — ${t.success} reported success, ${t.failure} failed, ${t.partial} partial, ${t.stopped} stopped, **${t.unknown} never reported an outcome**.`,
+    `- ⚠ Outcome is **self-reported** by the agent, and a run that never calls \`report\` lands as "unknown" — so these counts measure reporting at least as much as quality, and no success *rate* is derived from them. A derived outcome is Step 1 of \`docs/insights-revisit.md\`.`,
     `- Episodes captured: **${t.episodes}**.`,
     `- Friction (all-time): ${t.rejected} approvals rejected · ${t.budgetStops} budget stops · ${t.errors} episode errors.`,
     ``,


### PR DESCRIPTION
Step 0 of [`docs/insights-revisit.md`](https://github.com/vikasprogrammer/agent-os/blob/main/docs/insights-revisit.md).

`success / sessions` divides **self-reported** successes by **all** sessions, so its complement is dominated by runs that never called `report` at all:

- instapods, 30d: **334** `session.ended` with no outcome vs **302** `session.reported`
- instapods, lifetime `session.reported`: success 281 · partial 46 · **failure 1**
- instawp, lifetime: **6** failures across 1830 sessions

Both tenants computed ~55% "success" off that and broadcast it four ways. Scoping the fix by *channel* rather than by call site found two more than the plan listed — the same number was also reaching agents through the memory Insight they `recall`, and reaching humans as a DM.

| Channel | Reaches | Action |
|---|---|---|
| `deriveGuidance` success-rate line | every agent's system prompt, always | deleted |
| `runtime.effort.high` recommendation | owner, as an applyable config change | deleted; `recommendationResolved` retires persisted ones at read time |
| Tenant-shared memory Insight | any agent that calls `recall` | rate → raw counts incl. "never reported an outcome" |
| `success-drop` alert | a DM to a human | deleted (also drops an 8-week `measureLearning` scan per alert tick) |

**`agent-low` is deliberately kept** — it gates on `failed >= 2`, real reported failures, which is evidence `success-drop` never had. The KB fleet-learnings page keeps its counts, derives no percentage from them, and now states outcome is self-reported.

This is the same defect the 2026-07-31 correction fixed for approval friction (*a signal in every prompt needs a denominator and a sample*), missed here because this metric's denominator looked like one.

## Verification

`scripts/insights-signal-test.cjs` — 19 assertions across all four channels, added to `npm run test:governance`. **Verified to fail 10 of them against the pre-fix build** (`git stash` → rebuild → run):

```
✗ guidance asserts no success rate          ✗ no runtime.effort.high proposed
✗ guidance does not tell every agent to slow down   ✗ a legacy runtime.effort.high reads as resolved
✗ no success-drop alert on a 70-point reporting swing with zero failures
9 passed, 10 failed
```

It also pins that **real, denominated friction still fires** (approval-rejection rate, budget stops, errors → guidance + `policy.review` + `budget.review`), so this isn't a blanket muting.

Its `noRateWithoutFailures` case is the fixture **Step 1** must satisfy: two states differing *only* in how many runs reported, with identical real failures, must produce identical guidance.

Full `npm run test:governance` green (159 + 18 + 18 + … + 19). `npm run typecheck` and `cd web && npm run build` clean. No migration — guidance regenerates on the next reflect pass after deploy (≤2h instapods, ≤24h instawp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiTKjtdcF4ESbuYVWj2CfU