### PR TITLE
feat(deploy): make-live deploys every tenant on the box (v0.377.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.377.0] - 2026-08-20
+
+### Changed
+- `scripts/make-live.sh` deploys **every configured tenant on the box**, not just one. Targets come from
+  `AOS_LIVE_TARGETS="<tenant>:<checkout>:<port>[:<label>] …"` in the untracked env file (the older
+  single-tenant `AOS_LIVE_TENANT`/`CHECKOUT`/`LABEL`/`PORT`/`LOG` form still works when it's unset), and
+  `--only <tenant>` deploys one. Tenants sharing a checkout are synced and built once, then each service
+  restarted — which is why the phases are now build-everything-then-restart-everything: a broken commit
+  leaves EVERY server untouched instead of only the first one. Restarts run one tenant at a time and stop
+  at the first failed health check, naming the tenants that already moved plus the rollback command.
+  Fixes the standing footgun where a second tenant on the same box silently kept running old code because
+  the deploy script only ever kicked one launchd label.
+
 ## [0.376.0] - 2026-08-20
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,10 +84,15 @@ terminal in a test". Leftovers show as `ttyd … attach.sh /tmp/aos-*-test-*/tmu
   KeepAlive, home `~/agent-os-data/northwind` (kept OUTSIDE the repo checkout so a spawned agent's
   parent-dir CLAUDE.md walk can't pick up this repo's own CLAUDE.md; new tenants go alongside as
   `~/agent-os-data/<slug>`), on :3010, fronted by `tailscale serve` http→3010): **"make it live" is
