### PR TITLE
fix(inject): revert the pane-based submit verdict — it cannot tell delivered from parked (v0.356.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.356.3] — 2026-08-17
+### Fixed
+- **Reverted the pane-based submit verdict (v0.355.1, narrowed in v0.356.2); it cannot tell a delivered
+  message from a parked one.** A claude TUI renders a SUBMITTED message with the same `❯` prompt glyph —
+  and the same `[Pasted text #N]` chip — that an unsent one has, so a single capture cannot distinguish
+  them; and a mid-turn agent parks injected text on purpose until its turn boundary. Acting on that guess
+  stopped **two working runs** (`ses_987f7efc`, `ses_1171820b`) to `--resume` them. `injectText` now
+  reports keystroke delivery only, as it did before v0.355.1.
+  **What is KEPT is the part that actually fixed the original bug:** the settle before the submit `Enter`,
+  and a second Enter after a longer pause — the automated version of the human Enter that unstuck 8 parked
+  wake-ups. A silent late delivery is recoverable; killing a live run is not, so the verdict is gone until
+  it can be read from the transcript (where a submitted turn is unambiguous) rather than the screen.
+  `scripts/inject-submit-test.cjs` is now a real-tmux test of the mechanism (text + Enter reach the pane
+  and complete the line), and states plainly that `cat` in canonical mode cannot stand in for a TUI's
+  paste handling, instead of pretending to cover it.
+
 ## [0.356.2] — 2026-08-17
 ### Fixed
 - **The v0.355.1 submit check no longer kills a working run.** Verifying that injected text became a turn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.356.2",
+  "version": "0.356.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.356.2",
+      "version": "0.356.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.356.2",
+  "version": "0.356.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/inject-submit-test.cjs
+++ b/scripts/inject-submit-test.cjs
@@ -1,124 +1,69 @@
 #!/usr/bin/env node
-/* A delivered keystroke is not a delivered TURN (`composerParked` + `LocalSessionBackend.injectText`).
+/* Injected text reaches a live pane AS A SUBMITTED LINE (`LocalSessionBackend.injectText`), against real tmux.
  *
- * `injectText` used to return true whenever the two tmux calls exited 0. But an agent TUI collapses a big
- * send into a bracketed paste (`[Pasted text #N]`) and swallows a submit `Enter` that arrives while the
- * paste is still assembling — so the message sat in the composer, un-run, while the caller was told it had
- * landed. northwind 2026-08-17: 8 wake-ups parked across two agents, `check-resolve-tickets` showing
- * `❯ [Pasted text #4][Pasted text #5][Pasted text #6]` with a healthy idle claude in front of them, every
- * one recorded `delivered` and never retried. That false ack defeats the wake queue's whole guarantee.
+ * The bug this guards: `send-keys -l <text>` followed immediately by `send-keys Enter` loses the Enter when
+ * the text is large enough that the receiving TUI reads it as a bracketed paste — the Enter is swallowed by
+ * the still-assembling paste and the message sits unsent in the composer. northwind 2026-08-17: 8 wake-ups
+ * parked across two agents' input boxes, every one recorded `delivered` and never retried, until a human
+ * pressed Enter and all of them ran at once. `injectText` now settles before pressing Enter, and presses it
+ * twice with a longer pause the second time — the automated version of that human's late Enter.
  *
- * The fixtures below are REAL captures from that incident (parked) and from the same pane after a human
- * pressed Enter (submitted), trimmed to the last screenful. What this pins:
- *   - the paste chip on the prompt line reads as parked;
- *   - a cleared composer reads as submitted, even though the same text is echoed in the transcript above
- *     it — the check is anchored to the prompt line for exactly that reason;
- *   - a short typed message still on the prompt line reads as parked;
- *   - unrelated prompt content is not mistaken for our message.
+ * What this test does NOT do, deliberately: judge from the pane whether a turn started. Two builds tried
+ * (v0.355.1, v0.356.2) and both were wrong in production — a claude TUI renders a SUBMITTED message with
+ * the same `❯` glyph and paste chip as a parked one, and a mid-turn agent parks injected text on purpose.
+ * Acting on that guess stopped two working runs. A real verdict needs the transcript, not the screen; until
+ * that exists, `injectText` reports keystroke delivery and nothing more.
+ *
+ * Uses a real tmux pane running `cat`, which echoes what it receives and re-prints each COMPLETED line — so
+ * "the line was submitted" is observable without a claude in the loop. Skips (exit 0) where tmux is absent.
+ *
+ * Scope limit, stated rather than faked: `cat` reads in canonical mode (MAX_CANON), so it cannot stand in
+ * for a TUI's bracketed-paste handling and this test does not cover the multi-kilobyte case that produced
+ * the incident. What it pins is that the submit Enter is delivered as its own keypress and completes the
+ * line — the half that is testable off-production.
  */
