### PR TITLE
feat(v2): agent-first console at /v2, isolated from the classic app (v0.372.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.372.0]
+### Added
+- **A new agent-first console at `/v2`, isolated from the classic app.** A minimal, x.ai-style
+  surface where the agent — not a global page — is the unit: the left rail is just the fleet, and
+  selecting an agent opens a workspace with everything about it on one sub-nav — a chat-first
+  Overview, plus Automations, Insights, Memory and Settings. Insights that used to live on a
+  fleet-wide page are scoped into each agent. Built as its own Vite entry (`web/v2.html` →
+  `web/src/v2/`) with its own tokens and reset — no shared code with `App.tsx`, no change to the
+  classic console at `/`, which is untouched. Served at `/v2` by `src/server.ts`. This first cut
+  renders a mock fleet; the next increment wires it to live `/api/state` + `/api/sessions`.
+
 ## [0.371.0]
 ### Changed
 - **The terse brief was rewritten, measured head-to-head, and reverted — and the benchmark grew the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.371.0",
+  "version": "0.372.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.371.0",
+      "version": "0.372.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.371.0",
+  "version": "0.372.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -506,6 +506,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const idx = path.join(WEB_DIST, 'index.html');
     return sendFile(res, fs.existsSync(idx) ? idx : CONSOLE_HTML, 'text/html; charset=utf-8');
   }
+  // /v2 — the isolated agent-first console (its own Vite entry, web/dist/v2.html). Served like '/':
+  // a public SPA shell; its /api/* calls carry the same aos_sid cookie. Distinct from the classic
+  // console at '/', which is untouched. See web/src/v2/.
+  if (method === 'GET' && (p === '/v2' || p === '/v2/' || p === '/v2.html')) {
+    const idx = path.join(WEB_DIST, 'v2.html');
+    if (fs.existsSync(idx)) return sendFile(res, idx, 'text/html; charset=utf-8');
+    return end(res, 404);
+  }
   if (method === 'GET' && p === '/health') return sendJson(res, 200, { ok: true, tenant: os.tenant, name: os.tenantName, version: VERSION });
   // Public marketing landing page — a standalone static HTML doc (no auth, no React). Served straight
   // off disk from public/landing.html so it can be iterated on without a web build. Distinct from the

