### PR TITLE
fix(governance): refuse cross-session messages — claude 2.1.224 opened an ungoverned fleet-wide channel (v0.330.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.330.1] — 2026-08-09
+### Fixed
+- **Cross-session messaging is refused on governed runs.** Claude Code 2.1.224 shipped a per-session
+  inbox socket plus `SendMessage`/`ListAgents`, so any session can address any other session owned by
+  the same OS user on the same machine — which is every Agent OS run, across tenants, on one box. That
+  channel bypasses the gateway entirely: the gate hook's tool→capability table has no row for
+  `SendMessage`, so it falls through the `*)` "not a world side effect" arm — no policy check, no audit
+  event, none of the run-as identity, owner or provenance the governed A2A path
+  (`task_create`/`task_wait`/`notify`/poke-back) records. The delivery default made it worse rather
+  than safer: it keys off permission MODE, and an unattended run's `--dangerously-skip-permissions`
+  puts it in the bypass class, where a bypass→bypass pair is delivered with no approval dialog at all.
+  `terminal/claude-launch.sh` now writes `"crossSessionInbound": "refuse"` (Claude Code still binds the
+  socket, and drops everything arriving on it) and `"isolatePeerMachines": true` into every session's
+  `--settings` file. The `SendMessage`/`ListAgents` tools are deliberately NOT denied — the same
+  `SendMessage` serves subagents and agent teams within one session — so outbound remains available and
+  simply lands nowhere, since every governed session refuses. Governing the channel properly, as an
+  `agent.message` capability in the gate hook's routing table, is the follow-up.
+
 ## [0.330.0] — 2026-08-09
 ### Added
 - **Five new featured skill sources in the console's "Install from GitHub" dialog** — engineering and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,18 @@ taking".
 
 ## Gotchas
 
+- **Claude Code ships side-effect channels the gate hook doesn't know about — assume new ones.** The gate
+  hook's tool→capability table ends in `*) exit 0` ("any other built-in isn't a world side effect"), which
+  is right for `Read`/`Glob`/`Grep` and wrong the moment a release adds a tool that reaches outside the
+  session. **Cross-session messaging** (2.1.224) is the live example: each session binds an inbox socket
+  and `SendMessage`/`ListAgents` address any session owned by the same OS user on the same machine — i.e.
+  the whole fleet, across tenants, on one box — with no policy check, no audit event, and none of the
+  run-as identity/owner/provenance that `task_create`/`task_wait`/`notify`/poke-back carry. Its delivery
+  default keys off permission MODE, so `--dangerously-skip-permissions` (every unattended run) is the
+  bypass class and a bypass→bypass pair delivers with no dialog. Shut off at the settings layer in
+  `terminal/claude-launch.sh` (`crossSessionInbound: "refuse"` + `isolatePeerMachines: true`) rather than
+  by denying the tools, since the same `SendMessage` also serves subagents/agent teams inside one session.
+  When claude-code updates, diff the tools reference against that routing table.
 - `node:sqlite` emits an `ExperimentalWarning` on first use; `src/cli.ts` filters just that one line.
 - WAL mode creates `agent-os.db-wal`/`-shm` sidecars — all `*.db*` and `connectors/` are gitignored in
   `data/.gitignore`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.330.0",
