### PR TITLE
fix(feed): don't list a delegated task twice (card + nested run) (v0.370.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.370.1] — 2026-08-18
+### Fixed
+- **The feed no longer lists a delegated task twice.** A delegated run appears nested in its hand-off
+  chain; its "Task done" notification card was *also* shown flat at top level — the same work listed
+  twice. The Feed lens now drops a `message.task` card when that task's delegated run is already present
+  on the page (its session line, matched by `spawned_by = task:<id>`) — the run is the real thing, the
+  card is redundant. A task card with no run in view (done elsewhere / pruned by the window) still shows.
+
 ## [0.370.0]
 ### Added
 - **`npm run bench:verbosity` — a paired, controlled benchmark for `TERSE_OUTPUT_BRIEF`, and the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.370.0",
+  "version": "0.370.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.370.0",
+      "version": "0.370.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.370.0",
+  "version": "0.370.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5709,10 +5709,16 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
   const childrenOf = new Map<string, string[]>()
   const rootThreads: string[] = []
   if (lens === 'feed') {
+    // Tasks whose delegated RUN is already in this page — its session line (nested in the chain) is the
+    // real thing, so the matching "Task done" notification card would just list the same work twice.
+    const tasksWithRun = new Set<string>()
+    for (const it of items) if (isSessionKind(it) && it.spawnedBy?.startsWith('task:')) tasksWithRun.add(it.spawnedBy.slice(5))
     for (const it of items) {
       if (isSessionKind(it) && it.threadId) {
         const cur = byThread.get(it.threadId)
         if (!cur || it.ts > cur.ts) byThread.set(it.threadId, it)
+      } else if (it.kind === 'message.task' && it.target?.kind === 'task' && tasksWithRun.has(it.target.id)) {
+        continue // drop the redundant task card — its run is shown in the chain
       } else flatItems.push(it)
     }
     for (const [tid, it] of byThread) {


### PR DESCRIPTION
A delegated run shows **nested in its hand-off chain**; its **"Task done" notification card** was *also* shown flat at top level — the same work listed twice.

The Feed lens now drops a `message.task` card when that task's delegated run is already present on the page — matched by the session line's `spawned_by = task:<id>` against the card's `target.id`. The run is the real thing; the card is redundant. A task card with **no** run in view (task done elsewhere, or the run pruned by the time window) still shows.

Page-local dedup, consistent with the chain grouping. Web-only.

Verification: `cd web && npm run build` clean; store/governance unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)