### PR TITLE
fix(runtime-accounts): a lapsed or refreshed limit clears instead of freezing (v0.344.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.344.2] — 2026-08-13
+### Fixed
+- **A runtime account stayed stuck on "limited · resets …" long after it was usable again.** The
+  console reads accounts through `RuntimeAccountStore.list()`, but the lapsed-limit self-heal
+  (`recover()`) only ran inside `pick()`/`allLimited()` — i.e. on an actual launch. On an idle runtime
+  nothing called it, so a limit whose reset had already passed showed frozen indefinitely. `list()` (and
+  `get()`) now run `recover()` first, so an expired limit clears on the next console load.
+- **The Refresh button couldn't clear a stale limit.** `recordCheck` only updates the usage snapshot and
+  the `/check` handler re-parked an account limited *only* when the probe reported an exhausted window —
+  so a Refresh that authenticated and found the account healthy (e.g. weekly 75% / session 46%, nowhere
+  near the cap) refreshed the Usage cell but left the "limited" badge untouched. A healthy probe with no
+  exhausted window now clears the limit via the new `RuntimeAccountStore.clearLimit()`.
+
 ## [0.344.1] — 2026-08-13
 ### Fixed
 - **Opening a session on a busy box greeted you with tmux's raw `can't find session: aos-…`** — for a run

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.344.1",
+  "version": "0.344.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.344.1",
+      "version": "0.344.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.344.1",
+  "version": "0.344.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4517,7 +4517,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       os.runtimeAccounts.recordCheck(runtime, name, { ok: check.ok, note: check.note, usage: check.usage });
       // A now-valid token re-enables a previously auto-disabled account; usage-exhaustion re-parks it limited.
       if (check.ok === true && !acct.enabled && acct.checkOk === false) os.runtimeAccounts.setEnabled(runtime, name, true);
+      // Status reconciliation is the whole point of Refresh: an exhausted window re-parks it limited, while a
+      // token that authenticates with NO exhausted window clears a stale limit (recordCheck only touches the
+      // usage snapshot, so without this a healthy probe updated the % but left "limited · resets …" frozen).
       if (check.limitedUntil) os.runtimeAccounts.markLimited(runtime, name, check.limitedUntil);
+      else if (check.ok === true) os.runtimeAccounts.clearLimit(runtime, name);
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'runtime.account.checked', data: { runtime, name, ok: check.ok, note: check.note } });
       return sendJson(res, 200, { ok: true, account: os.runtimeAccounts.get(runtime, name), check: { ok: check.ok, note: check.note } });
     }

--- a/src/state/runtime-accounts.ts
+++ b/src/state/runtime-accounts.ts
@@ -119,12 +119,17 @@ const toAccount = (r: Row): RuntimeAccount => ({
 export class RuntimeAccountStore {
   constructor(private db: Db) {}
 
-  /** Every account across all runtimes, newest first — never exposes the api-key VALUE (only its vault ref). */
-  list(): RuntimeAccount[] {
+  /** Every account across all runtimes, newest first — never exposes the api-key VALUE (only its vault ref).
+   *  Self-heals first: a limit whose reset time has lapsed is cleared here too, not only inside pick()/
+   *  allLimited(). Without this the console (which reads through list()) shows "limited · resets …" frozen
+   *  long after the reset passed, since nothing launches to run recover() on an idle runtime. */
+  list(now: number = Date.now()): RuntimeAccount[] {
+    this.recover(now);
     return this.db.prepare('SELECT * FROM runtime_accounts ORDER BY runtime, created_at DESC').all<Row>().map(toAccount);
   }
 
-  get(runtime: CodingRuntimeId, name: string): RuntimeAccount | null {
+  get(runtime: CodingRuntimeId, name: string, now: number = Date.now()): RuntimeAccount | null {
+    this.recover(now);
     const r = this.db.prepare('SELECT * FROM runtime_accounts WHERE runtime = ? AND name = ?').get<Row>(runtime, name);
     return r ? toAccount(r) : null;
   }
@@ -188,6 +193,15 @@ export class RuntimeAccountStore {
                        WHEN limited_until IS NULL THEN ? ELSE MAX(limited_until, ?) END
                      WHERE runtime = ? AND name = ?`)
       .run(until, until, until, runtime, name);
+  }
+
+  /** Un-park an account: clear a 'limited' flag regardless of its reset time. Used when a definitive live
+   *  signal says the account is usable again — a Refresh probe that authenticates AND reports no exhausted
+   *  window — so a stale limit (e.g. an earlier burst/model-specific banner that parked it) doesn't survive
+   *  until its recorded reset. A no-op on an already-available account. */
+  clearLimit(runtime: CodingRuntimeId, name: string): void {
+    this.db.prepare("UPDATE runtime_accounts SET status = 'available', limited_until = NULL WHERE runtime = ? AND name = ? AND status = 'limited'")
+      .run(runtime, name);
   }
 
   /** Cache the outcome of a validation call (add-time / Refresh) — health + usage snapshot. Doesn't touch


### PR DESCRIPTION
## The bug

On the instawp box, a runtime account sat on **"limited · resets 13/08/2026, 18:42:52"** and the status never updated — even though its usage was well below the cap (weekly 75% / session 46%) and Refresh did nothing to the badge.

## Root cause — two independent gaps

1. **The console read path never self-heals.** The console lists accounts through `RuntimeAccountStore.list()`, but the lapsed-limit self-heal (`recover()`, which clears a limit once its reset time passes) only ran inside `pick()`/`allLimited()` — i.e. on an *actual launch*. On an idle runtime nothing calls those, so a limit whose reset had already passed showed frozen indefinitely.

2. **Refresh couldn't clear a stale limit.** `recordCheck` only updates the usage snapshot, and the `/check` handler re-parked an account limited **only when the probe reported an exhausted window**. So a Refresh that authenticated and found the account healthy refreshed the Usage cell but left `status='limited'` and the old `limited_until` untouched — exactly the "usage updates, badge frozen" symptom.

## The fix

- `list()` and `get()` now run `recover(now)` first, so an expired limit clears on the next console load (not only on a launch).
- New `RuntimeAccountStore.clearLimit()`; the `/check` (Refresh) handler now clears the limit when the probe authenticates with **no exhausted window** (`else if (check.ok === true)`), so a healthy Refresh un-parks a stale limit.

The `markLimited` re-park path (exhausted window → `markLimited`) is unchanged, so a genuinely-limited account still parks correctly; the self-heal only ever clears a limit whose reset has lapsed or that a live probe proves is gone.

## Verification

- `npm run typecheck` clean; `npm run build` clean.
- `npm run test:governance` — 58 passed, 0 failed (incl. `runtime-account-test.cjs`).
- Isolated in-process test of the store (scratch home): lapsed limit → `list()` returns `available`; future limit → stays `limited`; `clearLimit()` → `available`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)