-  `scripts/make-live.sh`** — it syncs the dedicated live checkout (`~/agent-os-live`) to `origin/main`,
-  installs only if a lockfile moved, builds both bundles, gates on `npm run test:governance`, restarts
-  via `launchctl kickstart` (never `pkill`), and verifies `/health` reports the version it just built,
-  printing the rollback command if it doesn't. `--dry-run` shows what would deploy. The manual
+  `scripts/make-live.sh`** — it syncs each dedicated live checkout (`~/agent-os-live`, and any other
+  tenant's own) to `origin/main`, installs only if a lockfile moved, builds both bundles, gates on
+  `npm run test:governance`, restarts via `launchctl kickstart` (never `pkill`), and verifies `/health`
+  reports the version it just built, printing the rollback command if it doesn't. It deploys **every
+  tenant listed in `AOS_LIVE_TARGETS`** (`<tenant>:<checkout>:<port>[:<label>]`, space-separated, in the
+  untracked `~/.agentric-live.env`) — a second tenant on the box silently keeping old code because the
+  script only kicked one launchd label was a real recurring bug. All builds run BEFORE any restart, so a
+  bad commit leaves every server untouched; `--only <tenant>` narrows it, `--dry-run` shows what would
+  deploy. The manual
   equivalent is `npm run build && launchctl kickstart -k gui/$(id -u)/com.agentos.northwind`; logs at
   `~/agent-os-data/northwind/server.log`; load/unload with `launchctl load -w|unload <plist>`.)
 - **Agent-facing MCP tools (`src/memory/memory-mcp.ts` — `recall`/`remember`/`revise`/`forget`, the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.376.0",
+  "version": "0.377.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.376.0",
+      "version": "0.377.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.376.0",
+  "version": "0.377.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/make-live.sh
+++ b/scripts/make-live.sh
@@ -1,142 +1,215 @@
 #!/usr/bin/env bash
-# "Make it live" — deploy origin/main to ONE tenant's service on a macOS box.
+# "Make it live" — deploy origin/main to this macOS box's tenant services.
 #
-# The live service runs from a DEDICATED checkout (~/agent-os-live), decoupled from the
-# shared primary checkout that several sessions edit concurrently, and is supervised by launchd
-# (com.agentos.<tenant> → scripts/run-tenant.sh <tenant> … :3010). Deploying is always the same
-# five steps — sync, install if deps moved, build both bundles, restart, verify — so they live here
-# instead of being retyped.
+# A live service runs from a DEDICATED checkout (never the shared primary that several sessions edit
+# concurrently) and is supervised by launchd (com.agentos.<tenant> → scripts/run-tenant.sh <tenant> …
+# :<port>). Deploying is always the same five steps — sync, install if deps moved, build both bundles,
+# restart, verify — so they live here instead of being retyped.
 #
-#   scripts/make-live.sh                 # deploy origin/main
+#   scripts/make-live.sh                 # deploy origin/main to every configured tenant
+#   scripts/make-live.sh --only <tenant> # …to one of them
 #   scripts/make-live.sh --dry-run       # show what WOULD deploy, change nothing
 #   scripts/make-live.sh --skip-tests    # skip the governance suite gate
-#   scripts/make-live.sh --force         # discard local changes in the live checkout
+#   scripts/make-live.sh --force         # discard local changes in a live checkout
 #
-# Deliberately ONE tenant per invocation: every other tenant on the box (and every Linux box) has
-# its own service, home and port. Which one is yours comes from an untracked env file — see below:
-#   AOS_LIVE_TENANT  AOS_LIVE_CHECKOUT  AOS_LIVE_LABEL  AOS_LIVE_PORT  AOS_LIVE_LOG  AOS_LIVE_REF
+# WHICH tenants belong to your box is your deployment's business, not this repo's — it comes from an
+# untracked env file (see below). Either form works:
+#   AOS_LIVE_TARGETS="acme:$HOME/agent-os-live:3010 beta:$HOME/agent-os-beta:3030"
+#       one entry per tenant, `tenant:checkout:port[:label]` (label defaults to com.agentos.<tenant>).
+#   AOS_LIVE_TENANT / AOS_LIVE_CHECKOUT / AOS_LIVE_LABEL / AOS_LIVE_PORT / AOS_LIVE_LOG
+#       the older single-tenant form, still honoured when AOS_LIVE_TARGETS is unset.
+#
+# Two tenants may share one checkout (each still has its own home, DB, port and launchd job). The
+# checkout is then synced/built ONCE and each service restarted — which is also why the phases below
+# are ordered build-everything-then-restart-everything.
 #
 # Safety properties worth keeping:
-#  - Nothing is restarted until the build AND the tests pass, so a broken commit leaves the running
-#    server untouched (it holds the old code in memory).
+#  - Nothing is restarted until every checkout's build AND tests pass, so a broken commit leaves every
+#    running server untouched (each holds its old code in memory).
 #  - The restart is `launchctl kickstart`, never `pkill -f "dist/cli.js serve"` — that command line is
 #    shared by every tenant process on this box and killing it took prod down on 2026-08-01.
 #  - A failed health check prints the exact rollback command rather than guessing.
+#  - Restarts happen one tenant at a time and stop at the first failure, so a bad deploy takes down at
+#    most one service; the report at the end says which tenants moved and which never got there.
 set -euo pipefail
 
-# Your box's real slug/label/paths belong to YOUR deployment, not to this repo — keep them in an
-# untracked env file (default `~/.agentric-live.env`) that this sources if present:
-#   AOS_LIVE_TENANT=acme  AOS_LIVE_CHECKOUT=…  AOS_LIVE_LABEL=…  AOS_LIVE_PORT=…  AOS_LIVE_LOG=…
 ENV_FILE="${AOS_LIVE_ENV:-$HOME/.agentric-live.env}"
 # shellcheck disable=SC1090
 [ -f "$ENV_FILE" ] && . "$ENV_FILE"
 
-TENANT="${AOS_LIVE_TENANT:-acme}"
-CHECKOUT="${AOS_LIVE_CHECKOUT:-$HOME/agent-os-live}"
-LABEL="${AOS_LIVE_LABEL:-com.agentos.$TENANT}"
-PORT="${AOS_LIVE_PORT:-3010}"
-LOG="${AOS_LIVE_LOG:-$HOME/agent-os-data/$TENANT/server.log}"
 REF="${AOS_LIVE_REF:-origin/main}"
 
-DRY=0; SKIP_TESTS=0; FORCE=0
-for arg in "$@"; do
-  case "$arg" in
+DRY=0; SKIP_TESTS=0; FORCE=0; ONLY=""
+while [ $# -gt 0 ]; do
+  case "$1" in
     --dry-run)    DRY=1 ;;
     --skip-tests) SKIP_TESTS=1 ;;
     --force)      FORCE=1 ;;
