### PR TITLE
fix(runtime-login): a rejected code re-arms the flow instead of dead-ending (v0.377.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.377.1] - 2026-08-20
+
+### Fixed
+- Guided runtime sign-in (Settings → Runtime accounts, and the setup wizard) kept rejecting valid codes.
+  Two causes, both ours. `injectText` presses Enter **twice** — right for an agent composer that can
+  swallow the first, wrong for a one-shot CLI prompt: the second press landed on claude's
+  `Press Enter to retry` screen, which silently re-runs the whole login with a **new PKCE challenge**,
+  so the link the human already had open no longer matched what the CLI was waiting for and every
+  subsequent code failed with `OAuth error: Request failed with status code 400`. The code is now
+  submitted with exactly one Enter (`injectText` takes an `enterPresses` count). And a rejected code is
+  treated as **recoverable** rather than fatal: the flow presses the retry prompt deliberately, waits for
+  the CLI's fresh authorize URL, and republishes it with a notice saying the earlier link is dead —
+  instead of telling the operator to "start again" while the pane re-armed behind their back. Bounded at
+  three rejections, then it hands over the manual `CLAUDE_CONFIG_DIR=… claude` path. Audited
+  `runtime.account.login.code.rejected`. Both sign-in surfaces now also say the code is the whole
+  string including its `#…` tail, and that each link is single-use.
+
 ## [0.377.0] - 2026-08-20
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.377.0",
+  "version": "0.377.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.377.0",
+      "version": "0.377.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.377.0",
+  "version": "0.377.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/runtime-login-test.cjs
+++ b/scripts/runtime-login-test.cjs
@@ -33,7 +33,7 @@ const spawned = [], killed = [];
 const backend = {
   spawn: (_s, spec) => spawned.push(spec),
   capturePane: () => pane,
-  injectText: (_s, tmux, text, submit) => { typed.push({ tmux, text, submit }); return true; },
+  injectText: (_s, tmux, text, submit, _verify, enterPresses) => { typed.push({ tmux, text, submit, enterPresses }); return true; },
   kill: (_s, tmux) => killed.push(tmux),
 };
 const audits = [];
