### PR TITLE
feat(verbosity): benchmark the terse brief instead of inferring it from production (v0.370.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.370.0]
+### Added
+- **`npm run bench:verbosity` — a paired, controlled benchmark for `TERSE_OUTPUT_BRIEF`, and the
+  negative result it returned.** `verbositySavings()` compares terse and normal sessions as they
+  happened on a live tenant; run against the real instapods DB it calls terse 28–92% WORSE on four of
+  five comparable agents. None of that was evidence, for three reasons the query cannot fix from the
+  inside: `term_sessions.output_tokens` is ~85% `tool_use` arguments and ~18% thinking (measured over 40
+  live transcripts), so it barely contains the narration the brief compresses; dividing by turns lets
+  the treatment move its own denominator (`marketing-manager` is 92% worse per turn and 25% cheaper per
+  session, from the same rows); and the arms are a 2026-08-07 cutover, not a split. So the brief is now
+  measured directly instead — `scripts/verbosity-benchmark.cjs` runs 14 tool-free prompts through both
+  arms of an otherwise identical `claude -p`, tools disallowed so the response is pure narration,
+  scoring provider-reported narration tokens (`output_tokens - thinking_tokens`) and a `mustMention`
+  completeness guard so brevity bought by dropping required facts scores as degradation. The brief is
+  read from `dist/`, so the text measured is always the text shipped. Two conditions — the brief alone,
+  and the brief behind a real ~14k-token `company.md` — put a number on dilution.
+  **The result: -0.6% and -4.6% mean narration change, terse shorter on 6/14 and 5/14 prompts.** The
+  treatment effect (13–18%) is smaller than the rep-to-rep spread within a single arm (22–24%), so the
+  brief's effect is not distinguishable from noise; completeness was unharmed, so it is not trading
+  substance for brevity either. Dilution is real but minor (4 points) and was not the cause — the brief
+  does not land even in a bare prompt. Contributing factor recorded in the source: 72% of its words tell
+  the model NOT to compress (312 words of carve-out and reassurance vs 123 instructing brevity).
+
 ## [0.369.1] — 2026-08-18
 ### Fixed
 - **The feed's live activity line no longer reads a bare capability id like `shell.exec`.** Two classifier

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.369.1",
+  "version": "0.370.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.369.1",
+      "version": "0.370.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.369.1",
+  "version": "0.370.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",
@@ -45,7 +45,8 @@
     "test:policy-reconcile": "node scripts/test-policy-reconcile.cjs",
     "test:review": "node scripts/review-notify-test.cjs",
     "test:outcome-vocab": "node scripts/outcome-vocabulary-test.cjs",
