### PR TITLE
fix(runtime-pool): refresh quota snapshots on the scheduler tick (v0.386.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.386.0] - 2026-08-24
+### Fixed
+- **Runtime-account quota snapshots now refresh on their own.** `refreshStaleUsage` was reachable
+  only from `GET /api/runtime-accounts`, so the usage reading was refreshed *only when a human
+  opened Settings → Runtime accounts*. On an unattended box the snapshot froze — `last_checked_at`
+  days old — while `pick()` kept dispatching live work to an account that had already hit its
+  weekly wall. The teardown limit-detector was no backstop: the tmux pane is too volatile, and it
+  fires on roughly 3 of 31 real quota deaths. So the pool learned an account was spent by burning
+  a real customer ticket on it. `Automations.tick` now sweeps too, using a longer
+  `BACKGROUND_USAGE_STALE_MS` (30 min) than the read path's 10 min. Self-throttling: only
+  snapshots past the window are probed, in-flight probes are de-duped and the batch is capped, so
+  the ~20s tick costs nothing until a reading actually ages out.
+  Measured on the instawp tenant before the fix: **~20% of inbound support tickets silently
+  dropped over three days** (including a cancellation and a billing request), every drop on an
+  account whose displayed quota was stale. Pinned by `scripts/runtime-usage-refresh-test.cjs` §6.
+
 ## [0.385.0] - 2026-08-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.385.0",
+  "version": "0.386.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.385.0",
+      "version": "0.386.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.385.0",
+  "version": "0.386.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/runtime-usage-refresh-test.cjs
+++ b/scripts/runtime-usage-refresh-test.cjs
@@ -23,7 +23,7 @@ let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
-const { staleUsageAccounts, refreshStaleUsage, USAGE_STALE_MS } = require(path.join(ROOT, 'dist/edge/runtime-account-usage.js'));
+const { staleUsageAccounts, refreshStaleUsage, USAGE_STALE_MS, BACKGROUND_USAGE_STALE_MS } = require(path.join(ROOT, 'dist/edge/runtime-account-usage.js'));
 
 const aos = loadAgentOS();
 const store = aos.runtimeAccounts;
@@ -109,6 +109,38 @@ const NOW = Date.now();
   await r.done;
   assert(store.get('claude-code', 'd').usage?.weekly?.usedPct === 55, 'the previous reading survives a probe that throws');
   assert(store.get('claude-code', 'd').enabled === true, 'a failed probe never disables an account');
