### PR TITLE
chore(brand): point everything at the renamed repo vikasprogrammer/agentric (v0.331.1)

### DIFF
--- a/.claude/skills/fleet-insights/SKILL.md
+++ b/.claude/skills/fleet-insights/SKILL.md
@@ -128,7 +128,7 @@ Follow the repo's standing workflow (see CLAUDE.md + memory) — **never edit th
    **root**) · `npm run demo` if you touched governance.
 4. Bump version (minor for a feature, patch for a fix) + move a CHANGELOG line under a new heading.
 5. Commit (with the `Co-Authored-By: Claude Opus 4.8 (1M context)` trailer), push, open **one**
-   consolidated PR with `gh ... --repo vikasprogrammer/agent-os`, then `gh pr merge --squash`.
+   consolidated PR with `gh ... --repo vikasprogrammer/agentric`, then `gh pr merge --squash`.
 
 Batching several branches? Use `scripts/wt.sh integrate` and one PR, per the shared-checkout rule.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.331.1] — 2026-08-10
+### Changed
+- **The GitHub repo is now `vikasprogrammer/agentric`.** Follow-through on the Agentric rebrand: the
+  repo slug is a public brand surface, and GitHub keeps a permanent redirect so existing clones,
+  remotes and issue links keep resolving (don't ever let a new repo claim the old `agent-os` name, or
+  that redirect dies). Swept the hardcoded slug out of the README clone block, `FEEDBACK_URL`, the
+  `gh --repo …` lines in CLAUDE.md / TODO.md / `scripts/wt.sh` / `docs/goals-plan.md` / the
+  fleet-insights skill, and both service `Documentation=` URLs (which still pointed at the wrong org).
+  Still `agent-os` on purpose: the npm package + CLI, `AGENT_OS_*`, the units, the data homes, the
+  local checkout paths, and the GitHub **App** slug `agent-os-instapods` — renaming that one changes
+  its installation URLs and breaks per-member GitHub auth.
+
 ## [0.331.0] — 2026-08-10
 ### Changed
 - **The product is now called Agentric (agentric.io).** Brand-layer rename only: every user-facing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,18 @@ brand/plugin code.
 ## Naming — "Agentric" is the brand, `agent-os` is the plumbing
 
 The product is **Agentric** (agentric.io). That name is the **brand layer only**: user-facing copy
-(console, README, `docs/`, agent-facing prompts, chat/bot display names, systemd `Description=`).
+(console, README, `docs/`, agent-facing prompts, chat/bot display names, systemd `Description=`) plus
+the **GitHub repo**, which is now **`vikasprogrammer/agentric`** — always pass `--repo
+vikasprogrammer/agentric` to `gh` (GitHub permanently redirects the old `agent-os` URL, so existing
+remotes keep working; never let a new repo claim that old name or the redirect dies).
+
 Everything load-bearing keeps the `agent-os` identifier and MUST NOT be renamed here — the CLI binary
 and npm package `agent-os`, `AGENT_OS_*` env vars, the `AOS_*` prefix, the `AgentOS` class, the
 `mcp__agentos__*` tool namespace, the `/agent-os <agent>` chat command, systemd/launchd unit names
-(`agent-os.service`, `com.agentos.instapods`), data homes (`~/agent-os-data/…`), `agent-os.db`, and the
-GitHub repo. Those are live across the tenant boxes and baked into absolute paths; a full internal
+(`agent-os.service`, `com.agentos.instapods`), data homes (`~/agent-os-data/…`), `agent-os.db`, the
+local checkout paths (`~/Projects/agent-os`, `~/agent-os-live`, `~/aos-wt`), and the GitHub **App**
+slug `agent-os-instapods` (renaming that one changes its installation URLs and breaks per-member
+GitHub auth). Those are live across the tenant boxes and baked into absolute paths; a full internal
 rename is a **migration**, folded into the next box move, never a standalone sweep.
 
 ## Build / run / test
