### PR TITLE
docs(deploy): ttyd base-path proxy_pass gotcha + apt root-shell ttyd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+### Documentation
+- Deployment: document the ttyd `-b /terminal` base-path gotcha — a trailing slash on the
+  `/terminal/` `proxy_pass` strips the prefix, ttyd 404s the WebSocket upgrade, and the browser
+  terminal renders as a black pane with `GET /terminal/ws → 502` while sessions run normally
+  (reads as "sessions won't spawn"). Added to the CLAUDE.md nginx gotcha list and the tenant
+  box-migration checklist, with the probe that distinguishes it from the backslash-403 and the
+  unconditional-`Connection: upgrade` 502, plus the cookie-jar false-401 diagnostic trap.
+- Deployment: note that Ubuntu's `ttyd` apt package auto-enables `ttyd.service`, a **root** login
+  shell on `:7681` separate from the app-spawned ttyd — disable it on any apt-installed box.
+
 ## [0.375.0]
 ### Changed
 - **A completion no longer resurrects a cold caller — the poke-back's resume lane is priced by what the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -562,6 +562,28 @@ in `src/types.ts` and `TeamStore.canRun()`.
   `/terminal/`+cookie → 200, no-cookie → 401, WS handshake (`Upgrade` + `Sec-WebSocket-Protocol: tty`) →
   101. Was isolated to umbrella (that one config was hand-written differently); jump-server + initech
   configs were clean.
+- **nginx gotcha on any hand-written vhost (hooli, 2026-08-20) — a trailing slash on the ttyd
+  `proxy_pass`.** The app launches ttyd with **`-b /terminal`**, so its WebSocket lives at
+  **`/terminal/ws`**. Writing the location as `proxy_pass http://127.0.0.1:3011/;` (**with** the trailing
+  slash) makes nginx strip the location prefix and ask ttyd for `/ws` — ttyd 404s the upgrade and drops
+  the connection, so the browser terminal is a **solid black pane** and the log shows
+  `GET /terminal/ws → 502` + `upstream prematurely closed connection while reading response header`.
+  Sessions meanwhile spawn and run perfectly (cost accrues, transcript written), so it reads as
+  "sessions are not spawning" when nothing is wrong with sessions. Fix = **drop the trailing slash**
+  (`proxy_pass http://127.0.0.1:3011;`) so the URI passes through unchanged. Note the 502 string is
+  identical to the umbrella `Connection: upgrade` gotcha above but the blast radius differs — that one
+  502s EVERY request, this one only `/terminal/ws`. Probe ttyd directly to tell them apart:
+  `curl -o /dev/null -w '%{http_code}' localhost:3011/terminal/` = 200 while `…:3011/ws` = 404 means the
+  base path is `/terminal` and your `proxy_pass` is rewriting it away. Verify the fix with the same WS
+  handshake as above → **101** with a cookie, **401** without.
+  ⚠ **Diagnostic trap while verifying:** `curl -b <jar>` against the loopback can return a misleading
+  **401** for `/terminal/` (the jar's `#HttpOnly_localhost` entry doesn't match), which looks exactly
+  like a broken `auth_request`. Re-test with an explicit `-H "Cookie: aos_sid=…"` before believing it.
+- **⚠ Ubuntu's `ttyd` apt package auto-enables a ROOT login shell.** `apt-get install ttyd` also installs
+  and **enables** `ttyd.service` — `/usr/bin/ttyd -W -i lo -p 7681 -O login` running as **root**, entirely
+  separate from the app-spawned ttyd on `TTYD_PORT`. It is loopback-bound, so not internet-reachable, but
+  it is a root shell on a box that runs agents and it returns on every reboot. Disable it on any box that
+  installs ttyd from apt: `sudo systemctl disable --now ttyd`.
 - **Hardened-unit gotcha — `ReadWritePaths=` dirs must pre-exist.** Under `ProtectHome=read-only` the
   unit fails to start with `status=226/NAMESPACE` (`Failed to set up mount namespacing: <path>: No such
   file or directory`) if any carve-out path is missing. On a fresh box `~/.config`/`~/.cache`/`~/.claude`

