### PR TITLE
feat(tasks): PR count on the board cards (v0.369.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.369.0] — 2026-08-18
+### Added
+- **PR count on the board cards.** "Did this task ship anything, and did it land?" now reads off the
+  board and list rows, not just the open task: a chip showing how many pull requests the task references,
+  coloured by the worst outstanding state — violet when everything merged, emerald while anything is
+  still open, red when they all closed unmerged — with the split in its tooltip. `GET /api/tasks` returns
+  `prCounts` from **two extra queries for the whole board** (~9 ms and +9 KB on a 1.3 MB payload,
+  measured on a copy of the live 408-task northwind board) and **no GitHub calls** — refreshing 500 cards
+  on a 5-second poll would burn the rate limit to render a number, so a chip shows the status that task's
+  own detail view last fetched.
+### Fixed
+- **The bulk PR parse undercounted 10 of 408 live tasks.** Its SQL prefilter (`LIKE '%/pull/%'`) dropped
+  the `api.github.com/…/pulls/<n>` form and every bare `PR #n` written in a note that carried no URL of
+  its own — so a card could show fewer PRs than the task's own sidebar listed, with nothing to say so.
+  Caught before shipping by a parity assertion that now runs over the whole board in
+  `scripts/task-pr-links-test.cjs`: bulk and per-task must return identical refs for every task.
+
 ## [0.368.0] — 2026-08-18
 ### Added
 - **A task filed as a draft can now be finished — or binned — where you're reading it.** The room's

--- a/docs/tasks-plan.md
+++ b/docs/tasks-plan.md
@@ -645,7 +645,24 @@ Status is the second half and strictly an enrichment. `GET /api/tasks/:id/prs` r
 the App's bot token, then anonymously (which answers for a public repo). Results cache in **`github_prs`**,
 a pure cache — every row is one API call away from being rebuilt — shared by every task that mentions the
 same PR. The detail payload carries the CACHED list so the sidebar paints instantly; the refresh is the
