### PR TITLE
feat(feed): the Feed page — console UI for the unified activity stream (v0.349.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.349.0] — 2026-08-14
+### Added
+- **The Feed page — the console surface for the unified activity stream (v0.348.0 backend).** A new
+  primary nav item (pinned by default) that renders `/api/feed` as one time-ordered stream, read two
+  ways via a lens toggle: **Feed** (by time) and **Goals** (the same lines grouped by outcome, each goal
+  collapsible with its rolled-up progress bar). Every line leads with attribution — the agent, the human
+  it runs as (avatar + name), a provenance hint (*via automation/task/chat*), and a clickable goal tag —
+  so "who is asking what" is answered in the row itself. Decisions are highlighted inline (amber for
+  approvals, sky for questions) and actioned in place: **Approve/Deny** (gated by `canApprove`, else a
+  "waiting on an owner-level approver" note) and **Reply** to a question, both resolving optimistically
+  and dropping off the 4s poll. A resolved/finished line carries a **Show history** toggle that lazy-loads
+  its step-by-step trail from `/api/feed/:runId/trail` (the append-only `audit_events` ⋃ `task_events`).
+  Filter chips (All · Needs you · Running · Done) carry live counts and, in the Feed lens, scope the
+  stream; keyset **Load more** paginates. Reuses the cross-domain status glyph, role-tinted chips, and
+  member-avatar primitives, so it reads as part of the existing console. `api.feed()` / `api.feedTrail()`
+  added to the client. The surviving `messages` cases (`update`, session-less notifications) folding into
+  the stream come next. See `docs/feed-plan.md`.
+
 ## [0.348.0] — 2026-08-14
 ### Added
 - **A unified activity feed (`os.feed`) — one stream to replace the inbox/tasks/sessions/notifications

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.348.0",
+  "version": "0.349.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.348.0",
+      "version": "0.349.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.348.0",
+  "version": "0.349.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,7 +15,7 @@ import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
 import { api, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskChild, type TaskRun, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskDiscussionDelivery, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type AgentProposalTrust, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type GoalUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
-import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval } from '@/lib/api'
+import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval, type FeedItem, type FeedResponse, type FeedFilter, type FeedTrailStep } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ENTITY_ID_SRC, entityHref, isEntityId } from '@/lib/entity-links'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
@@ -25,13 +25,13 @@ import { Xterm } from './Xterm'
 // Terminal font-size bounds (shared by TerminalFrame's state and the ImageDropZone stepper).
 const TERM_FONT_MIN = 8, TERM_FONT_MAX = 40
 
-type Route = 'overview' | 'inbox' | 'cockpit' | 'chat' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'goals' | 'tasks' | 'memory' | 'insights' | 'kb' | 'skills' | 'apps' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent' | 'docs' | 'profile'
+type Route = 'overview' | 'feed' | 'inbox' | 'cockpit' | 'chat' | 'sessions' | 'agents' | 'new-agent' | 'connectors' | 'team' | 'automations' | 'goals' | 'tasks' | 'memory' | 'insights' | 'kb' | 'skills' | 'apps' | 'files' | 'artifacts' | 'settings' | 'audit' | 'agent' | 'docs' | 'profile'
 // The full set of pages, used by the hash router to validate the URL on load. Keep in sync with Route.