-    -h|--help)    sed -n '2,20p' "$0"; exit 0 ;;
-    *)            echo "unknown option: $arg (try --help)" >&2; exit 2 ;;
+    --only)       shift; ONLY="${1:?--only needs a tenant slug}" ;;
+    --only=*)     ONLY="${1#--only=}" ;;
+    -h|--help)    sed -n '2,32p' "$0"; exit 0 ;;
+    *)            echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
   esac
+  shift
 done
 
 say()  { printf '\033[36m%s\033[0m\n' "$*"; }
+warn() { printf '\033[33m%s\033[0m\n' "$*" >&2; }
 fail() { printf '\033[31m%s\033[0m\n' "$*" >&2; exit 1; }
 
-[ -d "$CHECKOUT/.git" ] || fail "no live checkout at $CHECKOUT (set AOS_LIVE_CHECKOUT)"
-command -v launchctl >/dev/null || fail "launchctl not found — this script is for the macOS box"
-launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1 || fail "launchd job $LABEL is not loaded (launchctl load -w ~/Library/LaunchAgents/$LABEL.plist)"
-
-cd "$CHECKOUT"
-git fetch -q origin
-OLD="$(git rev-parse HEAD)"
-NEW="$(git rev-parse "$REF")"
-
-# What's about to land — the operator should see this before anything restarts.
-if [ "$OLD" = "$NEW" ]; then
-  say "already at $(git rev-parse --short "$NEW") — rebuilding + restarting anyway"
+# ── the target list ──────────────────────────────────────────────────────────────
+# Normalised to one `tenant:checkout:port:label` line per tenant, so everything below iterates over a
+# single shape whichever env form configured it.
+TARGETS=""
+if [ -n "${AOS_LIVE_TARGETS:-}" ]; then
+  for spec in $AOS_LIVE_TARGETS; do
+    t="${spec%%:*}"; rest="${spec#*:}"
+    c="${rest%%:*}"; rest="${rest#*:}"
+    p="${rest%%:*}"
+    l="${rest#*:}"; [ "$l" = "$p" ] && l="com.agentos.$t"
+    [ -n "$t" ] && [ -n "$c" ] && [ -n "$p" ] || fail "bad AOS_LIVE_TARGETS entry: $spec (want tenant:checkout:port[:label])"
+    TARGETS="$TARGETS$t:$c:$p:$l
+"
+  done
 else
-  say "deploying $(git rev-parse --short "$OLD") → $(git rev-parse --short "$NEW")"
-  git --no-pager log --oneline "$OLD..$NEW" | sed 's/^/  /'
+  t="${AOS_LIVE_TENANT:-acme}"
+  TARGETS="$t:${AOS_LIVE_CHECKOUT:-$HOME/agent-os-live}:${AOS_LIVE_PORT:-3010}:${AOS_LIVE_LABEL:-com.agentos.$t}
+"
 fi
 
-# A dedicated checkout should never be dirty; if it is, someone edited the live tree by hand and a
-# reset would silently destroy that work. Show it and stop.
-DIRTY="$(git status --porcelain)"
-if [ -n "$DIRTY" ] && [ "$FORCE" -ne 1 ]; then
-  echo "$DIRTY" | sed 's/^/  /'
-  fail "live checkout has local changes (above) — rerun with --force to discard them"
+if [ -n "$ONLY" ]; then
+  PICKED="$(printf '%s' "$TARGETS" | grep "^$ONLY:" || true)"
+  [ -n "$PICKED" ] || fail "--only $ONLY: not in the configured targets ($(printf '%s' "$TARGETS" | cut -d: -f1 | tr '\n' ' '))"
+  TARGETS="$PICKED
+"
 fi
