### PR TITLE
feat(insights): detect runtime deaths durably + a card for them — Step 2 (v0.337.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.337.0] — 2026-08-11
+### Fixed
+- **Runtime-death remediation was firing on ~10% of the events it exists for.** `detectUsageLimit` parks
+  an exhausted runtime account and retires one with a dead token, so the pool rotates away from it — but
+  it reads the **tmux pane**, which a run killed on its first API call has usually already lost. On the
+  live corpus the derived outcome finds **31** quota/auth deaths in 30 days; the detector had fired on
+  **3**, and the pool recorded **zero** `runtime.account.limited`/`.invalid` events. The machinery was
+  right and was not being reached. It now falls back to the transcript tail — durable, unlike the pane —
+  and every detection audit carries `via: 'pane' | 'transcript'` so the coverage this claims to fix is
+  itself measurable. The `usage` vs `auth` split is preserved end to end, and **auth wins a tie**: both
+  banners often appear together, and parking a dead token is the dangerous mistake — it "self-heals" at a
+  reset that will never fix it, then rejoins the pool still broken.
+
+### Added
+- **A card for runs the runtime killed** (`docs/insights-revisit.md` Step 2 — the first end-to-end signal
+  of the rebuild). These are the fleet's most common real failure and were invisible until the derived
+  outcome existed: an agent cannot report "I hit my quota" when the agent is what stopped existing, so the
+  runs looked like silence. Grouped by **runtime account**, not by agent — that is what a human acts on,
+  and the per-agent view misleads (the top "offender" was just the automation that runs every two hours,
+  while 23 of 31 deaths traced to one shared account). Fires at ≥3 deaths in 48h with one in the last 12h,
+  and says something different when there is no pool account at all (add rotation, rather than re-link
+  this one). Present tense by construction: deaths arrive in bursts (22 of 31 inside two days), so a long
+  window would re-alert for a month about a token replaced on day three — verified against the live
+  corpus, where the card fires when evaluated during the burst and is silent when evaluated today.
+  No buttons on the card: it deep-links to Settings → Runtime where the actions already live, because
+  building a bespoke action API before knowing whether anyone clicks through is the mistake this rebuild
+  exists to stop. Pinned by `scripts/runtime-death-alert-test.cjs` (13 assertions).
+
 ## [0.336.0] — 2026-08-11
 ### Fixed
 - **An unattended run that launches background work is no longer killed while it's still working.** The

--- a/docs/insights-revisit.md
+++ b/docs/insights-revisit.md
@@ -352,7 +352,46 @@ no verdict. They are the most interesting runs in the corpus, and no observable 
 > they produced **5 of the 11 out-of-sample errors**. Measuring the residual by its *share* rather than by
 > its share *of the mistakes* is the error. The hook is back in scope.
 
-### Step 2 — one signal, one card, one action
+### Step 2 — one signal, one card, one action ✅ shipped v0.337.0 (quota/auth deaths)
+
+The signal chosen was **runs the runtime killed** rather than repeat agent crashes: it is what the new
+outcome kept surfacing, and it is costing runs now. Building it turned up a bug worth more than the card.
+
+**The OS already knew how to fix this.** `detectUsageLimit` has always run at teardown, parking an
+exhausted account (`markLimited`, self-heals at the reset) and retiring a dead token (`markInvalid`), so
+the pool rotates away from it. It reads the **tmux pane** — which a run killed on its first API call has
+usually already lost. Measured on the live corpus:
+
+| | |
+|---|---|
+| quota/auth deaths the derived outcome finds (from the transcript) | **31** |
+| of those the pane-scan detector fired on | **3** |
+| `runtime.account.limited` / `.invalid` events in 30 days | **0** |
+
+So remediation was right and simply wasn't being reached, ~90% of the time. Step 2 feeds the same
+machinery from the **durable** source: when the pane says nothing, read the transcript tail. The
+`usage` vs `auth` split is preserved end to end, and **auth wins a tie** — both banners often appear
+together, and parking a dead token is the dangerous mistake (it "self-heals" at a reset that will never
+fix it, then rejoins the pool still broken). Every detection audit now carries `via: 'pane' | 'transcript'`,
+so the coverage this claims to fix is itself measurable.
+
+**The card.** Grouped by **runtime account**, not by agent — that is what a human acts on, and the
+per-agent view misleads: the top "offender" was simply the automation that runs every two hours, while
+23 of 31 deaths traced to one shared account. Fires at ≥3 deaths in 48h with one in the last 12h;
+different body when there is no pool account at all (add rotation, rather than re-link this one).
+
+Present tense by construction — deaths arrive in **bursts** (22 of 31 inside two days), so a long window
+would re-alert for a month about a token replaced on day three. Verified against the live corpus: the
+card fires when evaluated during the burst (`19 runs killed by the "…" account in 48h`) and is silent
+when evaluated today.
+
+- **Pinned:** `scripts/runtime-death-alert-test.cjs` (13 assertions, in `test:governance`).
+- **Not built:** buttons on the card. It deep-links to Settings → Runtime, where the actions already
+  live; adding a bespoke action API before knowing whether anyone clicks through is the mistake this
+  rebuild exists to stop. Whether the click-through happens is Step 4's measurement, and the
+  `via` stamp plus `runtime.account.*` audits are enough to answer it without new plumbing.
+
+### Step 2 (original plan)
 
 Pick the single highest-evidence problem in the live data — **repeat agent crashes** (§2b) — and
 build the whole vertical for it only:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.336.0",
