### PR TITLE
feat(agents): `subagentOnly` — a delegate that only needs a fresh context stops costing a session (v0.361.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.361.0] — 2026-08-17
+### Added
+- **`subagentOnly` on an agent manifest — a delegate that exists only to give a FRESH CONTEXT no longer
+  costs a whole governed session.** Some delegates are separate for a reason a sub-agent already
+  satisfies: a reviewer, a critic, a second opinion needs its own context and must not see the caller's
+  reasoning — and a sub-agent has exactly that, in-process, with no launch, MCP boot, CLAUDE.md reload or
+  tmux pane. Live evidence: instawp's `code-reviewer` is documented in engineer's *own* prompt as
+  `Agent(subagent_type: code-reviewer)` and **still took 12 task hand-offs in 7 days → 8 sessions, $111**,
+  for reviews the sub-agent path performs for a fraction of that. Setting `subagentOnly: true` makes the
+  agent lane (`POST /api/tasks/create`) refuse a task hand-off and name the cheap path instead; audited
+  `task.subagent_only.refused`. Readable/settable via `GET`/`PATCH /api/agents/:id`.
+- The flag is **deliberately narrow**, and the doc says when NOT to use it: not for a delegate that needs
+  its own credentials (a sub-agent runs under the caller's principal and budget), that runs long or on
+  shared infrastructure (it would hold the caller's turn open — instawp's `qa` averages 20 min
+  provisioning sandboxes and contending for a devX lock), that must outlive the caller's turn, or that
+  must observe work independently over time. Fresh context must be the *only* thing the split buys.
+- Human dispatch from the console is unaffected — a person choosing to run a session is a considered act,
+  not the reflex this guards.
+
 ## [0.360.0] — 2026-08-17
 ### Changed
 - **An agent can no longer auto-dispatch a task to itself.** `task_create({ assignee:'me',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.360.0",
+  "version": "0.361.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.360.0",
+      "version": "0.361.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.360.0",
+  "version": "0.361.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/self-dispatch-guard-test.cjs
+++ b/scripts/self-dispatch-guard-test.cjs
@@ -109,7 +109,32 @@ const { createHttpServer } = require(path.join(ROOT, 'dist/server.js'));
     tm.isPlanAutoDispatch = () => false;
   }
 
-  console.log('\n\x1b[1m5) the refusal is audited\x1b[0m');
+  console.log('\n\x1b[1m5) subagentOnly — a fresh context does not need a whole session\x1b[0m');
+  {
+    // instawp's `code-reviewer` is documented in engineer's OWN prompt as Agent(subagent_type:
+    // code-reviewer) and STILL took 12 task hand-offs in 7 days → 8 governed sessions, $111, for reviews
+    // the sub-agent path does for a fraction of it. The flag closes the expensive path.
+    aos.agents.set('reviewer', { id: 'reviewer', name: 'Reviewer', runtime: 'claude-code', dir: HOME, subagentOnly: true });
+    const before = countTasks();
+    const r = await create({ title: 'review PR 12', assignee: 'agent:reviewer', autoDispatch: true });
+    assert(r.ok === false, 'a task hand-off to a subagent-only delegate is refused', r);
+    assert(countTasks() === before, 'and writes nothing');
+    assert(/subagent_type/.test(r.error || ''), 'the refusal names the cheap path it should have used', r.error);
+    assert(/reviewer/.test(r.error || ''), 'and names the delegate', r.error);
+
+    // It is about the DELEGATE, not the flag on the task: even a plain board item is refused, because
+    // the point is that this agent never runs its own session at all.
+    const r2 = await create({ title: 'review later', assignee: 'agent:reviewer' });
+    assert(r2.ok === false, 'refused without autoDispatch too — it never runs its own session', r2);
+
+    // Everyone else is unaffected.
+    const r3 = await create({ title: 'deploy', assignee: 'agent:infra-ops', autoDispatch: true });
+    assert(r3.ok === true, 'a normal delegate is untouched', r3);
+    const n = aos.db.prepare("SELECT count(*) n FROM audit_events WHERE type = 'task.subagent_only.refused'").get().n;
+    assert(n === 2, 'both refusals are audited', n);
+  }
+
+  console.log('\n\x1b[1m6) the refusal is audited\x1b[0m');
   {
     const n = aos.db.prepare("SELECT count(*) n FROM audit_events WHERE type = 'task.self_dispatch.refused'").get().n;
     assert(n >= 3, 'every refusal leaves a row, so the saving is measurable rather than asserted', n);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1603,6 +1603,33 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // Strategist.plan / TerminalManager.markPlanAutoDispatch.
     const planAuto = tm.isPlanAutoDispatch(session);
 
+    // ── Sub-agent-only delegates ───────────────────────────────────────────────────────────────
+    // A delegate whose only reason to exist separately is a FRESH CONTEXT (a reviewer, a critic, a
+    // second opinion) does not need a governed session to provide one — a sub-agent already has its own
+    // context, cannot see the caller's reasoning, and costs no launch/MCP boot/CLAUDE.md reload/pane.
+    // Live evidence: instawp's `code-reviewer` is documented in engineer's OWN prompt as
+    // `Agent(subagent_type: code-reviewer)` and still took 12 task hand-offs in 7 days → 8 sessions,
+    // $111, for reviews the sub-agent path performs for a fraction of it.
+    // Refused on the agent lane only; a human dispatching from the console is a considered act.
+    if (assignee && assignee.startsWith('agent:')) {
+      const target = os.agents.get(assignee.slice('agent:'.length));
+      if (target?.subagentOnly) {
+        os.audit.append({
+          ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`,
+          type: 'task.subagent_only.refused', data: { title, assignee },
+        });
+        return sendJson(res, 200, {
+          ok: false,
+          error:
+            `"${target.id}" is reachable as a sub-agent, not as a task assignee — it exists to give you a ` +
+            `FRESH CONTEXT, which a sub-agent already provides without spawning a whole session. Use the ` +
+            `Agent tool with subagent_type: "${target.id}" and hand it what it needs to judge (the diff, ` +
+            `the PR number, the base ref). If you genuinely need work that outlives this turn, assign it ` +
+            `to an agent that runs its own sessions.`,
+        });
+      }
+    }
+
     // ── Self-dispatch refusal ──────────────────────────────────────────────────────────────────
     // An agent filing an auto-dispatch task for ITSELF is not delegation — it is the agent ending its
     // turn and immediately paying a full context reload to carry on doing what it was already doing.
