### PR TITLE
feat(feed): time window (default 24h) for fast loading; link provenance to its task (v0.353.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.353.0] — 2026-08-16
+### Added
+- **Feed time window (default last 24h) for fast loading.** A window selector — Last 24 hours / 2 days /
+  7 days / 30 days — bounds the stream, defaulting to **24h** so the first paint is small and quick. The
+  window is persisted in the URL (`?win=`) alongside lens/filter, and `since` is computed fresh on every
+  load/poll from the token (the URL stores the window, not a frozen timestamp). Crucially the window
+  prunes only the **done/info history** — a `running` session or an **open decision** (a pending approval
+  from days ago) always shows regardless of window, so speeding up the load never hides live work or
+  something that needs you (`FeedStore.list({ since })` → `ts >= since OR state='running' OR
+  status='pending'`; `feed-smoke` covers it).
+### Changed
+- **`· via task` (and `· via automation`) is now a link** that opens the originating task/automation in a
+  new tab, so a run's provenance connects to what triggered it.
+
 ## [0.352.0] — 2026-08-16
 ### Added
 - **See what a running session is doing, and connect every feed line to its object.** Two related feed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.352.0",
+  "version": "0.353.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.352.0",
+      "version": "0.353.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.352.0",
+  "version": "0.353.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/feed-smoke.cjs
+++ b/scripts/feed-smoke.cjs
@@ -92,6 +92,14 @@ assert.strictEqual(tk1.title, 'Task done — Write the API reference');
 // core lines target their session
 assert.deepStrictEqual(all.items.find((i) => i.uid === 'session:s_run').target, { kind: 'session', id: 's_run' });
 
+// 1b) time window prunes old DONE/info history but NEVER hides a live session or an open decision
+const recent = feed.list({ viewer: admin, since: T(4) }); // only the last 4 min of history
+const rUids = new Set(recent.items.map((i) => i.uid));
+assert.ok(rUids.has('session:s_run'), 'running session must survive the window');
+assert.ok(rUids.has('approval:a_pend') && rUids.has('question:q_pend'), 'open decisions must survive the window');
+assert.ok(!rUids.has('session:s_done') && !rUids.has('approval:a_res'), 'old done/resolved history should be pruned');
+assert.ok(!rUids.has('message:u1') && !rUids.has('message:n1'), 'old info/notifications should be pruned');
+
 // 2) attribution + goal tag resolved on the done session
 const doneItem = all.items.find((i) => i.uid === 'session:s_done');
 assert.strictEqual(doneItem.state, 'done');

--- a/src/server.ts
+++ b/src/server.ts
@@ -2707,6 +2707,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       goalId: url.searchParams.get('goal') || undefined,
       cursor: url.searchParams.get('cursor') || undefined,
       limit: Number(url.searchParams.get('limit')) || 40,
+      since: Number(url.searchParams.get('since')) || undefined,
     });
     // Live progress: for the RUNNING lines, attach the newest thing the agent just did (classified from
     // the audit tail, with the un-audited `update` note as a fallback), so a viewer can watch a session

