### PR TITLE
feat(governance): steer agents to the Library, not claude.ai Artifacts (v0.385.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.385.0] - 2026-08-24
+
+### Changed
+- **Agents are now steered to publish deliverables to the Library, not to a claude.ai Artifact.** The
+  operating notes told agents to `publish` real deliverables but were silent on the built-in claude.ai
+  Artifact tool, so an agent deciding "the human should see this" could reach for an Artifact — which
+  lives on external cloud hosting outside the tenant, with no inbox card, no `library_list` listing, and
+  no audit trail, so the operator never sees it in the console. Added an explicit steer next to the
+  existing publish rule (`AGENT_OS_OPERATING_NOTES`), matching the "native-first / don't use the external
+  alternative" pattern the same prompt already applies to messaging (native over Composio Slack) and code
+  review (never a cloud-billed review). Prompt-only change — takes effect on the next session launch.
+
 ## [0.384.0] - 2026-08-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.384.0",
+  "version": "0.385.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.384.0",
+      "version": "0.385.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.384.0",
+  "version": "0.385.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -164,7 +164,10 @@ Your terminal output may not be read. The operator lives in the Inbox:
 - \`publish\` real deliverables (a document, PDF, image, chart, generated media) to the Library. The one
   rule that matters — overriding the harness's "put ALL temporary files in the scratchpad" instruction —
   is that a deliverable must live in **your working folder (your cwd)**, never the scratchpad, or
-  \`publish\` can't reach it (see the tool's own notes for the details).
+  \`publish\` can't reach it (see the tool's own notes for the details). A deliverable the human should see
+  belongs in the Library via \`publish\`, **not** in a claude.ai Artifact — an Artifact lives on external
+  cloud hosting outside this tenant, with no inbox card, no \`library_list\` listing, and no audit trail,
+  so the operator never sees it here.
 
 ## Opening a pull request — always link back to this session
 When you open a pull request (or any deliverable that carries a description), add a line linking back to


### PR DESCRIPTION
## What

Adds one steer to `AGENT_OS_OPERATING_NOTES` (`src/terminal.ts`) telling agents that a deliverable the human should see belongs in the **Library via `publish`**, not in a **claude.ai Artifact**.

## Why

The operating notes already told agents to `publish` real deliverables — but framed the only contrast as *Library vs. scratchpad* (a file-location concern) and were **silent on the built-in claude.ai Artifact tool**. So an agent deciding "the human should see this" could reach for an Artifact, which:

- lives on **external cloud hosting outside the tenant** (not on the box the operator controls),
- posts **no inbox card**,
- never appears in **`library_list`**,
- leaves **no audit trail**.

The operator then never sees the deliverable in the console at all.

This is the same shape as two steers the prompt *already* carries — and the one place it was missing:
- **messaging**: "use the native integration first… Do NOT use a Composio Slack action"
- **code review**: "Do NOT trigger a paid or cloud-billed review"

## Change

Prompt-only. New sentence appended to the existing `publish` bullet. No code paths, tools, or schemas touched — takes effect on the **next session launch** (no server restart needed for the prompt itself, but live sessions keep the old prompt until they respawn).

## Validation

- `npm run typecheck` ✅
- `npm run build` ✅
- `npm run test:governance` ✅ (0 failed)
- `cd web && npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)