+  "version": "0.337.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.336.0",
+      "version": "0.337.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.336.0",
+  "version": "0.337.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -27,7 +27,7 @@
     "check-deps": "bash scripts/install-deps.sh --check",
     "dev": "ts-node src/cli.ts serve",
     "demo:dev": "ts-node src/demo.ts",
-    "test:governance": "node scripts/version-sync-test.cjs && node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/claude-config-isolation-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-discussion-delivery-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/poke-warm-caller-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs && node scripts/outcome-derivation-test.cjs && node scripts/turn-lifecycle-test.cjs && node scripts/outcome-vocabulary-test.cjs && node scripts/skill-presets-test.cjs && node scripts/review-notify-test.cjs && node scripts/turn-idle-background-guard-test.cjs",
+    "test:governance": "node scripts/version-sync-test.cjs && node scripts/governance-conformance.cjs && node scripts/tier-a-policy-test.cjs && node scripts/capability-registry-test.cjs && node scripts/idle-reaper-test.cjs && node scripts/dm-continuity-test.cjs && node scripts/alert-staleness-test.cjs && node scripts/run-as-identity-test.cjs && node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/claude-config-isolation-test.cjs && node scripts/verbosity-test.cjs && node scripts/chain-model-test.cjs && node scripts/tuning-patch-test.cjs && node scripts/task-runs-test.cjs && node scripts/task-discussion-delivery-test.cjs && node scripts/task-resume-test.cjs && node scripts/warm-chat-test.cjs && node scripts/poke-warm-caller-test.cjs && node scripts/agent-edit-guard-test.cjs && node scripts/goal-update-guard-test.cjs && node scripts/insights-signal-test.cjs && node scripts/outcome-derivation-test.cjs && node scripts/turn-lifecycle-test.cjs && node scripts/outcome-vocabulary-test.cjs && node scripts/skill-presets-test.cjs && node scripts/review-notify-test.cjs && node scripts/turn-idle-background-guard-test.cjs && node scripts/runtime-death-alert-test.cjs",
     "test:alert-staleness": "node scripts/alert-staleness-test.cjs",
     "test:deps": "node scripts/deps-freshness-test.cjs && node scripts/runtime-account-test.cjs && node scripts/runtime-login-test.cjs && node scripts/claude-config-seed-test.cjs && node scripts/claude-config-isolation-test.cjs",
     "test:dm-continuity": "node scripts/dm-continuity-test.cjs",