-    "test:skill-edit": "node scripts/skill-edit-proposal-test.cjs"
+    "test:skill-edit": "node scripts/skill-edit-proposal-test.cjs",
+    "bench:verbosity": "node scripts/verbosity-benchmark.cjs"
   },
   "keywords": [
     "agents",

--- a/scripts/verbosity-benchmark.cjs
+++ b/scripts/verbosity-benchmark.cjs
@@ -1,0 +1,328 @@
+#!/usr/bin/env node
+/**
+ * verbosity-benchmark — a PAIRED, CONTROLLED measurement of what `TERSE_OUTPUT_BRIEF` actually does.
+ *
+ * Why this exists, and why it is not `verbositySavings`
+ * ----------------------------------------------------
+ * `verbositySavings()` (src/edge/verbosity.ts) compares terse and normal sessions as they happened on a
+ * live tenant. Run against the real instapods DB it reports terse as 28–92% WORSE on four of five
+ * comparable agents — and none of that is evidence, because of three defects the query cannot fix from
+ * the inside:
+ *
+ *  1. **It measures the wrong quantity.** `term_sessions.output_tokens` is the raw provider counter, and
+ *     over 40 recent live transcripts the assistant's output bytes split ~85% `tool_use` arguments
+ *     (file writes, bash commands, patches) / ~15% `text` (narration). Thinking is a further ~18% of the
+ *     token counter. The brief compresses NARRATION ONLY. So even a brief that deleted every word of
+ *     narration could not move `output_tokens` by more than ~15%, and the ±50–90% swings the query
+ *     reports are tool-use volume — i.e. which task the agent happened to draw — not verbosity.
+ *  2. **The denominator moves with the treatment.** Terse changes turn SHAPE (fewer, denser turns), so
+ *     dividing by turns lets the treatment inflate its own per-turn number. On the live data
+ *     `marketing-manager` is 92% worse per turn and 25% cheaper per session, from the same rows.
+ *  3. **It is a cutover, not a split.** Every normal session predates 2026-08-07 and every terse one
+ *     follows it, so anything else that changed that day is inside the treatment arm.
+ *
+ * The fix is not a better query. It is to stop inferring causation from production and measure the
+ * brief directly, the way the `caveman` project does: same prompts, same model, one variable.
+ *
+ * Design
+ * ------
+ *  - **Paired.** Every prompt is run through both arms; the statistic is the per-prompt delta, so a
+ *    prompt that is simply long cancels out instead of loading one arm.
+ *  - **One variable.** Both arms are identical `claude -p` invocations. The treatment appends
+ *    `TERSE_OUTPUT_BRIEF` — read from `dist/` at run time, so the thing measured is always the thing
+ *    shipped (the same reason caveman's benchmark reads its SKILL.md rather than a copy).
+ *  - **Tools off.** The prompts are answerable from their own text and every tool is disallowed, so the
+ *    response is pure narration and the 85% that terse cannot touch is excluded by construction rather
+ *    than averaged over.
+ *  - **Narration tokens, provider-reported.** `output_tokens - thinking_tokens`. Not an estimate, and
+ *    not contaminated by reasoning the brief has no claim on.
+ *  - **A completeness guard.** Each prompt declares `mustMention` literals a correct answer must still
+ *    contain. Brevity that drops them is degradation, not saving, and the report scores it as such —
+ *    without this the benchmark rewards an empty response.
+ *  - **Two conditions.** `minimal` puts the brief in a bare system prompt: the CEILING, what it is worth
+ *    when the model can actually see it. `production` (via `--company <file>`) prepends a real
+ *    `session-*.company.md` first, which on the live fleet is ~14k tokens of which the brief is the last
+ *    660. The gap between the two conditions IS the dilution hypothesis, measured.
+ *
+ * `claude -p` exposes no temperature, so a cell is repeated `--reps` times and averaged. Runs are
+ * sequential and ordered; nothing here uses randomness, so a re-run with the same arguments is
+ * comparable to the last one.
+ *
+ * Usage
+ * -----
+ *   npm run build                                  # the brief is read from dist/
+ *   node scripts/verbosity-benchmark.cjs --model claude-haiku-4-5 --reps 2
+ *   node scripts/verbosity-benchmark.cjs --company ~/agent-os-data/<tenant>/connectors/session-<id>.company.md
+ *
+ *   --model <id>      model to benchmark (default claude-haiku-4-5 — pin the one you actually run)
+ *   --reps <n>        repetitions per cell (default 2)
+ *   --company <file>  also run the `production` condition with this system prompt prepended
+ *   --only <ids>      comma-separated prompt ids, for a smoke run
+ *   --out <file>      write the raw per-call results as JSON
+ *
+ * Spends real tokens: calls = prompts x arms x conditions x reps. It prints the plan and the running
+ * cost as it goes.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..');
+
+// ---------------------------------------------------------------------------- args
+
+function parseArgs(argv) {
+  const out = { model: 'claude-haiku-4-5', reps: 2, company: null, only: null, outFile: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--model') out.model = argv[++i];
+    else if (a === '--reps') out.reps = Math.max(1, parseInt(argv[++i], 10) || 1);
+    else if (a === '--company') out.company = argv[++i];
+    else if (a === '--only') out.only = argv[++i].split(',').map((s) => s.trim()).filter(Boolean);
+    else if (a === '--out') out.outFile = argv[++i];
+    else if (a === '--help' || a === '-h') out.help = true;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------- the brief under test
+
+/** Read the SHIPPED brief, so the benchmark can never drift from the prompt production uses. */
+function loadBrief() {
+  const distPath = path.join(ROOT, 'dist', 'edge', 'verbosity.js');
+  if (!fs.existsSync(distPath)) {
+    console.error('error: dist/edge/verbosity.js not found — run `npm run build` first.');
+    console.error('       (the brief is read from the build so the benchmark measures what ships)');
+    process.exit(1);
+  }
+  const { TERSE_OUTPUT_BRIEF } = require(distPath);
+  if (!TERSE_OUTPUT_BRIEF) {
+    console.error('error: dist/edge/verbosity.js exports no TERSE_OUTPUT_BRIEF.');
+    process.exit(1);
+  }
+  return TERSE_OUTPUT_BRIEF;
+}
+
+// ---------------------------------------------------------------------------- one call
+
+// Everything that could put a `tool_use` block in the response. Narration is what we are measuring;
+// a single Read call would swamp it (tool arguments are ~85% of real output tokens).
+const NO_TOOLS = [
+  'Bash', 'Read', 'Write', 'Edit', 'NotebookEdit', 'Glob', 'Grep',
+  'WebFetch', 'WebSearch', 'Task', 'TodoWrite', 'Agent', 'SlashCommand',
+];
+
+/**
+ * One `claude -p` call. Returns provider-reported usage plus the answer text, or null on failure
+ * (a failed cell is dropped from the averages rather than counted as zero — see the note in `main`).
+ * `cwd` is a scratch dir with no CLAUDE.md, so no project memory leaks into either arm.
+ */
+function runOne({ model, prompt, systemFile, cwd }) {
+  const args = [
+    '-p', prompt,
+    '--model', model,
+    '--output-format', 'json',
+    '--strict-mcp-config', '--mcp-config', '{"mcpServers":{}}',
+    '--disallowed-tools', ...NO_TOOLS,
+  ];
+  if (systemFile) args.push('--append-system-prompt-file', systemFile);
+  let raw;
+  try {
+    raw = execFileSync('claude', args, { cwd, encoding: 'utf8', timeout: 180_000, maxBuffer: 32 * 1024 * 1024 });
+  } catch (e) {
+    return { error: (e && e.message ? String(e.message) : 'spawn failed').slice(0, 200) };
+  }
+  let json;
+  try {
+    json = JSON.parse(raw);
+  } catch {
+    return { error: 'unparseable JSON from claude -p' };
+  }
+  if (json.is_error) return { error: String(json.result || 'is_error').slice(0, 200) };
+  const u = json.usage || {};
+  const outputTokens = u.output_tokens || 0;
+  const thinking = (u.output_tokens_details && u.output_tokens_details.thinking_tokens) || 0;
+  const text = String(json.result || '');
+  return {
+    // The metric. Thinking is billed as output but is reasoning, not narration — the brief makes no
+    // claim on it, so counting it would credit or blame terse for something it does not touch.
+    narrationTokens: Math.max(0, outputTokens - thinking),
+    outputTokens,
+    thinkingTokens: thinking,
+    costUsd: json.total_cost_usd || 0,
+    chars: text.length,
+    text,
+  };
+}
+
+/** Did the answer keep the facts a correct answer needs? Brevity that drops these is not a saving. */
+function complete(text, mustMention) {
+  const hay = text.toLowerCase();
+  const missing = (mustMention || []).filter((m) => !hay.includes(String(m).toLowerCase()));
+  return { ok: missing.length === 0, missing };
+}
+
+// ---------------------------------------------------------------------------- reporting
+
+const mean = (xs) => (xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0);
+const pct = (from, to) => (from > 0 ? ((from - to) / from) * 100 : 0);
+const fmtPct = (n) => `${n >= 0 ? '' : ''}${n.toFixed(1)}%`;
+
+/**
+ * Report one condition. Paired throughout: the headline is the mean of the PER-PROMPT reductions, not
+ * the reduction of the pooled means — pooling would let one long prompt dominate the result.
+ */
+function report(condition, rows) {
+  const byPrompt = new Map();
+  for (const r of rows) {
+    if (!byPrompt.has(r.promptId)) byPrompt.set(r.promptId, { normal: [], terse: [] });
+    byPrompt.get(r.promptId)[r.arm].push(r);
+  }
+
+  console.log(`\n${'='.repeat(96)}`);
+  console.log(`CONDITION: ${condition}`);
+  console.log('='.repeat(96));
+  console.log(
+    'prompt'.padEnd(26) + 'normal'.padStart(9) + 'terse'.padStart(9) + 'reduction'.padStart(12) +
+    '  completeness (normal → terse)',
+  );
+  console.log('-'.repeat(96));
+
+  const reductions = [];
+  let nOk = 0, nTot = 0, tOk = 0, tTot = 0;
+  let normalCost = 0, terseCost = 0;
+
+  for (const [id, arms] of byPrompt) {
+    const nTok = mean(arms.normal.map((r) => r.narrationTokens));
+    const tTok = mean(arms.terse.map((r) => r.narrationTokens));
+    if (!arms.normal.length || !arms.terse.length) continue;
+    const red = pct(nTok, tTok);
+    reductions.push(red);
+    for (const r of arms.normal) { nTot++; if (r.complete) nOk++; normalCost += r.costUsd; }
+    for (const r of arms.terse) { tTot++; if (r.complete) tOk++; terseCost += r.costUsd; }
+    const nC = `${arms.normal.filter((r) => r.complete).length}/${arms.normal.length}`;
+    const tC = `${arms.terse.filter((r) => r.complete).length}/${arms.terse.length}`;
+    const flag = arms.terse.some((r) => !r.complete) && arms.normal.every((r) => r.complete) ? '  <-- terse dropped required facts' : '';
+    console.log(
+      id.padEnd(26) + String(Math.round(nTok)).padStart(9) + String(Math.round(tTok)).padStart(9) +
+      fmtPct(red).padStart(12) + `  ${nC} → ${tC}${flag}`,
+    );
+  }
+
+  console.log('-'.repeat(96));
+  const headline = mean(reductions);
+  const wins = reductions.filter((r) => r > 0).length;
+  console.log(`mean per-prompt narration reduction : ${fmtPct(headline)}   (terse shorter on ${wins}/${reductions.length} prompts)`);
+  console.log(`completeness                        : normal ${nOk}/${nTot}, terse ${tOk}/${tTot}`);
+  console.log(`spend this condition                : normal $${normalCost.toFixed(4)}, terse $${terseCost.toFixed(4)}`);
+  if (tTot && tOk / tTot < nOk / Math.max(1, nTot)) {
+    console.log('WARNING: terse answered LESS completely than normal. A reduction bought by dropping');
+    console.log('         required facts is degradation, not saving — do not quote the headline alone.');
+  }
+  return { condition, headline, wins, total: reductions.length, normalComplete: nOk / Math.max(1, nTot), terseComplete: tOk / Math.max(1, tTot) };
+}
+
+// ---------------------------------------------------------------------------- main
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    console.log(fs.readFileSync(__filename, 'utf8').split('*/')[0].replace(/^\/\*\*?/, ''));
+    return;
+  }
+
+  const brief = loadBrief();
+  const spec = JSON.parse(fs.readFileSync(path.join(__dirname, 'verbosity-prompts.json'), 'utf8'));
+  let prompts = spec.prompts;
+  if (args.only) prompts = prompts.filter((p) => args.only.includes(p.id));
+  if (!prompts.length) {
+    console.error('error: no prompts selected');
+    process.exit(1);
+  }
+
+  // Scratch dir with no CLAUDE.md — a project memory file would load into BOTH arms and add thousands
+  // of tokens of instructions that are not the thing under test.
+  const work = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-vbench-'));
+
+  // The system prompts, written once and reused so the provider can cache the prefix.
+  const conditions = [];
+  const minimalNormal = ''; // no --append-system-prompt-file at all: the CLI's own default, untouched
+  const minimalTerse = path.join(work, 'minimal-terse.md');
+  fs.writeFileSync(minimalTerse, brief);
+  conditions.push({ name: 'minimal', normal: null, terse: minimalTerse });
+
+  if (args.company) {
+    const company = fs.readFileSync(args.company, 'utf8');
+    // The live file already ENDS with the brief when the tenant default is terse. Strip it so the
+    // control arm is genuinely untreated, then rebuild the treatment arm from the shipped text.
+    const idx = company.indexOf('# Output style — terse');
+    const base = (idx === -1 ? company : company.slice(0, idx)).trimEnd();
+    const prodNormal = path.join(work, 'prod-normal.md');
+    const prodTerse = path.join(work, 'prod-terse.md');
+    fs.writeFileSync(prodNormal, base);
+    fs.writeFileSync(prodTerse, `${base}\n\n${brief}`);
+    conditions.push({ name: 'production', normal: prodNormal, terse: prodTerse });
+    console.log(`production condition: ${args.company}`);
+    console.log(`  base system prompt ${base.length.toLocaleString()} chars (~${Math.round(base.length / 4).toLocaleString()} tokens)` +
+      `, brief adds ${brief.length.toLocaleString()} chars (~${Math.round(brief.length / 4).toLocaleString()} tokens)`);
+  }
+
+  const calls = prompts.length * 2 * conditions.length * args.reps;
+  console.log(`\nmodel ${args.model} | ${prompts.length} prompts | ${conditions.length} condition(s) | ${args.reps} rep(s) | ${calls} calls`);
+  console.log(`brief under test: ${brief.length} chars (from dist/)\n`);
+
+  const rows = [];
+  let done = 0, spend = 0, failures = 0;
+  for (const cond of conditions) {
+    for (const p of prompts) {
+      for (const arm of ['normal', 'terse']) {
+        for (let rep = 0; rep < args.reps; rep++) {
+          const res = runOne({ model: args.model, prompt: p.prompt, systemFile: cond[arm], cwd: work });
+          done++;
+          if (res.error) {
+            failures++;
+            process.stdout.write(`  [${done}/${calls}] ${cond.name}/${p.id}/${arm} FAILED: ${res.error}\n`);
+            continue;
+          }
+          const c = complete(res.text, p.mustMention);
+          spend += res.costUsd;
+          rows.push({
+            condition: cond.name, promptId: p.id, category: p.category, arm, rep,
+            narrationTokens: res.narrationTokens, outputTokens: res.outputTokens,
+            thinkingTokens: res.thinkingTokens, costUsd: res.costUsd, chars: res.chars,
+            complete: c.ok, missing: c.missing, text: res.text,
+          });
+          process.stdout.write(
+            `  [${done}/${calls}] ${cond.name}/${p.id}/${arm} ` +
+            `${String(res.narrationTokens).padStart(5)} tok${c.ok ? '' : ` INCOMPLETE (missing ${c.missing.join(', ')})`}` +
+            `  $${spend.toFixed(3)}\n`,
+          );
+        }
+      }
+    }
+  }
+
+  const summaries = [];
+  for (const cond of conditions) summaries.push(report(cond.name, rows.filter((r) => r.condition === cond.name)));
+
+  if (summaries.length === 2) {
+    const [min, prod] = summaries;
+    console.log(`\n${'='.repeat(96)}`);
+    console.log('DILUTION — what the same brief is worth in a bare prompt vs behind the real company context');
+    console.log('='.repeat(96));
+    console.log(`  minimal    ${fmtPct(min.headline)}`);
+    console.log(`  production ${fmtPct(prod.headline)}`);
+    console.log(`  the gap is what position and surrounding context cost the brief: ${fmtPct(min.headline - prod.headline)} of reduction lost.`);
+  }
+
+  console.log(`\ntotal spend $${spend.toFixed(4)}${failures ? ` | ${failures} call(s) failed and were dropped` : ''}`);
+  if (args.outFile) {
+    fs.writeFileSync(args.outFile, JSON.stringify({ model: args.model, reps: args.reps, briefChars: brief.length, rows }, null, 2));
+    console.log(`raw results → ${args.outFile}`);
+  }
+  console.log(`scratch dir (system prompts used): ${work}`);
+}
+
+main();

