### PR TITLE
feat(feed): live progress on running sessions + connect every line to its object (v0.352.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.352.0] — 2026-08-16
+### Added
+- **See what a running session is doing, and connect every feed line to its object.** Two related feed
+  improvements:
+  - **Live progress on running sessions.** Each `running` line now shows a one-liner of the newest thing
+    the agent just did — derived automatically from the audit tail via the same `classifyActivity` the
+    activity trail uses (with the un-audited `update` note as a fallback), refreshed by the 4s poll. You
+    can watch a session advance ("Ran: npm test", "Edited src/…", "Reported: …") without opening its
+    terminal; on finish the run's report summary is the line. Exposed as `FeedItem.lastActivity`,
+    enriched in the `/api/feed` handler and bounded to the page's running items.
+  - **Lines connect to what they're about.** New `FeedItem.target` decodes the real object behind a line
+    (`feedTarget`): a session/approval/question → its session; a folded message card → its encoded
+    `session_id` (`task:<id>` → the task, `goal:<id>` → the goal). So a *"Task done"* card now opens its
+    **task** and names it — *"Task done — Write the API reference"* — instead of a generic headline
+    pointing at a dead run id. The console's Open action routes by target kind (task/goal/session/artifact).
+  `feed-smoke` covers the target decode + combined task title. See `docs/feed-plan.md`.
+
 ## [0.351.0] — 2026-08-14
 ### Changed
 - **Feed page polish from live use.** Several refinements to how a line reads and how the page remembers you:

--- a/docs/feed-plan.md
+++ b/docs/feed-plan.md
@@ -96,6 +96,20 @@ inbox is no longer a separate read path:
   projects an `aud_member` scope column (a `member`-audience card's target), and the outer non-admin
   scope ORs it with the session's `run_as`/`spawned_by` — exactly reproducing the rule in SQL.
 
+## Live progress + connected lines (v0.352.0)
+
+- **What a running session is doing right now.** The `/api/feed` handler enriches each `running` item
+  with `lastActivity` — the newest legible thing the agent did, from `latestActivity()`: it scans the
+  audit tail newest-first through the same `classifyActivity` the activity trail uses (first non-noise
+  primitive wins), falling back to the latest `update` note. The console shows it as a live one-liner
+  under the title, refreshed by the 4s poll — visibility without opening the terminal. On finish, the
+  run's `report_summary` is already the line.
+- **Every line connects to its object.** `FeedItem.target` (`feedTarget()`) decodes what a line is
+  *about* from its kind + run id: session/approval/question → the session; a folded message card → its
+  encoded `session_id` (`task:<id>` → the task, `goal:<id>` → the goal, a real id → the session). So a
+  "Task done" card now opens its **task** and names it (the card's event + the task title, e.g.
+  *"Task done — Write the API reference"*) instead of pointing at a dead run id.
+
 ## Not in this slice
 
 Retiring the `messages` read path entirely (it remains the write-ahead for notifier delivery) and any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.351.0",
+  "version": "0.352.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.351.0",
+      "version": "0.352.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.351.0",
+  "version": "0.352.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/feed-smoke.cjs
+++ b/scripts/feed-smoke.cjs
@@ -55,6 +55,9 @@ run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,audience_k
 // an agent 'update' note on the running session (sessionOwner audience → scopes via the session)
 run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,audience_kind,audience_id,created_at) VALUES (?,?,?,?,?,?,?,?,?,?)`,
   'u1', 'update', 's_run', 'support-triage', 'Task Update', 'Progress: 3 of 5 tickets done', 'open', 'sessionOwner', 's_run', T(15));
+// a 'task' card: session_id encodes the real task (task:T9), body carries the task title
+run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,audience_kind,audience_id,created_at) VALUES (?,?,?,?,?,?,?,?,?,?)`,
+  'tk1', 'task', 'task:T9', 'docs-writer', 'Task done', 'Write the API reference', 'open', 'member', 'm1', T(11));
 // excluded: an 'approval' mirror (its own branch) and a 'completed' card (dupes session.done)
 run(`INSERT INTO messages (id,type,session_id,agent,title,body,status,created_at) VALUES (?,?,?,?,?,?,?,?)`,
   'x1', 'approval', 's_run', 'support-triage', 'Approval', '...', 'pending', T(13));
@@ -71,17 +74,23 @@ const admin = { id: 'boss', isAdmin: true };
 const m1 = { id: 'm1', isAdmin: false };
 const m2 = { id: 'm2', isAdmin: false };
 
