### PR TITLE
fix(feed): real icon + label for update/notification lines, not the raw kind (v0.370.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.370.4] — 2026-08-18
+### Fixed
+- **Folded notification/update lines get a real icon + label, not the raw kind.** A `message.update`
+  card rendered a generic muted dot whose tooltip/aria-label leaked the internal kind string
+  (`"message.update"`). Now an agent progress **update** shows a note icon labelled "Progress update", a
+  notification a bell, a published artifact a package, etc.; other lines' glyphs label as
+  "Approval" / "Question" / "Session" instead of the dotted id.
+
 ## [0.370.3] — 2026-08-18
 ### Fixed
 - **A done session in the feed now shows its verdict, not an empty dot.** The feed was rendering a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.370.3",
+  "version": "0.370.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.370.3",
+      "version": "0.370.4",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.370.3",
+  "version": "0.370.4",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5454,7 +5454,27 @@ function feedGlyph(it: FeedItem, s: Session | undefined): ReactNode {
     const Icon = v === 'none' ? CircleDashed : m.icon
     return <span className="inline-flex shrink-0" title={v === 'none' ? 'done — no report' : m.label}><Icon className={`h-4 w-4 ${m.tone}`} /></span>
   }
-  return <RoleIcon role={feedItemRole(it)} label={it.kind} className="h-4 w-4" />
+  // folded notification/update cards get their own marker (a note, a bell, …), not a generic muted dot
+  const info = INFO_GLYPH[it.kind]
+  if (info) { const Icon = info.icon; return <span className="inline-flex shrink-0" title={info.label}><Icon className="h-4 w-4 text-muted-foreground/70" aria-label={info.label} /></span> }
+  return <RoleIcon role={feedItemRole(it)} label={friendlyKind(it.kind)} className="h-4 w-4" />
+}
+
+/** Icon + human label for a folded message card, so a line reads "Progress update" — not the raw
+ *  internal kind ("message.update") that used to leak into the glyph's tooltip / aria-label. */
+const INFO_GLYPH: Record<string, { icon: LucideIcon; label: string }> = {
+  'message.update': { icon: MessageSquare, label: 'Progress update' },
+  'message.notification': { icon: Bell, label: 'Notification' },
+  'message.task': { icon: ListChecks, label: 'Task update' },
+  'message.artifact': { icon: Package, label: 'Published' },
+}
+
+/** A human name for a feed line's kind — for the status glyph's label where the raw dotted id would leak. */
+function friendlyKind(kind: string): string {
+  if (kind.startsWith('approval')) return 'Approval'
+  if (kind.startsWith('question')) return 'Question'
+  if (kind.startsWith('session')) return 'Session'
+  return INFO_GLYPH[kind]?.label ?? kind
 }
 
 /** A one-word origin hint from a session's provenance prefix (spawned_by). */


### PR DESCRIPTION
That `<circle-small … aria-label="message.update">` you spotted is the glyph for an agent **progress update** (the `update` tool note, folded into the feed) — but it was rendering a generic muted dot and leaking the internal kind string `message.update` into its tooltip/aria-label.

Now folded cards get their own marker + human label:
- **update** → a note icon, "Progress update"
- **notification** → a bell
- **task** → a checklist
- **artifact** → a package, "Published"

And other lines' glyphs label as **Approval / Question / Session** instead of the dotted id.

Web-only. Verification: `cd web && npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)