### PR TITLE
fix(v2): sort fleet by maturity + white light-theme background (v0.373.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.373.1]
+### Changed
+- **`/v2` polish:** the fleet rail is now ordered by **maturity, most mature first** (agents with no
+  track record sink to the bottom), and the most mature agent is selected by default. Maturity comes
+  from a single `/api/agents/stats` call on load, which also seeds the per-agent Insights cache so that
+  tab opens instantly. The light theme now sits on a **white** background instead of the warm-gray
+  ground.
+
 ## [0.373.0]
 ### Added
 - **The `/v2` agent-first console is now wired to live data.** The mock fleet is gone: the rail loads

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.373.0",
+  "version": "0.373.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.373.0",
+      "version": "0.373.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.373.0",
+  "version": "0.373.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/v2/App.tsx
+++ b/web/src/v2/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { api, type AgentInfo, type Automation, type MemoryRecord, type Member, type RuntimeTuning, type Session } from '@/lib/api'
+import { api, type AgentInfo, type AgentStats, type Automation, type MemoryRecord, type Member, type RuntimeTuning, type Session } from '@/lib/api'
 import { buildAgents, overviewStats, relTime, sessionRow, type AgentVM, type Status } from './data'
 import './v2.css'
 
@@ -116,7 +116,7 @@ function Automations({ items, loading }: { items: Automation[] | undefined; load
 
 function pct(n: number): string { return `${Math.round(n * 100)}%` }
 
-function Insights({ stats, loading }: { stats: import('@/lib/api').AgentStats | undefined; loading: boolean }) {
+function Insights({ stats, loading }: { stats: AgentStats | undefined; loading: boolean }) {
   if (loading || !stats) return <div className="panel"><div className="empty">Reading this agent’s track record…</div></div>
   if (stats.confidence === 'none' || stats.runs.total === 0) {
     return <div className="panel"><div className="empty">No signal yet — insights build up once this agent has some graded runs.</div></div>
@@ -204,7 +204,7 @@ function Settings({ config, prompt, loading }: { config: (RuntimeTuning & { desc
 interface Detail {
   automations?: Automation[]
   memory?: MemoryRecord[]
-  stats?: import('@/lib/api').AgentStats
+  stats?: AgentStats
   config?: RuntimeTuning & { description?: string }
   prompt?: string
 }
@@ -253,6 +253,7 @@ export default function App() {
   const [error, setError] = useState<string | null>(null)
   const [ready, setReady] = useState(false)
 
+  const [statsById, setStatsById] = useState<Record<string, AgentStats>>({})
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [tab, setTab] = useState<TabKey>('overview')
   const [filter, setFilter] = useState('')
@@ -271,12 +272,24 @@ export default function App() {
       setMe(m)
       if (!m) return
       try {
-        const [state, sess] = await Promise.all([api.state(), api.sessions()])
+        const [state, sess, statsResp] = await Promise.all([
+          api.state(),
+          api.sessions(),
+          api.agentStatsAll().catch(() => ({ stats: [] as AgentStats[] })),
+        ])
         if (cancelled) return
         setTenant(state.tenantName || state.tenant)
         setAgentsInfo(state.agents || [])
         setSessions(Array.isArray(sess) ? sess : [])
-        setSelectedId((state.agents && state.agents[0]?.id) || null)
+        // Maturity map drives the rail order; seed the per-agent Insights cache so that tab is instant.
+        const byId: Record<string, AgentStats> = {}
+        const seeded: Record<string, Detail> = {}
+        for (const s of statsResp.stats || []) { byId[s.agentId] = s; seeded[s.agentId] = { stats: s } }
+        setStatsById(byId)
+        setDetails(seeded)
+        // Default-select the most mature agent (top of the sorted rail).
+        const ordered = [...(state.agents || [])].sort((a, b) => (byId[b.id]?.maturity ?? -1) - (byId[a.id]?.maturity ?? -1))
+        setSelectedId(ordered[0]?.id ?? null)
       } catch {
         if (!cancelled) setError('Could not load the fleet. Is the server reachable?')
       } finally {
@@ -286,7 +299,11 @@ export default function App() {
     return () => { cancelled = true }
   }, [])
 
-  const agents = useMemo(() => buildAgents(agentsInfo, sessions), [agentsInfo, sessions])
+  // Fleet ordered by maturity, most mature first (agents with no track record sink to the bottom).
+  const agents = useMemo(() => {
+    const list = buildAgents(agentsInfo, sessions)
+    return list.sort((a, b) => (statsById[b.id]?.maturity ?? -1) - (statsById[a.id]?.maturity ?? -1))
+  }, [agentsInfo, sessions, statsById])
   const shown = useMemo(
     () => agents.filter((a) => a.id.toLowerCase().includes(filter.toLowerCase())),
     [agents, filter],

--- a/web/src/v2/v2.css
+++ b/web/src/v2/v2.css
@@ -26,7 +26,7 @@
 }
 @media (prefers-color-scheme: light) {
   :root {
-    --ground: #f7f6f3; --panel: #fff; --panel-2: #fbfaf8;
+    --ground: #ffffff; --panel: #ffffff; --panel-2: #f7f7f6;
     --ink: #17171a; --ink-dim: #55565a; --ink-faint: #8a8b8e;
     --line: rgba(0,0,0,0.09); --line-strong: rgba(0,0,0,0.16); --hover: rgba(0,0,0,0.035); --active: rgba(0,0,0,0.06);
     --run: #16a34a; --wait: #b7791f; --block: #dc2626; --idle: #8a8b8e;
@@ -41,7 +41,7 @@
   --run-soft:rgba(74,222,128,0.14); --wait-soft:rgba(244,183,64,0.14); --block-soft:rgba(251,107,107,0.14); color-scheme: dark;
 }
 :root[data-theme="light"] {
-  --ground:#f7f6f3; --panel:#fff; --panel-2:#fbfaf8; --ink:#17171a; --ink-dim:#55565a; --ink-faint:#8a8b8e;
+  --ground:#ffffff; --panel:#ffffff; --panel-2:#f7f7f6; --ink:#17171a; --ink-dim:#55565a; --ink-faint:#8a8b8e;
   --line:rgba(0,0,0,0.09); --line-strong:rgba(0,0,0,0.16); --hover:rgba(0,0,0,0.035); --active:rgba(0,0,0,0.06);
   --run:#16a34a; --wait:#b7791f; --block:#dc2626; --idle:#8a8b8e;
   --run-soft:rgba(22,163,74,0.12); --wait-soft:rgba(183,121,31,0.12); --block-soft:rgba(220,38,38,0.10); color-scheme: light;


### PR DESCRIPTION
Two small `/v2` UX/UI tweaks:

- **Fleet sorted by maturity** — the rail lists agents most-mature-first (those with no track record sink to the bottom), and the most mature agent is selected on load. Order comes from a single `/api/agents/stats` call, which also seeds the per-agent **Insights** cache so that tab opens instantly.
- **White background** in the light theme, replacing the warm-gray ground. Cards/lists read via their hairline borders.

Reads only; classic `/` untouched.

### Verification
- `npm run build` + web build clean (`tsc -b`), `npm run test:governance` 59/0.
- Authed smoke: `/api/agents/stats` returns `{stats:[{maturity,…}]}`; compiled CSS carries the white ground.

🤖 Generated with [Claude Code](https://claude.com/claude-code)