### PR TITLE
feat(setup): add GitHub App + memory layer to the install wizard (v0.384.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.384.0] - 2026-08-24
+
+### Added
+- **The setup wizard now covers GitHub and the memory layer** — the two things every install ended up
+  configuring later, after the first PR came out authored by a bot nobody recognised and after agents had
+  spent a month re-learning the same facts. Two new steps (`#/setup`, `GET /api/setup`), both optional and
+  skippable, sitting between the chat channel and the team:
+  - **Connect GitHub** — drives the one-click App-manifest flow (now shared with Settings → Integrations
+    via `web/src/lib/github-app.ts`, so one callback URL and one permission set), surfaces the
+    install-on-your-repos link (a GitHub App can only touch repos it is installed on — the step people
+    miss, and it looks exactly like a broken token), and shows the two halves separately: the OAuth pair
+    that lets each member link their own account so a run-as session authors as the human, and the
+    App id + private key that mint the company-bot token every other session pushes with. Either half
+    counts as configured; the step's detail names the one still missing.
+  - **Set up the memory layer** — the default recall is keyword-only, so an agent misses its own past work
+    whenever it words it differently. The step offers the two real upgrades: an OpenAI key for hybrid
+    (keyword + vector) recall on the built-in store with no new service to run, or AutoMem — the
+    recommended option — with a Test button before the save, since a wrong endpoint fails closed and every
+    recall comes back empty. It carries the backend-independent settings (ranking, maintenance, preload,
+    shared-write policy) through the save, because `PUT /api/settings/memory` REPLACES the config.
+
+  Both stay read-side only like every other step: status is re-derived from the store that owns the
+  setting (`GithubIdentity`, `settings.memoryConfig()`), so an App or backend configured anywhere else
+  ticks itself, and neither step ever echoes a secret. Pinned by `scripts/setup-wizard-test.cjs`.
+
 ## [0.383.0] - 2026-08-24
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,8 +389,11 @@ Key modules:
   the member-auth gate. Canonical tool↔route↔store matrix + the governance notes:
   `docs/agent-mcp-tools.md`. See also `docs/memory-layer-plan.md`.
 - `src/edge/setup.ts` — the **install wizard's** status roll-up (`GET /api/setup`, console `#/setup` +
