### PR TITLE
fix(sessions): the gate is the universal turn heartbeat (v0.326.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,28 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.326.0] — 2026-08-08
+### Fixed
+- **A session that was visibly generating could read `ready`.** The inverse of the v0.324.0 bug, and the
+  half that had no backstop: `isWorking` self-healed against a *stale* flag, but nothing could set the
+  flag back. Hook settings are written into the agent folder **at launch**, so a session launched before
+  `UserPromptSubmit` was wired never fires it — once its `busy_since` was cleared it could never regain
+  it. Observed live on `ses_c63f1492dc12ce06`: pane showing `Germinating… (1m 2s)`, gate events every few
+  seconds, `busy_since` NULL, console reading `ready`.
+  The heartbeat now lives on the **gate hook**, which is wired into every session that exists and is the
+  one thing that cannot be missing — it *is* the invariant. A tool call is proof a turn is running, so it
+  stamps `busy_since` too:
+  - with `answered: false`, so a tool call never retires a "waiting on you" card — only a human
+    submitting a prompt does (and a session blocked on an approval reads `needs you` regardless, since
+    that outranks `working`);
+  - re-stamping a flag older than `MID_TURN_MAX_MS`, which turns that ceiling from a dumb timer into an
+    honest **activity** test: a long turn still calling tools keeps its spinner, a wedged one emits
+    nothing and ages out. Without this a real 2h+ turn would have silently read `ready`.
+  - throttled to one write per 30s per session (in-memory, dropped by `clearTurnBusy` so the first tool
+    call of the next turn is never swallowed). The gate is a hot path and `node:sqlite` is synchronous —
+    a lock-taking write there is the event-loop blocking that has made a busy box feel unresponsive
+    before, and the statement is a no-op mid-turn anyway.
+
 ## [0.325.1] — 2026-08-08
 ### Changed
 - **Session status glyphs: `ready` takes the check, `done` takes a dim dot.** The dashed circle read as

--- a/docs/session-lifecycle-hooks.md
+++ b/docs/session-lifecycle-hooks.md
@@ -10,7 +10,7 @@ Reference for the events themselves: <https://code.claude.com/docs/en/hooks>.
 
 | Hook event | Script | Route | What it does |
 |---|---|---|---|
-| `PreToolUse` | `terminal/gate-hook.sh` | `/api/gate` | **The invariant** — every governed effect passes the gateway. Unrelated to status; listed so the table is the whole picture. |
+| `PreToolUse` | `terminal/gate-hook.sh` | `/api/gate` | **The invariant** — every governed effect passes the gateway. Also the **universal turn heartbeat**: a tool call is proof a turn is running (`markTurnBusy`, throttled to one write per 30s per session, since the gate is a hot path and `node:sqlite` is synchronous). |
 | `Notification` | `terminal/notify-hook.sh` | `/api/notify` | `permission_prompt` / `idle_prompt` / `agent_needs_input` → an inbox card + the per-session "needs you" bell, **and a turn-END** (blocked on a human is not generating). Other `notification_type`s (auth, elicitation, `agent_completed`) are dropped. |
 | `UserPromptSubmit` | `terminal/lifecycle-hook.sh` | `/api/session-event` | **Turn START** → `markTurnBusy` (stamps `busy_since`). |
 | `Stop` | `terminal/stop-hook.sh` | `/api/turn-idle` | **Turn END** → `markTurnIdle`: clears `busy_since` for every lane, and for an *unattended* run tears the pane down (the pile-up guard releases). |
@@ -84,8 +84,24 @@ turn older than the 2h ceiling); a genuinely in-flight turn is untouched, so it 
 backend: the interactive-lane clear, the turn-start signal, `StopFailure` teardown, each `SessionEnd`
 reason, all five `isWorking` clauses, and the ignore-unknown-events rule.
 
-## Gotcha
+## Gotcha — and why the gate is the heartbeat
 
 Hook settings are written into the agent folder **at launch** (`.claude/aos-settings.json`), so a change
