### PR TITLE
fix(poke): never resume a caller transcript while the agent is live elsewhere (v0.354.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.354.1] — 2026-08-16
+### Fixed
+- **A completion poke no longer starts a second claude in a workspace the agent is already working in.**
+  `Automations.pokeCaller` chose between "inject into the live pane" and "`--resume` the transcript" by
+  looking only at the CALLER'S TRANSCRIPT. A caller whose own conversation had exited took the resume
+  lane even when the same agent was mid-run under a *different* transcript — and all of an agent's
+  sessions share one workspace folder, so that put two claudes in the same directory (northwind
+  2026-08-16: `check-resolve-tickets` running since 12:36 got a poke that resumed its 2-day-old caller
+  transcript; both runs then worked the same support ticket). The poke was the only dispatch lane with no
+  per-agent guard — `dispatchTasks`, `dispatchTask({guard})` and chat-thread continuation all had one.
+  There is now a third lane between the two: cold transcript + a live session elsewhere on that agent →
+  deliver the poke into that session (the message already carries the task id, title and the delegate's
+  note, so it needs no transcript context). A wedged sibling is never killed — it is doing unrelated
+  work — so a failed inject falls through to the resume rather than ending someone else's run. Audited
+  `agent.poked via:'inject-sibling'` with the transcript it stood in for; pinned by
+  `scripts/poke-warm-caller-test.cjs` case 7.
+
 ## [0.354.0] — 2026-08-16
 ### Changed
 - **Reopening an ended session from the feed now warns + confirms.** Opening a *live* session attaches to

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.354.0",
+  "version": "0.354.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.354.0",
+      "version": "0.354.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.354.0",
+  "version": "0.354.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/poke-warm-caller-test.cjs
+++ b/scripts/poke-warm-caller-test.cjs
@@ -81,6 +81,9 @@ const mkCaller = (cs, opts = {}) => {
 const autos = new Automations(aos, tm);
 const poke = (cs, source) => autos.pokeCaller({ callerAgent: 'agent:caller', callerClaudeId: cs, runAs: alice.id, message: `✅ Really done: ${source}`, source });
 const sentTo = (id) => injected.filter((i) => i.tmux === 'aos-' + id);
+/** Retire every live pane of the caller agent. Cases about the RESUME lane need the agent fully idle:
+ *  a live session under ANY transcript is now a delivery target (case 10), not something to resume past. */
+const idleAgent = () => { for (const r of aos.db.prepare("SELECT tmux FROM term_sessions WHERE agent = 'caller'").all()) livePanes.delete(r.tmux); };
 const row = (id) => aos.db.prepare('SELECT status, busy_since FROM term_sessions WHERE id = ?').get(id);
 const pokeAudit = (id) => aos.db.prepare("SELECT data FROM audit_events WHERE run_id = ? AND type = 'agent.poked'").all(id).map((r) => JSON.parse(r.data));
 
@@ -108,6 +111,7 @@ console.log('\n\x1b[1m2) delivering puts the row back in step with reality\x1b[0
 
 console.log('\n\x1b[1m3) the pane really is gone — resume, as before\x1b[0m');
 {
+  idleAgent();
   const cs = 'cs-dead';
   const c = mkCaller(cs, { status: 'done', pane: false });
   const r = poke(cs, 'tsk_3');
@@ -121,6 +125,7 @@ console.log('\n\x1b[1m3) the pane really is gone — resume, as before\x1b[0m');
 
 console.log('\n\x1b[1m4) a human STOPPED the run — a leftover pane is not a destination\x1b[0m');
 {
+  idleAgent();
   const cs = 'cs-stopped';
   const c = mkCaller(cs, { status: 'stopped' });        // pane still listed, deliberately ended
   const before = spawned.length;
@@ -132,6 +137,7 @@ console.log('\n\x1b[1m4) a human STOPPED the run — a leftover pane is not a de
 
 console.log('\n\x1b[1m5) the inject fails on a live pane — kill it BEFORE resuming\x1b[0m');
 {
+  idleAgent();
   const cs = 'cs-wedged';
   const c = mkCaller(cs, { status: 'done' });
   injectWorks = false;
@@ -153,7 +159,32 @@ console.log('\n\x1b[1m6) a transcript spanning several rows — the NEWEST one o
   assert(sentTo(old).length === 0, 'the retired row was never written to');
 }
 
-console.log('\n\x1b[1m7) reachable() is the ONE liveness predicate — the pane, vetoed only by a deliberate end\x1b[0m');
+// The SECOND axis of liveness: the transcript is cold but the AGENT is not. All of an agent's sessions
+// share one workspace folder, so resuming here means two claudes in the same directory. northwind
+// 2026-08-16: `check-resolve-tickets` was running since 12:36 under one transcript when a poke resumed
+// its 2-day-old caller transcript into a second pane.
+console.log('\n\x1b[1m7) the caller transcript is cold but the AGENT is live elsewhere — deliver there, never resume\x1b[0m');
+{
+  idleAgent();
+  const cold = mkCaller('cs-cold', { status: 'done', pane: false });   // the caller's own conversation, exited
+  const warm = mkCaller('cs-other', { status: 'running' });            // same agent, different transcript, working
+  const before = spawned.length;
+  const r = poke('cs-cold', 'tsk_7');
+  assert(r.ok && r.sessionId === warm, 'the poke went to the agent\'s live session', r);
+  assert(spawned.length === before, 'NO second claude in the agent workspace', spawned.slice(before));
+  assert(sentTo(warm).some((i) => i.text.includes('tsk_7')), 'and it carries the task, so no transcript context is needed');
+  assert(sentTo(cold).length === 0, 'nothing typed at the retired transcript');
+  assert(pokeAudit(warm).some((d) => d.via === 'inject-sibling' && d.transcript === 'cs-cold'), 'audited via:inject-sibling with the transcript it stood in for', pokeAudit(warm));
+  // A wedged sibling must NOT be killed — it is doing someone else's work; fall through instead.
+  injectWorks = false;
+  const r2 = poke('cs-cold', 'tsk_7b');
+  injectWorks = true;
+  assert(spawned.length === before + 1, 'a failed sibling inject still resumes — the poke is never dropped', r2);
+  assert(livePanes.has('aos-' + warm), 'and the sibling pane survives (it is not the poke\'s to end)');
+  idleAgent();
+}
+
+console.log('\n\x1b[1m8) reachable() is the ONE liveness predicate — the pane, vetoed only by a deliberate end\x1b[0m');
 {
   assert(typeof tm.isAlive !== 'function', 'the status-folding `isAlive` is gone — no wrong choice to make');
   const c = mkCaller('cs-contrast', { status: 'done' });
@@ -169,7 +200,7 @@ console.log('\n\x1b[1m7) reachable() is the ONE liveness predicate — the pane,
 
 // The other two sites that read `status` as liveness. Both fail in the SAME direction as the poke — they
 // call a live agent free — but cost differently: one stacks a rival worker, one silently skips a delivery.
-console.log('\n\x1b[1m8) the dispatch pile-up guard counts a reported-but-warm worker as busy\x1b[0m');
+console.log('\n\x1b[1m9) the dispatch pile-up guard counts a reported-but-warm worker as busy\x1b[0m');
 {
   const t = aos.tasks.create({ tenant: aos.tenant, title: 'ship it', assignee: 'agent:caller', owner: alice.id, createdBy: alice.id });
   const worker = mkCaller('cs-worker', { status: 'done', spawned_by: `task:${t.id}` });  // reported, still up
@@ -181,7 +212,7 @@ console.log('\n\x1b[1m8) the dispatch pile-up guard counts a reported-but-warm w
   assert(!/already working/.test(after.reason || ''), 'and stops refusing once the pane is actually gone', after.reason);
 }
 
-console.log('\n\x1b[1m9) a freshly installed skill reaches a reported-but-warm session\x1b[0m');
+console.log('\n\x1b[1m10) a freshly installed skill reaches a reported-but-warm session\x1b[0m');
 {
   const reached = [];
   tm.materializeSkills = (sessionId) => { reached.push(sessionId); };

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -570,17 +570,21 @@ export class Automations {
 
   /**
    * Wake a CALLER agent with a completion poke — the "really done" signal a delegate sends back when it
-   * finishes a `poke_on_done` hand-off. Two delivery paths, chosen by whether the caller's transcript
-   * still has a LIVE session:
+   * finishes a `poke_on_done` hand-off. Three delivery paths, tried in order — deliver to a live pane
+   * before ever starting a claude, because the agent's sessions all share ONE workspace folder:
    *
    *  - **Live caller → inject** (the common interactive/resident case). The caller ended its turn and is
    *    sitting IDLE at the prompt — it will NOT observe the delegate's completion on its own (the bug this
    *    fixes: an interactive session had to be told "check that task status" by hand). So we type the poke
    *    into its live pane (`injectToSession`, submit): an idle claude runs it immediately, a mid-turn
    *    claude queues it to the next turn boundary — never a competing `--resume` on one conversation.
-   *  - **Dead caller → resume** (a headless caller that exited at turn-end). Nothing to type into, so we
-   *    `--resume` `callerClaudeId` in a fresh `poke:` run with `message` as the next turn, and the caller
-   *    continues its OWN plan with full context.
+   *  - **Cold transcript, but the AGENT is live elsewhere → inject into that sibling.** The caller's own
+   *    conversation exited, yet the same agent is mid-run under another transcript (a cron sweep, a
+   *    console run). Resuming would put a rival claude in its workspace, so the poke goes to the warm
+   *    pane instead — the message carries the task id, title and result, so it needs no prior context.
+   *  - **Nothing of this agent is live → resume** (a headless caller that exited at turn-end). Nothing to
+   *    type into, so we `--resume` `callerClaudeId` in a fresh `poke:` run with `message` as the next
+   *    turn, and the caller continues its OWN plan with full context.
    *
    * Fires IMMEDIATELY (unlike schedule(), whose 1-min floor makes it a scheduler, not a wake). The delegate
    * (task assignee) is always the actor, never the caller, so this can't self-wake. Audited `agent.poked`.
@@ -618,6 +622,36 @@ export class Automations {
       // claude still holds is worse than a late poke.
       if (injected.ok) return { ok: true, sessionId: liveSession.id, tmux: liveSession.tmux };
       this.tm.stopSession(liveSession.id, 'system');
+    }
+    // The caller's OWN transcript is cold — but liveness has a second axis the transcript lookup can't
+    // see: the caller AGENT may be working right now under a DIFFERENT transcript (its cron sweep, a
+    // console run, another hand-off). All of an agent's sessions run out of ONE workspace folder, so a
+    // `--resume` here puts a second claude in the same directory as a live one — the pile-up every other
+    // dispatch path already guards against (`dispatchTasks`, `dispatchTask({guard})`, chat continuation),
+    // and the poke was the only lane with no per-agent guard. Live on northwind 2026-08-16: task
+    // `tsk_f2d63c5f` closed while `check-resolve-tickets` had been running since 12:36 under transcript
+    // `a2182167`; the poke resumed the caller's 2-DAY-OLD transcript `83bc1aa7` into `ses_8e3da48b` and
+    // both panes ran the same agent's workspace at once.
+    // The poke message is self-contained (task id, title, delegate's note), so a warm sibling can act on
+    // it with no transcript context — delivering there beats both a rival claude and a dropped wake-up.
+    const sibling = this.db
+      .prepare('SELECT id, tmux FROM term_sessions WHERE agent = ? ORDER BY created_at DESC LIMIT 50')
+      .all<{ id: string; tmux: string }>(agentId)
+      .find((r) => this.tm.reachable(r.id));
+    if (sibling) {
+      const injected = this.tm.injectToSession(sibling.id, input.message, true, input.runAs ? `member:${input.runAs}` : 'system');
+      this.os.audit.append({
+        ts: Date.now(),
+        runId: sibling.id,
+        tenant: this.os.tenant,
+        principal: input.runAs ? `member:${input.runAs}` : 'system',
+        type: 'agent.poked',
+        data: { caller: agentId, source: input.source, runAs: input.runAs ?? null, via: 'inject-sibling', transcript: input.callerClaudeId, ok: injected.ok },
+      });
+      // Unlike the same-transcript lane above, a failed inject here must NOT kill the pane: that session
+      // is doing unrelated work for someone else. Fall through to the resume so the poke isn't dropped —
+      // a rare wedged-TUI pile-up is the lesser cost.
+      if (injected.ok) return { ok: true, sessionId: sibling.id, tmux: sibling.tmux };
     }
     const s = this.tm.createSession(agentId, input.title ?? `Poke ← ${input.source}`, input.message, `poke:${input.source}`, true, undefined, undefined, input.runAs, input.callerClaudeId);
     this.os.audit.append({


### PR DESCRIPTION
## The bug

A completion poke could start a **second claude in a workspace the agent was already working in**.

`Automations.pokeCaller` picked its delivery lane from the liveness of the **caller's transcript** only:
live pane → inject, otherwise `--resume`. But liveness has a second axis — the caller **agent** may be
mid-run under a *different* transcript (its cron sweep, a console run, another hand-off). All of an
agent's sessions run out of **one workspace folder**, so the resume lane put two claudes in the same
directory.

Live on northwind 2026-08-16: `check-resolve-tickets` had been running since 12:36 under transcript
`a2182167` when task `tsk_f2d63c5f` closed. The poke resumed the caller's **2-day-old** transcript
`83bc1aa7` into `ses_8e3da48b` — and both runs then worked the same support ticket.

The poke was the **only dispatch lane with no per-agent guard**; `dispatchTasks`, `dispatchTask({guard})`
and chat-thread continuation all have one.

## The fix

A third lane, between inject and resume: **cold transcript + a live session elsewhere on that agent →
deliver the poke there.** The message already carries the task id, title and the delegate's note, so a
warm sibling can act on it with no transcript context.

A wedged sibling is **never killed** (unlike the same-transcript lane, which kills before resuming) — it
is doing unrelated work for someone else, so a failed inject falls through to the resume and the poke is
still never dropped.

Audited `agent.poked` with `via: 'inject-sibling'` and the transcript it stood in for.

## Falsifier

`scripts/poke-warm-caller-test.cjs` case 7 (new): cold caller transcript + a live sibling → delivered to
the sibling, **no** new session, audit says `inject-sibling`; and a failed sibling inject resumes while
leaving the sibling's pane alive. The resume-lane cases (3/4/5) now idle the agent first — a live pane
under *any* transcript is a delivery target now, which is the point.

`npm run test:governance`: all green.

## Follow-up

This is the fourth lane-choice bug in the poke path (v0.307.0 stranded tasks, v0.334.1 status-vs-pane,
v0.334.2 `isAlive` deleted, this one). Each is the same shape: delivery decides its destination inline,
at fire time, from whichever liveness question the author happened to ask. Next PR replaces that with a
durable per-agent **wake queue** — completion enqueues, one tick worker delivers in a fixed priority
order and retries what it cannot deliver, so at most one claude per agent and nothing is ever dropped.