### PR TITLE
fix(runtime-login): a mid-render or wrapped authorize URL no longer kills the guided login (v0.341.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.341.1] — 2026-08-13
+### Fixed
+- **Guided runtime-account login failed hard on the first partial capture of the authorize URL.** The
+  poll scraped the CLI's `oauth/authorize?…` line and, the instant it saw a URL without a `state=` tail,
+  permanently failed the login with "the sign-in link came back incomplete from the runtime" — so a poll
+  that merely caught the line *mid-render*, or a URL the CLI wrapped across rows inside a fixed-width box
+  (real newlines `capture-pane -J` won't rejoin), killed the whole flow with no retry. Now an incomplete
+  URL is treated as transient: the poll keeps waiting for a whole one and only gives up after an 8s settle
+  window, and `extractAuthorizeUrl` reassembles a URL split across rows (conservatively — a row with a
+  space or prose, like the "Paste code" prompt, ends the URL and can never be fused into the query string).
+
 ## [0.341.0] — 2026-08-13
 ### Added
 - **The task hand-off chain is visible.** `parentId` — set whenever an agent spawns work out of work it

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.341.0",
+  "version": "0.341.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.341.0",
+      "version": "0.341.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.341.0",
+  "version": "0.341.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/runtime-login-test.cjs
+++ b/scripts/runtime-login-test.cjs
@@ -108,12 +108,30 @@ s = m.poll(s.id);
 assert(s.phase !== 'failed', 'a fresh login is not timed out');
 
 // A URL clipped at the pane's wrap point is what a too-narrow pane produced against the real CLI. Sending
-// the human to a truncated authorize request would fail in the browser and read as a product bug.
+// the human to a truncated authorize request would fail in the browser and read as a product bug — so a
+// clipped URL is NEVER shown. But a first capture can simply be mid-render, so an incomplete URL waits for
+// a whole one rather than failing on sight, and only fails if it stays clipped past the settle window.
 m = mk();
 pane = URL_SCREEN.replace(URL, URL.slice(0, 90));
 s = m.start('claude-code', 'clipped');
 s = m.poll(s.id);
-assert(s.phase === 'failed' && /incomplete/.test(s.error), 'a truncated sign-in link is refused, not shown', JSON.stringify(s));
+assert(s.phase === 'starting' && !s.url, 'a clipped sign-in link is not shown — the poll waits for a whole one', JSON.stringify(s));
+m.logins.get(s.id).urlSeenAt -= 9000;   // pretend the settle window elapsed with the URL still clipped
+s = m.poll(s.id);
+assert(s.phase === 'failed' && /incomplete/.test(s.error), 'a URL that stays clipped past the settle window fails closed', JSON.stringify(s));
+
+// The CLI can print the authorize URL wrapped across rows (e.g. a bordered box whose borders capture-pane
+// -J won't rejoin). It must be reassembled to the WHOLE URL, not clipped at the first row's fragment.
+m = mk();
+pane = [
+  "Browser didn't open? Use the url below to sign in (c to copy)",
+  '│ ' + URL.slice(0, 70) + '  │',
+  '│ ' + URL.slice(70) + '  │',
+  ' Paste code here if prompted >',
+].join('\n');
+s = m.start('claude-code', 'wrapped');
+s = m.poll(s.id);
+assert(s.phase === 'awaiting-code' && s.url === URL, 'a URL wrapped across rows is reassembled and surfaced whole', JSON.stringify(s));
 
 console.log('\n\x1b[1m3) Guards on what may be started at all\x1b[0m');
 m = mk();

--- a/src/edge/runtime-login.ts
+++ b/src/edge/runtime-login.ts
@@ -34,6 +34,9 @@ const TTL_MS = 15 * 60_000;
 /** The runtime's own login is the only thing that writes the credential file, so polling for it IS the
  *  completion check. Between the code being typed and the file appearing there's a token exchange. */
 const EXCHANGE_GRACE_MS = 60_000;
+/** A freshly-printed authorize URL can be caught mid-render, its `state=` tail not yet on screen. That's
+ *  transient — keep polling for a whole URL and only give up if it stays incomplete past this window. */
+const URL_SETTLE_MS = 8_000;
 
 export type LoginPhase = 'starting' | 'awaiting-code' | 'exchanging' | 'done' | 'failed';
 
@@ -56,15 +59,47 @@ interface Login extends LoginState {
   /** Prompts already answered, so a poll can't press Enter twice on the same screen. */
   answered: Set<string>;
   codeAt?: number;
+  /** When we first saw an authorize URL that wasn't yet whole — lets us wait out a mid-render capture
+   *  before deciding the link is genuinely clipped. */
+  urlSeenAt?: number;
 }
 
-/** The authorize URL, as printed in the pane. The pane is spawned wide enough that the CLI prints it on
- *  ONE line (see `cols` at spawn) — a hard-wrapped URL cannot be reassembled reliably, so the width is
- *  the guarantee here, and `looksWhole` below refuses to show a URL that arrived clipped anyway. */
+/** The authorize URL, as printed in the pane. The pane is spawned wide enough (see `cols` at spawn) that
+ *  the CLI usually prints it on ONE line, and `capture-pane -J` rejoins a soft wrap. Two things still break
+ *  a single-line scrape: the CLI can render the URL inside a fixed-width box whose borders force real
+ *  newlines `-J` won't rejoin, and a poll can catch the line MID-RENDER before its `state=` tail has landed.
+ *  So `extractAuthorizeUrl` reassembles across rows and `looksWhole` still refuses to hand back a URL that
+ *  never completed — a clipped link is worse than none (the human authorizes a broken request and blames us). */
 const URL_RE = /https:\/\/[^\s]*oauth\/authorize\?[^\s]+/;
+const URL_START_RE = /https:\/\/[^\s]*oauth\/authorize\?/;
+/** URL-legal characters (RFC 3986 unreserved + the sub-delims OAuth query strings use). A row that is
+ *  NOTHING BUT these is a wrapped URL continuation; a row with a space or prose (the "Paste code" prompt)
+ *  is not, and ends the URL — so reassembly can never fuse the prompt into the query string. */
+const URL_FRAG_RE = /^[A-Za-z0-9._~:/?#[\]@!$&'()*+,;=%-]+$/;
+/** Strip a boxed row's borders/padding (│ ┃ | leading markers, surrounding whitespace) before testing it. */
+const BOX_TRIM_RE = /^[\s│┃|>]+|[\s│┃|]+$/g;
 /** An OAuth authorize URL that lost its tail is worse than none: the human would authorize into a
  *  broken request and blame the product. Every provider's URL carries `state` last-ish, so require it. */
 const looksWhole = (u: string): boolean => /[?&]state=[^&\s]+/.test(u);
+
+/** Pull the authorize URL from a captured pane, reassembling it when the CLI wrapped it across rows (a
+ *  bordered box, or a hard wrap `capture-pane -J` left as real newlines). Take the URL-legal run after the
+ *  authorize marker, then append each following row that is purely a URL fragment, stopping the moment the
+ *  URL is whole or a row carries other text. Returns whatever we have — the caller's `looksWhole` decides
+ *  whether it's complete enough to show, so a still-partial reassembly is treated as "not ready yet". */
+export function extractAuthorizeUrl(pane: string): string | undefined {
+  const lines = pane.split('\n');
+  const start = lines.findIndex((l) => URL_START_RE.test(l));
+  if (start < 0) return undefined;
+  let url = lines[start].match(URL_RE)?.[0];
+  if (!url) return undefined;
+  for (let i = start + 1; i < lines.length && !looksWhole(url); i++) {
+    const frag = lines[i].replace(BOX_TRIM_RE, '');
+    if (!frag || !URL_FRAG_RE.test(frag)) break; // first non-fragment row ends the URL
+    url += frag;
+  }
+  return url;
+}
 /** Prompts the CLI shows before it gets to the browser step, each answered by accepting the highlighted
  *  default (theme → any; login method → "Claude account with subscription", which is what a pooled
  *  account must be). Matching on the question text, not on option numbering, which is likelier to shift. */
@@ -175,11 +210,20 @@ export class RuntimeLoginManager {
       }
     }
 
-    const url = pane.match(URL_RE)?.[0];
+    const url = extractAuthorizeUrl(pane);
     if (url && l.phase === 'starting') {
-      if (!looksWhole(url)) return toState(this.fail(l, 'the sign-in link came back incomplete from the runtime — start it again, or run the login on the box and add the dir by path'));
-      l.phase = 'awaiting-code';
-      l.url = url;
+      if (looksWhole(url)) {
+        l.phase = 'awaiting-code';
+        l.url = url;
+      } else {
+        // Caught mid-render: the URL's head printed before its `state=` tail landed. Keep polling for a
+        // whole one; only a URL that stays clipped past the settle window is genuinely broken. Failing on
+        // the first partial capture (as this did) turned a transient read into an unrecoverable login.
+        l.urlSeenAt ??= Date.now();
+        if (Date.now() - l.urlSeenAt > URL_SETTLE_MS) {
+          return toState(this.fail(l, 'the sign-in link came back incomplete from the runtime — start it again, or run the login on the box and add the dir by path'));
+        }
+      }
     }
     // The code was typed but no credential file yet: either the exchange is in flight, or the CLI is
     // sitting on an error we don't have a pattern for. Don't wait out the full TTL for the latter.


### PR DESCRIPTION
## Problem

Guided runtime-account login (Settings → Runtime accounts → "Sign in") failed with **"the sign-in link came back incomplete from the runtime — start it again, or run the login on the box and add the dir by path"** and no way forward but the manual fallback.

`RuntimeLoginManager.poll()` scraped the CLI's `oauth/authorize?…` line and, the instant it saw a URL without a `state=` tail, called `fail()` — a **permanent, immediate** failure with no retry (`runtime-login.ts:180`). Two real triggers despite the wide pane:

1. **Mid-render race** — a poll caught the URL line after its head printed but before the `state=` tail landed. A transient partial read became an unrecoverable login.
2. **Wrapped URL** — if the CLI prints the URL inside a fixed-width box, the borders force real newlines that `capture-pane -J` won't rejoin, so `URL_RE` only matched the first row (no `state=`).

## Fix

- **Incomplete URL is transient, not fatal.** `poll()` records when it first saw an incomplete authorize URL and keeps polling for a whole one; it only fails after an **8s settle window** (`URL_SETTLE_MS`). The next poll, once the line finishes rendering, succeeds.
- **Reassemble a wrapped URL.** New `extractAuthorizeUrl()` takes the URL-legal run after the authorize marker and appends each following row that is *purely* a URL fragment — stopping at the first row with a space or prose. A wrap is rejoined; the "Paste code" prompt can never be fused into the query string.
- The **"never show a clipped URL"** contract is unchanged: `looksWhole` still gates what's surfaced, so a genuinely-clipped URL still fails (after the settle window) with the same operator guidance + manual fallback.

## Verification

- `npm run typecheck` clean; both bundles build.
- `npm run test:governance` green — `runtime-login-test.cjs` updated to the new contract (a clipped URL **waits, not shown**; fails only past the settle window) and now also covers the **reassembly** path (a URL wrapped across boxed rows is surfaced whole).
- Extra offline checks against synthetic pane captures: single-line, mid-render partial, boxed multi-row wrap, hard-wrap, and the safety case (partial URL row immediately followed by the prompt → no fusion) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)