### PR TITLE
fix(feed): drop the blank live-activity line; more spacing between items (v0.370.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.370.2] — 2026-08-18
+### Fixed
+- **No more blank line after the live-activity dot.** The running-session "currently…" line sometimes
+  rendered a blinking green dot with nothing after it — the newest classified event had an empty summary.
+  `latestActivity` now skips empty-summary events and keeps scanning for the newest one that actually says
+  something (and the console guards the render on a non-empty summary too).
+- **More breathing room between feed items** (a touch more vertical spacing per line).
+
 ## [0.370.1] — 2026-08-18
 ### Fixed
 - **The feed no longer lists a delegated task twice.** A delegated run appears nested in its hand-off

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.370.1",
+  "version": "0.370.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.370.1",
+      "version": "0.370.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.370.1",
+  "version": "0.370.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -6689,7 +6689,9 @@ function latestActivity(os: AgentOS, runId: string): { primitive: string; summar
     .all<{ ts: number; type: string; data: string }>(os.tenant, runId);
   for (const r of rows) {
     const d = classifyActivity(r.type, safeJson(r.data));
-    if (d) return { primitive: d.primitive, summary: clipText(d.summary, 140), ts: r.ts };
+    // Require a non-empty summary — a classified-but-empty descriptor (e.g. a bare primitive) would render
+    // as a blinking dot with nothing after it. Keep scanning for the newest event that actually says something.
+    if (d && d.summary && d.summary.trim()) return { primitive: d.primitive, summary: clipText(d.summary, 140), ts: r.ts };
   }
   const u = os.db
     .prepare("SELECT created_at AS ts, body FROM messages WHERE session_id = ? AND type = 'update' ORDER BY created_at DESC LIMIT 1")

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5664,11 +5664,12 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
     ) : (
       <div>
         {snippet(it)}
-        {/* live progress: what the agent is doing right now, refreshed by the poll (no terminal needed) */}
-        {it.state === 'running' && it.lastActivity && (
+        {/* live progress: what the agent is doing right now, refreshed by the poll (no terminal needed).
+            Only render when there's an actual summary — otherwise the dot dangles with nothing after it. */}
+        {it.state === 'running' && it.lastActivity?.summary?.trim() && (
           <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
             <span className="inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-emerald-500 motion-safe:animate-pulse" />
-            <span className="min-w-0 truncate italic">{it.lastActivity.summary}</span>
+            <span className="min-w-0 truncate italic">{it.lastActivity.summary.trim()}</span>
           </div>
         )}
         {attribution(it, chain)}
@@ -5682,7 +5683,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
           </span>
           <span className="w-px flex-1 bg-border" />
         </div>
-        <div className="min-w-0 flex-1 pb-4">{body}</div>
+        <div className="min-w-0 flex-1 pb-6">{body}</div>
       </div>
     )
   }


### PR DESCRIPTION
Two small feed polish items from live use.

- **Blank after the blinking dot.** A running-session live line occasionally showed the pulsing green dot with no text — the newest classified audit event had an empty summary. `latestActivity` now skips empty-summary events and keeps scanning for the newest one that actually says something; the console also guards the render on a non-empty summary.
- **Spacing.** A touch more vertical room between feed items.

Verification: server + web build clean; governance unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)