### PR TITLE
docs(insights): fold "agent shape" into Step 5 as the top-ranked second signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+### Documented
+- **`docs/insights-revisit.md` Step 5 gains its top-ranked candidate: "agent shape"** — a card naming
+  delegates that do not need to be agents. Carries the measured case (instawp, 7 days: $8,640 of
+  agent→agent spend vs $1,027 human-started; 815 tasks filed by agents, 3 by humans; one line-question
+  → 19 sessions, $600), the skill / sub-agent / agent tier table, and the six signals the OS already
+  stores to compute it. Records the two things that make it hard: three agents hand-classified from
+  real data were **all wrong on the first pass** (`qa` looked like ceremony but averages 20.6 min
+  provisioning sandboxes; `apidocs-bot` owns a webhook; `code-reviewer` needed a sub-agent, not a
+  skill), and the gate audit **cannot** classify read-vs-write (8,573 of 9,139 decisions are
+  `shell.exec`). Explicitly not-to-be-built: a one-click "fold agent → skill" button — same reasoning
+  as Step 2's refusal to put buttons on the runtime-death card, plus the destination tier is usually
+  sub-agent, and a fold isn't done until every *caller's* prompt stops delegating.
 
 ## [0.369.0] — 2026-08-18
 ### Added

--- a/docs/insights-revisit.md
+++ b/docs/insights-revisit.md
@@ -494,9 +494,92 @@ was right — the subject was wrong).
 
 ### Step 5 — second signal (only now)
 
