### PR TITLE
fix(runtime-accounts): removing an account left its credential dir squatting on the name (v0.356.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.356.1] — 2026-08-17
+### Fixed
+- **Removing a runtime account from the console made its name unusable again.** `DELETE
+  /api/runtime-accounts/…` drops the row but (rightly) leaves the credential dir on disk, so the next
+  guided login for the same name hit the "already holds a login" guard and there was no way out of the
+  console — the operator had to ssh to the box and delete a directory. Hit live on instawp re-adding its
+  `instawp` claude account. The guard now distinguishes the two cases: a dir an account in the pool still
+  points at is refused **by that account's name** (removing it, or choosing another name, is the fix),
+  while an **orphaned** dir — no account references it — is moved aside to `<dir>.orphan-<ts>` and the
+  login continues into a clean dir. Moved, never deleted: the dir also holds the transcripts of the runs
+  made under that account. Audited `runtime.account.login.orphan.archived`.
+
 ## [0.356.0] — 2026-08-17
 ### Added
 - **A delegate can now say what it is blocked ON, and a human blocker no longer wakes the delegating

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.356.0",
+  "version": "0.356.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.356.0",
+      "version": "0.356.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.356.0",
+  "version": "0.356.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/runtime-login-test.cjs
+++ b/scripts/runtime-login-test.cjs
@@ -139,10 +139,30 @@ const boom = (fn) => { try { fn(); return ''; } catch (e) { return e.message; } 
 assert(/already exists/.test(boom(() => m.start('claude-code', 'overflow-1'))), 'a name already in the pool is refused');
 assert(/letters, numbers/.test(boom(() => m.start('claude-code', '../escape'))), 'a name that would escape the accounts dir is refused');
 assert(/required/.test(boom(() => m.start('claude-code', '   '))), 'an empty name is refused');
-fs.mkdirSync(path.join(accountsDir, 'claude-code', 'squatted'), { recursive: true });
-writeLogin('squatted');
-assert(/already holds a login/.test(boom(() => m.start('claude-code', 'squatted'))),
-  'a dir that already holds someone else\'s login is refused (it would "succeed" instantly against the wrong account)');
+// A dir an account in the pool POINTS AT is refused by name — reusing it would "succeed" instantly
+// against that account's credentials without the operator ever seeing the browser step.
+fs.mkdirSync(path.join(accountsDir, 'claude-code', 'in-use'), { recursive: true });
+writeLogin('in-use');
+aos.runtimeAccounts.add({ runtime: 'claude-code', name: 'by-path', kind: 'oauth', configDir: path.join(accountsDir, 'claude-code', 'in-use') });
+assert(/"by-path" account/.test(boom(() => m.start('claude-code', 'in-use'))),
+  'a dir another account already uses is refused, naming that account', boom(() => m.start('claude-code', 'in-use')));
+assert(fs.existsSync(credFile('in-use')), 'and that account\'s credentials are left exactly where they are');
+
+// An ORPHANED login — a dir left behind by an account the operator already removed — must NOT wedge the
+// name forever (that dead end could only be cleared by ssh'ing to the box). It is moved aside, not deleted:
+// the dir still holds the transcripts of the runs made under it.
+fs.mkdirSync(path.join(accountsDir, 'claude-code', 'orphan'), { recursive: true });
+writeLogin('orphan');
+pane = THEME;
+const orphanStart = m.start('claude-code', 'orphan');
+assert(orphanStart.phase === 'starting', 'an orphaned credential dir does not block a fresh login under the same name', JSON.stringify(orphanStart));
+assert(!fs.existsSync(credFile('orphan')), 'the new dir is clean — the old login cannot complete this flow instantly');
+const archived = fs.readdirSync(path.join(accountsDir, 'claude-code')).filter((d) => d.startsWith('orphan.orphan-'));
+assert(archived.length === 1 && fs.existsSync(path.join(accountsDir, 'claude-code', archived[0], '.credentials.json')),
+  'the orphan is archived beside it, never deleted', JSON.stringify(archived));
+assert(audits.some((a) => a.type === 'runtime.account.login.orphan.archived'), 'and the move is audited');
+m.cancel(orphanStart.id);
+
 assert(m.supported('codex').ok === false, 'a runtime whose login flow has not been walked is not offered');
 assert(m.supported('claude-code').ok === true, 'claude-code is offered');
 

--- a/src/edge/runtime-login.ts
+++ b/src/edge/runtime-login.ts
@@ -154,10 +154,25 @@ export class RuntimeLoginManager {
 
     const spec = CODING_RUNTIMES[runtime];
     const dir = path.join(this.deps.accountsDir, runtime, clean.replace(/\s+/g, '-'));
-    // A dir that already holds a login would let the flow "succeed" instantly against someone else's
-    // credentials — the operator would never see the browser step and would register the wrong account.
+    // A dir that already holds a login must never be reused blind: the flow would "succeed" instantly
+    // against whoever signed in there, and the operator would register the wrong account without ever
+    // seeing the browser step. But WHOSE login it holds decides what to do about it:
+    //  · an account in the pool points at this dir → refuse, and name that account, since removing it (or
+    //    picking another name) is the fix. Reachable when a dir was added BY PATH under a different label.
+    //  · nothing points at it → it is an ORPHAN of an account the operator already removed, or of an
+    //    attempt that died after the token landed. Refusing there was a dead end: the console had just
+    //    deleted the account, so re-adding under the SAME name became impossible without ssh'ing to the
+    //    box to delete a directory — the exact class of "the easy path silently doesn't work" this surface
+    //    exists to remove. Move it aside instead and continue into a clean dir. Moved, never deleted: the
+    //    dir also holds the transcripts of every run made under that account.
     if (fs.existsSync(path.join(dir, spec.credentialEnv.configDirFile))) {
-      throw new Error(`${dir} already holds a login — remove it first, or add it as a credential dir by path`);
+      const owner = this.deps.accounts.list().find((a) => a.configDir && path.resolve(a.configDir) === path.resolve(dir));
+      if (owner) throw new Error(`${dir} is the credential dir of the "${owner.name}" account — remove that account first, or use another name`);
+      const aside = `${dir}.orphan-${Date.now()}`;
+      try { fs.renameSync(dir, aside); } catch (e) {
+        throw new Error(`${dir} already holds a login and could not be moved aside (${(e as Error).message}) — remove it on the box, or add it as a credential dir by path`);
+      }
+      this.deps.audit('runtime.account.login.orphan.archived', { runtime, name: clean, dir, movedTo: aside });
     }
     fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
     const id = 'lg_' + crypto.randomBytes(6).toString('hex');

--- a/src/server.ts
+++ b/src/server.ts
@@ -4611,6 +4611,10 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         // removed account leaves no orphaned secret. An 'apikey' account only REFERENCES a user-managed vault
         // key (apiKeyRef), and 'oauth' has none, so neither is touched.
         if (acct?.kind === 'token') os.secrets.delete(os.tenant, `runtime-token:${runtime}:${name}`, '*');
+        // An 'oauth' account's credential DIR is deliberately left on disk: it may still be in use by a
+        // session that is mid-run, and it holds that account's transcripts. It is reclaimed lazily instead —
+        // a guided login that targets the same dir archives the orphan aside (see RuntimeLoginManager.start),
+        // so removing an account never blocks re-adding it under the same name.
         os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'runtime.account.removed', data: { runtime, name } });
         return sendJson(res, 200, { ok: true });
       }


