### PR TITLE
fix: restore the version after a concurrent-merge regression (v0.320.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.319.1] — 2026-08-08
+## [0.320.1] — 2026-08-08
 ### Removed
 - **The fleet-wide "success rate" is gone from every channel that broadcast it** (`docs/insights-revisit.md`
   Step 0). `success / sessions` divided *self-reported* successes by ALL sessions, so its complement was

--- a/docs/insights-revisit.md
+++ b/docs/insights-revisit.md
@@ -152,7 +152,7 @@ Principles for the rebuild, each a direct inversion of a root cause:
 - **One step at a time.** A step ships, then is measured on live data, then the next begins. Steps do
   not run in parallel.
 
-### Step 0 — stop the harm (no new capability) ✅ shipped v0.319.1
+### Step 0 — stop the harm (no new capability) ✅ shipped v0.320.1
 
 Retire every channel that broadcasts `success / sessions`. Scoping this by *channel* rather than by
 call site turned up **four**, not the two originally listed — the same number was also reaching agents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.319.1",
+  "version": "0.320.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.319.1",
+      "version": "0.320.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.319.1",
+  "version": "0.320.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
#588 branched off v0.319.0 and bumped to v0.319.1. #585 merged **v0.320.0** while it was open, so #588's squash carried its own `package.json` back over it — main landed on **0.319.1 with 0.320.0's code in it**, and the CHANGELOG listed 0.319.1 *above* 0.320.0. The live instapods box reported `0.319.1` while running both changes.

That matters because `/health` + the sidebar version is how we tell which build a long-running server is holding in memory — the first thing checked when a change "isn't taking". A version that moves backwards makes that check lie.

- `[0.319.1]` heading → `[0.320.1]` (the patch on top of 0.320.0, which is what the code actually is)
- `package.json` → 0.320.1
- Step 0 reference in `docs/insights-revisit.md` updated

No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiTKjtdcF4ESbuYVWj2CfU