### PR TITLE
fix(sessions): a take-over expires — give the claim exemption a ceiling (v0.345.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.345.0] — 2026-08-13
+### Fixed
+- **Claiming a session made it immortal.** The idle-interactive reaper skipped `claimed_by IS NOT NULL`
+  rows unconditionally — "a human owns that lifecycle" — but nothing ever expires a claim, so anyone who
+  hit "take over" and then closed the tab left a pane running forever. Live instawp: seven sessions
+  claimed by one member, idle **143–168 h**, skipped by the 72 h reaper every tick for a week. Together
+  with their peers they filled the concurrency cap and starved every scheduled run on the tenant for a
+  month (see v0.344.0, the other half of the same outage).
+  The exemption stays; it now has a **ceiling**, exactly like the blocked-on-a-human exemption directly
+  above it in the same sweep — which was unconditional for the same reason and got the same treatment.
+  New `claimedMaxHours` (Settings, default **72 h**, `0` restores the permanent exemption). A session
+  someone is **actually attached to** is still never cut, whatever the clock says: that is what "a human
+  owns it" should have meant. Reaped rows audit as `claimed-abandoned` and name who had claimed them, so
+  it reads as a traceable take-over expiry rather than the janitor closing an ownerless pane.
+- **`PUT /api/settings/concurrency` silently ignored `blockedMaxHours`.** The key was declared in the
+  request type and echoed back in the response, but had no handler — so setting it returned 200 with the
+  value unchanged. Now applied and audited like its siblings.
+
+### Changed
+- `scripts/idle-reaper-test.cjs` grows a claim-ceiling section (41 assertions total). Note one existing
+  assertion **inverted**: a 96 h-old claimed session used to be pinned as "left running", which was the
+  bug being asserted as correct.
+
 ## [0.344.2] — 2026-08-13
 ### Fixed
 - **A runtime account stayed stuck on "limited · resets …" long after it was usable again.** The

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.344.2",
+  "version": "0.345.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.344.2",
+      "version": "0.345.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.344.2",
+  "version": "0.345.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/idle-reaper-test.cjs
+++ b/scripts/idle-reaper-test.cjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 /* Idle-interactive reaper test — a detached member (headless=0) session idle past the configurable
- * timeout is closed (status→stopped), while recent/attached/claimed/disabled cases are left alone.
+ * timeout is closed (status→stopped), while recent/attached/disabled cases are left alone.
+ *
+ * Section 7 covers the CLAIM CEILING. `claimed_by IS NULL` used to exempt a claimed session from this
+ * sweep unconditionally, on the reasoning that a human owns its lifecycle. Nothing ever expired a claim,
+ * so someone who took a session over and closed the tab created an immortal pane: live instawp had seven
+ * sessions claimed by one member, idle 143-168h, skipped by the 72h reaper every tick for a week — until
+ * they and their peers filled the concurrency cap and starved every scheduled run on the tenant for a
+ * month. The exemption stays; it now has a ceiling, exactly like the blocked-on-a-human one above it.
  * Isolated home; backend kill/hasClient stubbed so no real tmux is needed. */
 const fs = require('fs');
 const os = require('os');
@@ -58,7 +65,7 @@ aos.settings.setUnattendedNoProgressMinutes(0);
 const stale = mkSession({ created_at: Date.now() - 96 * H });                 // 4 days idle → reap
 const recent = mkSession({ created_at: Date.now() - 2 * H });                 // 2h → keep
 const attachedStale = mkSession({ created_at: Date.now() - 96 * H, tmux: 'aos-ATTACHED' }); attached.add('aos-ATTACHED'); // in use → keep
-const claimedStale = mkSession({ created_at: Date.now() - 96 * H, claimed_by: 'm_bob' }); // human owns it → keep
+const claimedStale = mkSession({ created_at: Date.now() - 96 * H, claimed_by: 'm_bob' }); // claim went stale → reap
 const unattended = mkSession({ created_at: Date.now() - 96 * H, headless: 1 });   // sweep-2 territory, not sweep 3 → keep here
 const activeByLastAct = mkSession({ created_at: Date.now() - 96 * H, last_activity: Date.now() - 1 * H }); // recent turn → keep
 