### PR DESCRIPTION
## The dead end

Removing a pooled runtime account from **Settings → Runtime** drops the DB row but leaves the credential
dir on disk — deliberately: a session may still be mid-run authenticating from it, and the dir holds that
account's transcripts. But re-adding the account under the **same name** then tripped the guided login's
guard:

```
⚠ /home/ubuntu/tools/agent-os/data/runtime-accounts/claude-code/instawp already holds a login —
  remove it first, or add it as a credential dir by path
```

…and nothing in the console could clear it. The operator had to ssh to the box and `rm -rf` a directory —
the exact class of "the easy path silently doesn't work" this whole surface exists to remove. Hit live on
instawp re-adding its `instawp` claude account.

## The fix

The guard itself is load-bearing (reusing a dir that holds a login would "succeed" instantly against
whoever signed in there — wrong account registered, browser step never shown), so it isn't dropped. It now
asks **whose** login the dir holds:

- **an account in the pool points at this dir** → refuse, and name it: `… is the credential dir of the
  "by-path" account — remove that account first, or use another name`. Reachable when a dir was added *by
  path* under a different label.
- **nothing references it** → an orphan of an account the operator already removed, or of an attempt that
  died after the token landed → move it to `<dir>.orphan-<ts>` and continue into a clean dir, audited
  `runtime.account.login.orphan.archived`.

**Moved, never deleted** — the dir also carries the transcripts of every run made under that account.
Reclaiming it lazily (at reuse) rather than at DELETE time is what keeps a still-running session's
credential dir from being yanked out from under it; `server.ts` now says so where the account is removed.

## Verification

`scripts/runtime-login-test.cjs` covers both branches — the in-use dir is refused by the owning account's
name with its credentials left in place, the orphan is archived beside a clean new dir with the audit
event. 39/39 in that suite; `npm run test:governance` green end to end (58/58 webhook-ingress, feed smoke,
attach-grace, …); `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)