+const { spawnSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+
 const ROOT = path.resolve(__dirname, '..');
-const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-inject-submit-test-'));
-process.env.AGENT_OS_HOME = HOME;
-process.env.AGENT_OS_TENANT = 'testco';
-delete process.env.AGENT_OS_SECRET_KEY;
-const { composerParked } = require(path.join(ROOT, 'dist/edge/session-backend.js'));
-
 let pass = 0, fail = 0;
-const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d !== undefined ? ' — ' + JSON.stringify(d).slice(0, 200) : ''}`));
+const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d !== undefined ? ' — ' + JSON.stringify(d).slice(0, 300) : ''}`));
 
-const WAKE = '✅ Really done: engineer finished the task you handed off (tsk_2c220bafdd69cc55: "Uptime Kuma pods report the wrong installed version"). Result: fix merged and live. Pick your own work back up from here.';
-
-// The pane as it actually looked, with three wake-ups stacked in the input box.
-const PARKED = [
-  '  a decision, includes the pod list) and `tsk_ca9a1ae868ab0ff3` ("Deployment success" over a dead app service.',
-  '  on main meanwhile and overlaps it). Pick your own work back up from here.',
-  '────────────────────────────────────────────────────────────────────────────────────────────',
-  '❯ [Pasted text #4][Pasted text #5][Pasted text #6]save now writes a different file and restarts the app',
-  '────────────────────────────────────────────────────────────────────────────────────────────',
-  '   ◆ check-resolve-tickets #6271 · as Owner · Opus 5·high · ▓▓░░░░░░░░ 16% · wk 62% · $7.67  /rc',
-  '  ⏵⏵ auto mode on (shift+tab to cycle)',
-].join('\n');
-
-// The same pane after the Enter that finally submitted them: composer gone, text echoed in the transcript.
-const SUBMITTED = [
-  '  a decision, includes the pod list) and `tsk_ca9a1ae868ab0ff3` ("Deployment success" over a dead app service.',
-  '  on main meanwhile and overlaps it). Pick your own work back up from here.',
-  '────────────────────────────────────────────────────────────────────────────────────────────',
-  '   ◆ check-resolve-tickets #6271 · as Owner · Opus 5·high · ▓▓░░░░░░░░ 16% · wk 62% · $7.67  /rc',
-  '  ⏵⏵ auto mode on (shift+tab to cycle)',
-].join('\n');
-
-console.log('\n\x1b[1m1) the incident, both ways round\x1b[0m');
-assert(composerParked(PARKED, WAKE) === true, 'a paste chip on the prompt line is NOT a delivered turn');
-assert(composerParked(SUBMITTED, WAKE) === false, 'a cleared composer is');
-
-console.log('\n\x1b[1m2) the echo trap — why the check is anchored to the prompt line\x1b[0m');
-{
-  // After a real submit the message appears in the transcript. A naive "is the text on screen" check would
-  // call every successful delivery parked, and the queue would then resume beside a working agent forever.
-  const echoed = `  ${WAKE}\n────────────────────────────────\n  ⏵⏵ auto mode on`;
-  assert(composerParked(echoed, WAKE) === false, 'the same text in the TRANSCRIPT is not the composer');
+if (spawnSync('tmux', ['-V'], { stdio: 'ignore' }).status !== 0) {
+  console.log('inject-submit: tmux not installed — skipped');
+  process.exit(0);
 }
 
-console.log('\n\x1b[1m3) a small message is typed, not pasted — still has to be checked\x1b[0m');
+const { LocalSessionBackend } = require(path.join(ROOT, 'dist/edge/session-backend.js'));
+const SOCK = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'aos-inject-test-')), 'tmux.sock');
+const NAME = 'aos-inject-test';
+const tmux = (...a) => spawnSync('tmux', ['-S', SOCK, ...a], { encoding: 'utf8' });
+const pane = () => tmux('capture-pane', '-p', '-J', '-S', '-', '-t', NAME).stdout || '';   // full history: a long line scrolls off the screen
+const cleanup = () => { tmux('kill-server'); try { fs.rmSync(path.dirname(SOCK), { recursive: true, force: true }); } catch { /* best effort */ } };
+
+tmux('new-session', '-d', '-s', NAME, '-x', '200', '-y', '50', 'cat');
+const backend = new LocalSessionBackend(SOCK, () => {});
+
+console.log('\n\x1b[1m1) a short message is typed AND submitted\x1b[0m');
 {
-  const short = 'check the task status';
-  assert(composerParked(`❯ ${short}\n  ⏵⏵ auto mode on`, short) === true, 'typed text left on the prompt line reads as parked');
-  assert(composerParked('❯ ls -la\n  ⏵⏵ auto mode on', short) === false, 'somebody else\'s prompt content is not our message');
-  assert(composerParked('❯\n  ⏵⏵ auto mode on', short) === false, 'a bare prompt is clear');
+  const ok = backend.injectText('', NAME, 'check the task status', true);
+  const p = pane();
+  assert(ok === true, 'keystrokes delivered', ok);
+  // `cat` echoes the typed characters, then re-prints the line once Enter completes it. Two occurrences
+  // means the newline actually landed; one means it is still sitting on the input line unsent.
+  assert((p.match(/check the task status/g) || []).length >= 2, 'the line was SUBMITTED, not left on the input line', p.slice(-200));
 }
 