--- a/docs/tenant-box-migration.md
+++ b/docs/tenant-box-migration.md
@@ -264,6 +264,17 @@ connections; retry after the ban clears.
   the tmux server + live `claude` panes keep running (some mid-Slack-request → double-posts). After
   cutover, kill them explicitly: `tmux -S <home>/tmux.sock kill-server`, then `pkill -f '<old checkout
   path>'` for the double-forked stragglers — matching the checkout path spares the user's own `claude`.
+- **ttyd `proxy_pass` must NOT have a trailing slash.** ttyd runs with `-b /terminal`, so its WebSocket
+  is at `/terminal/ws`; `proxy_pass http://127.0.0.1:3011/;` strips the prefix, ttyd 404s the upgrade, and
+  the browser terminal is a black pane with `GET /terminal/ws → 502` (`upstream prematurely closed
+  connection`). Use `proxy_pass http://127.0.0.1:3011;`. Sessions run fine throughout, so it masquerades
+  as "sessions won't spawn". Tell it apart from the two look-alikes by probing ttyd directly:
+  `:3011/terminal/` = 200 + `:3011/ws` = 404 ⇒ base-path mismatch (not the backslash-403, not the
+  unconditional-`Connection: upgrade` 502).
+- **Disable the apt `ttyd.service`** — installing ttyd from apt on Ubuntu also enables a **root** login
+  shell on `:7681` (`-O login`), unrelated to the app's ttyd: `sudo systemctl disable --now ttyd`.
+- **A cookie-jar 401 is not an `auth_request` failure** — `curl -b <jar>` on loopback can miss the
+  `#HttpOnly_localhost` entry and 401 on `/terminal/`. Verify with an explicit `-H "Cookie: aos_sid=…"`.
 - **Never copy the box's private `id_rsa` to enroll the new box** (§6) — own keypair + push the pubkey.
 - **fail2ban bans the probing IP** when you SSH with wrong usernames — enroll with clean connections.
 - **Concurrency cap:** the derived default scales with RAM (`max(3, floor(GB/1.5))`), so a big box


### PR DESCRIPTION
Two findings from bringing up a fresh Linux tenant box.

### 1. Black browser terminal = trailing slash on the ttyd `proxy_pass`

The app launches ttyd with **`-b /terminal`**, so its WebSocket lives at `/terminal/ws`. A vhost written as `proxy_pass http://127.0.0.1:3011/;` (**with** the trailing slash) makes nginx strip the location prefix and ask ttyd for `/ws`; ttyd 404s the upgrade and drops the connection:

```
GET /terminal/ws?arg=aos-ses_… HTTP/1.1" 502
upstream prematurely closed connection while reading response header
upstream: "http://127.0.0.1:3011/ws?arg=aos-ses_…"
```

Sessions spawn and run perfectly the whole time — cost accrues, transcript is written, the pane is live in tmux — so it presents as **"sessions are not spawning"** when sessions are fine. Fix is dropping the trailing slash so the URI passes through unchanged.

The 502 string is identical to the existing unconditional-`Connection: upgrade` gotcha, and the blank-terminal symptom is identical to the backslash-403 one, so the docs now carry the probe that separates all three:

| probe | meaning |
|---|---|
| `:3011/terminal/` = 200, `:3011/ws` = 404 | base path rewritten away (this bug) |
| every request 502s, not just `/terminal/ws` | unconditional `Connection: upgrade` |
| `/terminal/ws` → **403** | literal backslash before `$variable` in the config |

Also records a diagnostic trap: `curl -b <jar>` on loopback can return **401** for `/terminal/` because the jar's `#HttpOnly_localhost` entry doesn't match — indistinguishable from a broken `auth_request` until you retry with an explicit `Cookie:` header.

### 2. Ubuntu's `ttyd` apt package auto-enables a root login shell

`apt-get install ttyd` also enables `ttyd.service`: `/usr/bin/ttyd -W -i lo -p 7681 -O login` as **root**, unrelated to the app-spawned ttyd on `TTYD_PORT`. Loopback-bound so not internet-reachable, but it is a root shell on a box that runs agents, and it comes back on every reboot. `sudo systemctl disable --now ttyd`.

### Scope

Docs only — CLAUDE.md nginx gotcha list, the tenant box-migration checklist, and a CHANGELOG `Unreleased` note. No version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)