-Only after Steps 2–4 hold. Candidates, ranked by live evidence: pending-approval pile-ups, automations
-failing repeatedly (`reliability.ts` already detects these), agents that never get used, stalled tasks.
-Each goes through the identical vertical: detect → card → action → measure.
+Only after Steps 2–4 hold. Candidates, ranked by live evidence: **agent shape** (below — the largest
+measured cost of any candidate here), pending-approval pile-ups, automations failing repeatedly
+(`reliability.ts` already detects these), agents that never get used, stalled tasks. Each goes through
+the identical vertical: detect → card → action → measure.
+
+#### Candidate: **agent shape** — "this delegate does not need to be an agent"
+
+**The evidence** (instawp, 7 days to 2026-08-17). Delegation, not human work, is what the fleet spends:
+
+| lane | conversations | spend |
+|---|---|---|
+| agent→agent `task:` | 437 | **$8,640** |
+| cron | 221 | $1,114 |
+| **human-started** | **77** | **$1,027** |
+
+**815 tasks were created by agents; 3 by humans.** A one-line question — *"can we disable bot detection
+for route welcome"* — became **19 descendant sessions, depth 5, $600**. Every hop is a fresh session
+paying a full context reload, which is why splitting work costs an agent fleet far more than it costs a
+human team: a human hand-off is a two-minute conversation between people who already hold the context.
+
+**The signal.** A delegate is separate for one of four reasons — its own **credentials**, **untrusted
+input** isolation, **async/long-running** work, or an **independent fresh context**. Only the last is
+satisfied by a sub-agent, and only knowledge (no isolation at all) is satisfied by a skill:
+
+| tier | gives you | costs |
+|---|---|---|
+| skill | knowledge, loaded into the *current* context | ~nothing |
+| sub-agent | a *fresh* context, in-process, caller's principal + budget | small |
+| agent | own session, own credentials, own lifetime | ~$20 + a launch |
+
+The card names delegates whose separation buys none of the top three — i.e. ones that should be a
+sub-agent or a skill. Computable today from what the OS already stores:
+
+| signal | source | what it rules out |
+|---|---|---|
+| own credentials | `shellSecrets` + `secret_assignments` | can't be a sub-agent (it runs under the caller's principal) |
+| `active_ms` per session | `term_sessions` | long work can't be a sub-agent — it holds the caller's turn open |
+| owns automations | `automations` | it's a trigger endpoint, not a delegation hop |
+| hand-off volume + sources | `tasks` | whether there is anything to save |
+| already reachable as a sub-agent | prompt refs + `.aos-managed.json` | both doors open ⇒ close the expensive one |
+| open / in-flight work | `tasks`, live sessions | blocks any action until drained |
+
+**⚠ The classifier is the hard part, and a plausible one is wrong.** Building the first two folds by
+hand, three agents were classified from real data and **all three were wrong on the first pass**:
+
+- `qa` — credentials byte-identical to `engineer`, so it read as pure ceremony (99 hand-offs/week). It
+  is not: **20.6 min average, 76 tool calls, `active_ms` 19.9 of 20.6** — it provisions sandboxes/devX
+  boxes, drives a real browser, and is the independent observer the branch-freeze protocol depends on.
+- `apidocs-bot` — no secrets, so it read as collapsible. It owns a live webhook automation; folding it
+  breaks the drift check.
+- `code-reviewer` — proposed as a *skill*. Wrong tier: a skill loads into the caller's context and its
+  entire value is **not seeing** the author's reasoning. It became `subagentOnly` (v0.361.0).
+
+So the card must state **which signal disqualified an agent**, not just a verdict — the verdict alone
+reproduces exactly the "detection without proposal" failure of §2b, with worse consequences, because
+acting on it deletes a teammate. Note also §2's lesson that a naive per-agent view misleads: rank by
+hand-offs **saved**, and show the denominator.
+
+**One signal that does NOT work today.** The gate audit cannot classify read-vs-write: of 9,139
+`gate.decision` events in the window, **8,573 are `shell.exec`** (then `file.write` 471,
+`connector.call` 93, `secret.put` 2). The capability grain cannot tell a `git diff` from a deploy, so
+"is this agent read-only?" is not derivable. Any classifier assuming otherwise is guessing.
+
+**Not to be built: a one-click "fold agent → skill" button.** Same reasoning as Step 2's refusal to put
+buttons on the runtime-death card, and stronger here. The mechanics are trivial (`CLAUDE.md` →
+`SKILL.md`); the judgement is where all three hand-classifications failed, and the destination tier is
+usually **sub-agent**, not skill — so a "→ skill" button bakes in the tier that fits least often. It is
+also not done when the skill exists: it is done when **every caller stops delegating**, which means
+editing other agents' `CLAUDE.md` — the clobber-prone path that already needed `assessClaudeMdEdit` +
+`baseHash` guards after two live incidents. A button that creates a skill and leaves nine prompts still
+calling `task_create(assignee:"agent:qa")` has added a duplicate and changed nothing.
+
+Ship the **recommendation read-only first**. An action follows only for the class the classifier earns
+confidence on (no credentials, short sessions, no automations, no in-flight work), listing the blockers
+and the referencing prompts before it acts.
+
+**Honest sizing, so this is not oversold.** On instawp the confident class is ~2 agents and ~8
+hand-offs/week. Two folds shipped by hand (`code-reviewer` → `subagentOnly`, plus the self-dispatch
+refusal) are worth ~$1,440/week. The remaining **$7,300/week sits in `infra-ops` (221 hand-offs),
+`engineer` (165) and `qa` (103)** — genuinely long, credentialed work that no fold can touch. That is
+an argument for the card being *diagnostic* rather than an action surface, and for the delegation
+budget (§ related) being the bigger lever.
+
+**Measured how** (Step 4's rule — measure the card, not our clicks): the fold's whole point is fewer
+sessions, so the outcome is `tasks` hand-offs to the named delegate before vs after, and the
+`task.subagent_only.refused` / `task.self_dispatch.refused` audits give the counterfactual directly.
 
 ### Step 6 — retire what didn't earn its place
 
@@ -557,4 +640,10 @@ Live DB paths: northwind `~/agent-os-data/northwind/agent-os.db`; globex
 - [`daily-digest-plan.md`](./daily-digest-plan.md) — the push surface Step 3 rides.
 - [`oversight-plane.md`](./oversight-plane.md) — the `Intervention` gap named there is the same gap
   Step 4 closes.
+- [`subagents-plan.md`](./subagents-plan.md) — the sub-agent tier the **agent shape** candidate
+  recommends folding into (`materializeSubagents`, `spawnableAsSubagent`, `usableSubagents`, and the
+  `subagentOnly` inverse added for it in v0.361.0).
+- [`webhook-ingress.md`](./webhook-ingress.md) — the sibling waste class found in the same pass: the
+  agent's own reply echoing back as an event and buying a session to be ignored, now filterable at the
+  ingress with `when`/`unless` instead of by a Claude session.
 - [`PILLARS.md`](./PILLARS.md) — Pillar 10; update its grade when Step 4 lands, not before.


### PR DESCRIPTION
Docs-only. Folds the 2026-08-17 delegation-cost work into the Insights rebuild rather than starting a separate plan — it's exactly a `detect → card → action → measure` vertical, and `insights-revisit.md` already has the discipline this needs.

## What's added

**Step 5 gains its top-ranked candidate: "agent shape"** — a card naming delegates that don't need to be agents.

The measured case (instawp, 7 days):

| lane | conversations | spend |
|---|---|---|
| agent→agent `task:` | 437 | **$8,640** |
| **human-started** | **77** | **$1,027** |

815 tasks filed by agents, 3 by humans. One line-question → 19 descendant sessions, depth 5, $600.

Plus the tier table (skill = knowledge in the current context / sub-agent = fresh context in-process / agent = own session, credentials, lifetime) and the six signals the OS already stores to compute the recommendation.

## The two findings that make it hard

Both recorded, because a *plausible* classifier here is wrong and acting on it deletes a teammate.

**1. Three agents hand-classified from real data were all wrong on the first pass:**
- `qa` — credentials byte-identical to `engineer`, so it read as pure ceremony (99 hand-offs/wk). It averages **20.6 min, 76 tool calls, `active_ms` 19.9 of 20.6** — provisioning sandboxes, driving a browser, and acting as the independent observer the branch-freeze protocol depends on.
- `apidocs-bot` — no secrets, read as collapsible. Owns a live webhook automation.
- `code-reviewer` — proposed as a *skill*. Wrong tier: a skill loads into the caller's context, and its whole value is **not seeing** the author's reasoning.

So the card must name **which signal disqualified an agent**, not just a verdict — otherwise it reproduces §2b's "detection without proposal" with worse consequences.

**2. The gate audit cannot classify read-vs-write.** Of 9,139 `gate.decision` events, **8,573 are `shell.exec`**. The grain can't tell a `git diff` from a deploy, so "is this agent read-only?" is not derivable today. Any classifier assuming otherwise is guessing.

## Explicitly not-to-be-built

A one-click "fold agent → skill" button. Same reasoning as Step 2 declining buttons on the runtime-death card, and stronger:

- the mechanics are trivial; the **judgement** is what failed 3/3
- the destination tier is usually **sub-agent**, so a "→ skill" button bakes in the rarest fit
- a fold isn't done when the skill exists — it's done when **every caller stops delegating**, which means editing other agents' `CLAUDE.md` via the clobber-prone path that already needed `assessClaudeMdEdit` + `baseHash` guards after two live incidents

## Sized honestly

The confident class on instawp is ~2 agents and ~8 hand-offs/week. **$7,300/week sits in `infra-ops` (221 hand-offs), `engineer` (165) and `qa` (103)** — long, credentialed work no fold can touch. That's an argument for this card being *diagnostic*, and for the delegation budget being the bigger lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