--- a/scripts/verbosity-prompts.json
+++ b/scripts/verbosity-prompts.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "note": "Tool-free prompts. Every one is answerable from the text in the prompt itself, so the assistant emits ONLY narration (text blocks) and no tool_use — which is the point: tool_use arguments are ~85% of a real session's output tokens and terse cannot compress them. Each prompt carries `mustMention`: literal substrings (case-insensitive) that a CORRECT answer has to contain. They are the completeness guard — a run that gets shorter by dropping them has not saved anything, it has degraded. Keep them to facts a terse answer must still state (identifiers, numbers, error strings), never to prose.",
+  "prompts": [
+    {
+      "id": "debug-off-by-one",
+      "category": "debugging",
+      "prompt": "This function is meant to return the last `n` items of `arr`, but `tail([1,2,3,4,5], 2)` returns `[4,5,undefined]`.\n\n```js\nfunction tail(arr, n) {\n  const out = [];\n  for (let i = arr.length - n; i <= arr.length; i++) out.push(arr[i]);\n  return out;\n}\n```\n\nWhat is wrong and how do I fix it?",
+      "mustMention": ["<=", "arr.length"]
+    },
+    {
+      "id": "explain-error",
+      "category": "debugging",
+      "prompt": "My Node service prints this and exits:\n\n```\nError: listen EADDRINUSE: address already in use :::3010\n    at Server.setupListenHandle [as _listen2] (node:net:1898:16)\n```\n\nWhat does this mean and what are my options?",
+      "mustMention": ["EADDRINUSE", "3010"]
+    },
+    {
+      "id": "review-diff",
+      "category": "review",
+      "prompt": "Review this diff and tell me if it is safe to merge.\n\n```diff\n-  const rate = limits[plan] ?? 100;\n+  const rate = limits[plan] || 100;\n   if (requests > rate) return deny();\n```\n\nThe `limits` map may legitimately contain `0` for a suspended plan.",
+      "mustMention": ["0", "||"]
+    },
+    {
+      "id": "sql-explain",
+      "category": "analysis",
+      "prompt": "Explain what this query returns and name one reason it might be slow on a large table.\n\n```sql\nSELECT agent, COUNT(*) AS n\n  FROM term_sessions\n WHERE created_at >= ? AND status = 'done'\n GROUP BY agent\n ORDER BY n DESC\n LIMIT 10;\n```",
+      "mustMention": ["agent", "created_at"]
+    },
+    {
+      "id": "status-report",
+      "category": "reporting",
+      "prompt": "You just finished a task. Here is what happened: you were asked to fix a failing test in `auth.test.ts`; the failure was a token expiry comparison using `<` instead of `<=`; you changed one line in `src/auth/token.ts:44`; the full suite now passes (128 tests); you did not touch anything else. Report the outcome.",
+      "mustMention": ["token.ts", "128"]
+    },
+    {
+      "id": "answer-narrow-question",
+      "category": "qa",
+      "prompt": "In one answer: does a SQLite `WAL` mode database still create the `-shm` file if only one process ever opens it?",
+      "mustMention": ["-shm"]
+    },
+    {
+      "id": "multi-step-plan",
+      "category": "planning",
+      "prompt": "I need to rename an environment variable from `OLD_TOKEN` to `NEW_TOKEN` across a Node service that runs on three machines under systemd. Give me the ordered steps so nothing breaks mid-rollout.",
+      "mustMention": ["OLD_TOKEN", "NEW_TOKEN"]
+    },
+    {
+      "id": "tradeoff-question",
+      "category": "qa",
+      "prompt": "Should I store a user's session token in a cookie or in localStorage for a server-rendered app? Give me your recommendation and the reason.",
+      "mustMention": ["cookie"]
+    },
+    {
+      "id": "summarize-tool-output",
+      "category": "reporting",
+      "prompt": "Here is the output of a command I just ran. Tell me what it means.\n\n```\n$ df -h /\nFilesystem      Size  Used Avail Capacity  Mounted on\n/dev/disk3s5    926Gi  879Gi   12Gi    99%    /\n```",
+      "mustMention": ["99%", "12Gi"]
+    },
+    {
+      "id": "regex-explain",
+      "category": "analysis",
+      "prompt": "What does this regex match, and give me one input it wrongly rejects: `^[a-z0-9]+(-[a-z0-9]+)*$`",
+      "mustMention": ["-"]
+    },
+    {
+      "id": "risky-op",
+      "category": "safety",
+      "prompt": "I want to reclaim space on the box. Is it safe for me to run `sudo rm -rf /var/log/*` on a production server?",
+      "mustMention": ["/var/log"]
+    },
+    {
+      "id": "api-design",
+      "category": "design",
+      "prompt": "I have an endpoint `POST /api/tasks` that creates a task. A caller sometimes retries after a timeout and I get duplicates. What is the standard fix?",
+      "mustMention": ["idempot"]
+    },
+    {
+      "id": "compare-two",
+      "category": "qa",
+      "prompt": "What is the practical difference between `git merge --squash` and `git rebase` for getting a feature branch onto main?",
+      "mustMention": ["squash", "rebase"]
+    },
+    {
+      "id": "config-question",
+      "category": "qa",
+      "prompt": "In nginx, my location block sets `proxy_set_header Upgrade $http_upgrade;` and `proxy_set_header Connection \"upgrade\";`. Every plain HTTP request to that upstream now returns 502. Why?",
+      "mustMention": ["502", "Connection"]
+    }
+  ]
+}

