### PR TITLE
fix(sessions): one liveness predicate, and it asks the pane — delete isAlive (v0.334.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.334.2] — 2026-08-11
+### Fixed
+- **One liveness predicate, and it asks the pane.** v0.334.1 fixed the poke-back's `status = 'running'`
+  liveness test by adding `TerminalManager.reachable`, and left the older status-folding `isAlive` in
+  place for the pile-up guards. A sweep of that method's remaining ten call sites found **every one of
+  them wrong in the same direction** — it calls a session with a live REPL dead:
+  - `takeOverSession` / `openChatSession` — a take-over of a run that had already `report`ed took the
+    "dead → resurrect" branch and relaunched claude **over its own live pane** instead of claiming it.
+  - `agentAskStatus` — a delegate that answered and was still wrapping up got graded `failed`, so the
+    caller unblocked on a false "your delegate died".
+  - `maybeHoldDelegate` — a HOLD or cancel aimed at a reported-but-working delegate decided there was
+    "nothing running to interrupt" and never reached it (the 2026-08-06 incident's remaining half).
+  - `refreshAgentSkills` — a just-approved skill install skipped the very session whose human approved
+    it, which then kept insisting it had no such skill until its next run.
+  - the dispatch pile-up guards (`fire`, `dispatchTask`, `dispatchTasks`, `task_wait`, the app-trigger
+    poll) — a busy agent read as free, so a second session stacked onto work already in flight.
+
+  Their shared shape is why this was worth doing as one pass rather than site by site: the fallback for
+  "dead" is almost always `claude --resume`, so a false negative doesn't degrade — it puts a **second
+  claude on a transcript the first still holds**. All ten now use `reachable`, and `isAlive` is
+  **deleted** rather than kept as a synonym: with two predicates, a nine-tenths-correct choice is always
+  available, and this class of bug already recurred once (the `resident` gate on `deliverToResident`).
+  Widening the pile-up guards stays bounded — the idle sweep's DONE-ORPHAN branch reaps exactly the
+  unattended `done`-with-a-pane rows they now count, and a human forcing work through passes
+  `guard: false`. `scripts/poke-warm-caller-test.cjs` grew cases 7–9 (no status-folding predicate
+  survives; the dispatch guard sees a warm worker; a skill install reaches a reported session).
+
 ## [0.334.1] — 2026-08-10
 ### Fixed
 - **A poke-back now wakes the caller that is still running, instead of starting a second claude beside

--- a/docs/tasks-plan.md
+++ b/docs/tasks-plan.md
@@ -362,13 +362,26 @@ instapods 2026-08-10: `ses_f4535e8f` reported at 16:13 and worked through 16:34;
 `ses_441cec`, which died 28s later, and the caller — never woken — re-derived the delegate's result by
 shelling out to `gh pr view`.
 
-Liveness is therefore asked of the **pane**: `TerminalManager.reachable(sessionId)`, the delivery-side
-counterpart to `isAlive` (which folds `status` in and is right for the pile-up guards it was written for).
-`reachable` still refuses a run a human `stop`ped or the sweep marked `crashed` — a surviving pane there is
-a leftover, not a destination. Delivery puts the row back to `running` + `busy_since` so the console stops
-reading idle through work it just triggered, and an inject that fails on a wedged pane kills that pane
-before the resume, mirroring `chatSend`. `deliverToResident` and `injectToSession` share the same test —
-they carried the same `status = 'running'` gate. Pinned by `scripts/poke-warm-caller-test.cjs`.
+Liveness is therefore asked of the **pane**: `TerminalManager.reachable(sessionId)`. It refuses a run a
+human `stop`ped or the sweep marked `crashed` — a surviving pane there is a leftover, not a destination —
+and falls back to the row under the launcher backend, which cannot poll panes. Delivery puts the row back
+to `running` + `busy_since` so the console stops reading idle through work it just triggered, and an inject
+that fails on a wedged pane kills that pane before the resume, mirroring `chatSend`.
+
+**`reachable` is the only liveness predicate; there is deliberately no second one.** It shipped beside the
+older status-folding `isAlive`, and a sweep of that method's ten call sites found every one of them wrong
+in the same direction — the take-over paths (`takeOverSession` / `openChatSession`) relaunched over a live
+pane instead of claiming it, `agentAskStatus` graded a still-running delegate `failed`, `maybeHoldDelegate`
+decided there was "nothing running to interrupt", `refreshAgentSkills` skipped the very session whose human
+had just approved the skill, and the dispatch pile-up guards called a busy agent free. Their shared shape:
+the fallback for "dead" is almost always `claude --resume`, so a false negative costs a rival claude on a
+live transcript. So `isAlive` was deleted rather than fixed — with two predicates a nine-tenths-correct
+choice is always available, and this is the class of bug that recurs (the `resident` gate on
+`deliverToResident`, instapods 2026-08-06, was the previous instance).
+
+Widening the pile-up guards is bounded, not open-ended: the idle sweep's DONE-ORPHAN branch exists exactly
+to reap an unattended `done` row still holding a pane, and a human forcing work through passes
+`guard: false`. Pinned by `scripts/poke-warm-caller-test.cjs`.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.334.1",
+  "version": "0.334.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.334.1",
+      "version": "0.334.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.334.1",
+  "version": "0.334.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/chain-model-test.cjs
+++ b/scripts/chain-model-test.cjs
@@ -171,9 +171,8 @@ console.log('\n\x1b[1msteering a live delegate\x1b[0m');
   const autos = new Automations(aos, tm);
   const injected = [];
   tm.backend.injectText = (space, tmuxName, body) => { injected.push({ tmux: tmuxName, body }); return true; };
-  // `isAlive` guards dispatch pile-ups; `reachable` decides delivery (a reported run keeps a live REPL).
-  // Only the delegate is up on either.
-  tm.isAlive = (id) => id === liveDelegate;
+  // `reachable` is the one liveness predicate — delivery AND the dispatch pile-up guards read it.
+  // Only the delegate is up.
   tm.reachable = (id) => id === liveDelegate;
 
   const held = mkTask({ title: 'ship batch 1', assignee: 'agent:builder', callerAgent: 'agent:manager', callerClaudeId: 'cs_mgr' });
@@ -201,12 +200,12 @@ console.log('\n\x1b[1msteering a live delegate\x1b[0m');
   assert(blocked.ok === false && /blocked/.test(blocked.reason), 'a blocked task refuses a guarded dispatch', blocked.reason);
   // …but a human forcing it from the console still gets PAST the park (it stops on this scratch home's
   // missing agent manifest, not on the block — spawning a real one would start a real tmux session).
-  tm.isAlive = () => false;
+  tm.reachable = () => false;
   const forced = autos.dispatchTask(held.id, { guard: false, by: 'human' });
   assert(!/blocked/.test(forced.reason || ''), 'a human forcing it is not refused for being blocked', forced.reason);
 
   // And a still-working delegate is never given a rival by the discussion path.
-  tm.isAlive = (id) => id === liveDelegate; tm.reachable = (id) => id === liveDelegate;
+  tm.reachable = (id) => id === liveDelegate;
   tm.deliverToResident = () => false;   // simulate an undeliverable pane
   tm.reviveResident = () => false;
   const before = aos.db.prepare('SELECT COUNT(*) AS c FROM term_sessions').get().c;

--- a/scripts/poke-warm-caller-test.cjs
+++ b/scripts/poke-warm-caller-test.cjs
@@ -153,14 +153,47 @@ console.log('\n\x1b[1m6) a transcript spanning several rows — the NEWEST one o
   assert(sentTo(old).length === 0, 'the retired row was never written to');
 }
 
-console.log('\n\x1b[1m7) reachable() vs isAlive() — the distinction the bug turned on\x1b[0m');
+console.log('\n\x1b[1m7) reachable() is the ONE liveness predicate — the pane, vetoed only by a deliberate end\x1b[0m');
 {
-  const cs = 'cs-contrast';
-  const c = mkCaller(cs, { status: 'done' });
-  assert(tm.isAlive(c) === false, "isAlive() is false for a reported run (right for pile-up guards)");
-  assert(tm.reachable(c) === true, 'reachable() is true — there is a live REPL to type into');
+  assert(typeof tm.isAlive !== 'function', 'the status-folding `isAlive` is gone — no wrong choice to make');
+  const c = mkCaller('cs-contrast', { status: 'done' });
+  assert(tm.reachable(c) === true, 'a reported run is live — there is a REPL to type into');
+  for (const s of ['stopped', 'crashed']) {
+    aos.db.prepare('UPDATE term_sessions SET status = ? WHERE id = ?').run(s, c);
+    assert(tm.reachable(c) === false, `${s} vetoes a surviving pane (a leftover, not a destination)`);
+  }
+  aos.db.prepare("UPDATE term_sessions SET status = 'done' WHERE id = ?").run(c);
   livePanes.delete('aos-' + c);
   assert(tm.reachable(c) === false, 'and false once the pane goes away');
+}
+
+// The other two sites that read `status` as liveness. Both fail in the SAME direction as the poke — they
+// call a live agent free — but cost differently: one stacks a rival worker, one silently skips a delivery.
+console.log('\n\x1b[1m8) the dispatch pile-up guard counts a reported-but-warm worker as busy\x1b[0m');
+{
+  const t = aos.tasks.create({ tenant: aos.tenant, title: 'ship it', assignee: 'agent:caller', owner: alice.id, createdBy: alice.id });
+  const worker = mkCaller('cs-worker', { status: 'done', spawned_by: `task:${t.id}` });  // reported, still up
+  aos.tasks.markDispatched(t.id, worker);
+  const guarded = autos.dispatchTask(t.id, { guard: true, by: 'test' });
+  assert(guarded.ok === false && /already working/.test(guarded.reason || ''), 'guarded dispatch refuses — no rival worker', guarded.reason);
+  livePanes.delete('aos-' + worker);
+  const after = autos.dispatchTask(t.id, { guard: true, by: 'test' });
+  assert(!/already working/.test(after.reason || ''), 'and stops refusing once the pane is actually gone', after.reason);
+}
+
+console.log('\n\x1b[1m9) a freshly installed skill reaches a reported-but-warm session\x1b[0m');
+{
+  const reached = [];
+  tm.materializeSkills = (sessionId) => { reached.push(sessionId); };
+  // Its own agent, so the sweep's row set is exactly this one session.
+  aos.agents.set('skiller', { id: 'skiller', name: 'Skiller', runtime: 'claude-code', dir: HOME });
+  const s = mkCaller('cs-skills', { status: 'done', headless: 0, agent: 'skiller' });  // interactive, reported, pane alive
+  tm.refreshAgentSkills('skiller');
+  assert(reached.includes(s), 'the live REPL is refreshed — not told to wait for its next run', reached);
+  reached.length = 0;
+  livePanes.delete('aos-' + s);
+  tm.refreshAgentSkills('skiller');
+  assert(reached.length === 0, 'a dead pane is still skipped');
 }
 
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);