@@ -553,7 +559,7 @@ finished work, and run the live service. **All development happens in per-sessio
 - `scripts/wt.sh integrate <name…>` — spin up a fresh `batch/<ts>` worktree off `origin/main` and merge
   the named feature branches into it. Then, **merge locally, push once**: bump the version + CHANGELOG
   a single time for the whole batch, `npm run build && (cd web && npm run build) && npm run test:governance`,
-  push the batch branch, and open **one consolidated PR** (`gh … --repo vikasprogrammer/agent-os`,
+  push the batch branch, and open **one consolidated PR** (`gh … --repo vikasprogrammer/agentric`,
   `gh pr merge --squash`). Never `switch`/branch the primary checkout to integrate.
 
 "Make it live" still runs from the primary checkout after `wt.sh sync` (build + `launchctl kickstart` —

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ It runs on your laptop with `npm run serve`, and scales to a multi-tenant server
 ## ⚡ Quickstart
 
 ```bash
-git clone https://github.com/vikasprogrammer/agent-os
-cd agent-os
+git clone https://github.com/vikasprogrammer/agentric
+cd agentric
 npm install && npm run build
 npm run serve          # → web console at http://localhost:3010
 ```
@@ -65,8 +65,8 @@ npm run demo           # a scripted run that shows approvals, budgets, dedupe & 
 > `tmux` + `ttyd` for the browser terminal (`brew install tmux ttyd`, or your distro's packages).
 
 > **A note on the name.** The product is **Agentric**; the plumbing is still called `agent-os` — the
-> repo, the npm package and CLI (`agent-os serve`), the `AGENT_OS_*` env vars, the service units and
-> the data home. Those are baked into running deployments, so they keep the old name on purpose.
+> npm package and CLI (`agent-os serve`), the `AGENT_OS_*` env vars, the service units and the data
+> home. Those are baked into running deployments, so they keep the old name on purpose.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -57,7 +57,7 @@ _Last updated: 2026-08-04._
 - **Sequencing:** Tier B is gated behind §4.2 (done). §4.1 build is gated behind the ContextForge
   adapter spike proving the suspend protocol.
 - **Don't lead with "control plane"** — the phrase is a red ocean; lead with the enforced primitive.
-- **Ship discipline:** branch → PR → squash-merge (`--repo vikasprogrammer/agent-os`); CI = `npm run
+- **Ship discipline:** branch → PR → squash-merge (`--repo vikasprogrammer/agentric`); CI = `npm run
   test:governance`. Concurrent-shipping churn is heavy — **commit, then rebase right before merge.**
 
 ---

--- a/agent-os.service
+++ b/agent-os.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Agentric - governed agent runtime + web console
-Documentation=https://github.com/InstaWP/agent-os
+Documentation=https://github.com/vikasprogrammer/agentric
 After=network.target
 Wants=network.target
 

--- a/deploy/aos-launcher.service
+++ b/deploy/aos-launcher.service
@@ -10,7 +10,7 @@
 
 [Unit]
 Description=Agentric - privileged per-member session launcher (Phase A trust root)
-Documentation=https://github.com/InstaWP/agent-os
+Documentation=https://github.com/vikasprogrammer/agentric
 After=network.target
 
 [Service]

--- a/docs/goals-plan.md
+++ b/docs/goals-plan.md
@@ -108,7 +108,7 @@ owner, parent (nested display), and the event history. `cd web && npm run build`
 
 ### 7. Ship
 Bump **minor** in `package.json` + move a CHANGELOG "Unreleased" line into the new version heading in the
-same commit (per repo convention). Branch → one PR → squash-merge (`--repo vikasprogrammer/agent-os`);
+same commit (per repo convention). Branch → one PR → squash-merge (`--repo vikasprogrammer/agentric`);
 CI = `npm run test:governance` from repo root.
 
 ---

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.331.0",
+  "version": "0.331.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/mouse-tui.mjs
+++ b/scripts/mouse-tui.mjs
@@ -33,7 +33,7 @@ function draw() {
   w('   5. www          www.google.com\r\n')
   w('   6. end of line, trailing period → visit instapods.io.\r\n')
   w('   7. in a sentence: see the deploy at ai.expresstech.io for details\r\n')
-  w('   8. parenthesised (github.com/vikasprogrammer/agent-os)\r\n')
+  w('   8. parenthesised (github.com/vikasprogrammer/agentric)\r\n')
   w('   9. uncommon TLD  my-shop.store  and a path one  foo.bar/baz\r\n')
   w('  10. osc-8 markup  \x1b]8;;https://claude.com/code\x1b\\the Claude Code site\x1b]8;;\x1b\\\r\n')
   w('  11. NOT a link   Component.tsx:42  ·  src/main.rs  ·  v1.2.io-beta\r\n\r\n')

--- a/scripts/wt.sh
+++ b/scripts/wt.sh
@@ -71,7 +71,7 @@ case "$cmd" in
     echo "  cd \"$dir\", then: bump version + CHANGELOG once for the batch, and"
     echo "    npm run build && (cd web && npm run build) && npm run test:governance"
     echo "    git push -u origin $branch"
-    echo "    gh pr create --repo vikasprogrammer/agent-os --base main --head $branch ... && gh pr merge --squash"
+    echo "    gh pr create --repo vikasprogrammer/agentric --base main --head $branch ... && gh pr merge --squash"
     ;;
   done)
     name="${1:-}"; [ -n "$name" ] || die "usage: wt.sh done <name>"

--- a/test/governance/conformance.json
+++ b/test/governance/conformance.json
@@ -1498,7 +1498,7 @@
       "args": {
         "tool": "Bash",
         "input": {
-          "command": "curl -sSL https://api.github.com/repos/vikasprogrammer/agent-os -o /tmp/repo.json"
+          "command": "curl -sSL https://api.github.com/repos/vikasprogrammer/agentric -o /tmp/repo.json"
         }
       },
       "expect": "allow",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -809,7 +809,7 @@ function TuningFields({ tuning, onChange, modelPlaceholder = 'inherit', inheritL
 
 /** Where the sidebar "Feedback" shortcut points — the project's GitHub issues tab, for bug reports
  *  and feature requests. Opens in a new tab. */
-const FEEDBACK_URL = 'https://github.com/vikasprogrammer/agent-os/issues'
+const FEEDBACK_URL = 'https://github.com/vikasprogrammer/agentric/issues'
 
 /** Minimal hash router — `#/<page>` with an optional detail segment (`#/sessions/<tmux>`) so a
  *  deep-linked view (an open terminal, later other pages' selections) survives a refresh and


### PR DESCRIPTION
Follow-through on #604. The repo is now **`vikasprogrammer/agentric`** — the last public brand
surface. GitHub keeps a permanent redirect, so existing clones/remotes/issue links keep resolving
(the old `agent-os` name must never be claimed by a new repo, or the redirect dies).

**Swept:** README clone block, console `FEEDBACK_URL`, the `gh --repo …` lines in CLAUDE.md /
TODO.md / `scripts/wt.sh` / `docs/goals-plan.md` / fleet-insights SKILL.md, both service
`Documentation=` URLs (they still pointed at the wrong org, `InstaWP/agent-os`). CHANGELOG history
links left as written.

**Deliberately not renamed** (now spelled out in CLAUDE.md → Naming): npm package + CLI `agent-os`,
`AGENT_OS_*`, `AOS_*`, `AgentOS`, `mcp__agentos__*`, `/agent-os <agent>`, unit names, data homes,
the local checkout paths (`~/Projects/agent-os`, `~/agent-os-live`, `~/aos-wt`), and the GitHub
**App** slug `agent-os-instapods` — renaming that changes its installation URLs and breaks
per-member GitHub auth.

Verified: `npm run typecheck` · `npm run build` · `cd web && npm run build` ·
`npm run test:governance` (exit 0, 18 suites green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUfffxY4hKv7M6wMCcaTz