--- a/src/edge/verbosity.ts
+++ b/src/edge/verbosity.ts
@@ -15,6 +15,30 @@
 // by model and by task. That is exactly why `verbositySavings` exists — the flag ships with the query
 // that can falsify it.
 //
+// AND IT DID. `npm run bench:verbosity` (scripts/verbosity-benchmark.cjs) ran the brief as a paired,
+// controlled A/B — 14 tool-free prompts, both arms, claude-sonnet-5, 2 reps, tools disallowed so the
+// response is pure narration. The result: a mean per-prompt narration change of **-0.6% in a bare
+// system prompt and -4.6% behind the real 14k-token company context**, with terse the shorter arm on
+// 6/14 and 5/14 prompts — a coin flip. The treatment effect (13–18%) is SMALLER than the rep-to-rep
+// spread WITHIN one arm (22–24%), so the brief's effect on narration length is not distinguishable
+// from noise. Completeness was unharmed (terse 28/28 vs normal 26/28 minimal), so it is not trading
+// brevity for substance either — it is simply not landing.
+//
+// Two things the benchmark also established, both of which invalidate reading `verbositySavings` as
+// evidence about this brief:
+//   - **`output_tokens` cannot measure narration.** Over 40 recent live transcripts the assistant's
+//     output bytes are ~85% `tool_use` ARGUMENTS (file writes, commands, patches) and ~15% `text`.
+//     Thinking is a further ~18% of the token counter. The brief compresses narration only, so even
+//     total compliance could not move `output_tokens` more than ~15% — and the ±50–90% per-agent
+//     swings the query reports on live data are tool-use volume, i.e. which task the agent drew.
+//   - **The brief spends 72% of its words telling the model NOT to compress.** 123 words instruct
+//     brevity; 312 are carve-outs and reassurance ("terse is not vague", "completeness wins over
+//     length every time"). For contrast the `caveman` project's SKILL.md — concrete drop-lists, a
+//     pattern template, a worked before/after example — benchmarks at 65% on the same kind of
+//     paired harness.
+// Re-run the benchmark before changing the text below, and again after. Do not quote a saving from
+// `verbositySavings` alone.
+//
 // The carve-out has a failure mode of its own, and it showed up live: a terse `engineer` run answered a
 // console question at essay length, and the owner had to reply "explain to me in 1 liner". Nothing was
 // broken — the answer landed in the exempt lane, and "write them in full, ordinary prose" reads as a
