### PR TITLE
fix(runtime): terse's carve-out is not a licence to be long (v0.337.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.337.2] — 2026-08-12
+### Fixed
+- **The terse brief's carve-out no longer reads as a licence to be long.** A terse `engineer` run
+  answered a console question at essay length and the owner had to reply "explain to me in 1 liner" —
+  which looked like the verbosity flag failing, and wasn't: the session was stamped `verbosity=terse`
+  and the workspace default is terse, but human-facing prose (`report`, `ask`, the chat replies) is
+  deliberately EXEMPT from compression so terse phrasing can't degrade memory, consolidation and the
+  surfaces teammates read. The exemption ended on "write them in full, ordinary prose", and that is the
+  half the model acted on. `TERSE_OUTPUT_BRIEF` now separates the two axes: those surfaces stay
+  uncompressed, keep their caveats and stay ordinary prose, but they must lead with the answer, must not
+  summarise and then restate the same content as detail, must not recount the steps to a finding the
+  finding implies, and must answer a narrow question narrowly before widening. Compression is still off
+  there; shape is not. Pinned by new assertions in `scripts/verbosity-test.cjs` that hold BOTH halves —
+  the brevity clauses and the "completeness wins over length" guarantee they must not eat.
+
 ## [0.337.1] — 2026-08-11
 ### Docs
 - **`docs/journal-plan.md`** — Step 3 of the Insights rebuild, planned concretely. The day-by-day

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.337.1",
+  "version": "0.337.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.337.1",
+      "version": "0.337.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.337.1",
+  "version": "0.337.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/verbosity-test.cjs
+++ b/scripts/verbosity-test.cjs
@@ -58,6 +58,15 @@ console.log('\n\x1b[1m3) the brief names its carve-outs\x1b[0m');
 for (const tool of ['report', 'remember', 'kb_write', 'task_update', 'ask', 'slack_reply', 'discord_reply'])
   assert(TERSE_OUTPUT_BRIEF.includes(tool), `exempts ${tool}`);
 assert(/[Ee]rror messages/.test(TERSE_OUTPUT_BRIEF) && /byte-for-byte/i.test(TERSE_OUTPUT_BRIEF), 'exempts error text verbatim');
+// …and the carve-out must not read as a licence to be long. A terse engineer run answered a console
+// question at essay length because "write them in full, ordinary prose" was the last word on the exempt
+// lane. Compression stays off there; shape does not.
+assert(/not a licence to be long/i.test(TERSE_OUTPUT_BRIEF), 'the exempt lane is still bound on SHAPE');
+assert(/[Ll]ead with the answer/.test(TERSE_OUTPUT_BRIEF), 'tells the exempt lane to lead with the answer');
+assert(/summary and then restate/i.test(TERSE_OUTPUT_BRIEF), 'bans the summary-then-restatement duplication');
+// The whole point of the carve-out survives it: prose and caveats stay.
+assert(/completeness wins over length/i.test(TERSE_OUTPUT_BRIEF), 'completeness still beats brevity');
+assert(/ordinary prose/.test(TERSE_OUTPUT_BRIEF), 'the exempt surfaces still keep ordinary prose');
 
 const aos = loadAgentOS();
 const db = aos.db;

--- a/src/edge/verbosity.ts
+++ b/src/edge/verbosity.ts
@@ -14,6 +14,15 @@
 // It is a prompt instruction, not an enforced transform: the model can ignore it, and compliance drifts
 // by model and by task. That is exactly why `verbositySavings` exists — the flag ships with the query
 // that can falsify it.
+//
+// The carve-out has a failure mode of its own, and it showed up live: a terse `engineer` run answered a
+// console question at essay length, and the owner had to reply "explain to me in 1 liner". Nothing was
+// broken — the answer landed in the exempt lane, and "write them in full, ordinary prose" reads as a
+// LICENCE to be long. So the exemption now says what it always meant: exempt from compression is not
+// exempt from shape. Those surfaces keep their prose and every caveat; they still lead with the answer
+// and still don't say a thing twice. That is a discipline the artifacts want anyway — a `report` whose
+// first line is the outcome is a better input to consolidation than one that arrives at it in paragraph
+// four.
 
 import type { DatabaseSync } from 'node:sqlite';
 