-separate call. `merged` is tracked apart from `closed` (GitHub reports a merged PR as closed, and rendering
+separate call.
+
+The **board** answers the same question without opening a card: `GET /api/tasks` returns `prCounts`
+(taskId → `{total, merged, open, closed, draft}`), rendered as a chip on each board card and list row.
+The single-task read costs two queries per task, which is right for one open task and wrong for 500, so
+`taskPrRefsBulk` inverts it into **two queries total** — rows pre-filtered in SQL to those that could
+mention a PR (`MENTIONS_PR_SQL`), grouped in JS, parsed through the same `refsFromScraps` as the detail
+view. Measured on a copy of the live northwind board: 408 tasks, 123 with links, **~9 ms** warm and
++9 KB on a 1.3 MB payload. The board makes **no GitHub calls** — 500 cards' worth of refreshes on a 5 s
+poll would burn the rate limit to render a number — so a chip shows the status that task's detail view
+last fetched: the count is always right, the merged/open split is as fresh as the last time someone
+opened it.
+
+The SQL prefilter is the one thing that can silently break this: a shape the parser accepts but the
+filter drops makes a card undercount a task whose own sidebar shows the link, and nothing would say so.
+The first cut did exactly that (`'%/pull/%'` missed the `api.github.com/…/pulls/` form and every bare
+`PR #n` in a note carrying no URL — 10 of 408 tasks). So the test asserts **parity**, per shape: bulk and
+per-task must return the same refs for every task on the board. `merged` is tracked apart from `closed` (GitHub reports a merged PR as closed, and rendering
 it that way reads as *abandoned*), and a PR with no status shows as a plain link, never a guessed state.
 Pinned by `scripts/task-pr-links-test.cjs`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.368.0",
+  "version": "0.369.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.368.0",
+      "version": "0.369.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.368.0",
+  "version": "0.369.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/task-pr-links-test.cjs
+++ b/scripts/task-pr-links-test.cjs
@@ -17,7 +17,7 @@ delete process.env.AGENT_OS_SECRET_KEY;
 let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
-const { extractPrRefs, taskPrRefs, prKey, PrCache, prSummary } = require(path.join(ROOT, 'dist/edge/task-prs.js'));
+const { extractPrRefs, taskPrRefs, taskPrRefsBulk, prKey, PrCache, prSummary } = require(path.join(ROOT, 'dist/edge/task-prs.js'));
 const aos = loadAgentOS();
 
 console.log('\n\x1b[1m1) the parser finds what agents actually write\x1b[0m');
@@ -84,6 +84,52 @@ assert(cache.stale(older).length === 3, 'and a status older than the TTL goes st
 
 const sum = prSummary(warm);
 assert(sum.total === 3 && sum.merged === 1 && sum.open === 1 && sum.closed === 1, 'the summary counts each state once', JSON.stringify(sum));
+
+console.log('\n\x1b[1m4) the board\'s bulk pass agrees with the per-task read, shape for shape\x1b[0m');
+// The board can't run two queries per card, so it inverts the read: two SQL-prefiltered scans, grouped in
+// JS. That prefilter is the risk — a shape the parser accepts but the SQL filters out makes a card
+// undercount a task whose own sidebar shows the link, and nothing would ever say so. (The first cut did
+// exactly this: it missed the api.github.com `/pulls/` form and every bare `PR #n` written in a note that
+// carried no URL — 10 of 408 tasks on the live northwind board.) So the assertion is PARITY, per shape.
+const bulkTasks = [];
+const mkLinked = (title, body, notes) => {
+  const t = aos.tasks.create({ tenant: aos.tenant, title, body, createdBy: 'm_alice' });
+  for (const n of notes ?? []) aos.tasks.update(t.id, { note: n, by: 'agent:engineer' });
+  bulkTasks.push(t.id);
+  return t.id;
+};
+mkLinked('plain url in the body', 'shipped https://github.com/acme/web/pull/1');
+mkLinked('url only in a note', '', ['done: https://github.com/acme/web/pull/2']);
+// The two shapes the first prefilter dropped:
+mkLinked('the gh api form', '', ['see https://api.github.com/repos/acme/web/pulls/3']);
+const bare = mkLinked('bare number in a LATER note', 'work starts at https://github.com/acme/web/pull/4', []);
+aos.db.prepare(`INSERT INTO messages (id, type, session_id, agent, title, body, status, created_at)
+                 VALUES (?, 'task.chat', ?, 'engineer', '', ?, 'open', ?)`)
+  .run('m_bare', `task:${bare}`, 'reverted in PR #5 — no link handy', Date.now() + 1000);
+mkLinked('a PR in the TITLE: merge PR #6', 'context https://github.com/acme/web/pull/7');
+mkLinked('mentions nothing at all', 'just prose about a pull-through cache');
+
+const all = aos.tasks.list({ tenant: aos.tenant, limit: 500 });
+const bulk = taskPrRefsBulk(aos.db, all);
+let mismatch = 0, missed = [];
+for (const t of all) {
+  const b = (bulk.get(t.id) ?? []).map(prKey).sort().join(',');
+  const single = taskPrRefs(aos.db, t.id, aos.tasks.get(t.id)).map(prKey).sort().join(',');
+  if (b !== single) { mismatch++; missed.push(`${t.title}: bulk[${b}] vs single[${single}]`); }
+}
+assert(mismatch === 0, 'every task on the board parses identically in bulk and on its own', missed.slice(0, 2).join(' | '));
+assert((bulk.get(bare) ?? []).length === 2, 'a bare "PR #5" in a note with no URL still reaches the board count', String((bulk.get(bare) ?? []).length));
+assert(!bulk.has(bulkTasks[bulkTasks.length - 1]), 'a task mentioning no PR is absent from the map (no empty rollups on the wire)');
+
+const rollups = cache.summaries(bulk);
+assert(Object.keys(rollups).length === bulk.size, 'one rollup per task that has links');
+// The title task (PR #6 + .../pull/7) references two PRs neither of which was ever fetched above.
+const unfetched = rollups[bulkTasks[4]];
+assert(unfetched.total === 2 && unfetched.merged + unfetched.open + unfetched.closed === 0,
+  'a never-fetched PR counts toward the card total but lands in no state bucket', JSON.stringify(unfetched));
+const firstRoll = cache.summaries(new Map([[t.id, refs]]));
+assert(firstRoll[t.id].total === 3 && firstRoll[t.id].merged === 1 && firstRoll[t.id].open === 1 && firstRoll[t.id].closed === 1,
+  'the cached states carry into the board rollup', JSON.stringify(firstRoll[t.id]));
 
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);
 fs.rmSync(HOME, { recursive: true, force: true });

--- a/src/edge/task-prs.ts
+++ b/src/edge/task-prs.ts
@@ -100,7 +100,11 @@ export function extractPrRefs(
     out.push(ref);
   };
   const body = String(text ?? '');
-  if (!body) return out;
+  // Cheap reject before any regex. The board parses every task's title+body on each poll, and most of
+  // them mention no PR at all — an indexOf pair is ~an order of magnitude cheaper than running three
+  // regexes over a long description to learn nothing. Mirrors MENTIONS_PR_SQL, and must stay a superset
+  // of what the patterns below accept.
+  if (!body || !(body.includes('/pull') || body.includes('PR #') || body.includes('PR#') || body.includes('pull request'))) return out;
   for (const re of [PR_URL_RE, PR_API_URL_RE]) {
     re.lastIndex = 0;
     let m: RegExpExecArray | null;
@@ -158,7 +162,12 @@ function taskScraps(db: Db, taskId: string, task: Task | undefined): Scrap[] {
  * "when did this task produce a PR" is the question the ordering answers.
  */
 export function taskPrRefs(db: Db, taskId: string, task: Task | undefined): PrRef[] {
-  const scraps = taskScraps(db, taskId, task);
+  return refsFromScraps(taskScraps(db, taskId, task));
+}
+
+/** The parse itself, over one task's texts. Shared by the single-task read and the board's bulk pass so
+ *  a card's count can never disagree with the list the task's own sidebar shows. */
+function refsFromScraps(scraps: Scrap[]): PrRef[] {
   const byKey = new Map<string, PrRef>();
   // Scraps are oldest-first, so the first sighting of a key wins and later repeats are ignored.
   const add = (r: { owner: string; repo: string; number: number; url: string }, s: Scrap) => {
@@ -178,6 +187,56 @@ export function taskPrRefs(db: Db, taskId: string, task: Task | undefined): PrRe
     for (const s of scraps) for (const r of extractPrRefs(s.text, ctx)) add(r, s);
   }
   return [...byKey.values()].sort((a, b) => a.at - b.at || a.number - b.number);
+}
+
+/**
+ * SQL prefilter for "this text could mention a PR" — the bulk pass's only defence against scanning every
+ * event and message body in JS. It must be a SUPERSET of what the parser accepts or the board would
+ * silently undercount a task its own detail view shows links for, which is exactly what the first cut
+ * did: `'%/pull/%'` alone missed the `api.github.com/…/pulls/<n>` form AND every bare `PR #<n>` written
+ * in a note that carried no URL of its own (10 of 408 tasks on the live northwind board). Widen this
+ * whenever `extractPrRefs` learns a new shape; `scripts/task-pr-links-test.cjs` fails the day it drifts.
+ */
+const MENTIONS_PR_SQL = "(body LIKE '%/pull/%' OR body LIKE '%/pulls/%' OR body LIKE '%PR #%' OR body LIKE '%PR#%' OR body LIKE '%pull request%')";
+
+/**
+ * The board's pass: PR refs for MANY tasks at once, as `taskId → refs` (tasks with none are absent).
+ *
+ * The single-task path issues two queries per task, which is right for one open task and wrong for a
+ * board of 500 — so this inverts it into **two queries total**, filtered in SQL to the rows that even
+ * mention a PR (`LIKE '%/pull/%'`, ~100 of 1.8k rows on the live northwind tenant, 2 ms) and then
+ * grouped in JS. The task's own title/body come from the list the caller already loaded, so no third
+ * query. Identical parse per task via `refsFromScraps`, so a card and its task detail can never disagree.
+ */
+export function taskPrRefsBulk(db: Db, tasks: Array<Pick<Task, 'id' | 'title' | 'body' | 'createdAt'>>): Map<string, PrRef[]> {
+  const out = new Map<string, PrRef[]>();
+  if (!tasks.length) return out;
+  const byTask = new Map<string, Scrap[]>();
+  const push = (taskId: string, scrap: Scrap) => {
+    const arr = byTask.get(taskId);
+    if (arr) arr.push(scrap); else byTask.set(taskId, [scrap]);
+  };
+  const known = new Set(tasks.map((t) => t.id));
+  for (const t of tasks) {
+    if (t.title) push(t.id, { text: t.title, at: t.createdAt, source: 'body' });
+    if (t.body) push(t.id, { text: t.body, at: t.createdAt, source: 'body' });
+  }
+  for (const r of db
+    .prepare(`SELECT task_id, kind, body, created_at FROM task_events WHERE ${MENTIONS_PR_SQL}`)
+    .all<{ task_id: string; kind: string; body: string; created_at: number }>()) {
+    if (known.has(r.task_id)) push(r.task_id, { text: r.body, at: r.created_at, source: r.kind === 'comment' ? 'discussion' : 'activity' });
+  }
+  for (const r of db
+    .prepare(`SELECT session_id, body, created_at FROM messages WHERE session_id LIKE 'task:%' AND type IN ('task.chat','task','task.mention') AND ${MENTIONS_PR_SQL}`)
+    .all<{ session_id: string; body: string; created_at: number }>()) {
+    const taskId = r.session_id.slice('task:'.length);
+    if (known.has(taskId)) push(taskId, { text: r.body, at: r.created_at, source: 'discussion' });
+  }
+  for (const [taskId, scraps] of byTask) {
+    const refs = refsFromScraps(scraps.sort((a, b) => a.at - b.at));
+    if (refs.length) out.set(taskId, refs);
+  }
+  return out;
 }
 
 // ── status cache ────────────────────────────────────────────────────────────────────────────────────
@@ -210,6 +269,27 @@ export class PrCache {
       .all<PrRow>(this.tenant, ...keys);
     const byKey = new Map(rows.map((r) => [r.id, r]));
     return refs.map((r) => toTaskPr(r, byKey.get(prKey(r))));
+  }
+
+  /**
+   * Board pass: `taskId → summary` for many tasks in ONE cache query. Offline by construction — the
+   * board never triggers a GitHub fetch, because 500 cards' worth of refreshes on every page load would
+   * burn the rate limit to render a number. A card therefore shows the status the task's own detail view
+   * last fetched, which is the correct trade: the count is always right, the merged/open split is as
+   * fresh as the last time someone opened that task.
+   */
+  summaries(refsByTask: Map<string, PrRef[]>): Record<string, TaskPrSummary> {
+    const out: Record<string, TaskPrSummary> = {};
+    if (!refsByTask.size) return out;
+    const keys = [...new Set([...refsByTask.values()].flat().map(prKey))];
+    const rows = this.db
+      .prepare(`SELECT * FROM github_prs WHERE tenant = ? AND id IN (${keys.map(() => '?').join(',')})`)
+      .all<PrRow>(this.tenant, ...keys);
+    const byKey = new Map(rows.map((r) => [r.id, r]));
+    for (const [taskId, refs] of refsByTask) {
+      out[taskId] = prSummary(refs.map((r) => toTaskPr(r, byKey.get(prKey(r)))));
+    }
+    return out;
   }
 
   /** Which of these need a (re)fetch — never fetched, or older than the TTL. `force` takes everything. */
@@ -283,9 +363,19 @@ function toTaskPr(ref: PrRef, row?: PrRow): TaskPr {
   };
 }
 
+/** The per-task rollup a board card and the sidebar header render. */
+export interface TaskPrSummary {
+  total: number;
+  merged: number;
+  open: number;
+  closed: number;
+  /** Of the open ones, how many are drafts — an open PR nobody is meant to review yet. */
+  draft: number;
+}
+
 /** Roll a task's PRs into the one-line summary the board/sidebar header shows. */
-export function prSummary(prs: TaskPr[]): { total: number; merged: number; open: number; closed: number; draft: number } {
-  const out = { total: prs.length, merged: 0, open: 0, closed: 0, draft: 0 };
+export function prSummary(prs: TaskPr[]): TaskPrSummary {
+  const out: TaskPrSummary = { total: prs.length, merged: 0, open: 0, closed: 0, draft: 0 };
   for (const p of prs) {
     if (p.state === 'merged') out.merged++;
     else if (p.state === 'closed') out.closed++;

--- a/src/server.ts
+++ b/src/server.ts
@@ -65,7 +65,7 @@ import { checkForUpdate, applyUpdate, restartService } from './edge/updater';
 import { checkDeps, checkDepUpdates, installDeps, updateNpmDep } from './edge/deps';
 import { CATALOG, redact } from './connectors/connectors';
 import { GithubIdentity } from './edge/github-identity';
-import { PrCache, taskPrRefs, prSummary, type PrToken } from './edge/task-prs';
+import { PrCache, taskPrRefs, taskPrRefsBulk, prSummary, type PrToken } from './edge/task-prs';
 import { convertAppManifest, userInstallationStatus } from './connectors/github';
 import { redactHost, type HostProtocol, type HostPosture } from './hosts/hosts';
 import { listConnectedAccounts, deleteConnectedAccount, listToolkits, serviceUserId, initiateConnection, verifyComposioWebhook, parseComposioEvent } from './connectors/composio';
@@ -3597,7 +3597,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // (the board shows title/labels; the description tab reads `detail.task.body` from GET /api/tasks/:id,
     // which still returns the full text). Search is server-side (`?q=`), so the client needs no haystack.
     const slim = tasks.map((t) => (t.body ? { ...t, body: clipText(t.body, LIST_CLIP) } : t));
-    return sendJson(res, 200, { tasks: slim, counts: os.tasks.counts(os.tenant), agents: terminalAgents(os).map((a) => a.id), discussions: tm.taskDiscussionSummaries(me) });
+    // Per-task PR rollups for the board cards — "did this one ship anything, and did it land?" without
+    // opening it. TWO extra queries for the whole board (the refs are parsed from rows pre-filtered in
+    // SQL; the states come from the `github_prs` cache), and NO GitHub calls: refreshing 500 cards on a
+    // page load would burn the rate limit to render a number. `prCounts` is parsed BEFORE the body clip
+    // above would matter — `tasks`, not `slim`, so a link past the clip point still counts.
+    const prCounts = new PrCache(os.db, os.tenant).summaries(taskPrRefsBulk(os.db, tasks));
+    return sendJson(res, 200, { tasks: slim, counts: os.tasks.counts(os.tenant), prCounts, agents: terminalAgents(os).map((a) => a.id), discussions: tm.taskDiscussionSummaries(me) });
   }
   if (taskId && method === 'GET') {
     const found = os.tasks.withEvents(taskId[1]);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, isDraftTask, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type HostMetrics, type RequestMetricsSnapshot, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskChild, type TaskRun, type TaskPr, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskDiscussionDelivery, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type AgentProposalTrust, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type GoalUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
+import { api, isDraftTask, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type HostMetrics, type RequestMetricsSnapshot, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskChild, type TaskRun, type TaskPr, type TaskPrSummary, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskDiscussionDelivery, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type AgentProposalTrust, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type GoalUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval, type FeedItem, type FeedResponse, type FeedFilter, type TaskRunState, type GoalChatState } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ENTITY_ID_SRC, entityHref, isEntityId } from '@/lib/entity-links'
@@ -9710,6 +9710,9 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
   )
   const [tasks, setTasks] = useState<Task[] | null>(null)
   const [discussions, setDiscussions] = useState<Record<string, TaskDiscussionSummary>>({})
+  /** taskId → its PR rollup, for the board/list cards. Server-computed in the list payload (no per-card
+   *  fetch); absent for a task that mentions no PR. */
+  const [prCounts, setPrCounts] = useState<Record<string, TaskPrSummary>>({})
   const [counts, setCounts] = useState<Record<TaskStatus, number>>({ todo: 0, doing: 0, blocked: 0, done: 0, cancelled: 0 })
   // Live sessions, cross-referenced against a task's lastSessionId to know which cards are running right now.
   const [sessions, setSessions] = useState<Session[]>([])
@@ -9848,6 +9851,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
     const r = await api.tasks(q)
     setTasks(r.tasks ?? [])
     setDiscussions(r.discussions ?? {})
+    setPrCounts(r.prCounts ?? {})
     if (r.counts) setCounts(r.counts)
     // Only the sessions a visible task points at (its `lastSessionId`) are needed here — to light up a
     // "doing" card as live via `liveOf`. Fetch exactly those instead of the whole ~950-row list on a 5 s
@@ -10023,6 +10027,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
           )}
           {dm && <span className={`inline-flex items-center gap-0.5 rounded px-1 text-[10px] ${dm.overdue ? 'bg-red-500/15 text-red-600' : dm.soon ? 'text-amber-600' : ''}`}><Clock className="h-2.5 w-2.5" />{dm.label}</span>}
           {t.goalId && goalChip(t.goalId)}
+          {prCounts[t.id] && <TaskPrChip s={prCounts[t.id]} />}
           {t.labels.map((l) => <Badge key={l} variant="outline" className="px-1.5 py-0 text-[10px]">{l}</Badge>)}
           <span className="ml-auto font-mono text-[10px] opacity-60">{t.id}</span>
         </div>
@@ -10675,6 +10680,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
                             </span>
                           )}
                           {t.goalId && goalChip(t.goalId, 'hidden shrink-0 sm:inline-flex')}
