### PR TITLE
fix(tasks): render markdown in task Discussion messages (v0.341.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.341.2] — 2026-08-13
+### Fixed
+- **A task Discussion rendered agent messages as raw markdown.** Agents write markdown, but the Discussion
+  body was drawn as plain text (only `@mentions` were pulled out), so `**bold**`, `` `inline code` ``
+  (branch names, `/code-review ultra 630`, `develop`/`master`), and numbered/bulleted lists all showed
+  their literal syntax. `DiscussionBody` now renders through `ReactMarkdown` (same `remarkGfm` +
+  `[[wiki]]`/entity linking + `mdComponents` as every other markdown surface), with a small `remarkMentions`
+  plugin so `@mentions` keep their highlight — and it no longer mistakes the `@` inside an email like
+  `user@example.com` for a mention.
+
 ## [0.341.1] — 2026-08-13
 ### Fixed
 - **Guided runtime-account login failed hard on the first partial capture of the authorize URL.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.341.1",
+  "version": "0.341.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.341.1",
+      "version": "0.341.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.341.1",
+  "version": "0.341.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6095,6 +6095,48 @@ function splitWikiNodes(value: string): any[] {
   return nodes.length ? nodes : [{ type: 'text', value }]
 }
 
+// Highlight `@mentions` inside rendered markdown — a remark plugin so mentions survive alongside real
+// markdown formatting (a Discussion body is agent-authored markdown, not plain text). Text nodes only:
+// never re-scan inside code or links, and never inside an email (the `@` must start a token).
+const MENTION_RE = /@[a-z0-9][a-z0-9._-]*/gi
+function remarkMentions(agentIds: Set<string>) {
+  return (tree: any) => {
+    const walk = (node: any) => {
+      if (!node || !Array.isArray(node.children)) return
+      const out: any[] = []
+      for (const child of node.children) {
+        if (child.type === 'code' || child.type === 'inlineCode' || child.type === 'link') { out.push(child); continue }
+        if (child.type === 'text' && child.value.includes('@')) { out.push(...splitMentionNodes(child.value, agentIds)); continue }
+        walk(child); out.push(child)
+      }
+      node.children = out
+    }
+    walk(tree)
+  }
+}
+function splitMentionNodes(value: string, agentIds: Set<string>): any[] {
+  const nodes: any[] = []
+  let last = 0
+  MENTION_RE.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = MENTION_RE.exec(value))) {
+    const before = m.index === 0 ? '' : value[m.index - 1]
+    if (/[\w@]/.test(before)) continue // '@' must start a token — skip emails / mid-word matches
+    if (m.index > last) nodes.push({ type: 'text', value: value.slice(last, m.index) })
+    const tok = m[0].slice(1).toLowerCase().replace(/[._-]+$/, '')
+    const isAgent = agentIds.has(tok)
+    // `data.hName`/`hProperties` map this synthetic node straight to a styled <span> in rehype.
+    nodes.push({
+      type: 'mention',
+      data: { hName: 'span', hProperties: { className: `rounded px-1 font-medium ${isAgent ? 'bg-sky-500/15 text-sky-600' : 'bg-muted text-foreground'}` } },
+      children: [{ type: 'text', value: m[0] }],
+    })
+    last = m.index + m[0].length
+  }
+  if (last < value.length) nodes.push({ type: 'text', value: value.slice(last) })
+  return nodes.length ? nodes : [{ type: 'text', value }]
+}
+
 // Markdown link · `[[wiki]]` · bare http(s) URL · in-app `#/route` · bare entity id, in priority order.
 const INLINE_LINK_RE = new RegExp(
   String.raw`\[([^\]]+)\]\((https?:\/\/[^\s)]+|#\/[^\s)]+)\)`
@@ -9935,21 +9977,11 @@ function DiscussionAvatars({ participants, members }: { participants: string[]; 
   )
 }
 
-/** Render Discussion body text with @mentions highlighted (agent mentions get the sky accent). */
+/** Render a Discussion body as markdown (agents author markdown), with @mentions highlighted — agent
+ *  mentions get the sky accent — and `[[wiki]]`/entity refs linked like every other markdown surface. */
 function DiscussionBody({ text, agents }: { text: string; agents: AgentInfo[] }) {
-  const parts = text.split(/(@[a-z0-9][a-z0-9._-]*)/gi)
-  return (
-    <>
-      {parts.map((part, i) => {
-        if (part[0] === '@') {
-          const tok = part.slice(1).toLowerCase().replace(/[._-]+$/, '')
-          const isAgent = agents.some((a) => a.id.toLowerCase() === tok)
-          return <span key={i} className={`rounded px-1 font-medium ${isAgent ? 'bg-sky-500/15 text-sky-600' : 'bg-muted text-foreground'}`}>{part}</span>
-        }
-        return <span key={i}>{part}</span>
-      })}
-    </>
-  )
+  const agentIds = useMemo(() => new Set(agents.map((a) => a.id.toLowerCase())), [agents])
+  return <ReactMarkdown remarkPlugins={[remarkGfm, remarkWikiLinks, [remarkMentions, agentIds]]} components={mdComponents}>{text}</ReactMarkdown>
 }
 
 /** One-line phrasing for a task state event in the merged Discussion timeline. */
@@ -10066,7 +10098,7 @@ function TaskDiscussion({ taskId, entries, unread, me, members, agents, onChange
                 {who.kind === 'agent' && <span className="flex items-center gap-0.5 rounded bg-sky-500/10 px-1 text-[9px] uppercase tracking-wide text-sky-600"><Bot className="h-2.5 w-2.5" />agent</span>}
                 <span className="ml-auto font-mono text-[10px] text-muted-foreground">{fmtDiscussionClock(e.at)}</span>
               </div>
-              <div className="whitespace-pre-wrap break-words text-[13px] leading-relaxed text-foreground"><DiscussionBody text={e.body} agents={agents} /></div>
+              <div className="break-words text-[13px] leading-relaxed text-foreground [&_pre]:whitespace-pre-wrap [&_pre]:break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"><DiscussionBody text={e.body} agents={agents} /></div>
             </div>
           </div>
         )


### PR DESCRIPTION
## What

A task **Discussion** rendered agent messages as **raw markdown**. Agents write markdown, but the Discussion body was drawn as plain text (only `@mentions` were pulled out), so `**bold**`, `` `inline code` `` (branch names, `/code-review ultra 630`, `develop`/`master`), and numbered/bulleted lists all showed their literal syntax.

Reported with a screenshot of a live instawp task discussion.

## Fix

`DiscussionBody` now renders through `ReactMarkdown` using the same `remarkGfm` + `[[wiki]]`/entity-linking (`remarkWikiLinks`) + `mdComponents` as every other markdown surface in the console. A new small `remarkMentions` remark plugin re-highlights `@mentions` **after** markdown parsing (a `data.hName`/`hProperties` node → styled `<span>`), so:

- agent mentions keep the sky accent, other mentions the neutral chip — same styling as before;
- it only fires on text nodes (never inside code spans or links);
- the `@` inside an email like `user@example.com` is no longer mistaken for a mention (an improvement over the old plain-text splitter).

The message wrapper drops `whitespace-pre-wrap` (markdown now owns block layout) and trims the outer paragraph margins so chat stays dense.

## Verification

- `cd web && npm run build` ✓ (tsc + vite)
- Rendered the exact discussion content from the report through the real `react-markdown` pipeline via `react-dom/server` — bold/code/lists render, `@engineer`/`@qa` highlight, `user@example.com` stays a mailto link.
- `npm run test:governance` → 58 passed, 0 failed (version/lockfile in sync at v0.341.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)