@@ -38,6 +47,14 @@ export const TERSE_OUTPUT_BRIEF =
   '`discord_reply`/`discord_send`/`discord_dm`, `clickup_reply`, `telegram_reply`). Those are read by ' +
   'teammates, or feed memory and consolidation, and terse phrasing there costs far more than it saves. ' +
   'Write them in full, ordinary prose.\n\n' +
+  '**Exempt from compression is not a licence to be long.** Those surfaces keep ordinary prose and every ' +
+  'caveat, but the same discipline applies to their SHAPE. Lead with the answer, the finding or the ' +
+  'outcome in the first sentence, then give only what a reader needs in order to act on it or trust it. ' +
+  'Do not write a summary and then restate the same content as detail. Do not recount the steps you took ' +
+  'to reach a finding the finding already implies. Do not pad a section so it looks complete, and do not ' +
+  'add a closing paragraph that repeats the opening one. Every extra sentence has to earn its place with ' +
+  'content a reader would miss if it were cut. When someone asks a narrow question, answer THAT question ' +
+  'first — offer the wider context after it, or not at all.\n\n' +
   '**Terse is not vague, and not curt.** If brevity would drop a caveat, a risk, or a reason a person ' +
   'needs, keep it — completeness wins over length every time. A human who asks you to explain something ' +
   'is asking for the explanation; give it to them properly. This is about cutting words that carry ' +


### PR DESCRIPTION
## What broke

A live `engineer` run answered a console question at essay length. The owner had to reply *"explain to me in 1 liner"* — and reasonably asked whether the terse verbosity knob was working at all.

It was. The session is stamped `verbosity=terse`, and the workspace default is `terse` (168 of the last 200 instapods sessions). Nothing in the plumbing failed.

## Why it still read as a wall of text

`TERSE_OUTPUT_BRIEF` deliberately **exempts** everything a human reads or that feeds the learning loop — `report`, `remember`, `kb_write`, `ask`, `notify`, the chat replies. That carve-out is correct and stays: compressed prose in a `report` degrades consolidation, and in a `slack_reply` it degrades a conversation, both far from the flag that caused it.

But the exemption's last word was *"Write them in full, ordinary prose"*, and that is the half the model acted on. **Compression and shape are two different axes**, and only one of them should have been switched off there.

## The change

The exempt lane keeps its prose and every caveat, and gains a shape rule:

- lead with the answer, the finding, or the outcome in the first sentence
- don't write a summary and then restate the same content as detail
- don't recount the steps taken to reach a finding the finding already implies
- don't pad a section to look complete, or close by repeating the opening
- answer a narrow question narrowly first; widen after, or not at all

Discipline the artifacts want anyway — a `report` whose first line is the outcome is a better input to consolidation than one that arrives at it in paragraph four.

## Falsifier

`scripts/verbosity-test.cjs` now pins **both halves**, so a future edit can't win brevity by eating the guarantee that protects it:

- the brevity clauses are present (`not a licence to be long`, `lead with the answer`, the summary-then-restatement ban)
- **and** `completeness wins over length` and `ordinary prose` survive

## What this does NOT claim

Terse's effect on cost is still unproven. The per-agent both-arm comparison on live instapods data (60d, output tokens/turn, normal → terse) went the wrong way for 4 of 6 agents:

| agent | normal | terse |
|---|---:|---:|
| marketing-manager | 22,840 | 47,412 |
| churn-analyzer | 23,423 | 38,638 |
| check-resolve-tickets | 10,641 | 14,538 |
| app-packager | 25,875 | 23,593 |
| marketing-site | 91,188 | 38,962 |
| pod-migrator | 71,118 | 40,239 |

Observational and confounded (model and effort moved too, and a flip isn't randomised) — but `output_tokens` is dominated by tool-call arguments and thinking, not narration, so a prompt aimed at prose was always aiming at a small slice. This PR fixes the surface the human actually complained about; it does not claim a saving. `verbositySavings()` remains the query that can contradict either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)