### PR TITLE
feat(v2): read-only session viewer — our own, not terminal/chat (v0.374.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.374.0]
+### Added
+- **`/v2` session viewer — our own, not the terminal or a chat box.** Clicking a recent session opens a
+  read-only, human-readable timeline built on `/api/sessions/:id/conversation`: the person's prompts,
+  the agent's replies (rendered as markdown), and each governed **activity** (tool action with an
+  ok/running/error status) — with inline cards for any artifacts, KB pages, or apps the run produced. A
+  header carries the title, status/verdict, cost, duration, turns and model; live runs still link out to
+  the classic terminal, and runs with no persisted transcript get a friendly empty state. Reuses the
+  shared `react-markdown` dependency (code-split, so the v2 core stays small).
+
 ## [0.373.4]
 ### Added
 - **`/v2` per-agent live-session count.** Each agent row in the rail now shows a small badge with how

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.373.4",
+  "version": "0.374.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.373.4",
+      "version": "0.374.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.373.4",
+  "version": "0.374.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/v2/App.tsx
+++ b/web/src/v2/App.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { api, type AgentInfo, type AgentStats, type Automation, type MemoryRecord, type Member, type RuntimeTuning, type Session } from '@/lib/api'
 import { buildAgents, overviewStats, relTime, sessionRow, type AgentVM, type Status } from './data'
+import SessionViewer from './SessionViewer'
 import './v2.css'
 
 // Agentric v2 — the agent-first console, wired to live data. Each agent carries its own