-  a dismissible banner): six post-install steps (runtime credential → company context → Composio key →
-  chat channel → team → agents). Deliberately **read-side only** — each step is re-derived from the store
+  a dismissible banner): eight post-install steps (runtime credential → company context → Composio key →
+  chat channel → GitHub App → memory layer → team → agents). The GitHub step counts EITHER half of the App
+  (OAuth pair = members commit as themselves · App id + private key = the company-bot push token); the
+  memory step counts only a real upgrade over the keyword-only default (an embedder on the built-in store,
+  or automem/libSQL). Deliberately **read-side only** — each step is re-derived from the store
   that owns that setting and the wizard UI writes through that setting's EXISTING endpoint, so a step
   finished by CLI/another admin ticks itself and no step can disagree with its Settings page. The only
   state it owns is `settings: setup_state` (dismissal + per-step "not now" — intent isn't derivable).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.383.0",
+  "version": "0.384.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.383.0",
+      "version": "0.384.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.383.0",
+  "version": "0.384.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/setup-wizard-test.cjs
+++ b/scripts/setup-wizard-test.cjs
@@ -34,6 +34,7 @@ const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${
 const { TenantRegistry } = require(path.join(ROOT, 'dist/tenant-registry.js'));
 const { createHttpServer } = require(path.join(ROOT, 'dist/server.js'));
 const { buildSetupStatus, skipSetupStep, dismissSetup, claudeAuthEvidence, SETUP_STEP_IDS } = require(path.join(ROOT, 'dist/edge/setup.js'));
+const { GithubIdentity } = require(path.join(ROOT, 'dist/edge/github-identity.js'));
 
 const registry = new TenantRegistry(ROOT, 0);
 registry.bootAll();
@@ -77,6 +78,37 @@ aos.settings.setDiscordBotToken('Bot abc.def', owner.email);
 assert(step('chat').status === 'done' && step('chat').detail.includes('Discord'), 'any one chat channel satisfies the chat step and is named');
 aos.settings.setDiscordBotToken('', owner.email);
 
+// GitHub: either half of the App is evidence — the OAuth pair (members commit as themselves) or the
+// App id + key (the bot token every other session pushes with). Both are read from the stores that own
+// them, so an App configured from Settings → Integrations ticks here with no wizard-side write.
+assert(step('github').status === 'todo', 'a fresh install has no GitHub App');
+const gh = new GithubIdentity(aos);
+gh.setClientSecret('ghs_secret', owner.email);
+assert(step('github').status === 'todo', 'half the OAuth pair is not a connected App');
+aos.settings.setGithubClientId('Iv1.clientid', owner.email);
+assert(step('github').status === 'done', 'client id + secret completes it (per-member sign-in works)');
+assert(!JSON.stringify(step('github')).includes('ghs_secret'), 'the step never echoes the client secret');
+assert(step('github').detail.includes('no bot fallback'), 'and it says the company-bot half is still missing');
+aos.settings.setGithubAppSlug('acme-agent-os', owner.email);
+assert(step('github').detail.includes('acme-agent-os'), 'the App slug is named, so a wrong App is visible');
+gh.setClientSecret('', owner.email);
+aos.settings.setGithubClientId('', owner.email);
+assert(step('github').status === 'todo', 'removing the credentials re-opens it');
+
+// Memory: the default sqlite backend is keyword-only, which is the thing this step exists to fix — so
+// "configured" means an embedder or a real vector store, and each is read back from the saved config.
+assert(step('memory').status === 'todo', 'keyword-only recall (the default) leaves the memory step open');
+aos.settings.setMemoryConfig({ backend: 'sqlite' }, owner.email);
+assert(step('memory').status === 'todo', 'an explicit sqlite config with no embedder is still keyword-only');
+aos.settings.setMemoryConfig({ backend: 'sqlite', sqlite: { embeddings: { provider: 'openai', url: 'https://api.openai.com/v1', model: 'text-embedding-3-small', apiKey: 'sk-secret-key' } } }, owner.email);
+assert(step('memory').status === 'done', 'adding an embedder to the built-in store completes it');
+assert(!JSON.stringify(step('memory')).includes('sk-secret-key'), 'the step never echoes the embedding API key');
+aos.settings.setMemoryConfig({ backend: 'automem', automem: { endpoint: '', token: 'tok-secret' } }, owner.email);
+assert(step('memory').status === 'todo', 'automem selected with no endpoint is not configured');
+aos.settings.setMemoryConfig({ backend: 'automem', automem: { endpoint: 'https://automem.example.com:8001', token: 'tok-secret' } }, owner.email);
+assert(step('memory').status === 'done' && step('memory').detail.includes('automem.example.com'), 'an automem endpoint completes it and is named');
+assert(!JSON.stringify(step('memory')).includes('tok-secret'), 'the step never echoes the automem token');
+
 assert(step('team').status === 'todo', 'a one-person install has the team step open');
 const plain = mkMember('mem@testco.dev', 'member');
 assert(step('team').status === 'done', 'inviting a teammate completes it');
@@ -115,7 +147,7 @@ assert(!step('chat').skipped, 'un-skip restores it');
 assert(!status(0).complete, 'an install with required work left is not complete');
 
 console.log('\n\x1b[1m5) Completion + dismissal are separate facts\x1b[0m');
-for (const id of ['composio', 'chat', 'team']) skipSetupStep(aos, id, true, owner.email);
+for (const id of ['composio', 'chat', 'github', 'team']) skipSetupStep(aos, id, true, owner.email);
 fs.writeFileSync(path.join(FAKE_CLAUDE, '.credentials.json'), '{}');
 assert(status(1).complete, 'every step done or skipped = complete');
 dismissSetup(aos, true, owner.email);

--- a/src/edge/setup.ts
+++ b/src/edge/setup.ts
@@ -3,7 +3,8 @@
  *
  * A fresh `agent-os serve` boots into a console that WORKS but can do nothing interesting: no company
  * context (so every agent runs context-free), possibly no runtime credential (so a session hangs on a
- * login picker), no Composio key (so no connectors), no chat channel, no teammates, one seeded agent.
+ * login picker), no Composio key (so no connectors), no chat channel, no GitHub App (so every push is
+ * authored by whatever credential the box carries), keyword-only memory, no teammates, one seeded agent.
  * Every one of those is already settable somewhere in Settings — the problem is that a new operator has
  * no idea WHICH of them matter or in what order, and nothing tells them when they're done.
  *
@@ -21,10 +22,12 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import type { AgentOS } from '../kernel.js';
+import { GithubIdentity } from './github-identity.js';
 
 /** Steps, in the order the wizard walks them. Order is the recommendation: credentials first (nothing
- *  runs without them), then context (every run is worse without it), then the optional reach. */
-export const SETUP_STEP_IDS = ['claude', 'company', 'composio', 'chat', 'team', 'agents'] as const;
+ *  runs without them), then context (every run is worse without it), then reach (connectors, chat,
+ *  GitHub), then memory (how much of a run survives it), then the people and the fleet. */
+export const SETUP_STEP_IDS = ['claude', 'company', 'composio', 'chat', 'github', 'memory', 'team', 'agents'] as const;
 export type SetupStepId = (typeof SETUP_STEP_IDS)[number];
 
 export interface SetupStep {
@@ -123,6 +126,63 @@ function keychainHasClaude(): boolean {
   } catch { return false; }
 }
 
