### PR TITLE
feat(governance): tell a denied agent why + list real capabilities (v0.382.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,34 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
-## [0.382.0] - 2026-08-24
+## [0.383.0] - 2026-08-24
+
+### Changed
+- **A denied action now tells the agent WHY and WHICH capability fired, instead of an opaque "this action
+  is blocked".** The classifier already computed a human reason (`describeMatch` for a JSON rule,
+  `hostGovernanceDecision`/`fileGovernanceDecision` for the engine-level guards — e.g. `ssh.exec: host
+  could not be identified`, `any action: destructive`) and rode it on the audit trail and approval cards,
+  but `TerminalManager.gate()` dropped it on the floor before the wire (`GateResult` had no field for it).
+  It now carries `reason` + the classified `capability` back through `/api/gate` to the PreToolUse hook,
+  which surfaces them: `Agentric policy: denied [ssh.exec] — ssh.exec: host could not be identified. …use
+  policy_check to see the governing rule, then policy_propose or ask a human to change it — do not attempt
+  to route around the gate.` An agent that can see which rule blocked it can comply or take the sanctioned
+  path; a guess at an opaque deny is indistinguishable from probing for a way around the gate. Diagnosability,
+  not permissiveness — no decision changed, and a bare `{decision:'deny'}` from an older server still renders
+  cleanly (the hook can outlive a server upgrade). Covers the kill-switch, email-identity, and policy denies.
+
+- **`list_capabilities` now reports the REAL governed surface, not the demo plugin registry.** It was
+  sourcing `/api/agent/policy` from `os.registry.list()` — which only ever holds the five zero-dependency
+  demo capabilities (`echo.run`, `slack.post`, `stripe.refund`, `prod.restart`, `paid.action`), none of
+  which a live agent can act on — so on every real tenant the tool returned pure noise. The endpoint now
+  builds its capability list from `governedCapabilities()` (new, in `src/capabilities/normalize.ts`): the
+  structural capabilities the gate hook classifies tool calls into (`shell.exec`, `file.write`,
+  `connector.connect`/`call`, `email.send`, `net.connect`, `ssh.exec`) plus the canonical provider-independent
+  ones the normalizer resolves connector calls to (`payments.refund`, `repo.pr.create`, …). Each still carries
+  its dry-run policy verdict; the tool output notes that host-egress and file-write guards apply additional
+  arg/host-dependent tightening at gate time, and points to `policy_check` for an exact preview.
+
+## [0.382.0] - 2026-08-22
 
 ### Added
 - **The Agentric status line now installs into any claude session on any machine, with one command.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.382.0",
+  "version": "0.383.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.382.0",
+      "version": "0.383.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.382.0",
+  "version": "0.383.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/capabilities/normalize.ts
+++ b/src/capabilities/normalize.ts
@@ -90,3 +90,43 @@ export function capabilityDescriptor(id: string): CapabilityDescriptor | undefin
 export function knownCapabilities(): CapabilityDescriptor[] {
   return [...DESCRIPTORS];
 }