--- a/src/state/feed.ts
+++ b/src/state/feed.ts
@@ -207,7 +207,7 @@ export class FeedStore {
   constructor(private db: Db) {}
 
   /** One page of the stream, newest first, scoped to what `viewer` may see. */
-  list(opts: { viewer: FeedViewer; filter?: FeedFilter; goalId?: string; cursor?: string; limit?: number }): FeedPage {
+  list(opts: { viewer: FeedViewer; filter?: FeedFilter; goalId?: string; cursor?: string; limit?: number; since?: number }): FeedPage {
     const limit = Math.max(1, Math.min(opts.limit ?? 40, 100));
     const where: string[] = [];
     const params: unknown[] = [];
@@ -230,6 +230,11 @@ export class FeedStore {
       where.push(`(${parts.join(' OR ')})`);
       params.push(...p);
     }
+
+    // Time window (fast default load): prune the DONE/info history older than `since`, but never hide a
+    // live session or an open decision just because it's old — a 2-day-old pending approval still needs
+    // you. So running + pending rows always pass, whatever the window.
+    if (opts.since) { where.push("(ts >= ? OR state = 'running' OR status = 'pending')"); params.push(opts.since); }
 
     const cur = parseCursor(opts.cursor);
     if (cur) { where.push('(ts < ? OR (ts = ? AND uid < ?))'); params.push(cur.ts, cur.ts, cur.uid); }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5253,6 +5253,15 @@ function QuestionReply({ m }: { m: Msg }) {
 // between inbox · tasks · sessions · notifications.
 // ────────────────────────────────────────────────────────────────────────────
 
+// Time windows for the feed. Default 24h keeps the first paint small + fast; live sessions and open
+// decisions are shown regardless of window (the server never prunes those). `label` is the menu text.
+const FEED_WINDOWS: { key: string; days: number; label: string }[] = [
+  { key: '24h', days: 1, label: 'Last 24 hours' },
+  { key: '2d', days: 2, label: 'Last 2 days' },
+  { key: '7d', days: 7, label: 'Last 7 days' },
+  { key: '30d', days: 30, label: 'Last 30 days' },
+]
+
 const FEED_FILTERS: { key: FeedFilter; label: string; countKey?: keyof FeedResponse['counts'] }[] = [
   { key: 'all', label: 'All' },
   { key: 'needsYou', label: 'Needs you', countKey: 'needsYou' },
@@ -5301,11 +5310,16 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
   const lens: 'feed' | 'goals' = params.get('lens') === 'goals' ? 'goals' : 'feed'
   const rawFilter = params.get('filter')
   const filter: FeedFilter = (['all', 'needsYou', 'running', 'done'] as const).includes(rawFilter as FeedFilter) ? (rawFilter as FeedFilter) : 'all'
-  const setUrl = (next: { lens?: 'feed' | 'goals'; filter?: FeedFilter }) => {
+  const rawWin = params.get('win')
+  const win = FEED_WINDOWS.some((w) => w.key === rawWin) ? (rawWin as string) : '24h' // default: last 24h, fast load
+  const winDays = FEED_WINDOWS.find((w) => w.key === win)!.days
+  const setUrl = (next: { lens?: 'feed' | 'goals'; filter?: FeedFilter; win?: string }) => {
     const l = next.lens ?? lens
     const f = next.filter ?? filter
+    const w = next.win ?? win
     const p: Record<string, string> = { lens: l }
     if (l === 'feed' && f !== 'all') p.filter = f
+    if (w !== '24h') p.win = w
     setQuery(p)
   }
 
@@ -5324,15 +5338,18 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
   const effLimit = lens === 'goals' ? Math.max(limit, 80) : limit
 
   const load = async () => {
-    const p = await api.feed({ filter: effFilter, limit: effLimit }).catch(() => null)
+    // `since` is computed fresh on every load from the chosen window token, so a refresh (and each poll)
+    // uses a moving cutoff — the URL stores the window, not a frozen timestamp.
+    const since = Date.now() - winDays * 86_400_000
+    const p = await api.feed({ filter: effFilter, limit: effLimit, since }).catch(() => null)
     if (p && Array.isArray(p.items)) setPage(p)
   }
-  useEffect(() => { setPage(null); load() /* eslint-disable-next-line */ }, [effFilter, effLimit])
+  useEffect(() => { setPage(null); load() /* eslint-disable-next-line */ }, [effFilter, effLimit, win])
   useEffect(() => {
     const t = setInterval(() => { if (!replyTo) load() }, 4000)
     return () => clearInterval(t)
     /* eslint-disable-next-line */
-  }, [effFilter, effLimit, replyTo])
+  }, [effFilter, effLimit, win, replyTo])
   useEffect(() => { const t = setInterval(() => setNow(Date.now()), 1000); return () => clearInterval(t) }, [])
   useEffect(() => { if (lens === 'goals') api.goals().then((r) => setProgress(r.progress ?? {})).catch(() => {}) }, [lens])
 
@@ -5388,8 +5405,20 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
     )
   }
 
+  // The provenance hint — and when it points at a real object (a task/automation that spawned the run),
+  // make it a link that opens that object in a new tab.
+  const provChip = (it: FeedItem) => {
+    const sb = it.spawnedBy
+    const label = provenanceHint(sb)
+    if (!sb || !label) return null
+    const href = sb.startsWith('task:') ? navHref('tasks', sb.slice(5))
+      : sb.startsWith('automation:') ? navHref('automations', sb.slice('automation:'.length))
+      : null
+    if (href) return <a href={href} target="_blank" rel="noreferrer" className="inline-flex items-center gap-0.5 hover:text-foreground hover:underline">· {label}<ExternalLink className="h-2.5 w-2.5" /></a>
+    return <span>· {label}</span>
+  }
+
   const attribution = (it: FeedItem) => {
-    const prov = provenanceHint(it.spawnedBy)
     const s = isSessionKind(it) ? sessionById.get(it.runId) : undefined
     return (
       <div className="mt-1.5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-muted-foreground">
@@ -5397,7 +5426,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
         {/* the session's status word, exactly as the Sessions page renders it (same sessionState + tones) */}
         {s && <span className={statusTone(s, waiting.has(s.id))}>{statusLabel(s, waiting.has(s.id))}</span>}
         {it.runAs && <span className="inline-flex items-center gap-1">for <PrincipalTag id={it.runAs} members={members} /></span>}
-        {prov && <span>· {prov}</span>}
+        {provChip(it)}
         {it.goal && <button onClick={() => nav('goals', it.goal!.id)} className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 hover:text-foreground"><Target className="h-3 w-3" />{it.goal.title}</button>}
         {typeof it.tokens === 'number' && it.tokens > 0 && <span className="tabular-nums">{formatTokenCount(it.tokens)}</span>}
         <span className="tabular-nums">{timeAgo(it.ts)}</span>
@@ -5513,12 +5542,19 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
             })}
           </div>
         )}
