### PR TITLE
fix(v2): slim Overview + move stats to Insights + fix link-buttons (v0.373.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.373.2]
+### Changed
+- **`/v2` Overview slimmed down.** Dropped the "everything about this agent lives here" blurb and moved
+  the four stat tiles (Runs·7d, Cost·7d, Live now, Needs you) onto the **Insights** tab, so Overview is
+  just the chat console + recent sessions. The agent description in the workspace header is now clamped
+  to two lines instead of taking over the header.
+### Fixed
+- **`/v2` button styling.** Buttons rendered as links (Run agent, the send arrow, the console chips, New
+  agent) were showing underlines and the send `↑` wasn't centered — the links are now styled as proper
+  buttons (no underline, flex-centered content).
+
 ## [0.373.1]
 ### Changed
 - **`/v2` polish:** the fleet rail is now ordered by **maturity, most mature first** (agents with no

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.373.1",
+  "version": "0.373.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.373.1",
+      "version": "0.373.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.373.1",
+  "version": "0.373.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/v2/App.tsx
+++ b/web/src/v2/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { api, type AgentInfo, type AgentStats, type Automation, type MemoryRecord, type Member, type RuntimeTuning, type Session } from '@/lib/api'
 import { buildAgents, overviewStats, relTime, sessionRow, type AgentVM, type Status } from './data'
 import './v2.css'
@@ -28,11 +28,9 @@ function StatePill({ status, text }: { status: Status; text: string }) {
 
 function Overview({ agent }: { agent: AgentVM }) {
   const now = Date.now()
-  const stats = overviewStats(agent.sessions, now)
   const recent = agent.sessions.slice(0, 6)
   return (
     <div className="panel">
-      <p className="thesis">Everything about this agent lives here — no hunting across a dozen global pages.</p>
       <div className="console">
         <div className="prompt">
           <textarea rows={1} placeholder={`Message ${agent.id}…  ask it to do something, or start a session`} />
@@ -43,12 +41,6 @@ function Overview({ agent }: { agent: AgentVM }) {
           <span className="chip">◈ run-as: you</span>
           <a className="chip" href={`/?spawn=${encodeURIComponent(agent.id)}`}>◱ Open live session</a>
         </div>
-      </div>
-      <div className="stat-row">
-        <div className="stat"><div className="k">Runs · 7d</div><div className="v">{stats.runs}</div><div className="sub">across all triggers</div></div>
-        <div className="stat"><div className="k">Cost · 7d</div><div className="v">{stats.cost}</div><div className="sub">sum of run cost</div></div>
-        <div className="stat"><div className="k">Live now</div><div className="v">{stats.live}</div><div className="sub">sessions alive</div></div>
-        <div className="stat"><div className="k">Needs you</div><div className="v">{stats.needs}</div><div className="sub">blocked on a human</div></div>
       </div>
       <div className="section-title"><h3>Recent sessions</h3><a href="/">All sessions →</a></div>
       {recent.length === 0
@@ -116,29 +108,42 @@ function Automations({ items, loading }: { items: Automation[] | undefined; load
 
 function pct(n: number): string { return `${Math.round(n * 100)}%` }
 
-function Insights({ stats, loading }: { stats: AgentStats | undefined; loading: boolean }) {
-  if (loading || !stats) return <div className="panel"><div className="empty">Reading this agent’s track record…</div></div>
-  if (stats.confidence === 'none' || stats.runs.total === 0) {
-    return <div className="panel"><div className="empty">No signal yet — insights build up once this agent has some graded runs.</div></div>
-  }
-  const rows: { t: string; d: string; when: string }[] = [
-    { t: `Maturity ${pct(stats.maturity)} · ${stats.confidence} confidence`, d: `Autonomy ${pct(stats.autonomy)}, denial rate ${pct(stats.denialRate)}, over ${stats.runs.total} runs (${stats.runs.done} done, ${stats.runs.crashed} crashed).`, when: stats.lastRunAt ? `${relTime(stats.lastRunAt)} ago` : '' },
-    { t: `Human ratings: ${stats.rated.up}↑ / ${stats.rated.down}↓`, d: stats.successRate != null ? `Self-reported success rate ${pct(stats.successRate)} across ${stats.outcomes.success + stats.outcomes.failure + stats.outcomes.inconclusive} reported runs.` : 'Not enough reported outcomes to rate success yet.', when: '' },
-    { t: `Gate: ${stats.actions.autoApproved} auto-approved, ${stats.actions.humanGated} sent to a human, ${stats.actions.denied} denied`, d: `${stats.actions.governed} governed effects total. ${stats.deniedRuns} run(s) hit a hard deny.`, when: '' },
-  ]
-  return (
-    <div className="panel">
-      <p className="thesis">Learned from this agent’s own runs — the fleet-wide Insights page folds into each agent.</p>
-      <div className="list">
-        {rows.map((x, i) => (
-          <div className="item" key={i}>
-            <span className="grow" style={{ padding: '2px 0' }}><div className="t">{x.t}</div><div className="d">{x.d}</div></span>
-            {x.when ? <span className="when">{x.when}</span> : null}
-          </div>
-        ))}
-      </div>
+function Insights({ agent, stats, loading }: { agent: AgentVM; stats: AgentStats | undefined; loading: boolean }) {
+  const s = overviewStats(agent.sessions)
+  const tiles = (
+    <div className="stat-row">
+      <div className="stat"><div className="k">Runs · 7d</div><div className="v">{s.runs}</div><div className="sub">across all triggers</div></div>
+      <div className="stat"><div className="k">Cost · 7d</div><div className="v">{s.cost}</div><div className="sub">sum of run cost</div></div>
+      <div className="stat"><div className="k">Live now</div><div className="v">{s.live}</div><div className="sub">sessions alive</div></div>
+      <div className="stat"><div className="k">Needs you</div><div className="v">{s.needs}</div><div className="sub">blocked on a human</div></div>
     </div>
   )
+  let body: ReactNode
+  if (loading && !stats) {
+    body = <div className="empty">Reading this agent’s track record…</div>
+  } else if (!stats || stats.confidence === 'none' || stats.runs.total === 0) {
+    body = <div className="empty">No maturity signal yet — it builds up once this agent has graded runs.</div>
+  } else {
+    const rows: { t: string; d: string; when: string }[] = [
+      { t: `Maturity ${pct(stats.maturity)} · ${stats.confidence} confidence`, d: `Autonomy ${pct(stats.autonomy)}, denial rate ${pct(stats.denialRate)}, over ${stats.runs.total} runs (${stats.runs.done} done, ${stats.runs.crashed} crashed).`, when: stats.lastRunAt ? `${relTime(stats.lastRunAt)} ago` : '' },
+      { t: `Human ratings: ${stats.rated.up}↑ / ${stats.rated.down}↓`, d: stats.successRate != null ? `Self-reported success rate ${pct(stats.successRate)} across ${stats.outcomes.success + stats.outcomes.failure + stats.outcomes.inconclusive} reported runs.` : 'Not enough reported outcomes to rate success yet.', when: '' },
+      { t: `Gate: ${stats.actions.autoApproved} auto-approved, ${stats.actions.humanGated} sent to a human, ${stats.actions.denied} denied`, d: `${stats.actions.governed} governed effects total. ${stats.deniedRuns} run(s) hit a hard deny.`, when: '' },
+    ]
+    body = (
+      <>
+        <p className="thesis">Learned from this agent’s own runs — the fleet-wide Insights page folds into each agent.</p>
+        <div className="list">
+          {rows.map((x, i) => (
+            <div className="item" key={i}>
+              <span className="grow" style={{ padding: '2px 0' }}><div className="t">{x.t}</div><div className="d">{x.d}</div></span>
+              {x.when ? <span className="when">{x.when}</span> : null}
+            </div>
+          ))}
+        </div>
+      </>
+    )
+  }
+  return <div className="panel">{tiles}{body}</div>
 }
 
 /* ─────────────────────────── Memory ─────────────────────────── */
@@ -236,7 +241,7 @@ function Workspace({ agent, tab, onTab, detail, loadingTab }: {
       </nav>
       {tab === 'overview' && <Overview agent={agent} />}
       {tab === 'automations' && <Automations items={detail.automations} loading={loadingTab} />}
-      {tab === 'insights' && <Insights stats={detail.stats} loading={loadingTab} />}
+      {tab === 'insights' && <Insights agent={agent} stats={detail.stats} loading={loadingTab} />}
       {tab === 'memory' && <Memory items={detail.memory} loading={loadingTab} />}
       {tab === 'settings' && <Settings config={detail.config} prompt={detail.prompt} loading={loadingTab} />}
     </main>

--- a/web/src/v2/v2.css
+++ b/web/src/v2/v2.css
@@ -100,19 +100,19 @@ body { background: var(--ground); }
 .rail-mini { padding: 4px 9px; }
 .rail-mini a { display: flex; align-items: center; gap: 9px; padding: 7px 9px; border-radius: 8px; color: var(--ink-dim); text-decoration: none; font-size: 12.5px; cursor: pointer; }
 .rail-mini a:hover { background: var(--hover); color: var(--ink); }
-.new-agent { margin-top: 6px; border: 1px dashed var(--line-strong); color: var(--ink-dim); border-radius: 9px; padding: 8px 9px; text-align: center; cursor: pointer; font-size: 12.5px; background: transparent; font-family: var(--font); width: 100%; }
+.new-agent { margin-top: 6px; border: 1px dashed var(--line-strong); color: var(--ink-dim); border-radius: 9px; padding: 8px 9px; text-align: center; cursor: pointer; font-size: 12.5px; background: transparent; font-family: var(--font); width: 100%; text-decoration: none; display: block; }
 .new-agent:hover { background: var(--hover); color: var(--ink); }
 
 .workspace { padding: 22px 26px 60px; max-width: 940px; margin: 0 auto; width: 100%; }
 .ws-head { display: flex; align-items: flex-start; gap: 16px; padding-bottom: 16px; }
 .ws-title { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; display: flex; align-items: center; gap: 11px; }
 .ws-handle { font-family: var(--mono); font-size: 12px; color: var(--ink-faint); }
-.ws-blurb { color: var(--ink-dim); font-size: 13.5px; margin-top: 5px; max-width: 62ch; }
+.ws-blurb { color: var(--ink-dim); font-size: 13.5px; margin-top: 5px; max-width: 62ch; display: -webkit-box; -webkit-line-clamp: 2; line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
 .status-pill { font-family: var(--mono); font-size: 11px; letter-spacing: 0.02em; padding: 3px 9px 3px 8px; border-radius: var(--r-pill); display: inline-flex; align-items: center; gap: 6px; border: 1px solid var(--line); color: var(--ink-dim); text-transform: uppercase; }
 .status-pill.run { color: var(--run); border-color: color-mix(in srgb, var(--run) 30%, transparent); background: var(--run-soft); }
 .status-pill.wait { color: var(--wait); border-color: color-mix(in srgb, var(--wait) 30%, transparent); background: var(--wait-soft); }
 .status-pill.block { color: var(--block); border-color: color-mix(in srgb, var(--block) 30%, transparent); background: var(--block-soft); }
-.btn { font-family: var(--font); font-size: 13px; font-weight: 520; border-radius: 9px; padding: 8px 14px; cursor: pointer; border: 1px solid var(--line-strong); background: var(--ink); color: var(--ground); }
+.btn { font-family: var(--font); font-size: 13px; font-weight: 520; border-radius: 9px; padding: 8px 14px; cursor: pointer; border: 1px solid var(--line-strong); background: var(--ink); color: var(--ground); text-decoration: none; display: inline-flex; align-items: center; justify-content: center; gap: 6px; white-space: nowrap; }
 .btn:hover { opacity: 0.9; }
 .btn.ghost { background: transparent; color: var(--ink); border-color: var(--line); }
 .btn.ghost:hover { background: var(--hover); }
@@ -138,9 +138,9 @@ body { background: var(--ground); }
 .console .prompt { display: flex; align-items: flex-end; gap: 10px; }
 .console textarea { flex: 1; resize: none; background: transparent; border: none; outline: none; color: var(--ink); font-family: var(--font); font-size: 15px; line-height: 1.5; min-height: 44px; padding: 6px 2px; }
 .console textarea::placeholder { color: var(--ink-faint); }
-.send { width: 36px; height: 36px; border-radius: 9px; border: 1px solid var(--line-strong); background: var(--ink); color: var(--ground); cursor: pointer; flex: none; font-size: 16px; }
+.send { width: 36px; height: 36px; border-radius: 9px; border: 1px solid var(--line-strong); background: var(--ink); color: var(--ground); cursor: pointer; flex: none; font-size: 16px; display: inline-flex; align-items: center; justify-content: center; text-decoration: none; line-height: 1; }
 .console .row2 { display: flex; align-items: center; gap: 8px; margin-top: 10px; padding-top: 10px; border-top: 1px solid var(--line); flex-wrap: wrap; }
-.chip { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); border: 1px solid var(--line); border-radius: var(--r-pill); padding: 3px 9px; cursor: pointer; background: transparent; }
+.chip { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); border: 1px solid var(--line); border-radius: var(--r-pill); padding: 3px 9px; cursor: pointer; background: transparent; text-decoration: none; display: inline-flex; align-items: center; gap: 5px; }
 .chip:hover { background: var(--hover); color: var(--ink); }
 
 .section-title { display: flex; align-items: baseline; justify-content: space-between; margin: 24px 0 12px; }


### PR DESCRIPTION
Overview redo per feedback:

1. **Removed** the "everything about this agent lives here…" blurb.
2. **Moved** the four stat tiles (Runs·7d, Cost·7d, Live now, Needs you) from Overview onto the **Insights** tab (which now leads with them, then the maturity track record). Overview is now just the chat console + recent sessions.
3. **Fixed button UI** — Run agent, the send `↑`, the console chips, and New agent were rendered as `<a>` links and kept their underline / off-center icon. They're now styled as proper buttons (no underline, flex-centered).
4. **Clamped** the agent description in the workspace header to two lines so it stops taking over the header.

Reads only; classic `/` untouched. Build + `tsc -b` clean, governance 59/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)