### PR TITLE
feat(feed): fold messages notifications into the stream; goals lens default (v0.350.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.350.0] — 2026-08-14
+### Added
+- **The feed folds in the `messages` notification class, and the Goals lens is the default.** Two changes
+  to the activity feed (v0.348/0.349):
+  - **Notifications/updates now appear in the stream.** A fourth `UNION` branch in `FeedStore` folds the
+    surviving `messages` cards — `update` (an agent's progress note), `notification` (a session-less
+    `notify`/system card), `task` (a Tasks notification) and `artifact` (a published deliverable) — into
+    the feed under a new `state='info'` (an ambient event, neither a decision nor running/done). It
+    deliberately excludes `approval`/`question` (their own branches) and `completed` (it duplicates the
+    session's `done` line), and drops dismissed cards. Visibility reproduces `TerminalManager.canViewMsg`
+    exactly in SQL — the branch projects a `member`-audience target (`aud_member`) and the non-admin scope
+    ORs it with the session's `run_as`/`spawned_by`, so a card is visible to its addressed member OR the
+    session's human, owner/admin see all. So the old inbox is no longer a separate read surface — the one
+    stream carries it. `scripts/feed-smoke.cjs` gains coverage for the fold + the audience scope.
+  - **Goals is now the default lens, collapsed.** Opening the Feed shows the outcome-first view with every
+    goal section collapsed (a clean overview — title, progress, count), plus a one-click **Expand all /
+    Collapse all** toggle. The Feed (by-time) lens and its filters are one click away.
+  See `docs/feed-plan.md`.
+
 ## [0.349.0] — 2026-08-14
 ### Added
 - **The Feed page — the console surface for the unified activity stream (v0.348.0 backend).** A new

--- a/docs/feed-plan.md
+++ b/docs/feed-plan.md
@@ -82,8 +82,21 @@ tiebreak across the union.
 ordering, attribution/goal joins, JSON arg parsing, counts, every filter, the goal lens, viewer scoping,
 keyset pagination, and the trail.
 
+## Folded: the `messages` notification class (v0.350.0)
+
+A fourth union branch folds the notification/update cards from `messages` into the stream, so the old
+inbox is no longer a separate read path:
+
+- **Included** — `update` (an agent's progress note), `notification` (a session-less `notify`/system
+  card), `task` (a Tasks notification), `artifact` (a published deliverable). All carry the new
+  `state = 'info'` (neither a decision nor running/done — an ambient event).
+- **Excluded** — `approval` and `question` (their own branches already cover them), and `completed`
+  (it duplicates the session's own `done` line). Dismissed cards (`dismissed_at`) drop out.
+- **Visibility** mirrors `TerminalManager.canViewMsg` = `canViewAudience` OR `canViewRow`. The branch
+  projects an `aud_member` scope column (a `member`-audience card's target), and the outer non-admin
+  scope ORs it with the session's `run_as`/`spawned_by` — exactly reproducing the rule in SQL.
+
 ## Not in this slice
 
-The React console surface (the feed/goal-lens UI) and folding the surviving `messages` cases
-(`type='update'`, audience-addressed session-less notifications) into a fourth union branch. This slice
-is the backend view + endpoints the console will consume.
+Retiring the `messages` read path entirely (it remains the write-ahead for notifier delivery) and any
+per-member read/dismiss state on the feed itself.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.349.0",
+  "version": "0.350.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.349.0",
+      "version": "0.350.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.349.0",
+  "version": "0.350.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/feed-smoke.cjs
+++ b/scripts/feed-smoke.cjs
@@ -48,16 +48,38 @@ run(`INSERT INTO audit_events (ts,run_id,tenant,type,principal,data) VALUES (?,?
 run(`INSERT INTO task_events (id,task_id,kind,body,author,session_id,created_at) VALUES (?,?,?,?,?,?,?)`,
   'te1', 't1', 'status', 'doing→done', 'agent:pod-troubleshooter', 's_done', T(4));
 
+// --- folded message rows (notification/update class) ---
+// a session-less notification addressed to member m1 (aud_member scope)
+run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,audience_kind,audience_id,created_at) VALUES (?,?,?,?,?,?,?,?,?,?)`,
+  'n1', 'notification', '', 'system', 'Heads up', 'Nightly backup finished', 'open', 'member', 'm1', T(12));
+// an agent 'update' note on the running session (sessionOwner audience → scopes via the session)
+run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,audience_kind,audience_id,created_at) VALUES (?,?,?,?,?,?,?,?,?,?)`,
+  'u1', 'update', 's_run', 'support-triage', 'Task Update', 'Progress: 3 of 5 tickets done', 'open', 'sessionOwner', 's_run', T(15));
+// excluded: an 'approval' mirror (its own branch) and a 'completed' card (dupes session.done)
+run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,created_at) VALUES (?,?,?,?,?,?,?,?)`,
+  'x1', 'approval', 's_run', 'support-triage', 'Approval', '...', 'pending', T(13));
+run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,created_at) VALUES (?,?,?,?,?,?,?,?)`,
+  'x2', 'completed', 's_done', 'pod-troubleshooter', 'Done', '...', 'open', T(14));
+// excluded: a dismissed notification (a human hid it)
+run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,audience_kind,audience_id,dismissed_at,created_at) VALUES (?,?,?,?,?,?,?,?,?,?,?)`,
+  'd1', 'notification', '', 'system', 'Old', '...', 'open', 'member', 'm1', T(1), T(16));
+
 const feed = new FeedStore(db);
 const admin = { id: 'boss', isAdmin: true };
 const m1 = { id: 'm1', isAdmin: false };
 const m2 = { id: 'm2', isAdmin: false };
 
