### PR TITLE
feat(feed): hierarchical feed — fold the hand-off chain, collapsed by default (v0.365.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.364.0] — 2026-08-17
+## [0.365.0] — 2026-08-17
+### Added
+- **The feed is now hierarchical — it folds the hand-off chain.** Session lines no longer sprawl: runs of
+  one conversation collapse to a single line (by `threadId`), and a delegated run nests under the caller
+  that spawned it (`parentThreadId`) — the same chain the sessions list and chain rail already derive,
+  now mapped onto the feed. A root line with delegated work shows a **"N delegated runs"** toggle and is
+  **collapsed by default**, so a delegation burst reads as one entry you can expand. Crucially the fold
+  applies to **session lines only** — pending approvals/questions and notifications stay flat at top
+  level, so collapsing a chain never hides something that needs you. Thread identity is enriched onto
+  session-backed feed items in the `/api/feed` handler via the new `TerminalManager.threadsFor` (reuses
+  `chainLinks`; `FeedItem.threadId`/`parentThreadId`). See `docs/feed-plan.md`.
 ### Added
 - **Per-endpoint timings — "which API is taking the most time", answered in the console.** Settings → System
   → **Endpoint timings**, plus `GET /api/metrics/requests` (owner/admin) and a reset. Ranked by **total**

--- a/docs/feed-plan.md
+++ b/docs/feed-plan.md
@@ -110,6 +110,23 @@ inbox is no longer a separate read path:
   "Task done" card now opens its **task** and names it (the card's event + the task title, e.g.
   *"Task done — Write the API reference"*) instead of pointing at a dead run id.
 