-// 1) admin sees the 5 core items + 2 folded messages (n1, u1); the 3 excluded ones never appear
+// 1) admin sees the 5 core items + 3 folded messages (n1, u1, tk1); the 3 excluded ones never appear
 const all = feed.list({ viewer: admin });
-assert.strictEqual(all.items.length, 7, `expected 7 items, got ${all.items.length}`);
+assert.strictEqual(all.items.length, 8, `expected 8 items, got ${all.items.length}`);
 assert.deepStrictEqual(all.items.slice(0, 5).map((i) => i.uid), ['question:q_pend', 'approval:a_pend', 'session:s_run', 'approval:a_res', 'session:s_done'], 'core ordering changed');
 const uids = new Set(all.items.map((i) => i.uid));
-assert.ok(uids.has('message:n1') && uids.has('message:u1'), 'folded notification/update missing');
+assert.ok(uids.has('message:n1') && uids.has('message:u1') && uids.has('message:tk1'), 'folded notification/update/task missing');
 assert.ok(!uids.has('message:x1') && !uids.has('message:x2') && !uids.has('message:d1'), 'excluded/dismissed message leaked into feed');
 // folded rows carry the info state + their content as the title
 const n1 = all.items.find((i) => i.uid === 'message:n1');
 assert.strictEqual(n1.state, 'info');
 assert.strictEqual(n1.title, 'Nightly backup finished');
+// a task card connects to its real task (target) and names it (event — task title)
+const tk1 = all.items.find((i) => i.uid === 'message:tk1');
+assert.deepStrictEqual(tk1.target, { kind: 'task', id: 'T9' }, `task target=${JSON.stringify(tk1.target)}`);
+assert.strictEqual(tk1.title, 'Task done — Write the API reference');
+// core lines target their session
+assert.deepStrictEqual(all.items.find((i) => i.uid === 'session:s_run').target, { kind: 'session', id: 's_run' });
 
 // 2) attribution + goal tag resolved on the done session
 const doneItem = all.items.find((i) => i.uid === 'session:s_done');
@@ -116,7 +125,7 @@ assert.strictEqual(g1.items.length, 2, `goal filter items=${g1.items.length}`);
 assert.deepStrictEqual(g1.items.map((i) => i.uid).sort(), ['approval:a_res', 'session:s_done']);
 
 // 7) scoping — m1 owns everything + is the audience of n1/u1 (7); m2 owns nothing and is addressed by nothing (0)
-assert.strictEqual(feed.list({ viewer: m1 }).items.length, 7, 'owner/addressee should see own rows + member-audience cards');
+assert.strictEqual(feed.list({ viewer: m1 }).items.length, 8, 'owner/addressee should see own rows + member-audience cards');
 assert.strictEqual(feed.list({ viewer: m2 }).items.length, 0, 'a stranger should see nothing (incl. member-audience cards for others)');
 assert.strictEqual(feed.counts(m2, 0).needsYou, 0, 'stranger needsYou must be 0');
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2708,6 +2708,10 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       cursor: url.searchParams.get('cursor') || undefined,
       limit: Number(url.searchParams.get('limit')) || 40,
     });
+    // Live progress: for the RUNNING lines, attach the newest thing the agent just did (classified from
+    // the audit tail, with the un-audited `update` note as a fallback), so a viewer can watch a session
+    // advance without opening its terminal. Bounded to the running items on the page (a handful).
+    for (const it of page.items) if (it.state === 'running') it.lastActivity = latestActivity(os, it.runId);
     const now = new Date();
     const dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
     return sendJson(res, 200, { ...page, counts: os.feed.counts(viewer, dayStart) });