-console.log('\n\x1b[1m4) degenerate input never reports a false failure\x1b[0m');
+console.log('\n\x1b[1m2) submit:false types without sending\x1b[0m');
 {
-  assert(composerParked('', WAKE) === false, 'an empty capture is not evidence of parking');
-  assert(composerParked('❯ x', 'hi') === false, 'a too-short head is not matched (no 2-char coincidences)');
+  const before = (pane().match(/draft only/g) || []).length;
+  backend.injectText('', NAME, 'draft only', false);
+  const after = (pane().match(/draft only/g) || []).length;
+  assert(after === before + 1, 'it appears once (echoed), not twice (echoed + submitted)', { before, after });
 }
 
-// ── the caller policy: WHEN the check may be trusted ────────────────────────────────────────────────
-// Verifying unconditionally cost a working run within the hour of shipping: a MID-TURN claude parks
-// injected text in its composer on purpose and submits it at the next turn boundary — the documented
-// contract of injectToSession — and that is indistinguishable from a failed submit by looking at the
-// pane. northwind 2026-08-17: `ses_987f7efc` (fleet-janitor) was 3 minutes into a turn when a second
-// wake-up arrived; the queued text read as "parked" and the same-transcript rule killed the run to
-// resume it. So the composer check is only consulted when the row says no turn is in flight.
-const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
-const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
-const aos = loadAgentOS();
-const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
-const seen = [];
-tm.backend.aliveNames = () => new Set(['aos-ses_busy', 'aos-ses_idle']);
-tm.backend.injectText = (_s, tmux, text, submit, verify) => { seen.push({ tmux, verify }); return verify === false; };
-tm.backend.capturePane = () => '';
-tm.backend.hasClient = () => false;
-aos.agents.set('a', { id: 'a', name: 'A', runtime: 'claude-code', dir: HOME });
-
-const mk = (id, over) => {
-  const now = Date.now();
-  aos.db.prepare(`INSERT INTO term_sessions (id,agent,title,task,tmux,status,headless,resident,secret,created_at,updated_at,busy_since,last_activity)
-    VALUES (?,?,?,?,?,?,1,0,'s',?,?,?,?)`).run(id, 'a', 't', 'x', 'aos-' + id, 'running', now - 60_000, now, over.busy_since, over.last_activity);
-};
-mk('ses_busy', { busy_since: Date.now() - 30_000, last_activity: null });   // mid-turn
-mk('ses_idle', { busy_since: null, last_activity: Date.now() - 30_000 });   // sitting at the prompt
-
-console.log('\n\x1b[1m5) a MID-TURN agent is never called a failure\x1b[0m');
-{
-  const r = tm.injectToSession('ses_busy', 'result of the task you handed off', true, 'system');
-  const call = seen.find((c) => c.tmux === 'aos-ses_busy');
-  assert(call && call.verify === false, 'the composer check is skipped while a turn is in flight', call);
-  assert(r.ok === true, 'and a queued message counts as delivered — never kill a working run over it', r);
-}
-
-console.log('\n\x1b[1m6) an IDLE agent is still verified\x1b[0m');
-{
-  const r = tm.injectToSession('ses_idle', 'result of the task you handed off', true, 'system');
-  const call = seen.find((c) => c.tmux === 'aos-ses_idle');
-  assert(call && call.verify === true, 'nothing is running, so a full composer IS evidence of a failed submit', call);
-  assert(r.ok === false && /composer/.test(r.error || ''), 'and the failure propagates, so the wake queue holds it', r);
-}
-
+cleanup();
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);
-try { fs.rmSync(HOME, { recursive: true, force: true }); } catch { /* best effort */ }
 process.exit(fail === 0 ? 0 : 1);