@@ -68,7 +75,9 @@ assert(statusOf(stale) === 'stopped', 'detached 4-day-idle member session → st
 assert(killed.includes('aos-' + stale), 'its pane was killed');
 assert(statusOf(recent) === 'running', 'recent (2h) session → left running');
 assert(statusOf(attachedStale) === 'running', 'attached session (client present) → left running');
-assert(statusOf(claimedStale) === 'running', 'claimed take-over → left running');
+// Was 'left running' — an unconditional exemption, and the leak this file now pins against. 96h idle is
+// past the default 72h claim ceiling, so the take-over is abandonment.
+assert(statusOf(claimedStale) === 'stopped', 'claimed take-over idle past the ceiling → stopped');
 assert(statusOf(unattended) === 'running', 'headless=1 unattended → not touched by sweep 3');
 assert(statusOf(activeByLastAct) === 'running', 'old but recent last_activity → left running');
 
@@ -164,6 +173,50 @@ const blockedForever = mkSession({ created_at: Date.now() - 200 * H });
 askAt(blockedForever, 150);
 tm.reapIdleSessions();
 assert(statusOf(blockedForever) === 'running', '0 → a 150h-old block is never cut');
+
+console.log('\n\x1b[1m7) the claim ceiling — a take-over expires, it is not a permanent exemption\x1b[0m');
+aos.settings.setInteractiveIdleTimeoutHours(48);
+aos.settings.setBlockedMaxHours(72);
+assert(aos.settings.claimedMaxHours() === 72, 'unset → 72h default');
+assert(aos.settings.setClaimedMaxHours(0) === 0, 'set 0 → 0 (permanent exemption restored)');
+assert(aos.settings.setClaimedMaxHours(99999) === 24 * 30, 'clamps to 30 days max');
+
+// 0 = the OLD behaviour, kept as an escape hatch for anyone who wants take-overs to be forever.
+aos.settings.setClaimedMaxHours(0);
+const claimedForever = mkSession({ created_at: Date.now() - 400 * H, claimed_by: 'm_bob' });
+tm.reapIdleSessions();
+assert(statusOf(claimedForever) === 'running', '0 → even a 400h-idle claim is never cut');
+
+aos.settings.setClaimedMaxHours(72);
+const claimedWeekOld = mkSession({ created_at: Date.now() - 168 * H, claimed_by: 'm_bob' });   // the live case
+const claimedFresh = mkSession({ created_at: Date.now() - 10 * H, claimed_by: 'm_bob' });      // still theirs
+const claimedAttached = mkSession({ created_at: Date.now() - 400 * H, claimed_by: 'm_bob', tmux: 'aos-CLAIMED-ATTACHED' });
+attached.add('aos-CLAIMED-ATTACHED');
+const claimedActive = mkSession({ created_at: Date.now() - 400 * H, claimed_by: 'm_bob', last_activity: Date.now() - 2 * H });
+tm.reapIdleSessions();
+
+assert(statusOf(claimedWeekOld) === 'stopped', 'claimed + idle a week → stopped (the instawp case)');
+assert(statusOf(claimedFresh) === 'running', 'claimed + idle 10h → still theirs');
+assert(statusOf(claimedActive) === 'running', 'claimed + a turn 2h ago → still theirs');
+// The one rule that must never be overridden by a clock: someone is literally attached right now.
+assert(statusOf(claimedAttached) === 'running', 'claimed + ATTACHED → never cut, whatever the age');
+
+// The audit has to name the person, so a reaped take-over is traceable rather than looking like the
+// janitor closing an ownerless pane.
+const ev = aos.db.prepare("SELECT data FROM audit_events WHERE type='session.reaped' AND run_id=? ORDER BY ts DESC LIMIT 1").get(claimedWeekOld);
+const parsed = ev ? JSON.parse(ev.data) : {};
+assert(parsed.reason === 'claimed-abandoned', 'audited as claimed-abandoned, not idle-interactive', JSON.stringify(parsed));
+assert(parsed.claimedBy === 'm_bob', 'and names who had claimed it');
+
+// A ceiling SHORTER than the idle timeout must still see its own rows — the scan window is widened to the
+// more permissive of the two clocks, so a claim can expire before an ordinary idle session would.
+aos.settings.setInteractiveIdleTimeoutHours(200);
+aos.settings.setClaimedMaxHours(24);
+const claimedShortCeiling = mkSession({ created_at: Date.now() - 48 * H, claimed_by: 'm_bob' });
+const unclaimedSameAge = mkSession({ created_at: Date.now() - 48 * H });
+tm.reapIdleSessions();
+assert(statusOf(claimedShortCeiling) === 'stopped', 'claim ceiling below the idle timeout still applies');
+assert(statusOf(unclaimedSameAge) === 'running', '…and the longer idle timeout still protects unclaimed rows');
 
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}IDLE REAPER: ${pass}/${pass + fail} passed\x1b[0m`);
 try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -83,6 +83,7 @@ const MAX_CONCURRENT_KEY = 'max_concurrent_sessions'; // whole-box concurrency c
 const INTERACTIVE_IDLE_HOURS_KEY = 'interactive_idle_timeout_hours'; // auto-close a detached member session idle past this; unset → 48h, 0 → off
 const UNATTENDED_MAX_HOURS_KEY = 'unattended_max_runtime_hours'; // hard runtime ceiling for a headless/unattended run (stuck-mid-turn backstop); unset → 24h, 0 → off
 const BLOCKED_MAX_HOURS_KEY = 'blocked_max_hours'; // force-close an interactive session waiting this long on an unanswered card; unset → 72h, 0 → off
+const CLAIMED_MAX_HOURS_KEY = 'claimed_max_hours'; // force-close a CLAIMED interactive session idle this long; unset → 72h, 0 → off (permanent take-over exemption)
 const UNATTENDED_NO_PROGRESS_MIN_KEY = 'unattended_no_progress_minutes'; // reap a headless run that never made a tool call (never-started: rate-limit/trust-hang/lost-prompt); unset → 30m, 0 → off
 const KILL_SWITCH_KEY = 'kill_switch'; // workspace-wide emergency stop (JSON KillSwitchState)
 const SUPPRESSED_BUILTINS_KEY = 'suppressed_builtins'; // built-in agent ids an admin deleted (JSON string[]); boot won't re-seed them
@@ -1046,6 +1047,38 @@ export class SettingsStore {
     const clamped = !Number.isFinite(n) || n < 0 ? 72 : n === 0 ? 0 : Math.min(Math.max(Math.round(n), 1), 24 * 30);
     this.set(BLOCKED_MAX_HOURS_KEY, String(clamped), by);
     return this.blockedMaxHours();
+  }
+
+  /**
+   * Hours after which a **claimed** interactive session that nobody has touched is treated as abandoned
+   * rather than owned — the ceiling on the take-over exemption.
+   *
+   * Claiming a session ("take over" in the console) hands its lifecycle to a human, and the idle reaper
+   * skipped `claimed_by IS NOT NULL` rows unconditionally so it could not close something a person was
+   * driving. Unconditionally is the problem: nothing ever expires a claim, so a human who takes a session
+   * over and closes the tab creates an immortal pane. Live instawp: seven sessions claimed by one member,
+   * idle **143–168 h**, skipped by the 72 h reaper every tick for a week, until they and their peers had
+   * filled the concurrency cap and starved every scheduled run on the tenant.
+   *
+   * This is the same shape as the blocked-on-a-human exemption directly above, which was unconditional
+   * for the same reason and got the same treatment: keep the exemption, give it a ceiling.
+   *
+   * Default **72 h**, matching {@link blockedMaxHours} — three days without a keystroke is abandonment,
+   * not ownership. Clamped 1 h–30 d; `0` disables (restoring the permanent exemption). A session with
+   * someone **attached** is never cut by this, whatever the clock says: they are right there.
+   */
+  claimedMaxHours(): number {
+    const n = Number(this.getRow(CLAIMED_MAX_HOURS_KEY)?.value);
+    if (!Number.isFinite(n)) return 72; // unset → default
+    if (n <= 0) return 0;               // explicit 0 → disabled (permanent take-over exemption)
+    return Math.min(Math.max(Math.round(n), 1), 24 * 30);
+  }
+
+  setClaimedMaxHours(hours: number, by?: string): number {
+    const n = Number(hours);
+    const clamped = !Number.isFinite(n) || n < 0 ? 72 : n === 0 ? 0 : Math.min(Math.max(Math.round(n), 1), 24 * 30);
+    this.set(CLAIMED_MAX_HOURS_KEY, String(clamped), by);
+    return this.claimedMaxHours();
   }
 
   /** Minutes after which a headless/unattended run that has made ZERO progress — never a completed turn

--- a/src/server.ts
+++ b/src/server.ts
@@ -4334,11 +4334,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const value = os.settings.maxConcurrentSessions(); // operator override (null = unset)
     const resolved = autos.concurrencyCap();           // effective cap the scheduler enforces (0 = unlimited)
     const source = envLocked ? 'env' : value != null ? 'setting' : 'derived';
-    return sendJson(res, 200, { value, resolved, derived: derivedConcurrencyCap(), source, envLocked, alive: tm.aliveSessionCount(), admitted: tm.admissionSessionCount(), parked: tm.parkedSessionCount(), idleHours: os.settings.interactiveIdleTimeoutHours(), unattendedMaxHours: os.settings.unattendedMaxHours(), unattendedNoProgressMinutes: os.settings.unattendedNoProgressMinutes(), blockedMaxHours: os.settings.blockedMaxHours() });
+    return sendJson(res, 200, { value, resolved, derived: derivedConcurrencyCap(), source, envLocked, alive: tm.aliveSessionCount(), admitted: tm.admissionSessionCount(), parked: tm.parkedSessionCount(), idleHours: os.settings.interactiveIdleTimeoutHours(), unattendedMaxHours: os.settings.unattendedMaxHours(), unattendedNoProgressMinutes: os.settings.unattendedNoProgressMinutes(), blockedMaxHours: os.settings.blockedMaxHours(), claimedMaxHours: os.settings.claimedMaxHours() });
   }
   if (method === 'PUT' && p === '/api/settings/concurrency') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    const b = await readBody(req) as { value?: unknown; idleHours?: unknown; unattendedMaxHours?: unknown; unattendedNoProgressMinutes?: unknown; blockedMaxHours?: unknown };
+    const b = await readBody(req) as { value?: unknown; idleHours?: unknown; unattendedMaxHours?: unknown; unattendedNoProgressMinutes?: unknown; blockedMaxHours?: unknown; claimedMaxHours?: unknown };
     // Cap: `null`/'' clears the override (→ derived default); 0 = unlimited; N>0 = cap. Only touched when the
     // key is present, so a PUT that only sets idleHours leaves the cap alone.
     if ('value' in b) {
@@ -4370,7 +4370,23 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       const savedM = os.settings.setUnattendedNoProgressMinutes(m, me.email);
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.noProgress.updated', data: { unattendedNoProgressMinutes: savedM } });
     }
-    return sendJson(res, 200, { ok: true, value: os.settings.maxConcurrentSessions(), resolved: autos.concurrencyCap(), derived: derivedConcurrencyCap(), idleHours: os.settings.interactiveIdleTimeoutHours(), unattendedMaxHours: os.settings.unattendedMaxHours(), unattendedNoProgressMinutes: os.settings.unattendedNoProgressMinutes(), blockedMaxHours: os.settings.blockedMaxHours() });
+    // Blocked-on-a-human ceiling (hours): 0 = off. This key was already declared in the body type and read
+    // back in the response, but had no handler — so a PUT setting it returned 200 with the value silently
+    // unchanged. Present-only, like the rest.
+    if ('blockedMaxHours' in b) {
+      const h = Number(b.blockedMaxHours);
+      if (!Number.isFinite(h) || h < 0) return sendJson(res, 400, { error: 'blockedMaxHours must be a non-negative number (0 = off)' });
+      const savedH = os.settings.setBlockedMaxHours(h, me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.blockedMax.updated', data: { blockedMaxHours: savedH } });
+    }
+    // Claim ceiling (hours): how long a claimed-but-untouched session keeps its take-over exemption. 0 = off.
+    if ('claimedMaxHours' in b) {
+      const h = Number(b.claimedMaxHours);
+      if (!Number.isFinite(h) || h < 0) return sendJson(res, 400, { error: 'claimedMaxHours must be a non-negative number (0 = off)' });
+      const savedH = os.settings.setClaimedMaxHours(h, me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.claimedMax.updated', data: { claimedMaxHours: savedH } });
+    }
+    return sendJson(res, 200, { ok: true, value: os.settings.maxConcurrentSessions(), resolved: autos.concurrencyCap(), derived: derivedConcurrencyCap(), idleHours: os.settings.interactiveIdleTimeoutHours(), unattendedMaxHours: os.settings.unattendedMaxHours(), unattendedNoProgressMinutes: os.settings.unattendedNoProgressMinutes(), blockedMaxHours: os.settings.blockedMaxHours(), claimedMaxHours: os.settings.claimedMaxHours() });
   }
 
   // ── Runtime account POOL (launch-time credential rotation) — owner-managed ──────────────

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3086,10 +3086,31 @@ export class TerminalManager {
       const idleCutoff = Date.now() - idleHours * 3600_000;
       const blockedHours = this.os.settings.blockedMaxHours();
       const blockedCutoff = blockedHours > 0 ? Date.now() - blockedHours * 3600_000 : null;
-      const stale = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status FROM term_sessions WHERE headless = 0 AND resident = 0 AND claimed_by IS NULL AND status IN ('running','done') AND COALESCE(last_activity, created_at) < ?")
-        .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string }>(idleCutoff);
+      // CLAIM CEILING. `claimed_by IS NULL` was the third unconditional exemption in this sweep, and it
+      // leaked exactly like the other two: claiming hands a session's lifecycle to a human, but nothing
+      // ever expires a claim, so someone who takes a session over and closes the tab creates an immortal
+      // pane. Live instawp: seven sessions claimed by one member, idle 143–168 h, skipped by the 72 h
+      // reaper every tick for a week — until they and their peers filled the concurrency cap and starved
+      // every scheduled run on the tenant for a month. The exemption stays; it just gets a ceiling, like
+      // `blockedMaxHours` above. `0` restores the old forever-exemption. Someone actually ATTACHED is
+      // still never cut (checked below) — that is what "a human owns it" should have meant all along.
+      const claimedHours = this.os.settings.claimedMaxHours();
+      const claimedCutoff = claimedHours > 0 ? Date.now() - claimedHours * 3600_000 : null;
+      // Widen the scan to the more permissive of the two clocks, then decide per row — otherwise a claim
+      // ceiling SHORTER than the idle timeout would never see its own rows.
+      const scanCutoff = claimedCutoff == null ? idleCutoff : Math.max(idleCutoff, claimedCutoff);
+      const stale = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, claimed_by, last_activity, created_at FROM term_sessions WHERE headless = 0 AND resident = 0 AND status IN ('running','done') AND COALESCE(last_activity, created_at) < ?")
+        .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; claimed_by: string | null; last_activity: number | null; created_at: number }>(scanCutoff);
       for (const r of stale) {
         try {
+          const idleSince = r.last_activity ?? r.created_at;
+          // Claimed: exempt unless the claim itself has gone stale. Unclaimed: the ordinary idle clock —
+          // re-checked here because the scan may have been widened past it for the claimed rows.
+          if (r.claimed_by) {
+            if (claimedCutoff == null || idleSince >= claimedCutoff) continue;
+          } else if (idleSince >= idleCutoff) {
+            continue;
+          }
           // A reaped 'running' row flips to 'stopped' and drops out of the query next tick; a 'done' row keeps
           // its status (below), so skip one whose pane is already gone to avoid re-killing / re-auditing it
           // every tick. Only applies when we can poll liveness (local backend); null → fall through as before.
@@ -3098,7 +3119,7 @@ export class TerminalManager {
           if (this.backend.hasClient(space, r.tmux) === true) continue; // someone's attached — it's in use
           // Blocked on a person: leave it — unless nobody has answered inside the ceiling above, at which
           // point it is abandoned, not waiting.
-          let reason = 'idle-interactive';
+          let reason = r.claimed_by ? 'claimed-abandoned' : 'idle-interactive';
           const blockedAt = this.oldestPendingBlockAt(r.id);
           if (blockedAt !== undefined) {
             if (blockedCutoff == null || blockedAt >= blockedCutoff) continue;
@@ -3112,7 +3133,11 @@ export class TerminalManager {
           this.blockResume(r.id); // stay reaped against a ttyd auto-reconnect; a deliberate Resume clears it
           this.audit(r.id, r.agent, 'session.reaped', reason === 'blocked-timeout'
             ? { reason, blockedHours, blockedForMs: Date.now() - (blockedAt as number), status: r.status }
-            : { reason, idleHours, status: r.status });
+            // Name WHO abandoned it: a claim reaped out from under someone should be traceable to the
+            // person who took it over, not read as the janitor closing an ownerless pane.
+            : reason === 'claimed-abandoned'
+              ? { reason, claimedHours, claimedBy: r.claimed_by, idleForMs: Date.now() - idleSince, status: r.status }
+              : { reason, idleHours, status: r.status });
         } catch { /* one bad row must not stop the sweep */ }
       }
     }


### PR DESCRIPTION
## The bug

The idle-interactive reaper skipped claimed sessions unconditionally:

```sql
WHERE headless = 0 AND resident = 0 AND claimed_by IS NULL AND ...
```
> *Skip claimed take-overs — a human owns that lifecycle.*

Nothing ever expires a claim. So anyone who hits "take over" and then closes the tab leaves a pane running **forever**.

Live instawp: **seven sessions claimed by one member, idle 143–168 hours**, skipped by the 72h reaper every tick for a week. Together with their peers they filled the concurrency cap and starved every scheduled run on the tenant for a month. #633 stopped parked panes *blocking* the scheduler; this stops them *accumulating*.

## Why it's the same mistake twice

This is the third unconditional exemption in this one sweep, and it leaked exactly like the other two. The comment directly above it already says so about the blocked-on-a-human case:

> *"No pending human block" was an unconditional exemption, and that is the same mistake the done-orphan leak was: nothing expires an unanswered card.*

That one kept its exemption and gained a ceiling (`blockedMaxHours`). So does this one.

## The fix

- **`claimedMaxHours`** — Settings, default **72h**, `0` restores the permanent exemption. Clamped 1h–30d.
- **Attached is still absolute.** A session someone is actually attached to is never cut, whatever the clock says — that's what "a human owns it" should have meant all along.
- The scan window widens to the more permissive of the two clocks, so a claim ceiling *shorter* than the idle timeout still sees its own rows.
- Reaped rows audit as `claimed-abandoned` and **name who had claimed them**, so an expired take-over is traceable rather than reading as the janitor closing an ownerless pane.

Also fixes **`PUT /api/settings/concurrency` silently ignoring `blockedMaxHours`** — the key was declared in the request type and echoed back in the response, but had no handler, so a PUT returned 200 with the value unchanged.

## Verification

`scripts/idle-reaper-test.cjs` grows a claim-ceiling section — 41 assertions total. Covers the live case (claimed + idle a week → reaped), claimed-but-recent and claimed-with-a-recent-turn (kept), claimed + attached (never cut at 400h), `0` restoring the old forever-exemption, the short-ceiling scan-window case, and that the audit names the claimer.

⚠️ **One existing assertion is inverted by this PR**: a 96h-old claimed session was previously pinned as `'left running'` — the bug, asserted as correct. It now expects `'stopped'`.

Full gate green (951 assertions); both bundles build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)