+/**
+ * GitHub: is there an App this workspace can act through?
+ *
+ * Two independent halves, and a workspace usefully has either:
+ *   • the OAuth pair (client id + secret) — lets each MEMBER link their own account, so a run-as session
+ *     commits and opens PRs as the actual human (`injectMemberGithub`);
+ *   • the App credentials (App id + private key) — mint installation tokens so the company BOT can push
+ *     on every installed repo when the run-as human hasn't linked (or there is none).
+ * Neither present → the box's ambient git credential is whatever happens to be lying around, which is
+ * how "the bot authored it" and "git push: permission denied" both happen.
+ */
+export function githubEvidence(agentOs: AgentOS): { status: 'done' | 'todo'; detail: string } {
+  const gh = new GithubIdentity(agentOs);
+  const oauth = gh.configured();
+  const bot = gh.botConfigured();
+  if (!oauth && !bot) return { status: 'todo', detail: 'no GitHub App — agents push with whatever credential the box happens to have' };
+  const slug = gh.appSlug();
+  const parts = [
+    oauth ? 'per-member sign-in ready' : 'no OAuth pair — members cannot link their own account',
+    bot ? 'company-bot token available' : 'no bot fallback — a session with no linked human cannot push',
+  ];
+  return { status: 'done', detail: `${slug ? `App “${slug}”` : 'App credentials set'} · ${parts.join(' · ')}` };
+}
+
+/**
+ * Memory: can agents recall anything they didn't just do?
+ *
+ * The default sqlite backend is keyword-only (FTS5 bm25) — it finds a memory when the words match and
+ * misses it when they don't, which is most of the time. So this step is satisfied by either upgrade:
+ * add an embedder to sqlite (hybrid keyword + cosine, one API key, zero new services), or point the
+ * plane at a real vector store (automem — graph + vectors, and the one we recommend — or libSQL).
+ * Read from the SAME setting Settings → Memory writes; a config-file default is deliberately not
+ * counted, because the wizard's job is to get the DB layer configured.
+ */
+export function memoryEvidence(agentOs: AgentOS): { status: 'done' | 'todo'; detail: string } {
+  const cfg = agentOs.settings.memoryConfig();
+  const backend = cfg?.backend ?? 'sqlite';
+  if (backend === 'automem') {
+    const ep = cfg?.automem?.endpoint ?? '';
+    return ep
+      ? { status: 'done', detail: `AutoMem at ${hostOf(ep)} — graph + vector recall` }
+      : { status: 'todo', detail: 'AutoMem selected but no endpoint set — recall falls back to keywords' };
+  }
+  if (backend === 'libsql') {
+    const emb = cfg?.libsql?.embeddings;
+    return { status: 'done', detail: emb ? `libSQL vectors + ${emb.provider} embeddings (${emb.model})` : 'libSQL store — lexical only, no embedder set' };
+  }
+  const emb = cfg?.sqlite?.embeddings;
+  if (emb?.url && emb?.model) return { status: 'done', detail: `hybrid recall — sqlite + ${emb.provider} embeddings (${emb.model})` };
+  return { status: 'todo', detail: 'keyword-only recall — an agent misses its own past work whenever it words it differently' };
+}
+
+/** Host of a URL for display, or the raw string when it isn't parseable. Never shows a token. */
+function hostOf(u: string): string {
+  try { return new URL(u).host; } catch { return u; }
+}
+
 export interface SetupInputs {
   /** Agents in the fleet, excluding the ones every install is seeded with — a seeded `agent-author`
    *  is not evidence that anybody built a team. */
@@ -144,6 +204,8 @@ export function buildSetupStatus(agentOs: AgentOS, inputs: SetupInputs): SetupSt
   const telegram = agentOs.settings.telegramConfigured();
   const members = agentOs.team.listMembers();
   const claude = claudeAuthEvidence(agentOs, inputs.probes);
+  const github = githubEvidence(agentOs);
+  const memory = memoryEvidence(agentOs);
 
   const chatOn = [slack && 'Slack', discord && 'Discord', telegram && 'Telegram'].filter(Boolean) as string[];
 
@@ -183,6 +245,24 @@ export function buildSetupStatus(agentOs: AgentOS, inputs: SetupInputs): SetupSt
       status: chatOn.length ? 'done' : 'todo',
       detail: chatOn.length ? `${chatOn.join(' + ')} connected` : 'none connected — the console is the only way in',
       skipped: skipped.has('chat'),
+    },
+    {
+      id: 'github',
+      title: 'Connect GitHub',
+      why: 'Coding agents live on git. The App lets each member link their own account — so a PR is authored by the human the run acts as — and gives every other session a company-bot token to push with.',
+      required: false,
+      status: github.status,
+      detail: github.detail,
+      skipped: skipped.has('github'),
+    },
+    {
+      id: 'memory',
+      title: 'Set up the memory layer',
+      why: 'Out of the box recall is keyword-only, so agents re-learn the same things forever. Add an OpenAI key for hybrid recall on the built-in store, or point it at AutoMem for real graph + vector memory.',
+      required: false,
+      status: memory.status,
+      detail: memory.detail,
+      skipped: skipped.has('memory'),
     },
     {
       id: 'team',

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,6 +18,7 @@ import { api, isDraftTask, EFFORTS, PERMISSION_MODES, type PermissionMode, type 
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval, type FeedItem, type FeedResponse, type FeedFilter, type TaskRunState, type GoalChatState } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ENTITY_ID_SRC, entityHref, isEntityId } from '@/lib/entity-links'
+import { createGithubApp } from '@/lib/github-app'
 import { ConnectorsPage, GithubMineCard } from '@/connectors'
 import { SetupPage, SetupBanner } from '@/setup'
 import { docPages } from '@/docs'