-here reaches a session only when it is next launched. Already-running sessions keep the old hook set —
-which is exactly why `isWorking` has to self-heal rather than rely on a beacon arriving.
+here reaches a session only when it is next launched. Already-running sessions keep the old hook set.
+
+That cuts **both ways**, and only one direction was covered at first. A stale flag self-heals (clauses
+2–5 above). The opposite failure does not: a session launched before `UserPromptSubmit` was wired had no
+way to *set* the flag once it was cleared, so it read `ready` while visibly generating — observed live on
+`ses_c63f1492dc12ce06`, whose pane showed `Germinating… (1m 2s)` and which was emitting gate events every
+few seconds with `busy_since` NULL.
+
+Hence the heartbeat lives on the **gate hook**, which is wired into every session that exists, and is the
+one thing that cannot be missing — it *is* the invariant. A tool call is proof a turn is running, so it
+stamps `busy_since` too. Two properties matter:
+
+- it stamps with `answered: false`, so a tool call never retires a "waiting on you" card (only a human
+  submitting a prompt does). A session blocked on an approval still reads `needs you` regardless, since
+  that outranks `working`;
+- it re-stamps a flag older than `MID_TURN_MAX_MS`, which turns the ceiling into an honest **activity**
+  test: a long turn that is still calling tools keeps its spinner, a wedged one emits nothing and ages
+  out. Without that arm a real 2h+ turn would silently read `ready`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.325.1",
+  "version": "0.326.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.325.1",
+      "version": "0.326.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.325.1",
+  "version": "0.326.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/turn-lifecycle-test.cjs
+++ b/scripts/turn-lifecycle-test.cjs
@@ -201,7 +201,44 @@ console.log('    anthropics/claude-code#9516 — so the Notification bell is the
   assert(row(id).busy_since != null, 'a NOISE notification kind changes nothing');
 }
 
