### PR TITLE
feat(v2): per-agent live-session count in the rail (v0.373.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.373.4]
+### Added
+- **`/v2` per-agent live-session count.** Each agent row in the rail now shows a small badge with how
+  many sessions that agent has live right now (green, or amber when it's the one waiting on a human).
+  Hidden when the agent has none. Complements the fleet summary above it.
+
 ## [0.373.3]
 ### Added
 - **`/v2` fleet glance in the rail.** Under the Fleet header, a compact summary shows how many sessions

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.373.3",
+  "version": "0.373.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.373.3",
+      "version": "0.373.4",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.373.3",
+  "version": "0.373.4",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/v2/App.tsx
+++ b/web/src/v2/App.tsx
@@ -410,15 +410,19 @@ export default function App() {
           {error ? <div className="empty" style={{ margin: 8 }}>{error}</div> : null}
           {shown.length === 0 && !error
             ? <div className="empty" style={{ margin: 8 }}>No agents.</div>
-            : shown.map((a) => (
-              <button key={a.id} className={`agent-row ${a.id === selectedId ? 'active' : ''}`} onClick={() => selectAgent(a.id)}>
-                <span className={`dot ${a.status}`} />
-                <span className="col">
-                  <div className="nm">{a.id}</div>
-                  <div className="meta">{a.statusText}</div>
-                </span>
-              </button>
-            ))}
+            : shown.map((a) => {
+              const live = a.sessions.filter((s) => s.alive || s.status === 'running').length
+              return (
+                <button key={a.id} className={`agent-row ${a.id === selectedId ? 'active' : ''}`} onClick={() => selectAgent(a.id)}>
+                  <span className={`dot ${a.status}`} />
+                  <span className="col">
+                    <div className="nm">{a.id}</div>
+                    <div className="meta">{a.statusText}</div>
+                  </span>
+                  {live > 0 ? <span className={`agent-count ${a.status === 'wait' ? 'wait' : ''}`} title={`${live} live session${live === 1 ? '' : 's'}`}>{live}</span> : null}
+                </button>
+              )
+            })}
           <a className="new-agent" href="/" style={{ textDecoration: 'none', display: 'block' }}>＋  New agent</a>
           <div className="rail-sep" />
           <div className="rail-mini">

--- a/web/src/v2/v2.css
+++ b/web/src/v2/v2.css
@@ -99,6 +99,8 @@ body { background: var(--ground); }
 .agent-row .nm { font-size: 13px; line-height: 1.25; color: var(--ink); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .agent-row .meta { font-family: var(--mono); font-size: 10.5px; color: var(--ink-faint); }
 .agent-row .col { min-width: 0; flex: 1; }
+.agent-count { flex: none; font-family: var(--mono); font-variant-numeric: tabular-nums; font-size: 10.5px; line-height: 15px; padding: 0 6px; border-radius: var(--r-pill); color: var(--run); background: var(--run-soft); border: 1px solid color-mix(in srgb, var(--run) 30%, transparent); }
+.agent-count.wait { color: var(--wait); background: var(--wait-soft); border-color: color-mix(in srgb, var(--wait) 30%, transparent); }
 .rail-sep { height: 1px; background: var(--line); margin: 8px 8px; }
 .rail-mini { padding: 4px 9px; }
 .rail-mini a { display: flex; align-items: center; gap: 9px; padding: 7px 9px; border-radius: 8px; color: var(--ink-dim); text-decoration: none; font-size: 12.5px; cursor: pointer; }


### PR DESCRIPTION
Each agent row in the rail now shows a small badge with how many sessions that agent has **live right now** — green, or amber when it's the one waiting on a human. Hidden when the agent has none. Computed from the already-loaded sessions; complements the fleet summary. Classic `/` untouched; build + governance 59/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)