+
+  console.log('\n\x1b[1m6) The SCHEDULER TICK refreshes the snapshot with no human read\x1b[0m');
+  // The bug this pins: refreshStaleUsage was reachable ONLY from GET /api/runtime-accounts, so on an
+  // unattended box the snapshot froze and pick() kept dispatching to an account that had already hit its
+  // weekly wall. Measured on the instawp tenant: ~20% of inbound support tickets silently dropped over
+  // three days, each discovered by burning a real customer ticket. Automations.tick now sweeps too.
+  reset();
+  mk('e');
+  // A snapshot that is fresh for the BACKGROUND window must not be probed by the tick...
+  store.recordCheck('claude-code', 'e', { ok: true, note: 'valid', usage: usage(20, 5), now: NOW - 60_000 });
+  let probed = 0;
+  r = refreshStaleUsage(aos, { staleMs: BACKGROUND_USAGE_STALE_MS, probe: async () => { probed++; return { ok: true, note: 'valid', usage: usage(20, 5) }; } });
+  await r.done;
+  assert(probed === 0, 'a snapshot inside the background window costs nothing on a 20s tick');
+
+  // ...but one older than the background window is re-probed, and an exhausted reading parks the account
+  // BEFORE the next pick() can hand it live work.
+  const eReset = NOW + 7200_000;
+  store.recordCheck('claude-code', 'e', { ok: true, note: 'valid', usage: usage(20, 5), now: NOW - BACKGROUND_USAGE_STALE_MS - 1 });
+  r = refreshStaleUsage(aos, {
+    staleMs: BACKGROUND_USAGE_STALE_MS,
+    probe: async () => { probed++; return { ok: true, note: 'valid · weekly 100% used', usage: { weekly: { usedPct: 100, resetsAt: eReset } }, limitedUntil: eReset }; },
+  });
+  await r.done;
+  assert(probed === 1, 'a snapshot older than the background window IS probed without any console read');
+  assert(store.get('claude-code', 'e').usage?.weekly?.usedPct === 100, 'the tick applies the fresh reading');
+  const spent = store.get('claude-code', 'e');
+  assert(spent.status === 'limited' && spent.limitedUntil === eReset,
+    'an exhausted account is parked by the background sweep, not by a dropped ticket', `status=${spent.status}`);
+
+  assert(BACKGROUND_USAGE_STALE_MS > USAGE_STALE_MS,
+    'the background window is longer than the read window (nobody is watching a screen)');
 
   console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m`);
   try { fs.rmSync(HOME, { recursive: true, force: true }); } catch { /* best effort */ }

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -22,6 +22,7 @@ import { classifyIntent, SOCIAL_REPLY } from './intent';
 import { answerAsk } from './ask';
 import { ensureConcierge, ensureOperator, CONCIERGE_ID, OPERATOR_ID } from './concierge';
 import { sweepStrandedTasks } from './task-reconcile';
+import { refreshStaleUsage, BACKGROUND_USAGE_STALE_MS } from './runtime-account-usage';
 import { WakeupQueue } from './wakeups';
 import {
   DEDUPE_TTL_MS,
@@ -1788,6 +1789,13 @@ export class Automations {
     // Advance any in-flight async video renders (poll → ingest on completion). Fire-and-forget: it's
     // async, tick is sync, and a poll error must never break the scheduler loop.
     void this.tm.pollVideoJobs().catch(() => {});
+    // Keep the runtime-account quota snapshot fresh. Until this existed the snapshot was refreshed ONLY
+    // when a human opened Settings → Runtime accounts, so on an unattended box `pick()` kept dispatching to
+    // an account that had already hit its weekly wall — and the way we found out was a dropped customer
+    // ticket. Self-throttling: `refreshStaleUsage` probes only accounts staler than
+    // BACKGROUND_USAGE_STALE_MS, de-dupes in-flight probes and caps the batch, so calling it on every ~20s
+    // tick costs nothing until a snapshot actually ages out. Fire-and-forget for the same reason as above.
+    void refreshStaleUsage(this.os, { staleMs: BACKGROUND_USAGE_STALE_MS }).done.catch(() => {});
     // Whole-box concurrency cap (#137). Count sessions already alive and stop firing NEW scheduler spawns
     // once we hit the ceiling. A deferred spawn isn't stamped `lastFiredAt` (and a `once` isn't disabled),
     // so it retries next tick: a `once`/`task` stays due indefinitely; a `cron` is retried only within its

--- a/src/edge/runtime-account-usage.ts
+++ b/src/edge/runtime-account-usage.ts
@@ -8,12 +8,18 @@
  * a human last clicked — and an account that hit its wall in a run the teardown detector missed (or under
  * a different process) kept showing a comfortable percentage.
  *
- * This module closes that gap without a new scheduler tick: whoever READS the pool (the owner-only
+ * This module closes that gap from two directions. Whoever READS the pool (the owner-only
  * `GET /api/runtime-accounts`) kicks a background probe of every enabled Claude account whose snapshot is
  * older than {@link USAGE_STALE_MS}, and the response says which accounts are refreshing so the console can
- * re-read once they land. Reads are rare (an owner opening Settings), the probe is one 1-token Haiku call
- * per account (see `runtime-account-check.ts`), and in-flight probes are de-duped — so the cost is bounded
- * by the staleness window, not by how often the page is polled.
+ * re-read once they land. The probe is one 1-token Haiku call per account (see `runtime-account-check.ts`)
+ * and in-flight probes are de-duped, so the cost is bounded by the staleness window, not by how often the
+ * page is polled.
+ *
+ * ⚠ The read path ALONE was not enough, because it is driven by a human opening Settings. On a box nobody
+ * is watching, the snapshot simply froze: `last_checked_at` sat days old while the pool kept dispatching to
+ * an account that had already hit its wall. So `Automations.tick` ALSO calls {@link refreshStaleUsage},
+ * with the longer {@link BACKGROUND_USAGE_STALE_MS} window — the pool now learns an account is spent from a
+ * cheap probe instead of from a dropped customer ticket.
  *
  * Deliberately NOT done here: re-enabling a DISABLED account. `enabled = 0` means either a human removed it
  * from rotation or a live 401 auto-disabled it; a background probe silently putting either back into
@@ -26,6 +32,20 @@ import { checkClaudeToken, readConfigDirToken, RuntimeCheckResult } from './runt
 /** A snapshot older than this is re-probed on the next read. Long enough that opening Settings twice in a
  *  row costs nothing, short enough that the number on screen is about the current quota window. */
 export const USAGE_STALE_MS = 10 * 60_000;
+/**
+ * The same, for the BACKGROUND sweep on the scheduler tick (see {@link refreshStaleUsage}'s caller in
+ * `Automations.tick`). Longer than the read-path window because nobody is looking at a screen: this only
+ * has to be short relative to how fast an account can burn through its quota unnoticed.
+ *
+ * 30 minutes, from the live failure it exists to prevent: on 2026-08-23 the `vikasprogrammer` account went
+ * from 58% to 100% of its weekly window across an evening (~4 runs at $7–13 each). Between the read-path
+ * refresh — which only fires when a human opens Settings → Runtime accounts — and the teardown limit
+ * detector, which the pane is too volatile to make reliable (it caught 3 of 31 real quota deaths; see
+ * `TerminalManager.detectUsageLimit`), a spent account kept advertising a comfortable percentage and
+ * `pick()` kept handing it live work. On the instawp tenant that silently dropped ~20% of inbound support
+ * tickets over three days, each one discovered only by burning a real customer ticket on it.
+ */
+export const BACKGROUND_USAGE_STALE_MS = 30 * 60_000;
 /** Most accounts probed per sweep — a bound on the cost of one page load, not a pool size limit. The rest
  *  are picked up by the next read (they stay stale, so nothing is skipped permanently). */
 export const MAX_PER_SWEEP = 8;


### PR DESCRIPTION
## The bug

`refreshStaleUsage` was reachable from exactly one place — `GET /api/runtime-accounts`. That route is the owner-only Settings → Runtime accounts page, so **the quota snapshot only refreshed when a human opened it.**

On an unattended box it froze. Observed live on instawp: `last_checked_at` days stale while `pick()` kept handing work to an account that had already hit its weekly wall.

The teardown limit-detector doesn't cover this — the module comment in `terminal.ts` already records that the tmux pane is too volatile, and it fired on **3 of 31** real quota deaths. So the pool learned an account was spent *by burning a real customer ticket on it*.

## Impact measured before the fix

Over three days on the instawp support ingress:

- **~20% of inbound tickets silently dropped** (peak 38% in one 8-hour stretch)
- Casualties included a **cancellation request** and a **billing/dunning reply**
- Every drop landed on an account whose displayed quota was stale
- No alert fires — the session is marked `done`, `outcome=unknown`, tool_calls 0, no report

Customers weren't left hanging (the humans are fast), but the agent contributed nothing and nothing recorded that it hadn't.

## The fix

`Automations.tick` now calls `refreshStaleUsage` as well, with a longer `BACKGROUND_USAGE_STALE_MS` (30 min) than the read path's `USAGE_STALE_MS` (10 min) — nobody is watching a screen; it only has to be short relative to how fast an account burns through. 30 min comes from the live case: `vikasprogrammer` went 58% → 100% of its weekly window across one evening.

Self-throttling by construction, so calling it on a ~20s tick is free until a reading actually ages out:
- only accounts staler than the window are probed
- in-flight probes are de-duped across callers
- the batch is capped (`MAX_PER_SWEEP`)
- one 1-token Haiku call per account
- disabled accounts are still never silently revived

## Tests

`scripts/runtime-usage-refresh-test.cjs` §6 (new, 5 assertions) — a fresh snapshot is not probed on tick; a stale one **is**, with no console read; the result is applied; an exhausted account is parked by the sweep rather than by a dropped ticket; and the background window is longer than the read window.

Full gate green (`npm run test:governance`, exit 0).

## Not in scope

While writing the test I found that `usedPct: 100` alone does **not** park an account — parking comes from the probe returning `limitedUntil`. That matches a production reading of `instawp available · weekly 100%`. Whether a 100% weekly reading should park on its own is a separate question and isn't changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)