@@ -8103,19 +8104,9 @@ function GithubSetupGuide() {
   const [err, setErr] = useState('')
   const create = async () => {
     setBusy(true); setErr('')
-    const r = await api.githubManifest(org.trim() || undefined)
-    if (r.error || !r.postUrl || !r.manifest) { setBusy(false); return setErr(r.error || 'Could not prepare the manifest.') }
-    // Hand GitHub the manifest via a real form POST (it's too large for a query string); this navigates
-    // to GitHub's "Create this GitHub App?" confirmation, after which it redirects back with the creds.
-    const form = document.createElement('form')
-    form.method = 'POST'
-    form.action = r.postUrl
-    form.style.display = 'none'
-    const input = document.createElement('input')
-    input.type = 'hidden'; input.name = 'manifest'; input.value = r.manifest
-    form.appendChild(input)
-    document.body.appendChild(form)
-    form.submit()
+    // Shared with the setup wizard — see lib/github-app.ts. On success the browser navigates to GitHub.
+    const e = await createGithubApp(org)
+    if (e) { setBusy(false); setErr(e) }
   }
   return (
     <div className="rounded-md border">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1312,7 +1312,7 @@ export interface GovernanceThresholds {
 }
 
 // ── install wizard ───────────────────────────────────────────────────────────────
-export type SetupStepId = 'claude' | 'company' | 'composio' | 'chat' | 'team' | 'agents'
+export type SetupStepId = 'claude' | 'company' | 'composio' | 'chat' | 'github' | 'memory' | 'team' | 'agents'
 export interface SetupStep {
   id: SetupStepId
   title: string

--- a/web/src/lib/github-app.ts
+++ b/web/src/lib/github-app.ts
@@ -1,0 +1,33 @@
+/**
+ * GitHub App creation via GitHub's **app-manifest** flow, shared by Settings → Integrations and the
+ * setup wizard.
+ *
+ * The server renders a pre-filled manifest (name, this box's callback URL, least-privilege permissions);
+ * GitHub only accepts it as a real form POST — it is far too large for a query string — so this builds a
+ * hidden form and submits it, navigating to GitHub's "Create this GitHub App?" confirmation. GitHub then
+ * creates the App and redirects back to the server with its credentials, which is why nothing here has to
+ * be copied or pasted.
+ *
+ * Lives in `lib` rather than in either page because two callers driving the same flow through two
+ * slightly different hand-rolled forms is how a callback URL quietly diverges.
+ */
+import { api } from './api'
+
+/** Kick off the flow. Resolves with an error string when the manifest can't be prepared; on success the
+ *  browser has already navigated to GitHub and nothing after this runs. */
+export async function createGithubApp(org?: string): Promise<string | null> {
+  const r = await api.githubManifest(org?.trim() || undefined)
+  if (r.error || !r.postUrl || !r.manifest) return r.error || 'Could not prepare the manifest.'
+  const form = document.createElement('form')
+  form.method = 'POST'
+  form.action = r.postUrl
+  form.style.display = 'none'
+  const input = document.createElement('input')
+  input.type = 'hidden'
+  input.name = 'manifest'
+  input.value = r.manifest
+  form.appendChild(input)
+  document.body.appendChild(form)
+  form.submit()
+  return null
+}

--- a/web/src/setup.tsx
+++ b/web/src/setup.tsx
@@ -26,8 +26,9 @@ import { Card, CardContent } from '@/components/ui/card'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import {
   api, type Member, type Role, type SetupStatus, type SetupStep, type SetupStepId,
-  type RuntimeLogin, type IntegrationsResp, type CatalogAgent,
+  type RuntimeLogin, type IntegrationsResp, type CatalogAgent, type MemorySettings, type MemorySettingsReq,
 } from '@/lib/api'
+import { createGithubApp } from '@/lib/github-app'
 
 // ── shared bits ──────────────────────────────────────────────────────────────────
 function Hint({ children }: { children: ReactNode }) {
@@ -103,8 +104,8 @@ export function SetupPage({ me, step, onStep, onDone }: {
         <div>
           <h2 className="flex items-center gap-2 text-lg font-semibold"><Sparkles className="h-4 w-4" /> Set up your workspace</h2>
           <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
-            Six things decide whether this install is useful. Each one links to the setting that owns it — finish
-            them here, or anywhere else, and this page notices either way.
+            {status.total} things decide whether this install is useful. Each one links to the setting that owns it —
+            finish them here, or anywhere else, and this page notices either way.
           </p>
         </div>
         <div className="flex items-center gap-3">
@@ -153,6 +154,8 @@ export function SetupPage({ me, step, onStep, onDone }: {
             {current.id === 'company' && <CompanyStep onChanged={load} />}
             {current.id === 'composio' && <ComposioStep onChanged={load} />}
             {current.id === 'chat' && <ChatStep onChanged={load} />}
+            {current.id === 'github' && <GithubStep onChanged={load} />}
+            {current.id === 'memory' && <MemoryStep onChanged={load} />}
             {current.id === 'team' && <TeamStep onChanged={load} />}
             {current.id === 'agents' && <AgentsStep onChanged={() => { load(); onDone?.() }} />}
 
@@ -409,7 +412,217 @@ function ChatStep({ onChanged }: { onChanged: () => void }) {
   )
 }
 
-// ── 5. team ──────────────────────────────────────────────────────────────────────
+// ── 5. GitHub ────────────────────────────────────────────────────────────────────
+/**
+ * The App is two credentials that do different jobs, and an install wants both: the OAuth pair lets a
+ * member link their own account (so a PR is authored by the human the session runs as), and the App
+ * id + private key mint the company-bot token every OTHER session pushes with. The one-click manifest
+ * flow creates an App with both halves already correct — the manual fields exist for an App that
+ * already exists.
+ */
+function GithubStep({ onChanged }: { onChanged: () => void }) {
+  const [resp, setResp] = useState<IntegrationsResp | null>(null)
+  const [org, setOrg] = useState('')
+  const [id, setId] = useState('')
+  const [secret, setSecret] = useState('')
+  const [busy, setBusy] = useState(false)
+  const { hint, say } = useSaveHint()
+  const load = () => api.integrations().then((r) => { if (!r.error) setResp(r) }).catch(() => {})
+  useEffect(() => { load() }, [])
+  const gh = resp?.github
+
+  const create = async () => {
+    setBusy(true)
+    const err = await createGithubApp(org)   // on success the browser leaves for GitHub
+    if (err) { setBusy(false); say('⚠ ' + err, 8000) }
+  }
+  const saveManual = async () => {
+    setBusy(true)
+    const r = await api.saveIntegrations({
+      ...(id.trim() ? { githubClientId: id.trim() } : {}),
+      ...(secret.trim() ? { githubClientSecret: secret.trim() } : {}),
+    })
+    setBusy(false)
+    if (r.error) return say('⚠ ' + r.error, 8000)
+    setId(''); setSecret(''); say('saved'); load(); onChanged()
+  }
+
+  return (
+    <div className="space-y-3">
+      {!gh?.configured && (
+        <div className="space-y-2 rounded-md border bg-muted/20 p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Input value={org} onChange={(e) => setOrg(e.target.value.trim())} placeholder="your-org (optional)" className="h-8 w-56 font-mono text-xs" />
+            <Button onClick={create} disabled={busy}>{busy ? 'Opening GitHub…' : 'Create GitHub App'}</Button>
+          </div>
+          <Hint>
+            GitHub opens a confirmation with everything pre-filled — name, this server's callback URL, and least-privilege
+            permissions (Contents + Pull requests, no webhook) — then hands the credentials straight back here. Nothing to
+            copy. Leave the org blank to create it under your personal account; you must be signed in to GitHub in this browser.
+          </Hint>
+        </div>
+      )}
+
+      {gh?.installUrl && (
+        <div className="space-y-1 rounded-md border bg-muted/20 p-3">
+          <div className="text-xs font-medium">Install it on your repositories</div>
+          <Hint>A GitHub App can only touch repos it is installed on — this is the step people miss, and it looks exactly like a broken token.</Hint>
+          <Link href={gh.installUrl}>Install “{gh.slug}” on your repos</Link>
+        </div>
+      )}
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        <div className="rounded-md border p-2">
+          <div className="text-xs font-medium">
+            Per-member sign-in{' '}
+            {gh?.configured
+              ? <Badge variant="outline" className="ml-1 border-emerald-500/40 text-[10px] text-emerald-600 dark:text-emerald-400">ready</Badge>
+              : <Badge variant="outline" className="ml-1 text-[10px]">not set</Badge>}
+          </div>
+          <Hint>Each teammate connects their own account from <a className="underline" href="#/connectors">Connections</a>; a session running as them then commits and opens PRs under their name.</Hint>
+        </div>
+        <div className="rounded-md border p-2">
+          <div className="text-xs font-medium">
+            Company bot{' '}
+            {gh?.botReady
+              ? <Badge variant="outline" className="ml-1 border-emerald-500/40 text-[10px] text-emerald-600 dark:text-emerald-400">active</Badge>
+              : <Badge variant="outline" className="ml-1 text-[10px]">not set</Badge>}
+          </div>
+          <Hint>The fallback: an App id + private key mint a short-lived installation token so an unattended run with no linked human can still push. Add them in <a className="underline" href="#/settings/integrations">Settings → Integrations</a>.</Hint>
+        </div>
+      </div>
+
+      <details className="rounded-md border" open={!gh?.configured}>
+        <summary className="cursor-pointer select-none px-3 py-2 text-xs text-muted-foreground hover:text-foreground">
+          {gh?.configured ? 'Replace the credentials manually' : 'Already have an App? Paste its credentials'}
+        </summary>
+        <div className="space-y-2 border-t p-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Input value={id} onChange={(e) => setId(e.target.value.trim())} placeholder={gh?.clientId ? 'client id saved — type to replace' : 'client id'} className="h-8 w-64 font-mono text-xs" />
+            <Input value={secret} onChange={(e) => setSecret(e.target.value)} type="password" placeholder={gh?.clientSecret ? '•••• saved — type to replace' : 'client secret'} className="h-8 w-64 font-mono text-xs" />
+            <Button onClick={saveManual} disabled={busy || (!id.trim() && !secret.trim())}>Save</Button>
+          </div>
+          <Hint>Set the app's authorization callback URL to this server's <span className="font-mono">/api/github/callback</span>.</Hint>
+        </div>
+      </details>
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+    </div>
+  )
+}
+
+// ── 6. memory layer ──────────────────────────────────────────────────────────────
+/**
+ * Two upgrades over the keyword-only default, and the choice is genuinely a trade: an embedder on the
+ * built-in sqlite store is one API key and no new infrastructure; AutoMem is a real graph + vector
+ * service — better recall, at the cost of running (or paying for) it. Everything else on Settings →
+ * Memory (ranking, maintenance, preload, shared-write policy) is carried through untouched, because
+ * `PUT /api/settings/memory` REPLACES the config: sending a bare backend would silently wipe them.
+ */
+function MemoryStep({ onChanged }: { onChanged: () => void }) {
+  const [view, setView] = useState<MemorySettings | null>(null)
+  const [choice, setChoice] = useState<'sqlite' | 'automem'>('sqlite')
+  const [key, setKey] = useState('')
+  const [endpoint, setEndpoint] = useState('')
+  const [token, setToken] = useState('')
+  const [busy, setBusy] = useState(false)
+  const { hint, say } = useSaveHint()
+
+  const load = () => api.memorySettings().then((r) => {
+    if (r.error) return
+    setView(r)
+    if (r.backend === 'automem') { setChoice('automem'); setEndpoint(r.automem?.endpoint ?? '') }
+  }).catch(() => {})
+  useEffect(() => { load() }, [])
+
+  /** Carry the backend-independent settings forward — see the note above. */
+  const carry = (): Partial<MemorySettingsReq> => ({
+    ...(view?.ranking ? { ranking: view.ranking } : {}),
+    ...(view?.maintenance ? { maintenance: view.maintenance } : {}),
+    ...(view?.sharedWrites ? { sharedWrites: view.sharedWrites } : {}),
+    ...(view?.preload ? { preload: view.preload } : {}),
+  })
+  const body = (): MemorySettingsReq => choice === 'automem'
+    ? { backend: 'automem', automem: { endpoint: endpoint.trim(), ...(token.trim() ? { token: token.trim() } : {}) }, ...carry() }
+    : {
+        backend: 'sqlite',
+        sqlite: { embeddings: { enabled: true, provider: 'openai', url: 'https://api.openai.com/v1', model: 'text-embedding-3-small', dimensions: 1536, ...(key.trim() ? { apiKey: key.trim() } : {}) } },
+        ...carry(),
+      }
+
+  const test = async () => {
+    setBusy(true)
+    const r = await api.testMemorySettings(body())
+    setBusy(false)
+    say(r.error ? '⚠ ' + r.error : `reachable — ${r.health?.backend ?? 'ok'}`, 8000)
+  }
+  const save = async () => {
+    setBusy(true)
+    const r = await api.saveMemorySettings(body())
+    setBusy(false)
+    if (r.error) return say('⚠ ' + r.error, 8000)
+    setKey(''); setToken(''); say('saved — recall switches over immediately, no restart'); load(); onChanged()
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="grid gap-2 sm:grid-cols-2">
+        {([
+          { id: 'sqlite' as const, title: 'Built-in store + embeddings', blurb: 'One OpenAI key. Hybrid keyword + vector recall in the workspace DB — no new service to run.' },
+          { id: 'automem' as const, title: 'AutoMem (recommended)', blurb: 'A real memory service (graph + vectors): better recall, consolidation, and relationships between memories.' },
+        ]).map((o) => (
+          <button
+            key={o.id}
+            onClick={() => setChoice(o.id)}
+            className={`rounded-md border p-3 text-left text-xs transition-colors ${choice === o.id ? 'border-foreground/30 bg-muted' : 'hover:bg-muted/50'}`}
+          >
+            <div className="font-medium">
+              {o.title}
+              {view?.backend === o.id && <Badge variant="outline" className="ml-2 border-emerald-500/40 text-[10px] text-emerald-600 dark:text-emerald-400">active</Badge>}
+            </div>
+            <div className="mt-1 text-[11px] text-muted-foreground">{o.blurb}</div>
+          </button>
+        ))}
+      </div>
+
+      {choice === 'sqlite' ? (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Input value={key} onChange={(e) => setKey(e.target.value)} type="password" placeholder={view?.sqlite?.embeddings?.apiKeySet ? 'key set — paste to replace' : 'sk-… (OpenAI API key)'} className="h-8 w-96 font-mono text-xs" />
+            <Button onClick={save} disabled={busy || (!key.trim() && !view?.sqlite?.embeddings?.apiKeySet)}>{busy ? 'Saving…' : 'Turn on hybrid recall'}</Button>
+          </div>
+          <Hint>
+            Embeds every memory with <span className="font-mono">text-embedding-3-small</span> (1536 dims) and ranks recall by
+            keywords AND meaning. Vectors live in a column of this workspace's own database, so there is nothing else to run —
+            embedding calls are billed by OpenAI and are cheap. Prefer a local embedder? Ollama is on{' '}
+            <a className="underline" href="#/settings/memory">Settings → Memory</a>.
+          </Hint>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <Input value={endpoint} onChange={(e) => setEndpoint(e.target.value)} placeholder="https://automem.internal:8001" className="h-8 w-72 font-mono text-xs" />
+            <Input value={token} onChange={(e) => setToken(e.target.value)} type="password" placeholder={view?.automem?.tokenSet ? 'token set — paste to replace' : 'token'} className="h-8 w-52 font-mono text-xs" />
+            <Button variant="outline" onClick={test} disabled={busy || !endpoint.trim()}>Test</Button>
+            <Button onClick={save} disabled={busy || !endpoint.trim()}>{busy ? 'Saving…' : 'Use AutoMem'}</Button>
+          </div>
+          <Hint>
+            AutoMem is a self-hostable REST service (FalkorDB graph + Qdrant vectors) —{' '}
+            <Link href="https://github.com/verygoodplugins/mcp-automem">deploy it</Link>, then paste its base URL and token here.
+            Test before you save: a wrong endpoint fails closed and every recall comes back empty. Existing memories stay in the
+            local ledger — <a className="underline" href="#/settings/memory">Settings → Memory</a> migrates them up afterwards.
+          </Hint>
+        </div>
+      )}
+      {hint && <p className="text-xs text-muted-foreground">{hint}</p>}
+      <Hint>
+        Either way the memories themselves are written by agents (<span className="font-mono">remember</span>) and by the nightly
+        reflect pass — this only decides how well they are found again.
+      </Hint>
+    </div>
+  )
+}
+
+// ── 7. team ──────────────────────────────────────────────────────────────────────
 function TeamStep({ onChanged }: { onChanged: () => void }) {
   const [email, setEmail] = useState('')
   const [role, setRole] = useState<Role>('member')
@@ -456,7 +669,7 @@ function TeamStep({ onChanged }: { onChanged: () => void }) {
   )
 }
 
-// ── 6. agents ────────────────────────────────────────────────────────────────────
+// ── 8. agents ────────────────────────────────────────────────────────────────────
 function AgentsStep({ onChanged }: { onChanged: () => void }) {
   const [catalog, setCatalog] = useState<CatalogAgent[]>([])
   const [busy, setBusy] = useState('')


### PR DESCRIPTION
Two new optional steps in the setup checklist (`#/setup`, `GET /api/setup`), between the chat channel and the team.

### Connect GitHub
Drives the same one-click App-manifest flow as Settings → Integrations — extracted to `web/src/lib/github-app.ts` so both callers share one callback URL and permission set. Surfaces the install-on-your-repos link (an App can only touch repos it's installed on — the step people miss, and it looks exactly like a broken token) and shows the App's two halves separately:

- **OAuth pair** — each member links their own account, so a run-as session authors PRs as the human.
- **App id + private key** — the company-bot installation token every other session pushes with.

Either half counts as configured; the step detail names the half still missing.

### Set up the memory layer
The default recall is keyword-only, so an agent misses its own past work whenever it words it differently. The step offers the two real upgrades:

- an **OpenAI key** for hybrid (keyword + vector) recall on the built-in sqlite store — no new service to run;
- **AutoMem** (recommended) with a **Test** before the save, since a wrong endpoint fails closed and every recall comes back empty.

The save carries ranking / maintenance / preload / shared-write policy forward, because `PUT /api/settings/memory` REPLACES the config.

### Invariants kept
Both steps stay read-side only like every other one — status is re-derived from the store that owns the setting (`GithubIdentity`, `settings.memoryConfig()`), so an App or backend configured by CLI or another admin ticks itself, and neither step ever echoes a secret.

### Test plan
- `scripts/setup-wizard-test.cjs` — 52 assertions, extended with: either GitHub half completing the step, half an OAuth pair not counting, the slug named in the detail, removal re-opening it; sqlite-without-embedder still todo, an embedder completing it, automem-without-endpoint todo, an endpoint completing it and being named; plus no-secret-echo checks on the client secret, embedding key and automem token.
- `npm run test:governance` green · `npm run typecheck` · `cd web && npm run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)