-// 1) admin sees all 5 items, newest first
+// 1) admin sees the 5 core items + 2 folded messages (n1, u1); the 3 excluded ones never appear
 const all = feed.list({ viewer: admin });
-assert.strictEqual(all.items.length, 5, `expected 5 items, got ${all.items.length}`);
-const order = all.items.map((i) => i.uid);
-assert.deepStrictEqual(order, ['question:q_pend', 'approval:a_pend', 'session:s_run', 'approval:a_res', 'session:s_done'], `bad order: ${order}`);
+assert.strictEqual(all.items.length, 7, `expected 7 items, got ${all.items.length}`);
+assert.deepStrictEqual(all.items.slice(0, 5).map((i) => i.uid), ['question:q_pend', 'approval:a_pend', 'session:s_run', 'approval:a_res', 'session:s_done'], 'core ordering changed');
+const uids = new Set(all.items.map((i) => i.uid));
+assert.ok(uids.has('message:n1') && uids.has('message:u1'), 'folded notification/update missing');
+assert.ok(!uids.has('message:x1') && !uids.has('message:x2') && !uids.has('message:d1'), 'excluded/dismissed message leaked into feed');
+// folded rows carry the info state + their content as the title
+const n1 = all.items.find((i) => i.uid === 'message:n1');
+assert.strictEqual(n1.state, 'info');
+assert.strictEqual(n1.title, 'Nightly backup finished');
 
 // 2) attribution + goal tag resolved on the done session
 const doneItem = all.items.find((i) => i.uid === 'session:s_done');
@@ -90,9 +112,9 @@ const g1 = feed.list({ viewer: admin, goalId: 'g1' });
 assert.strictEqual(g1.items.length, 2, `goal filter items=${g1.items.length}`);
 assert.deepStrictEqual(g1.items.map((i) => i.uid).sort(), ['approval:a_res', 'session:s_done']);
 
-// 7) scoping — m1 owns everything, m2 owns nothing
-assert.strictEqual(feed.list({ viewer: m1 }).items.length, 5, 'run-as owner should see own rows');
-assert.strictEqual(feed.list({ viewer: m2 }).items.length, 0, 'a stranger should see nothing');
+// 7) scoping — m1 owns everything + is the audience of n1/u1 (7); m2 owns nothing and is addressed by nothing (0)
+assert.strictEqual(feed.list({ viewer: m1 }).items.length, 7, 'owner/addressee should see own rows + member-audience cards');
+assert.strictEqual(feed.list({ viewer: m2 }).items.length, 0, 'a stranger should see nothing (incl. member-audience cards for others)');
 assert.strictEqual(feed.counts(m2, 0).needsYou, 0, 'stranger needsYou must be 0');
 
 // 8) keyset pagination
@@ -112,4 +134,4 @@ assert.strictEqual(steps[0].kind, 'approval.requested');
 assert.strictEqual(steps[2].kind, 'task.status');
 assert.strictEqual(steps[1].detail.approved, true, 'audit detail should be parsed JSON');
 
-console.log('✓ feed smoke: 9 groups passed');
+console.log('✓ feed smoke: 9 groups passed (incl. folded message rows + audience scope)');