@@ -67,7 +91,9 @@ export interface VerbosityArm {
   /** Conversation turns across them — the denominator. A run with more turns costs more for reasons
    *  that have nothing to do with verbosity, so totals are not comparable; per-turn is. */
   turns: number;
-  /** Mean output tokens per turn — the metric the brief acts on DIRECTLY. */
+  /** Mean output tokens per turn. NOT a measure of narration length — see the correction on
+   *  {@link verbositySavings}. `output_tokens` is dominated by tool-call arguments and thinking, both
+   *  of which the brief leaves untouched. */
   outputPerTurn: number;
   /** Mean total USD per turn — what actually lands on the bill (output is a minority of it). */
   usdPerTurn: number;


### PR DESCRIPTION
## What

`verbositySavings()` judges terse from live sessions. Against the real instapods DB it calls terse **28–92% worse** on four of five comparable agents. That number is not evidence, and this PR replaces the way we ask the question.

Three defects the query cannot fix from the inside:

1. **It measures the wrong quantity.** Across 40 recent live transcripts, assistant output bytes are **~85% `tool_use` arguments** (file writes, commands, patches) and **~15% `text`**; thinking is a further ~18% of the token counter. The brief compresses narration only — total compliance could not move `output_tokens` by more than ~15%, so the ±50–90% per-agent swings are tool-use volume, i.e. which task the agent drew.
2. **The denominator moves with the treatment.** Terse changes turn shape, so dividing by turns lets it inflate its own number. `marketing-manager` is 92% worse per turn and 25% cheaper per session — same rows.
3. **It is a cutover, not a split.** Every normal session predates 2026-08-07 and every terse one follows it.

## The benchmark

`npm run bench:verbosity` — 14 tool-free prompts through both arms of an otherwise identical `claude -p`:

- **Paired** — the statistic is the per-prompt delta, so a naturally long prompt cancels instead of loading one arm.
- **Tools disallowed** — the response is pure narration, so the 85% the brief cannot touch is excluded by construction rather than averaged over.
- **Narration tokens, provider-reported** — `output_tokens - thinking_tokens`. Not an estimate.
- **Completeness guard** — each prompt declares `mustMention` literals. Brevity that drops them scores as degradation, not saving; without it the benchmark rewards an empty answer.
- **Brief read from `dist/`** — the measured text is always the shipped text.
- **Two conditions** — brief alone (the ceiling), and brief behind a real ~14k-token `company.md` (production). The gap is the dilution hypothesis, measured.

## Result — claude-sonnet-5, 2 reps

| condition | mean narration change | terse shorter on | completeness (normal → terse) |
|---|---|---|---|
| minimal | **−0.6%** | 6/14 | 26/28 → 28/28 |
| production | **−4.6%** | 5/14 | 25/28 → 26/28 |

The treatment effect (13–18%) is **smaller than the rep-to-rep spread within a single arm** (22–24%). The brief's effect on narration length is not distinguishable from noise.

Completeness was unharmed, so it is not trading substance for brevity either. And dilution is real but minor (4 points) — **it was not the cause**: the brief fails to land even in a bare prompt, so per-turn reinforcement would have reinforced something that does not work.

One structural candidate, recorded in the source next to the text it judges: **72% of the brief's words tell the model NOT to compress** — 312 words of carve-out and reassurance ("terse is not vague", "completeness wins over length every time") against 123 instructing brevity.

## Scope

No behaviour change. The brief and the flag are untouched pending a rewrite, which should be measured with this harness before and after. `verbositySavings`'s misleading doc comment is corrected; the function is left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)