### PR TITLE
fix(inject): only verify the submit when the agent was idle (v0.356.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.356.2] — 2026-08-17
+### Fixed
+- **The v0.355.1 submit check no longer kills a working run.** Verifying that injected text became a turn
+  is only meaningful when the agent was IDLE when we typed: a MID-TURN claude parks injected text in its
+  composer on purpose and submits it at the next turn boundary — the documented contract of
+  `injectToSession` — and from the outside that is indistinguishable from a failed submit. Within an hour
+  of shipping, `ses_987f7efc` (fleet-janitor) was 3 minutes into a turn when a second wake-up arrived; the
+  queued text read as "parked", `injectText` returned false, and the same-transcript rule stopped a
+  working run to `--resume` it (one occurrence, work continued on the same transcript). `injectToSession`
+  now asks `isWorking` first and passes `verify: false` while a turn is in flight, so a queued message
+  counts as delivered; the settle + Enter still run either way, since that is what makes the paste land as
+  a queued message rather than loose keys. Idle sessions are verified exactly as before. Pinned by two new
+  cases in `scripts/inject-submit-test.cjs`.
+
 ## [0.356.1] — 2026-08-17
 ### Fixed
 - **Removing a runtime account from the console made its name unusable again.** `DELETE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.356.1",
+  "version": "0.356.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.356.1",
+      "version": "0.356.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.356.1",
+  "version": "0.356.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/inject-submit-test.cjs
+++ b/scripts/inject-submit-test.cjs
@@ -16,8 +16,14 @@
  *   - a short typed message still on the prompt line reads as parked;
  *   - unrelated prompt content is not mistaken for our message.
  */
+const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const ROOT = path.resolve(__dirname, '..');
+const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-inject-submit-test-'));
+process.env.AGENT_OS_HOME = HOME;
+process.env.AGENT_OS_TENANT = 'testco';
+delete process.env.AGENT_OS_SECRET_KEY;
 const { composerParked } = require(path.join(ROOT, 'dist/edge/session-backend.js'));
 
 let pass = 0, fail = 0;
@@ -71,5 +77,48 @@ console.log('\n\x1b[1m4) degenerate input never reports a false failure\x1b[0m')
   assert(composerParked('❯ x', 'hi') === false, 'a too-short head is not matched (no 2-char coincidences)');
 }
 
+// ── the caller policy: WHEN the check may be trusted ────────────────────────────────────────────────
+// Verifying unconditionally cost a working run within the hour of shipping: a MID-TURN claude parks
+// injected text in its composer on purpose and submits it at the next turn boundary — the documented
+// contract of injectToSession — and that is indistinguishable from a failed submit by looking at the
+// pane. northwind 2026-08-17: `ses_987f7efc` (fleet-janitor) was 3 minutes into a turn when a second
+// wake-up arrived; the queued text read as "parked" and the same-transcript rule killed the run to
+// resume it. So the composer check is only consulted when the row says no turn is in flight.
+const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
+const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+const aos = loadAgentOS();
+const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+const seen = [];
+tm.backend.aliveNames = () => new Set(['aos-ses_busy', 'aos-ses_idle']);
+tm.backend.injectText = (_s, tmux, text, submit, verify) => { seen.push({ tmux, verify }); return verify === false; };
+tm.backend.capturePane = () => '';
+tm.backend.hasClient = () => false;
+aos.agents.set('a', { id: 'a', name: 'A', runtime: 'claude-code', dir: HOME });
+
+const mk = (id, over) => {
+  const now = Date.now();
+  aos.db.prepare(`INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,resident,secret,created_at,updated_at,busy_since,last_activity)
+    VALUES (?,?,?,?,?,?,1,0,'s',?,?,?,?)`).run(id, 'a', 't', 'x', 'aos-' + id, 'running', now - 60_000, now, over.busy_since, over.last_activity);
+};
+mk('ses_busy', { busy_since: Date.now() - 30_000, last_activity: null });   // mid-turn
+mk('ses_idle', { busy_since: null, last_activity: Date.now() - 30_000 });   // sitting at the prompt
+
+console.log('\n\x1b[1m5) a MID-TURN agent is never called a failure\x1b[0m');
+{
+  const r = tm.injectToSession('ses_busy', 'result of the task you handed off', true, 'system');
+  const call = seen.find((c) => c.tmux === 'aos-ses_busy');
+  assert(call && call.verify === false, 'the composer check is skipped while a turn is in flight', call);
+  assert(r.ok === true, 'and a queued message counts as delivered — never kill a working run over it', r);
+}
+
+console.log('\n\x1b[1m6) an IDLE agent is still verified\x1b[0m');
+{
+  const r = tm.injectToSession('ses_idle', 'result of the task you handed off', true, 'system');
+  const call = seen.find((c) => c.tmux === 'aos-ses_idle');
+  assert(call && call.verify === true, 'nothing is running, so a full composer IS evidence of a failed submit', call);
+  assert(r.ok === false && /composer/.test(r.error || ''), 'and the failure propagates, so the wake queue holds it', r);
+}
+
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);
+try { fs.rmSync(HOME, { recursive: true, force: true }); } catch { /* best effort */ }
 process.exit(fail === 0 ? 0 : 1);

--- a/src/edge/session-backend.ts
+++ b/src/edge/session-backend.ts
@@ -45,7 +45,10 @@ export interface SessionBackend {
   /** Type `text` into a live session's pty (tmux send-keys), optionally pressing Enter to submit.
    *  Used to hand a running claude a reference (e.g. the path of a console-uploaded image). Returns
    *  false if the inject couldn't be delivered (no session, or backend can't reach the socket). */
-  injectText(space: string, tmuxName: string, text: string, submit: boolean): boolean;
+  /** Type into a live pane. `verify` (default true) asks the backend to CONFIRM the text became a turn
+   *  rather than parking in the composer; pass false when the session is mid-turn, where parking is the
+   *  correct behaviour and confirming it would report a working agent as failed. */
+  injectText(space: string, tmuxName: string, text: string, submit: boolean, verify?: boolean): boolean;
   /** Live tmux session names, or null when liveness can't be polled (→ rely on end signals). */
   aliveNames(): Set<string> | null;
   /** Per-session resident memory: tmux session name → summed RSS **in KiB** of that session's pane
@@ -193,7 +196,7 @@ export class LocalSessionBackend implements SessionBackend {
    * Where the pane cannot be captured (the launcher backend's uid-private socket) the check is skipped and
    * we keep the old optimistic `true` — unverifiable is not the same as failed.
    */
-  injectText(_space: string, tmuxName: string, text: string, submit: boolean): boolean {
+  injectText(_space: string, tmuxName: string, text: string, submit: boolean, verify = true): boolean {
     // `-l` = literal: send the bytes as typed, not as tmux key names (a path could contain `;`, `-`,
     // etc.). Submit is a SEPARATE send-keys with the `Enter` key name so it's interpreted as a return.
     const r = spawnSync('tmux', ['-S', this.tmuxSocket, 'send-keys', '-t', tmuxName, '-l', text], { stdio: 'ignore' });
@@ -202,6 +205,10 @@ export class LocalSessionBackend implements SessionBackend {
     for (let attempt = 1; attempt <= SUBMIT_ATTEMPTS; attempt++) {
       sleepSync(PASTE_SETTLE_MS * attempt);   // let the paste finish assembling before the Enter lands
       spawnSync('tmux', ['-S', this.tmuxSocket, 'send-keys', '-t', tmuxName, 'Enter'], { stdio: 'ignore' });
+      // Mid-turn (`verify` false): the TUI holds the text until the turn boundary BY DESIGN, so a full
+      // composer proves nothing and calling it a failure gets a working run killed. The settle + Enter
+      // above still runs — it is what makes the paste land as a queued message rather than loose keys.
+      if (!verify) return true;
       const visible = this.visiblePane(tmuxName);
       if (visible === null) return true;                       // can't look — don't invent a failure
       if (!composerParked(visible, text)) return true;         // composer is clear → the turn started

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4161,8 +4161,8 @@ export class TerminalManager {
    * session (there is no pane to type into).
    */
   injectToSession(sessionId: string, text: string, submit: boolean, by: string): { ok: boolean; error?: string } {
-    const row = this.db.prepare('SELECT tmux, status, run_as, spawned_by FROM term_sessions WHERE id = ?')
-      .get<{ tmux: string; status: string; run_as: string | null; spawned_by: string | null }>(sessionId);
+    const row = this.db.prepare('SELECT id, tmux, status, run_as, spawned_by, busy_since, last_activity, created_at FROM term_sessions WHERE id = ?')
+      .get<{ id: string; tmux: string; status: string; run_as: string | null; spawned_by: string | null; busy_since: number | null; last_activity: number | null; created_at: number }>(sessionId);
     if (!row) return { ok: false, error: 'unknown session' };
     const body = (text || '').replace(/\r?\n+/g, ' ').trim();
     if (!body) return { ok: false, error: 'nothing to send' };
@@ -4170,11 +4170,20 @@ export class TerminalManager {
     // "not live — open it first" while the pane is right there is the visible half of the poke-back bug.
     if (!this.reachable(sessionId)) return { ok: false, error: 'session is not live — open it first' };
     const space = this.spaceFor(row.run_as ?? row.spawned_by);
-    // `injectText` returns whether the agent GOT THE TURN, not whether tmux took the bytes: a large
+    // `injectText` reports whether the agent GOT THE TURN, not whether tmux took the bytes — a large
     // injection lands as a bracketed paste and an Enter fired in the same instant is swallowed, leaving
-    // the message parked in the composer. Treating that as delivered is a silent drop — the wake queue
-    // marks the row `delivered` and never retries it (northwind 2026-08-17, 8 parked wake-ups).
-    const ok = this.backend.injectText(space, row.tmux, body, submit);
+    // the message parked in the composer, which the wake queue would then record as `delivered` and never
+    // retry (northwind 2026-08-17, 8 parked wake-ups).
+    //
+    // But that check is only meaningful when the agent was IDLE when we typed. A MID-TURN claude parks
+    // injected text in its composer ON PURPOSE and submits it at the next turn boundary — that is the
+    // documented contract of this method, and it looks identical to a failed submit from the outside. The
+    // first build verified unconditionally and paid for it within the hour: `ses_987f7efc` (fleet-janitor)
+    // was 3 minutes into a turn when a second wake-up arrived, the queued text read as "parked", and the
+    // same-transcript rule KILLED a working run to resume it. So we verify only when the row says no turn
+    // is in flight; while it is working, a queued message is a delivered message.
+    const working = this.isWorking(row, this.backend.aliveNames());
+    const ok = this.backend.injectText(space, row.tmux, body, submit, !working);
     if (!ok) return { ok: false, error: 'the terminal never submitted it — still sitting in the composer' };
     // Submitted text starts a turn, so mark the session busy (the Stop-hook beacon clears it) — without
     // it a poke delivered into a warm pane leaves the console reading idle through the work it triggered.


### PR DESCRIPTION
Hotfix for a false positive I shipped in #648, caught by the same live watch that found the original bug.

## What went wrong

#648 taught `injectText` to confirm that injected text actually became a turn, so a message parked in the
composer stops being reported as delivered. Correct for an **idle** agent. Wrong for a **working** one: a
mid-turn claude parks injected text in its composer *on purpose* and submits it at the next turn boundary —
that is the documented contract of `injectToSession` ("a mid-turn claude queues it to the next turn
boundary") — and from the outside it looks exactly like a failed submit.

Within the hour of shipping:

```
07:56:32  ses_987f7efc (fleet-janitor) spawned by a poke, starts working
07:57:36  …gated tool calls, mid-turn…
07:59:43  second wake-up → inject → text queued behind the running turn
          → composer "parked" → injectText false
          → same-transcript rule: stopSession, then --resume as ses_1171820b
```

One occurrence. Work continued on the same transcript, so nothing was lost beyond the in-flight turn — but
killing a live run is not a trade this check is allowed to make, and it would have repeated on every
inject into a busy agent.

## The fix

`injectToSession` asks `isWorking` first — the same predicate that drives the console spinner, which
already encodes every "is a turn actually in flight" subtlety (launch-time prediction, `last_activity >
busy_since`, the mid-turn ceiling) — and passes `verify: false` while a turn is in flight. A queued message
is a delivered message.

The settle + `Enter` still run in both modes: that is what makes a large paste land as a *queued message*
rather than loose keys. An idle session is verified exactly as before, so the parked-wake-up bug #648 fixed
stays fixed.

## Falsifier

Two cases added to `scripts/inject-submit-test.cjs`, driving the real `TerminalManager`:
- **mid-turn** (`busy_since` set, no later activity) → backend receives `verify: false`, result `ok: true`
- **idle** (no `busy_since`) → backend receives `verify: true`, a parked composer propagates as `ok: false`
  so the wake queue holds the message

`npm run test:governance`: green.