-        {lens === 'goals' && goalGroups.length > 0 && (
-          <Button size="sm" variant="ghost" className="ml-auto text-xs text-muted-foreground"
-            onClick={() => setOpenGoals(allGoalsOpen ? new Set() : new Set(goalGroups.map((g) => g.id)))}>
-            {allGoalsOpen ? 'Collapse all' : 'Expand all'}
-          </Button>
-        )}
+        <div className="ml-auto flex items-center gap-2">
+          {lens === 'goals' && goalGroups.length > 0 && (
+            <Button size="sm" variant="ghost" className="text-xs text-muted-foreground"
+              onClick={() => setOpenGoals(allGoalsOpen ? new Set() : new Set(goalGroups.map((g) => g.id)))}>
+              {allGoalsOpen ? 'Collapse all' : 'Expand all'}
+            </Button>
+          )}
+          {/* time window — default 24h keeps the load small; live + pending items always show regardless */}
+          <select value={win} onChange={(e) => setUrl({ win: e.target.value })} aria-label="Time window"
+            className="rounded-md border border-border bg-card px-2 py-1 text-xs text-muted-foreground hover:text-foreground focus:outline-none focus-visible:ring-2 focus-visible:ring-ring">
+            {FEED_WINDOWS.map((w) => <option key={w.key} value={w.key}>{w.label}</option>)}
+          </select>
+        </div>
       </div>
 
       {/* stream */}
@@ -5526,7 +5562,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
         <div className="py-16 text-center text-sm text-muted-foreground">Loading the fleet’s activity…</div>
       ) : items.length === 0 ? (
         <div className="py-16 text-center text-sm text-muted-foreground">
-          {filter === 'needsYou' ? 'Nothing needs you right now. The fleet is running itself.' : 'No activity to show.'}
+          {filter === 'needsYou' ? 'Nothing needs you right now. The fleet is running itself.' : `No activity in the ${(FEED_WINDOWS.find((w) => w.key === win)!.label).toLowerCase()}. Try a longer window.`}
         </div>
       ) : lens === 'feed' ? (
         <>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1814,12 +1814,13 @@ export const api = {
   taskAttachmentUrl: (taskId: string, attId: string) => `/api/tasks/${taskId}/attachments/${attId}/raw`,
 
   /** One page of the unified activity feed. `goalId` scopes to the goal lens; `cursor` is keyset pagination. */
-  feed: (opts: { filter?: FeedFilter; goalId?: string; cursor?: string; limit?: number } = {}) => {
+  feed: (opts: { filter?: FeedFilter; goalId?: string; cursor?: string; limit?: number; since?: number } = {}) => {
     const qs = new URLSearchParams()
     if (opts.filter && opts.filter !== 'all') qs.set('filter', opts.filter)
     if (opts.goalId) qs.set('goal', opts.goalId)
     if (opts.cursor) qs.set('cursor', opts.cursor)
     if (opts.limit) qs.set('limit', String(opts.limit))
+    if (opts.since) qs.set('since', String(opts.since))
     const q = qs.toString()
     return call<FeedResponse>('GET', '/api/feed' + (q ? '?' + q : ''))
   },


### PR DESCRIPTION
## Time window (default 24h) — fast loading

A window selector — **Last 24 hours / 2 days / 7 days / 30 days** — bounds the stream, defaulting to **24h** so the first paint is small and quick. Persisted in the URL (`?win=`) alongside lens/filter; `since` is computed fresh on every load/poll from the token (the URL stores the *window*, not a frozen timestamp).

**Key safety:** the window prunes only the **done/info history**. A `running` session or an **open decision** (e.g. a pending approval from two days ago) always shows regardless of window — so speeding up the load never hides live work or something that needs you:

```sql
ts >= :since OR state = 'running' OR status = 'pending'
```

`FeedStore.list({ since })`; `/api/feed?since=<ms>`; `feed-smoke` asserts old done/resolved/info rows prune while running + pending survive.

## Also: `· via task` links to its task

The provenance hint (`· via task`, `· via automation`) is now a link that opens the originating task/automation **in a new tab** — a run connects back to what triggered it.

## Verification

- `feed-smoke` — 9 groups pass (adds the window prune/keep assertions).
- `npm run test:governance` green; both bundles build clean.

See `docs/feed-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)