+
+/** One entry in the governed-capability surface: the id policy targets + why it's governed. */
+export interface GovernedCapability {
+  id: string;
+  description: string;
+}
+
+/**
+ * The STRUCTURAL capabilities the gate hook assigns purely by tool shape (terminal/gate-hook.sh) plus
+ * the two the terminal gate reclassifies host egress into (net.connect / ssh.exec). These are the real
+ * ids an agent's tool calls collapse to before the policy classifies them — independent of any tenant's
+ * connector plugins.
+ */
+const STRUCTURAL: GovernedCapability[] = [
+  { id: 'shell.exec', description: 'Run a shell command (the Bash tool). The command is parsed into facts — destructive flags, delete counts, host egress via ssh/curl — so a risky command can be gated or denied even though the tool is just "Bash".' },
+  { id: 'file.write', description: 'Create or edit a file (Edit/Write/apply_patch). Writes to protected paths (credentials, workspace state) are denied; writes outside your own folder may be gated when the file-write guard is on.' },
+  { id: 'connector.connect', description: 'Start an OAuth grant that connects a third-party app for the whole workspace (INITIATE_CONNECTION). Owner-gated.' },
+  { id: 'connector.call', description: 'Call a connected third-party tool over MCP. Payment / PR / messaging actions normalize to the canonical capabilities below so one rule governs them across providers.' },
+  { id: 'email.send', description: 'Send an outbound email. Gated by recipient — internal (your org domains) is lighter than external.' },
+  { id: 'net.connect', description: 'Open a network connection to a host (host-egress governance, when enabled). An unknown or un-granted host pauses for approval; a host with a "never" posture is denied.' },
+  { id: 'ssh.exec', description: 'Run a command on a remote host over SSH (host-egress governance, when enabled). An unknown or un-granted host pauses for owner approval; a host with a "never" posture is denied.' },
+];
+
+/**
+ * The REAL governed capability surface an agent faces: the structural capabilities above plus the
+ * canonical (provider-independent) capabilities the normalizer resolves connector calls to. This — NOT
+ * the demo execution registry (src/capabilities/examples.ts, whose echo.run/stripe.refund/… only exist
+ * so the zero-dependency demo runs) — is what `list_capabilities` reports on a live tenant. Deduped so
+ * email.send (both structural and canonical) appears once.
+ */
+export function governedCapabilities(): GovernedCapability[] {
+  const seen = new Set(STRUCTURAL.map((s) => s.id));
+  const canonical = DESCRIPTORS
+    .filter((d) => !seen.has(d.id))
+    .map((d) => ({
+      id: d.id,
+      description: `Canonical ${d.effects.join('/')} action (${d.risk} risk) — normalized from e.g. ${d.providers.slice(0, 2).join(', ')}.`,
+    }));
+  return [...STRUCTURAL, ...canonical];
+}

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -3094,7 +3094,14 @@ async function listCapabilities(): Promise<string> {
   if (data.error) return `Could not list capabilities: ${data.error}`;
   const caps = data.capabilities ?? [];
   if (!caps.length) return 'No governed capabilities are registered.';
-  return caps.map((c) => `- ${c.id} — ${verdict(c.effect, c.level)}${c.description ? `: ${c.description}` : ''}`).join('\n');
+  const lines = caps.map((c) => `- ${c.id} — ${verdict(c.effect, c.level)}${c.description ? `: ${c.description}` : ''}`);
+  return [
+    'Governed capabilities (what your tool calls classify into). The verdict shown is the base outcome',
+    'with no risky arguments; the same action can still be gated or denied once the gate parses the actual',
+    'command/host/path. Use policy_check with a concrete capability + args to preview the exact verdict.',
+    '',
+    ...lines,
+  ].join('\n');
 }
 
 async function policyCheck(args: Record<string, unknown>): Promise<string> {

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import { pruneAuditMirror } from './governance/audit';
 import { requestMetrics } from './edge/request-metrics';
 import { pendingAlerts } from './edge/alerts';
 import { exampleCapabilities } from './capabilities/examples';
+import { governedCapabilities } from './capabilities/normalize';
 import { evaluate } from './observability/evaluation';
 import { TerminalManager, AGENT_OS_OPERATING_NOTES, type ProposedAutomation } from './terminal';
 import { classifyActivity, clipText, ActivityCategory, ActivityEffect, ActivityTarget } from './state/session-activity';
@@ -750,12 +751,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const agent = tm.sessionAgent(session);
     if (!agent) return sendJson(res, 404, { error: 'unknown session' });
     if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
-    const capabilities = os.registry.list().map((c) => {
+    // The REAL governed surface (structural + canonical capabilities), NOT os.registry — that only holds
+    // the demo execution plugins (echo.run/stripe.refund/…) so the zero-dep demo runs, and surfacing them
+    // to a live agent as its "capabilities" was pure noise it couldn't act on. Each verdict is the dry-run
+    // of the JSON policy for empty args (the base outcome); host-egress + file-write guards apply ADDITIONAL
+    // engine-level tightening at gate time (args/host dependent), so this is a floor, not the last word.
+    const capabilities = governedCapabilities().map((c) => {
       const d = tm.policyCheck(session, agent, c.id, {});
       return {
         id: c.id,
         description: c.description,
-        defaultRisk: c.defaultRisk,
         effect: d.effect,
         level: d.effect === 'approve' ? d.level : undefined,
       };

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -518,7 +518,11 @@ export interface FeedMessage {
 }
 
 type GateStatus = 'pending' | 'allow' | 'deny';
-type GateResult = { decision: 'allow' | 'deny' | 'pending'; gateId?: string; note?: string };
+// On a deny, `reason` (the classifier's human account — see describeMatch/hostGovernanceDecision) and the
+// classified `capability` ride back to the hook so the agent is told WHY it was blocked and WHICH rule
+// fired, instead of an opaque "this action is blocked". The rich reason already existed (audit trail +
+// approval cards); it was just dropped before the wire. Diagnosability, not permissiveness.
+type GateResult = { decision: 'allow' | 'deny' | 'pending'; gateId?: string; note?: string; reason?: string; capability?: string };
 
 /** The automation columns the per-row label/source/authz helpers read — see `TerminalManager.withRowCache`. */
 interface AutomationLookup {
@@ -4307,7 +4311,7 @@ export class TerminalManager {
     // Workspace emergency stop — deny every action before classifying anything.
     if (this.os.settings.killSwitch().engaged) {
       this.audit(sessionId, agent, 'gate.killswitch', { capability });
-      return { decision: 'deny' };
+      return { decision: 'deny', reason: 'workspace emergency stop (kill switch) is engaged — every action is blocked until an owner disengages it', capability };
     }
     // Host-egress governance (Phase 2b): OFF unless the workspace switch is on. When on, pass the
     // agent's granted host matchers (org + shared + the session's run-as member's personal) so the
@@ -4329,7 +4333,7 @@ export class TerminalManager {
       if (emailDenial) {
         this.audit(sessionId, agent, 'gate.email.blocked', { capability, reason: emailDenial, recipients: args.emailRecipients ?? [] });
         this.audit(sessionId, agent, 'gate.decision', { capability, decision: { effect: 'deny', riskClass: 'deny', reason: emailDenial } });
-        return { decision: 'deny' };
+        return { decision: 'deny', reason: emailDenial, capability };
       }
     }
     // Host egress reclassification (Phase 2b): shell.exec → net.connect / ssh.exec when this command
@@ -4425,7 +4429,7 @@ export class TerminalManager {
       }
       return { decision: 'allow' };
     }
-    if (decision.effect === 'deny') return { decision: 'deny' };
+    if (decision.effect === 'deny') return { decision: 'deny', reason: decision.reason, capability };
 
     // Auto-approval list: an owner has said "always approve THIS action" for this exact brief signature,
     // so clear it without a card or notification. Only reachable for an `approve` (the deny/never tier

--- a/terminal/gate-hook.sh
+++ b/terminal/gate-hook.sh
@@ -127,9 +127,19 @@ while :; do
   gid=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");console.log(o.gateId||"")})')
   # An `instruct`: the gate allowed the effect but attached an advisory note (e.g. a detected loop).
   note=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");process.stdout.write(o.note||"")})')
+  # On a deny the gate now returns WHY (the classifier's reason) and WHICH capability was classified, so
+  # the agent can comply or take the sanctioned path (policy_propose / ask a human) instead of guessing —
+  # a guess at an opaque deny is indistinguishable from probing for a way around the gate.
+  reason=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");process.stdout.write(o.reason||"")})')
+  dcap=$(printf '%s' "$resp" | node -e 'let d="";process.stdin.on("data",c=>d+=c).on("end",()=>{const o=JSON.parse(d||"{}");process.stdout.write(o.capability||"")})')
   case "$dec" in
     allow) if [ -n "$note" ]; then emit_allow_note "Agentric: allowed by policy." "$note"; else emit allow "Agentric: allowed by policy."; fi ;;
-    deny)  emit deny "Agentric policy: denied — this action is blocked (irreversible or not permitted)." ;;
+    deny)
+      denymsg="Agentric policy: denied"
+      [ -n "$dcap" ] && denymsg="$denymsg [$dcap]"
+      [ -n "$reason" ] && denymsg="$denymsg — $reason"
+      denymsg="$denymsg. This is a hard block, not a pending approval; no human can approve it as-is. If you believe it should be permitted, use policy_check to see the governing rule, then policy_propose or ask a human to change it — do not attempt to route around the gate."
+      emit deny "$denymsg" ;;
     pending) break ;;
     *) echo "Agentric: gate unreachable — blocking this action until it responds…" >&2; sleep 2 ;;
   esac


### PR DESCRIPTION
## Why

A live infra-ops agent hit a hard `never` deny and had **nothing to act on**: the message was `Agentric policy: denied — this action is blocked`, naming neither the capability nor the rule, and `list_capabilities` returned only the five demo stand-ins (`echo.run`, `stripe.refund`, …). Its own words: *"an agent that can't see which rule blocked it can only guess, and guessing at a deny looks indistinguishable from probing for a way around it."* Both are real gaps; neither loosens governance.

## What changed

**1. A deny now says why + which capability.** The classifier already built a human reason (`describeMatch` for a JSON rule; `hostGovernanceDecision`/`fileGovernanceDecision` for the engine-level guards) and rode it on the audit trail + approval cards — but `TerminalManager.gate()` dropped it before the wire (`GateResult` had no field). It now carries `reason` + the classified `capability` through `/api/gate` to the PreToolUse hook:

> `Agentric policy: denied [ssh.exec] — ssh.exec: host could not be identified. This is a hard block, not a pending approval… use policy_check to see the governing rule, then policy_propose or ask a human to change it — do not attempt to route around the gate.`

Covers the kill-switch, email-identity, and policy denies. A bare `{decision:'deny'}` from an older server (the hook/MCP can outlive a restart) still renders cleanly. **No decision changed** — diagnosability, not permissiveness.

**2. `list_capabilities` reports the real governed surface.** `/api/agent/policy` sourced its capability list from `os.registry.list()` — the demo *execution* plugin table, which only ever holds the five zero-dep stand-ins, none of which a live agent can act on. Now built from `governedCapabilities()` (new, `src/capabilities/normalize.ts`): the **structural** caps the gate classifies into (`shell.exec`, `file.write`, `connector.connect`/`call`, `email.send`, `net.connect`, `ssh.exec`) plus the **canonical** provider-independent ones (`payments.refund`, `repo.pr.create`, …). Each still carries its dry-run verdict; the tool notes host-egress/file-write guards tighten further at gate time and points to `policy_check`.

## Verification
- `npm run test:governance` — green (version-sync + conformance + all suites).
- Isolated `tm.gate()` on `rm -rf /` → `{decision:'deny', reason:'any action: destructive', capability:'shell.exec'}`; benign `ls -la` → allow.
- `governedCapabilities()` → 13 real ids, zero mock leakage; hook deny-message assembly verified with and without `reason`/`capability`.

## Not in scope
This does **not** unblock the infra-ops SSH load-test that prompted it — that's a live governance decision (and the "it's staging, trust me" classification is exactly what the gate shouldn't take on faith). This only makes the *deny legible*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)