### PR TITLE
feat(v2): fleet session glance in the rail (v0.373.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.373.3]
+### Added
+- **`/v2` fleet glance in the rail.** Under the Fleet header, a compact summary shows how many sessions
+  are **live** and **running** right now, plus a **waiting** count (only when something is blocked on a
+  human). Derived from the sessions already loaded — no extra request.
+
 ## [0.373.2]
 ### Changed
 - **`/v2` Overview slimmed down.** Dropped the "everything about this agent lives here" blurb and moved

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.373.2",
+  "version": "0.373.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.373.2",
+      "version": "0.373.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.373.2",
+  "version": "0.373.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/v2/App.tsx
+++ b/web/src/v2/App.tsx
@@ -374,7 +374,11 @@ export default function App() {
     )
   }
 
-  const needsYou = sessions.filter((s) => (s.alive || s.status === 'running') && s.blocked).length
+  // Fleet-wide session glance for the rail.
+  const liveSessions = sessions.filter((s) => s.alive || s.status === 'running')
+  const runningCount = liveSessions.filter((s) => s.working).length
+  const needsYou = liveSessions.filter((s) => s.blocked).length
+  const liveCount = liveSessions.length
 
   return (
     <div className="app">
@@ -394,6 +398,11 @@ export default function App() {
           <div className="rail-head">
             <span className="eyebrow">Fleet</span>
             <span className="eyebrow">{shown.length} agent{shown.length === 1 ? '' : 's'}</span>
+          </div>
+          <div className="rail-substat">
+            <span className="s"><span className="dot idle" style={{ opacity: liveCount ? 0.7 : 0.4 }} /><b>{liveCount}</b> live</span>
+            <span className="s"><span className="dot run" style={{ boxShadow: 'none' }} /><b>{runningCount}</b> running</span>
+            {needsYou > 0 ? <span className="s"><span className="dot wait" style={{ boxShadow: 'none' }} /><b>{needsYou}</b> waiting</span> : null}
           </div>
           <div className="rail-search">
             <input placeholder="Search agents…" value={filter} onChange={(e) => setFilter(e.target.value)} />

--- a/web/src/v2/v2.css
+++ b/web/src/v2/v2.css
@@ -78,6 +78,9 @@ body { background: var(--ground); }
 
 .rail { border-right: 1px solid var(--line); padding: 14px 10px; display: flex; flex-direction: column; gap: 4px; position: sticky; top: 52px; align-self: start; height: calc(100vh - 52px); overflow: auto; }
 .rail-head { display: flex; align-items: center; justify-content: space-between; padding: 4px 8px 8px; }
+.rail-substat { display: flex; flex-wrap: wrap; gap: 4px 12px; padding: 0 8px 10px; font-family: var(--mono); font-size: 11px; color: var(--ink-dim); }
+.rail-substat .s { display: inline-flex; align-items: center; gap: 6px; }
+.rail-substat b { color: var(--ink); font-weight: 600; }
 .rail-search { margin: 0 6px 8px; }
 .rail-search input { width: 100%; background: var(--panel); border: 1px solid var(--line); border-radius: 9px; color: var(--ink); padding: 7px 10px; font-size: 12.5px; font-family: var(--font); outline: none; }
 .rail-search input::placeholder { color: var(--ink-faint); }


### PR DESCRIPTION
Adds a compact fleet summary under the rail's Fleet header — **live** and **running** session counts now, plus a **waiting** count when something is blocked on a human. Computed from the already-loaded sessions (no extra request). Classic `/` untouched; build + governance 59/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)