@@ -92,14 +92,40 @@ assert(s.phase === 'failed' && /no longer running/.test(s.error), 'a dead pane f
 assert(!aos.runtimeAccounts.get('claude-code', 'gone'), 'nothing is registered');
 assert(!fs.existsSync(path.join(accountsDir, 'claude-code', 'gone')), 'and the empty credential dir is cleaned up');
 
+// A rejected code is RECOVERABLE, and getting this wrong is what made the live failure self-perpetuating:
+// the CLI parks on "Press Enter to retry", and any Enter there re-runs the whole flow with a NEW PKCE
+// challenge. So a stray press (the composer's default double-Enter) silently invalidated the link the
+// human already had open, and their next code was rejected for a reason nothing on screen explained.
 m = mk();
 pane = URL_SCREEN;
 s = m.start('claude-code', 'badcode');
 s = m.poll(s.id);
+const beforeSubmit = typed.length;
 m.submitCode(s.id, 'nope');
-pane = 'Invalid code provided. Please try again.';
+assert(typed[beforeSubmit].enterPresses === 1, 'the code is submitted with exactly ONE Enter — a second lands on the retry prompt and re-arms the flow');
+pane = 'OAuth error: Request failed with status code 400\n Press Enter to retry.';
+const beforeRetry = typed.length;
 s = m.poll(s.id);
-assert(s.phase === 'failed' && /rejected that code/.test(s.error), 'a rejected code is surfaced instead of waiting out the timeout', JSON.stringify(s));
+assert(s.phase === 'starting' && !s.url, 'a rejected code re-arms the login instead of ending it', JSON.stringify(s));
+assert(/rejected/.test(s.notice || ''), 'and says so, telling the human the earlier link is dead', JSON.stringify(s));
+assert(s.codeAttempts === 1, 'the rejection is counted');
+assert(typed.length === beforeRetry + 1 && typed[beforeRetry].enterPresses === 1, 'exactly one Enter is pressed on the retry prompt');
+assert(audits.some((a) => a.type === 'runtime.account.login.code.rejected'), 'the rejection is audited');
+// The retry prints a FRESH url — that, not the stale one, is what the console must show.
+const URL2 = URL.replace('state=xyz', 'state=fresh2');
+pane = `Browser didn't open? Use the url below to sign in (c to copy)\n${URL2}\n Paste code here if prompted >`;
+s = m.poll(s.id);
+assert(s.phase === 'awaiting-code' && s.url === URL2, 'the fresh link replaces the dead one', JSON.stringify(s));
+m.submitCode(s.id, 'nope2');
+assert(!m.poll(s.id).notice, 'submitting again clears the stale notice');
+// …but it does not loop forever: a code that keeps failing ends with the manual fallback.
+for (let i = 0; i < 4 && m.poll(s.id).phase !== 'failed'; i++) {
+  pane = 'OAuth error: Request failed with status code 400\n Press Enter to retry.';
+  s = m.poll(s.id);
+  if (s.phase === 'starting') { pane = URL_SCREEN.replace('state=xyz', `state=r${i}`); s = m.poll(s.id); m.submitCode(s.id, 'nope'); }
+}
+assert(s.phase === 'failed' && /sign in on the box/.test(s.error), 'repeated rejections stop and hand over the manual path', JSON.stringify(s));
+assert(!aos.runtimeAccounts.get('claude-code', 'badcode'), 'nothing is registered from a failed login');
 
 m = mk();
 pane = THEME;

--- a/src/edge/runtime-login.ts
+++ b/src/edge/runtime-login.ts
@@ -50,6 +50,11 @@ export interface LoginState {
   url?: string;
   /** Why it failed, in operator language, with the manual fallback when relevant. */
   error?: string;
+  /** A recoverable hiccup the human needs to know about while the flow CONTINUES — today: the runtime
+   *  rejected a code and the pane has been re-armed with a fresh link. Cleared once they act on it. */
+  notice?: string;
+  /** How many codes have been rejected so far. Bounded by {@link MAX_CODE_ATTEMPTS}. */
+  codeAttempts: number;
   startedAt: number;
 }
 
@@ -107,8 +112,18 @@ const PROMPTS: { key: string; re: RegExp }[] = [
   { key: 'theme', re: /Choose the text style/i },
   { key: 'method', re: /Select login method/i },
 ];
-/** The CLI rejected the pasted code — worth surfacing verbatim rather than waiting out the TTL. */
+/** The CLI rejected the pasted code — worth surfacing verbatim rather than waiting out the TTL. Matches
+ *  both the older wording ("Invalid code provided") and what claude 2.1.237 prints for a bad/expired code
+ *  or a code exchanged against a stale PKCE challenge: `OAuth error: Request failed with status code 400`. */
 const BAD_CODE_RE = /(invalid|expired|failed).{0,30}(code|token|authoriz)/i;
+/** The CLI parks on this after a rejected code and re-runs the whole flow when Enter is pressed — which
+ *  mints a NEW authorize URL (new state + PKCE challenge). That is the recovery path, and also the reason
+ *  a stray Enter is destructive: it re-arms silently, so any code from the link the human already opened
+ *  is then guaranteed to fail. We press it deliberately and re-publish the fresh link. */
+const RETRY_PROMPT_RE = /Press Enter to retry/i;
+/** Rejected codes tolerated before giving up. Two is enough to cover a mistyped/half-copied paste without
+ *  looping a human through a URL that some environmental problem will reject every time. */
+const MAX_CODE_ATTEMPTS = 3;
 
 export class RuntimeLoginManager {
   private readonly logins = new Map<string, Login>();
@@ -190,7 +205,7 @@ export class RuntimeLoginManager {
       // needs no reassembly heuristic.
       cols: 900,
     });
-    const login: Login = { id, runtime, name: clean, phase: 'starting', startedAt: Date.now(), dir, tmux, answered: new Set() };
+    const login: Login = { id, runtime, name: clean, phase: 'starting', startedAt: Date.now(), dir, tmux, answered: new Set(), codeAttempts: 0 };
     this.logins.set(id, login);
     this.deps.audit('runtime.account.login.started', { runtime, name: clean, dir });
     return toState(login);
@@ -214,7 +229,28 @@ export class RuntimeLoginManager {
     const pane = this.deps.backend.capturePane('', l.tmux);
     if (pane == null) return toState(this.fail(l, 'the login process is no longer running — start it again'));
 
-    if (BAD_CODE_RE.test(pane)) return toState(this.fail(l, 'the runtime rejected that code — start again and copy the code from the browser exactly'));
+    // A rejected code is recoverable, and used to be treated as fatal. The CLI is sitting on "Press Enter
+    // to retry", which re-runs the flow and prints a NEW authorize URL — so drive that ourselves and hand
+    // the human a fresh link, rather than telling them to start over while the pane quietly re-arms with a
+    // challenge the link in their browser no longer matches. That mismatch is what made a second attempt
+    // fail as reliably as the first.
+    if (BAD_CODE_RE.test(pane)) {
+      if (l.codeAttempts >= MAX_CODE_ATTEMPTS) {
+        return toState(this.fail(l, `the runtime rejected ${l.codeAttempts} codes — sign in on the box with CLAUDE_CONFIG_DIR=${l.dir} claude, then add that dir by path`));
+      }
+      l.codeAttempts++;
+      this.deps.audit('runtime.account.login.code.rejected', { runtime: l.runtime, name: l.name, attempt: l.codeAttempts });
+      // Re-arm: press Enter on the retry prompt, drop the stale URL, and go back to waiting for the CLI to
+      // print the next one. `answered` is reset because the retry replays the same pre-browser prompts.
+      if (RETRY_PROMPT_RE.test(pane)) this.deps.backend.injectText('', l.tmux, '', true, true, 1);
+      l.phase = 'starting';
+      l.url = undefined;
+      l.urlSeenAt = undefined;
+      l.codeAt = undefined;
+      l.answered = new Set();
+      l.notice = 'that code was rejected — a fresh sign-in link is being prepared, open THAT one (the previous link is no longer valid)';
+      return toState(l);
+    }
 
     // Answer each pre-browser prompt once, by accepting its highlighted default.
     for (const p of PROMPTS) {
@@ -226,7 +262,7 @@ export class RuntimeLoginManager {
     }
 
     const url = extractAuthorizeUrl(pane);
-    if (url && l.phase === 'starting') {
+    if (url && l.phase === 'starting' && l.url === undefined) {
       if (looksWhole(url)) {
         l.phase = 'awaiting-code';
         l.url = url;
@@ -256,9 +292,14 @@ export class RuntimeLoginManager {
     if (l.phase !== 'awaiting-code') throw new Error(`this login is ${l.phase}, not waiting for a code`);
     const clean = code.trim();
     if (!clean) throw new Error('code required');
-    if (!this.deps.backend.injectText('', l.tmux, clean, true)) throw new Error('could not reach the login process — start it again');
+    // ONE Enter, deliberately: the backend's default double-press exists for an agent composer that can
+    // swallow the first one. Here the second lands on the screen the first produced — "Press Enter to
+    // retry" after a bad code — silently re-running the flow with a new PKCE challenge, so the console's
+    // link and the CLI's expectation drifted apart and every later code was rejected.
+    if (!this.deps.backend.injectText('', l.tmux, clean, true, true, 1)) throw new Error('could not reach the login process — start it again');
     l.phase = 'exchanging';
     l.codeAt = Date.now();
+    l.notice = undefined;
     return toState(l);
   }
 
@@ -320,5 +361,6 @@ export class RuntimeLoginManager {
 }
 
 const toState = (l: Login): LoginState => ({
-  id: l.id, runtime: l.runtime, name: l.name, phase: l.phase, url: l.url, error: l.error, startedAt: l.startedAt,
+  id: l.id, runtime: l.runtime, name: l.name, phase: l.phase, url: l.url, error: l.error,
+  notice: l.notice, codeAttempts: l.codeAttempts, startedAt: l.startedAt,
 });

--- a/src/edge/session-backend.ts
+++ b/src/edge/session-backend.ts
@@ -48,7 +48,12 @@ export interface SessionBackend {
   /** Type into a live pane. `verify` (default true) asks the backend to CONFIRM the text became a turn
    *  rather than parking in the composer; pass false when the session is mid-turn, where parking is the
    *  correct behaviour and confirming it would report a working agent as failed. */
-  injectText(space: string, tmuxName: string, text: string, submit: boolean, verify?: boolean): boolean;
+  /** `enterPresses` (default {@link SUBMIT_ATTEMPTS}) is how many times Enter is pressed after the text
+   *  settles. Two is right for an agent composer, where a swallowed Enter parks the message. It is WRONG
+   *  for a one-shot CLI prompt: there the second Enter lands on whatever screen the first produced — on
+   *  claude's login that is "Press Enter to retry", so the stray press silently re-armed the flow with a
+   *  fresh PKCE challenge while the console still showed the old link. Pass 1 for prompts like that. */
+  injectText(space: string, tmuxName: string, text: string, submit: boolean, verify?: boolean, enterPresses?: number): boolean;
   /** Live tmux session names, or null when liveness can't be polled (→ rely on end signals). */
   aliveNames(): Set<string> | null;
   /** Per-session resident memory: tmux session name → summed RSS **in KiB** of that session's pane
@@ -183,13 +188,13 @@ export class LocalSessionBackend implements SessionBackend {
    * actually carry it — see `docs/tasks-plan.md` §3.6 for the transcript-based check that should replace
    * this comment.
    */
-  injectText(_space: string, tmuxName: string, text: string, submit: boolean, _verify = true): boolean {
+  injectText(_space: string, tmuxName: string, text: string, submit: boolean, _verify = true, enterPresses = SUBMIT_ATTEMPTS): boolean {
     // `-l` = literal: send the bytes as typed, not as tmux key names (a path could contain `;`, `-`,
     // etc.). Submit is a SEPARATE send-keys with the `Enter` key name so it's interpreted as a return.
     const r = spawnSync('tmux', ['-S', this.tmuxSocket, 'send-keys', '-t', tmuxName, '-l', text], { stdio: 'ignore' });
     if (r.status !== 0) return false;
     if (!submit) return true;
-    for (let attempt = 1; attempt <= SUBMIT_ATTEMPTS; attempt++) {
+    for (let attempt = 1; attempt <= Math.max(1, enterPresses); attempt++) {
       sleepSync(PASTE_SETTLE_MS * attempt);   // let the paste finish assembling before the Enter lands
       spawnSync('tmux', ['-S', this.tmuxSocket, 'send-keys', '-t', tmuxName, 'Enter'], { stdio: 'ignore' });
     }
@@ -343,7 +348,7 @@ export class LauncherSessionBackend implements SessionBackend {
     void this.client.stopSession(space, tmuxName).catch(() => undefined);
   }
 
-  injectText(_space: string, _tmuxName: string, _text: string, _submit: boolean): boolean {
+  injectText(_space: string, _tmuxName: string, _text: string, _submit: boolean, _verify?: boolean, _enterPresses?: number): boolean {
     // Under uid isolation the session's tmux lives on a member-private (0700) socket the app can't
     // reach; injecting would need a launcher verb. Not yet supported — callers degrade gracefully
     // (the file is still saved; only the auto-typed reference is skipped).

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16932,11 +16932,16 @@ function RuntimeAccountsSettings({ me }: { me: Member }) {
                   <span className="text-xs font-medium">Signing in as <span className="font-mono">{login.name}</span></span>
                   <button className="text-xs text-muted-foreground hover:text-foreground" onClick={cancelLogin}>Cancel</button>
                 </div>
-                {login.phase === 'starting' && <p className="text-xs text-muted-foreground">Starting the runtime's sign-in — the authorization link appears here in a moment…</p>}
+                {login.notice && (
+                  <p className="rounded-md border border-amber-500/40 bg-amber-500/5 px-2 py-1 text-xs text-amber-700 dark:text-amber-400">{login.notice}</p>
+                )}
+                {login.phase === 'starting' && <p className="text-xs text-muted-foreground">{login.notice ? 'Preparing a fresh authorization link…' : "Starting the runtime's sign-in — the authorization link appears here in a moment…"}</p>}
                 {login.phase === 'awaiting-code' && login.url && (
                   <div className="space-y-2">
                     <p className="text-xs text-muted-foreground">
-                      1. Open this link and authorize as the account you're adding, then 2. paste the code it gives you.
+                      1. Open this link and authorize as the account you're adding, then 2. paste the code it gives you —
+                      the WHOLE string, including the <span className="font-mono">#…</span> tail. Each link is single-use: if a
+                      code is rejected, wait for the fresh link that appears here rather than re-using the page you already opened.
                     </p>
                     <div className="flex items-center gap-2">
                       <a href={login.url} target="_blank" rel="noreferrer" className="truncate text-xs text-blue-600 underline dark:text-blue-400">{login.url}</a>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -139,7 +139,15 @@ export interface RuntimeSpecInfo {
 /** A guided sign-in in flight: the console starts it, shows `url` for the human to authorize, takes the
  *  code back, and the runtime's own CLI writes the credential dir. */
 export type LoginPhase = 'starting' | 'awaiting-code' | 'exchanging' | 'done' | 'failed'
-export interface RuntimeLogin { id: string; runtime: string; name: string; phase: LoginPhase; url?: string; error?: string; startedAt: number }
+export interface RuntimeLogin {
+  id: string; runtime: string; name: string; phase: LoginPhase; url?: string; error?: string
+  /** A recoverable hiccup while the flow CONTINUES — a rejected code, with a fresh link on the way.
+   *  Distinct from `error`, which ends the login. */
+  notice?: string
+  /** Codes rejected so far in this login. */
+  codeAttempts?: number
+  startedAt: number
+}
 /** `refreshing` = `<runtime>/<name>` for each account whose usage snapshot is being re-probed in the
  *  background right now (the read kicked it — see src/edge/runtime-account-usage.ts). The `accounts` in
  *  THIS response are the pre-probe reading, so a non-empty list means "read again shortly for fresh %". */

--- a/web/src/setup.tsx
+++ b/web/src/setup.tsx
@@ -234,10 +234,15 @@ function ClaudeStep({ status, onChanged }: { status: SetupStatus; onChanged: () 
             <span className="text-xs font-medium">Signing in as <span className="font-mono">{login.name}</span></span>
             <button className="text-xs text-muted-foreground hover:text-foreground" onClick={cancel}>Cancel</button>
           </div>
-          {login.phase === 'starting' && <Hint>Starting the runtime's sign-in — the authorization link appears here in a moment…</Hint>}
+          {login.notice && <p className="rounded-md border border-amber-500/40 bg-amber-500/5 px-2 py-1 text-[11px] text-amber-700 dark:text-amber-400">{login.notice}</p>}
+          {login.phase === 'starting' && <Hint>{login.notice ? 'Preparing a fresh authorization link…' : "Starting the runtime's sign-in — the authorization link appears here in a moment…"}</Hint>}
           {login.phase === 'awaiting-code' && login.url && (
             <div className="space-y-2">
-              <Hint>1. Open the link and authorize, then 2. paste the code it gives you.</Hint>
+              <Hint>
+                1. Open the link and authorize, then 2. paste the code it gives you — the WHOLE string, including the
+                <span className="font-mono"> #…</span> tail. Each link is single-use: if a code is rejected, use the fresh
+                link that appears here, not the page you already have open.
+              </Hint>
               <Link href={login.url}>Open the authorization page</Link>
               <div className="flex items-center gap-2">
                 <Input value={code} onChange={(e) => setCode(e.target.value)} placeholder="paste code" className="h-8 w-72 font-mono text-xs" />


### PR DESCRIPTION
## Symptom

Guided sign-in (Settings → Runtime accounts) repeatedly answered **"⚠ the runtime rejected that code — start again and copy the code from the browser exactly"** for codes that were copied correctly.

## Root cause (reproduced against claude 2.1.237 on a scratch tenant)

Two, both ours:

1. **`injectText` presses Enter twice.** That is right for an agent composer, which can swallow the first press mid-paste. It is wrong for a one-shot CLI prompt: the second press landed on claude's `Press Enter to retry` screen, which **re-runs the whole login and mints a new PKCE challenge**. The console kept displaying the *old* authorize URL, so the code the human pasted was exchanged against a challenge the CLI had already discarded → `OAuth error: Request failed with status code 400`. Self-perpetuating: each attempt re-armed the pane again.
2. **A rejected code was fatal.** The operator was told to start over while the pane had silently re-armed, so the "obvious" retry (reuse the browser tab already open) was guaranteed to fail.

Captured panes: one Enter → `OAuth error… / Press Enter to retry`, stays there. Two Enters → back at `Select login method`, then a **new** authorize URL with a different `state`.

## Fix

- `injectText` takes an `enterPresses` count (default unchanged at 2); the login submits with exactly **1**.
- A rejected code is now **recoverable**: press the retry prompt deliberately, wait for the CLI's fresh URL, republish it with a notice that the earlier link is dead. Bounded at 3 rejections, then hand over the manual `CLAUDE_CONFIG_DIR=… claude` path. Audited `runtime.account.login.code.rejected`.
- Both sign-in surfaces (Settings + the setup wizard) now say the code is the whole string **including the `#…` tail**, and that each link is single-use.

## Test

`scripts/runtime-login-test.cjs` — 48 assertions (13 new): one-Enter submit, re-arm instead of fail, the notice, the counter, the audit, the fresh URL replacing the dead one, the notice clearing on resubmit, and the bounded give-up with nothing registered. Full governance suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)