--- a/scripts/runtime-death-alert-test.cjs
+++ b/scripts/runtime-death-alert-test.cjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/* Runtime-death detection + card (docs/insights-revisit.md, Step 2).
+ *
+ * The signal: runs the RUNTIME killed — a usage limit or a dead token — as opposed to work that failed.
+ * It is the fleet's most common real failure and was invisible until the derived outcome existed, because
+ * the agent cannot report "I hit my quota" when the agent is what stopped existing.
+ *
+ * Two things are pinned here:
+ *  1. the `usage` vs `auth` split, which decides whether the pool PARKS an account (self-heals at the
+ *     reset) or RETIRES it (a bad token never recovers), and
+ *  2. the card's present tense — deaths arrive in bursts, so a window that keeps counting a burst from two
+ *     weeks ago re-alerts for a month about a token someone already replaced. */
+const fs = require('fs');
+const os_ = require('os');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os_.tmpdir(), 'aos-death-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
+
+let pass = 0, fail = 0;
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
+
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { detectAlerts } = require(path.join(ROOT, 'dist/edge/alerts.js'));
+const { readTranscriptEnd } = require(path.join(ROOT, 'dist/edge/outcome.js'));
+
+const aos = loadAgentOS();
+const NOW = Date.now();
+const HOUR = 3600_000;
+
+const tdir = fs.mkdtempSync(path.join(os_.tmpdir(), 'aos-death-transcripts-'));
+const asst = (text) => JSON.stringify({ message: { role: 'assistant', content: [{ type: 'text', text }] } });
+const writeTranscript = (id, lines) => fs.writeFileSync(path.join(tdir, `${id}.jsonl`), lines.map(asst).join('\n'));
+const find = (id) => { const p = path.join(tdir, `${id}.jsonl`); return fs.existsSync(p) ? p : undefined; };
+
+let n = 0;
+/** An unattended run that died `hoursAgo`, on `account`, with `banner` as its last words. */
+function mkDeath({ agent = 'worker', account = 'acct-a', hoursAgo = 1, banner = "You've hit your weekly limit · resets Aug 1" }) {
+  const id = 'ts_' + (++n), at = NOW - hoursAgo * HOUR, convo = 'convo_' + n;
+  aos.db.prepare(
+    'INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,spawned_by,created_at,updated_at,' +
+      'claude_session_id,tool_calls,active_ms,runtime_account) VALUES (?,?,?,?,?,?,1,?,?,?,?,?,?,?)',
+  ).run(id, agent, 't', 'x', 'aos-' + id, 'done', 'automation:au_1', at, at + 5_000, convo, 1, 5_000, account);
+  writeTranscript(convo, ['starting the sweep', banner]);
+  return id;
+}
+
+console.log('\n\x1b[1mRuntime deaths — the runtime killed the run, not the work\x1b[0m');
+
+// ── the usage / auth split ─────────────────────────────────────────────────────────────────────────
+{
+  writeTranscript('t-usage', ['working', "You've hit your weekly limit · resets Aug 1 at 8:30pm"]);
+  writeTranscript('t-session', ['working', "You've hit your session limit · resets 12:40pm"]);
+  writeTranscript('t-auth', ['working', 'Please run /login · API Error: 401 OAuth access token has expired.']);
+  writeTranscript('t-both', ['working', "You've hit your weekly limit", 'Please run /login · API Error: 401 OAuth access token has expired.']);
+  writeTranscript('t-clean', ['working', 'x'.repeat(400) + ' Watermark updated, Discord summary sent.']);
+
+  assert(readTranscriptEnd('t-usage', find).deathKind === 'usage', 'a weekly limit is a usage death (park the account)');
+  assert(readTranscriptEnd('t-session', find).deathKind === 'usage', 'a session limit is a usage death');
+  assert(readTranscriptEnd('t-auth', find).deathKind === 'auth', 'an expired token is an auth death (retire the account)');
+  // Both banners appear together in real output. Parking a DEAD token is the dangerous mistake: it
+  // self-heals at a reset that will never fix it, and the account rejoins the pool still broken.
+  assert(readTranscriptEnd('t-both', find).deathKind === 'auth', 'when both banners appear, auth wins — never park a dead token');
+  assert(readTranscriptEnd('t-clean', find).died === false, 'a clean finish is not a death');
+}
+
+// ── the card ───────────────────────────────────────────────────────────────────────────────────────
+const deathCards = (at) => detectAlerts(aos, at).filter((a) => a.key.startsWith('runtime-deaths:'));
+{
+  mkDeath({ hoursAgo: 2 });
+  mkDeath({ hoursAgo: 3 });
+  assert(deathCards(NOW).length === 0, 'two deaths is not a card — one expired token mid-run is normal');
+
+  mkDeath({ hoursAgo: 4 });
+  const cards = deathCards(NOW);
+  assert(cards.length === 1, 'three deaths in the window raises one card', JSON.stringify(cards.map((c) => c.key)));
+  assert(cards[0].key === 'runtime-deaths:acct-a', 'the card is keyed by the ACCOUNT — that is what a human acts on');
+  assert(/3 runs killed/.test(cards[0].title), 'the title counts the runs', cards[0].title);
+  assert(cards[0].route === 'settings' && cards[0].detail === 'runtime', 'the card deep-links to where the fix is');
+}
+
+// ── present tense ──────────────────────────────────────────────────────────────────────────────────
+{
+  // The same three deaths, read three days later: the burst is over and the card must be gone. A count
+  // over a long window only ever grows, which is how the old crash alert nagged for weeks about a fixed
+  // problem (see alert-staleness-test.cjs).
+  assert(deathCards(NOW + 72 * HOUR).length === 0, 'the card stands down once the burst stops — it describes now, not history');
+
+  // A fresh death on a DIFFERENT account is its own card, not a merged one.
+  for (let i = 0; i < 3; i++) mkDeath({ account: 'acct-b', hoursAgo: 1, agent: 'other' });
+  const cards = deathCards(NOW);
+  assert(cards.length === 2, 'two failing accounts raise two cards', JSON.stringify(cards.map((c) => c.key)));
+
+  // The box default (no pool account) gets a DIFFERENT remedy — add rotation, not replace a token.
+  for (let i = 0; i < 3; i++) mkDeath({ account: null, hoursAgo: 1, agent: 'solo' });
+  const box = deathCards(NOW).find((c) => c.key.includes('box default'));
+  assert(!!box && /no rotation pool/.test(box.body), 'with no pool account the card says to ADD one, not to re-link', box && box.body.slice(-90));
+}
+
+fs.rmSync(tdir, { recursive: true, force: true });
+fs.rmSync(HOME, { recursive: true, force: true });
+console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m\n`);
+process.exit(fail ? 1 : 0);

--- a/src/edge/alerts.ts
+++ b/src/edge/alerts.ts
@@ -10,6 +10,7 @@
  */
 import type { AgentOS } from '../kernel';
 import { buildInsights, RECENT_DAYS } from './insights';
+import { deriveRunOutcomes } from './outcome';
 
 const COOLDOWN_MS = 3 * 24 * 3_600_000; // don't re-alert the same key within 3 days
 /** Clean work runs since the last crash that count as "recovered" — enough to not be a lucky single pass,
@@ -90,6 +91,9 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
     }
   }
 
+  // Runs the RUNTIME killed — quota exhausted or a dead token — rather than work that failed.
+  for (const d of runtimeDeaths(os, now)) out.push(d);
+
   // Approvals piling up on a human.
   const oldestH = ins.friction.oldestPendingAgeMs ? Math.round(ins.friction.oldestPendingAgeMs / 3_600_000) : 0;
   if (ins.friction.pendingApprovals >= 3 && oldestH >= 4) {
@@ -102,6 +106,69 @@ export function detectAlerts(os: AgentOS, now = Date.now()): InsightAlert[] {
     });
   }
 
+  return out;
+}
+
+/** How far back a death still counts as "happening". Deaths arrive in BURSTS — on the live corpus 22 of
+ *  31 landed inside two days — so a 30-day window would keep shouting for a month about a token someone
+ *  replaced on day three. */
+const DEATH_WINDOW_MS = 48 * 3_600_000;
+/** …and at least one must be this recent, or the condition is over. */
+const DEATH_FRESH_MS = 12 * 3_600_000;
+/** Below this it's noise: one expired token mid-run is normal and the pool already rotates around it. */
+const DEATH_MIN = 3;
+
+/**
+ * **Runs the runtime killed** — the fleet's most common real failure and, until the derived outcome
+ * existed, an invisible one: the agent cannot report "I hit my quota" because the agent is what stopped
+ * existing, so these runs looked like silent successes.
+ *
+ * Grouped by the **runtime account** rather than by agent, because that is what a human acts on. The
+ * per-agent view is misleading here: on the live corpus the top "offender" was simply the automation that
+ * runs every two hours, while 23 of 31 deaths traced to one shared account.
+ *
+ * Present-tense by construction (the standing lesson from `alert-staleness-test.cjs`): a burst two weeks
+ * ago is over, and a `died-early`/`runtime-death` count over a long window would keep re-firing about it.
+ */
+function runtimeDeaths(os: AgentOS, now: number): InsightAlert[] {
+  const runs = deriveRunOutcomes(os, { since: now - DEATH_WINDOW_MS, until: now })
+    .filter((r) => r.basis === 'runtime-death' || r.basis === 'died-early');
+  if (!runs.length) return [];
+
+  const rows = os.db
+    .prepare(`SELECT id, runtime_account FROM term_sessions WHERE id IN (${runs.map(() => '?').join(',')})`)
+    .all<{ id: string; runtime_account: string | null }>(...runs.map((r) => r.runId));
+  const acctOf = new Map(rows.map((r) => [r.id, r.runtime_account]));
+
+  const groups = new Map<string, { n: number; last: number; agents: Set<string> }>();
+  for (const r of runs) {
+    // No pool account → the box's own credentials. Still worth saying: it is the same outage, and the
+    // fix ("add accounts so the fleet can rotate") is different from "replace this one".
+    const key = acctOf.get(r.runId) ?? '(box default)';
+    const g = groups.get(key) ?? { n: 0, last: 0, agents: new Set<string>() };
+    g.n++; g.last = Math.max(g.last, r.at); g.agents.add(r.agent);
+    groups.set(key, g);
+  }
+
+  const out: InsightAlert[] = [];
+  for (const [account, g] of groups) {
+    if (g.n < DEATH_MIN || now - g.last > DEATH_FRESH_MS) continue;
+    const pool = account !== '(box default)';
+    const who = [...g.agents].slice(0, 4).join(', ') + (g.agents.size > 4 ? `, +${g.agents.size - 4} more` : '');
+    out.push({
+      key: `runtime-deaths:${account}`,
+      severity: 'high',
+      title: `${g.n} runs killed by ${pool ? `the “${account}” account` : 'the box credentials'} in 48h`,
+      body:
+        `${g.n} unattended runs were killed by the runtime — a usage limit or an expired token — not by the work failing. ` +
+        `Affected: ${who}. These runs did nothing and reported nothing, so they look like silence rather than failure.\n\n` +
+        (pool
+          ? `The pool parks a limited account automatically and drops one whose token is dead, so this clears itself IF another account can take the load. ${g.n} deaths in 48h means it could not — re-link “${account}” or add another account so the fleet can rotate.`
+          : `There is no rotation pool on this box, so every agent shares one set of credentials and they all stop together. Adding a second runtime account is the fix.`),
+      route: 'settings',
+      detail: 'runtime',
+    });
+  }
   return out;
 }
 

--- a/src/edge/outcome.ts
+++ b/src/edge/outcome.ts
@@ -153,12 +153,20 @@ const DIED_EARLY_MS = 30_000;
  * Signatures are matched against the transcript TAIL only — a run that recovered from a rate limit
  * mid-way and carried on must not be called dead because the phrase appears somewhere in its history.
  */
-const RUNTIME_DEATH = [
-  /hit your weekly limit/i,
-  /hit your session limit/i,
-  /OAuth access token has expired/i,
-  /Please run \/login/i,
-  /Credit balance is too low/i,
+/** The two death classes behave differently downstream and must not be merged: a usage limit means the
+ *  credentials are FINE and exhausted (park the account, it self-heals at the reset), while an auth
+ *  failure means the token is bad and will never recover on its own (drop the account until a human
+ *  replaces it). `src/terminal.ts` already encodes exactly this split — this is the same judgement made
+ *  from the durable source. */
+export type DeathKind = 'usage' | 'auth';
+const RUNTIME_DEATH: [RegExp, DeathKind][] = [
+  [/hit your weekly limit/i, 'usage'],
+  [/hit your session limit/i, 'usage'],
+  [/Credit balance is too low/i, 'usage'],
+  [/usage limit reached/i, 'usage'],
+  [/OAuth access token has expired/i, 'auth'],
+  [/Please run \/login/i, 'auth'],
+  [/invalid bearer token/i, 'auth'],
 ];
 const INTERRUPTED = /Request interrupted by user/i;
 /** Tail window. Big enough to hold a closing summary (the longest seen is ~3.3KB), small enough that an
@@ -168,7 +176,13 @@ const TAIL_BYTES = 8_000;
 const SUBSTANTIVE_CHARS = 200;
 
 /** What the transcript says about how a run ended. `undefined` when there is no transcript to read. */
-export interface TranscriptEnd { died: boolean; interrupted: boolean; closingChars: number }
+export interface TranscriptEnd {
+  died: boolean;
+  /** Which kind of death, when one was found — `usage` parks the account, `auth` retires it. */
+  deathKind?: DeathKind;
+  interrupted: boolean;
+  closingChars: number;
+}
 
 /** Read the tail of a conversation's transcript. Never throws: a missing or unreadable transcript is a
  *  normal case (95% coverage on the live box, and none on a machine that didn't run the agent). */
@@ -201,8 +215,14 @@ export function readTranscriptEnd(convoId: string, find = findTranscript): Trans
       if (text.trim()) closing = text.trim();
     } catch { /* partial or non-message line */ }
   }
+  // Auth wins a tie: the two banners can appear together ("Please run /login · API Error: 401 …"), and a
+  // bad token must not be parked as if it were merely exhausted — parking self-heals at a reset that will
+  // never fix it, and the account silently returns to the pool still broken.
+  const hits = RUNTIME_DEATH.filter(([re]) => re.test(tail)).map(([, k]) => k);
+  const deathKind = hits.includes('auth') ? 'auth' : hits[0];
   return {
-    died: RUNTIME_DEATH.some((re) => re.test(tail)),
+    died: hits.length > 0,
+    ...(deathKind ? { deathKind } : {}),
     interrupted: INTERRUPTED.test(tail),
     closingChars: closing.length,
   };

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -37,6 +37,7 @@ import { VendorError, retryableStatus, timedFetch, withRetry, vendorErrorInfo } 
 import { DEFAULT_VIDEO_COST_PER_SEC_USD, DEFAULT_VIDEO_DURATION_SEC, resolveVideoBackend, videoBackend, VideoBackend } from './edge/video-gen';
 import { understandMedia } from './edge/media-understand';
 import { readSessionCost } from './edge/session-cost';
+import { readTranscriptEnd } from './edge/outcome';
 import { TERSE_OUTPUT_BRIEF } from './edge/verbosity';
 import { pendingBackgroundWork, BACKGROUND_GRACE_MS, UNATTENDED_TURN_BRIEF } from './edge/background-work';
 import { findCodexRollout, readCodexCost, readCodexConversation } from './edge/codex-transcript';
@@ -3353,7 +3354,26 @@ export class TerminalManager {
       const row = this.db.prepare('SELECT agent, runtime_account FROM term_sessions WHERE id = ?')
         .get<{ agent: string; runtime_account: string | null }>(sessionId);
       if (!row) return;
-      const text = this.backend.capturePane(space, tmux);
+      // The pane is the fast path, but it is VOLATILE — a run killed on its first API call has usually
+      // already lost its pane by teardown, and `capturePane` then returns nothing. Measured on the live
+      // corpus: of 31 runs the derived outcome identifies as quota/auth deaths (from the
+      // transcript, which is durable), this detector had fired on **3**, and the pool recorded ZERO
+      // `runtime.account.limited` / `.invalid` events in 30 days. So the remediation machinery below was
+      // right and simply wasn't being reached. Fall back to the transcript tail, which says the same thing
+      // and outlives the pane. See docs/insights-revisit.md Step 2.
+      let text = this.backend.capturePane(space, tmux);
+      let via = 'pane';
+      if (!text || !(TerminalManager.USAGE_LIMIT_RE.test(text) || TerminalManager.AUTH_FAIL_RE.test(text))) {
+        const claudeId = this.db.prepare('SELECT claude_session_id FROM term_sessions WHERE id = ?')
+          .get<{ claude_session_id: string | null }>(sessionId)?.claude_session_id;
+        const end = claudeId ? readTranscriptEnd(claudeId) : undefined;
+        if (end?.died) {
+          // Hand the classifier the phrase it expects rather than re-deriving here, so the two sources
+          // can never disagree about what counts as a limit vs a bad token.
+          text = end.deathKind === 'auth' ? 'oauth token expired' : 'hit your weekly limit';
+          via = 'transcript';
+        }
+      }
       if (!text) return;
       const usageLimited = TerminalManager.USAGE_LIMIT_RE.test(text);
       // A usage-limit banner is checked first — it's the benign, self-healing case; an auth failure is only
@@ -3365,19 +3385,19 @@ export class TerminalManager {
       if (authFailed) {
         if (row.runtime_account) {
           this.os.runtimeAccounts.markInvalid(runtime, row.runtime_account, 'auto-disabled: a run authenticated with this token and was rejected (401)');
-          this.audit(sessionId, 'system', 'runtime.account.invalid', { runtime, account: row.runtime_account });
+          this.audit(sessionId, 'system', 'runtime.account.invalid', { runtime, account: row.runtime_account, via });
         } else {
-          this.audit(sessionId, 'system', 'runtime.auth_failed', { runtime });
+          this.audit(sessionId, 'system', 'runtime.auth_failed', { runtime, via });
         }
         return;
       }
       const until = this.parseLimitReset(text) ?? Date.now() + 60 * 60_000; // 1h fallback keeps it parked but self-heals
       if (row.runtime_account) {
         this.os.runtimeAccounts.markLimited(runtime, row.runtime_account, until);
-        this.audit(sessionId, 'system', 'runtime.account.limited', { runtime, account: row.runtime_account, until });
+        this.audit(sessionId, 'system', 'runtime.account.limited', { runtime, account: row.runtime_account, until, via });
       } else {
         // No pool account → the box's single default hit its limit; surface it (an operator adds accounts to rotate).
-        this.audit(sessionId, 'system', 'runtime.usage_limited', { runtime, until });
+        this.audit(sessionId, 'system', 'runtime.usage_limited', { runtime, until, via });
       }
     } catch { /* detection is best-effort — never block teardown */ }
   }


### PR DESCRIPTION
The first end-to-end signal of the Insights rebuild: **runs the runtime killed** — a usage limit or a dead token — as opposed to work that failed. These were invisible until Step 1's derived outcome existed, because an agent cannot report "I hit my quota" when the agent is what stopped existing. The runs looked like silence.

Building it turned up a bug worth more than the card.

## The OS already knew how to fix this

`detectUsageLimit` has always run at teardown, parking an exhausted account (self-heals at the reset) or retiring one whose token is dead, so the pool rotates away from it. It reads the **tmux pane** — which a run killed on its first API call has usually already lost. On the live corpus:

| | |
|---|---|
| quota/auth deaths the derived outcome finds (from the transcript) | **31** |
| of those the pane-scan detector fired on | **3** |
| `runtime.account.limited` / `.invalid` events in 30 days | **0** |

Remediation was right and simply wasn't being reached, ~90% of the time. It now falls back to the **transcript tail** — durable, unlike the pane — and every detection audit carries `via: 'pane' | 'transcript'`, so the coverage this claims to fix is itself measurable.

The `usage` vs `auth` split is preserved end to end and **auth wins a tie**: both banners often appear together, and parking a dead token is the dangerous mistake — it "self-heals" at a reset that will never fix it, then rejoins the pool still broken.

## The card

Grouped by **runtime account**, not by agent. The per-agent view misleads — the top "offender" was just the automation that runs every two hours, while **23 of 31** deaths traced to one shared account, and the account is what a human acts on. Fires at ≥3 deaths in 48h with one in the last 12h; different body when there's no pool account at all (add rotation, rather than re-link this one).

**Present tense by construction.** Deaths arrive in bursts — 22 of 31 inside two days — so a long window would re-alert for a month about a token replaced on day three. Verified against the live corpus: evaluated *during* the burst it fires (`19 runs killed by the "…" account in 48h`); evaluated *today* it is silent.

## No buttons on the card

It deep-links to Settings → Runtime, where the actions already live. Building a bespoke action API before knowing whether anyone clicks through is the mistake this rebuild exists to stop. Whether the click-through happens is Step 4's measurement, and the `via` stamp plus existing `runtime.account.*` audits answer it without new plumbing.

## Verification

`scripts/runtime-death-alert-test.cjs` — 13 assertions, added to `test:governance`: the usage/auth split, auth-wins-a-tie, the ≥3 threshold, per-account grouping, the box-default variant, and the stand-down once the burst ends. Full suite green; typecheck and web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AiTKjtdcF4ESbuYVWj2CfU