--- a/src/edge/session-backend.ts
+++ b/src/edge/session-backend.ts
@@ -98,28 +98,6 @@ function sleepSync(ms: number): void {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
 }
 
-/**
- * Is `text` still sitting UNSUBMITTED in the pane's composer? Pure over a visible-screen capture, so it is
- * testable against real captures (`scripts/inject-submit-test.cjs`) instead of only in production.
- *
- * Two signals, both read off the prompt line (`❯ …`) rather than the pane at large — after a successful
- * submit the same text is echoed into the transcript above, so "the text appears somewhere" would report
- * every delivery as parked:
- *  - the TUI's paste chip, `[Pasted text #N]`, which is how a big injection renders while it waits; or
- *  - the head of the injected text itself, for a send small enough to be typed rather than pasted.
- */
-export function composerParked(visiblePane: string, text: string): boolean {
-  const head = (text || '').replace(/\s+/g, ' ').trim().slice(0, 24);
-  for (const line of visiblePane.split('\n')) {
-    const m = /^\s*[❯>»]\s+(\S.*)$/.exec(line);
-    if (!m) continue;
-    const composer = m[1];
-    if (/\[Pasted text #\d+\]/.test(composer)) return true;
-    if (head.length >= 8 && composer.replace(/\s+/g, ' ').includes(head)) return true;
-  }
-  return false;
-}
-
 /** POSIX single-quote a value for a `KEY='value'` shell assignment (handles embedded quotes). */
 function sq(v: string): string {
   return `'${v.replace(/'/g, `'\\''`)}'`;
@@ -180,23 +158,24 @@ export class LocalSessionBackend implements SessionBackend {
   /**
    * Type `text` into a live pane, optionally submitting it as a turn.
    *
-   * The return value means **the agent got the turn**, not "tmux accepted the bytes" — that distinction is
-   * the whole point of the verify loop below, and getting it wrong cost us a class of silent drop. An agent
-   * TUI collapses a large send into a bracketed PASTE (`[Pasted text #N]`), and a submit `Enter` fired in
-   * the same instant is swallowed by the still-assembling paste instead of submitting it. Both tmux calls
-   * still exit 0, so the old code returned `true` for a message that was sitting untouched in the composer.
-   * Live on northwind 2026-08-17: 8 wake-ups parked across two agents' input boxes — `check-resolve-tickets`
-   * showed `❯ [Pasted text #4][Pasted text #5][Pasted text #6]` with a healthy claude idle in front of it,
-   * while every one of those wake-ups was recorded `delivered` and never retried. A human pressing Enter
-   * minutes later submitted them all, which is exactly what the settle-then-Enter below does.
+   * The mechanism that matters is the SETTLE: an agent TUI collapses a large `send-keys -l` into a
+   * bracketed paste (`[Pasted text #N]`), and a submit `Enter` fired in the same instant is swallowed by
+   * the still-assembling paste, leaving the message unsent in the composer. northwind 2026-08-17: 8
+   * wake-ups parked across two agents' input boxes, each recorded `delivered` and never retried, until a
+   * human pressed Enter and all of them ran at once. Settling and then pressing Enter — twice, with a
+   * longer pause the second time — is what a human's late Enter does, and it is why this loop exists.
    *
-   * So: settle, Enter, then LOOK at the composer; retry once with a longer settle; report failure if the
-   * text is still parked. `false` propagates to `injectToSession` → the wake queue holds the message and
-   * retries it (and eventually falls back to `--resume`), which is the behaviour that makes it durable.
-   * Where the pane cannot be captured (the launcher backend's uid-private socket) the check is skipped and
-   * we keep the old optimistic `true` — unverifiable is not the same as failed.
+   * It does NOT try to confirm the outcome by reading the pane, and two live incidents say why. A claude
+   * TUI renders a SUBMITTED message with the same `❯` prompt glyph (and the same paste chip) that a parked
+   * one has, so a single capture cannot tell "still in the composer" from "sent and echoed above it"; and
+   * a MID-TURN agent parks injected text on purpose until its turn boundary, which is correct behaviour
+   * that looked identical to failure. Acting on that guess stopped two working runs (`ses_987f7efc`,
+   * `ses_1171820b`) to `--resume` them. A silent late delivery is recoverable; killing a live run is not,
+   * so this returns whether the KEYSTROKES were delivered and leaves the verdict to a signal that can
+   * actually carry it — see `docs/tasks-plan.md` §3.6 for the transcript-based check that should replace
+   * this comment.
    */
-  injectText(_space: string, tmuxName: string, text: string, submit: boolean, verify = true): boolean {
+  injectText(_space: string, tmuxName: string, text: string, submit: boolean, _verify = true): boolean {
     // `-l` = literal: send the bytes as typed, not as tmux key names (a path could contain `;`, `-`,
     // etc.). Submit is a SEPARATE send-keys with the `Enter` key name so it's interpreted as a return.
     const r = spawnSync('tmux', ['-S', this.tmuxSocket, 'send-keys', '-t', tmuxName, '-l', text], { stdio: 'ignore' });
@@ -205,23 +184,8 @@ export class LocalSessionBackend implements SessionBackend {
     for (let attempt = 1; attempt <= SUBMIT_ATTEMPTS; attempt++) {
       sleepSync(PASTE_SETTLE_MS * attempt);   // let the paste finish assembling before the Enter lands
       spawnSync('tmux', ['-S', this.tmuxSocket, 'send-keys', '-t', tmuxName, 'Enter'], { stdio: 'ignore' });
-      // Mid-turn (`verify` false): the TUI holds the text until the turn boundary BY DESIGN, so a full
-      // composer proves nothing and calling it a failure gets a working run killed. The settle + Enter
-      // above still runs — it is what makes the paste land as a queued message rather than loose keys.
-      if (!verify) return true;
-      const visible = this.visiblePane(tmuxName);
-      if (visible === null) return true;                       // can't look — don't invent a failure
-      if (!composerParked(visible, text)) return true;         // composer is clear → the turn started
     }
-    return false;
-  }
-
-  /** The pane's VISIBLE screen (no scrollback) — the composer check must not match the same text sitting
-   *  in the transcript above it, which `-S -` would include. */
-  private visiblePane(tmuxName: string): string | null {
-    const r = spawnSync('tmux', ['-S', this.tmuxSocket, 'capture-pane', '-p', '-J', '-t', tmuxName], { encoding: 'utf8' });
-    if (r.error || r.status !== 0) return null;
-    return r.stdout ?? '';
+    return true;
   }
 
   aliveNames(): Set<string> | null {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4161,8 +4161,8 @@ export class TerminalManager {
    * session (there is no pane to type into).
    */
   injectToSession(sessionId: string, text: string, submit: boolean, by: string): { ok: boolean; error?: string } {
-    const row = this.db.prepare('SELECT id, tmux, status, run_as, spawned_by, busy_since, last_activity, created_at FROM term_sessions WHERE id = ?')
-      .get<{ id: string; tmux: string; status: string; run_as: string | null; spawned_by: string | null; busy_since: number | null; last_activity: number | null; created_at: number }>(sessionId);
+    const row = this.db.prepare('SELECT tmux, status, run_as, spawned_by FROM term_sessions WHERE id = ?')
+      .get<{ tmux: string; status: string; run_as: string | null; spawned_by: string | null }>(sessionId);
     if (!row) return { ok: false, error: 'unknown session' };
     const body = (text || '').replace(/\r?\n+/g, ' ').trim();
     if (!body) return { ok: false, error: 'nothing to send' };
@@ -4170,21 +4170,12 @@ export class TerminalManager {
     // "not live — open it first" while the pane is right there is the visible half of the poke-back bug.
     if (!this.reachable(sessionId)) return { ok: false, error: 'session is not live — open it first' };
     const space = this.spaceFor(row.run_as ?? row.spawned_by);
-    // `injectText` reports whether the agent GOT THE TURN, not whether tmux took the bytes — a large
-    // injection lands as a bracketed paste and an Enter fired in the same instant is swallowed, leaving
-    // the message parked in the composer, which the wake queue would then record as `delivered` and never
-    // retry (northwind 2026-08-17, 8 parked wake-ups).
-    //
-    // But that check is only meaningful when the agent was IDLE when we typed. A MID-TURN claude parks
-    // injected text in its composer ON PURPOSE and submits it at the next turn boundary — that is the
-    // documented contract of this method, and it looks identical to a failed submit from the outside. The
-    // first build verified unconditionally and paid for it within the hour: `ses_987f7efc` (fleet-janitor)
-    // was 3 minutes into a turn when a second wake-up arrived, the queued text read as "parked", and the
-    // same-transcript rule KILLED a working run to resume it. So we verify only when the row says no turn
-    // is in flight; while it is working, a queued message is a delivered message.
-    const working = this.isWorking(row, this.backend.aliveNames());
-    const ok = this.backend.injectText(space, row.tmux, body, submit, !working);
-    if (!ok) return { ok: false, error: 'the terminal never submitted it — still sitting in the composer' };
+    // `injectText` reports that the KEYSTROKES were delivered — deliberately not that a turn started. Two
+    // live incidents killed that ambition: a claude TUI renders a submitted message with the same `❯`
+    // glyph and paste chip as a parked one, and a mid-turn agent parks injected text on purpose, so a pane
+    // capture cannot tell delivered from parked. Guessing stopped two working runs. See session-backend.ts.
+    const ok = this.backend.injectText(space, row.tmux, body, submit);
+    if (!ok) return { ok: false, error: 'could not deliver keystrokes to the terminal' };
     // Submitted text starts a turn, so mark the session busy (the Stop-hook beacon clears it) — without
     // it a poke delivered into a warm pane leaves the console reading idle through the work it triggered.
     if (submit) {


### PR DESCRIPTION
Reverts the verdict half of #648, narrowed in #652. Keeps the half that works.

## Why

The check judged "did this become a turn?" by reading the pane. It cannot: a claude TUI renders a
**submitted** message with the same `❯` prompt glyph — and the same `[Pasted text #N]` chip — that an
unsent one has. Straight off the live fleet, both long since submitted:

```
aos-ses_903a6e   ❯ yes fix storygieai now and draft the customer a note
aos-ses_a07ea85e ❯ done, push it
```

Both match the "parked" predicate. On top of that, a mid-turn agent parks injected text *on purpose* until
its turn boundary. The check was guessing, and it guessed wrong twice in production:

```
07:59:43  ses_987f7efc (fleet-janitor)  3 min into a turn, queued text read as parked  → stopped
08:11:47  ses_1171820b (fleet-janitor)  15s after a delivery, same misread             → stopped
```

Each was stopped only to be `--resume`d on the same transcript, so no work was lost — but killing live runs
is not a trade this check is allowed to make, and #652's "only verify when idle" narrowing did not stop it
(a delivery stamps `last_activity`, which makes `isWorking` read the very turn it just started as over).

## What's kept

The settle. `send-keys -l <text>` then **wait**, then `Enter`, then wait longer and `Enter` again — the
automated version of the human Enter that unstuck 8 parked wake-ups this morning. That is the mechanism
that fixed the original bug; the verdict was a separate, wrong idea bolted to it.

`injectText` returns keystroke delivery, exactly as before #648.

## What replaces the verdict

Nothing, for now — deliberately. A silent late delivery is recoverable; a killed run is not. The real
signal is the transcript: claude appends a `user` entry the moment a message is submitted, so a
1-2s poll of the session's jsonl answers the question unambiguously instead of inferring it from pixels.
That's the follow-up, noted in `docs/tasks-plan.md` §3.6.

## Test

`scripts/inject-submit-test.cjs` rewritten against **real tmux** (skips cleanly where tmux is absent): the
text and its submit Enter reach the pane and complete the line; `submit:false` types without sending. It
states its own scope limit rather than faking coverage — `cat` reads in canonical mode, so it cannot stand
in for a TUI's bracketed-paste handling, and the multi-kilobyte case is exercised in production.

`npm run test:governance`: green.