+                          {prCounts[t.id] && <span className="shrink-0"><TaskPrChip s={prCounts[t.id]} /></span>}
                           {unmetCount(t) > 0 && <span className="shrink-0 rounded bg-amber-500/15 px-1 text-[10px] text-amber-600" title="Waiting on unfinished blockers">⏳ {unmetCount(t)}</span>}
                           {live && <span className={`inline-flex shrink-0 items-center gap-1 font-mono text-[10px] ${statusTone(live)}`}><SessionStatus s={live} iconClass="h-3 w-3" />{statusLabel(live)} · {fmtElapsed(now - live.createdAt)}</span>}
                           {t.labels.map((l) => <Badge key={l} variant="outline" className="hidden shrink-0 px-1 py-0 text-[10px] md:inline-flex">{l}</Badge>)}
@@ -11349,6 +11355,30 @@ function TaskPullRequests({ taskId, prs, onRefreshed }: { taskId: string; prs: T
         })}
       </div>
     </div>
+  )
+}
+
+/**
+ * A task card's PR chip — "this one shipped 2, one merged", readable without opening the task.
+ *
+ * Colour follows the WORST outstanding state rather than the count: all merged is the only green-light
+ * case (violet), anything still open is in-flight (emerald), and everything closed unmerged is the
+ * outcome worth noticing (red). Status here is whatever the task's detail view last fetched — the board
+ * never calls GitHub — so the number is always right even when the split is a few minutes stale.
+ */
+function TaskPrChip({ s }: { s: TaskPrSummary }) {
+  if (!s.total) return null
+  const parts = [s.merged && `${s.merged} merged`, s.open && `${s.open} open`, s.closed && `${s.closed} closed`].filter(Boolean)
+  const known = s.merged + s.open + s.closed
+  const Icon = s.open > 0 ? GitPullRequest : s.merged === s.total ? GitMerge : s.closed === s.total && s.total > 0 ? GitPullRequestClosed : GitPullRequest
+  const cls = s.open > 0 ? 'text-emerald-600' : s.merged === s.total ? 'text-violet-500' : s.closed === s.total ? 'text-red-500' : 'text-muted-foreground'
+  return (
+    <span
+      className={`inline-flex items-center gap-0.5 text-[10px] ${cls}`}
+      title={`${s.total} pull request${s.total === 1 ? '' : 's'}${parts.length ? ` — ${parts.join(', ')}` : ''}${known < s.total ? ` (${s.total - known} with no status yet)` : ''}`}
+    >
+      <Icon className="h-2.5 w-2.5" />{s.total}
+    </span>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1894,7 +1894,7 @@ export const api = {
   kbRevert: (id: string, rev: number) => call<{ ok: boolean; page?: KbPage; error?: string }>('POST', `/api/kb/page/${id}/revert`, { rev }),
   kbDelete: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/kb/page/${id}`),
 
-  tasks: (q = '', status = '') => call<{ tasks: Task[]; counts: Record<TaskStatus, number>; agents: string[]; discussions?: Record<string, TaskDiscussionSummary> }>('GET', `/api/tasks?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
+  tasks: (q = '', status = '') => call<{ tasks: Task[]; counts: Record<TaskStatus, number>; prCounts?: Record<string, TaskPrSummary>; agents: string[]; discussions?: Record<string, TaskDiscussionSummary> }>('GET', `/api/tasks?q=${encodeURIComponent(q)}${status ? `&status=${status}` : ''}`),
   task: (id: string) => call<{ task?: Task; events?: TaskEvent[]; attachments?: TaskAttachment[]; dependents?: string[]; children?: TaskChild[]; runs?: TaskRun[]; prs?: TaskPr[]; discussion?: TaskTimelineEntry[]; unread?: number; choices?: { id: string; agentId: string; message: string }[]; error?: string }>('GET', `/api/tasks/${id}`),
   /** The task's PRs with their status refreshed from GitHub (stale-only unless `refresh`). Separate from
    *  the detail payload because it makes network calls — the detail's `prs` render instantly from cache. */


### PR DESCRIPTION
## What

A PR chip on every board card and list row: how many pull requests the task references, coloured by the **worst outstanding state** — violet when everything merged, emerald while anything is still open, red when they all closed unmerged — with the split (`2 pull requests — 1 merged, 1 open`) in the tooltip.

## How it's cheap

The single-task read (v0.367.0) costs two queries per task. That's right for one open task and wrong for a board of 500, so `taskPrRefsBulk` inverts it into **two queries total**: rows pre-filtered in SQL to those that could mention a PR, grouped in JS, then parsed through the **same** `refsFromScraps` the detail view uses — so a card's count can never disagree with the list its own sidebar shows.

Measured on a copy of the live 408-task northwind board: **~9 ms** warm (60 ms cold), 123 tasks with links, **+9 KB on a 1.3 MB payload**. A JS fast-path (`indexOf` before any regex) is what takes it from 61 ms to 9 ms — most tasks mention no PR and shouldn't pay for three regexes to learn that.

**No GitHub calls from the board.** Refreshing 500 cards on a 5-second poll would burn the rate limit to render a number, so a chip shows the status that task's own detail view last fetched: the count is always right, the merged/open split is as fresh as the last time someone opened it.

## The bug this caught before shipping

The first prefilter was `LIKE '%/pull/%'`. It dropped the `api.github.com/…/pulls/<n>` form **and** every bare `PR #n` written in a note that carried no URL of its own — so a card would show fewer PRs than the task's sidebar listed, silently, on **10 of 408 live tasks**.

The fix is a widened superset filter (`MENTIONS_PR_SQL`), but the durable part is the assertion: the test now runs **parity across the whole board** — bulk and per-task must return identical refs for every task — with one seeded task per shape (plain URL, URL only in a note, the `gh api` form, a bare number in a later note, a PR in the title, and one mentioning nothing).

## Validation

- `scripts/task-pr-links-test.cjs` grew to 30 assertions (parity, bare-number recall in bulk, no empty rollups on the wire, rollup states).
- Full `npm run test:governance` green; `npm run typecheck`; `cd web && npm run build`.
- Parity + timings measured against a copy of the live northwind DB (0/408 mismatches after the fix, 10/408 before).
- Board screenshot-verified in a scratch tenant: green 2 on an in-flight task, violet 1 on a merged one, red 1 on a closed-unmerged one, no chip on a task with none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C65rFssCqehc1Uz7SkQNe7