-console.log('\n\x1b[1m8) an unknown event is ignored, not a crash\x1b[0m');
+console.log('\n\x1b[1m8) the GATE is the universal turn heartbeat\x1b[0m');
+console.log('   (UserPromptSubmit only reaches sessions launched since that hook shipped — hook settings');
+console.log('    are written at launch — so an already-running session needs a signal it already emits)');
+{
+  const id = mk({ busy_since: null });               // an older session: no UserPromptSubmit will ever fire
+  assert(seen(id).working === false, 'starts idle');
+  tm.markTurnBusy(id, { answered: false });          // ← what the gate does on every tool call
+  assert(row(id).busy_since != null, 'a tool call stamps the turn');
+  assert(seen(id).working === true, 'so it reads working while it generates');
+}
+{
+  // A tool call is not a human answering — it must not retire a "waiting on you" card. (And a session
+  // blocked on an approval reads `needs you` anyway, which outranks working.)
+  const id = mk({ busy_since: null });
+  tm.notify(id, 'agent-demo', 'idle_prompt', 'waiting');
+  tm.markTurnBusy(id, { answered: false });
+  const card = aos.db.prepare("SELECT COUNT(*) c FROM messages WHERE session_id = ? AND type = 'notification' AND status = 'open'").get(id).c;
+  assert(card === 1, 'the waiting card survives a tool call');
+}
+{
+  // The throttle must never swallow the FIRST tool call of a turn, however soon it follows the last one.
+  const id = mk({ busy_since: null });
+  tm.markTurnBusy(id, { answered: false });
+  tm.markTurnIdle(id);                                // turn ends
+  assert(row(id).busy_since === null, 'turn ended');
+  tm.markTurnBusy(id, { answered: false });           // next turn starts immediately
+  assert(row(id).busy_since != null, 'the next turn stamps straight away — the throttle is dropped on clear');
+  assert(seen(id).working === true, 'and it reads working again');
+}
+{
+  // A long but ACTIVE turn keeps re-stamping past the ceiling; a WEDGED one produces nothing and ages out.
+  const id = mk({ busy_since: Date.now() - 3 * HOUR });
+  assert(seen(id).working === false, 'a 3h-old stamp with no activity is wedged, not working');
+  tm.markTurnBusy(id, { answered: false });           // …but a tool call proves otherwise
+  assert(seen(id).working === true, 'a tool call revives it — the ceiling measures ACTIVITY, not turn age');
+}
+
+console.log('\n\x1b[1m9) an unknown event is ignored, not a crash\x1b[0m');
 {
   const id = mk();
   const before = row(id).busy_since;

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -53,6 +53,10 @@ const WARM_CONFIRM_MS = 12_000;
  *  for minutes; one still "busy" after this is wedged, and protecting it would mean never reclaiming
  *  its pane. */
 const MID_TURN_MAX_MS = 2 * 3600_000;
+/** How long one in-memory "this session is mid-turn" stamp suppresses the gate's heartbeat write. The
+ *  gate fires on every tool call and `node:sqlite` is synchronous, so the write must not ride the hot
+ *  path more often than it has to; the DB statement is a no-op mid-turn anyway. */
+const BUSY_STAMP_THROTTLE_MS = 30_000;
 const VIDEO_MAX_DURATION_SEC = 60;         // clamp the requested clip length
 const VIDEO_JOB_TTL_MS = 20 * 60_000;      // give up on a render after 20 minutes
 const VIDEO_MAX_POLLS = 200;               // poll-attempt ceiling (belt-and-suspenders with the TTL)
@@ -738,6 +742,9 @@ export class TerminalManager {
    *  "tmux up" can't be read as "nothing is running" — which would let a second turn launch a
    *  competing claude on the same transcript. */
   private readonly launching = new Set<string>();
+  /** sessionId → when the gate heartbeat last stamped it. Purely a write throttle (see
+   *  {@link BUSY_STAMP_THROTTLE_MS}); the DB is the source of truth and `clearTurnBusy` drops the entry. */
+  private readonly busyStamped = new Map<string, number>();
   /** Pending "did that warm turn actually start?" checks, keyed by session — see `confirmWarmTurn`.
    *  Held so a newer message can cancel the previous check instead of racing it. */
   private readonly warmChecks = new Map<string, ReturnType<typeof setTimeout>>();
@@ -909,10 +916,11 @@ export class TerminalManager {
    *     turn-end path, including the ones the old code reached without clearing `busy_since` — so
    *     `last_activity > busy_since` means "that turn is over" even on a row latched by an older build.
    *     This is what heals the existing fleet without waiting on anything.
-   *  5. **the turn is not ANCIENT.** A turn running longer than `MID_TURN_MAX_MS` is wedged, not working
-   *     — the same judgement the resident reaper already makes. The backstop for a run that produced no
-   *     end signal at all (a hook that never fired, a pane wedged mid-generation): it stops reading as
-   *     "working" on its own instead of spinning forever.
+   *  5. **the stamp is not ANCIENT.** Older than `MID_TURN_MAX_MS` = wedged, not working — the same
+   *     judgement the resident reaper makes. This measures ACTIVITY, not turn age: the gate re-stamps
+   *     past the ceiling (see {@link markTurnBusy}), so a genuinely long turn keeps its spinner while a
+   *     wedged one — which emits nothing — ages out. The backstop for a run that produced no end signal
+   *     at all, so it stops reading as "working" on its own instead of spinning forever.
    */
   private isWorking(r: { id: string; tmux: string; status: string; busy_since: number | null; last_activity: number | null }, alive: Set<string> | null): boolean {
     if (r.busy_since == null) return false;
@@ -3028,25 +3036,48 @@ export class TerminalManager {
     }
   }
 
-  /** A turn STARTED — stamp `busy_since` (the console's "working") and the idle clock with it.
-   *  `WHERE busy_since IS NULL` makes a prompt queued INSIDE a running turn a no-op: it must not restart
-   *  the staleness window, and it must certainly not move `last_activity` past `busy_since`, which is how
-   *  {@link isWorking} recognises a turn that has already ended. */
-  markTurnBusy(sessionId: string): void {
+  /**
+   * A turn is RUNNING — stamp `busy_since` (the console's "working") and the idle clock with it. Two
+   * callers, because a turn announces itself two ways and old sessions only have the second:
+   *   - `UserPromptSubmit` (`answered: true`) — the turn's actual start, for sessions launched since the
+   *     lifecycle hook shipped;
+   *   - the GATE, on every tool call (`answered: false`) — the universal heartbeat. A tool call is proof
+   *     a turn is running, and the gate hook is wired into every session that exists, so this is what
+   *     keeps an already-running session honest.
+   *
+   * `busy_since IS NULL` makes it idempotent within a turn: a queued prompt or the 40th tool call must
+   * not restart the staleness window, and must certainly not move `last_activity` past `busy_since`,
+   * which is how {@link isWorking} recognises a turn that has already ended.
+   *
+   * The `OR busy_since < <stale floor>` arm is what turns the `MID_TURN_MAX_MS` ceiling from a dumb
+   * timer into an honest wedged-turn test. A turn that is genuinely still running keeps producing tool
+   * calls, so it re-stamps and never ages out; a turn that is wedged produces nothing, so its flag goes
+   * stale and {@link isWorking} drops it. Without this arm a real 2h+ turn would silently read `ready`.
+   *
+   * `answered` says whether a HUMAN produced this signal. Only then is an open "waiting on you" card
+   * retired — otherwise a session would keep reading `needs you` (which outranks `working`) through the
+   * whole turn it just started. That closes the loop the interrupt case opens: interrupt → idle_prompt
+   * card → you type → card gone, spinner back. A tool call is not an answer, so it never clears a card.
+   */
+  markTurnBusy(sessionId: string, opts: { answered?: boolean } = {}): void {
     const now = Date.now();
-    this.db.prepare('UPDATE term_sessions SET busy_since = ?, last_activity = ?, updated_at = ? WHERE id = ? AND busy_since IS NULL')
-      .run(now, now, now, sessionId);
-    // A prompt submitted IS the human answering — retire any open "waiting on you" card, or the session
-    // would keep reading `needs you` (which outranks `working`) through the whole turn it just started.
-    // This is the close of the loop the interrupt case opens: interrupt → idle_prompt card → you type →
-    // card gone, spinner back.
-    this.clearNotifications(sessionId);
+    // The gate calls this on EVERY tool call, and `node:sqlite` is synchronous — a write that takes a
+    // lock on the gate's hot path is exactly the event-loop blocking that made a busy box feel
+    // unresponsive before. The DB statement is already a no-op mid-turn (the WHERE matches nothing), so
+    // skip even issuing it when we stamped this session moments ago. `clearTurnBusy` drops the entry, so
+    // the first tool call of the NEXT turn always reaches the DB however soon it arrives.
+    if (opts.answered === false && now - (this.busyStamped.get(sessionId) ?? 0) < BUSY_STAMP_THROTTLE_MS) return;
+    this.busyStamped.set(sessionId, now);
+    this.db.prepare('UPDATE term_sessions SET busy_since = ?, last_activity = ?, updated_at = ? WHERE id = ? AND (busy_since IS NULL OR busy_since < ?)')
+      .run(now, now, now, sessionId, now - MID_TURN_MAX_MS);
+    if (opts.answered !== false) this.clearNotifications(sessionId);
   }
 
   /** A turn ENDED — drop `busy_since`. The one place that clears it, so every end path (Stop hook,
    *  StopFailure, SessionEnd, a terminal status transition) agrees. */
   private clearTurnBusy(sessionId: string): void {
     this.db.prepare('UPDATE term_sessions SET busy_since = NULL WHERE id = ? AND busy_since IS NOT NULL').run(sessionId);
+    this.busyStamped.delete(sessionId);   // so the next turn's first tool call isn't swallowed by the throttle
   }
 
   /** Was text delivered into this session within `ms`? Reads the `chat.delivered` / `session.inject`
@@ -3924,6 +3955,14 @@ export class TerminalManager {
     }
     this.audit(sessionId, agent, 'gate.attempt', { capability, args, reasoning, ...sub });
     this.audit(sessionId, agent, 'gate.decision', { capability, decision, brief, ...sub });
+    // A tool call is PROOF a turn is running — this is the universal turn heartbeat. `UserPromptSubmit`
+    // only reaches sessions launched since that hook shipped (hook settings are written at launch), so
+    // without this an already-running session that had its `busy_since` cleared could never get it back
+    // and read `ready` while visibly generating. The gate hook, by contrast, is wired into every session
+    // that exists — it is the invariant. `answered: false`: a tool call is not a human answering, so it
+    // must not retire a waiting card (and a session blocked on an approval still reads `needs you`,
+    // which outranks `working`, so setting the flag here cannot mask a block).
+    this.markTurnBusy(sessionId, { answered: false });
 
     if (decision.effect === 'allow') {
       // Behavioural-failure watch (phase 3): the effect is allowed, but if it completes a no-progress


### PR DESCRIPTION
Reported: a session actively doing work shows `ready`.

Yes — because it was launched **before** the lifecycle hook shipped. But it's a real hole either way: #593 made `isWorking` self-heal against a *stale* flag, and left the opposite direction with **no backstop at all** — nothing could set the flag back.

Hook settings are written into the agent folder **at launch**, so a session launched before `UserPromptSubmit` was wired never fires it. Once its `busy_since` was cleared it could never regain it.

Confirmed on the reported session `ses_c63f1492dc12ce06`:

```
pane:        ✽ Germinating… (1m 2s · ↓ 2.6k tokens)
gate events: every few seconds
busy_since:  NULL          ← nothing left that could set it
console:     ready
```

## Fix — put the heartbeat on the one hook that cannot be missing

The **gate hook** is wired into every session that exists; it *is* the invariant. A tool call is proof a turn is running, so it stamps `busy_since` too.

Three properties that make it safe:

- **`answered: false`** — a tool call is not a human answering, so it never retires a "waiting on you" card. (A session blocked on an approval reads `needs you` regardless — that outranks `working`.)
- **it re-stamps a flag older than `MID_TURN_MAX_MS`**, turning that ceiling from a dumb timer into an honest **activity** test: a long turn still calling tools keeps its spinner, a wedged one emits nothing and ages out. Without this arm a real 2h+ turn would silently read `ready` — the same class of bug in a new place.
- **throttled to one write per 30s per session** (in-memory, dropped by `clearTurnBusy` so the first tool call of the next turn is never swallowed). The gate is a hot path and `node:sqlite` is synchronous — a lock-taking write there is the event-loop blocking that has made a busy box feel unresponsive before, and the statement is a no-op mid-turn anyway.

## Verification

9 new assertions in `scripts/turn-lifecycle-test.cjs` (49 total): an old session with no `UserPromptSubmit` goes working on a tool call; a tool call doesn't clear a waiting card; the throttle never swallows the first call of a turn; a 3h-old stamp is wedged *until* a tool call revives it. Full suite green.

**Deploy note:** server restart required. Works on already-running sessions — that's the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUfffxY4hKv7M6wMCcaTz