@@ -4279,7 +4306,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       const runtimes = Object.values(CODING_RUNTIMES).map((r) => ({
         id: r.id, label: r.label, suggestedModels: r.suggestedModels, capabilities: r.capabilities,
       }));
-      return sendJson(res, 200, { agent: ag.id, runtime: ag.runtime, runtimes, description: ag.description, model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, verbosity: ag.verbosity, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, usableSubagents: ag.usableSubagents ?? [], spawnableAsSubagent: ag.spawnableAsSubagent !== false, chatReachable: ag.chatReachable !== false, netMode: ag.netMode ?? 'open', category: ag.category, icon: ag.icon });
+      return sendJson(res, 200, { agent: ag.id, runtime: ag.runtime, runtimes, description: ag.description, model: ag.model, effort: ag.effort, permissionMode: ag.permissionMode, verbosity: ag.verbosity, examplePrompts: ag.examplePrompts, shellSecrets: ag.shellSecrets, usableSubagents: ag.usableSubagents ?? [], spawnableAsSubagent: ag.spawnableAsSubagent !== false, subagentOnly: ag.subagentOnly === true, chatReachable: ag.chatReachable !== false, netMode: ag.netMode ?? 'open', category: ag.category, icon: ag.icon });
     }
     const b = await readBody(req);
     // Runtime change (owner/admin). Validate BEFORE the tuning, so the tuning is checked against the
@@ -4311,6 +4338,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // Consent to being spawned as a sub-agent (default true → drop the key; false → internal, never
     // materialised into anyone's `.claude/agents`, even an explicit list). Owner/admin-only, like netMode.
     const spawnableAsSubagent = 'spawnableAsSubagent' in b ? (b.spawnableAsSubagent === false ? false : undefined) : ag.spawnableAsSubagent;
+    // Reachable ONLY as a sub-agent, never as a task assignee (default false → drop the key). For a
+    // delegate whose separation buys only a fresh context; the agent lane refuses a task hand-off to it.
+    const subagentOnly = 'subagentOnly' in b ? (b.subagentOnly === true ? true : undefined) : ag.subagentOnly;
     // Reachable from the open chat router (Slack/Discord/ClickUp `/agentname`). Default true → drop the key;
     // false → excluded from the front door (still runnable via console/tasks/delegation). Owner/admin-only.
     const chatReachable = 'chatReachable' in b ? (b.chatReachable === false ? false : undefined) : ag.chatReachable;
@@ -4321,7 +4351,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const category = 'category' in b ? sanitizeCategory(b.category) : ag.category;
     const icon = 'icon' in b ? sanitizeIcon(b.icon) : ag.icon;
     const description = 'description' in b ? String(b.description ?? '').trim() : ag.description;
