### PR TITLE
fix(feed): show a done session's verdict icon, not an empty dot (v0.370.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.370.3] — 2026-08-18
+### Fixed
+- **A done session in the feed now shows its verdict, not an empty dot.** The feed was rendering a
+  finished session with the neutral "ended" glyph (a tiny muted circle) regardless of how it went — so
+  even a successful run looked empty. It now shows the run's **verdict** like the sessions list and chain
+  rail do: a green check for success, red ✕ for failure/crash, amber slash for partial; a run that ended
+  without calling `report` gets a dashed ring ("done — no report") — clearer than a bare pip, still
+  claiming nothing. Live sessions are unchanged (working / ready / needs-you).
+
 ## [0.370.2] — 2026-08-18
 ### Fixed
 - **No more blank line after the live-activity dot.** The running-session "currently…" line sometimes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.370.2",
+  "version": "0.370.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.370.2",
+      "version": "0.370.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.370.2",
+  "version": "0.370.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, type ReactNode, type DragEvent as ReactDragEvent, type MouseEvent as ReactMouseEvent, type KeyboardEvent as ReactKeyboardEvent, type ChangeEvent as ReactChangeEvent } from 'react'
 import { Inbox as InboxIcon, TerminalSquare, Play, Plus, Check, X, Square, Rocket, Plug, Trash2, Users, User, LogOut, Copy, Zap, Brain, Building2, ChevronDown, SlidersHorizontal, Pencil, FileText, HelpCircle, CheckCircle2, XCircle, Clock, Send, LayoutGrid, List, ArrowLeft, Bot, FolderTree, Folder, File as FileIcon, FileCode, Save, ChevronRight, Sparkles, Package, Image as ImageIcon, Film, Download, Search, BookText, BookOpen, History as HistoryIcon, ScrollText, Bell, AlertTriangle, Activity, Lightbulb, Moon, Upload, FolderPlus, ListChecks, PanelLeftClose, PanelLeftOpen, PanelRightClose, PanelRightOpen, RefreshCw, ThumbsUp, ThumbsDown, Target, ExternalLink, Paperclip, KeyRound, Blocks, FilePlus, Maximize2, Minimize2, Filter, Share2, Lock, Gauge, Timer } from 'lucide-react'
 // The session-status glyph set (see STATE_META) — one icon per state, plus the chain rail's verdict icons.
-import { LoaderCircle, CircleSmall, CircleStop, CircleCheck, CircleX, CircleSlash, Circle, CircleDot, Ban, Copy as CopyIcon } from 'lucide-react'
+import { LoaderCircle, CircleSmall, CircleStop, CircleCheck, CircleX, CircleSlash, Circle, CircleDot, CircleDashed, Ban, Copy as CopyIcon } from 'lucide-react'
 import { GitPullRequest, GitPullRequestClosed, GitMerge, Wrench, Code2, Bug, MessageSquare, Mail, Megaphone, PenTool, Database, Server, Cloud, Shield, Calendar, LineChart, BarChart3, DollarSign, ShoppingCart, Headphones, Cog, Compass, Flag, Heart, Star, Globe, GitBranch, Palette, Camera, Music, Feather, Wand2, Boxes, Terminal, Webhook, CalendarClock, Hash, Cpu, MoreHorizontal, Power, PowerOff, Pin, PinOff, type LucideIcon } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
@@ -5441,6 +5441,22 @@ function feedItemRole(it: FeedItem): StatusRole {
   return 'ok'
 }
 
+/** The status glyph for a feed line. A LIVE session reads exactly like the sessions list
+ *  (working/ready/needs-you). A FINISHED session shows its VERDICT — a green check for success, red ✕ for
+ *  failure/crash, amber for partial — like the sessions list and chain rail, instead of the neutral
+ *  "ended" dot that made every done run (even a success) look empty. A run that ended without a report
+ *  gets a dashed ring ("done — no report"), clearer than a bare pip but still claiming nothing. */
+function feedGlyph(it: FeedItem, s: Session | undefined): ReactNode {
+  if (s && isLive(s)) return <SessionStatus s={s} iconClass="h-4 w-4" />
+  if (isSessionKind(it)) {
+    const v = it.kind === 'session.crashed' ? 'failure' : (verdictOf(it.outcome ?? undefined) ?? 'none')
+    const m = VERDICT_META[v]
+    const Icon = v === 'none' ? CircleDashed : m.icon
+    return <span className="inline-flex shrink-0" title={v === 'none' ? 'done — no report' : m.label}><Icon className={`h-4 w-4 ${m.tone}`} /></span>
+  }
+  return <RoleIcon role={feedItemRole(it)} label={it.kind} className="h-4 w-4" />
+}
+
 /** A one-word origin hint from a session's provenance prefix (spawned_by). */
 function provenanceHint(spawnedBy: string | null): string | null {
   if (!spawnedBy) return null
@@ -5679,7 +5695,7 @@ function FeedPage({ me, members, sessions, nav, onOpen, query, setQuery }: { me:
       <div key={it.uid} className="flex gap-3">
         <div className="flex flex-col items-center">
           <span className="grid h-7 w-7 shrink-0 place-items-center rounded-lg bg-muted/60">
-            {s ? <SessionStatus s={s} iconClass="h-4 w-4" /> : <RoleIcon role={feedItemRole(it)} label={it.kind} className="h-4 w-4" />}
+            {feedGlyph(it, s)}
           </span>
           <span className="w-px flex-1 bg-border" />
         </div>


### PR DESCRIPTION
A finished session in the feed was drawn with the neutral **ended** glyph (a tiny muted circle) — regardless of outcome — so even a **successful** run looked like an empty dot.

The feed now shows the run's **verdict**, the same vocabulary the sessions list and chain rail already use:
- **success** → green check
- **failure / crash** → red ✕
- **partial** → amber slash
- **no report** (ended, nobody called `report`) → a dashed ring ("done — no report") — clearer than a bare pip, but claims nothing

Live sessions are unchanged (working / ready / needs-you via `SessionStatus`). Reuses `VERDICT_META` / `verdictOf`. Web-only.

Verification: `cd web && npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)