--- a/scripts/warm-chat-test.cjs
+++ b/scripts/warm-chat-test.cjs
@@ -78,7 +78,7 @@ console.log('\x1b[1m\n2) no pane → cold in-place resume, still resident\x1b[0m
   assert(spawned.length === before, 'launch deferred off the response path');
   // …and the session must still read as live meanwhile, or a fast second message would launch a rival
   // claude onto the same transcript.
-  assert(tm.isAlive(id) === true, 'reported live while its launch is in flight');
+  assert(tm.reachable(id) === true, 'reported live while its launch is in flight');
 }
 
 console.log('\x1b[1m\n3) a report-ended chat (done row, live pane) still takes a warm turn\x1b[0m');

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -647,7 +647,7 @@ export class Automations {
    * the no-pile-ups rule for cron/webhook; "Run now" from the console passes guard: false.
    */
   fire(a: Automation, opts: { guard: boolean; extra?: string; runAs?: string; mode?: ExecMode; slack?: { channel: string; threadTs: string }; discord?: { channel: string; messageId: string }; telegram?: { chat: string; messageThreadId?: string; messageId: string }; clickup?: { taskId: string; commentId: string }; resumeClaudeId?: string } = { guard: true }): FireResult {
-    if (opts.guard && a.lastSessionId && this.tm.isAlive(a.lastSessionId)) {
+    if (opts.guard && a.lastSessionId && this.tm.reachable(a.lastSessionId)) {
       return { ok: false, reason: 'previous session still running' };
     }
     // Don't spawn a scheduled/triggered run into an exhausted quota — it would just hit the usage limit and
@@ -704,7 +704,7 @@ export class Automations {
     const agentId = (t.assignee || '').startsWith('agent:') ? t.assignee!.slice('agent:'.length) : '';
     if (!agentId) return { ok: false, reason: 'task has no agent assignee' };
     if (!this.os.agents.has(agentId)) return { ok: false, reason: `unknown agent: ${agentId}` };
-    if (guard && t.lastSessionId && this.tm.isAlive(t.lastSessionId)) {
+    if (guard && t.lastSessionId && this.tm.reachable(t.lastSessionId)) {
       return { ok: false, reason: 'a session is already working this task' };
     }
     // Defer a guarded (scheduler-driven) dispatch when the agent's runtime pool is exhausted — retried next
@@ -1199,7 +1199,7 @@ export class Automations {
       // Delivery failed but the run is STILL WORKING: spawning a second agent onto the same task is how a
       // "stand down" ends up executed by a fresh run while the original keeps building (instapods
       // 2026-08-06). Report the failure instead of duplicating the worker.
-      if (this.tm.isAlive(boundId)) { emit('undeliverable', boundId); return { status: 'none', sessionId: boundId }; }
+      if (this.tm.reachable(boundId)) { emit('undeliverable', boundId); return { status: 'none', sessionId: boundId }; }
     }
     const seed = buildTaskPrompt({ id: t.id, title: t.title, body: t.body, criteria: t.criteria }) +
       `\n\nA teammate pulled you into the discussion:\n${authorLabel}: ${text}\n\nReply in the discussion with task_say({ id: "${t.id}", message: "…" }).`;
@@ -1784,12 +1784,16 @@ export class Automations {
   private dispatchTasks(budget: number = Infinity): void {
     try {
       if (budget <= 0) return; // whole-box concurrency cap already reached — dispatch nothing this tick
-      // Agents already running a task session (their `task:<id>` spawn is still alive) — skip this tick.
+      // Agents already running a task session (their `task:<id>` spawn still has a live claude) — skip this
+      // tick. Liveness is the PANE (`reachable`), not the row: a task run that called `report` and is still
+      // wrapping up holds the agent's workspace, and stacking a second session on it is the pile-up this
+      // guard exists to prevent. Bounded — the idle sweep's DONE-ORPHAN branch reaps exactly these panes,
+      // and a human forcing a dispatch passes `guard: false`.
       const busy = new Set<string>();
       for (const r of this.db
-        .prepare("SELECT id, agent FROM term_sessions WHERE spawned_by LIKE 'task:%' AND status = 'running'")
+        .prepare("SELECT id, agent FROM term_sessions WHERE spawned_by LIKE 'task:%' AND status IN ('running','done')")
         .all<{ id: string; agent: string }>()) {
-        if (this.tm.isAlive(r.id)) busy.add(r.agent);
+        if (this.tm.reachable(r.id)) busy.add(r.agent);
       }
       for (const t of this.os.tasks.dispatchable(this.os.tenant)) {
         if (budget <= 0) break; // hit the concurrency cap mid-drain — the rest retry next tick

--- a/src/server.ts
+++ b/src/server.ts
@@ -1710,7 +1710,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const t = os.tasks.get(String(b.id || ''));
     if (!t) return sendJson(res, 200, { ok: false, error: 'task not found' });
     const terminal = t.status === 'done' || t.status === 'cancelled';
-    if (!terminal && t.status !== 'blocked' && (t.assignee || '').startsWith('agent:') && !(t.lastSessionId && tm.isAlive(t.lastSessionId))) {
+    if (!terminal && t.status !== 'blocked' && (t.assignee || '').startsWith('agent:') && !(t.lastSessionId && tm.reachable(t.lastSessionId))) {
       autos.dispatchTask(t.id, { guard: true, by: `wait:${agent}` });
     }
     // The delegate's closing "what I did" — the newest comment (task_update writes the done note as one).
@@ -2139,7 +2139,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         if (terminal || cur.status === 'blocked' || Date.now() >= deadline) {
           return sendJson(res, 200, { ok: true, taskId: task.id, status: cur.status, terminal, note: os.tasks.latestNote(task.id) ?? null });
         }
-        if (!(cur.lastSessionId && tm.isAlive(cur.lastSessionId))) autos.dispatchTask(task.id, { guard: true, by: `app:${slug}` });
+        if (!(cur.lastSessionId && tm.reachable(cur.lastSessionId))) autos.dispatchTask(task.id, { guard: true, by: `app:${slug}` });
         await sleep(1500);
       }
     }

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -573,7 +573,7 @@ function maybeHoldDelegate(tm: TerminalManager, os: AgentOS, notice: TaskNotice)
   if (t.status !== 'blocked' && t.status !== 'cancelled') return;
   if (!t.lastSessionId) return;
   if (notice.by === t.assignee) return;               // the delegate parked itself — it already knows
-  if (!tm.isAlive(t.lastSessionId)) return;           // nothing running to interrupt
+  if (!tm.reachable(t.lastSessionId)) return;         // nothing running to interrupt (the PANE, not the row)
   const note = os.tasks.latestNote(t.id) || '(no reason given)';
   const who = notice.by.startsWith('agent:') ? notice.by.slice('agent:'.length) : (os.team.getMember(notice.by)?.name ?? 'a teammate');
   const verb = t.status === 'cancelled' ? 'CANCELLED' : 'put on HOLD';

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -750,7 +750,7 @@ export class TerminalManager {
   private readonly reliability = new ReliabilityMonitor();
   private readonly reliabilityOn = process.env.AOS_RELIABILITY !== '0';
   /** Sessions whose runtime launch is SCHEDULED but whose pane doesn't exist yet (see
-   *  `launchAgentRuntime`). `isAlive` counts them as live so the window between "row written" and
+   *  `launchAgentRuntime`). `reachable` counts them as live so the window between "row written" and
    *  "tmux up" can't be read as "nothing is running" — which would let a second turn launch a
    *  competing claude on the same transcript. */
   private readonly launching = new Set<string>();
@@ -1844,34 +1844,26 @@ export class TerminalManager {
     return { available: true, totalRss: sessions.reduce((n, s) => n + s.rss, 0), sessions };
   }
 
-  /** Is this session's tmux shell still alive? (The automations guard against pile-ups.) */
-  isAlive(sessionId: string): boolean {
-    // A launch that is scheduled but hasn't reached tmux yet IS a live run — see `launching`.
-    if (this.launching.has(sessionId)) return true;
-    const r = this.db.prepare('SELECT tmux, status FROM term_sessions WHERE id = ?').get<{ tmux: string; status: string }>(sessionId);
-    if (!r) return false;
-    if (r.status !== 'running') return false; // already marked dead by a previous check
-    const alive = this.backend.aliveNames();
-    if (!alive) return true; // launcher backend: can't poll; the row says running, so treat as alive
-    return alive.has(r.tmux);
-  }
-
   /**
-   * Can we still DELIVER text into this session's claude? — the honest liveness test, and deliberately
-   * NOT `isAlive`.
+   * Is this session's claude still up? — the ONE liveness predicate. Every caller that asks "can I type
+   * into this run / is this agent already working / did that delegate die" asks this.
    *
-   * `status` is a report of what the run last *said about itself*, not whether its process is up: an
-   * agent that calls `report` is stamped `done` (see `reportSession`) while its claude keeps running for
-   * as long as the turn lasts — and a long-lived agent typically reports well before the delegate it
-   * handed off to finishes. `isAlive` folds that status in (`status !== 'running' → false`), which is
-   * right for the pile-up guards it was written for and wrong for delivery: it declares a session with a
-   * live REPL unreachable. Live example (instapods, 2026-08-10): `ses_f4535e8f` reported at 16:13, kept
-   * working until 16:34, and the 16:31 poke-back for its delegate saw `done`, skipped the live pane, and
-   * `--resume`d a SECOND claude onto the same transcript — the outcome `chatSend` calls "the one worse
-   * than a slow turn". The second process died 28s later and the poke was never seen.
+   * It asks the **pane**, never the row's `status`, because `status` reports what the run last *said
+   * about itself*: an agent that calls `report` is stamped `done` (see `reportSession`) while its claude
+   * keeps running. That is not an edge case — it is the normal shape of a long-lived run, which is why
+   * the idle reaper has a whole "DONE ORPHAN" branch for a `done` row still holding a pane, and why
+   * `isWorking` (the console's spinner) already ignored status.
    *
-   * So this asks the PANE, and only refuses on a status that means a human or the sweep ended the run
-   * deliberately (`stopped`/`crashed`) — where a surviving pane is a leftover, not a destination.
+   * There used to be a second, status-folding predicate (`isAlive`: `status !== 'running' → false`).
+   * Every one of its ten call sites was wrong in the same direction — it declares a session with a live
+   * REPL dead — and the failures were the expensive kind, because the fallback for "dead" is almost
+   * always `claude --resume`, i.e. a SECOND claude on a transcript the first still holds. Live on
+   * instapods 2026-08-10: `ses_f4535e8f` reported at 16:13 and worked until 16:34; its 16:31 poke-back
+   * saw `done`, skipped the live pane, and spawned `ses_441cec`, which died 28s later — the poke was
+   * never seen. So the two were folded into this one; don't reintroduce a status-based variant.
+   *
+   * Refuses only a status that means someone ended the run deliberately (`stopped`) or the sweep buried
+   * it (`crashed`) — a pane surviving either is a leftover, not a destination.
    */
   reachable(sessionId: string): boolean {
     if (this.launching.has(sessionId)) return true; // scheduled; its pane is imminent
@@ -2254,7 +2246,7 @@ export class TerminalManager {
    * in milliseconds instead of after the mints, and it keeps one launch from stalling other requests.
    *
    * The row is registered in {@link launching} for the gap between "scheduled" and "pane exists", so
-   * `isAlive` reports the session as live throughout and the busy/pile-up guards that depend on it
+   * `reachable` reports the session as live throughout and the busy/pile-up guards that depend on it
    * (chatSend, dispatchTask) can't double-launch into the same transcript. Errors are audited rather
    * than thrown: there is no caller left to catch them.
    */
@@ -2538,7 +2530,7 @@ export class TerminalManager {
     const row = this.db.prepare('SELECT agent, secret, claude_session_id, run_as, spawned_by, status FROM term_sessions WHERE id = ?')
       .get<{ agent: string; secret: string | null; claude_session_id: string | null; run_as: string | null; spawned_by: string | null; status: string }>(sessionId);
     if (!row || !row.claude_session_id) return false;
-    if (this.isAlive(sessionId)) return false; // caller should have delivered instead
+    if (this.reachable(sessionId)) return false; // caller should have delivered instead
     const body = (text || '').trim();
     if (!body) return false;
     const actingMember = this.resolveActingMember(runAs ?? row.run_as ?? undefined);
@@ -2587,9 +2579,9 @@ export class TerminalManager {
     if (!body) return 'error';
     const actingMember = this.resolveActingMember(runAs ?? row.run_as ?? undefined);
 
-    // WARM — the pane is still up, so the turn costs nothing but the model. Checked on the PANE, not on
-    // `isAlive`: a chat session that ended its last turn with `report` reads `done` while its claude is
-    // very much alive, and a new human turn is exactly what makes it running again.
+    // WARM — the pane is still up, so the turn costs nothing but the model. Checked on the PANE (the rule
+    // `reachable` now carries everywhere): a chat session that ended its last turn with `report` reads
+    // `done` while its claude is very much alive, and a new human turn is what makes it running again.
     if (this.paneAlive(row.tmux)) {
       const before = this.transcriptMark(row.claude_session_id);
       this.db.prepare("UPDATE term_sessions SET status = 'running', headless = 0, resident = 1, task = ?, run_as = ?, updated_at = ? WHERE id = ?")
@@ -2622,11 +2614,11 @@ export class TerminalManager {
     return 'sent';
   }
 
-  /** Is this tmux pane up? Unlike {@link isAlive} this asks ONLY about the pane, ignoring the row's
-   *  status — a chat session that ended a turn with `report` is `done` with a live claude still in it.
-   *  `aliveNames()` is null when liveness can't be polled (launcher backend / failed poll); we then
-   *  answer false so the caller takes the cold path, which is correct-by-relaunch rather than a
-   *  send-keys into the dark. */
+  /** Is this tmux pane up? The raw question behind {@link reachable}, minus the row entirely — no
+   *  `launching` grace and no `stopped`/`crashed` veto, so `chatSend` can ask about a pane it may be
+   *  about to kill. `aliveNames()` is null when liveness can't be polled (launcher backend / failed
+   *  poll); we then answer false so the caller takes the cold path, which is correct-by-relaunch rather
+   *  than a send-keys into the dark. */
   private paneAlive(tmux: string): boolean {
     const alive = this.backend.aliveNames();
     return alive ? alive.has(tmux) : false;
@@ -2739,8 +2731,10 @@ export class TerminalManager {
     if (!runtimeSupports(manifest?.runtime, 'attachableUnattended') || !manifest?.dir) {
       return { ok: false, error: `this agent's runtime has no attachable session to take over` };
     }
-    // A turn is still generating → attach to the live pane, no relaunch (identical to a live take-over).
-    if (this.isAlive(sessionId)) return this.claimSession(sessionId, by);
+    // The pane is still up → attach to it, no relaunch (identical to a live take-over). Pane, not status:
+    // a run that already called `report` still owns its claude, and relaunching over it is the two-claudes
+    // outcome — a take-over must claim what is there.
+    if (this.reachable(sessionId)) return this.claimSession(sessionId, by);
     // Dead → resurrect the transcript. Needs the pinned claude session id to `--resume` from.
     if (!row.claude_session_id) return { ok: false, error: 'this run has no conversation to resume yet' };
     this.allowResume(sessionId);
@@ -2783,8 +2777,8 @@ export class TerminalManager {
       return { ok: false, error: `this agent's runtime does not support resident chat sessions` };
     }
     if (!row.claude_session_id) return { ok: false, error: 'this chat has no conversation to open yet' };
-    // A turn is still generating → attach to the live pane, no relaunch.
-    if (this.isAlive(sessionId)) return this.claimSession(sessionId, by);
+    // The pane is still up → attach to it, no relaunch (see `takeOverSession` — same reasoning).
+    if (this.reachable(sessionId)) return this.claimSession(sessionId, by);
     // Idle/dead → resurrect as an interactive resident TUI (resumes the transcript, no seed prompt).
     this.allowResume(sessionId);
     this.db.prepare("UPDATE term_sessions SET status = 'running', headless = 0, resident = 1, claimed_by = ?, claimed_at = ?, last_activity = ?, updated_at = ? WHERE id = ?")
@@ -3856,10 +3850,13 @@ export class TerminalManager {
   refreshAgentSkills(agent: string): { reloaded: number } {
     const manifest = this.os.agents.get(agent);
     if (!manifest || !runtimeSupports(manifest.runtime, 'nativeSkills') || !manifest.dir) return { reloaded: 0 };
+    // No `status` filter — liveness is the pane (`reachable`). A session that reported still has the REPL
+    // the `/reload-skills` inject needs, and skipping it meant the human who just approved the install
+    // watched the agent keep saying it has no such skill.
     const rows = this.db
-      .prepare(`SELECT id, tmux, run_as, spawned_by FROM term_sessions WHERE agent = ? AND status = 'running' AND headless = 0`)
+      .prepare(`SELECT id, tmux, run_as, spawned_by FROM term_sessions WHERE agent = ? AND headless = 0`)
       .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null }>(agent)
-      .filter((r) => this.isAlive(r.id));
+      .filter((r) => this.reachable(r.id));
     if (!rows.length) return { reloaded: 0 };
     // Sync the library (incl. the just-installed skill) into the agent's watched .claude/skills — once;
     // all of the agent's sessions run out of the same folder.
@@ -3896,9 +3893,8 @@ export class TerminalManager {
     if (!row) return { ok: false, error: 'unknown session' };
     const body = (text || '').replace(/\r?\n+/g, ' ').trim();
     if (!body) return { ok: false, error: 'nothing to send' };
-    // `reachable`, not `isAlive`: a session that reported still has a live REPL to type into, and telling
-    // its own console "not live — open it first" while the pane is right there is the visible half of the
-    // poke-back bug.
+    // `reachable`: a session that reported still has a live REPL to type into, and telling its own console
+    // "not live — open it first" while the pane is right there is the visible half of the poke-back bug.
     if (!this.reachable(sessionId)) return { ok: false, error: 'session is not live — open it first' };
     const space = this.spaceFor(row.run_as ?? row.spawned_by);
     const ok = this.backend.injectText(space, row.tmux, body, submit);
@@ -4926,7 +4922,9 @@ export class TerminalManager {
     if (!a) return { status: 'failed' };
     if (a.status === 'answered') return { status: 'answered', answer: a.answer ?? undefined };
     if (a.status === 'failed') return { status: 'failed' };
-    if (a.delegate_run_id && Date.now() - a.created_at > ASK_AGENT_GRACE_MS && !this.isAlive(a.delegate_run_id)) {
+    // `reachable`, not the row: a delegate that answered with `report` and is still finishing up is not a
+    // dead delegate, and grading it `failed` would unblock the caller with a lie.
+    if (a.delegate_run_id && Date.now() - a.created_at > ASK_AGENT_GRACE_MS && !this.reachable(a.delegate_run_id)) {
       this.db.prepare("UPDATE agent_asks SET status = 'failed' WHERE id = ? AND status = 'pending'").run(id);
       return { status: 'failed' };
     }


### PR DESCRIPTION
Follow-up to #610. That PR fixed `pokeCaller`'s `status = 'running'` liveness test by adding `TerminalManager.reachable`, and left the older status-folding `isAlive` in place for the pile-up guards. Sweeping its remaining **ten** call sites found every one of them wrong in the same direction — `isAlive` calls a session with a live REPL dead.

## The ten sites

| site | what the false negative did |
|---|---|
| `takeOverSession`, `openChatSession` | took the "dead → resurrect" branch and relaunched claude **over its own live pane** instead of claiming it, for any run that had called `report` |
| `agentAskStatus` | graded a still-running delegate `failed`, unblocking the caller on a false "your delegate died" |
| `maybeHoldDelegate` (tenant-registry) | a HOLD/cancel aimed at a reported-but-working delegate found "nothing running to interrupt" — the remaining half of the 2026-08-06 incident |
| `refreshAgentSkills` | skipped the very session whose human had just approved the skill install; that agent kept insisting it had no such skill |
| `continueTaskThread`, `reviveResident` | delivery guards, same shape as the poke |
| `fire`, `dispatchTask`, `dispatchTasks`, `task_wait`, app-trigger poll | pile-up guards read a busy agent as free and stacked a second session on work in flight |

The shared shape is why this is one pass rather than site by site: **the fallback for "dead" is almost always `claude --resume`**, so a false negative here doesn't degrade gracefully — it puts a second claude on a transcript the first still holds.

## What changed

All ten use `reachable`. `isAlive` is **deleted**, not kept as a synonym — with two near-identical predicates a nine-tenths-correct choice is always available, and this class already recurred once before the poke bug (the `resident` gate on `deliverToResident`, instapods 2026-08-06). Its doc comment now carries the whole rule so the next reader doesn't reintroduce a status-based variant.

Widening the pile-up guards is bounded, not open-ended: the idle sweep's **DONE-ORPHAN** branch exists precisely to reap an unattended `done` row still holding a pane — i.e. exactly the rows those guards now count — and a human forcing work through passes `guard: false`. The `dispatchTasks` busy-set query widened to `status IN ('running','done')` to match.

Also worth noting `isWorking` (the console's spinner) already ignored `status` and asked the pane. The UI has been right about this the whole time; the control paths weren't.

## Test

`scripts/poke-warm-caller-test.cjs` → 28 checks, cases 7–9 added:
- no status-folding predicate survives (`typeof tm.isAlive !== 'function'`), and `reachable` is the pane vetoed only by `stopped`/`crashed`
- the dispatch guard refuses a rival worker while a reported-but-warm task run holds the pane, and stops refusing once the pane is gone
- a freshly installed skill reaches a reported-but-warm interactive session, and still skips a dead pane

`chain-model-test` / `warm-chat-test` stubs updated to the single predicate. Full `test:governance` green; web bundle builds. `docs/tasks-plan.md` §3.5 documents why there is exactly one predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUfffxY4hKv7M6wMCcaTz