+## Hierarchical feed — folding the hand-off chain (v0.365.0)
+
+The Feed lens groups session lines by the delegation chain instead of listing every run flat:
+
+- **Fold a conversation** — runs sharing a `threadId` (`claude_session_id`, i.e. pokes/continuations)
+  collapse to their newest line.
+- **Nest a delegation** — a run whose `parentThreadId` is present nests under the caller conversation
+  that spawned it. A root with descendants shows a **"N delegated runs"** toggle, collapsed by default.
+- **Decisions stay flat** — only session lines fold. Pending approvals/questions and notifications remain
+  top-level, so collapsing a chain never hides an action item.
+
+Thread identity is enriched onto session-backed items in the `/api/feed` handler via
+`TerminalManager.threadsFor(runIds)` — a thin public wrapper over the existing `chainLinks` (session →
+its task → the task's `caller_claude_id`), so the feed and the sessions list/chain rail derive the tree
+the same way. The client builds the forest from `threadId`/`parentThreadId` and renders it indented; the
+grouping is within the loaded page (like the sessions list).
+
 ## Not in this slice
 
 Retiring the `messages` read path entirely (it remains the write-ahead for notifier delivery) and any

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.364.0",
+  "version": "0.365.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.364.0",
+      "version": "0.365.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.364.0",
+  "version": "0.365.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -2841,6 +2841,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // the audit tail, with the un-audited `update` note as a fallback), so a viewer can watch a session
     // advance without opening its terminal. Bounded to the running items on the page (a handful).
     for (const it of page.items) if (it.state === 'running') it.lastActivity = latestActivity(os, it.runId);
+    // Hand-off chain: stamp thread identity on session-backed items so the console can collapse a
+    // delegation burst under its root (same threadId/parentThreadId the sessions list + chain rail use).
+    const threads = tm.threadsFor(page.items.filter((it) => it.target?.kind === 'session').map((it) => it.target!.id));
+    for (const it of page.items) {
+      const th = it.target?.kind === 'session' ? threads.get(it.target.id) : undefined;
+      if (th) { it.threadId = th.threadId; it.parentThreadId = th.parentThreadId; }
+    }
     const now = new Date();
     const dayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
     return sendJson(res, 200, { ...page, counts: os.feed.counts(viewer, dayStart) });

--- a/src/state/feed.ts
+++ b/src/state/feed.ts
@@ -53,6 +53,11 @@ export interface FeedItem {
   // for a RUNNING session: the newest thing the agent just did, so you can watch progress without
   // opening the terminal. Enriched by the route (classifyActivity over the audit tail); null otherwise.
   lastActivity?: { primitive: string; summary: string; ts: number } | null;
+  // hand-off chain grouping (enriched by the route via TerminalManager.threadsFor). `threadId` folds a
+  // conversation's runs; `parentThreadId` nests it under the caller that delegated it — so the feed can
+  // collapse a delegation burst under one root. Only set on session-backed items.
+  threadId?: string;
+  parentThreadId?: string;
 }
 
 /** Decode the object a feed line points at from its kind + run id. Session/approval/question lines are

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1386,6 +1386,31 @@ export class TerminalManager {
   }
 
   /**
+   * Thread identity for a set of run ids — the feed's hook into the same hand-off chain the sessions list
+   * and chain rail use. `threadId` folds a conversation's runs (a poke/continuation shares one
+   * `claude_session_id`); `parentThreadId` is the caller conversation that delegated it (via `chainLinks`).
+   * A self-parent (a poke waking itself) is dropped to `undefined` so it reads as a root. Batched like the
+   * list path so it stays cheap on the feed poll.
+   */
+  threadsFor(runIds: string[]): Map<string, { threadId: string; parentThreadId?: string }> {
+    const out = new Map<string, { threadId: string; parentThreadId?: string }>();
+    const ids = [...new Set(runIds.filter(Boolean))];
+    if (!ids.length) return out;
+    const rows: SessionRow[] = [];
+    for (let i = 0; i < ids.length; i += 400) {
+      const page = ids.slice(i, i + 400);
+      rows.push(...this.db.prepare(`SELECT * FROM term_sessions WHERE id IN (${page.map(() => '?').join(',')})`).all<SessionRow>(...page));
+    }
+    const links = this.chainLinks(rows);
+    for (const r of rows) {
+      const threadId = r.claude_session_id ?? r.id;
+      const parent = links.get(r.id)?.parentThreadId;
+      out.set(r.id, { threadId, parentThreadId: parent && parent !== threadId ? parent : undefined });
+    }
+    return out;
+  }
+
+  /**
    * The HAND-OFF CHAIN a session belongs to — the tree the console's chain rail renders, and the answer
    * to "where is this piece of work right now?" that a flat session list can't give.
    *

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5428,6 +5428,8 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
 
   const [openGoals, setOpenGoals] = useState<Set<string>>(new Set()) // goal sections start collapsed
   const [expanded, setExpanded] = useState<Set<string>>(new Set()) // which snippets are shown in full
+  const [openThreads, setOpenThreads] = useState<Set<string>>(new Set()) // which hand-off chains are expanded (default collapsed)
+  const toggleThread = (tid: string) => setOpenThreads((s) => { const n = new Set(s); n.has(tid) ? n.delete(tid) : n.add(tid); return n })
   const [limit, setLimit] = useState(40)
   const [page, setPage] = useState<FeedResponse | null>(null)
   const [progress, setProgress] = useState<Record<string, GoalProgress>>({})
@@ -5533,11 +5535,12 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
     return <span>· {label}</span>
   }
 
-  const attribution = (it: FeedItem) => {
+  const attribution = (it: FeedItem, chain?: { count: number; open: boolean; onToggle: () => void }) => {
     const s = isSessionKind(it) ? sessionById.get(it.runId) : undefined
     return (
       <div className="mt-1.5 flex flex-wrap items-center gap-x-2.5 gap-y-1 text-xs text-muted-foreground">
         {it.agent && <span className="inline-flex items-center gap-1 rounded bg-muted px-1.5 py-0.5 font-medium text-foreground/80"><Bot className="h-3 w-3" />{it.agent}</span>}
+        {chain && <button onClick={chain.onToggle} className="inline-flex items-center gap-1 rounded bg-primary/10 px-1.5 py-0.5 font-medium text-primary hover:bg-primary/15">{chain.open ? <ChevronDown className="h-3 w-3" /> : <ChevronRight className="h-3 w-3" />}{chain.count} delegated {chain.count === 1 ? 'run' : 'runs'}</button>}
         {/* the session's status word, exactly as the Sessions page renders it (same sessionState + tones) */}
         {s && <span className={statusTone(s, waiting.has(s.id))}>{statusLabel(s, waiting.has(s.id))}</span>}
         {it.runAs && <span className="inline-flex items-center gap-1">for <PrincipalTag id={it.runAs} members={members} /></span>}
@@ -5586,7 +5589,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
     return null
   }
 
-  const line = (it: FeedItem) => {
+  const line = (it: FeedItem, chain?: { count: number; open: boolean; onToggle: () => void }) => {
     const isDecision = it.state === 'decision'
     const isQuestion = it.kind.startsWith('question')
     const s = isSessionKind(it) ? sessionById.get(it.runId) : undefined
@@ -5609,7 +5612,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
             <span className="min-w-0 truncate italic">{it.lastActivity.summary}</span>
           </div>
         )}
-        {attribution(it)}
+        {attribution(it, chain)}
       </div>
     )
     return (
@@ -5637,6 +5640,46 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
     }
   }
   const allGoalsOpen = goalGroups.length > 0 && goalGroups.every((g) => openGoals.has(g.id))
