### PR TITLE
fix(notifications): agent-edit proposal DMs link to the target agent's settings page (v0.335.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.335.2] — 2026-08-11
+### Fixed
+- **An "Edit proposed for X" DM now links to X's own settings page.** The review DM for an
+  `agent_propose_update` said "Review it in the Agentric console" and pointed at the Agents index, so a
+  reviewer landing there had to find the target agent themselves — five proposals in one batch meant five
+  identical links. `ReviewNotice` gained an optional `link` (page + detail + label) that overrides the
+  kind's default page, and the agent-edit proposal sets it to `#/agent/<target>`, where the review card
+  actually lives (parity with the inbox row, which has deep-linked by target all along). Pinned by
+  `scripts/review-notify-test.cjs`, now part of `npm run test:governance`.
+
 ## [0.335.1] — 2026-08-11
 ### Changed
 - **README rewritten, and the feature list is now complete.** The old README documented roughly a third

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.335.1",
+  "version": "0.335.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.335.1",
+      "version": "0.335.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.335.1",
+  "version": "0.335.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,7 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/version-sync-test.cjs && node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/claude-config-isolation-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-discussion-delivery-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/poke-warm-caller-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs && node scripts/outcome-derivation-test.cjs && node scripts/turn-lifecycle-test.cjs && node scripts/outcome-vocabulary-test.cjs && node scripts/skill-presets-test.cjs",
+    "test:governance": "node scripts/version-sync-test.cjs && node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/claude-config-isolation-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-discussion-delivery-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/poke-warm-caller-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs && node scripts/outcome-derivation-test.cjs && node scripts/turn-lifecycle-test.cjs && node scripts/outcome-vocabulary-test.cjs && node scripts/skill-presets-test.cjs && node scripts/review-notify-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:deps": "node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/claude-config-isolation-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",

--- a/scripts/review-notify-test.cjs
+++ b/scripts/review-notify-test.cjs
@@ -91,6 +91,35 @@ const discordStub = { dmUser: async () => ({ ok: false }) };
   assert(/console\.test\/#\/settings\/secrets/.test(sent[0].text), 'DM deep-links to Settings → Secrets', sent[0].text);
   assert(/🔑/.test(sent[0].text), 'DM carries the secret icon');
 
+  console.log('\n\x1b[1m7) an agent-edit proposal DMs the TARGET agent\'s settings page, not the Agents index\x1b[0m');
+  // The reviewer approves the card on `#/agent/<target>`; dropping them on the index made them hunt for
+  // it. The proposal carries its own deep-link, so the DM lands where the review card actually is.
+  const mk = (id, prompt) => {
+    const dir = path.join(aos.paths.userAgents, id);
+    fs.mkdirSync(dir, { recursive: true });
+    const manifest = { id, version: '1.0.0', description: `${id} agent`, principal: `svc-${id}`, policyContext: 'default@v3', runtime: 'claude-code' };
+    fs.writeFileSync(path.join(dir, 'agent.json'), JSON.stringify(manifest, null, 2) + '\n');
+    fs.writeFileSync(path.join(dir, 'CLAUDE.md'), prompt);
+    aos.registerAgent({ ...manifest, dir });
+    return id;
+  };
+  const EDITOR = mk('editor-bot', '# Editor\n\n## Method\n\nDo the work.\n');
+  const TARGET = mk('blog-optimizer', '# Blog optimizer\n\n## Method\n\nRewrite the headline.\n\n## Gotchas\n\nKeep the slug.\n');
+  aos.settings.setAgentProposalTrust({ minMaturity: 0, autoApplyAt: 1, autoApply: false }, 'test');
+  const es = tm.createSession(EDITOR, 'edit test', 'task');
+  const before7 = notices.length;
+  const prop = tm.proposeAgentUpdate(es.id, EDITOR, { id: TARGET, rationale: 'add a shipping note', claudeMdAppend: '## Shipping\n\nHand off.' });
+  assert(prop.ok && prop.outcome === 'pending_approval', 'proposal queued for review', prop);
+  const n7 = notices[before7];
+  assert(n7 && n7.kind === 'agent.update.proposed' && n7.link && n7.link.page === 'agent' && n7.link.detail === TARGET,
+    'the notice carries the target-agent deep-link', n7 && JSON.stringify(n7.link));
+  sent.length = 0;
+  await notifyReview(aos, slackStub, discordStub, 'https://console.test', n7);
+  assert(sent.length === 1 && new RegExp(`console\\.test/#/agent/${TARGET}`).test(sent[0].text),
+    "DM deep-links to the target agent's settings page", sent[0] && sent[0].text);
+  assert(!/Agentric console/.test(sent[0].text) && new RegExp(`${TARGET}'s settings`).test(sent[0].text),
+    'and names that page in the link label', sent[0] && sent[0].text);
+
   console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);
   try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
   process.exit(fail === 0 ? 0 : 1);

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -675,11 +675,15 @@ export async function notifyReview(os: AgentOS, slack: Pick<SlackSocket, 'dmUser
   const recipients = resolveRecipients(os, notice.audience ?? { kind: 'admins' });
   if (!recipients.length) return;
   const { icon, page } = REVIEW_PRESENTATION[notice.kind];
-  const url = consolePage(consoleOrigin, page);
+  // A notice about ONE named object carries its own deep-link (an `agent.update.proposed` → that agent's
+  // settings page). Otherwise fall back to the kind's page, where the reviewer finds the card in a list.
+  const url = notice.link ? consolePage(consoleOrigin, notice.link.page, notice.link.detail) : consolePage(consoleOrigin, page);
+  const label = notice.link?.label ?? 'Agentric console';
+  const lead = notice.link?.label ? 'Review it on' : 'Review it in the';
   const text = (p: ChatPlatform) =>
     `${icon} ${notice.title} (agent ${notice.agent})` +
     (notice.summary && notice.summary !== notice.title ? `\n${notice.summary}` : '') +
-    `\nReview it in the ${chatLink(p, url, 'Agentric console')}.`;
+    `\n${lead} ${chatLink(p, url, label)}.`;
   const dms = await deliverDM(slack, discord, os, recipients, text);
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'review.notified', data: { kind: notice.kind, agent: notice.agent, recipients: recipients.length, dms } });
 }

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -667,6 +667,12 @@ export interface ReviewNotice {
    *  every review card is addressed to. A PERSONAL connection request overrides it to the run's own
    *  member, since only they can complete the OAuth for their own account. */
   audience?: Audience;
+  /** Where the DM's link lands, when the card is about ONE named object and the kind's default page is a
+   *  list. Overrides {@link REVIEW_PRESENTATION}'s page for this notice: an `agent.update.proposed` points
+   *  at `#/agent/<target>` — the target agent's settings page, where the review card actually is — instead
+   *  of dropping the reviewer on the Agents index to find it themselves (parity with the inbox row, which
+   *  has deep-linked by target all along). `label` names the destination in the DM text. */
+  link?: { page: string; detail?: string; label?: string };
 }
 
 /** The spec an agent proposes for a new automation — the subset of `AddAutomationInput` an agent may
@@ -4602,7 +4608,7 @@ export class TerminalManager {
    * fires in ONE place — parity with how approvals/questions/tasks already reach a human. The notifier is
    * advisory: a failed push never wedges the request.
    */