@@ -26,7 +27,7 @@ function StatePill({ status, text }: { status: Status; text: string }) {
 
 /* ─────────────────────────── Overview (chat-first) ─────────────────────────── */
 
-function Overview({ agent }: { agent: AgentVM }) {
+function Overview({ agent, onOpen }: { agent: AgentVM; onOpen: (s: Session) => void }) {
   const now = Date.now()
   const recent = agent.sessions.slice(0, 6)
   return (
@@ -50,14 +51,14 @@ function Overview({ agent }: { agent: AgentVM }) {
             {recent.map((s) => {
               const r = sessionRow(s, now)
               return (
-                <div className="item" key={r.key}>
+                <button className="item item-btn" key={r.key} onClick={() => onOpen(s)} title="Open session viewer">
                   <span className={`dot ${r.tag || 'idle'}`} style={r.tag ? undefined : { opacity: 0.4 }} />
                   <span className="grow"><div className="t">{r.t}</div><div className="d">{r.d}</div></span>
                   {r.tag
                     ? <span className={`tag ${r.tag}`}>{r.tagText}</span>
                     : <span className={`verdict ${r.verdict === 'ok' ? 'ok' : 'warn'}`}>{r.verText}</span>}
                   <span className="when">{r.when}</span>
-                </div>
+                </button>
               )
             })}
           </div>
@@ -214,8 +215,8 @@ interface Detail {
   prompt?: string
 }
 
-function Workspace({ agent, tab, onTab, detail, loadingTab }: {
-  agent: AgentVM; tab: TabKey; onTab: (t: TabKey) => void; detail: Detail; loadingTab: boolean
+function Workspace({ agent, tab, onTab, detail, loadingTab, onOpenSession }: {
+  agent: AgentVM; tab: TabKey; onTab: (t: TabKey) => void; detail: Detail; loadingTab: boolean; onOpenSession: (s: Session) => void
 }) {
   const counts: Record<string, number | undefined> = {
     automations: detail.automations?.length,
@@ -239,7 +240,7 @@ function Workspace({ agent, tab, onTab, detail, loadingTab }: {
           </button>
         ))}
       </nav>
-      {tab === 'overview' && <Overview agent={agent} />}
+      {tab === 'overview' && <Overview agent={agent} onOpen={onOpenSession} />}
       {tab === 'automations' && <Automations items={detail.automations} loading={loadingTab} />}
       {tab === 'insights' && <Insights agent={agent} stats={detail.stats} loading={loadingTab} />}
       {tab === 'memory' && <Memory items={detail.memory} loading={loadingTab} />}
@@ -262,6 +263,7 @@ export default function App() {
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [tab, setTab] = useState<TabKey>('overview')
   const [filter, setFilter] = useState('')
+  const [openSession, setOpenSession] = useState<Session | null>(null)
 
   // Per-agent lazy detail cache, keyed by agent id.
   const [details, setDetails] = useState<Record<string, Detail>>({})
@@ -356,7 +358,7 @@ export default function App() {
     if (agent) void loadDetail(agent.id, tab)
   }, [agent, tab, loadDetail])
 
-  function selectAgent(id: string) { setSelectedId(id); setTab('overview') }
+  function selectAgent(id: string) { setSelectedId(id); setTab('overview'); setOpenSession(null) }
 
   // ── render gates ──
   if (me === undefined || (!ready && me)) {
@@ -434,9 +436,11 @@ export default function App() {
           </div>
         </aside>
 
-        {agent
-          ? <Workspace agent={agent} tab={tab} onTab={setTab} detail={details[agent.id] || {}} loadingTab={loadingTab} />
-          : <main className="workspace"><div className="empty" style={{ marginTop: 40 }}>No agents to show yet.</div></main>}
+        {openSession
+          ? <SessionViewer session={openSession} onBack={() => setOpenSession(null)} />
+          : agent
+            ? <Workspace agent={agent} tab={tab} onTab={setTab} detail={details[agent.id] || {}} loadingTab={loadingTab} onOpenSession={setOpenSession} />
+            : <main className="workspace"><div className="empty" style={{ marginTop: 40 }}>No agents to show yet.</div></main>}
       </div>
     </div>
   )

--- a/web/src/v2/SessionViewer.tsx
+++ b/web/src/v2/SessionViewer.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+import { api, type ChatTurn, type ConversationResp, type Session } from '@/lib/api'
+import { fmtUsd } from './data'
+
+// Our own read-only session viewer — not the tmux terminal, not a chat box. It renders the friendly
+// conversation timeline from /api/sessions/:id/conversation: the human's prompts, the agent's replies
+// (markdown), and classified activity (governed tool actions with status + inline artifact/KB/app cards).
+
+function clock(ts: number): string {
+  try { return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) } catch { return '' }
+}
+function fmtDuration(ms: number | undefined): string | null {
+  if (!ms || ms < 1000) return null
+  const s = Math.round(ms / 1000)
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m ${s % 60}s`
+  return `${Math.floor(m / 60)}h ${m % 60}m`
+}
+
+function isLive(s: Session): boolean { return s.alive === true || s.status === 'running' }
+
+function headStatus(s: Session): { cls: string; text: string } {
+  if (isLive(s)) {
+    if (s.blocked) return { cls: 'wait', text: 'blocked on you' }
+    return { cls: 'run', text: s.working ? 'running' : 'live' }
+  }
+  if (s.status === 'crashed') return { cls: 'block', text: 'crashed' }
+  if (s.outcome === 'failure') return { cls: 'block', text: 'failed' }
+  if (s.outcome === 'partial') return { cls: 'wait', text: 'partial' }
+  return { cls: 'idle', text: s.status === 'stopped' ? 'stopped' : 'done' }
+}
+
+function ActivityCards({ t }: { t: Extract<ChatTurn, { kind: 'activity' }> }) {
+  return (
+    <>
+      {t.artifacts?.length ? (
+        <div className="v-cards">
+          {t.artifacts.map((a) => (
+            <a className="v-card" key={a.id} href={a.raw} target="_blank" rel="noreferrer">
+              {a.isImage ? <img src={a.raw} alt={a.title} /> : <span className="v-card-kind">{a.kind || 'file'}</span>}
+              <span className="v-card-title">{a.title}</span>
+            </a>
+          ))}
+        </div>
+      ) : null}
+      {t.kbPages?.length ? (
+        <div className="v-cards">
+          {t.kbPages.map((k) => <span className="v-chip" key={`${k.section}/${k.slug}`}>📄 {k.title}</span>)}
+        </div>
+      ) : null}
+      {t.apps?.length ? (
+        <div className="v-cards">
+          {t.apps.map((ap) => <span className="v-chip" key={ap.id}>▦ {ap.name}{ap.published ? '' : ' · draft'}</span>)}
+        </div>
+      ) : null}
+    </>
+  )
+}
+
+function Turn({ t, agentId }: { t: ChatTurn; agentId: string }) {
+  if (t.kind === 'user') {
+    return (
+      <div className="v-turn v-user">
+        <div className="v-who">You <span className="v-time">{clock(t.ts)}</span></div>
+        <div className="v-body v-pre">{t.text}</div>
+      </div>
+    )
+  }
+  if (t.kind === 'assistant') {
+    return (
+      <div className="v-turn v-assistant">
+        <div className="v-who">{agentId} <span className="v-time">{clock(t.ts)}</span></div>
+        <div className="v-body md"><ReactMarkdown remarkPlugins={[remarkGfm]}>{t.text}</ReactMarkdown></div>
+      </div>
+    )
+  }
+  // activity
+  const dotCls = t.status === 'error' ? 'block' : t.status === 'running' ? 'run' : 'idle'
+  return (
+    <div className="v-turn v-activity">
+      <span className={`dot ${dotCls}`} style={t.status === 'running' ? undefined : { boxShadow: 'none' }} />
+      <div className="grow">
+        <div className="v-act-line"><span className="v-tool">{t.tool}</span> {t.label}</div>
+        {t.detail ? <div className="v-act-detail">{t.detail}</div> : null}
+        <ActivityCards t={t} />
+      </div>
+      <span className="v-time">{clock(t.ts)}</span>
+    </div>
+  )
+}
+
+export default function SessionViewer({ session, onBack }: { session: Session; onBack: () => void }) {
+  const [convo, setConvo] = useState<ConversationResp | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setLoading(true); setConvo(null)
+    api.conversation(session.id)
+      .then((r) => { if (!cancelled) { setConvo(r); setLoading(false) } })
+      .catch(() => { if (!cancelled) { setConvo({ turns: [], found: false }); setLoading(false) } })
+    return () => { cancelled = true }
+  }, [session.id])
+
+  const st = headStatus(session)
+  const agentId = convo?.agent || session.agent
+  const dur = fmtDuration(session.activeMs)
+  const meta: string[] = []
+  if (session.costUsd != null) meta.push(fmtUsd(session.costUsd))
+  if (dur) meta.push(dur)
+  if (session.turns) meta.push(`${session.turns} turn${session.turns === 1 ? '' : 's'}`)
+  if (session.model) meta.push(session.model)
+
+  const live = isLive(session)
+  const turns = convo?.turns ?? []
+
+  return (
+    <main className="workspace viewer">
+      <button className="v-back" onClick={onBack}>← {agentId}</button>
+      <div className="v-head">
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div className="v-title">{session.title?.trim() || session.task?.trim() || '(untitled run)'}</div>
+          <div className="v-meta">
+            <span className={`status-pill ${st.cls}`}>{st.cls === 'idle' ? '●' : null} {st.text}</span>
+            {meta.map((m, i) => <span className="v-metabit mono" key={i}>{m}</span>)}
+          </div>
+        </div>
+        {live ? <a className="btn ghost" href={`/?session=${encodeURIComponent(session.id)}`}>Open terminal →</a> : null}
+      </div>
+
+      {session.summary ? <div className="v-summary">{session.summary}</div> : null}
+
+      {loading ? (
+        <div className="empty">Loading conversation…</div>
+      ) : turns.length === 0 ? (
+        <div className="empty">
+          No readable transcript for this run.
+          {live ? <><br /><br />It’s still running — <a href={`/?session=${encodeURIComponent(session.id)}`}>open the live terminal</a>.</> : null}
+        </div>
+      ) : (
+        <div className="v-timeline">
+          {turns.map((t, i) => <Turn key={i} t={t} agentId={agentId} />)}
+          {live ? <div className="v-live-note">● still running — this is the conversation so far</div> : null}
+        </div>
+      )}
+    </main>
+  )
+}

--- a/web/src/v2/v2.css
+++ b/web/src/v2/v2.css
@@ -189,6 +189,53 @@ body { background: var(--ground); }
 
 .thesis { font-size: 12px; color: var(--ink-faint); border-left: 2px solid var(--line-strong); padding: 2px 0 2px 12px; margin: 0 0 18px; }
 
+/* clickable recent-session rows */
+.item-btn { background: transparent; border: 0; border-bottom: 1px solid var(--line); width: 100%; text-align: left; font: inherit; color: inherit; cursor: pointer; }
+
+/* ── session viewer ── */
+.viewer { max-width: 820px; }
+.v-back { background: transparent; border: none; color: var(--ink-dim); font-family: var(--font); font-size: 12.5px; cursor: pointer; padding: 0; margin-bottom: 14px; }
+.v-back:hover { color: var(--ink); }
+.v-head { display: flex; align-items: flex-start; gap: 14px; padding-bottom: 14px; border-bottom: 1px solid var(--line); }
+.v-title { font-size: 18px; font-weight: 600; letter-spacing: -0.02em; text-wrap: balance; }
+.v-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; margin-top: 9px; }
+.v-metabit { font-size: 11.5px; color: var(--ink-dim); }
+.v-summary { font-size: 13px; color: var(--ink-dim); border-left: 2px solid var(--line-strong); padding: 4px 0 4px 12px; margin: 16px 0 0; }
+.v-timeline { margin-top: 4px; }
+.v-turn { padding: 16px 0; border-bottom: 1px solid var(--line); }
+.v-who { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ink-faint); margin-bottom: 7px; display: flex; align-items: center; gap: 8px; }
+.v-time { color: var(--ink-faint); font-family: var(--mono); font-size: 10.5px; text-transform: none; letter-spacing: 0; }
+.v-pre { white-space: pre-wrap; font-size: 13.5px; line-height: 1.55; }
+.v-activity { display: flex; align-items: flex-start; gap: 10px; }
+.v-activity .grow { flex: 1; min-width: 0; }
+.v-act-line { font-size: 13px; }
+.v-tool { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); border: 1px solid var(--line); border-radius: var(--r-pill); padding: 1px 7px; margin-right: 4px; }
+.v-act-detail { font-size: 12px; color: var(--ink-dim); margin-top: 3px; white-space: pre-wrap; }
+.v-cards { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+.v-card { display: inline-flex; align-items: center; gap: 8px; border: 1px solid var(--line); border-radius: 8px; padding: 6px 10px; text-decoration: none; color: var(--ink); font-size: 12px; max-width: 260px; }
+.v-card:hover { background: var(--hover); }
+.v-card img { width: 34px; height: 34px; object-fit: cover; border-radius: 5px; }
+.v-card-kind { font-family: var(--mono); font-size: 10px; text-transform: uppercase; color: var(--ink-faint); border: 1px solid var(--line); border-radius: 4px; padding: 1px 5px; }
+.v-card-title { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v-chip { font-family: var(--mono); font-size: 11px; color: var(--ink-dim); border: 1px solid var(--line); border-radius: var(--r-pill); padding: 3px 9px; }
+.v-live-note { font-family: var(--mono); font-size: 11px; color: var(--run); padding: 14px 0; }
+
+/* markdown inside an assistant turn */
+.md { font-size: 13.5px; line-height: 1.6; color: var(--ink); }
+.md > *:first-child { margin-top: 0; }
+.md > *:last-child { margin-bottom: 0; }
+.md p { margin: 0 0 10px; }
+.md h1, .md h2, .md h3, .md h4 { font-size: 14px; font-weight: 600; margin: 16px 0 8px; letter-spacing: -0.01em; }
+.md ul, .md ol { margin: 0 0 10px; padding-left: 20px; }
+.md li { margin: 3px 0; }
+.md a { color: var(--ink); text-decoration: underline; text-underline-offset: 2px; }
+.md code { font-family: var(--mono); font-size: 12px; background: var(--panel-2); border: 1px solid var(--line); border-radius: 4px; padding: 0 4px; }
+.md pre { background: var(--panel-2); border: 1px solid var(--line); border-radius: 8px; padding: 12px; overflow-x: auto; margin: 0 0 10px; }
+.md pre code { background: none; border: none; padding: 0; }
+.md blockquote { border-left: 2px solid var(--line-strong); margin: 0 0 10px; padding-left: 12px; color: var(--ink-dim); }
+.md table { border-collapse: collapse; font-size: 12.5px; display: block; overflow-x: auto; }
+.md th, .md td { border: 1px solid var(--line); padding: 5px 9px; text-align: left; }
+
 @media (max-width: 760px) {
   .layout { grid-template-columns: 1fr; }
   .rail { display: none; }


### PR DESCRIPTION
Our own **session viewer** for `/v2` — not the tmux terminal, not a chat box. Clicking a recent session opens a read-only, human-readable timeline.

### Data
`GET /api/sessions/:id/conversation` — the same friendly timeline the classic chat view uses:
- **user** turns — the person's prompts
- **assistant** turns — the agent's replies, rendered as **markdown**
- **activity** turns — each governed tool action with an ok / running / error status, plus inline cards for any **artifacts** (images render inline), **KB pages**, or **apps** the run produced

### Chrome
Header shows title, status/verdict pill, cost, duration, turns, model. Live runs link out to the classic terminal; runs with no persisted transcript get a friendly empty state. Back link returns to the agent.

### Notes
- New component `web/src/v2/SessionViewer.tsx`; reuses the shared `react-markdown` dep (no raw HTML → no XSS). v2 core bundle ~23 KB.
- Read-only; classic `/` untouched.

### Verification
- `tsc -b` + web/server build clean; `npm run test:governance` 59/0.
- Route smoke: `/api/sessions/:id/conversation` present (404 on unknown id, viewer-scoped server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)