@@ -6411,6 +6415,23 @@ function runView(r: Run) {
 /** Parse a stored JSON column, degrading to a `{ raw }` wrapper rather than throwing on bad data. */
 function safeJson(s: string): Record<string, unknown> {
   try { const v = JSON.parse(s); return v && typeof v === 'object' ? v : { value: v }; } catch { return { raw: s }; }
+}
+/** The newest legible thing a run did — powers the feed's live "currently…" line on a running session.
+ *  Scans the audit tail newest-first for the first non-noise primitive (same classifier the activity
+ *  trail uses); falls back to the latest `update` note (the one primitive that isn't audited). Null when
+ *  nothing legible has happened yet. Bounded LIMIT so it's cheap to call per running item each poll. */
+function latestActivity(os: AgentOS, runId: string): { primitive: string; summary: string; ts: number } | null {
+  const rows = os.db
+    .prepare('SELECT ts, type, data FROM audit_events WHERE tenant = ? AND run_id = ? ORDER BY ts DESC, id DESC LIMIT 15')
+    .all<{ ts: number; type: string; data: string }>(os.tenant, runId);
+  for (const r of rows) {
+    const d = classifyActivity(r.type, safeJson(r.data));
+    if (d) return { primitive: d.primitive, summary: clipText(d.summary, 140), ts: r.ts };
+  }
+  const u = os.db
+    .prepare("SELECT created_at AS ts, body FROM messages WHERE session_id = ? AND type = 'update' ORDER BY created_at DESC LIMIT 1")
+    .get<{ ts: number; body: string }>(runId);
+  return u ? { primitive: 'update', summary: clipText(u.body, 140), ts: u.ts } : null;
 }
 /** Resolve the requested inbox scope from `?scope=`. Only owner/admin may see the `all` oversight view;
  *  a member is always pinned to `mine` (they can't see others' cards regardless, so this just keeps the

--- a/src/state/feed.ts
+++ b/src/state/feed.ts
@@ -47,6 +47,25 @@ export interface FeedItem {
   outcome: string | null;
   rating: string | null;
   hasTrail: boolean; // resolved/finished → the step-by-step history is fetchable
+  // the live object this line is ABOUT — so a click connects to it (a task card → its task, not a
+  // dead "session" id). Decoded from provenance/session_id; null for a session-less notification.
+  target: { kind: 'session' | 'task' | 'goal' | 'artifact'; id: string } | null;
+  // for a RUNNING session: the newest thing the agent just did, so you can watch progress without
+  // opening the terminal. Enriched by the route (classifyActivity over the audit tail); null otherwise.
+  lastActivity?: { primitive: string; summary: string; ts: number } | null;
+}
+
+/** Decode the object a feed line points at from its kind + run id. Session/approval/question lines are
+ *  about their session; a folded message card encodes its real target in `session_id` (`task:<id>`,
+ *  `goal:<id>`, a real session id, or blank for a session-less notification). */
+export function feedTarget(kind: string, runId: string): FeedItem['target'] {
+  if (kind.startsWith('session') || kind.startsWith('approval') || kind.startsWith('question'))
+    return runId ? { kind: 'session', id: runId } : null;
+  // message.* — runId is the card's session_id
+  if (runId.startsWith('task:')) return { kind: 'task', id: runId.slice(5) };
+  if (runId.startsWith('goal:')) return { kind: 'goal', id: runId.slice(5) };
+  if (runId && !runId.includes(':')) return { kind: 'session', id: runId }; // a real session (e.g. an update)
+  return null;
 }
 
 export interface FeedPage {
@@ -170,7 +189,10 @@ WITH feed AS (
     COALESCE(s.run_as, CASE WHEN m.audience_kind='member' THEN m.audience_id END) AS run_as,
     s.spawned_by AS spawned_by,
     t.goal_id AS goal_id, g.title AS goal_title,
-    CASE WHEN m.type IN ('update','notification') THEN COALESCE(NULLIF(m.body,''), m.title) ELSE m.title END AS title,
+    CASE
+      WHEN m.type IN ('update','notification') THEN COALESCE(NULLIF(m.body,''), m.title)
+      WHEN NULLIF(m.body,'') IS NOT NULL THEN m.title || ' — ' || m.body
+      ELSE m.title END AS title,
     NULL AS capability, NULL AS level, NULL AS args,
     m.status AS status, NULL AS cost_usd, NULL AS tokens, m.outcome AS outcome, NULL AS rating,
     CASE WHEN m.audience_kind='member' THEN m.audience_id ELSE NULL END AS aud_member
@@ -321,6 +343,7 @@ function mapRow(r: FeedRow): FeedItem {
     goal: r.goal_id ? { id: r.goal_id, title: r.goal_title ?? '(untitled goal)' } : null,
     title: r.title ?? '',
     ref: { table: r.ref_table, id: r.ref_id },
+    target: feedTarget(r.kind, r.run_id),
     capability: r.capability,
     level: r.level,
     args: r.args ? safeParse(r.args) : null,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5352,12 +5352,19 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
     await api.answerQuestion(it.ref.id, text).catch(() => {})
     markBusy(it.uid, false); load()
   }
-  // Open the associated session: its live terminal if we still have the row, else the Sessions page.
-  const canOpen = (it: FeedItem): boolean => Boolean(it.runId) && (sessionById.has(it.runId) || isSessionKind(it))
-  const openSession = (it: FeedItem) => {
-    const s = sessionById.get(it.runId)
-    if (s) onOpen(s.tmux, s.title || it.agent || 'Session')
-    else nav('sessions', it.runId)
+  // Connect the line to the real object it's about — a task card opens its task, a session opens its
+  // live terminal (or the Sessions page), a goal opens the goal. This is the "everything connects" bit.
+  const canOpen = (it: FeedItem): boolean => it.target !== null
+  const openTarget = (it: FeedItem) => {
+    const t = it.target
+    if (!t) return
+    if (t.kind === 'session') {
+      const s = sessionById.get(t.id)
+      if (s) onOpen(s.tmux, s.title || it.agent || 'Session')
+      else nav('sessions', t.id)
+    } else if (t.kind === 'task') nav('tasks', t.id)
+    else if (t.kind === 'goal') nav('goals', t.id)
+    else if (t.kind === 'artifact') nav('artifacts', t.id)
   }
   const toggleExpand = (uid: string) => setExpanded((s) => { const n = new Set(s); n.has(uid) ? n.delete(uid) : n.add(uid); return n })
 
@@ -5394,7 +5401,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
         {it.goal && <button onClick={() => nav('goals', it.goal!.id)} className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 hover:text-foreground"><Target className="h-3 w-3" />{it.goal.title}</button>}
         {typeof it.tokens === 'number' && it.tokens > 0 && <span className="tabular-nums">{formatTokenCount(it.tokens)}</span>}
         <span className="tabular-nums">{timeAgo(it.ts)}</span>
-        {canOpen(it) && <button onClick={() => openSession(it)} className="inline-flex items-center gap-1 hover:text-foreground"><ExternalLink className="h-3 w-3" />Open</button>}
+        {canOpen(it) && <button onClick={() => openTarget(it)} className="inline-flex items-center gap-1 hover:text-foreground"><ExternalLink className="h-3 w-3" />{it.target && it.target.kind !== 'session' ? `Open ${it.target.kind}` : 'Open'}</button>}
       </div>
     )
   }
@@ -5447,6 +5454,13 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
     ) : (
       <div>
         {snippet(it)}
+        {/* live progress: what the agent is doing right now, refreshed by the poll (no terminal needed) */}
+        {it.state === 'running' && it.lastActivity && (
+          <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500 motion-safe:animate-pulse" />
+            <span className="min-w-0 truncate italic">{it.lastActivity.summary}</span>
+          </div>
+        )}
         {attribution(it)}
       </div>
     )

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1566,6 +1566,10 @@ export interface FeedItem {
   outcome: string | null
   rating: string | null
   hasTrail: boolean
+  /** The live object this line is about — a click connects to it (task card → its task, not a dead run id). */
+  target: { kind: 'session' | 'task' | 'goal' | 'artifact'; id: string } | null
+  /** For a running session: the newest thing the agent just did (audit-derived), so you can watch progress. */
+  lastActivity?: { primitive: string; summary: string; ts: number } | null
 }
 export interface FeedCounts { needsYou: number; running: number; doneToday: number }
 export interface FeedResponse { items: FeedItem[]; nextCursor: string | null; counts: FeedCounts }


### PR DESCRIPTION
Two related asks from live use: *see what a running session is actually doing*, and *make a "Task done" line say which task + link to it*.

## 1. Live progress on running sessions

Each `running` line now shows a one-liner of **the newest thing the agent just did** — derived automatically from the audit tail via the same `classifyActivity` the activity trail uses (first non-noise primitive wins; falls back to the un-audited `update` note), refreshed by the existing 4s poll. So you can watch a session advance — "Ran: npm test", "Edited src/…", "Reported: …" — **without opening its terminal**. On finish, the run's report summary is already the line.

- `FeedItem.lastActivity`, enriched in the `/api/feed` handler (bounded to the page's running items — a handful), reusing `latestActivity()`.

## 2. Every line connects to its object

A task card stores `session_id='task:<id>'` and `body=<task title>`, but the feed was treating `task:xxx` as a dead session id — so the line read a generic "Task done" and Open went nowhere.

New `FeedItem.target` (`feedTarget`) decodes what a line is *about*:
- session / approval / question → its **session**
- a folded message card → its encoded `session_id`: `task:<id>` → the **task**, `goal:<id>` → the **goal**, a real id → the session

So a "Task done" card now **opens its task** and names it — *"Task done — Write the API reference"*. The console's Open routes by target kind (task/goal/session/artifact). This is the "everything connects" piece.

## Verification

- `feed-smoke` extended: a `task` card decodes to `{kind:'task', id:'T9'}` with the combined title; core lines target their session. 9 groups pass.
- `npm run test:governance` green; both bundles build clean (server tsc + web tsc/vite).
- Live-activity is route-level (reuses the classifier the `/activity` route already ships) — visual check on make-live.

See `docs/feed-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)