-  private postReviewCard(input: { type: ReviewNotice['kind']; sessionId: string; agent: string; title: string; body: string; args?: Record<string, unknown>; summary?: string; audience?: Audience }): void {
+  private postReviewCard(input: { type: ReviewNotice['kind']; sessionId: string; agent: string; title: string; body: string; args?: Record<string, unknown>; summary?: string; audience?: Audience; link?: ReviewNotice['link'] }): void {
     // Providing/publishing/granting is an owner/admin act — address the review card to the admin tier by
     // default. A caller can override (e.g. a personal connection request, which only its own member can
     // complete) by passing an explicit `audience`.
@@ -4613,7 +4619,7 @@ export class TerminalManager {
       ...(input.args ? { args: input.args } : {}),
       audienceKind: audience.kind, audienceId: audienceIdOf(audience),
     });
-    try { this.reviewNotifier?.({ sessionId: input.sessionId, agent: input.agent, kind: input.type, title: input.title, summary: input.summary ?? input.body, audience }); }
+    try { this.reviewNotifier?.({ sessionId: input.sessionId, agent: input.agent, kind: input.type, title: input.title, summary: input.summary ?? input.body, audience, ...(input.link ? { link: input.link } : {}) }); }
     catch { /* out-of-band push is advisory — never let it wedge the request */ }
   }
 
@@ -5575,6 +5581,8 @@ export class TerminalManager {
       // the target moved while the card sat in the queue (a full replacement would silently undo the change).
       args: { target, fields, rationale: rationaleText, preview: previewText, maturity, demoted, baseHash: contentHash(current), ...(risk ? { bytesBefore: risk.bytesBefore, bytesAfter: risk.bytesAfter, droppedHeadings: risk.droppedHeadings } : {}) },
       summary: `${proposer} (maturity ${pct}/100) proposes editing ${target} (${previewText})`,
+      // The review card lives on the TARGET agent's settings page — link there, not the Agents index.
+      link: { page: 'agent', detail: target, label: `${target}'s settings` },
     });
     this.audit(sessionId, proposer, 'agent.update.proposed', { target, fields: Object.keys(fields), maturity, demoted, destructive: risk?.destructive ?? false, bytesBefore: risk?.bytesBefore, bytesAfter: risk?.bytesAfter });
     return {


### PR DESCRIPTION
An `agent_propose_update` DM read:

> ✏️ Edit proposed for blog-optimizer (agent agent-author)
> agent-author (maturity 71/100) proposes editing blog-optimizer (CLAUDE.md (system prompt))
> Review it in the Agentric console.

…and the link went to the Agents **index**. Five proposals in one batch = five identical links, and the reviewer hunts for the agent whose settings page holds the review card. The console inbox row has deep-linked by target all along; the DM had not.

## Change
- `ReviewNotice` gains optional `link: { page, detail?, label? }` — a per-notice override of `REVIEW_PRESENTATION`'s default page, for cards about ONE named object.
- `postReviewCard` passes it through; `proposeAgentUpdate` sets `{ page: 'agent', detail: target, label: "<target>'s settings" }`.
- `notifyReview` builds the URL from the link when present ("Review it on [blog-optimizer's settings](…/#/agent/blog-optimizer).") and falls back to the old kind page + "Agentric console" wording otherwise — every other review kind is byte-identical.

## Test
`scripts/review-notify-test.cjs` gains case 7 (real `proposeAgentUpdate` → notice carries the link → DM lands on `#/agent/<target>`), and the script is now in `npm run test:governance`. Full gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUfffxY4hKv7M6wMCcaTz