+
+command -v launchctl >/dev/null || fail "launchctl not found — this script is for the macOS box"
+
+# Per-checkout scratch state (bash 3.2 on macOS has no associative arrays): one file per checkout,
+# named after its path, holding the commit it was on before the sync — that's what a rollback needs.
+STATE="$(mktemp -d)"
+trap 'rm -rf "$STATE"' EXIT
+key_for() { printf '%s' "$1" | tr -c 'A-Za-z0-9' '_'; }
+
+log_for() {  # tenant → its server.log (AOS_LIVE_LOG only names the single-tenant one)
+  if [ -n "${AOS_LIVE_LOG:-}" ] && [ "$1" = "${AOS_LIVE_TENANT:-}" ]; then printf '%s' "$AOS_LIVE_LOG"
+  else printf '%s' "$HOME/agent-os-data/$1/server.log"; fi
+}
+
+# ── phase 0: preflight every target before touching anything ─────────────────────
+CHECKOUTS=""
+while IFS=: read -r TENANT CHECKOUT PORT LABEL; do
+  [ -n "$TENANT" ] || continue
+  [ -d "$CHECKOUT/.git" ] || fail "$TENANT: no live checkout at $CHECKOUT"
+  launchctl print "gui/$(id -u)/$LABEL" >/dev/null 2>&1 \
+    || fail "$TENANT: launchd job $LABEL is not loaded (launchctl load -w ~/Library/LaunchAgents/$LABEL.plist)"
+  case " $CHECKOUTS " in *" $CHECKOUT "*) ;; *) CHECKOUTS="$CHECKOUTS $CHECKOUT" ;; esac
+done <<EOF
+$TARGETS
+EOF
+
+say "targets: $(printf '%s' "$TARGETS" | cut -d: -f1 | tr '\n' ' ')"
+
+# ── phase 1: sync + build every checkout (no service is restarted in here) ───────
+for CHECKOUT in $CHECKOUTS; do
+  cd "$CHECKOUT"
+  git fetch -q origin
+  OLD="$(git rev-parse HEAD)"
+  NEW="$(git rev-parse "$REF")"
+  echo "$OLD" >"$STATE/$(key_for "$CHECKOUT").old"
+
+  if [ "$OLD" = "$NEW" ]; then
+    say "$CHECKOUT: already at $(git rev-parse --short "$NEW") — rebuilding + restarting anyway"
+  else
+    say "$CHECKOUT: deploying $(git rev-parse --short "$OLD") → $(git rev-parse --short "$NEW")"
+    git --no-pager log --oneline "$OLD..$NEW" | sed 's/^/  /'
+  fi
+
+  # A dedicated checkout should never be dirty; if it is, someone edited the live tree by hand and a
+  # reset would silently destroy that work. Show it and stop.
+  DIRTY="$(git status --porcelain)"
+  if [ -n "$DIRTY" ] && [ "$FORCE" -ne 1 ]; then
+    echo "$DIRTY" | sed 's/^/  /'
+    fail "$CHECKOUT has local changes (above) — rerun with --force to discard them"
+  fi
+
+  [ "$DRY" -eq 1 ] && continue
+
+  git reset --hard -q "$NEW"
+
+  # Dependencies only when the lockfiles actually moved (a full install on every deploy is ~30s of
+  # nothing). `git diff --quiet` between the two commits is the honest test.
+  if [ "$OLD" != "$NEW" ]; then
+    if ! git diff --quiet "$OLD" "$NEW" -- package-lock.json package.json; then
+      say "root deps changed → npm install"
+      npm install --no-audit --no-fund >/dev/null
+    fi
+    if ! git diff --quiet "$OLD" "$NEW" -- web/package-lock.json web/package.json; then
+      say "web deps changed → npm install"
+      (cd web && npm install --no-audit --no-fund >/dev/null)
+    fi
+  fi
+
+  # Build output is captured, not streamed: tsc says nothing on success and vite writes its chunk-size
+  # advice to stderr on every run. On failure the log is printed, so nothing is actually hidden.
+  BUILD_LOG=/tmp/aos-make-live-build.log
+  say "building server"
+  npm run build >"$BUILD_LOG" 2>&1 \
+    || { tail -30 "$BUILD_LOG" >&2; fail "server build failed in $CHECKOUT — every live server untouched, still on its old code"; }
+  say "building console"
+  (cd web && npm run build >"$BUILD_LOG" 2>&1) \
+    || { tail -30 "$BUILD_LOG" >&2; fail "web build failed in $CHECKOUT — every live server untouched, still on its old code"; }
+
+  if [ "$SKIP_TESTS" -eq 1 ]; then
+    say "skipping governance suite (--skip-tests)"
+  else
+    say "running governance suite"
+    npm run test:governance >/tmp/aos-make-live-tests.log 2>&1 \
+      || { tail -20 /tmp/aos-make-live-tests.log >&2; fail "governance suite failed in $CHECKOUT — NOTHING restarted"; }
+    tail -1 /tmp/aos-make-live-tests.log
+  fi
+done
 
 if [ "$DRY" -eq 1 ]; then say "dry run — nothing changed"; exit 0; fi
 