--- a/src/state/feed.ts
+++ b/src/state/feed.ts
@@ -26,7 +26,7 @@ export interface FeedItem {
   uid: string; // "<source>:<id>" — unique + the keyset-pagination tiebreak
   ts: number; // epoch ms, the sort key
   kind: string; // session.running | session.done | approval.pending | approval.approved | question.pending | …
-  state: 'running' | 'done' | 'decision';
+  state: 'running' | 'done' | 'decision' | 'info';
   // attribution — always resolved, the thing the old inbox lacked
   runId: string;
   agent: string | null;
@@ -70,7 +70,7 @@ export interface TrailStep {
 interface FeedRow {
   ts: number;
   uid: string;
-  state: 'running' | 'done' | 'decision';
+  state: 'running' | 'done' | 'decision' | 'info';
   kind: string;
   run_id: string;
   ref_table: string;
@@ -88,6 +88,7 @@ interface FeedRow {
   cost_usd: number | null;
   outcome: string | null;
   rating: string | null;
+  aud_member: string | null; // scope-only: a 'member'-audience card's target member id (never returned)
 }
 
 /**
@@ -108,7 +109,8 @@ WITH feed AS (
     t.goal_id AS goal_id, g.title AS goal_title,
     COALESCE(NULLIF(s.report_summary,''), s.title) AS title,
     NULL AS capability, NULL AS level, NULL AS args,
-    s.status AS status, s.cost_usd AS cost_usd, s.outcome AS outcome, s.rating AS rating
+    s.status AS status, s.cost_usd AS cost_usd, s.outcome AS outcome, s.rating AS rating,
+    NULL AS aud_member
   FROM term_sessions s
   LEFT JOIN tasks t ON t.last_session_id = s.id
   LEFT JOIN goals g ON g.id = t.goal_id
@@ -125,7 +127,8 @@ WITH feed AS (
     t.goal_id AS goal_id, g.title AS goal_title,
     a.reason AS title,
     a.capability AS capability, a.level AS level, a.args AS args,
-    a.status AS status, NULL AS cost_usd, NULL AS outcome, NULL AS rating
+    a.status AS status, NULL AS cost_usd, NULL AS outcome, NULL AS rating,
+    NULL AS aud_member
   FROM approvals a
   LEFT JOIN term_sessions s ON s.id = a.run_id
   LEFT JOIN tasks t ON t.last_session_id = s.id
@@ -142,11 +145,38 @@ WITH feed AS (
     t.goal_id AS goal_id, g.title AS goal_title,
     q.prompt AS title,
     NULL AS capability, NULL AS level, NULL AS args,
-    q.status AS status, NULL AS cost_usd, NULL AS outcome, NULL AS rating
+    q.status AS status, NULL AS cost_usd, NULL AS outcome, NULL AS rating,
+    NULL AS aud_member
   FROM questions q
   LEFT JOIN term_sessions s ON s.id = q.run_id
   LEFT JOIN tasks t ON t.last_session_id = s.id
   LEFT JOIN goals g ON g.id = t.goal_id
+
+  UNION ALL
+  -- 4 ── MESSAGES: the notification/update class the other three don't cover — an agent's 'update' note,
+  -- a session-less 'notification'/'task' card, a published 'artifact'. NOT 'approval'/'question' (their
+  -- own branches) nor 'completed' (it duplicates the session's done line). Visibility mirrors canViewMsg:
+  -- the session's human (run_as/spawned_by, like every branch) OR a 'member'-audience card's target
+  -- (aud_member) — the outer scope ORs both. Dismissed cards drop out.
+  SELECT
+    m.created_at AS ts,
+    'message:' || m.id AS uid,
+    'info' AS state,
+    'message.' || m.type AS kind,
+    m.session_id AS run_id, 'messages' AS ref_table, m.id AS ref_id,
+    m.agent AS agent,
+    COALESCE(s.run_as, CASE WHEN m.audience_kind='member' THEN m.audience_id END) AS run_as,
+    s.spawned_by AS spawned_by,
+    t.goal_id AS goal_id, g.title AS goal_title,
+    CASE WHEN m.type IN ('update','notification') THEN COALESCE(NULLIF(m.body,''), m.title) ELSE m.title END AS title,
+    NULL AS capability, NULL AS level, NULL AS args,
+    m.status AS status, NULL AS cost_usd, m.outcome AS outcome, NULL AS rating,
+    CASE WHEN m.audience_kind='member' THEN m.audience_id ELSE NULL END AS aud_member
+  FROM messages m
+  LEFT JOIN term_sessions s ON s.id = m.session_id
+  LEFT JOIN tasks t ON t.last_session_id = s.id
+  LEFT JOIN goals g ON g.id = t.goal_id
+  WHERE m.type IN ('update','notification','task','artifact') AND m.dismissed_at IS NULL
 )`;
 
 export class FeedStore {
@@ -165,8 +195,17 @@ export class FeedStore {
 
     if (opts.goalId) { where.push('goal_id = ?'); params.push(opts.goalId); }
 
-    const scope = this.scopeSql('', opts.viewer);
-    if (scope.sql) { where.push(scope.sql); params.push(...scope.params); }
+    // Scope on the union: the session's human (run_as/spawned_by/own-automation) OR — for a folded
+    // message row — a 'member'-audience card addressed to the viewer (aud_member). Together this is
+    // exactly canViewSpawn/canViewRow OR canViewMsg's member branch. Owner/admin: no clause (see all).
+    if (!opts.viewer.isAdmin) {
+      const autos = this.myAutomations(opts.viewer.id);
+      const parts = ['run_as = ?', 'spawned_by = ?', 'aud_member = ?'];
+      const p: unknown[] = [opts.viewer.id, opts.viewer.id, opts.viewer.id];
+      if (autos.length) { parts.push(`spawned_by IN (${autos.map(() => '?').join(',')})`); p.push(...autos); }
+      where.push(`(${parts.join(' OR ')})`);
+      params.push(...p);
+    }
 
     const cur = parseCursor(opts.cursor);
     if (cur) { where.push('(ts < ? OR (ts = ? AND uid < ?))'); params.push(cur.ts, cur.ts, cur.uid); }
@@ -235,10 +274,7 @@ export class FeedStore {
    */
   private scopeSql(prefix: string, viewer: FeedViewer): { sql: string; params: unknown[] } {
     if (viewer.isAdmin) return { sql: '', params: [] };
-    const autoIds = this.db
-      .prepare('SELECT id FROM automations WHERE created_by = ?')
-      .all<{ id: string }>(viewer.id)
-      .map((a) => `automation:${a.id}`);
+    const autoIds = this.myAutomations(viewer.id);
     const parts = [`${prefix}run_as = ?`, `${prefix}spawned_by = ?`];
     const params: unknown[] = [viewer.id, viewer.id];
     if (autoIds.length) {
@@ -246,6 +282,14 @@ export class FeedStore {
       params.push(...autoIds);
     }
     return { sql: `(${parts.join(' OR ')})`, params };
+  }
+
+  /** The viewer's own automations, as `automation:<id>` provenance strings (for the scope clause). */
+  private myAutomations(viewerId: string): string[] {
+    return this.db
+      .prepare('SELECT id FROM automations WHERE created_by = ?')
+      .all<{ id: string }>(viewerId)
+      .map((a) => `automation:${a.id}`);
   }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5262,6 +5262,7 @@ const FEED_FILTERS: { key: FeedFilter; label: string; countKey?: keyof FeedRespo
 
 /** Map a feed line to the cross-domain status role (drives its glyph + tone). */
 function feedItemRole(it: FeedItem): StatusRole {
+  if (it.state === 'info') return 'ended'
   if (it.state === 'decision') return 'needsHuman'
   if (it.state === 'running') return 'busy'
   if (it.kind === 'approval.rejected' || it.outcome === 'failure' || it.kind === 'session.crashed') return 'failed'
@@ -5293,8 +5294,9 @@ function trailLabel(step: FeedTrailStep): string {
 }
 
 function FeedPage({ me, members, nav }: { me: Member; members: Member[]; nav: (r: Route, detail?: string) => void }) {
-  const [lens, setLens] = useState<'feed' | 'goals'>('feed')
+  const [lens, setLens] = useState<'feed' | 'goals'>('goals')
   const [filter, setFilter] = useState<FeedFilter>('all')
+  const [openGoals, setOpenGoals] = useState<Set<string>>(new Set()) // goal sections start collapsed
   const [limit, setLimit] = useState(40)
   const [page, setPage] = useState<FeedResponse | null>(null)
   const [progress, setProgress] = useState<Record<string, GoalProgress>>({})
@@ -5438,7 +5440,11 @@ function FeedPage({ me, members, nav }: { me: Member; members: Member[]; nav: (r
           </div>
         ) : (
           <div>
-            <div className="text-sm"><span className="font-medium">{it.agent}</span>{it.title ? <span className="text-foreground/90"> · {it.title}</span> : null}</div>
+            <div className="text-sm">
+              {it.agent && <span className="font-medium">{it.agent}</span>}
+              {it.agent && it.title && <span className="text-muted-foreground"> · </span>}
+              {it.title && <span className="text-foreground/90">{it.title}</span>}
+            </div>
             {attribution(it)}
             {trailBlock(it)}
           </div>
@@ -5469,6 +5475,7 @@ function FeedPage({ me, members, nav }: { me: Member; members: Member[]; nav: (r
       goalGroups[i].items.push(it)
     }
   }
+  const allGoalsOpen = goalGroups.length > 0 && goalGroups.every((g) => openGoals.has(g.id))
 
   return (
     <div className="mx-auto max-w-3xl">
@@ -5493,6 +5500,12 @@ function FeedPage({ me, members, nav }: { me: Member; members: Member[]; nav: (r
             })}
           </div>
         )}
+        {lens === 'goals' && goalGroups.length > 0 && (
+          <Button size="sm" variant="ghost" className="ml-auto text-xs text-muted-foreground"
+            onClick={() => setOpenGoals(allGoalsOpen ? new Set() : new Set(goalGroups.map((g) => g.id)))}>
+            {allGoalsOpen ? 'Collapse all' : 'Expand all'}
+          </Button>
+        )}
       </div>
 
       {/* stream */}
@@ -5516,8 +5529,8 @@ function FeedPage({ me, members, nav }: { me: Member; members: Member[]; nav: (r
           {goalGroups.map((g) => {
             const pct = g.id !== '__none__' ? progress[g.id]?.percent : undefined
             return (
-              <details key={g.id} open className="group overflow-hidden rounded-xl border border-border bg-muted/20">
-                <summary className="flex cursor-pointer list-none items-center gap-3 px-4 py-3">
+              <details key={g.id} open={openGoals.has(g.id)} className="group overflow-hidden rounded-xl border border-border bg-muted/20">
+                <summary onClick={(e) => { e.preventDefault(); setOpenGoals((s) => { const n = new Set(s); n.has(g.id) ? n.delete(g.id) : n.add(g.id); return n }) }} className="flex cursor-pointer list-none items-center gap-3 px-4 py-3">
                   <ChevronRight className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
                   {g.id !== '__none__' ? <Target className="h-4 w-4 shrink-0 text-muted-foreground" /> : <List className="h-4 w-4 shrink-0 text-muted-foreground" />}
                   <span className="truncate font-semibold">{g.title}</span>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1548,8 +1548,8 @@ export type FeedFilter = 'all' | 'needsYou' | 'running' | 'done'
 export interface FeedItem {
   uid: string // "<source>:<id>" — stable id + pagination tiebreak
   ts: number
-  kind: string // session.running | session.done | approval.pending | approval.approved | question.pending | …
-  state: 'running' | 'done' | 'decision'
+  kind: string // session.running | session.done | approval.pending | question.pending | message.update | message.notification | …
+  state: 'running' | 'done' | 'decision' | 'info'
   runId: string
   agent: string | null
   runAs: string | null // the accountable human (member id)


### PR DESCRIPTION
## What

Two changes to the activity feed (builds on #639/#640).

### 1. The `messages` notification class folds into the stream

A fourth `UNION` branch in `FeedStore` folds the surviving inbox cards into the feed, so **the old inbox is no longer a separate read path**:

- **Included** — `update` (agent progress note), `notification` (session-less `notify`/system card), `task` (Tasks notification), `artifact` (published deliverable). All carry a new **`state='info'`** — an ambient event, neither a decision nor running/done.
- **Excluded** — `approval`/`question` (their own branches already cover them), `completed` (duplicates the session's `done` line). Dismissed cards drop out.
- **Visibility reproduces `TerminalManager.canViewMsg` exactly in SQL** (`canViewAudience` OR `canViewRow`): the branch projects a `member`-audience target (`aud_member`), and the non-admin scope ORs it with the session's `run_as`/`spawned_by`. So a card is visible to its addressed member OR the session's human; owner/admin see all.

### 2. Goals is the default lens, collapsed (requested)

Opening the Feed now shows the **outcome-first** view with every goal section **collapsed** (clean overview: title · progress · count), plus a one-click **Expand all / Collapse all** toggle. The by-time Feed lens and its filters are one click away. Folded notifications render as neutral `info` lines (null-agent handled).

## Verification

- `scripts/feed-smoke.cjs` extended: asserts `update`+`notification` fold in, `approval`/`completed`/dismissed stay out, `info` state + content-as-title, and the audience scope (m1 sees member-audience cards, m2 sees none). **9 groups pass.**
- Full `npm run test:governance` green; `cd web && npm run build` (tsc + vite) clean.
- UI visual check is on make-live.

## Next

Retire `messages` as a read path entirely (it stays the write-ahead for notifier delivery); optional per-member read/dismiss on the feed.

See `docs/feed-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)