-const ROUTES: Route[] = ['overview', 'inbox', 'cockpit', 'chat', 'sessions', 'agents', 'new-agent', 'connectors', 'team', 'automations', 'goals', 'tasks', 'memory', 'insights', 'kb', 'skills', 'apps', 'files', 'artifacts', 'settings', 'audit', 'agent', 'docs', 'profile']
+const ROUTES: Route[] = ['overview', 'feed', 'inbox', 'cockpit', 'chat', 'sessions', 'agents', 'new-agent', 'connectors', 'team', 'automations', 'goals', 'tasks', 'memory', 'insights', 'kb', 'skills', 'apps', 'files', 'artifacts', 'settings', 'audit', 'agent', 'docs', 'profile']
 // The single source of truth for a page's human name — used for the header <h1> AND the browser-tab
 // title, so both always agree. The `agent` detail page appends the agent id at the call site.
 const ROUTE_TITLES: Record<Route, string> = {
-  overview: 'Overview', inbox: 'Inbox', cockpit: 'Cockpit', chat: 'Chat', sessions: 'Sessions', agents: 'Agents',
+  overview: 'Overview', feed: 'Feed', inbox: 'Inbox', cockpit: 'Cockpit', chat: 'Chat', sessions: 'Sessions', agents: 'Agents',
   'new-agent': 'New agent', agent: 'Agent', connectors: 'Connections', team: 'Team',
   automations: 'Automations', goals: 'Goals', tasks: 'Tasks', memory: 'Memory', insights: 'Insights',
   kb: 'Knowledge Base', skills: 'Skills', apps: 'Apps', files: 'Files', artifacts: 'Library', audit: 'Audit log',
@@ -1110,9 +1110,10 @@ function UpdateNotice({ compact = false }: { compact?: boolean } = {}) {
  *  this list; Sessions is the middle switcher; Feedback is an external link. `route` drives active
  *  state; `adminOnly` hides the item entirely from members who can't view that page (so they can't pin
  *  what they can't see). Order here is the canonical order items render in, whether in Main or Manage. */
-type NavKey = 'cockpit' | 'chat' | 'goals' | 'tasks' | 'artifacts' | 'automations' | 'kb' | 'memory' | 'insights' | 'skills' | 'apps' | 'connectors' | 'team' | 'files' | 'audit' | 'settings' | 'docs'
+type NavKey = 'feed' | 'cockpit' | 'chat' | 'goals' | 'tasks' | 'artifacts' | 'automations' | 'kb' | 'memory' | 'insights' | 'skills' | 'apps' | 'connectors' | 'team' | 'files' | 'audit' | 'settings' | 'docs'
 interface NavMeta { key: NavKey; route: Route; label: string; icon: ReactNode; adminOnly?: boolean; beta?: boolean }
 const PINNABLE_NAV: NavMeta[] = [
+  { key: 'feed',        route: 'feed',        label: 'Feed',        icon: <Activity className="h-4 w-4" />, beta: true },
   { key: 'cockpit',     route: 'cockpit',     label: 'Cockpit',     icon: <Gauge className="h-4 w-4" />, beta: true },
   { key: 'chat',        route: 'chat',        label: 'Chat',        icon: <MessageSquare className="h-4 w-4" />, beta: true },
   { key: 'goals',       route: 'goals',       label: 'Goals',       icon: <Target className="h-4 w-4" /> },
@@ -1133,7 +1134,7 @@ const PINNABLE_NAV: NavMeta[] = [
 ]
 /** The default pin layout applied when a member has never customized (navPins === null): the three
  *  workspace surfaces that used to be hardwired into Main. Everything else starts under Manage. */
-const DEFAULT_PINNED_NAV: NavKey[] = ['cockpit', 'goals', 'tasks', 'artifacts']
+const DEFAULT_PINNED_NAV: NavKey[] = ['feed', 'cockpit', 'goals', 'tasks', 'artifacts']
 
 function Console({ me }: { me: Member }) {
   const [state, setState] = useState<StateResp | null>(null)
@@ -1728,6 +1729,7 @@ function Console({ me }: { me: Member }) {
           {route === 'team' && <TeamPage me={me} onProfileChange={refreshState} />}
           {route === 'profile' && <ProfilePage me={state?.me ?? me} prefs={prefs} onSavePrefs={savePrefs} onProfileChange={refreshState} />}
           {route === 'automations' && <AutomationsPage me={me} agents={state?.agents ?? []} sessions={sessions} serverTz={state?.serverTz} onOpen={openTerminal} nav={nav} agentFilter={detail} />}
+          {route === 'feed' && <FeedPage me={me} members={members} nav={nav} />}
           {route === 'goals' && <GoalsPage me={me} goalId={detail} nav={nav} />}
           {route === 'tasks' && <TasksPage me={me} agents={state?.agents ?? []} taskId={detail} onOpen={openTerminal} nav={nav} />}
           {route === 'memory' && <MemoryPage agents={state?.agents ?? []} me={me} />}
@@ -5240,6 +5242,302 @@ function QuestionReply({ m }: { m: Msg }) {
         </div>
       )}
     </>
+  )
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FeedPage — the unified activity stream (docs/feed-plan.md). One time-ordered
+// view over sessions/approvals/questions, read by time (Feed) or outcome (Goals).
+// Attribution is on every line; decisions are highlighted and actioned inline;
+// a resolved line keeps its history (the append-only trail). Replaces the split
+// between inbox · tasks · sessions · notifications.
+// ────────────────────────────────────────────────────────────────────────────
+
+const FEED_FILTERS: { key: FeedFilter; label: string; countKey?: keyof FeedResponse['counts'] }[] = [
+  { key: 'all', label: 'All' },
+  { key: 'needsYou', label: 'Needs you', countKey: 'needsYou' },
+  { key: 'running', label: 'Running', countKey: 'running' },
+  { key: 'done', label: 'Done', countKey: 'doneToday' },
+]
+
+/** Map a feed line to the cross-domain status role (drives its glyph + tone). */
+function feedItemRole(it: FeedItem): StatusRole {
+  if (it.state === 'decision') return 'needsHuman'
+  if (it.state === 'running') return 'busy'
+  if (it.kind === 'approval.rejected' || it.outcome === 'failure' || it.kind === 'session.crashed') return 'failed'
+  if (it.kind === 'approval.cancelled' || it.outcome === 'partial' || it.kind === 'session.stopped') return 'partial'
+  return 'ok'
+}
+
+/** A one-word origin hint from a session's provenance prefix (spawned_by). */
+function provenanceHint(spawnedBy: string | null): string | null {
+  if (!spawnedBy) return null
+  if (spawnedBy.startsWith('automation:')) return 'via automation'
+  if (spawnedBy.startsWith('task:')) return 'via task'
+  if (spawnedBy.startsWith('chat:')) return 'via chat'
+  if (spawnedBy.startsWith('ask:')) return 'via delegation'
+  return null
+}
+
+/** Prettify a trail step's raw kind (audit type / task.<kind>) into a human label. */
+function trailLabel(step: FeedTrailStep): string {
+  const k = step.kind
+  const d = step.detail as Record<string, unknown> | string | null
+  if (k === 'approval.requested') return 'Approval requested'
+  if (k === 'approval.decided' || k === 'approval.resolved') return d && typeof d === 'object' && d.approved ? 'Approved' : 'Decided'
+  if (k === 'question.asked') return 'Question asked'
+  if (k === 'question.answered') return 'Answered'
+  if (k === 'gate.decision') return 'Action ran'
+  if (k.startsWith('task.')) return typeof d === 'string' && d ? d : k.slice(5)
+  return k.replace(/[._]/g, ' ')
+}
+
+function FeedPage({ me, members, nav }: { me: Member; members: Member[]; nav: (r: Route, detail?: string) => void }) {
+  const [lens, setLens] = useState<'feed' | 'goals'>('feed')
+  const [filter, setFilter] = useState<FeedFilter>('all')
+  const [limit, setLimit] = useState(40)
+  const [page, setPage] = useState<FeedResponse | null>(null)
+  const [progress, setProgress] = useState<Record<string, GoalProgress>>({})
+  const [trails, setTrails] = useState<Record<string, FeedTrailStep[] | 'loading'>>({})
+  const [busy, setBusy] = useState<Set<string>>(new Set())
+  const [replyTo, setReplyTo] = useState<string | null>(null)
+  const [replyText, setReplyText] = useState('')
+  const [, setNow] = useState(Date.now())
+
+  // The Goals lens groups the whole stream by outcome, so it always reads unfiltered + a bit deeper.
+  const effFilter: FeedFilter = lens === 'goals' ? 'all' : filter
+  const effLimit = lens === 'goals' ? Math.max(limit, 80) : limit
+
+  const load = async () => {
+    const p = await api.feed({ filter: effFilter, limit: effLimit }).catch(() => null)
+    if (p && Array.isArray(p.items)) setPage(p)
+  }
+  useEffect(() => { setPage(null); load() /* eslint-disable-next-line */ }, [effFilter, effLimit])
+  useEffect(() => {
+    const t = setInterval(() => { if (!replyTo) load() }, 4000)
+    return () => clearInterval(t)
+    /* eslint-disable-next-line */
+  }, [effFilter, effLimit, replyTo])
+  useEffect(() => { const t = setInterval(() => setNow(Date.now()), 1000); return () => clearInterval(t) }, [])
+  useEffect(() => { if (lens === 'goals') api.goals().then((r) => setProgress(r.progress ?? {})).catch(() => {}) }, [lens])
+
+  const items = page?.items ?? []
+  const counts = page?.counts
+
+  const toggleTrail = async (runId: string) => {
+    if (trails[runId]) { setTrails((t) => { const n = { ...t }; delete n[runId]; return n }); return }
+    setTrails((t) => ({ ...t, [runId]: 'loading' }))
+    const r = await api.feedTrail(runId).catch(() => ({ steps: [] as FeedTrailStep[] }))
+    setTrails((t) => ({ ...t, [runId]: r.steps ?? [] }))
+  }
+  const markBusy = (uid: string, on: boolean) => setBusy((b) => { const n = new Set(b); on ? n.add(uid) : n.delete(uid); return n })
+  const decide = async (it: FeedItem, approved: boolean) => {
+    markBusy(it.uid, true)
+    const r = await api.resolve(it.ref.id, approved)
+    if (r.error) markBusy(it.uid, false); else load()
+  }
+  const sendReply = async (it: FeedItem) => {
+    const text = replyText.trim(); if (!text) return
+    markBusy(it.uid, true); setReplyTo(null); setReplyText('')
+    await api.answerQuestion(it.ref.id, text).catch(() => {})
+    markBusy(it.uid, false); load()
+  }
+
+  // ── shared line renderer ──
+  const attribution = (it: FeedItem) => {
+    const prov = provenanceHint(it.spawnedBy)
+    return (
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-muted-foreground">
+        {it.agent && <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-medium text-foreground/80"><Bot className="h-3 w-3" />{it.agent}</span>}
+        {it.runAs && <span className="inline-flex items-center gap-1">for <PrincipalTag id={it.runAs} members={members} /></span>}
+        {prov && <span>· {prov}</span>}
+        {it.goal && <button onClick={() => nav('goals', it.goal!.id)} className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 hover:text-foreground"><Target className="h-3 w-3" />{it.goal.title}</button>}
+        {typeof it.costUsd === 'number' && it.costUsd > 0 && <span className="tabular-nums">${it.costUsd.toFixed(2)}</span>}
+        <span className="tabular-nums">{timeAgo(it.ts)}</span>
+      </div>
+    )
+  }
+
+  const decisionActions = (it: FeedItem) => {
+    const isApproval = it.kind.startsWith('approval')
+    const isQuestion = it.kind.startsWith('question')
+    if (isApproval) {
+      if (!canApprove(me.role, (it.level as 'head' | 'owner') ?? 'owner'))
+        return <div className="mt-2 text-xs text-muted-foreground">Waiting on an {it.level ?? 'owner'}-level approver.</div>
+      return (
+        <div className="mt-2 flex gap-2">
+          <Button size="sm" className="h-7 px-2.5 text-xs" disabled={busy.has(it.uid)} onClick={() => decide(it, true)}><Check className="mr-1 h-3.5 w-3.5" />Approve</Button>
+          <Button size="sm" variant="destructive" className="h-7 px-2.5 text-xs" disabled={busy.has(it.uid)} onClick={() => decide(it, false)}><X className="mr-1 h-3.5 w-3.5" />Deny</Button>
+          <Button size="sm" variant="ghost" className="h-7 px-2.5 text-xs" onClick={() => nav('sessions', it.runId)}>Open</Button>
+        </div>
+      )
+    }
+    if (isQuestion) {
+      if (replyTo === it.uid) return (
+        <div className="mt-2 flex flex-col gap-2">
+          <Textarea autoFocus value={replyText} onChange={(e) => setReplyText(e.target.value)} rows={2} placeholder="Your answer…" className="text-sm" />
+          <div className="flex gap-2">
+            <Button size="sm" className="h-7 px-2.5 text-xs" disabled={busy.has(it.uid) || !replyText.trim()} onClick={() => sendReply(it)}><Send className="mr-1 h-3.5 w-3.5" />Send</Button>
+            <Button size="sm" variant="ghost" className="h-7 px-2.5 text-xs" onClick={() => { setReplyTo(null); setReplyText('') }}>Cancel</Button>
+          </div>
+        </div>
+      )
+      return (
+        <div className="mt-2 flex gap-2">
+          <Button size="sm" className="h-7 px-2.5 text-xs" disabled={busy.has(it.uid)} onClick={() => { setReplyTo(it.uid); setReplyText('') }}><Send className="mr-1 h-3.5 w-3.5" />Reply</Button>
+          <Button size="sm" variant="ghost" className="h-7 px-2.5 text-xs" onClick={() => nav('sessions', it.runId)}>Open thread</Button>
+        </div>
+      )
+    }
+    return null
+  }
+
+  const trailBlock = (it: FeedItem) => {
+    if (!it.hasTrail) return null
+    const t = trails[it.runId]
+    return (
+      <div className="mt-2">
+        <button onClick={() => toggleTrail(it.runId)} className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground">
+          {t ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+          {t ? 'Hide history' : 'Show history'}
+        </button>
+        {t === 'loading' && <div className="mt-1 pl-4 text-xs text-muted-foreground">Loading…</div>}
+        {Array.isArray(t) && (
+          t.length === 0
+            ? <div className="mt-1 pl-4 text-xs text-muted-foreground">No recorded steps.</div>
+            : <ol className="mt-2 space-y-2 border-l border-border pl-3.5">
+                {t.map((s, i) => (
+                  <li key={i} className="relative text-xs">
+                    <span className={`absolute -left-[18px] top-1 h-2 w-2 rounded-full ${s.source === 'task' ? 'bg-emerald-500' : 'bg-muted-foreground/50'}`} />
+                    <span className="font-medium text-foreground/80">{trailLabel(s)}</span>
+                    {s.author && <span className="text-muted-foreground"> · {principalLabel(s.author, members)}</span>}
+                    <span className="ml-1 tabular-nums text-muted-foreground">{timeAgo(s.ts)}</span>
+                  </li>
+                ))}
+              </ol>
+        )}
+      </div>
+    )
+  }
+
+  const line = (it: FeedItem) => {
+    const isDecision = it.state === 'decision'
+    const isQuestion = it.kind.startsWith('question')
+    const body = (
+      <>
+        {isDecision ? (
+          <div className={`rounded-lg border px-3 py-2.5 ${isQuestion ? 'border-sky-300 bg-sky-50/40 dark:border-sky-500/30 dark:bg-sky-500/5' : 'border-amber-300 bg-amber-50/40 dark:border-amber-500/30 dark:bg-amber-500/5'}`}>
+            <div className={`text-[11px] font-medium uppercase tracking-wide ${isQuestion ? 'text-sky-600' : 'text-amber-600'}`}>
+              {isQuestion ? 'Question' : `Approval${it.capability ? ` · ${it.capability}` : ''}`}
+            </div>
+            <div className="mt-1 text-sm">
+              {isQuestion ? <><span className="font-medium">{it.agent}</span> asked: “{it.title}”</> : it.title}
+            </div>
+            {attribution(it)}
+            {decisionActions(it)}
+          </div>
+        ) : (
+          <div>
+            <div className="text-sm"><span className="font-medium">{it.agent}</span>{it.title ? <span className="text-foreground/90"> · {it.title}</span> : null}</div>
+            {attribution(it)}
+            {trailBlock(it)}
+          </div>
+        )}
+      </>
+    )
+    return (
+      <div key={it.uid} className="flex gap-3">
+        <div className="flex flex-col items-center">
+          <span className="grid h-7 w-7 shrink-0 place-items-center rounded-lg bg-muted/60">
+            <RoleIcon role={feedItemRole(it)} label={it.kind} className="h-4 w-4" />
+          </span>
+          <span className="w-px flex-1 bg-border" />
+        </div>
+        <div className="min-w-0 flex-1 pb-4">{body}</div>
+      </div>
+    )
+  }
+
+  // ── goals lens grouping ──
+  const goalGroups: { id: string; title: string; items: FeedItem[] }[] = []
+  if (lens === 'goals') {
+    const idx = new Map<string, number>()
+    for (const it of items) {
+      const gid = it.goal?.id ?? '__none__'
+      let i = idx.get(gid)
+      if (i === undefined) { i = goalGroups.length; idx.set(gid, i); goalGroups.push({ id: gid, title: it.goal?.title ?? 'Not linked to a goal', items: [] }) }
+      goalGroups[i].items.push(it)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl">
+      {/* controls: lens + (feed-only) filters */}
+      <div className="sticky top-0 z-10 -mx-1 mb-3 flex flex-wrap items-center gap-2 bg-background/85 px-1 py-2 backdrop-blur">
+        <div className="inline-flex rounded-lg border border-border bg-muted/40 p-0.5">
+          <button onClick={() => setLens('feed')} className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium ${lens === 'feed' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground'}`}><List className="h-3.5 w-3.5" />Feed</button>
+          <button onClick={() => setLens('goals')} className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1 text-xs font-medium ${lens === 'goals' ? 'bg-card text-foreground shadow-sm' : 'text-muted-foreground'}`}><Target className="h-3.5 w-3.5" />Goals</button>
+        </div>
+        {lens === 'feed' && (
+          <div className="flex flex-wrap gap-1.5">
+            {FEED_FILTERS.map((f) => {
+              const n = f.countKey && counts ? counts[f.countKey] : undefined
+              const on = filter === f.key
+              const amber = f.key === 'needsYou'
+              return (
+                <button key={f.key} onClick={() => setFilter(f.key)}
+                  className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium ${on ? (amber ? 'border-transparent bg-amber-500/15 text-amber-600' : 'border-transparent bg-primary/10 text-primary') : 'border-border bg-card text-muted-foreground hover:text-foreground'}`}>
+                  {f.label}{typeof n === 'number' && n > 0 && <span className="tabular-nums opacity-80">{n}</span>}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* stream */}
+      {page === null ? (
+        <div className="py-16 text-center text-sm text-muted-foreground">Loading the fleet’s activity…</div>
+      ) : items.length === 0 ? (
+        <div className="py-16 text-center text-sm text-muted-foreground">
+          {filter === 'needsYou' ? 'Nothing needs you right now. The fleet is running itself.' : 'No activity to show.'}
+        </div>
+      ) : lens === 'feed' ? (
+        <>
+          {items.map(line)}
+          {page.nextCursor && (
+            <div className="pt-2 text-center">
+              <Button size="sm" variant="ghost" className="text-xs text-muted-foreground" onClick={() => setLimit((l) => l + 40)}>Load more</Button>
+            </div>
+          )}
+        </>
+      ) : (
+        <div className="space-y-3">
+          {goalGroups.map((g) => {
+            const pct = g.id !== '__none__' ? progress[g.id]?.percent : undefined
+            return (
+              <details key={g.id} open className="group overflow-hidden rounded-xl border border-border bg-muted/20">
+                <summary className="flex cursor-pointer list-none items-center gap-3 px-4 py-3">
+                  <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+                  {g.id !== '__none__' ? <Target className="h-4 w-4 shrink-0 text-muted-foreground" /> : <List className="h-4 w-4 shrink-0 text-muted-foreground" />}
+                  <span className="truncate font-semibold">{g.title}</span>
+                  <span className="ml-auto flex items-center gap-3">
+                    {typeof pct === 'number' && (
+                      <span className="hidden items-center gap-2 sm:flex">
+                        <span className="h-1.5 w-24 overflow-hidden rounded-full bg-muted"><span className="block h-full rounded-full bg-emerald-500" style={{ width: `${pct}%` }} /></span>
+                        <span className="w-9 text-right text-xs tabular-nums text-muted-foreground">{pct}%</span>
+                      </span>
+                    )}
+                    <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{g.items.length}</Badge>
+                  </span>
+                </summary>
+                <div className="border-t border-border bg-background px-4 pt-3">{g.items.map(line)}</div>
+              </details>
+            )
+          })}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1541,6 +1541,36 @@ export interface SessionChain {
   updatedAt: number
 }
 
+// ── Unified activity feed (os.feed) — one stream over sessions/approvals/questions. See docs/feed-plan.md.
+export type FeedFilter = 'all' | 'needsYou' | 'running' | 'done'
+/** One line in the stream. A running/finished session, or a pending/resolved approval or question —
+ *  all projected to this shape by the server's UNION view, with attribution joined onto every row. */
+export interface FeedItem {
+  uid: string // "<source>:<id>" — stable id + pagination tiebreak
+  ts: number
+  kind: string // session.running | session.done | approval.pending | approval.approved | question.pending | …
+  state: 'running' | 'done' | 'decision'
+  runId: string
+  agent: string | null
+  runAs: string | null // the accountable human (member id)
+  spawnedBy: string | null // raw provenance: "automation:…" | "task:…" | a member id | null
+  goal: { id: string; title: string } | null
+  title: string
+  ref: { table: string; id: string }
+  capability: string | null
+  level: string | null // head | owner (decisions)
+  args: unknown | null
+  status: string | null // pending | approved | rejected | cancelled | answered | <session status>
+  costUsd: number | null
+  outcome: string | null
+  rating: string | null
+  hasTrail: boolean
+}
+export interface FeedCounts { needsYou: number; running: number; doneToday: number }
+export interface FeedResponse { items: FeedItem[]; nextCursor: string | null; counts: FeedCounts }
+/** One step of a line's history, rebuilt from the append-only logs (audit_events ⋃ task_events). */
+export interface FeedTrailStep { ts: number; source: 'audit' | 'task'; kind: string; author: string | null; detail: unknown }
+
 export const api = {
   /** Current member, or null if not authenticated (401). Drives the login gate. */
   me: async (): Promise<Member | null> => {
@@ -1777,6 +1807,19 @@ export const api = {
   deleteTaskAttachment: (taskId: string, attId: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/tasks/${taskId}/attachments/${attId}`),
   /** Direct URL to an attachment's bytes (inline; for download/preview links). */
   taskAttachmentUrl: (taskId: string, attId: string) => `/api/tasks/${taskId}/attachments/${attId}/raw`,
+
+  /** One page of the unified activity feed. `goalId` scopes to the goal lens; `cursor` is keyset pagination. */
+  feed: (opts: { filter?: FeedFilter; goalId?: string; cursor?: string; limit?: number } = {}) => {
+    const qs = new URLSearchParams()
+    if (opts.filter && opts.filter !== 'all') qs.set('filter', opts.filter)
+    if (opts.goalId) qs.set('goal', opts.goalId)
+    if (opts.cursor) qs.set('cursor', opts.cursor)
+    if (opts.limit) qs.set('limit', String(opts.limit))
+    const q = qs.toString()
+    return call<FeedResponse>('GET', '/api/feed' + (q ? '?' + q : ''))
+  },
+  /** The step-by-step history behind one feed line, rebuilt from the append-only logs. */
+  feedTrail: (runId: string) => call<{ steps: FeedTrailStep[] }>('GET', `/api/feed/${runId}/trail`),
 
   goals: (q = '', status = '') => call<{ goals: Goal[]; counts: GoalCounts; progress: Record<string, GoalProgress>; autoPlan?: boolean }>('GET', `/api/goals?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
   setAutoPlanGoals: (on: boolean) => call<{ ok: boolean; autoPlan?: boolean; error?: string }>('POST', '/api/goals/autoplan', { on }),


### PR DESCRIPTION
## What

The console surface for the `/api/feed` backend (v0.348.0, #639). One page that renders the fleet's activity as a single time-ordered stream, replacing the need to reconcile inbox · tasks · sessions · notifications.

## The page

- **Two lenses** (toggle top-left): **Feed** (by time) and **Goals** (the same lines grouped by outcome — each goal collapsible with its rolled-up progress bar from `api.goals`).
- **Attribution on every line**: the agent, the human it *runs as* (avatar + name via `PrincipalTag`), a provenance hint (*via automation/task/chat*), and a clickable goal tag → `nav('goals', id)`.
- **Decisions inline**: amber cards for approvals, sky for questions. **Approve/Deny** gated by `canApprove(me.role, level)` (else a "waiting on an owner-level approver" note); **Reply** opens an inline textarea → `api.answerQuestion`. Both resolve optimistically and fall off the 4s poll.
- **History that doesn't disappear**: a resolved/finished line has a **Show history** toggle that lazy-loads its trail from `/api/feed/:runId/trail` (append-only `audit_events` ⋃ `task_events`).
- **Filters + pagination**: chips (All · Needs you · Running · Done) with live counts; keyset **Load more**.

Reuses the existing design system — the cross-domain `RoleIcon` status glyph, `roleChip` tints, `MemberAvatar`/`PrincipalTag`, `timeAgo` — so it reads as native console, not a bolt-on.

## Wiring

- `web/src/lib/api.ts`: `FeedItem`/`FeedResponse`/`FeedCounts`/`FeedTrailStep` types + `api.feed()` / `api.feedTrail()`.
- `web/src/App.tsx`: new `FeedPage`, `'feed'` added to `Route`/`ROUTES`/`ROUTE_TITLES`, a pinned-by-default nav item, and the render case.

## Verification

- `cd web && npm run build` — `tsc -b` clean (component type-checks against the real API types) + vite bundle OK.
- Backend it calls is already store-tested (`scripts/feed-smoke.cjs`, merged in #639) and the route handler is a thin wrapper.
- **UI is verified by typecheck + build; the definitive visual check is on make-live in the browser** — a full HTTP+auth+registry harness was disproportionate for this slice. Recommend an eyeball pass after deploy.

## Next

Fold the surviving `messages` cases (`type='update'`, audience-addressed notifications) into the stream so the old inbox can retire as a read path.

See `docs/feed-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)