### PR TITLE
feat(v2): wire the /v2 agent-first console to live data (v0.373.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.373.0]
+### Added
+- **The `/v2` agent-first console is now wired to live data.** The mock fleet is gone: the rail loads
+  the real roster from `/api/state`, each agent's status dot is derived from its live sessions
+  (`running` / `waiting on you` / `idle`), and Overview shows real 7-day stats + recent sessions from
+  `/api/sessions`. The per-agent tabs lazy-load on open and cache: Automations (`/api/automations`,
+  filtered to the agent), Memory (`/api/memory`), Insights (the agent's real maturity/gate track record
+  from `/api/agents/:id/stats`, framed per-agent), and Settings (live model/effort/verbosity +
+  CLAUDE.md from `/api/agents/:id/{config,claude}`, read-only this cut). Not signed in → a sign-in
+  prompt back to `/`; empty/loading/error states throughout. Reads only for now — send, run, and edit
+  link back to the classic console; those become native in the next increment. The classic app at `/`
+  is still untouched, and v2 reuses the shared typed client (`web/src/lib/api.ts`) rather than
+  duplicating it.
+
 ## [0.372.0]
 ### Added
 - **A new agent-first console at `/v2`, isolated from the classic app.** A minimal, x.ai-style

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.372.0",
+  "version": "0.373.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.372.0",
+      "version": "0.373.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.372.0",
+  "version": "0.373.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/v2/App.tsx
+++ b/web/src/v2/App.tsx
@@ -1,14 +1,14 @@
-import { useMemo, useState } from 'react'
-import { AGENTS, TABS, type Agent, type SessionRow, type Status } from './data'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { api, type AgentInfo, type Automation, type MemoryRecord, type Member, type RuntimeTuning, type Session } from '@/lib/api'
+import { buildAgents, overviewStats, relTime, sessionRow, type AgentVM, type Status } from './data'
 import './v2.css'
 
-// Agentric v2 — an isolated, agent-first console. Each agent carries its own automations,
-// insights, memory and settings; the classic multi-page console lives untouched at "/".
-// This surface is chat-first: an agent's Overview opens on a prompt console.
+// Agentric v2 — the agent-first console, wired to live data. Each agent carries its own
+// automations, insights, memory and settings; the classic multi-page app lives untouched at "/".
 //