+# ── phase 2: restart + verify each service ───────────────────────────────────────
 START=$(date +%s)
-git reset --hard -q "$NEW"
+DEPLOYED=""
+while IFS=: read -r TENANT CHECKOUT PORT LABEL; do
+  [ -n "$TENANT" ] || continue
+  OLD="$(cat "$STATE/$(key_for "$CHECKOUT").old")"
+  VERSION="$(node -p "require('$CHECKOUT/package.json').version")"
+  LOG="$(log_for "$TENANT")"
 
-# Dependencies only when the lockfiles actually moved (a full install on every deploy is ~30s of
-# nothing). `git diff --quiet` between the two commits is the honest test.
-if [ "$OLD" != "$NEW" ]; then
-  if ! git diff --quiet "$OLD" "$NEW" -- package-lock.json package.json; then
-    say "root deps changed → npm install"
-    npm install --no-audit --no-fund >/dev/null
-  fi
-  if ! git diff --quiet "$OLD" "$NEW" -- web/package-lock.json web/package.json; then
-    say "web deps changed → npm install"
-    (cd web && npm install --no-audit --no-fund >/dev/null)
-  fi
-fi
+  say "restarting $LABEL (:$PORT)"
+  launchctl kickstart -k "gui/$(id -u)/$LABEL"
 
-# Build output is captured, not streamed: tsc says nothing on success and vite writes its chunk-size
-# advice to stderr on every run. On failure the log is printed, so nothing is actually hidden.
-BUILD_LOG=/tmp/aos-make-live-build.log
-say "building server"
-npm run build >"$BUILD_LOG" 2>&1 \
-  || { tail -30 "$BUILD_LOG" >&2; fail "server build failed — live server untouched, still on $(git rev-parse --short "$OLD")"; }
-say "building console"
-(cd web && npm run build >"$BUILD_LOG" 2>&1) \
-  || { tail -30 "$BUILD_LOG" >&2; fail "web build failed — live server untouched, still on $(git rev-parse --short "$OLD")"; }
+  # Verify the running process actually reports the version we just built — the single check that tells
+  # "the change took effect" apart from "a long-running server is still holding the old code".
+  LIVE=""
+  for _ in $(seq 1 30); do
+    sleep 1
+    LIVE="$(curl -fsS --max-time 2 "http://127.0.0.1:$PORT/health" 2>/dev/null || true)"
+    case "$LIVE" in *"\"version\":\"$VERSION\""*) break ;; esac
+  done
 