+  "version": "0.330.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.330.0",
+      "version": "0.330.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.330.0",
+  "version": "0.330.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/context-injection-test.cjs
+++ b/scripts/context-injection-test.cjs
@@ -125,6 +125,15 @@ async function main() {
   const launch = fs.readFileSync(path.join(ROOT, 'terminal/claude-launch.sh'), 'utf8');
   assert(/"allow": \["mcp__agentos"\]/.test(launch), 'allow-list uses the mcp__agentos wildcard');
   assert(!/mcp__agentos__task_update"/.test(launch), 'old partial enumerated allow-list removed');
+  // Cross-session messaging (claude ≥2.1.224) reaches every session owned by the same OS user on the
+  // box — the whole fleet, across tenants — through a channel the gate hook has no capability row for.
+  // Refused at the settings layer; the tools themselves stay (SendMessage also serves subagents/teams).
+  assert(/"crossSessionInbound": "refuse"/.test(launch), 'cross-session inbound messages are refused');
+  assert(/"isolatePeerMachines": true/.test(launch), 'cross-machine sends require explicit approval');
+  assert(
+    !/"deny":[^\n]*SendMessage/.test(launch),
+    'SendMessage is NOT deny-listed (that would also kill subagents / agent teams)',
+  );
 
   console.log(`\n\x1b[1mResult:\x1b[0m ${pass} passed, ${fail} failed\n`);
   process.exit(fail ? 1 : 0);

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -154,8 +154,28 @@ mkdir -p .claude
 # --settings flag are NOT trust-gated, so the pre-allows are honored. (Hooks + deny rules apply either
 # way — only `allow` is gated — verified.) Clear any stale auto-discovered file from older launches.
 rm -f .claude/settings.json
+# CROSS-SESSION MESSAGING (claude ≥ 2.1.224) is OFF for governed runs. Claude Code binds a per-session
+# inbox socket and lets any session reach any other on the same machine via its `SendMessage`/`ListAgents`
+# tools. Every Agent OS run is a claude session owned by the SAME OS user on the SAME box, so out of the
+# box the whole fleet — across tenants — is mutually addressable through a channel the gateway never sees:
+# the gate hook's tool→capability table has no row for `SendMessage`, so it falls to the `*)` arm and the
+# call is unaudited, un-policed, and carries none of the run-as identity, owner or provenance that the
+# governed A2A path (`task_create`/`task_wait`/`notify`/poke-back) records. Worse, the default that
+# decides delivery keys off permission MODE: an unattended run uses --dangerously-skip-permissions, i.e.
+# the bypass class, and a bypass→bypass pair is DELIVERED with no dialog. So `refuse` here — Claude Code
+# still binds the socket but drops everything arriving on it. A value from the --settings flag wins over
+# user settings, and project/local `refuse` would win over us, which is the safe direction.
+# `isolatePeerMachines` requires explicit approval before a message leaves the box (cross-machine sends
+# are reply-only and need Remote Control, so with inbound refused this can't actually fire — it's the
+# belt to the braces, and it can't hang an unattended run).
+# NOT denied: the `SendMessage`/`ListAgents` TOOLS. The same `SendMessage` serves subagents and agent
+# teams inside one session, so a permissions deny would take those out too. Outbound stays available and
+# lands nowhere, because every governed session refuses. Governing it properly — an `agent.message`
+# capability in the gate hook's routing table, policy-gated and audited — is the follow-up.
 cat > .claude/aos-settings.json <<JSON
 {
+  "crossSessionInbound": "refuse",
+  "isolatePeerMachines": true,
   "permissions": {
     "allow": ["mcp__agentos"]$DENY_LINE
   },


### PR DESCRIPTION
## What

Claude Code **2.1.224** ships [cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging): each session binds a per-session inbox socket, and `SendMessage`/`ListAgents` address any session owned by the same OS user on the same machine. The live Mac Mini is on 2.1.226, so this arrived fleet-wide with no code change on our side.

Every Agent OS run is such a session. Out of the box the whole fleet — **across tenants, on one box** — became mutually addressable through a channel the gateway never sees.

## Why it's a governance hole

- The gate hook's tool→capability table (`terminal/gate-hook.sh:101-116`) has no row for `SendMessage`, so it falls through the `*) exit 0` arm — the "any other built-in isn't a world side effect" default. No policy check, no audit event.
- It routes around the governed A2A path (`task_create`/`task_wait`/`notify`/poke-back), which carries run-as identity, owner and provenance and folds into `sessionChain`. A `SendMessage` leaves no row anywhere.
- The delivery default keys off permission **mode**, not identity: an unattended run uses `--dangerously-skip-permissions`, i.e. the bypass class, and a bypass→bypass pair is **delivered with no approval dialog**. The hardened lane is the *least* protected one.

Bounded by design — a peer message can't approve a pending prompt, change config/`CLAUDE.md`, or run a slash command, and the receiving agent's own gate still fires on any effect. What leaked is coordination, text, and cross-tenant isolation.

## Change

`terminal/claude-launch.sh` writes two keys into every session's `--settings` file:

```json
"crossSessionInbound": "refuse",
"isolatePeerMachines": true
```

Claude Code still binds the socket and drops everything arriving on it. `isolatePeerMachines` is belt-to-the-braces: cross-machine sends are reply-only and need Remote Control, so with inbound refused it can't fire, and it can't hang an unattended run.

The `SendMessage`/`ListAgents` **tools are deliberately not deny-listed** — the same `SendMessage` serves subagents and agent teams inside a single session, so a deny would take those out too. Outbound stays available and lands nowhere, because every governed session refuses.

Follow-up (not in this PR): govern the channel properly as an `agent.message` capability in the gate hook's routing table — policy-gated, audited, run-as aware. That turns it into a low-latency peer channel the task plane doesn't have.

## Testing

- `npm run typecheck` — clean
- `npm run test:governance` — all suites pass
- `npm run test:context` — the three new launcher assertions pass (`refuse`, `isolatePeerMachines`, and that `SendMessage` is *not* deny-listed). One unrelated failure in that script (`always-on tools all present — missing: ask`) reproduces unchanged on `main`; pre-existing, not touched here.
- Settings heredoc re-rendered with the surrounding shell vars and parsed with `node` to confirm the JSON stays valid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiKurWa52Lm3CJrbTdCa2W