+
+  // ── feed lens: fold the hand-off chain ──
+  // Session lines fold by conversation (threadId → newest run) and nest under the caller that delegated
+  // them (parentThreadId). Everything else — pending decisions, notifications — stays FLAT at top level, so
+  // collapsing a chain never hides something you need to act on. Roots + flat items interleave by time.
+  const byThread = new Map<string, FeedItem>()
+  const flatItems: FeedItem[] = []
+  const childrenOf = new Map<string, string[]>()
+  const rootThreads: string[] = []
+  if (lens === 'feed') {
+    for (const it of items) {
+      if (isSessionKind(it) && it.threadId) {
+        const cur = byThread.get(it.threadId)
+        if (!cur || it.ts > cur.ts) byThread.set(it.threadId, it)
+      } else flatItems.push(it)
+    }
+    for (const [tid, it] of byThread) {
+      if (it.parentThreadId && byThread.has(it.parentThreadId)) {
+        const arr = childrenOf.get(it.parentThreadId) ?? []
+        arr.push(tid); childrenOf.set(it.parentThreadId, arr)
+      } else rootThreads.push(tid)
+    }
+  }
+  const descCount = (tid: string): number => (childrenOf.get(tid) ?? []).reduce((n, k) => n + 1 + descCount(k), 0)
+  const feedEntries: ({ ts: number; item: FeedItem } | { ts: number; tid: string })[] = [
+    ...flatItems.map((it) => ({ ts: it.ts, item: it })),
+    ...rootThreads.map((tid) => ({ ts: byThread.get(tid)!.ts, tid })),
+  ].sort((a, b) => b.ts - a.ts)
+  const renderThread = (tid: string, depth: number): ReactNode => {
+    const it = byThread.get(tid)!
+    const kids = (childrenOf.get(tid) ?? []).slice().sort((a, b) => byThread.get(b)!.ts - byThread.get(a)!.ts)
+    const open = openThreads.has(tid)
+    const n = descCount(tid)
+    return (
+      <div key={tid} className={depth > 0 ? 'ml-3 border-l border-border/60 pl-3' : ''}>
+        {line(it, n > 0 ? { count: n, open, onToggle: () => toggleThread(tid) } : undefined)}
+        {open && kids.map((k) => renderThread(k, depth + 1))}
+      </div>
+    )
+  }
 
   return (
     <div className="mx-auto max-w-3xl">
@@ -5685,7 +5728,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
         </div>
       ) : lens === 'feed' ? (
         <>
-          {items.map(line)}
+          {feedEntries.map((e) => 'tid' in e ? renderThread(e.tid, 0) : line(e.item))}
           {page.nextCursor && (
             <div className="pt-2 text-center">
               <Button size="sm" variant="ghost" className="text-xs text-muted-foreground" onClick={() => setLimit((l) => l + 40)}>Load more</Button>
@@ -5712,7 +5755,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
                     <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">{g.items.length}</Badge>
                   </span>
                 </summary>
-                <div className="border-t border-border bg-background px-4 pt-3">{g.items.map(line)}</div>
+                <div className="border-t border-border bg-background px-4 pt-3">{g.items.map((it) => line(it))}</div>
               </details>
             )
           })}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1607,6 +1607,9 @@ export interface FeedItem {
   target: { kind: 'session' | 'task' | 'goal' | 'artifact'; id: string } | null
   /** For a running session: the newest thing the agent just did (audit-derived), so you can watch progress. */
   lastActivity?: { primitive: string; summary: string; ts: number } | null
+  /** Hand-off chain grouping — folds a conversation's runs and nests a delegated run under its caller. */
+  threadId?: string
+  parentThreadId?: string
 }
 export interface FeedCounts { needsYou: number; running: number; doneToday: number }
 export interface FeedResponse { items: FeedItem[]; nextCursor: string | null; counts: FeedCounts }


### PR DESCRIPTION
The feed was a flat list; a delegation burst (a session dispatching several sub-agents) sprawled into many top-level lines. This maps the **existing hand-off chain** onto the feed so it reads hierarchically.

## What

- **Fold a conversation** — runs sharing a `threadId` (`claude_session_id` — pokes/continuations) collapse to their newest line.
- **Nest a delegation** — a run whose `parentThreadId` is present nests under the caller conversation that spawned it. A root with descendants shows a **"N delegated runs"** toggle, **collapsed by default** — a burst reads as one entry you expand.
- **Decisions never hide** — only session lines fold. Pending approvals/questions and notifications stay flat at top level, so collapsing a chain can't bury an action item.

## How (reuses existing machinery)

Thread identity is enriched onto session-backed feed items in the `/api/feed` handler via a new `TerminalManager.threadsFor(runIds)` — a thin public wrapper over the existing `chainLinks` (session → its dispatching task → the task's `caller_claude_id`). So the feed derives the *same* tree the sessions list and chain rail already show. `FeedItem.threadId`/`parentThreadId`; the client builds the forest and renders it indented (within the loaded page, like the sessions list).

## Verification

- `feed-smoke` 9 groups pass (thread fields are additive/undefined without chain data); `npm run test:governance` green; both bundles build clean (tsc `noUnusedLocals` + vite).
- Chain grouping itself is visual — check on make-live with a real delegation.

See `docs/feed-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)