-if [ "$SKIP_TESTS" -eq 1 ]; then
-  say "skipping governance suite (--skip-tests)"
-else
-  say "running governance suite"
-  npm run test:governance >/tmp/aos-make-live-tests.log 2>&1 \
-    || { tail -20 /tmp/aos-make-live-tests.log >&2; fail "governance suite failed — NOT restarting (still serving $(git rev-parse --short "$OLD"))"; }
-  tail -1 /tmp/aos-make-live-tests.log
-fi
-
-VERSION="$(node -p "require('$CHECKOUT/package.json').version")"
-say "restarting $LABEL"
-launchctl kickstart -k "gui/$(id -u)/$LABEL"
-
-# Verify the running process actually reports the version we just built — the single check that tells
-# "the change took effect" apart from "a long-running server is still holding the old code".
-LIVE=""
-for _ in $(seq 1 30); do
-  sleep 1
-  LIVE="$(curl -fsS --max-time 2 "http://127.0.0.1:$PORT/health" 2>/dev/null || true)"
-  case "$LIVE" in *"\"version\":\"$VERSION\""*) break ;; esac
-done
-
-case "$LIVE" in
-  *"\"version\":\"$VERSION\""*)
-    say "live: $LIVE"
-    say "done in $(( $(date +%s) - START ))s — $(git rev-parse --short "$NEW") @ v$VERSION"
-    ;;
-  *)
-    echo "--- last 30 lines of $LOG ---" >&2
-    tail -30 "$LOG" >&2 || true
-    fail "health check never reported v$VERSION (last response: ${LIVE:-none}).
+  case "$LIVE" in
+    *"\"version\":\"$VERSION\""*)
+      say "live: $LIVE"
+      DEPLOYED="$DEPLOYED $TENANT"
+      ;;
+    *)
+      echo "--- last 30 lines of $LOG ---" >&2
+      tail -30 "$LOG" >&2 || true
+      [ -n "$DEPLOYED" ] && warn "already deployed before this failure:$DEPLOYED"
+      fail "$TENANT: health check never reported v$VERSION (last response: ${LIVE:-none}).
 Roll back with:
   git -C $CHECKOUT reset --hard $OLD && (cd $CHECKOUT && npm run build && cd web && npm run build) && launchctl kickstart -k gui/$(id -u)/$LABEL"
-    ;;
-esac
+      ;;
+  esac
+done <<EOF
+$TARGETS
+EOF
+
+say "done in $(( $(date +%s) - START ))s —$DEPLOYED"


### PR DESCRIPTION
## Why

The Mac Mini runs several tenants; `scripts/make-live.sh` only ever kicked one launchd label. Every other tenant kept serving old code out of memory while the checkout on disk had moved on — `personal` was found eleven versions behind exactly this way, and the new `doosra` tenant would have repeated it.

## What

- Targets come from `AOS_LIVE_TARGETS="<tenant>:<checkout>:<port>[:<label>] …"` in the untracked env file. The older single-tenant `AOS_LIVE_TENANT`/`CHECKOUT`/`LABEL`/`PORT`/`LOG` form still works when it's unset, so nothing existing breaks.
- `--only <tenant>` deploys one target.
- Tenants sharing a checkout (label ≠ home ≠ port, same code) sync and build **once**, then each service restarts.
- Phases reordered to **build everything → restart everything**: a broken commit now leaves every server untouched instead of just the ones after the failure.
- Restarts run one tenant at a time and stop at the first failed health check, naming the tenants that already moved plus the rollback command for the one that didn't.

Bash 3.2 / BSD-safe (no associative arrays — per-checkout state is a file in a mktemp dir).

## Test

`bash -n`, a `--dry-run` over two real targets (one behind, one current — both reported correctly), and a real `--only doosra` deploy: rebuilt, restarted, `/health` reported the version just built.

🤖 Generated with [Claude Code](https://claude.com/claude-code)