### PR TITLE
docs(claude): import the maintainer decoder ring instead of hand-reading it (v0.335.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.335.5] — 2026-08-11
+### Changed
+- **CLAUDE.md imports the maintainer's decoder ring instead of expecting it to be read by hand.** The
+  public manual documents that the real tenants/hosts/IPs live in `~/.claude/agentric-fleet.local.md`,
+  but nothing loaded that file, so a session had the placeholders and not the mapping. It's an
+  `@~/.claude/agentric-fleet.local.md` import now: resolved on a maintainer's machine, a no-op missing
+  file on anyone else's clone. The manual itself stays committed and placeholder-only — the alternative
+  (gitignoring CLAUDE.md) would strip the repo's operating manual from every fresh clone while leaving
+  it in history anyway.
+
 ## [0.335.4] — 2026-08-11
 ### Fixed
 - **The two remaining external image links are committed assets now.** `docs/ARCHITECTURE.md` embedded

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,13 @@ The real values live OUTSIDE the repo, on this machine only:
 - **`~/.claude/skills/fleet-insights/`** — the maintainer skill that reads the live tenant DBs over ssh.
   It used to ship here; it carries ssh targets, so it is personal-scope now and must not come back.
 
+The decoder ring is imported below, so on a maintainer's machine the real values are in context without
+ever entering the repo; on anyone else's clone the import is simply a missing file and this stays a
+placeholder-only public manual. **Never inline what it resolves to** — write the placeholder here and let
+the import do the decoding.
+
+@~/.claude/agentric-fleet.local.md
+
 ## Build / run / test
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.335.4",
+  "version": "0.335.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.335.4",
+      "version": "0.335.5",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.335.4",
+  "version": "0.335.5",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
## What

CLAUDE.md now ends its "This repo is PUBLIC" section with:

```
@~/.claude/agentric-fleet.local.md
```

## Why

The section already says the real tenants/hosts/IPs/App slugs live in that file — but nothing ever loaded it, so a session held the placeholders and not the mapping, and the decoder ring had to be opened by hand every time.

The import resolves on a maintainer's machine and is a no-op missing file on anyone else's clone, so the private values reach context without ever entering the repo.

## Why not just gitignore CLAUDE.md

Considered and rejected:

- It's the repo's operating manual (57KB). A public repo without it gives a fresh clone, a contributor, or an agent nothing.
- The history was already rewritten and force-pushed — `git rm --cached` removes it from HEAD only; it stays in all 1292 commits regardless.
- Untracked means one machine's copy: no backup, no review, no diff when it drifts.
- It fixes 1/N — the same private values can leak via `docs/`, `scripts/`, or a commit message. Placeholder discipline is repo-wide.

Docs + version bump only; `npm run test:governance` passes (19/19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ZUfffxY4hKv7M6wMCcaTz