### PR TITLE
fix(tasks): poke the caller that is still running instead of resuming a second claude beside it (v0.334.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.334.1] — 2026-08-10
+### Fixed
+- **A poke-back now wakes the caller that is still running, instead of starting a second claude beside
+  it.** When a delegate closed a `poke_on_done` hand-off, the OS chose between typing into the caller's
+  live pane and `--resume`ing its transcript in a new session — and it made that choice on the session
+  row's `status`. `status` is not liveness: an agent that calls `report` is stamped `done` while its
+  claude keeps running, which is the *normal* shape for a caller (hand off work, report, carry on while
+  the delegate finishes). So those pokes all took the resume lane and opened a **second claude on a
+  transcript the first still held** — what `chatSend` calls "the one outcome worse than a slow turn".
+  Observed on instapods 2026-08-10: `ses_f4535e8f` reported at 16:13 and worked until 16:34; its 16:31
+  poke spawned `ses_441cec`, which died 28s later, and the caller never saw the result — it re-derived it
+  by shelling out to `gh pr view`. Liveness is now asked of the **pane** (`TerminalManager.reachable`),
+  which delivers into a reported-but-warm session, still refuses a run a human `stop`ped or the sweep
+  marked `crashed`, puts the row back to `running` + busy when text lands, and — if the inject fails on a
+  wedged pane — kills it before falling back to the resume. The same test now backs console injection and
+  task-room delivery, which shared the `status = 'running'` gate. Pinned by
+  `scripts/poke-warm-caller-test.cjs`.
+
 ## [0.334.0] — 2026-08-10
 ### Added
 - **A bare entity id is now a link wherever it is displayed.** Agents constantly reference a row by its

--- a/docs/tasks-plan.md
+++ b/docs/tasks-plan.md
@@ -348,6 +348,28 @@ marker silently so it can never fire later. A row skipped for budget stays **unm
 still owes it. Replayed over the live instawp backlog: settles in 3 ticks (~60s), 8 callers woken, 1 task
 auto-closed, 12 cold ones marked silently.
 
+### 3.5 Where the poke LANDS — the pane, never the status column
+
+`pokeCaller` has two lanes: type the wake-up into the caller's live pane, or `--resume` its transcript in a
+new session. Which one it takes is the whole correctness question, because the resume lane is only safe
+when nothing else holds that transcript.
+
+It used to choose on the session row's `status`, and **`status` is not liveness**. An agent that calls
+`report` is stamped `done` (`reportSession`) while its claude keeps running — and that is the *normal*
+shape for a caller: hand off, report, keep working while the delegate finishes minutes later. Every one of
+those pokes took the resume lane and opened a second claude on a transcript the first still held. Live on
+instapods 2026-08-10: `ses_f4535e8f` reported at 16:13 and worked through 16:34; its 16:31 poke spawned
+`ses_441cec`, which died 28s later, and the caller — never woken — re-derived the delegate's result by
+shelling out to `gh pr view`.
+
+Liveness is therefore asked of the **pane**: `TerminalManager.reachable(sessionId)`, the delivery-side
+counterpart to `isAlive` (which folds `status` in and is right for the pile-up guards it was written for).
+`reachable` still refuses a run a human `stop`ped or the sweep marked `crashed` — a surviving pane there is
+a leftover, not a destination. Delivery puts the row back to `running` + `busy_since` so the console stops
+reading idle through work it just triggered, and an inject that fails on a wedged pane kills that pane
+before the resume, mirroring `chatSend`. `deliverToResident` and `injectToSession` share the same test —
+they carried the same `status = 'running'` gate. Pinned by `scripts/poke-warm-caller-test.cjs`.
+
 ---
 
 ## 4. Agent-facing MCP tools — `src/memory/memory-mcp.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.334.0",