-// TODO(next): replace the mock AGENTS import with live data — GET /api/state for the roster,
-// GET /api/sessions?agent=<id> for Recent sessions — using the same aos_sid cookie the classic
-// app relies on. Keep the shape in data.ts as the adapter target.
+// Data: /api/state (roster + me), /api/sessions (status + recent runs), /api/automations (per agent),
+// and lazily /api/memory, /api/agents/:id/{config,claude,stats}. All reads for this cut — actions
+// (send, run, edit) link back to the classic app for now.
 
 function toggleTheme() {
   const root = document.documentElement
@@ -17,81 +17,94 @@ function toggleTheme() {
   root.setAttribute('data-theme', cur === 'dark' ? 'light' : 'dark')
 }
 
+const TAB_KEYS = ['overview', 'automations', 'insights', 'memory', 'settings'] as const
+type TabKey = (typeof TAB_KEYS)[number]
+
 function StatePill({ status, text }: { status: Status; text: string }) {
-  return (
-    <span className={`status-pill ${status}`}>
-      {status === 'idle' ? '●' : null} {text}
-    </span>
-  )
+  return <span className={`status-pill ${status}`}>{status === 'idle' ? '●' : null} {text}</span>
 }
 
-function SessionItem({ s }: { s: SessionRow }) {
-  return (
-    <div className="item">
-      <span className={`dot ${s.tag || 'idle'}`} style={s.tag ? undefined : { opacity: 0.4 }} />
-      <span className="grow">
-        <div className="t">{s.t}</div>
-        <div className="d">{s.d}</div>
-      </span>
-      {s.tag
-        ? <span className={`tag ${s.tag}`}>{s.tagText}</span>
-        : <span className={`verdict ${s.verdict}`}>{s.verText}</span>}
-      <span className="when">{s.when}</span>
-    </div>
-  )
-}
+/* ─────────────────────────── Overview (chat-first) ─────────────────────────── */
 
-function Overview({ a }: { a: Agent }) {
+function Overview({ agent }: { agent: AgentVM }) {
+  const now = Date.now()
+  const stats = overviewStats(agent.sessions, now)
+  const recent = agent.sessions.slice(0, 6)
   return (
     <div className="panel">
       <p className="thesis">Everything about this agent lives here — no hunting across a dozen global pages.</p>
       <div className="console">
         <div className="prompt">
-          <textarea rows={1} placeholder={`Message ${a.id}…  ask it to do something, or start a session`} />
-          <button className="send" title="Run">↑</button>
+          <textarea rows={1} placeholder={`Message ${agent.id}…  ask it to do something, or start a session`} />
+          <a className="send" title="Open a session in the classic console" href={`/?spawn=${encodeURIComponent(agent.id)}`}>↑</a>
         </div>
         <div className="row2">
           <span className="chip">▤ Create a task</span>
           <span className="chip">◈ run-as: you</span>
-          <span className="chip">◱ Open live session</span>
+          <a className="chip" href={`/?spawn=${encodeURIComponent(agent.id)}`}>◱ Open live session</a>
         </div>
       </div>
       <div className="stat-row">
-        <div className="stat"><div className="k">Runs · 7d</div><div className="v">{a.stats.runs}</div><div className="sub">across all triggers</div></div>
-        <div className="stat"><div className="k">Cost · 7d</div><div className="v">{a.stats.cost}</div><div className="sub">max-per-conversation</div></div>
-        <div className="stat"><div className="k">Auto-approve</div><div className="v">{a.stats.approve}</div><div className="sub">gate outcomes</div></div>
-        <div className="stat"><div className="k">Memories</div><div className="v">{a.stats.memories}</div><div className="sub">agent-scoped recall</div></div>
+        <div className="stat"><div className="k">Runs · 7d</div><div className="v">{stats.runs}</div><div className="sub">across all triggers</div></div>
+        <div className="stat"><div className="k">Cost · 7d</div><div className="v">{stats.cost}</div><div className="sub">sum of run cost</div></div>
+        <div className="stat"><div className="k">Live now</div><div className="v">{stats.live}</div><div className="sub">sessions alive</div></div>
+        <div className="stat"><div className="k">Needs you</div><div className="v">{stats.needs}</div><div className="sub">blocked on a human</div></div>
       </div>
-      <div className="section-title"><h3>Recent sessions</h3><a>All sessions →</a></div>
-      <div className="list">
-        {a.sessions.map((s, i) => <SessionItem key={i} s={s} />)}
-      </div>
+      <div className="section-title"><h3>Recent sessions</h3><a href="/">All sessions →</a></div>
+      {recent.length === 0
+        ? <div className="empty">No sessions yet — message this agent above to start one.</div>
+        : (
+          <div className="list">
+            {recent.map((s) => {
+              const r = sessionRow(s, now)
+              return (
+                <div className="item" key={r.key}>
+                  <span className={`dot ${r.tag || 'idle'}`} style={r.tag ? undefined : { opacity: 0.4 }} />
+                  <span className="grow"><div className="t">{r.t}</div><div className="d">{r.d}</div></span>
+                  {r.tag
+                    ? <span className={`tag ${r.tag}`}>{r.tagText}</span>
+                    : <span className={`verdict ${r.verdict === 'ok' ? 'ok' : 'warn'}`}>{r.verText}</span>}
+                  <span className="when">{r.when}</span>
+                </div>
+              )
+            })}
+          </div>
+        )}
     </div>
   )
 }
 
-function Automations({ a }: { a: Agent }) {
-  if (!a.automations.length) {
+/* ─────────────────────────── Automations ─────────────────────────── */
+
+function autoDetail(a: Automation): string {
+  const bits: string[] = [a.type]
+  if (a.type === 'cron' && a.schedule) bits.push(a.schedule)
+  else if (a.filter) bits.push(a.filter)
+  return bits.join(' · ')
+}
+function Automations({ items, loading }: { items: Automation[] | undefined; loading: boolean }) {
+  if (loading || !items) return <div className="panel"><div className="empty">Loading automations…</div></div>
+  if (!items.length) {
     return (
       <div className="panel">
         <div className="empty">
           No automations yet. This agent only runs when you message it or hand it a task.
           <br /><br />
-          <button className="btn ghost">＋ Add a trigger</button>
+          <a className="btn ghost" href="/">＋ Add a trigger in the classic console</a>
         </div>
       </div>
     )
   }
   return (
     <div className="panel">
-      <div className="section-title"><h3>Triggers that wake this agent</h3><a>＋ Add trigger</a></div>
+      <div className="section-title"><h3>Triggers that wake this agent</h3><a href="/">＋ Add trigger</a></div>
       <div className="list">
-        {a.automations.map((x, i) => (
-          <div className="item" key={i}>
-            <span className="dot run" style={{ boxShadow: 'none' }} />
-            <span className="grow"><div className="t">{x.t}</div><div className="d">{x.d}</div></span>
-            <span className="when">{x.when}</span>
-            <span className={`tag ${x.tag}`}>{x.tagText}</span>
+        {items.map((a) => (
+          <div className="item" key={a.id}>
+            <span className={`dot ${a.enabled ? 'run' : 'idle'}`} style={a.enabled ? { boxShadow: 'none' } : { opacity: 0.4 }} />
+            <span className="grow"><div className="t">{a.name}</div><div className="d">{autoDetail(a)}</div></span>
+            <span className="when">{a.lastFiredAt ? `${relTime(a.lastFiredAt)} ago` : (a.nextRunAt ? 'scheduled' : 'idle')}</span>
+            <span className={`tag ${a.enabled ? 'run' : ''}`}>{a.enabled ? 'on' : 'off'}</span>
           </div>
         ))}
       </div>
@@ -99,18 +112,28 @@ function Automations({ a }: { a: Agent }) {
   )
 }
 
-function Insights({ a }: { a: Agent }) {
-  if (!a.insights.length) {
-    return <div className="panel"><div className="empty">No insights yet — they appear once this agent has enough graded runs to learn from.</div></div>
+/* ─────────────────────────── Insights (this agent's real stats) ─────────────────────────── */
+
+function pct(n: number): string { return `${Math.round(n * 100)}%` }
+
+function Insights({ stats, loading }: { stats: import('@/lib/api').AgentStats | undefined; loading: boolean }) {
+  if (loading || !stats) return <div className="panel"><div className="empty">Reading this agent’s track record…</div></div>
+  if (stats.confidence === 'none' || stats.runs.total === 0) {
+    return <div className="panel"><div className="empty">No signal yet — insights build up once this agent has some graded runs.</div></div>
   }
+  const rows: { t: string; d: string; when: string }[] = [
+    { t: `Maturity ${pct(stats.maturity)} · ${stats.confidence} confidence`, d: `Autonomy ${pct(stats.autonomy)}, denial rate ${pct(stats.denialRate)}, over ${stats.runs.total} runs (${stats.runs.done} done, ${stats.runs.crashed} crashed).`, when: stats.lastRunAt ? `${relTime(stats.lastRunAt)} ago` : '' },
+    { t: `Human ratings: ${stats.rated.up}↑ / ${stats.rated.down}↓`, d: stats.successRate != null ? `Self-reported success rate ${pct(stats.successRate)} across ${stats.outcomes.success + stats.outcomes.failure + stats.outcomes.inconclusive} reported runs.` : 'Not enough reported outcomes to rate success yet.', when: '' },
+    { t: `Gate: ${stats.actions.autoApproved} auto-approved, ${stats.actions.humanGated} sent to a human, ${stats.actions.denied} denied`, d: `${stats.actions.governed} governed effects total. ${stats.deniedRuns} run(s) hit a hard deny.`, when: '' },
+  ]
   return (
     <div className="panel">
-      <p className="thesis">Learned from this agent’s own graded runs — the fleet-wide Insights page is gone; each agent carries its own.</p>
+      <p className="thesis">Learned from this agent’s own runs — the fleet-wide Insights page folds into each agent.</p>
       <div className="list">
-        {a.insights.map((x, i) => (
+        {rows.map((x, i) => (
           <div className="item" key={i}>
             <span className="grow" style={{ padding: '2px 0' }}><div className="t">{x.t}</div><div className="d">{x.d}</div></span>
-            <span className="when">{x.when}</span>
+            {x.when ? <span className="when">{x.when}</span> : null}
           </div>
         ))}
       </div>
@@ -118,16 +141,22 @@ function Insights({ a }: { a: Agent }) {
   )
 }
 
-function Memory({ a }: { a: Agent }) {
+/* ─────────────────────────── Memory ─────────────────────────── */
+
+function Memory({ items, loading }: { items: MemoryRecord[] | undefined; loading: boolean }) {
+  if (loading || !items) return <div className="panel"><div className="empty">Loading memory…</div></div>
+  if (!items.length) return <div className="panel"><div className="empty">This agent hasn’t remembered anything yet.</div></div>
+  const now = Date.now()
   return (
     <div className="panel">
-      <div className="section-title"><h3>What this agent remembers</h3><a>Search memory →</a></div>
-      {a.memories.map((m, i) => (
-        <div className="memory-card" key={i}>
-          <div className="body">{m.body}</div>
+      <div className="section-title"><h3>What this agent remembers</h3><a href="/">Search memory →</a></div>
+      {items.map((m) => (
+        <div className="memory-card" key={m.id}>
+          <div className="body">{m.content}</div>
           <div className="foot">
-            <span className="kind">{m.kind}</span>
-            <span className="mono" style={{ color: 'var(--ink-faint)', fontSize: 11 }}>recalled {m.recalled} · {m.when} ago</span>
+            <span className="kind">{m.type || 'note'}</span>
+            {m.scope === 'tenant' ? <span className="kind">shared</span> : null}
+            <span className="mono" style={{ color: 'var(--ink-faint)', fontSize: 11 }}>{relTime(m.ts, now)} ago</span>
           </div>
         </div>
       ))}
@@ -135,7 +164,9 @@ function Memory({ a }: { a: Agent }) {
   )
 }
 
-function Seg({ current, opts }: { current: string; opts: string[] }) {
+/* ─────────────────────────── Settings (real tuning, read-only this cut) ─────────────────────────── */
+
+function Seg({ current, opts }: { current?: string; opts: string[] }) {
   return (
     <div className="seg">
       {opts.map((o) => <button key={o} className={o === current ? 'on' : ''}>{o}</button>)}
@@ -143,37 +174,48 @@ function Seg({ current, opts }: { current: string; opts: string[] }) {
   )
 }
 
-function Settings({ a }: { a: Agent }) {
+function Settings({ config, prompt, loading }: { config: (RuntimeTuning & { description?: string }) | undefined; prompt: string | undefined; loading: boolean }) {
+  if (loading || !config) return <div className="panel"><div className="empty">Loading settings…</div></div>
   return (
     <div className="panel">
+      <p className="thesis">Reflecting this agent’s live config. Editing lands next — for now, changes are made in the classic console.</p>
       <div className="field">
         <div className="lbl">Model<div className="h">The engine this agent runs on</div></div>
-        <Seg current={a.model} opts={['haiku-4.5', 'sonnet-5', 'opus-4.8']} />
+        <Seg current={config.model || 'workspace default'} opts={['haiku-4.5', 'sonnet-5', 'opus-4.8', config.model || 'workspace default'].filter((v, i, a) => a.indexOf(v) === i)} />
       </div>
       <div className="field">
         <div className="lbl">Reasoning effort<div className="h">Depth vs. speed &amp; cost</div></div>
-        <Seg current={a.effort} opts={['low', 'medium', 'high']} />
+        <Seg current={config.effort || 'inherit'} opts={['low', 'medium', 'high', 'xhigh', 'max']} />
       </div>
       <div className="field">
         <div className="lbl">Verbosity<div className="h">Terse compresses narration only — never artifacts</div></div>
-        <Seg current={a.verbosity} opts={['normal', 'terse']} />
+        <Seg current={config.verbosity || 'normal'} opts={['normal', 'terse']} />
       </div>
       <div className="field">
         <div className="lbl">System prompt<div className="h">CLAUDE.md · this agent’s identity</div></div>
-        <div className="prompt-box">{a.prompt}</div>
-      </div>
-      <div className="field">
-        <div className="lbl" style={{ color: 'var(--block)' }}>Danger zone<div className="h">Delete this agent and its history</div></div>
-        <div>
-          <button className="btn ghost" style={{ borderColor: 'color-mix(in srgb, var(--block) 40%, transparent)', color: 'var(--block)' }}>Delete agent</button>
-        </div>
+        <div className="prompt-box">{prompt && prompt.trim() ? prompt : 'No CLAUDE.md for this agent.'}</div>
       </div>
     </div>
   )
 }
 
-function Workspace({ agent, tab, onTab }: { agent: Agent; tab: string; onTab: (t: string) => void }) {
-  const Panel = { overview: Overview, automations: Automations, insights: Insights, memory: Memory, settings: Settings }[tab] || Overview
+/* ─────────────────────────── Workspace ─────────────────────────── */
+
+interface Detail {
+  automations?: Automation[]
+  memory?: MemoryRecord[]
+  stats?: import('@/lib/api').AgentStats
+  config?: RuntimeTuning & { description?: string }
+  prompt?: string
+}
+
+function Workspace({ agent, tab, onTab, detail, loadingTab }: {
+  agent: AgentVM; tab: TabKey; onTab: (t: TabKey) => void; detail: Detail; loadingTab: boolean
+}) {
+  const counts: Record<string, number | undefined> = {
+    automations: detail.automations?.length,
+    memory: detail.memory?.length,
+  }
   return (
     <main className="workspace">
       <div className="ws-head">
@@ -182,77 +224,184 @@ function Workspace({ agent, tab, onTab }: { agent: Agent; tab: string; onTab: (t
           <div className="ws-handle">{agent.handle}</div>
           <div className="ws-blurb">{agent.blurb}</div>
         </div>
-        <button className="btn">Run agent</button>
+        <a className="btn" href={`/?spawn=${encodeURIComponent(agent.id)}`}>Run agent</a>
       </div>
       <nav className="subnav">
-        {TABS.map((t) => (
-          <button key={t.key} className={t.key === tab ? 'active' : ''} onClick={() => onTab(t.key)}>
-            {t.label}{t.count ? <span className="count">{t.count(agent)}</span> : null}
+        {TAB_KEYS.map((k) => (
+          <button key={k} className={k === tab ? 'active' : ''} onClick={() => onTab(k)}>
+            {k[0].toUpperCase() + k.slice(1)}
+            {counts[k] != null ? <span className="count">{counts[k]}</span> : null}
           </button>
         ))}
       </nav>
-      <Panel a={agent} />
+      {tab === 'overview' && <Overview agent={agent} />}
+      {tab === 'automations' && <Automations items={detail.automations} loading={loadingTab} />}
+      {tab === 'insights' && <Insights stats={detail.stats} loading={loadingTab} />}
+      {tab === 'memory' && <Memory items={detail.memory} loading={loadingTab} />}
+      {tab === 'settings' && <Settings config={detail.config} prompt={detail.prompt} loading={loadingTab} />}
     </main>
   )
 }
 
+/* ─────────────────────────── App ─────────────────────────── */
+
 export default function App() {
-  const [selectedId, setSelectedId] = useState(AGENTS[0].id)
-  const [tab, setTab] = useState('overview')
+  const [me, setMe] = useState<Member | null | undefined>(undefined) // undefined = still checking
+  const [agentsInfo, setAgentsInfo] = useState<AgentInfo[]>([])
+  const [sessions, setSessions] = useState<Session[]>([])
+  const [tenant, setTenant] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [ready, setReady] = useState(false)
+
+  const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [tab, setTab] = useState<TabKey>('overview')
   const [filter, setFilter] = useState('')
 
-  const shown = useMemo(
-    () => AGENTS.filter((a) => a.id.toLowerCase().includes(filter.toLowerCase())),
-    [filter],
-  )
-  const agent = AGENTS.find((a) => a.id === selectedId) || AGENTS[0]
+  // Per-agent lazy detail cache, keyed by agent id.
+  const [details, setDetails] = useState<Record<string, Detail>>({})
+  const [loadingTab, setLoadingTab] = useState(false)
+  const inflight = useRef<Set<string>>(new Set())
 
-  function selectAgent(id: string) {
-    setSelectedId(id)
-    setTab('overview')
+  // Initial load.
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      const m = await api.me()
+      if (cancelled) return
+      setMe(m)
+      if (!m) return
+      try {
+        const [state, sess] = await Promise.all([api.state(), api.sessions()])
+        if (cancelled) return
+        setTenant(state.tenantName || state.tenant)
+        setAgentsInfo(state.agents || [])
+        setSessions(Array.isArray(sess) ? sess : [])
+        setSelectedId((state.agents && state.agents[0]?.id) || null)
+      } catch {
+        if (!cancelled) setError('Could not load the fleet. Is the server reachable?')
+      } finally {
+        if (!cancelled) setReady(true)
+      }
+    })()
+    return () => { cancelled = true }
+  }, [])
+
+  const agents = useMemo(() => buildAgents(agentsInfo, sessions), [agentsInfo, sessions])
+  const shown = useMemo(
+    () => agents.filter((a) => a.id.toLowerCase().includes(filter.toLowerCase())),
+    [agents, filter],
+  )
+  const agent = agents.find((a) => a.id === selectedId) || agents[0] || null
+
+  // Lazy-load the detail a tab needs, once per (agent, tab), cached.
+  const loadDetail = useCallback(async (agentId: string, which: TabKey) => {
+    if (which === 'overview') return
+    const key = `${agentId}:${which}`
+    const have = details[agentId]
+    if (which === 'automations' && have?.automations) return
+    if (which === 'memory' && have?.memory) return
+    if (which === 'insights' && have?.stats) return
+    if (which === 'settings' && have?.config) return
+    if (inflight.current.has(key)) return
+    inflight.current.add(key)
+    setLoadingTab(true)
+    try {
+      const patch: Detail = {}
+      if (which === 'automations') {
+        const r = await api.automations()
+        patch.automations = (r.automations || []).filter((a) => a.agentId === agentId)
+      } else if (which === 'memory') {
+        const r = await api.memory(agentId, '', 40)
+        patch.memory = r.memories || []
+      } else if (which === 'insights') {
+        const r = await api.agentStats(agentId)
+        patch.stats = r.stats
+      } else if (which === 'settings') {
+        const [cfg, cl] = await Promise.all([api.agentConfig(agentId), api.agentClaude(agentId)])
+        patch.config = cfg
+        patch.prompt = cl.content || ''
+      }
+      setDetails((prev) => ({ ...prev, [agentId]: { ...prev[agentId], ...patch } }))
+    } catch {
+      /* leave the tab in its loading-fallback empty state */
+    } finally {
+      inflight.current.delete(key)
+      setLoadingTab(false)
+    }
+  }, [details])
+
+  useEffect(() => {
+    if (agent) void loadDetail(agent.id, tab)
+  }, [agent, tab, loadDetail])
+
+  function selectAgent(id: string) { setSelectedId(id); setTab('overview') }
+
+  // ── render gates ──
+  if (me === undefined || (!ready && me)) {
+    return <div className="app"><div style={{ padding: 40, color: 'var(--ink-faint)' }} className="mono">Loading…</div></div>
   }
+  if (me === null) {
+    return (
+      <div className="app">
+        <div style={{ maxWidth: 380, margin: '18vh auto', textAlign: 'center' }}>
+          <div className="brand" style={{ justifyContent: 'center', fontSize: 18 }}><span className="mark" aria-hidden="true" /> Agentric</div>
+          <p style={{ color: 'var(--ink-dim)', marginTop: 16 }}>Sign in to view your fleet.</p>
+          <a className="btn" style={{ display: 'inline-block', marginTop: 8, textDecoration: 'none' }} href="/">Go to sign in →</a>
+        </div>
+      </div>
+    )
+  }
+
+  const needsYou = sessions.filter((s) => (s.alive || s.status === 'running') && s.blocked).length
 
   return (
     <div className="app">
       <div className="topbar">
         <div className="brand"><span className="mark" aria-hidden="true" /> Agentric</div>
-        <span className="tenant-pill"><span className="dot run" style={{ width: 6, height: 6, boxShadow: 'none' }} /> instapods</span>
+        <span className="tenant-pill"><span className="dot run" style={{ width: 6, height: 6, boxShadow: 'none' }} /> {tenant || '…'}</span>
         <div className="spacer" />
         <a className="topbar-link" href="/">Classic view →</a>
         <button className="icon-btn" title="Toggle theme" onClick={toggleTheme}>◐</button>
-        <button className="icon-btn" title="Inbox — 2 need you">Inbox <span className="badge">2</span></button>
+        <a className="icon-btn" href="/" title={needsYou ? `${needsYou} need you` : 'Inbox'} style={{ textDecoration: 'none' }}>
+          Inbox {needsYou ? <span className="badge">{needsYou}</span> : null}
+        </a>
       </div>
 
       <div className="layout">
         <aside className="rail">
           <div className="rail-head">
             <span className="eyebrow">Fleet</span>
-            <span className="eyebrow">{shown.length} agents</span>
+            <span className="eyebrow">{shown.length} agent{shown.length === 1 ? '' : 's'}</span>
           </div>
           <div className="rail-search">
             <input placeholder="Search agents…" value={filter} onChange={(e) => setFilter(e.target.value)} />
           </div>
-          {shown.map((a) => (
-            <button key={a.id} className={`agent-row ${a.id === selectedId ? 'active' : ''}`} onClick={() => selectAgent(a.id)}>
-              <span className={`dot ${a.status}`} />
-              <span className="col">
-                <div className="nm">{a.id}</div>
-                <div className="meta">{a.statusText}</div>
-              </span>
-            </button>
-          ))}
-          <button className="new-agent">＋  New agent</button>
+          {error ? <div className="empty" style={{ margin: 8 }}>{error}</div> : null}
+          {shown.length === 0 && !error
+            ? <div className="empty" style={{ margin: 8 }}>No agents.</div>
+            : shown.map((a) => (
+              <button key={a.id} className={`agent-row ${a.id === selectedId ? 'active' : ''}`} onClick={() => selectAgent(a.id)}>
+                <span className={`dot ${a.status}`} />
+                <span className="col">
+                  <div className="nm">{a.id}</div>
+                  <div className="meta">{a.statusText}</div>
+                </span>
+              </button>
+            ))}
+          <a className="new-agent" href="/" style={{ textDecoration: 'none', display: 'block' }}>＋  New agent</a>
           <div className="rail-sep" />
           <div className="rail-mini">
             <span className="eyebrow" style={{ paddingLeft: 9 }}>Fleet-wide</span>
-            <a>◱  Sessions</a>
-            <a>▤  Tasks</a>
-            <a>◈  Audit</a>
-            <a>⚙  Settings &amp; Team</a>
+            <a href="/">◱  Sessions</a>
+            <a href="/">▤  Tasks</a>
+            <a href="/">◈  Audit</a>
+            <a href="/">⚙  Settings &amp; Team</a>
           </div>
         </aside>
 
-        <Workspace agent={agent} tab={tab} onTab={setTab} />
+        {agent
+          ? <Workspace agent={agent} tab={tab} onTab={setTab} detail={details[agent.id] || {}} loadingTab={loadingTab} />
+          : <main className="workspace"><div className="empty" style={{ marginTop: 40 }}>No agents to show yet.</div></main>}
       </div>
     </div>
   )

--- a/web/src/v2/data.ts
+++ b/web/src/v2/data.ts
@@ -1,126 +1,139 @@
-// v2 mock fleet — real instapods/instawp domain flavor. This is scaffolding: the next
-// increment swaps it for live /api/state + /api/sessions calls (see App.tsx TODO).
+// v2 view-model adapters — turn the live API shapes (@/lib/api) into what the agent-first
+// console renders. Pure functions, no fetching (App.tsx owns the requests + caching).
+
+import type { AgentInfo, Session } from '@/lib/api'
 
 export type Status = 'run' | 'wait' | 'block' | 'idle'
 
+/** One agent as the rail + workspace render it. Its own live/recent sessions ride along so the
+ *  rail dot and Overview don't each re-scan the full sessions list. */
+export interface AgentVM {
+  id: string
+  handle: string
+  status: Status
+  statusText: string
+  blurb: string
+  system: boolean
+  sessions: Session[] // this agent's sessions, newest first
+}
+
+const DAY = 86_400_000
+
+/** Compact relative time: "now" / "12m" / "3h" / "2d" / "5w". */
+export function relTime(ts: number | undefined, now = Date.now()): string {
+  if (!ts) return ''
+  const s = Math.max(0, Math.round((now - ts) / 1000))
+  if (s < 45) return 'now'
+  const m = Math.round(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.round(m / 60)
+  if (h < 24) return `${h}h`
+  const d = Math.round(h / 24)
+  if (d < 7) return `${d}d`
+  return `${Math.round(d / 7)}w`
+}
+
+export function fmtUsd(n: number | undefined): string {
+  if (!n) return '$0'
+  if (n < 1) return `$${n.toFixed(2)}`
+  if (n < 1000) return `$${n.toFixed(n < 100 ? 1 : 0)}`
+  return `$${(n / 1000).toFixed(1)}k`
+}
+
+/** How the source is labelled on a session subline. */
+export function sourceLabel(s: Session): string {
+  switch (s.sourceKind) {
+    case 'manual': return 'console'
+    case 'cron': return 'cron'
+    case 'webhook': return 'webhook'
+    case 'slack': return 'slack'
+    case 'discord': return 'discord'
+    case 'telegram': return 'telegram'
+    case 'composio': return 'composio'
+    case 'scheduled': return 'scheduled'
+    case 'task': return 'task'
+    case 'chat': return 'chat'
+    case 'system': return 'system'
+    default: return s.headless ? 'unattended' : 'session'
+  }
+}
+
+function isLive(s: Session): boolean {
+  return s.alive === true || s.status === 'running'
+}
+
+/** Rail dot + one-word status for an agent, derived from its live sessions. */
+export function deriveStatus(sessions: Session[], system: boolean): { status: Status; statusText: string } {
+  const live = sessions.filter(isLive)
+  if (live.some((s) => s.blocked)) return { status: 'wait', statusText: 'waiting on you' }
+  if (live.some((s) => s.working)) return { status: 'run', statusText: 'running' }
+  if (live.length) return { status: 'run', statusText: 'live' }
+  return { status: 'idle', statusText: system ? 'system · idle' : 'idle' }
+}
+
+/** One recent-sessions row: a live tag OR a finished verdict. */
 export interface SessionRow {
-  t: string; d: string; when: string
-  tag?: Status; tagText?: string
-  verdict?: 'ok' | 'warn'; verText?: string
-}
-export interface AutomationRow { t: string; d: string; tag: Status; tagText: string; when: string }
-export interface InsightRow { t: string; d: string; when: string }
-export interface MemoryRow { body: string; kind: string; when: string; recalled: string }
-
-export interface Agent {
-  id: string; handle: string; status: Status; statusText: string; blurb: string
-  stats: { runs: string; cost: string; approve: string; memories: string }
-  sessions: SessionRow[]
-  automations: AutomationRow[]
-  insights: InsightRow[]
-  memories: MemoryRow[]
-  model: string; effort: string; verbosity: string; permission: string
-  prompt: string
+  key: string
+  t: string
+  d: string
+  when: string
+  tag?: Status
+  tagText?: string
+  verdict?: 'ok' | 'warn' | 'bad'
+  verText?: string
 }
 
-export const AGENTS: Agent[] = [
-  {
-    id: 'support-ops', handle: 'agent:support-ops', status: 'run', statusText: 'running',
-    blurb: 'Triage inbound FreeScout tickets, answer what it can, and delegate code work to the coding agent.',
-    stats: { runs: '312', cost: '$48.20', approve: '96%', memories: '84' },
-    sessions: [
-      { t: 'Reply drafted for ticket #4821 — DNS propagation', d: 'FreeScout · run-as varun', tag: 'run', tagText: 'running', when: 'now' },
-      { t: 'Delegated “fix pod restart loop” to coding', d: 'task:9f2a · A2A hand-off', verdict: 'ok', verText: '✓ done', when: '12m' },
-      { t: 'Weekly support digest', d: 'cron · Mon 09:00', verdict: 'ok', verText: '✓ done', when: '2d' },
-    ],
-    automations: [
-      { t: 'FreeScout ticket created', d: 'webhook · /hooks/fs-inbound', tag: 'run', tagText: 'on', when: '312 runs' },
-      { t: '@mention in #support', d: 'slack · thread continuity on', tag: 'run', tagText: 'on', when: '58 runs' },
-      { t: 'Weekly support digest', d: 'cron · 0 9 * * 1', tag: 'run', tagText: 'on', when: '11 runs' },
-    ],
-    insights: [
-      { t: '53% of runs decide to do nothing', d: 'Half of triage sessions end with no action — a cheaper pre-filter on the webhook payload would cut spend.', when: '7d' },
-      { t: 'Most-delegated: “restart loop”', d: '9 of 14 hand-offs to coding were the same class of pod crash — a candidate for a dedicated automation.', when: '7d' },
-    ],
-    memories: [
-      { body: 'FreeScout is LIVE on Agent OS and working real tickets — no longer a pilot. Route billing questions to the finance channel, not engineering.', kind: 'project', when: '3d', recalled: '11×' },
-      { body: 'Varun prefers a one-line summary at the top of every ticket reply before the detail.', kind: 'feedback', when: '9d', recalled: '27×' },
-      { body: 'Pod “restart loop” usually = OOM on the Launch plan; suggest a plan bump before deep debugging.', kind: 'reference', when: '14d', recalled: '6×' },
-    ],
-    model: 'opus-4.8', effort: 'medium', verbosity: 'terse', permission: 'auto',
-    prompt: '# support-ops\n\nYou triage inbound FreeScout tickets for Instapods. Answer what you can from the\nknowledge base. Delegate code changes to `agent:coding` via a task. Never issue a\nrefund or change a plan without an owner approval — the gate will stop you.',
-  },
-  {
-    id: 'pod-troubleshooter', handle: 'agent:pod-troubleshooter', status: 'wait', statusText: 'waiting on you',
-    blurb: 'Diagnose failing pods from logs and metrics; propose a fix, then wait for a human before touching production.',
-    stats: { runs: '146', cost: '$31.90', approve: '89%', memories: '52' },
-    sessions: [
-      { t: 'Approval needed — restart pod umbrella-web', d: 'gate · capability pod.restart', tag: 'wait', tagText: 'blocked on you', when: '4m' },
-      { t: 'Diagnosed 502 on aos.ai.instawp.io', d: 'nginx upgrade-map · root cause found', verdict: 'ok', verText: '✓ done', when: '1h' },
-    ],
-    automations: [
-      { t: 'Uptime Kuma alert → diagnose', d: 'webhook · /hooks/kuma', tag: 'run', tagText: 'on', when: '146 runs' },
-    ],
-    insights: [
-      { t: 'Approval latency: 22 min median', d: 'Diagnoses are fast but wait ~22 min for a human — an “always-approve restart on staging” rule would unblock the common case.', when: '7d' },
-    ],
-    memories: [
-      { body: 'nginx conditional Connection: upgrade — a hardcoded value 502s every plain HTTP request. Use the $connection_upgrade map.', kind: 'reference', when: '5d', recalled: '4×' },
-      { body: 'Never restart a prod pod without an approval; staging is fine to self-serve once the rule lands.', kind: 'feedback', when: '20d', recalled: '9×' },
-    ],
-    model: 'opus-4.8', effort: 'high', verbosity: 'normal', permission: 'auto',
-    prompt: '# pod-troubleshooter\n\nDiagnose failing pods from logs + metrics. Propose the smallest fix. Production\nchanges (restart, redeploy, plan change) MUST go through an approval — surface the\ndiagnosis and wait via `ask`.',
-  },
-  {
-    id: 'coding', handle: 'agent:coding', status: 'idle', statusText: 'idle',
-    blurb: 'Implements changes handed off as tasks — writes code, opens a PR authored as the requesting human.',
-    stats: { runs: '203', cost: '$102.40', approve: '92%', memories: '61' },
-    sessions: [
-      { t: 'PR #675 — feed icon + label fix', d: 'authored as vikas · squash-merged', verdict: 'ok', verText: '✓ merged', when: '6h' },
-      { t: 'Fix pod restart loop (from support-ops)', d: 'task:9f2a · run-as varun', verdict: 'ok', verText: '✓ done', when: '1d' },
-    ],
-    automations: [],
-    insights: [
-      { t: 'Highest cost per run in the fleet', d: 'Averages 2.1× the fleet — long transcripts. Terse verbosity on narration could trim ~15% without touching artifacts.', when: '7d' },
-    ],
-    memories: [
-      { body: 'Primary checkout stays clean on main; develop in per-session worktrees via scripts/wt.sh. Ship batches as one PR.', kind: 'project', when: '2d', recalled: '18×' },
-      { body: 'Always pass --repo vikasprogrammer/agentric to gh — the CLI targets the fork parent otherwise.', kind: 'reference', when: '8d', recalled: '14×' },
-    ],
-    model: 'opus-4.8', effort: 'high', verbosity: 'normal', permission: 'auto',
-    prompt: '# coding\n\nYou implement changes handed to you as tasks. Work in a worktree, keep the diff\nsmall, open a PR. Close your own loop with task_update(done).',
-  },
-  {
-    id: 'billing-watch', handle: 'agent:billing-watch', status: 'run', statusText: 'running',
-    blurb: 'Watches Stripe + plan changes for anomalies and posts a heads-up before anything bills.',
-    stats: { runs: '58', cost: '$9.10', approve: '100%', memories: '19' },
-    sessions: [
-      { t: 'Flagged 3 pods approaching plan limits', d: 'posted to #ops', tag: 'run', tagText: 'running', when: 'now' },
-    ],
-    automations: [{ t: 'Nightly billing sweep', d: 'cron · 0 2 * * *', tag: 'run', tagText: 'on', when: '58 runs' }],
-    insights: [],
-    memories: [{ body: 'A first card grants a one-time $10 credit — don’t flag a new pod’s trial as unpaid.', kind: 'reference', when: '30d', recalled: '3×' }],
-    model: 'haiku-4.5', effort: 'low', verbosity: 'terse', permission: 'auto',
-    prompt: '# billing-watch\n\nNightly, scan pods + plans for anomalies. Post a heads-up; never change a plan\nyourself.',
-  },
-  {
-    id: 'consolidator', handle: 'agent:consolidator', status: 'idle', statusText: 'system · idle',
-    blurb: 'The learning gardener — abstracts recurring patterns from fleet episodes into shared memory and KB pages.',
-    stats: { runs: '41', cost: '$14.60', approve: '—', memories: '203' },
-    sessions: [{ t: 'Consolidated 62 episodes → 4 shared memories', d: 'reflect pass · headless', verdict: 'ok', verText: '✓ done', when: '18h' }],
-    automations: [{ t: 'Reflect pass', d: 'cron · 0 */6 * * *', tag: 'run', tagText: 'on', when: '41 runs' }],
-    insights: [],
-    memories: [{ body: 'Recurring fleet pattern: agents self-delegate then wait — 98% of tasks are agent→agent. Consider a delegation budget.', kind: 'project', when: '1d', recalled: '2×' }],
-    model: 'sonnet-5', effort: 'medium', verbosity: 'terse', permission: 'auto',
-    prompt: '# consolidator\n\nSystem agent. Abstract recurring, durable patterns from recent episodes into shared\nmemories + KB pages via your own tools. Do not act on the world.',
-  },
-]
+export function sessionRow(s: Session, now = Date.now()): SessionRow {
+  const t = s.title?.trim() || s.task?.trim() || '(untitled run)'
+  const d = [sourceLabel(s), s.runAsLabel ? `run-as ${s.runAsLabel}` : ''].filter(Boolean).join(' · ')
+  const when = relTime(s.updatedAt || s.createdAt, now)
+  const base = { key: s.id, t, d, when }
+  if (isLive(s)) {
+    if (s.blocked) return { ...base, tag: 'wait', tagText: 'blocked on you' }
+    return { ...base, tag: 'run', tagText: s.working ? 'running' : 'live' }
+  }
+  const outcome = s.outcome
+  if (s.status === 'crashed') return { ...base, verdict: 'bad', verText: '✗ crashed' }
+  if (s.status === 'stopped') return { ...base, verdict: 'warn', verText: '■ stopped' }
+  if (outcome === 'failure') return { ...base, verdict: 'bad', verText: '✗ failed' }
+  if (outcome === 'partial') return { ...base, verdict: 'warn', verText: '~ partial' }
+  return { ...base, verdict: 'ok', verText: '✓ done' }
+}
 
-export interface TabDef { key: string; label: string; count?: (a: Agent) => number }
-export const TABS: TabDef[] = [
-  { key: 'overview', label: 'Overview' },
-  { key: 'automations', label: 'Automations', count: (a) => a.automations.length },
-  { key: 'insights', label: 'Insights', count: (a) => a.insights.length },
-  { key: 'memory', label: 'Memory', count: (a) => a.memories.length },
-  { key: 'settings', label: 'Settings' },
-]
+/** Build the fleet view models from /api/state agents + /api/sessions rows. */
+export function buildAgents(agents: AgentInfo[], sessions: Session[]): AgentVM[] {
+  const byAgent = new Map<string, Session[]>()
+  for (const s of sessions) {
+    const arr = byAgent.get(s.agent)
+    if (arr) arr.push(s)
+    else byAgent.set(s.agent, [s])
+  }
+  return agents.map((a) => {
+    const mine = (byAgent.get(a.id) || []).slice().sort((x, y) => (y.updatedAt || y.createdAt) - (x.updatedAt || x.createdAt))
+    const system = !!(a.builtIn && a.id === 'consolidator') || mine.some((s) => s.system)
+    const { status, statusText } = deriveStatus(mine, system)
+    return {
+      id: a.id,
+      handle: `agent:${a.id}`,
+      status,
+      statusText,
+      blurb: a.description || 'No description yet.',
+      system,
+      sessions: mine,
+    }
+  })
+}
+
+/** Overview stat tiles, all derived from the agent's own sessions (no extra requests). */
+export function overviewStats(sessions: Session[], now = Date.now()) {
+  const wk = sessions.filter((s) => (s.updatedAt || s.createdAt) > now - 7 * DAY)
+  const cost = wk.reduce((sum, s) => sum + (s.costUsd || 0), 0)
+  const live = sessions.filter(isLive)
+  const needs = live.filter((s) => s.blocked).length
+  return {
+    runs: String(wk.length),
+    cost: fmtUsd(cost),
+    live: String(live.length),
+    needs: String(needs),
+  }
+}


### PR DESCRIPTION
## What

`/v2` (shipped in #677 as a mock) is now **wired to live data**. No behavior change to the classic console at `/`.

- **Rail** — real roster from `/api/state`; each agent's status dot derived from its live sessions (`running` / `waiting on you` / `live` / `idle`).
- **Overview** (chat-first) — real 7-day stats (runs, cost, live, needs-you) + recent sessions from `/api/sessions`, each row showing a live tag or a finished verdict.
- **Automations** — `/api/automations`, filtered to the agent (lazy + cached).
- **Insights** — the agent's *real* track record from `/api/agents/:id/stats` (maturity, autonomy, denial rate, ratings, gate outcomes), framed per-agent. "No signal yet" until it has graded runs.
- **Memory** — `/api/memory` for the agent.
- **Settings** — live model / effort / verbosity + CLAUDE.md from `/api/agents/:id/{config,claude}` (read-only this cut).

## How

- Reuses the shared typed client `web/src/lib/api.ts` — vite code-splits it into its own `api-*.js` chunk, so nothing is duplicated and the v2 bundle stays ~17 KB.
- New pure adapter module `web/src/v2/data.ts` (status derivation, relative time, session→row, stat tiles) — no fetching, easy to reason about.
- Per-tab detail lazy-loads on open and caches per agent; sign-in / loading / empty / error states throughout.

## Scope

**Reads only.** Send, Run, and edit link back to the classic console; they become native next. `/` untouched.

## Verification

- `npm run build` + `cd web && npm run build` — clean; `tsc -b` passes against the real API types.
- `npm run test:governance` — 59 passed, 0 failed.
- Authenticated local smoke against every endpoint v2 consumes (`/api/state`, `/api/sessions`, `/api/automations`, `/api/agents/:id/{config,claude,stats}`, `/api/memory`) — all return the expected shapes; empty/loading/sign-in states confirmed on a fresh home.

🤖 Generated with [Claude Code](https://claude.com/claude-code)