-    const next: AgentManifest = { ...ag, runtime, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, verbosity: tuning.verbosity, examplePrompts: prompts, shellSecrets, usableSubagents, spawnableAsSubagent, chatReachable, netMode: netMode === 'open' ? undefined : netMode, category, icon };
+    const next: AgentManifest = { ...ag, runtime, description, model: tuning.model, effort: tuning.effort, permissionMode: tuning.permissionMode, verbosity: tuning.verbosity, examplePrompts: prompts, shellSecrets, usableSubagents, spawnableAsSubagent, subagentOnly, chatReachable, netMode: netMode === 'open' ? undefined : netMode, category, icon };
     const { dir: _dir, ...onDisk } = next; // `dir` is set at load, not persisted
     fs.writeFileSync(path.join(ag.dir, 'agent.json'), JSON.stringify(onDisk, null, 2) + '\n');
     os.registerAgent(next);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1385,6 +1385,26 @@ export interface AgentManifest extends RuntimeTuning {
    *  opt-out is absolute — a hard "don't spawn me"). Use for governance-sensitive personas (trust &
    *  safety, a destructive migrator) you don't want silently run under someone else's identity/budget. */
   spawnableAsSubagent?: boolean;
+  /** The inverse of {@link spawnableAsSubagent}: this agent is reachable ONLY as a sub-agent, never as a
+   *  task assignee. Default `false` (both paths open).
+   *
+   *  For a delegate whose only reason to be separate is a FRESH CONTEXT — a reviewer, a second opinion, a
+   *  critic — a whole governed session is the expensive way to buy that. A sub-agent already gives the
+   *  isolation (its own context, capped toolset, no sight of the caller's reasoning) in-process, without
+   *  a launch, an MCP boot, a CLAUDE.md reload or a tmux pane. Measured on the live instawp fleet: the
+   *  `code-reviewer` agent was documented in engineer's own prompt as a sub-agent AND still received 12
+   *  task hand-offs in 7 days, which spawned 8 governed sessions costing **$111** to do what the
+   *  sub-agent path does for a fraction of that.
+   *
+   *  Set `true` only when a fresh context is the ONLY thing the separation buys. It is the wrong flag for
+   *  a delegate that needs its own CREDENTIALS (a sub-agent runs under the caller's principal and budget),
+   *  that runs LONG or on shared infrastructure (it would hold the caller's turn open — instawp's `qa`
+   *  averages 20 minutes provisioning sandboxes and contending for a devX lock), that must survive the
+   *  caller's turn, or that must observe the work INDEPENDENTLY over time rather than answer one question.
+   *
+   *  Enforced on the agent lane only (`POST /api/tasks/create`): a human deliberately dispatching a
+   *  session from the console is a considered act, not the reflex this guards. */
+  subagentOnly?: boolean;
   /** Whether this agent is reachable from the OPEN chat router — a `/agent-os <id>` / `/<id>` message on
    *  Slack, Discord, or a ClickUp task comment. Default `true`. Set `false` to keep the agent OFF the
    *  external front door (excluded from `routeChat` + the addressable-agent help list), so a comment can't


### PR DESCRIPTION
Follow-up to #658, and the generalisable half of it.

## The finding

agent-os **already** materialises fleet agents as claude-code sub-agent types, and instawp's engineer **already** documents `Agent(subagent_type: code-reviewer)` as the standing pattern — in its own prompt, twice.

It still filed **12 task hand-offs to `code-reviewer` in 7 days → 8 governed sessions → $111**, for reviews the sub-agent path performs for a fraction of that. Both doors were open, so the expensive one kept getting used.

## The principle

A delegate is separate for one of four reasons: its own **credentials**, **untrusted input** isolation, **async/long-running** work, or an **independent fresh context**.

Only the last one is satisfied by a sub-agent — and where that's the *only* reason, a whole governed session is the expensive way to buy it. A sub-agent already has its own context, can't see the caller's reasoning, and costs no launch, MCP boot, CLAUDE.md reload or tmux pane.

`subagentOnly: true` closes the expensive door: the agent lane refuses a task hand-off and names the cheap path in the refusal. Audited `task.subagent_only.refused`. Readable/settable on `GET`/`PATCH /api/agents/:id`.

## Deliberately narrow — when NOT to use it

The doc comment is explicit, because the failure mode here is over-application:

- **needs its own credentials** — a sub-agent runs under the *caller's* principal and budget
- **runs long / on shared infra** — it would hold the caller's turn open. instawp's `qa` averages **20 minutes** (max 70) provisioning sandboxes, driving a browser and contending for a devX lock. It is emphatically **not** a candidate, despite having credentials identical to engineer's.
- **must outlive the caller's turn**
- **must observe the work independently over time** rather than answer one question

Fresh context has to be the *only* thing the split buys.

Human dispatch from the console is untouched — a person choosing to run a session is a considered act, not the reflex this guards.

## Verification

`npm run typecheck`, build, `npm run test:governance` all green. `scripts/self-dispatch-guard-test.cjs` now **24 assertions** (was 17): refused with and without `autoDispatch` (the point is the *delegate*, not the flag), nothing written, the refusal names both the cheap path and the delegate, normal delegates unaffected, both refusals audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