+  "version": "0.334.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.334.0",
+      "version": "0.334.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.334.0",
+  "version": "0.334.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,7 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/version-sync-test.cjs && node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-discussion-delivery-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs && node scripts/outcome-derivation-test.cjs && node scripts/turn-lifecycle-test.cjs && node scripts/outcome-vocabulary-test.cjs && node scripts/skill-presets-test.cjs",
+    "test:governance": "node scripts/version-sync-test.cjs && node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-discussion-delivery-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/poke-warm-caller-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs && node scripts/outcome-derivation-test.cjs && node scripts/turn-lifecycle-test.cjs && node scripts/outcome-vocabulary-test.cjs && node scripts/skill-presets-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:deps": "node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",

--- a/scripts/chain-model-test.cjs
+++ b/scripts/chain-model-test.cjs
@@ -171,7 +171,10 @@ console.log('\n\x1b[1msteering a live delegate\x1b[0m');
   const autos = new Automations(aos, tm);
   const injected = [];
   tm.backend.injectText = (space, tmuxName, body) => { injected.push({ tmux: tmuxName, body }); return true; };
+  // `isAlive` guards dispatch pile-ups; `reachable` decides delivery (a reported run keeps a live REPL).
+  // Only the delegate is up on either.
   tm.isAlive = (id) => id === liveDelegate;
+  tm.reachable = (id) => id === liveDelegate;
 
   const held = mkTask({ title: 'ship batch 1', assignee: 'agent:builder', callerAgent: 'agent:manager', callerClaudeId: 'cs_mgr' });
   var liveDelegate = mkRun({ agent: 'builder', claude_session_id: 'cs_build', spawned_by: `task:${held.id}`, status: 'running', title: 'Task: ship batch 1' });
@@ -180,7 +183,7 @@ console.log('\n\x1b[1msteering a live delegate\x1b[0m');
 
   // An unattended run is an attachable TUI — delivery must reach it (this is what was broken).
   assert(tm.deliverToResident(liveDelegate, 'stand down') === true, 'a live UNATTENDED run can be messaged');
-  assert(tm.deliverToResident(mkRun({ status: 'done' }), 'x') === false, 'a finished run cannot');
+  assert(tm.deliverToResident(mkRun({ status: 'done' }), 'x') === false, 'a run with no live pane cannot');
 
   // A HOLD by the caller reaches the run that is doing the work.
   injected.length = 0;
@@ -203,7 +206,7 @@ console.log('\n\x1b[1msteering a live delegate\x1b[0m');
   assert(!/blocked/.test(forced.reason || ''), 'a human forcing it is not refused for being blocked', forced.reason);
 
   // And a still-working delegate is never given a rival by the discussion path.
-  tm.isAlive = (id) => id === liveDelegate;
+  tm.isAlive = (id) => id === liveDelegate; tm.reachable = (id) => id === liveDelegate;
   tm.deliverToResident = () => false;   // simulate an undeliverable pane
   tm.reviveResident = () => false;
   const before = aos.db.prepare('SELECT COUNT(*) AS c FROM term_sessions').get().c;