--- a/web/src/v2/App.tsx
+++ b/web/src/v2/App.tsx
@@ -1,0 +1,259 @@
+import { useMemo, useState } from 'react'
+import { AGENTS, TABS, type Agent, type SessionRow, type Status } from './data'
+import './v2.css'
+
+// Agentric v2 — an isolated, agent-first console. Each agent carries its own automations,
+// insights, memory and settings; the classic multi-page console lives untouched at "/".
+// This surface is chat-first: an agent's Overview opens on a prompt console.
+//
+// TODO(next): replace the mock AGENTS import with live data — GET /api/state for the roster,
+// GET /api/sessions?agent=<id> for Recent sessions — using the same aos_sid cookie the classic
+// app relies on. Keep the shape in data.ts as the adapter target.
+
+function toggleTheme() {
+  const root = document.documentElement
+  const cur = root.getAttribute('data-theme')
+    || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+  root.setAttribute('data-theme', cur === 'dark' ? 'light' : 'dark')
+}
+
+function StatePill({ status, text }: { status: Status; text: string }) {
+  return (
+    <span className={`status-pill ${status}`}>
+      {status === 'idle' ? '●' : null} {text}
+    </span>
+  )
+}
+
+function SessionItem({ s }: { s: SessionRow }) {
+  return (
+    <div className="item">
+      <span className={`dot ${s.tag || 'idle'}`} style={s.tag ? undefined : { opacity: 0.4 }} />
+      <span className="grow">
+        <div className="t">{s.t}</div>
+        <div className="d">{s.d}</div>
+      </span>
+      {s.tag
+        ? <span className={`tag ${s.tag}`}>{s.tagText}</span>
+        : <span className={`verdict ${s.verdict}`}>{s.verText}</span>}
+      <span className="when">{s.when}</span>
+    </div>
+  )
+}
+
+function Overview({ a }: { a: Agent }) {
+  return (
+    <div className="panel">
+      <p className="thesis">Everything about this agent lives here — no hunting across a dozen global pages.</p>
+      <div className="console">
+        <div className="prompt">
+          <textarea rows={1} placeholder={`Message ${a.id}…  ask it to do something, or start a session`} />
+          <button className="send" title="Run">↑</button>
+        </div>
+        <div className="row2">
+          <span className="chip">▤ Create a task</span>
+          <span className="chip">◈ run-as: you</span>
+          <span className="chip">◱ Open live session</span>
+        </div>
+      </div>
+      <div className="stat-row">
+        <div className="stat"><div className="k">Runs · 7d</div><div className="v">{a.stats.runs}</div><div className="sub">across all triggers</div></div>
+        <div className="stat"><div className="k">Cost · 7d</div><div className="v">{a.stats.cost}</div><div className="sub">max-per-conversation</div></div>
+        <div className="stat"><div className="k">Auto-approve</div><div className="v">{a.stats.approve}</div><div className="sub">gate outcomes</div></div>
+        <div className="stat"><div className="k">Memories</div><div className="v">{a.stats.memories}</div><div className="sub">agent-scoped recall</div></div>
+      </div>
+      <div className="section-title"><h3>Recent sessions</h3><a>All sessions →</a></div>
+      <div className="list">
+        {a.sessions.map((s, i) => <SessionItem key={i} s={s} />)}
+      </div>
+    </div>
+  )
+}
+
+function Automations({ a }: { a: Agent }) {
+  if (!a.automations.length) {
+    return (
+      <div className="panel">
+        <div className="empty">
+          No automations yet. This agent only runs when you message it or hand it a task.
+          <br /><br />
+          <button className="btn ghost">＋ Add a trigger</button>
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="panel">
+      <div className="section-title"><h3>Triggers that wake this agent</h3><a>＋ Add trigger</a></div>
+      <div className="list">
+        {a.automations.map((x, i) => (
+          <div className="item" key={i}>
+            <span className="dot run" style={{ boxShadow: 'none' }} />
+            <span className="grow"><div className="t">{x.t}</div><div className="d">{x.d}</div></span>
+            <span className="when">{x.when}</span>
+            <span className={`tag ${x.tag}`}>{x.tagText}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Insights({ a }: { a: Agent }) {
+  if (!a.insights.length) {
+    return <div className="panel"><div className="empty">No insights yet — they appear once this agent has enough graded runs to learn from.</div></div>
+  }
+  return (
+    <div className="panel">
+      <p className="thesis">Learned from this agent’s own graded runs — the fleet-wide Insights page is gone; each agent carries its own.</p>
+      <div className="list">
+        {a.insights.map((x, i) => (
+          <div className="item" key={i}>
+            <span className="grow" style={{ padding: '2px 0' }}><div className="t">{x.t}</div><div className="d">{x.d}</div></span>
+            <span className="when">{x.when}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function Memory({ a }: { a: Agent }) {
+  return (
+    <div className="panel">
+      <div className="section-title"><h3>What this agent remembers</h3><a>Search memory →</a></div>
+      {a.memories.map((m, i) => (
+        <div className="memory-card" key={i}>
+          <div className="body">{m.body}</div>
+          <div className="foot">
+            <span className="kind">{m.kind}</span>
+            <span className="mono" style={{ color: 'var(--ink-faint)', fontSize: 11 }}>recalled {m.recalled} · {m.when} ago</span>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Seg({ current, opts }: { current: string; opts: string[] }) {
+  return (
+    <div className="seg">
+      {opts.map((o) => <button key={o} className={o === current ? 'on' : ''}>{o}</button>)}
+    </div>
+  )
+}
+
+function Settings({ a }: { a: Agent }) {
+  return (
+    <div className="panel">
+      <div className="field">
+        <div className="lbl">Model<div className="h">The engine this agent runs on</div></div>
+        <Seg current={a.model} opts={['haiku-4.5', 'sonnet-5', 'opus-4.8']} />
+      </div>
+      <div className="field">
+        <div className="lbl">Reasoning effort<div className="h">Depth vs. speed &amp; cost</div></div>
+        <Seg current={a.effort} opts={['low', 'medium', 'high']} />
+      </div>
+      <div className="field">
+        <div className="lbl">Verbosity<div className="h">Terse compresses narration only — never artifacts</div></div>
+        <Seg current={a.verbosity} opts={['normal', 'terse']} />
+      </div>
+      <div className="field">
+        <div className="lbl">System prompt<div className="h">CLAUDE.md · this agent’s identity</div></div>
+        <div className="prompt-box">{a.prompt}</div>
+      </div>
+      <div className="field">
+        <div className="lbl" style={{ color: 'var(--block)' }}>Danger zone<div className="h">Delete this agent and its history</div></div>
+        <div>
+          <button className="btn ghost" style={{ borderColor: 'color-mix(in srgb, var(--block) 40%, transparent)', color: 'var(--block)' }}>Delete agent</button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Workspace({ agent, tab, onTab }: { agent: Agent; tab: string; onTab: (t: string) => void }) {
+  const Panel = { overview: Overview, automations: Automations, insights: Insights, memory: Memory, settings: Settings }[tab] || Overview
+  return (
+    <main className="workspace">
+      <div className="ws-head">
+        <div style={{ flex: 1 }}>
+          <div className="ws-title">{agent.id} <StatePill status={agent.status} text={agent.statusText} /></div>
+          <div className="ws-handle">{agent.handle}</div>
+          <div className="ws-blurb">{agent.blurb}</div>
+        </div>
+        <button className="btn">Run agent</button>
+      </div>
+      <nav className="subnav">
+        {TABS.map((t) => (
+          <button key={t.key} className={t.key === tab ? 'active' : ''} onClick={() => onTab(t.key)}>
+            {t.label}{t.count ? <span className="count">{t.count(agent)}</span> : null}
+          </button>
+        ))}
+      </nav>
+      <Panel a={agent} />
+    </main>
+  )
+}
+
+export default function App() {
+  const [selectedId, setSelectedId] = useState(AGENTS[0].id)
+  const [tab, setTab] = useState('overview')
+  const [filter, setFilter] = useState('')
+
+  const shown = useMemo(
+    () => AGENTS.filter((a) => a.id.toLowerCase().includes(filter.toLowerCase())),
+    [filter],
+  )
+  const agent = AGENTS.find((a) => a.id === selectedId) || AGENTS[0]
+
+  function selectAgent(id: string) {
+    setSelectedId(id)
+    setTab('overview')
+  }
+
+  return (
+    <div className="app">
+      <div className="topbar">
+        <div className="brand"><span className="mark" aria-hidden="true" /> Agentric</div>
+        <span className="tenant-pill"><span className="dot run" style={{ width: 6, height: 6, boxShadow: 'none' }} /> instapods</span>
+        <div className="spacer" />
+        <a className="topbar-link" href="/">Classic view →</a>
+        <button className="icon-btn" title="Toggle theme" onClick={toggleTheme}>◐</button>
+        <button className="icon-btn" title="Inbox — 2 need you">Inbox <span className="badge">2</span></button>
+      </div>
+
+      <div className="layout">
+        <aside className="rail">
+          <div className="rail-head">
+            <span className="eyebrow">Fleet</span>
+            <span className="eyebrow">{shown.length} agents</span>
+          </div>
+          <div className="rail-search">
+            <input placeholder="Search agents…" value={filter} onChange={(e) => setFilter(e.target.value)} />
+          </div>
+          {shown.map((a) => (
+            <button key={a.id} className={`agent-row ${a.id === selectedId ? 'active' : ''}`} onClick={() => selectAgent(a.id)}>
+              <span className={`dot ${a.status}`} />
+              <span className="col">
+                <div className="nm">{a.id}</div>
+                <div className="meta">{a.statusText}</div>
+              </span>
+            </button>
+          ))}
+          <button className="new-agent">＋  New agent</button>
+          <div className="rail-sep" />
+          <div className="rail-mini">
+            <span className="eyebrow" style={{ paddingLeft: 9 }}>Fleet-wide</span>
+            <a>◱  Sessions</a>
+            <a>▤  Tasks</a>
+            <a>◈  Audit</a>
+            <a>⚙  Settings &amp; Team</a>
+          </div>
+        </aside>
+
+        <Workspace agent={agent} tab={tab} onTab={setTab} />
+      </div>
+    </div>
+  )
+}

--- a/web/src/v2/data.ts
+++ b/web/src/v2/data.ts
@@ -1,0 +1,126 @@
+// v2 mock fleet — real instapods/instawp domain flavor. This is scaffolding: the next
+// increment swaps it for live /api/state + /api/sessions calls (see App.tsx TODO).
+
+export type Status = 'run' | 'wait' | 'block' | 'idle'
+
+export interface SessionRow {
+  t: string; d: string; when: string
+  tag?: Status; tagText?: string
+  verdict?: 'ok' | 'warn'; verText?: string
+}
+export interface AutomationRow { t: string; d: string; tag: Status; tagText: string; when: string }
+export interface InsightRow { t: string; d: string; when: string }
+export interface MemoryRow { body: string; kind: string; when: string; recalled: string }
+
+export interface Agent {
+  id: string; handle: string; status: Status; statusText: string; blurb: string
+  stats: { runs: string; cost: string; approve: string; memories: string }
+  sessions: SessionRow[]
+  automations: AutomationRow[]
+  insights: InsightRow[]
+  memories: MemoryRow[]
+  model: string; effort: string; verbosity: string; permission: string
+  prompt: string
+}
+
+export const AGENTS: Agent[] = [
+  {
+    id: 'support-ops', handle: 'agent:support-ops', status: 'run', statusText: 'running',
+    blurb: 'Triage inbound FreeScout tickets, answer what it can, and delegate code work to the coding agent.',
+    stats: { runs: '312', cost: '$48.20', approve: '96%', memories: '84' },
+    sessions: [
+      { t: 'Reply drafted for ticket #4821 — DNS propagation', d: 'FreeScout · run-as varun', tag: 'run', tagText: 'running', when: 'now' },
+      { t: 'Delegated “fix pod restart loop” to coding', d: 'task:9f2a · A2A hand-off', verdict: 'ok', verText: '✓ done', when: '12m' },
+      { t: 'Weekly support digest', d: 'cron · Mon 09:00', verdict: 'ok', verText: '✓ done', when: '2d' },
+    ],
+    automations: [
+      { t: 'FreeScout ticket created', d: 'webhook · /hooks/fs-inbound', tag: 'run', tagText: 'on', when: '312 runs' },
+      { t: '@mention in #support', d: 'slack · thread continuity on', tag: 'run', tagText: 'on', when: '58 runs' },
+      { t: 'Weekly support digest', d: 'cron · 0 9 * * 1', tag: 'run', tagText: 'on', when: '11 runs' },
+    ],
+    insights: [
+      { t: '53% of runs decide to do nothing', d: 'Half of triage sessions end with no action — a cheaper pre-filter on the webhook payload would cut spend.', when: '7d' },
+      { t: 'Most-delegated: “restart loop”', d: '9 of 14 hand-offs to coding were the same class of pod crash — a candidate for a dedicated automation.', when: '7d' },
+    ],
+    memories: [
+      { body: 'FreeScout is LIVE on Agent OS and working real tickets — no longer a pilot. Route billing questions to the finance channel, not engineering.', kind: 'project', when: '3d', recalled: '11×' },
+      { body: 'Varun prefers a one-line summary at the top of every ticket reply before the detail.', kind: 'feedback', when: '9d', recalled: '27×' },
+      { body: 'Pod “restart loop” usually = OOM on the Launch plan; suggest a plan bump before deep debugging.', kind: 'reference', when: '14d', recalled: '6×' },
+    ],
+    model: 'opus-4.8', effort: 'medium', verbosity: 'terse', permission: 'auto',
+    prompt: '# support-ops\n\nYou triage inbound FreeScout tickets for Instapods. Answer what you can from the\nknowledge base. Delegate code changes to `agent:coding` via a task. Never issue a\nrefund or change a plan without an owner approval — the gate will stop you.',
+  },
+  {
+    id: 'pod-troubleshooter', handle: 'agent:pod-troubleshooter', status: 'wait', statusText: 'waiting on you',
+    blurb: 'Diagnose failing pods from logs and metrics; propose a fix, then wait for a human before touching production.',
+    stats: { runs: '146', cost: '$31.90', approve: '89%', memories: '52' },
+    sessions: [
+      { t: 'Approval needed — restart pod umbrella-web', d: 'gate · capability pod.restart', tag: 'wait', tagText: 'blocked on you', when: '4m' },
+      { t: 'Diagnosed 502 on aos.ai.instawp.io', d: 'nginx upgrade-map · root cause found', verdict: 'ok', verText: '✓ done', when: '1h' },
+    ],
+    automations: [
+      { t: 'Uptime Kuma alert → diagnose', d: 'webhook · /hooks/kuma', tag: 'run', tagText: 'on', when: '146 runs' },
+    ],
+    insights: [
+      { t: 'Approval latency: 22 min median', d: 'Diagnoses are fast but wait ~22 min for a human — an “always-approve restart on staging” rule would unblock the common case.', when: '7d' },
+    ],
+    memories: [
+      { body: 'nginx conditional Connection: upgrade — a hardcoded value 502s every plain HTTP request. Use the $connection_upgrade map.', kind: 'reference', when: '5d', recalled: '4×' },
+      { body: 'Never restart a prod pod without an approval; staging is fine to self-serve once the rule lands.', kind: 'feedback', when: '20d', recalled: '9×' },
+    ],
+    model: 'opus-4.8', effort: 'high', verbosity: 'normal', permission: 'auto',
+    prompt: '# pod-troubleshooter\n\nDiagnose failing pods from logs + metrics. Propose the smallest fix. Production\nchanges (restart, redeploy, plan change) MUST go through an approval — surface the\ndiagnosis and wait via `ask`.',
+  },
+  {
+    id: 'coding', handle: 'agent:coding', status: 'idle', statusText: 'idle',
+    blurb: 'Implements changes handed off as tasks — writes code, opens a PR authored as the requesting human.',
+    stats: { runs: '203', cost: '$102.40', approve: '92%', memories: '61' },
+    sessions: [
+      { t: 'PR #675 — feed icon + label fix', d: 'authored as vikas · squash-merged', verdict: 'ok', verText: '✓ merged', when: '6h' },
+      { t: 'Fix pod restart loop (from support-ops)', d: 'task:9f2a · run-as varun', verdict: 'ok', verText: '✓ done', when: '1d' },
+    ],
+    automations: [],
+    insights: [
+      { t: 'Highest cost per run in the fleet', d: 'Averages 2.1× the fleet — long transcripts. Terse verbosity on narration could trim ~15% without touching artifacts.', when: '7d' },
+    ],
+    memories: [
+      { body: 'Primary checkout stays clean on main; develop in per-session worktrees via scripts/wt.sh. Ship batches as one PR.', kind: 'project', when: '2d', recalled: '18×' },
+      { body: 'Always pass --repo vikasprogrammer/agentric to gh — the CLI targets the fork parent otherwise.', kind: 'reference', when: '8d', recalled: '14×' },
+    ],
+    model: 'opus-4.8', effort: 'high', verbosity: 'normal', permission: 'auto',
+    prompt: '# coding\n\nYou implement changes handed to you as tasks. Work in a worktree, keep the diff\nsmall, open a PR. Close your own loop with task_update(done).',
+  },
+  {
+    id: 'billing-watch', handle: 'agent:billing-watch', status: 'run', statusText: 'running',
+    blurb: 'Watches Stripe + plan changes for anomalies and posts a heads-up before anything bills.',
+    stats: { runs: '58', cost: '$9.10', approve: '100%', memories: '19' },
+    sessions: [
+      { t: 'Flagged 3 pods approaching plan limits', d: 'posted to #ops', tag: 'run', tagText: 'running', when: 'now' },
+    ],
+    automations: [{ t: 'Nightly billing sweep', d: 'cron · 0 2 * * *', tag: 'run', tagText: 'on', when: '58 runs' }],
+    insights: [],
+    memories: [{ body: 'A first card grants a one-time $10 credit — don’t flag a new pod’s trial as unpaid.', kind: 'reference', when: '30d', recalled: '3×' }],
+    model: 'haiku-4.5', effort: 'low', verbosity: 'terse', permission: 'auto',
+    prompt: '# billing-watch\n\nNightly, scan pods + plans for anomalies. Post a heads-up; never change a plan\nyourself.',
+  },
+  {
+    id: 'consolidator', handle: 'agent:consolidator', status: 'idle', statusText: 'system · idle',
+    blurb: 'The learning gardener — abstracts recurring patterns from fleet episodes into shared memory and KB pages.',
+    stats: { runs: '41', cost: '$14.60', approve: '—', memories: '203' },
+    sessions: [{ t: 'Consolidated 62 episodes → 4 shared memories', d: 'reflect pass · headless', verdict: 'ok', verText: '✓ done', when: '18h' }],
+    automations: [{ t: 'Reflect pass', d: 'cron · 0 */6 * * *', tag: 'run', tagText: 'on', when: '41 runs' }],
+    insights: [],
+    memories: [{ body: 'Recurring fleet pattern: agents self-delegate then wait — 98% of tasks are agent→agent. Consider a delegation budget.', kind: 'project', when: '1d', recalled: '2×' }],
+    model: 'sonnet-5', effort: 'medium', verbosity: 'terse', permission: 'auto',
+    prompt: '# consolidator\n\nSystem agent. Abstract recurring, durable patterns from recent episodes into shared\nmemories + KB pages via your own tools. Do not act on the world.',
+  },
+]
+
+export interface TabDef { key: string; label: string; count?: (a: Agent) => number }
+export const TABS: TabDef[] = [
+  { key: 'overview', label: 'Overview' },
+  { key: 'automations', label: 'Automations', count: (a) => a.automations.length },
+  { key: 'insights', label: 'Insights', count: (a) => a.insights.length },
+  { key: 'memory', label: 'Memory', count: (a) => a.memories.length },
+  { key: 'settings', label: 'Settings' },
+]

--- a/web/src/v2/main.tsx
+++ b/web/src/v2/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App.tsx'
+
+createRoot(document.getElementById('v2root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)

--- a/web/src/v2/v2.css
+++ b/web/src/v2/v2.css
@@ -1,0 +1,192 @@
+/* Agentric v2 — an isolated, agent-first console surface.
+   Self-contained: its own tokens + reset, no dependency on the classic app's theme or tailwind. */
+:root {
+  --ground: #0b0b0c;
+  --panel: #101012;
+  --panel-2: #141416;
+  --ink: #edede8;
+  --ink-dim: #a1a1a0;
+  --ink-faint: #6b6b6a;
+  --line: rgba(255, 255, 255, 0.09);
+  --line-strong: rgba(255, 255, 255, 0.16);
+  --hover: rgba(255, 255, 255, 0.045);
+  --active: rgba(255, 255, 255, 0.08);
+  --run: #4ade80;
+  --wait: #f4b740;
+  --block: #fb6b6b;
+  --idle: #6b6b6a;
+  --run-soft: rgba(74, 222, 128, 0.14);
+  --wait-soft: rgba(244, 183, 64, 0.14);
+  --block-soft: rgba(251, 107, 107, 0.14);
+  --r-card: 12px;
+  --r-pill: 999px;
+  --font: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, monospace;
+  color-scheme: dark;
+}
+@media (prefers-color-scheme: light) {
+  :root {
+    --ground: #f7f6f3; --panel: #fff; --panel-2: #fbfaf8;
+    --ink: #17171a; --ink-dim: #55565a; --ink-faint: #8a8b8e;
+    --line: rgba(0,0,0,0.09); --line-strong: rgba(0,0,0,0.16); --hover: rgba(0,0,0,0.035); --active: rgba(0,0,0,0.06);
+    --run: #16a34a; --wait: #b7791f; --block: #dc2626; --idle: #8a8b8e;
+    --run-soft: rgba(22,163,74,0.12); --wait-soft: rgba(183,121,31,0.12); --block-soft: rgba(220,38,38,0.10);
+    color-scheme: light;
+  }
+}
+:root[data-theme="dark"] {
+  --ground:#0b0b0c; --panel:#101012; --panel-2:#141416; --ink:#edede8; --ink-dim:#a1a1a0; --ink-faint:#6b6b6a;
+  --line:rgba(255,255,255,0.09); --line-strong:rgba(255,255,255,0.16); --hover:rgba(255,255,255,0.045); --active:rgba(255,255,255,0.08);
+  --run:#4ade80; --wait:#f4b740; --block:#fb6b6b; --idle:#6b6b6a;
+  --run-soft:rgba(74,222,128,0.14); --wait-soft:rgba(244,183,64,0.14); --block-soft:rgba(251,107,107,0.14); color-scheme: dark;
+}
+:root[data-theme="light"] {
+  --ground:#f7f6f3; --panel:#fff; --panel-2:#fbfaf8; --ink:#17171a; --ink-dim:#55565a; --ink-faint:#8a8b8e;
+  --line:rgba(0,0,0,0.09); --line-strong:rgba(0,0,0,0.16); --hover:rgba(0,0,0,0.035); --active:rgba(0,0,0,0.06);
+  --run:#16a34a; --wait:#b7791f; --block:#dc2626; --idle:#8a8b8e;
+  --run-soft:rgba(22,163,74,0.12); --wait-soft:rgba(183,121,31,0.12); --block-soft:rgba(220,38,38,0.10); color-scheme: light;
+}
+
+* { box-sizing: border-box; }
+html, body { height: 100%; margin: 0; }
+body { background: var(--ground); }
+
+.app {
+  font-family: var(--font); background: var(--ground); color: var(--ink);
+  min-height: 100vh; -webkit-font-smoothing: antialiased; font-size: 14px; line-height: 1.5;
+}
+.mono { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.eyebrow { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.12em; text-transform: uppercase; color: var(--ink-faint); }
+
+.topbar {
+  height: 52px; display: flex; align-items: center; gap: 16px; padding: 0 18px; border-bottom: 1px solid var(--line);
+  position: sticky; top: 0; z-index: 20; background: color-mix(in srgb, var(--ground) 86%, transparent); backdrop-filter: blur(8px);
+}
+.brand { display: flex; align-items: center; gap: 9px; font-weight: 560; letter-spacing: -0.01em; }
+.mark { width: 18px; height: 18px; position: relative; display: inline-block; }
+.mark::before { content:""; position:absolute; inset:0; border:1.5px solid var(--ink); border-radius:4px; transform: rotate(45deg); }
+.mark::after { content:""; position:absolute; inset:5px; background: var(--ink); border-radius:1.5px; transform: rotate(45deg); }
+.tenant-pill { font-family: var(--mono); font-size: 11.5px; color: var(--ink-dim); border: 1px solid var(--line); border-radius: var(--r-pill); padding: 3px 10px; display: inline-flex; gap: 6px; align-items: center; }
+.topbar .spacer { flex: 1; }
+.topbar-link { font-size: 12.5px; color: var(--ink-faint); text-decoration: none; }
+.topbar-link:hover { color: var(--ink); }
+.icon-btn { height: 32px; min-width: 32px; padding: 0 9px; border: 1px solid var(--line); background: transparent; color: var(--ink-dim); border-radius: 8px; cursor: pointer; display: inline-flex; align-items: center; gap: 7px; font-size: 12.5px; font-family: var(--font); }
+.icon-btn:hover { background: var(--hover); color: var(--ink); }
+.icon-btn .badge { font-family: var(--mono); font-size: 10.5px; background: var(--wait); color: #1a1200; border-radius: var(--r-pill); padding: 0 5px; line-height: 15px; font-weight: 600; }
+
+.layout { display: grid; grid-template-columns: 256px 1fr; min-height: calc(100vh - 52px); }
+
+.rail { border-right: 1px solid var(--line); padding: 14px 10px; display: flex; flex-direction: column; gap: 4px; position: sticky; top: 52px; align-self: start; height: calc(100vh - 52px); overflow: auto; }
+.rail-head { display: flex; align-items: center; justify-content: space-between; padding: 4px 8px 8px; }
+.rail-search { margin: 0 6px 8px; }
+.rail-search input { width: 100%; background: var(--panel); border: 1px solid var(--line); border-radius: 9px; color: var(--ink); padding: 7px 10px; font-size: 12.5px; font-family: var(--font); outline: none; }
+.rail-search input::placeholder { color: var(--ink-faint); }
+.rail-search input:focus-visible { border-color: var(--line-strong); }
+.agent-row { display: flex; align-items: center; gap: 10px; padding: 8px 9px; border-radius: 9px; cursor: pointer; border: 1px solid transparent; width: 100%; text-align: left; background: transparent; font-family: var(--font); }
+.agent-row:hover { background: var(--hover); }
+.agent-row.active { background: var(--active); border-color: var(--line); }
+.dot { width: 7px; height: 7px; border-radius: 50%; flex: none; background: var(--idle); }
+.dot.run { background: var(--run); box-shadow: 0 0 0 3px var(--run-soft); }
+.dot.wait { background: var(--wait); box-shadow: 0 0 0 3px var(--wait-soft); }
+.dot.block { background: var(--block); box-shadow: 0 0 0 3px var(--block-soft); }
+@media (prefers-reduced-motion: no-preference) {
+  .dot.run { animation: pulse 2.4s ease-in-out infinite; }
+  @keyframes pulse { 0%,100%{ box-shadow:0 0 0 3px var(--run-soft);} 50%{ box-shadow:0 0 0 5px transparent;} }
+}
+.agent-row .nm { font-size: 13px; line-height: 1.25; color: var(--ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.agent-row .meta { font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint); }
+.agent-row .col { min-width: 0; flex: 1; }
+.rail-sep { height: 1px; background: var(--line); margin: 8px 8px; }
+.rail-mini { padding: 4px 9px; }
+.rail-mini a { display: flex; align-items: center; gap: 9px; padding: 7px 9px; border-radius: 8px; color: var(--ink-dim); text-decoration: none; font-size: 12.5px; cursor: pointer; }
+.rail-mini a:hover { background: var(--hover); color: var(--ink); }
+.new-agent { margin-top: 6px; border: 1px dashed var(--line-strong); color: var(--ink-dim); border-radius: 9px; padding: 8px 9px; text-align: center; cursor: pointer; font-size: 12.5px; background: transparent; font-family: var(--font); width: 100%; }
+.new-agent:hover { background: var(--hover); color: var(--ink); }
+
+.workspace { padding: 22px 26px 60px; max-width: 940px; margin: 0 auto; width: 100%; }
+.ws-head { display: flex; align-items: flex-start; gap: 16px; padding-bottom: 16px; }
+.ws-title { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; display: flex; align-items: center; gap: 11px; }
+.ws-handle { font-family: var(--mono); font-size: 12px; color: var(--ink-faint); }
+.ws-blurb { color: var(--ink-dim); font-size: 13.5px; margin-top: 5px; max-width: 62ch; }
+.status-pill { font-family: var(--mono); font-size: 11px; letter-spacing: 0.02em; padding: 3px 9px 3px 8px; border-radius: var(--r-pill); display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--line); color: var(--ink-dim); text-transform: uppercase; }
+.status-pill.run { color: var(--run); border-color: color-mix(in srgb, var(--run) 30%, transparent); background: var(--run-soft); }
+.status-pill.wait { color: var(--wait); border-color: color-mix(in srgb, var(--wait) 30%, transparent); background: var(--wait-soft); }
+.status-pill.block { color: var(--block); border-color: color-mix(in srgb, var(--block) 30%, transparent); background: var(--block-soft); }
+.btn { font-family: var(--font); font-size: 13px; font-weight: 520; border-radius: 9px; padding: 8px 14px; cursor: pointer; border: 1px solid var(--line-strong); background: var(--ink); color: var(--ground); }
+.btn:hover { opacity: 0.9; }
+.btn.ghost { background: transparent; color: var(--ink); border-color: var(--line); }
+.btn.ghost:hover { background: var(--hover); }
+
+.subnav { display: flex; gap: 2px; border-bottom: 1px solid var(--line); margin: 6px 0 22px; overflow-x: auto; }
+.subnav button { font-family: var(--font); background: transparent; border: none; color: var(--ink-faint); cursor: pointer; padding: 10px 12px; font-size: 13px; position: relative; white-space: nowrap; display: inline-flex; align-items: center; gap: 7px; }
+.subnav button:hover { color: var(--ink); }
+.subnav button.active { color: var(--ink); }
+.subnav button.active::after { content:""; position: absolute; left: 8px; right: 8px; bottom: -1px; height: 2px; background: var(--ink); border-radius: 2px; }
+.subnav .count { font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint); border: 1px solid var(--line); border-radius: var(--r-pill); padding: 0 6px; line-height: 15px; }
+.subnav button.active .count { color: var(--ink-dim); border-color: var(--line-strong); }
+
+.panel { animation: fade .18s ease; }
+@media (prefers-reduced-motion: no-preference) { @keyframes fade { from { opacity: 0; transform: translateY(3px);} to{opacity:1; transform:none;} } }
+
+.stat-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px; margin-bottom: 22px; }
+.stat { border: 1px solid var(--line); border-radius: var(--r-card); padding: 13px 14px; background: var(--panel); }
+.stat .k { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ink-faint); }
+.stat .v { font-family: var(--mono); font-size: 22px; margin-top: 6px; letter-spacing: -0.01em; }
+.stat .sub { font-size: 11.5px; color: var(--ink-dim); margin-top: 2px; }
+
+.console { border: 1px solid var(--line); border-radius: 16px; background: var(--panel); padding: 16px; margin-bottom: 24px; }
+.console .prompt { display: flex; align-items: flex-end; gap: 10px; }
+.console textarea { flex: 1; resize: none; background: transparent; border: none; outline: none; color: var(--ink); font-family: var(--font); font-size: 15px; line-height: 1.5; min-height: 44px; padding: 6px 2px; }
+.console textarea::placeholder { color: var(--ink-faint); }
+.send { width: 36px; height: 36px; border-radius: 9px; border: 1px solid var(--line-strong); background: var(--ink); color: var(--ground); cursor: pointer; flex: none; font-size: 16px; }
+.console .row2 { display: flex; align-items: center; gap: 8px; margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--line); flex-wrap: wrap; }
+.chip { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); border: 1px solid var(--line); border-radius: var(--r-pill); padding: 3px 9px; cursor: pointer; background: transparent; }
+.chip:hover { background: var(--hover); color: var(--ink); }
+
+.section-title { display: flex; align-items: baseline; justify-content: space-between; margin: 24px 0 12px; }
+.section-title h3 { font-size: 13px; font-weight: 600; margin: 0; letter-spacing: -0.01em; }
+.section-title a { font-size: 12px; color: var(--ink-dim); text-decoration: none; cursor: pointer; }
+.section-title a:hover { color: var(--ink); }
+
+.list { border: 1px solid var(--line); border-radius: var(--r-card); overflow: hidden; background: var(--panel); }
+.item { display: flex; align-items: center; gap: 12px; padding: 12px 14px; border-bottom: 1px solid var(--line); }
+.item:last-child { border-bottom: none; }
+.item:hover { background: var(--hover); }
+.item .grow { flex: 1; min-width: 0; }
+.item .t { font-size: 13px; }
+.item .d { font-size: 11.5px; color: var(--ink-dim); margin-top: 2px; }
+.item .when { font-family: var(--mono); font-size: 11px; color: var(--ink-faint); white-space: nowrap; }
+.tag { font-family: var(--mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; color: var(--ink-dim); border: 1px solid var(--line); border-radius: var(--r-pill); padding: 1px 7px; white-space: nowrap; }
+.tag.run { color: var(--run); border-color: color-mix(in srgb, var(--run) 30%, transparent); }
+.tag.wait { color: var(--wait); border-color: color-mix(in srgb, var(--wait) 30%, transparent); }
+.tag.block { color: var(--block); border-color: color-mix(in srgb, var(--block) 30%, transparent); }
+.verdict { font-family: var(--mono); font-size: 12px; white-space: nowrap; }
+.verdict.ok { color: var(--run); }
+.verdict.warn { color: var(--wait); }
+
+.field { display: grid; grid-template-columns: 180px 1fr; gap: 16px; align-items: center; padding: 14px 0; border-bottom: 1px solid var(--line); }
+.field:last-child { border-bottom: none; }
+.field .lbl { font-size: 13px; }
+.field .lbl .h { font-size: 11.5px; color: var(--ink-dim); margin-top: 2px; }
+.seg { display: inline-flex; border: 1px solid var(--line); border-radius: 9px; overflow: hidden; }
+.seg button { font-family: var(--mono); font-size: 12px; background: transparent; border: none; color: var(--ink-dim); padding: 6px 13px; cursor: pointer; border-right: 1px solid var(--line); }
+.seg button:last-child { border-right: none; }
+.seg button.on { background: var(--ink); color: var(--ground); }
+.seg button:not(.on):hover { background: var(--hover); color: var(--ink); }
+.prompt-box { border: 1px solid var(--line); border-radius: var(--r-card); background: var(--panel-2); padding: 12px 14px; font-family: var(--mono); font-size: 12px; color: var(--ink-dim); white-space: pre-wrap; line-height: 1.6; }
+
+.empty { color: var(--ink-faint); font-size: 13px; padding: 28px; text-align: center; border: 1px dashed var(--line); border-radius: var(--r-card); }
+
+.memory-card { border: 1px solid var(--line); border-radius: var(--r-card); background: var(--panel); padding: 13px 15px; margin-bottom: 10px; }
+.memory-card .body { font-size: 13px; line-height: 1.55; }
+.memory-card .foot { display: flex; align-items: center; gap: 8px; margin-top: 9px; }
+.kind { font-family: var(--mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em; padding: 1px 7px; border-radius: var(--r-pill); border: 1px solid var(--line); color: var(--ink-dim); }
+
+.thesis { font-size: 12px; color: var(--ink-faint); border-left: 2px solid var(--line-strong); padding: 2px 0 2px 12px; margin: 0 0 18px; }
+
+@media (max-width: 760px) {
+  .layout { grid-template-columns: 1fr; }
+  .rail { display: none; }
+  .stat-row { grid-template-columns: repeat(2, 1fr); }
+  .field { grid-template-columns: 1fr; gap: 8px; }
+}

--- a/web/v2.html
+++ b/web/v2.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Agentric v2</title>
+  </head>
+  <body>
+    <div id="v2root"></div>
+    <script type="module" src="/src/v2/main.tsx"></script>
+  </body>
+</html>

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -15,6 +15,8 @@ export default defineConfig({
       input: {
         main: fileURLToPath(new URL('./index.html', import.meta.url)),
         termbed: fileURLToPath(new URL('./termbed.html', import.meta.url)),
+        // v2: the isolated agent-first console at /v2 (its own entry, no shared code with App.tsx).
+        v2: fileURLToPath(new URL('./v2.html', import.meta.url)),
       },
     },
   },


### PR DESCRIPTION
## What

A new **agent-first console at `/v2`**, fully isolated from the classic multi-page app at `/`.

The classic console has ~18 flat global pages (Agents, Sessions, Tasks, Automations, Knowledge, Memory, Insights, Team, Audit…). `/v2` flips that: the **agent is the unit**. The left rail is just the fleet; selecting an agent opens a workspace where *everything about it* lives on one sub-nav:

- **Overview** — chat-first (an x.ai-style prompt console), plus 7-day stats and recent sessions
- **Automations** — the triggers that wake this agent
- **Insights** — scoped to this agent's own graded runs (the fleet-wide Insights page folds in here)
- **Memory** — what this agent remembers
- **Settings** — model / effort / verbosity / system prompt

Visual direction models `x.ai/bot`: near-monochrome, the only chroma is agent state (running / waiting / blocked).

## How it stays isolated

- Its own Vite entry: `web/v2.html` → `web/src/v2/` (App, main, data, css), the same multi-page pattern as `termbed`.
- Its own tokens + reset in `web/src/v2/v2.css` — **no shared code with `App.tsx`**, no tailwind/theme coupling.
- Served at `/v2` by `src/server.ts` (public SPA shell like `/`; `/api/*` calls carry the same `aos_sid` cookie). The classic console at `/` is untouched.

## Scope of this cut

First increment renders a **mock fleet** (instapods-flavored). The next increment wires it to live `/api/state` (roster) + `/api/sessions` (recent sessions) — `web/src/v2/data.ts` is the adapter shape. Chat send, live terminal, and the fleet-wide links are stubs.

## Verification

- `npm run build` + `cd web && npm run build` — both clean; emits `dist/v2.html` + `v2-*.{js,css}`.
- `npm run test:governance` — 59 passed, 0 failed.
- Served on an ephemeral port: `GET /v2` → 200, renders `#v2root` + loads the v2 bundle; `GET /` → still the classic `#root` app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)