### PR TITLE
fix(console): one outcome vocabulary — the chain rail was hiding real verdicts (v0.327.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.327.0] — 2026-08-08
+### Fixed
+- **Agents that reported a verdict were shown as if they had said nothing.** The `report` tool's enum is
+  `success | failure | partial`, but the loopback route stores whatever it is handed
+  (`String(b.outcome || 'success')`), so **`completed`**, **`progressed`** and **`blocked`** are all in
+  the live data — `src/edge/outcome.ts` already folds them in as synonyms when deriving a verdict. The
+  console mapped none of them: a chain node that reported `completed` fell through to its process status
+  and rendered **`done`**, identical to a run that never reported, and `blocked` — a failure — rendered
+  grey instead of red. One shared outcome vocabulary (`VERDICT_OF` / `VERDICT_META`) now backs both the
+  sessions list and the chain rail, and an unrecognised value prints verbatim in a neutral tone rather
+  than being forced into a bucket (the agent's own account beats a guess).
+- **`report()` did not clear `busy_since` when the run left a usable summary.** That branch also renames
+  the row from the summary, and it was missed when every other terminal transition was fixed in v0.324.0
+  — so the most common way a run ends kept the "working" flag latched.
+
+### Changed
+- **The chain rail stopped speaking its own dialect.** It said `pass` / `failed` where the sessions list
+  said `success` / `failure` for the identical fact — and `pass` misread as "parse" often enough to be
+  reported. Both surfaces now use the same words. `duplicate` stays rail-only: it is a property of the
+  chain, not of the run, and nothing else can say it.
+- **`report` normalises the outcome at the WRITE** (`normalizeOutcome`), so the column stops accumulating
+  synonyms and the downstream folding is belt-and-braces rather than load-bearing. It also fixes the chat
+  mirror sending ☑️ for a run that plainly succeeded. Unrecognised words are still stored verbatim.
+- `scripts/outcome-vocabulary-test.cjs`, wired into `npm run test:governance` (14 assertions).
+
 ## [0.326.0] — 2026-08-08
 ### Fixed
 - **A session that was visibly generating could read `ready`.** The inverse of the v0.324.0 bug, and the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.326.0",
+  "version": "0.327.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,7 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs && node scripts/outcome-derivation-test.cjs && node scripts/turn-lifecycle-test.cjs",
+    "test:governance": "node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs && node scripts/outcome-derivation-test.cjs && node scripts/turn-lifecycle-test.cjs && node scripts/outcome-vocabulary-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:deps": "node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",
@@ -43,7 +43,8 @@
     "test:context": "node scripts/context-injection-test.cjs",
     "test:policy-context": "node scripts/test-policy-context.cjs",
     "test:policy-reconcile": "node scripts/test-policy-reconcile.cjs",
-    "test:review": "node scripts/review-notify-test.cjs"
+    "test:review": "node scripts/review-notify-test.cjs",
+    "test:outcome-vocab": "node scripts/outcome-vocabulary-test.cjs"
   },
   "keywords": [
     "agents",

--- a/scripts/outcome-vocabulary-test.cjs
+++ b/scripts/outcome-vocabulary-test.cjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+/* The OUTCOME vocabulary — what a finished run says came of it.
+ *
+ * The `report` tool's enum is success|failure|partial, but the loopback route stores whatever it is
+ * handed (`String(b.outcome || 'success')`), so `completed`, `progressed` and `blocked` are all in the
+ * live data. `src/edge/outcome.ts` folds them in as synonyms; the console mapped NONE of them, so a chain
+ * node that had reported `completed` rendered `done` — identical to a run that never reported at all —
+ * and `blocked`, a failure, rendered grey instead of red.
+ *
+ * This pins the write-side normalisation. The read-side mapping (VERDICT_OF/VERDICT_META in web/src) is
+ * pure presentation and is verified by screenshot; what must not regress is that the DB stops
+ * accumulating synonyms and that `report` closes the turn out properly.
+ *
+ * Isolated home; the session backend is stubbed. */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-outcome-vocab-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+const aos = loadAgentOS();
+const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+tm.backend.aliveNames = () => new Set();
+tm.backend.kill = () => {};
+tm.backend.capturePane = () => '';
+tm.backend.hasClient = () => false;
+
+// The row's `outcome` column is stamped by stampInsights (off the `session.reported` audit row), which
+// runs inside listSessions — so drive that before reading, exactly as the console does.
+const row = (id) => { tm.listSessions(); return aos.db.prepare('SELECT * FROM term_sessions WHERE id = ?').get(id); };
+let n = 0;
+const mk = () => {
+  const id = 'ses_out_' + (++n), now = Date.now();
+  aos.db.prepare(`INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,resident,secret,spawned_by,run_as,busy_since,created_at,updated_at)
+    VALUES (?,?,?,?,?,'running',0,0,'s','m_a','m_a',?,?,?)`).run(id, 'agent-demo', 'provisional title', 'task', 'aos-' + id, now, now, now);
+  return id;
+};
+
+console.log('\n\x1b[1m1) the synonyms agents actually write are normalised at the WRITE\x1b[0m');
+for (const [given, want] of [['completed', 'success'], ['progressed', 'partial'], ['blocked', 'failure'], ['error', 'failure']]) {
+  const id = mk();
+  tm.report(id, 'agent-demo', given, 'did the thing');
+  assert(row(id).outcome === want, `\`${given}\` → \`${want}\``, 'got ' + row(id).outcome);
+}
+
+console.log('\n\x1b[1m2) the canonical three pass straight through\x1b[0m');
+for (const v of ['success', 'partial', 'failure']) {
+  const id = mk();
+  tm.report(id, 'agent-demo', v, 'did the thing');
+  assert(row(id).outcome === v, `\`${v}\` is unchanged`);
+}
+
+console.log('\n\x1b[1m3) casing/whitespace normalise; an UNKNOWN word is kept verbatim\x1b[0m');
+{
+  const id = mk();
+  tm.report(id, 'agent-demo', '  Completed ', 'x');
+  assert(row(id).outcome === 'success', 'trimmed + lowercased before mapping', row(id).outcome);
+}
+{
+  const id = mk();
+  tm.report(id, 'agent-demo', 'deferred', 'x');
+  assert(row(id).outcome === 'deferred', 'an unrecognised word survives — the agent\'s own account beats a guess');
+}
+
+console.log('\n\x1b[1m4) reporting closes the turn out — with OR without a usable summary\x1b[0m');
+console.log('   (the with-summary branch renames the row, and used to skip the busy_since clear)');
+{
+  const id = mk();
+  tm.report(id, 'agent-demo', 'success', 'Imported 1,204 rows and verified the totals.');
+  const r = row(id);
+  assert(r.status === 'done', 'status → done');
+  assert(r.busy_since === null, 'busy_since cleared on the RENAMING branch');
+  assert(r.title !== 'provisional title', 'and the run is retitled from its own summary');
+}
+{
+  const id = mk();
+  tm.report(id, 'agent-demo', 'success', '');
+  const r = row(id);
+  assert(r.status === 'done', 'status → done');
+  assert(r.busy_since === null, 'busy_since cleared on the no-summary branch');
+}
+
+console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m\n`);
+try { fs.rmSync(HOME, { recursive: true, force: true }); } catch { /* best effort */ }
+process.exit(fail ? 1 : 0);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -57,6 +57,18 @@ const MID_TURN_MAX_MS = 2 * 3600_000;
  *  gate fires on every tool call and `node:sqlite` is synchronous, so the write must not ride the hot
  *  path more often than it has to; the DB statement is a no-op mid-turn anyway. */
 const BUSY_STAMP_THROTTLE_MS = 30_000;
+
+/** The `report` tool's enum is `success | failure | partial`, but the loopback route stores whatever it
+ *  is handed (`String(b.outcome || 'success')`), so agents have written `completed`, `progressed` and
+ *  `blocked` into the column too — `src/edge/outcome.ts` already folds those in as synonyms when it
+ *  derives a verdict, and the console now does the same. Normalising at the WRITE keeps one canonical
+ *  vocabulary in the DB, so the synonym folding downstream is belt-and-braces rather than load-bearing
+ *  (and the chat mirror stops sending ☑️ for a run that plainly succeeded). An unrecognised word is kept
+ *  VERBATIM: the agent's own account beats a guess, and every reader has a pass-through for it. */
+const OUTCOME_SYNONYMS: Record<string, string> = {
+  completed: 'success', progressed: 'partial', blocked: 'failure', error: 'failure',
+};
+const normalizeOutcome = (o: string): string => OUTCOME_SYNONYMS[o.trim().toLowerCase()] ?? o.trim().toLowerCase();
 const VIDEO_MAX_DURATION_SEC = 60;         // clamp the requested clip length
 const VIDEO_JOB_TTL_MS = 20 * 60_000;      // give up on a render after 20 minutes
 const VIDEO_MAX_POLLS = 200;               // poll-attempt ceiling (belt-and-suspenders with the TTL)
@@ -4905,6 +4917,7 @@ export class TerminalManager {
    *  episode), so the next run recalls the lesson, not just that a session happened. */
   report(sessionId: string, agent: string, outcome: string, summary: string, lessons?: string): void {
     if (this.hasCompleted(sessionId)) return;
+    outcome = normalizeOutcome(outcome);
     this.clearNotifications(sessionId);
     this.addMessage({ type: 'completed', sessionId, agent, title: `Completed — ${agent}`, body: summary || '(no summary)', status: 'open', outcome, audienceKind: 'sessionOwner', audienceId: sessionId });
     // A task-dispatched run signs off IN its task's Discussion too (§3.2), so the delegate's closing note
@@ -4924,7 +4937,7 @@ export class TerminalManager {
     // never persists one), so the agent's report is the reliable source. Skip when empty so a good
     // title isn't blanked.
     const aiTitle = titleFromSummary(summary);
-    if (aiTitle) this.db.prepare("UPDATE term_sessions SET title = ?, status = 'done', updated_at = ? WHERE id = ?").run(aiTitle, Date.now(), sessionId);
+    if (aiTitle) this.db.prepare("UPDATE term_sessions SET title = ?, status = 'done', busy_since = NULL, updated_at = ? WHERE id = ?").run(aiTitle, Date.now(), sessionId);
     else this.db.prepare("UPDATE term_sessions SET status = 'done', busy_since = NULL, updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
     this.audit(sessionId, agent, 'session.reported', { outcome, summary });
     // Deliberate semantic memory — the agent's note to its future self. Higher importance than an

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -135,6 +135,33 @@ function SessionStatus({ s, label = false, dark = false, className = '', iconCla
  *  a fixed-width column). Same vocabulary as {@link SessionStatus}. */
 const statusLabel = (s: Session, waiting = false): string => STATE_META[sessionState(s, waiting)].label
 
+/** ── THE outcome vocabulary ──────────────────────────────────────────────────────────────────────
+ *  What a FINISHED run says came of it, as opposed to how its process ended. Shared by the sessions
+ *  list and the chain rail, which used to disagree twice over.
+ *
+ *  The `report` tool's enum is `success | failure | partial`, but the server stores whatever it is handed
+ *  (`String(b.outcome || 'success')`), so the synonyms **`completed`**, **`progressed`** and **`blocked`**
+ *  are all in the live data — `src/edge/outcome.ts` already folds them in when it derives a verdict. The
+ *  UI mapped NONE of them: three agents that had reported a real verdict rendered as `done`, i.e. exactly
+ *  like a run that said nothing, and `blocked` — a failure — rendered grey instead of red.
+ *
+ *  An unrecognised value is shown verbatim in a neutral tone rather than forced into a bucket: printing
+ *  the agent's own word is honest, and silently calling it a success would not be. */
+type Verdict = 'success' | 'partial' | 'failure' | 'none'
+const VERDICT_OF: Record<string, Verdict> = {
+  success: 'success', completed: 'success',
+  partial: 'partial', progressed: 'partial',
+  failure: 'failure', blocked: 'failure', error: 'failure',
+  unknown: 'none',   // the stamp for "the run ended and nobody called `report`"
+}
+const VERDICT_META: Record<Verdict, { label: string; tone: string; icon: LucideIcon }> = {
+  success: { label: 'success', tone: 'text-emerald-600', icon: CircleCheck },
+  partial: { label: 'partial', tone: 'text-amber-600', icon: CircleSlash },
+  failure: { label: 'failure', tone: 'text-red-600', icon: CircleX },
+  none: { label: 'no report', tone: 'text-muted-foreground/70', icon: CircleSmall },
+}
+const verdictOf = (outcome?: string): Verdict | undefined => (outcome ? VERDICT_OF[outcome] : undefined)
+
 /** The RESULT word: what the agent said came of the run, falling back to how the process ended. `done`
  *  only means "the process exited" — it's the outcome that says whether the work landed, so once a run
  *  has reported its own verdict that's what the list shows. A finished run with no report reads
@@ -144,8 +171,8 @@ const resultLabel = (s: Session, waiting = false): string => {
   if (waiting || s.blocked || isLive(s)) return statusLabel(s, waiting)
   if (s.status === 'crashed' || s.status === 'stopped') return s.status
   if (!s.outcome) return s.status              // not stamped yet — fall back to the process view
-  if (s.outcome === 'unknown') return 'no report'
-  return s.outcome
+  const v = verdictOf(s.outcome)
+  return v ? VERDICT_META[v].label : s.outcome // an unmapped value prints as the agent wrote it
 }
 
 /** Colour for the result word — green only when the agent actually claims success, red on failure or a
@@ -154,10 +181,9 @@ const resultLabel = (s: Session, waiting = false): string => {
 const resultTone = (s: Session, waiting = false): string => {
   if (waiting || s.blocked || isLive(s)) return STATE_META[sessionState(s, waiting)].tone
   if (s.status === 'crashed') return 'text-red-600'
-  const o = s.outcome
-  if (o === 'success') return 'text-emerald-600'
-  if (o === 'failure' || o === 'error') return 'text-red-600'
-  if (o === 'partial' || s.status === 'stopped') return 'text-amber-600'
+  const v = verdictOf(s.outcome)
+  if (v && v !== 'none') return VERDICT_META[v].tone
+  if (s.status === 'stopped') return 'text-amber-600'
   return 'text-muted-foreground'
 }
 
@@ -3382,11 +3408,16 @@ const countDescendants = (g: SessionGroup): number =>
 /** Is this conversation working right now? (Same rule as `isLive` for a session row.) */
 const nodeLive = (n: ChainNode): boolean => Boolean(n.alive) || n.status === 'running'
 
-/** The chain node's state word + tone. The LIVE half is the shared vocabulary ({@link STATE_META}) so a
- *  node in the rail reads exactly like the same run in the sidebar, the tab strip and the list — the rail
- *  used to say "running" for a conversation that had finished its turn twenty minutes ago. Once a node is
- *  finished the rail keeps its own richer verdict words (pass / failed / partial / duplicate / no report),
- *  which is more than a session row shows and is the point of the rail. */
+/** The chain node's state word + tone, from the two shared vocabularies: {@link STATE_META} while it is
+ *  LIVE, {@link VERDICT_META} once it has finished. So a node reads exactly like the same run in the
+ *  sidebar, the tab strip and the list.
+ *
+ *  It used to carry a third, private set of words — `pass` / `failed` where the list said `success` /
+ *  `failure` for the identical fact (and `pass` misread as "parse" often enough to be reported). Worse,
+ *  it only knew the three enum values, so a node that reported `completed`, `progressed` or `blocked`
+ *  fell through to `n.status` and rendered `done`: an agent that HAD delivered a verdict looked exactly
+ *  like one that never reported. `duplicate` stays a rail-only word — it is a property of the chain, not
+ *  of the run, and nothing else can say it. */
 const nodeState = (n: ChainNode): { label: string; tone: string; icon: LucideIcon; anim: string; live?: boolean } => {
   const shared = (st: SessionState, live?: boolean) => {
     const m = STATE_META[st]
@@ -3396,11 +3427,12 @@ const nodeState = (n: ChainNode): { label: string; tone: string; icon: LucideIco
   if (nodeLive(n)) return shared(n.working ? 'working' : 'idle', true)
   if (n.duplicateOf) return { label: 'duplicate', tone: 'text-amber-600', icon: CopyIcon, anim: '' }
   if (n.status === 'crashed') return shared('crashed')
-  if (n.outcome === 'success') return { label: 'pass', tone: 'text-emerald-600', icon: CircleCheck, anim: '' }
-  if (n.outcome === 'failure' || n.outcome === 'error') return { label: 'failed', tone: 'text-red-600', icon: CircleX, anim: '' }
-  if (n.outcome === 'partial') return { label: 'partial', tone: 'text-amber-600', icon: CircleSlash, anim: '' }
+  const v = verdictOf(n.outcome)
+  if (v && v !== 'none') return { ...VERDICT_META[v], anim: '' }
   if (n.status === 'stopped') return shared('stopped')
-  return { label: n.outcome === 'unknown' ? 'no report' : n.status, tone: 'text-muted-foreground/70', icon: CircleSmall, anim: '' }
+  // `unknown` (ended, nobody reported) → "no report"; an unmapped value prints as the agent wrote it.
+  const m = VERDICT_META.none
+  return { label: v === 'none' ? m.label : (n.outcome || n.status), tone: m.tone, icon: m.icon, anim: '' }
 }
 
 /** Conversations with a live pane — what the Chain toggle badges when nothing needs a human and nothing


### PR DESCRIPTION
Asked whether the chain sidebar's words (`pass`, `no report`, `partial`) are correct. Two were wrong — and one was **hiding data**.

## 1. Agents that reported a verdict were shown as if they'd said nothing

The `report` tool's enum is `success | failure | partial`, but the loopback route stores whatever it's handed (`String(b.outcome || 'success')`). So **`completed`**, **`progressed`** and **`blocked`** are all in the live data — `src/edge/outcome.ts` already folds them in as synonyms when deriving a verdict.

The console mapped **none** of them. A node that reported `completed` fell through to its process status and rendered `done` — identical to a run that never reported at all. `blocked`, a failure, rendered grey instead of red.

| Reported | Rail said | Should say |
|---|---|---|
| `completed` | done (grey) | success (green) |
| `progressed` | done (grey) | partial (amber) |
| `blocked` | done (grey) | failure (red) |

## 2. The rail spoke its own dialect

`pass` / `failed` where the sessions list said `success` / `failure` for the identical fact — and `pass` misread as "parse" often enough to be reported. Both surfaces now share one `VERDICT_OF` / `VERDICT_META`. An unrecognised value prints **verbatim** in a neutral tone rather than being forced into a bucket: the agent's own account beats a guess. `duplicate` stays rail-only — it's a property of the chain, not the run.

**`no report` was correct and stays.** `unknown` is the stamp for a run that ended without calling `report` — 216 of 558 rows on live instapods, so it's a real and useful finding, not a blank.

## Also fixed alongside

- **`report()` didn't clear `busy_since`** on the branch that renames the row from its summary — i.e. the *most common* way a run ends kept the "working" flag latched. Every other terminal transition was fixed in #593; this one was missed.
- **`report()` now normalises the outcome at the write**, so the column stops accumulating synonyms and the downstream folding is belt-and-braces rather than load-bearing. Also stops the chat mirror posting ☑️ for a run that plainly succeeded. Unrecognised words are still stored verbatim.

## Verification

Screenshotted the rail against a stubbed chain covering every outcome value that can land — before showing three grey `done` rows, after showing success/partial/failure in the right tones. New `scripts/outcome-vocabulary-test.cjs` (14 assertions) in `test:governance`; full suite green.

**Deploy note:** server restart required (touches `src/terminal.ts`).

*(Pushed as `feat/outcome-vocabulary` — a stale, already-merged `feat/chain-rail` branch from #563 is still on the remote.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUfffxY4hKv7M6wMCcaTz