--- a/scripts/poke-warm-caller-test.cjs
+++ b/scripts/poke-warm-caller-test.cjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/* A poke-back reaches the caller that is STILL RUNNING (Automations.pokeCaller + TerminalManager.reachable).
+ *
+ * When a delegate closes a `poke_on_done` hand-off, the OS wakes the caller: into its live pane if it has
+ * one, else by `--resume`ing its transcript in a new session. Choosing between those two used to be
+ * `status = 'running'` — and `status` is not liveness. An agent that calls `report` is stamped `done` while
+ * its claude keeps running, which is the NORMAL shape for a caller: it hands off work, reports, and carries
+ * on for minutes while the delegate finishes. Every one of those took the resume lane, starting a SECOND
+ * claude on a transcript the first still held — the outcome `chatSend` calls "the one worse than a slow
+ * turn". Live on instapods 2026-08-10: `ses_f4535e8f` reported 16:13, worked until 16:34, and its 16:31
+ * poke spawned `ses_441cec` which died 28s later; the caller never saw it and re-derived the result by hand.
+ *
+ * Pins: reported-but-warm delivers in place; a dead pane still resumes; a human `stop` is never overridden;
+ * delivery puts the row back to `running`+busy; a failed inject kills the pane BEFORE resuming; and the
+ * newest row wins for a transcript that spans several sessions.
+ *
+ * Isolated home; the session backend is stubbed, so no tmux and no real `claude` are involved.
+ */
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-poke-warm-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d !== undefined ? ' — ' + JSON.stringify(d).slice(0, 300) : ''}`));
+
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+const { Automations } = require(path.join(ROOT, 'dist/edge/automations.js'));
+
+const aos = loadAgentOS();
+const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+
+// ── stub backend: we control which panes are "alive" and record every keystroke delivery ────────
+const livePanes = new Set();
+const injected = [];
+let injectWorks = true;
+tm.backend.aliveNames = () => new Set(livePanes);
+tm.backend.injectText = (_s, tmux, text) => { injected.push({ tmux, text }); return injectWorks && livePanes.has(tmux); };
+tm.backend.spawn = (_s, o) => { livePanes.add(o.tmuxName); };
+tm.backend.kill = (_s, tmux) => { livePanes.delete(tmux); };
+tm.backend.capturePane = () => '';
+tm.backend.hasClient = () => false;
+
+aos.agents.set('caller', { id: 'caller', name: 'Caller', runtime: 'claude-code', dir: HOME });
+aos.team.bootstrapOwner('alice@testco.dev', 'Alice');
+const alice = aos.team.getMemberByEmail('alice@testco.dev');
+
+// Capture the resume lane rather than launching it — we only care THAT it was taken, and with what.
+let n = 0, clock = Date.now() - 3_600_000;
+const spawned = [];
+tm.createSession = (agent, title, task, spawnedBy, headless, slack, discord, runAs, resumeClaudeId) => {
+  const id = 'ses_poke_' + (++n);
+  spawned.push({ id, agent, spawnedBy, resumeClaudeId: resumeClaudeId ?? null, task });
+  aos.db.prepare(`INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,resident,run_as,spawned_by,claude_session_id,created_at,updated_at)
+    VALUES (?,?,?,?,?,'running',1,0,?,?,?,?,?)`)
+    .run(id, agent, title || 't', task || 'x', 'aos-' + id, runAs ?? null, spawnedBy ?? null, resumeClaudeId ?? ('cuid_' + id), (clock += 1000), clock);
+  return { id, tmux: 'aos-' + id };
+};
+
+/** A caller session row on transcript `cs`, in whatever status + pane state the case needs. */
+const mkCaller = (cs, opts = {}) => {
+  const id = 'ses_c_' + (++n);
+  const { pane, ...over } = opts;
+  const cols = {
+    id, agent: 'caller', title: 'daily sweep', task: 'sweep', tmux: 'aos-' + id,
+    status: 'running', headless: 0, resident: 0, claude_session_id: cs, secret: 'sec',
+    spawned_by: alice.id, run_as: alice.id, busy_since: null, last_activity: null,
+    created_at: (clock += 1000), updated_at: clock, ...over,
+  };
+  aos.db.prepare(`INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,resident,claude_session_id,secret,spawned_by,run_as,busy_since,last_activity,created_at,updated_at)
+    VALUES (@id,@agent,@title,@task,@tmux,@status,@headless,@resident,@claude_session_id,@secret,@spawned_by,@run_as,@busy_since,@last_activity,@created_at,@updated_at)`).run(cols);
+  if (pane !== false) livePanes.add(cols.tmux);
+  return id;
+};
+const autos = new Automations(aos, tm);
+const poke = (cs, source) => autos.pokeCaller({ callerAgent: 'agent:caller', callerClaudeId: cs, runAs: alice.id, message: `✅ Really done: ${source}`, source });
+const sentTo = (id) => injected.filter((i) => i.tmux === 'aos-' + id);
+const row = (id) => aos.db.prepare('SELECT status, busy_since FROM term_sessions WHERE id = ?').get(id);
+const pokeAudit = (id) => aos.db.prepare("SELECT data FROM audit_events WHERE run_id = ? AND type = 'agent.poked'").all(id).map((r) => JSON.parse(r.data));
+
+console.log('\n\x1b[1m1) the caller REPORTED but its claude is still running — deliver in place\x1b[0m');
+{
+  const cs = 'cs-reported';
+  const c = mkCaller(cs, { status: 'done' });          // exactly what `report` leaves behind
+  const before = spawned.length;
+  const r = poke(cs, 'tsk_1');
+  assert(r.ok && r.sessionId === c, 'poke resolved to the existing session', r);
+  assert(sentTo(c).some((i) => i.text.includes('tsk_1')), 'the message was typed into its live pane');
+  assert(spawned.length === before, 'NO second claude spawned on the transcript', spawned.slice(before));
+  assert(pokeAudit(c).some((d) => d.via === 'inject'), 'audited via:inject', pokeAudit(c));
+}
+
+console.log('\n\x1b[1m2) delivering puts the row back in step with reality\x1b[0m');
+{
+  const cs = 'cs-restore';
+  const c = mkCaller(cs, { status: 'done' });
+  poke(cs, 'tsk_2');
+  const after = row(c);
+  assert(after.status === 'running', "status back to 'running' — it is working again", after);
+  assert(after.busy_since > 0, 'busy_since stamped, so the console spins on `working`', after);
+}
+
+console.log('\n\x1b[1m3) the pane really is gone — resume, as before\x1b[0m');
+{
+  const cs = 'cs-dead';
+  const c = mkCaller(cs, { status: 'done', pane: false });
+  const r = poke(cs, 'tsk_3');
+  const s = spawned[spawned.length - 1];
+  assert(r.ok && r.sessionId === s.id, 'a new session carries the poke', r);
+  assert(s.resumeClaudeId === cs, 'and it RESUMES the caller transcript (not a cold start)', s);
+  assert(s.spawnedBy === 'poke:tsk_3', 'stamped with poke provenance', s);
+  assert(sentTo(c).length === 0, 'nothing was typed at the dead pane');
+  assert(pokeAudit(s.id).some((d) => d.via === 'resume'), 'audited via:resume', pokeAudit(s.id));
+}
+
+console.log('\n\x1b[1m4) a human STOPPED the run — a leftover pane is not a destination\x1b[0m');
+{
+  const cs = 'cs-stopped';
+  const c = mkCaller(cs, { status: 'stopped' });        // pane still listed, deliberately ended
+  const before = spawned.length;
+  const r = poke(cs, 'tsk_4');
+  assert(sentTo(c).length === 0, 'nothing typed into a stopped run');
+  assert(spawned.length === before + 1, 'the poke took the resume lane instead', r);
+  assert(tm.reachable(c) === false, 'reachable() refuses stopped/crashed rows');
+}
+
+console.log('\n\x1b[1m5) the inject fails on a live pane — kill it BEFORE resuming\x1b[0m');
+{
+  const cs = 'cs-wedged';
+  const c = mkCaller(cs, { status: 'done' });
+  injectWorks = false;
+  const before = spawned.length;
+  const r = poke(cs, 'tsk_5');
+  injectWorks = true;
+  assert(spawned.length === before + 1, 'fell through to a resume — the poke is never dropped', r);
+  assert(!livePanes.has('aos-' + c), 'the wedged pane was killed first (never two claudes on one transcript)');
+  assert(tm.reachable(c) === false, 'and the old run is no longer a delivery target', row(c));
+}
+
+console.log('\n\x1b[1m6) a transcript spanning several rows — the NEWEST one owns the pane\x1b[0m');
+{
+  const cs = 'cs-chain';
+  const old = mkCaller(cs, { status: 'done', pane: false });   // an earlier run on the same transcript
+  const cur = mkCaller(cs, { status: 'done' });                // the live one, created later
+  const r = poke(cs, 'tsk_6');
+  assert(r.sessionId === cur, 'delivered to the current run', r);
+  assert(sentTo(old).length === 0, 'the retired row was never written to');
+}
+
+console.log('\n\x1b[1m7) reachable() vs isAlive() — the distinction the bug turned on\x1b[0m');
+{
+  const cs = 'cs-contrast';
+  const c = mkCaller(cs, { status: 'done' });
+  assert(tm.isAlive(c) === false, "isAlive() is false for a reported run (right for pile-up guards)");
+  assert(tm.reachable(c) === true, 'reachable() is true — there is a live REPL to type into');
+  livePanes.delete('aos-' + c);
+  assert(tm.reachable(c) === false, 'and false once the pane goes away');
+}
+
+console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);
+try { fs.rmSync(HOME, { recursive: true, force: true }); } catch { /* best effort */ }
+process.exit(fail === 0 ? 0 : 1);

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -555,10 +555,17 @@ export class Automations {
     if (!input.callerClaudeId) return { ok: false, reason: 'no caller transcript to resume' };
     // Prefer delivering into the caller's OWN live session if it still has one bound to this transcript —
     // an idle interactive/resident caller would otherwise never learn the delegate finished.
+    //
+    // Liveness is `reachable` (the pane), NOT the row's `status`. A caller that handed off work and then
+    // called `report` is stamped `done` with its claude still running — the common shape, since a delegate
+    // usually finishes minutes after the caller last reported. Filtering on `status = 'running'` here sent
+    // every one of those down the resume lane, starting a SECOND claude on a transcript the first was
+    // still holding. Newest row first: a transcript resumed before now spans several rows and only the
+    // latest can own the pane.
     const liveSession = this.db
-      .prepare("SELECT id, tmux FROM term_sessions WHERE claude_session_id = ? AND status = 'running'")
+      .prepare('SELECT id, tmux FROM term_sessions WHERE claude_session_id = ? ORDER BY created_at DESC')
       .all<{ id: string; tmux: string }>(input.callerClaudeId)
-      .find((r) => this.tm.isAlive(r.id));
+      .find((r) => this.tm.reachable(r.id));
     if (liveSession) {
       const injected = this.tm.injectToSession(liveSession.id, input.message, true, input.runAs ? `member:${input.runAs}` : 'system');
       this.os.audit.append({
@@ -570,8 +577,11 @@ export class Automations {
         data: { caller: agentId, source: input.source, runAs: input.runAs ?? null, via: 'inject', ok: injected.ok },
       });
       // Keystrokes landed → the caller has (or will imminently have) the result. On the rare inject failure
-      // (unreadable pane) fall through to a resume so the poke is never silently dropped.
+      // (a wedged TUI, an unreadable socket) fall through to a resume so the poke is never silently
+      // dropped — but kill the pane first, exactly as `chatSend` does: resuming a transcript that another
+      // claude still holds is worse than a late poke.
       if (injected.ok) return { ok: true, sessionId: liveSession.id, tmux: liveSession.tmux };
+      this.tm.stopSession(liveSession.id, 'system');
     }
     const s = this.tm.createSession(agentId, input.title ?? `Poke ← ${input.source}`, input.message, `poke:${input.source}`, true, undefined, undefined, input.runAs, input.callerClaudeId);
     this.os.audit.append({

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1857,6 +1857,44 @@ export class TerminalManager {
   }
 
   /**
+   * Can we still DELIVER text into this session's claude? — the honest liveness test, and deliberately
+   * NOT `isAlive`.
+   *
+   * `status` is a report of what the run last *said about itself*, not whether its process is up: an
+   * agent that calls `report` is stamped `done` (see `reportSession`) while its claude keeps running for
+   * as long as the turn lasts — and a long-lived agent typically reports well before the delegate it
+   * handed off to finishes. `isAlive` folds that status in (`status !== 'running' → false`), which is
+   * right for the pile-up guards it was written for and wrong for delivery: it declares a session with a
+   * live REPL unreachable. Live example (instapods, 2026-08-10): `ses_f4535e8f` reported at 16:13, kept
+   * working until 16:34, and the 16:31 poke-back for its delegate saw `done`, skipped the live pane, and
+   * `--resume`d a SECOND claude onto the same transcript — the outcome `chatSend` calls "the one worse
+   * than a slow turn". The second process died 28s later and the poke was never seen.
+   *
+   * So this asks the PANE, and only refuses on a status that means a human or the sweep ended the run
+   * deliberately (`stopped`/`crashed`) — where a surviving pane is a leftover, not a destination.
+   */
+  reachable(sessionId: string): boolean {
+    if (this.launching.has(sessionId)) return true; // scheduled; its pane is imminent
+    const r = this.db.prepare('SELECT tmux, status FROM term_sessions WHERE id = ?').get<{ tmux: string; status: string }>(sessionId);
+    if (!r) return false;
+    if (r.status === 'stopped' || r.status === 'crashed') return false; // deliberately ended — don't revive by keystroke
+    const alive = this.backend.aliveNames();
+    if (!alive) return r.status === 'running'; // launcher backend: can't poll the pane, so fall back to the row
+    return alive.has(r.tmux);
+  }
+
+  /**
+   * A session we just delivered into was stamped `done` by its own `report` but is demonstrably still
+   * running — put the row back in step with reality so the console spins on `working` and the crash
+   * sweep watches it again. Terminal states set by a human (`stopped`) or the sweep (`crashed`) are
+   * never touched: `reachable` already refuses to deliver into those.
+   */
+  private restoreRunningAfterDelivery(sessionId: string): void {
+    this.db.prepare("UPDATE term_sessions SET status = 'running', updated_at = ? WHERE id = ? AND status = 'done'")
+      .run(Date.now(), sessionId);
+  }
+
+  /**
    * The MOST RECENT session bound to a Slack thread (`channel` + `thread_ts`), for thread continuity:
    * a follow-up message in a thread resumes THAT run's agent + claude conversation. Returns the agent,
    * its run-as, and the pinned `claudeSessionId` needed to `--resume`. Undefined when nothing is bound
@@ -2448,8 +2486,10 @@ export class TerminalManager {
     // not reach the agent executing the task, and `continueTaskThread` fell through to spawning a SECOND
     // agent on the same task while the first kept working. Observed live on instapods 2026-08-06
     // (tsk_67de2dfe): the stand-down went to a fresh run, the real one ran on for 25+ minutes.
-    if (!row || row.status !== 'running') return false;
-    if (!this.isAlive(sessionId)) return false;
+    // Liveness is the PANE, not the row's `status` — the same lesson one layer up. An agent that called
+    // `report` reads `done` with its claude still running, and gating on `status = 'running'` made those
+    // sessions unreachable exactly like the `resident` gate above did (see `reachable`).
+    if (!row || !this.reachable(sessionId)) return false;
     const body = (text || '').replace(/\r?\n+/g, ' ').trim(); // one-line: a stray newline would submit early
     if (!body) return false;
     const space = this.spaceFor(row.run_as ?? row.spawned_by);
@@ -2462,6 +2502,7 @@ export class TerminalManager {
       // the message QUEUES behind a running turn — the session is busy either way.
       this.db.prepare('UPDATE term_sessions SET last_activity = ?, busy_since = COALESCE(busy_since, ?), updated_at = ? WHERE id = ?')
         .run(Date.now(), Date.now(), Date.now(), sessionId);
+      this.restoreRunningAfterDelivery(sessionId); // a reported-but-warm session is working again
       const agent = this.sessionAgent(sessionId) ?? '';
       // `queued` = the message will wait for claude to finish the current turn before it's read.
       this.audit(sessionId, agent, 'chat.delivered', { chars: body.length, turn, queued: turn === 'busy' || turn === 'blocked' });
@@ -3855,11 +3896,22 @@ export class TerminalManager {
     if (!row) return { ok: false, error: 'unknown session' };
     const body = (text || '').replace(/\r?\n+/g, ' ').trim();
     if (!body) return { ok: false, error: 'nothing to send' };
-    if (row.status !== 'running' || !this.isAlive(sessionId)) return { ok: false, error: 'session is not live — open it first' };
+    // `reachable`, not `isAlive`: a session that reported still has a live REPL to type into, and telling
+    // its own console "not live — open it first" while the pane is right there is the visible half of the
+    // poke-back bug.
+    if (!this.reachable(sessionId)) return { ok: false, error: 'session is not live — open it first' };
     const space = this.spaceFor(row.run_as ?? row.spawned_by);
     const ok = this.backend.injectText(space, row.tmux, body, submit);
     if (!ok) return { ok: false, error: 'could not deliver keystrokes to the terminal' };
-    this.db.prepare('UPDATE term_sessions SET last_activity = ?, updated_at = ? WHERE id = ?').run(Date.now(), Date.now(), sessionId);
+    // Submitted text starts a turn, so mark the session busy (the Stop-hook beacon clears it) — without
+    // it a poke delivered into a warm pane leaves the console reading idle through the work it triggered.
+    if (submit) {
+      this.db.prepare('UPDATE term_sessions SET last_activity = ?, busy_since = COALESCE(busy_since, ?), updated_at = ? WHERE id = ?')
+        .run(Date.now(), Date.now(), Date.now(), sessionId);
+      this.restoreRunningAfterDelivery(sessionId);
+    } else {
+      this.db.prepare('UPDATE term_sessions SET last_activity = ?, updated_at = ? WHERE id = ?').run(Date.now(), Date.now(), sessionId);
+    }
     this.audit(sessionId, this.sessionAgent(sessionId) ?? '', 'session.inject', { by, chars: body.length, submit });
     return { ok: true };
   }


### PR DESCRIPTION
## The bug

A `poke_on_done` hand-off wakes the caller one of two ways: type into its live pane, or `--resume` its transcript in a new session. `Automations.pokeCaller` picked between them with `WHERE claude_session_id = ? AND status = 'running'`.

`status` is not liveness. An agent that calls `report` is stamped `done` (`reportSession`) while its claude keeps running — and that is the *normal* shape for a caller: hand off work, report, keep working while the delegate finishes minutes later. So those pokes all fell to the resume lane and opened a **second claude on a transcript the first still held** — what `chatSend` already calls "the one outcome worse than a slow turn".

### Live evidence (instapods, 2026-08-10)

| time | event |
|---|---|
| 16:13:20 | `ses_f4535e8f` (check-resolve-tickets) calls `report` → row flipped to `status='done'`, pane still alive |
| 16:20:32 | it creates `tsk_416fe958` for `engineer`, `poke_on_done=1` |
| 16:31:38 | engineer finishes → `agent.poked {"via":"resume"}` → spawns `ses_441cec` |
| 16:32:06 | `ses_441cec` → `session.stopped` (28s alive) |
| 16:33:16 → 16:34:37 | `ses_f4535e8f` still emitting `gate.attempt` — alive the whole time |

The caller never received the poke. It found out about PR #494 by shelling out to `gh pr view 494`.

## The fix

`TerminalManager.reachable(sessionId)` — the delivery-side counterpart to `isAlive`, which folds `status` in and stays as-is for the pile-up guards it was written for. `reachable` asks the **pane**, and refuses only a status that means someone ended the run deliberately (`stopped`/`crashed`), where a surviving pane is a leftover rather than a destination. Falls back to the row under the launcher backend, which can't poll panes, so Linux/uid-isolation behaviour is unchanged.

- `pokeCaller` uses it, newest row first (a resumed transcript spans several rows; only the latest can own the pane).
- Delivery restores `running` + stamps `busy_since`, so the console stops reading idle through work it just triggered.
- An inject that fails on a wedged pane now **kills that pane before** falling back to the resume, mirroring `chatSend`.
- `deliverToResident` and `injectToSession` carried the same `status = 'running'` gate — fixed with it. That also removes the console's "session is not live — open it first" on a session whose pane is right there.

## Test

`scripts/poke-warm-caller-test.cjs` (22 checks, added to `npm run test:governance`), isolated home + stubbed backend. Verified as a falsifier: on the pre-fix build, cases 1 and 2 fail exactly where the live incident did.

Covers: reported-but-warm delivers in place with no second spawn · a dead pane still resumes with `poke:` provenance and the right transcript · a human `stop` is never overridden · delivery restores `running`+busy · a failed inject kills the pane first · newest row wins · `reachable` vs `isAlive` contrasted directly.

Full `test:governance` green; `web` bundle builds. `docs/tasks-plan.md` §3.5 documents the rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUfffxY4hKv7M6wMCcaTz