### PR TITLE
fix(md-pdf): squeeze wide table columns, not the label column (v0.378.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.378.1] - 2026-08-20
+
+### Fixed
+- Markdown → PDF: a table too wide for the page squeezed every column by the same factor, so a 6-char
+  label column ("Field", "Name") was clipped to `Na…` while a 90-char prose cell kept most of its text —
+  losing exactly the part that makes a row readable. Column widths are now water-filled: raise a cap
+  until the row fits, keep every column narrower than the cap whole, and clip only the ones above it.
+
 ## [0.378.0] - 2026-08-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.378.0",
+  "version": "0.378.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.378.0",
+      "version": "0.378.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.378.0",
+  "version": "0.378.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/md-pdf-test.cjs
+++ b/scripts/md-pdf-test.cjs
@@ -24,7 +24,7 @@ delete process.env.AGENT_OS_SECRET_KEY;
 let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
-const { markdownToPdf, parseBlocks, parseInline, isMarkdownArtifact, textWidth } = require(path.join(ROOT, 'dist/edge/md-pdf.js'));
+const { markdownToPdf, parseBlocks, parseInline, isMarkdownArtifact, textWidth, fitColumns } = require(path.join(ROOT, 'dist/edge/md-pdf.js'));
 
 console.log('\n\x1b[1m1) Block parsing — a fence is text, not markdown\x1b[0m');
 const blocks = parseBlocks([
@@ -104,6 +104,16 @@ assert(/\/Type \/Page\b[\s\S]*\/Type \/Page\b/.test(long), 'a long document pagi
 const pageCount = Number(/\/Count (\d+)/.exec(long)[1]);
 assert(pageCount >= 2, `the page tree reports ${pageCount} pages`);
 assert(new RegExp(`\\(1 / ${pageCount}\\) Tj`).test(long), 'page numbers know the total');
+
+console.log('\n\x1b[1m5b) Table columns: clip the wide ones, keep the narrow ones whole\x1b[0m');
+assert(JSON.stringify(fitColumns([5, 8, 10], 100)) === JSON.stringify([5, 8, 10]), 'a table that fits is left alone');
+const squeezed = fitColumns([6, 90, 12], 60);
+assert(squeezed[0] === 6 && squeezed[2] === 12, 'narrow columns survive a squeeze intact — they carry the labels');
+assert(squeezed[1] < 90 && squeezed.reduce((a, w) => a + w, 0) <= 60, 'only the wide column is clipped, and the row fits');
+assert(fitColumns([80, 80, 80], 12).every((w) => w >= 4), 'an impossible budget still leaves every column readable');
+const tbl = markdownToPdf(['| Field | Value | Source |', '| --- | --- | --- |',
+  ['| Name | Airbtics, LLC | ', 'site footer plus a very long provenance note '.repeat(4), '|'].join('')].join('\n')).toString('latin1');
+assert(/\(Field/.test(tbl) && /Name/.test(tbl), 'the label column is not truncated away');
 
 console.log('\n\x1b[1m6) Links become real annotations\x1b[0m');
 const linked = markdownToPdf('See [the docs](https://example.com/docs) for more.\n').toString('latin1');

--- a/src/edge/md-pdf.ts
+++ b/src/edge/md-pdf.ts
@@ -471,12 +471,14 @@ export function markdownToPdf(md: string, opts: MdPdfOptions = {}): Buffer {
         // correctly at a glance, which is what a table in a report is for.
         const size = 8.6;
         const cols = Math.max(...b.rows.map((r) => r.length));
-        const widths: number[] = [];
-        for (let c = 0; c < cols; c++) widths.push(Math.max(...b.rows.map((r) => (r[c] ?? '').length)));
-        const total = widths.reduce((a, w) => a + w + 3, 0);
-        const budget = Math.floor((CONTENT_W) / ((W_MONO * size) / 1000));
-        const scale = total > budget ? budget / total : 1;
-        const fit = widths.map((w) => Math.max(3, Math.floor((w + 3) * scale) - 3));
+        const want: number[] = [];
+        for (let c = 0; c < cols; c++) want.push(Math.max(...b.rows.map((r) => (r[c] ?? '').length)));
+        const budget = Math.floor(CONTENT_W / ((W_MONO * size) / 1000)) - (cols - 1) * 2;
+        // Water-filling, not uniform scaling. Scaling every column by the same factor squeezes a narrow
+        // column (a 6-char label) as hard as a 90-char prose cell, and the label — the part that makes the
+        // row readable — is what disappears. Instead find the cap that fits and clip only the columns
+        // above it, so short columns always survive whole.
+        const fit = fitColumns(want, Math.max(cols * MIN_COL, budget));
         b.rows.forEach((row, ri) => {
           const text = row.map((cell, c) => (cell.length > fit[c] ? cell.slice(0, Math.max(1, fit[c] - 1)) + '…' : cell.padEnd(fit[c]))).join('  ');
           need(size * 1.4);
@@ -546,6 +548,29 @@ function assemble(pages: PageDraw[], title?: string): Buffer {
   out(`trailer\n<< /Size ${count} /Root 1 0 R /Info ${infoNum} 0 R >>\nstartxref\n${xrefAt}\n%%EOF\n`);
 
   return Buffer.concat(chunks);
+}
+
+/** Smallest a table column may be squeezed to before it stops carrying information. */
+const MIN_COL = 4;
+
+/**
+ * Choose column widths that fit `budget` characters in total, clipping only the columns wide enough to
+ * afford it. Raise a cap until the total reaches the budget: every column narrower than the cap keeps
+ * its full width, every wider one is clipped to the cap. That is what a reader wants from a squeezed
+ * table — labels intact, long prose cells truncated.
+ */
+export function fitColumns(want: number[], budget: number): number[] {
+  const total = want.reduce((a, w) => a + w, 0);
+  if (total <= budget) return want.slice();
+  let cap = MIN_COL;
+  for (;;) {
+    const used = want.reduce((a, w) => a + Math.min(w, cap), 0);
+    const next = want.reduce((a, w) => a + Math.min(w, cap + 1), 0);
+    if (next > budget || cap > 400) break;
+    cap++;
+    if (used === next) continue;   // no column is at the cap any more — nothing left to grow
+  }
+  return want.map((w) => Math.max(MIN_COL, Math.min(w, cap)));
 }
 
 /** Is this artifact one we can turn into a PDF? Markdown only for now — a `.txt` would work too, but


### PR DESCRIPTION
Rendering a real Library artifact showed the flaw: a too-wide table scaled every column by the same factor, so the 6-char label column became `Na…` while a 90-char prose cell kept most of its text. Widths are now water-filled — raise a cap until the row fits, keep narrower columns whole, clip only the ones above the cap. 5 new assertions in `scripts/md-pdf-test.cjs` (53 total), and re-checked through a real PDF renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)