### PR TITLE
refactor(verbosity): retire the savings query; report adoption instead (v0.389.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.389.0]
+### Changed
+- **`verbositySavings()` is retired; the console now reports terse ADOPTION, not savings.** The flag
+  shipped beside a query meant to falsify it — cost per turn, terse arm against normal arm, on live
+  traffic — and Settings → Runtime defaults rendered the deltas in green and amber. Four controlled
+  benchmark runs established that the query cannot mean what it was read to mean, so it is removed
+  rather than caveated. Three defects, none fixable from inside a query over `term_sessions`:
+  `output_tokens` is ~85% `tool_use` arguments and ~18% thinking, so it barely contains the narration
+  the brief compresses (against the live instapods DB it called terse 28–92% *worse* on four of five
+  agents — that was tool-use volume); dividing by turns lets the treatment move its own denominator
+  (`marketing-manager` read 92% worse per turn and 25% cheaper per session from the same rows); and
+  the two arms are a 2026-08-07 cutover rather than a split.
+  `verbosityAdoption()` replaces it — per-level session counts, per agent, over a trailing window, with
+  pre-flag rows kept in their own `unstamped` bucket so the panel cannot overstate the flag's reach. A
+  row count is a claim the data supports. `GET /api/settings/verbosity-savings` becomes
+  `GET /api/settings/verbosity-adoption`; the panel's caption now states the measured ceiling (~1% of
+  spend, because narration is a small share of what an agent emits) and points at
+  `npm run bench:verbosity` for the effect question, which belongs to a controlled experiment and not
+  to a comparison of live runs.
+  The removed test assertions were all **passing** — the arithmetic was correct throughout. That is the
+  point worth keeping: a well-tested number can still be the wrong number, and no amount of per-turn
+  hygiene turned `output_tokens` into a measure of narration.
+
 ## [0.388.0]
 ### Added
 - **`npm run bench:verbosity-turns` — the multi-turn harness, and the answer on per-turn

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.388.0",
+  "version": "0.389.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.388.0",
+      "version": "0.389.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.388.0",
+  "version": "0.389.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/verbosity-test.cjs
+++ b/scripts/verbosity-test.cjs
@@ -24,7 +24,7 @@ let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
 const { resolveRuntimeTuning, sanitizeRuntimeTuning } = require(path.join(ROOT, 'dist/types.js'));
-const { verbositySavings, TERSE_OUTPUT_BRIEF } = require(path.join(ROOT, 'dist/edge/verbosity.js'));
+const { verbosityAdoption, TERSE_OUTPUT_BRIEF } = require(path.join(ROOT, 'dist/edge/verbosity.js'));
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
 const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
 
@@ -85,62 +85,52 @@ console.log('\n\x1b[1m5) prompt injection\x1b[0m');
   assert(!tm.buildCompanyMd().includes(head), 'an un-migrated caller (no arg) appends nothing');
 }
 
-console.log('\n\x1b[1m6) savings — per-turn, and hard to fool\x1b[0m');
-const DAY = 24 * 3600_000;
+console.log('\n\x1b[1m6) adoption — counts, and only counts\x1b[0m');
+// The predecessor of this section tested the savings math: output-per-turn, USD-per-turn, the
+// under-powered-arm guard. Those assertions were removed with the query in v0.389.0. They were all
+// PASSING — the arithmetic was correct — which is exactly the trap: a well-tested number can still be
+// the wrong number. `output_tokens` is ~85% tool-call arguments, so no amount of per-turn hygiene made
+// it a measure of the narration the brief compresses. What replaced it reports who ran which level,
+// which is a claim a row count can actually support.
+const DAY = 86_400_000;
 let n = 0;
-/** One costed, terminal session. `verbosity` null = a run from before the flag existed. */
-const mkRun = (agent, verbosity, turns, output, usd, ageDays = 1) => {
+const mkRun = (agent, verbosity, ageDays = 1) => {
   const id = 'ts_' + (++n), at = Date.now() - ageDays * DAY;
   db.prepare(`INSERT INTO term_sessions (id,agent,title,task,tmux,status,created_at,updated_at,turns,output_tokens,cost_usd,verbosity)
-              VALUES (?,?,'t','x',?,'done',?,?,?,?,?,?)`)
-    .run(id, agent, 'aos-' + id, at, at + 60_000, turns, output, usd, verbosity);
+              VALUES (?,?,'t','x',?,'done',?,?,10,10000,1.0,?)`)
+    .run(id, agent, 'aos-' + id, at, at + 60_000, verbosity);
 };
-const agentRow = (agent, days = 30) => verbositySavings(db, days).byAgent.find((a) => a.agent === agent);
+const agentRow = (agent, days = 30) => verbosityAdoption(db, days).byAgent.find((a) => a.agent === agent);
 
-// alpha: terse halves output per turn and is 20% cheaper per turn.
-for (let i = 0; i < 6; i++) mkRun('alpha', 'normal', 10, 10_000, 1.0);
-for (let i = 0; i < 6; i++) mkRun('alpha', 'terse', 10, 5_000, 0.8);
+for (let i = 0; i < 6; i++) mkRun('alpha', 'normal');
+for (let i = 0; i < 4; i++) mkRun('alpha', 'terse');
+for (let i = 0; i < 9; i++) mkRun('beta', 'terse');
 {
   const a = agentRow('alpha');
-  assert(a && a.normal.outputPerTurn === 1000 && a.terse.outputPerTurn === 500, 'output/turn is computed per turn');
-  assert(a.outputDelta === 50 && a.usdDelta === 20, 'reports −50% output, −20% USD');
+  assert(a && a.normal === 6 && a.terse === 4, 'counts each level per agent');
+  const totals = verbosityAdoption(db).sessions;
+  assert(totals.normal === 6 && totals.terse === 13, 'workspace totals sum every agent');
 }
-
-// beta: identical per-turn economics, but the terse runs are 5× LONGER. Totals would call that a
-// regression; per-turn must not.
-for (let i = 0; i < 6; i++) mkRun('beta', 'normal', 2, 2_000, 0.2);
-for (let i = 0; i < 6; i++) mkRun('beta', 'terse', 10, 5_000, 0.8);
-assert(agentRow('beta').outputDelta === 50, 'a longer terse run does not fake a regression');
-
-// gamma: a spectacular ratio off one run per arm — noise, and must not be reported as a delta.
-mkRun('gamma', 'normal', 10, 10_000, 1.0);
-mkRun('gamma', 'terse', 10, 1_000, 0.1);
+// An agent that only ever ran one way is still real adoption — unlike the old comparison, which had
+// to drop it for want of a second arm.
+assert(agentRow('beta').terse === 9 && agentRow('beta').normal === 0, 'a single-level agent is still listed');
+// Sorted so the heaviest terse users lead — the question the panel exists to answer.
+assert(verbosityAdoption(db).byAgent[0].agent === 'beta', 'ordered by terse runs, most first');
 {
-  const g = agentRow('gamma');
-  assert(g.comparable === false && g.outputDelta === null, 'an under-powered arm reports no delta');
-}
-
-// delta: terse only. Comparing it to itself would be meaningless, so it is not a row at all.
-for (let i = 0; i < 8; i++) mkRun('delta', 'terse', 10, 5_000, 0.5);
-assert(!agentRow('delta'), 'an agent that only ran one way is excluded from byAgent');
-
-{
-  const before = verbositySavings(db);
-  for (let i = 0; i < 20; i++) mkRun('alpha', null, 10, 999_999, 99);  // pre-flag rows, wildly expensive
-  const after = verbositySavings(db);
-  assert(after.normal.turns === before.normal.turns && after.terse.turns === before.terse.turns,
-    'pre-flag (NULL verbosity) rows count toward neither arm');
+  // Pre-flag rows are attributable to neither level. They are counted as `unstamped` rather than
+  // silently folded into `normal`, so the panel cannot overstate how far the flag has spread.
+  for (let i = 0; i < 5; i++) mkRun('alpha', null);
+  const s = verbosityAdoption(db).sessions;
+  assert(s.unstamped === 5 && s.normal === 6, 'un-stamped rows are their own bucket, not normal');
+  assert(agentRow('alpha').normal === 6 && agentRow('alpha').terse === 4, 'and they do not reach byAgent');
 }
 {
-  const before = verbositySavings(db).normal.sessions;
+  // Cost is no longer read at all, so a live, unpriced row is ordinary adoption data.
   db.prepare(`INSERT INTO term_sessions (id,agent,title,task,tmux,status,created_at,updated_at,turns,output_tokens,cost_usd,verbosity)
-              VALUES ('ts_live','alpha','t','x','aos-live','running',?,?,5,5000,NULL,'normal')`).run(Date.now(), Date.now());
-  assert(verbositySavings(db).normal.sessions === before, 'a live/uncosted row is excluded until it is priced');
+              VALUES ('ts_live','alpha','t','x','aos-live','running',?,?,5,5000,NULL,'terse')`).run(Date.now(), Date.now());
+  assert(agentRow('alpha').terse === 5, 'a running, uncosted run counts — adoption does not wait on a price');
 }
-
-// epsilon: real both-arm data, but outside the window.
-for (let i = 0; i < 10; i++) mkRun('epsilon', 'normal', 10, 10_000, 1.0, 90);
-for (let i = 0; i < 10; i++) mkRun('epsilon', 'terse', 10, 5_000, 0.5, 90);
+for (let i = 0; i < 10; i++) mkRun('epsilon', 'terse', 90);
 assert(!agentRow('epsilon', 30), 'the trailing window excludes older runs');
 assert(!!agentRow('epsilon', 120), 'and a wider window finds them again');
 

--- a/src/edge/verbosity.ts
+++ b/src/edge/verbosity.ts
@@ -12,10 +12,11 @@
 // compresses the transcript's NARRATION only and names the exempt surfaces explicitly.
 //
 // It is a prompt instruction, not an enforced transform: the model can ignore it, and compliance drifts
-// by model and by task. That is exactly why `verbositySavings` exists — the flag ships with the query
-// that can falsify it.
+// by model and by task. So the flag shipped beside a query that was meant to falsify it —
+// `verbositySavings()`, comparing the two arms' cost per turn on live traffic.
 //
-// AND IT DID. `npm run bench:verbosity` (scripts/verbosity-benchmark.cjs) ran the brief as a paired,
+// THAT QUERY WAS THE WRONG INSTRUMENT, and it has been retired (v0.389.0, see `verbosityAdoption`
+// below). What actually falsified the flag was a controlled experiment. `npm run bench:verbosity` (scripts/verbosity-benchmark.cjs) ran the brief as a paired,
 // controlled A/B — 14 tool-free prompts, both arms, claude-sonnet-5, 2 reps, tools disallowed so the
 // response is pure narration. The result: a mean per-prompt narration change of **-0.6% in a bare
 // system prompt and -4.6% behind the real 14k-token company context**, with terse the shorter arm on
@@ -24,20 +25,21 @@
 // from noise. Completeness was unharmed (terse 28/28 vs normal 26/28 minimal), so it is not trading
 // brevity for substance either — it is simply not landing.
 //
-// Two things the benchmark also established, both of which invalidate reading `verbositySavings` as
-// evidence about this brief:
+// Two things the benchmark also established, the first of which is why the live query had to go
+// rather than be caveated:
 //   - **`output_tokens` cannot measure narration.** Over 40 recent live transcripts the assistant's
 //     output bytes are ~85% `tool_use` ARGUMENTS (file writes, commands, patches) and ~15% `text`.
 //     Thinking is a further ~18% of the token counter. The brief compresses narration only, so even
 //     total compliance could not move `output_tokens` more than ~15% — and the ±50–90% per-agent
-//     swings the query reports on live data are tool-use volume, i.e. which task the agent drew.
+//     swings the retired query reported on live data were tool-use volume, i.e. which task the agent
+//     drew.
 //   - **The brief spends 72% of its words telling the model NOT to compress.** 123 words instruct
 //     brevity; 312 are carve-outs and reassurance ("terse is not vague", "completeness wins over
 //     length every time"). For contrast the `caveman` project's SKILL.md — concrete drop-lists, a
 //     pattern template, a worked before/after example — benchmarks at 65% on the same kind of
 //     paired harness.
-// Re-run the benchmark before changing the text below, and again after. Do not quote a saving from
-// `verbositySavings` alone.
+// Re-run the benchmark before changing the text below, and again after. There is no longer a live
+// query that will give you a saving figure, and that is deliberate.
 //
 // A REWRITE WAS TRIED AND REJECTED (v0.371.0). The obvious fix for the 72/28 ratio was written — a
 // named delete-list of filler words and constructions instead of "prefer a sentence to a paragraph",
@@ -140,115 +142,77 @@ export const TERSE_OUTPUT_BRIEF =
   'is asking for the explanation; give it to them properly. This is about cutting words that carry ' +
   'nothing, never about withholding substance or being blunt with people.';
 
-/** One arm of the comparison: what a set of sessions cost, per turn. */
-export interface VerbosityArm {
-  /** Sessions with usable cost data (a parsed transcript). */
-  sessions: number;
-  /** Conversation turns across them — the denominator. A run with more turns costs more for reasons
-   *  that have nothing to do with verbosity, so totals are not comparable; per-turn is. */
-  turns: number;
-  /** Mean output tokens per turn. NOT a measure of narration length — see the correction on
-   *  {@link verbositySavings}. `output_tokens` is dominated by tool-call arguments and thinking, both
-   *  of which the brief leaves untouched. */
-  outputPerTurn: number;
-  /** Mean total USD per turn — what actually lands on the bill (output is a minority of it). */
-  usdPerTurn: number;
-}
-
-export interface VerbosityComparison {
-  normal: VerbosityArm;
-  terse: VerbosityArm;
-  /** Percent reduction terse vs normal, positive = cheaper. Null when either arm is under-powered. */
-  outputDelta: number | null;
-  usdDelta: number | null;
-  /** True when both arms clear {@link MIN_SESSIONS_PER_ARM} — i.e. the deltas are worth reading. */
-  comparable: boolean;
-}
-
-export interface VerbositySavings extends VerbosityComparison {
-  /** Per-agent breakdown, only for agents that have run BOTH ways (the only fair comparison — see the
-   *  note on `verbositySavings`). Sorted by the agent with the most terse turns first. */
-  byAgent: Array<{ agent: string } & VerbosityComparison>;
-}
-
-/** Below this, an arm is noise: a couple of runs of different tasks say nothing about verbosity. */
-const MIN_SESSIONS_PER_ARM = 5;
-
-function arm(row: { sessions: number; turns: number; output: number; usd: number } | undefined): VerbosityArm {
-  const turns = row?.turns ?? 0;
-  return {
-    sessions: row?.sessions ?? 0,
-    turns,
-    outputPerTurn: turns ? Math.round((row?.output ?? 0) / turns) : 0,
-    usdPerTurn: turns ? +((row?.usd ?? 0) / turns).toFixed(4) : 0,
-  };
-}
-
-function compare(normal: VerbosityArm, terse: VerbosityArm): VerbosityComparison {
-  const comparable = normal.sessions >= MIN_SESSIONS_PER_ARM && terse.sessions >= MIN_SESSIONS_PER_ARM;
-  const pct = (a: number, b: number) => (comparable && a > 0 ? +(((a - b) / a) * 100).toFixed(1) : null);
-  return {
-    normal,
-    terse,
-    outputDelta: pct(normal.outputPerTurn, terse.outputPerTurn),
-    usdDelta: pct(normal.usdPerTurn, terse.usdPerTurn),
-    comparable,
-  };
+/**
+ * Adoption of the terse flag over a trailing window — WHO is running which level, and nothing more.
+ *
+ * This replaces `verbositySavings()`, which reported output-tokens-per-turn and USD-per-turn deltas
+ * between the two arms and presented them as a saving. That number was retired in v0.389.0 because it
+ * cannot mean what it was read to mean, and it was read that way: against the live instapods DB it
+ * called terse 28-92% WORSE on four of five agents, which was not evidence of anything.
+ *
+ * Three defects, none fixable from inside a query over `term_sessions`:
+ *
+ *  1. **Wrong quantity.** `output_tokens` is ~85% `tool_use` ARGUMENTS (file writes, commands,
+ *     patches) and ~15% `text`, with thinking a further ~18% of the counter (measured over 40 live
+ *     transcripts). The brief compresses narration only, so the metric barely contains the thing the
+ *     flag acts on; the large per-agent swings were tool-use volume, i.e. which task the agent drew.
+ *  2. **A denominator the treatment moves.** Terse changes turn SHAPE, so dividing by turns lets it
+ *     inflate its own per-turn number — `marketing-manager` read 92% worse per turn and 25% cheaper
+ *     per session, from the same rows.
+ *  3. **A cutover, not a split.** Every normal session predated 2026-08-07 and every terse one
+ *     followed it, so everything else that changed that day sat inside the treatment arm.
+ *
+ * The effect question is now answered by controlled experiment instead — `npm run bench:verbosity`
+ * (single-turn) and `npm run bench:verbosity-turns` (multi-turn), both paired, both shipping a
+ * bootstrap CI that refuses a verdict inside the noise. What they found: the brief is not
+ * distinguishable from no brief at all; per-turn reinforcement IS (+6.8%, CI [+0.5, +13.3]) but is
+ * worth ~$0.13/month fleet-wide, because narration is ~15% of output tokens and this moves ~7% of
+ * that. Terse is a style preference with a ~1% ceiling on spend, not a cost lever, and no console
+ * surface should imply otherwise.
+ *
+ * So what remains here is the honest half: how far the setting has actually spread. Useful for
+ * "which agents am I running terse?" and safe to read literally, because a count of rows is exactly
+ * what it claims to be.
+ */
+export interface VerbosityAdoption {
+  windowDays: number;
+  /** Sessions started in the window, by resolved level. `unstamped` are rows from before the flag
+   *  existed (or runs that never resolved one) — attributable to neither level. */
+  sessions: { normal: number; terse: number; unstamped: number };
+  /** Per-agent counts, most terse runs first. An agent appears once it has run at either level. */
+  byAgent: Array<{ agent: string; normal: number; terse: number }>;
 }
 
 /**
- * Compare what terse and normal sessions actually cost, per turn, over a trailing window.
- *
- * This is deliberately an OBSERVATIONAL comparison, not a claim of causation, and it is easy to fool
- * yourself with. Two guards are built in:
- *
- *  - **Per-turn, not per-session.** A long run costs more because it did more, not because it was
- *    wordy. Turns are the denominator (the same reasoning as any rate metric — a raw counter over a
- *    growing corpus tells you nothing about the present).
- *  - **`byAgent` only lists agents that ran BOTH ways.** The fleet-wide numbers are still confounded:
- *    if you flip your cron-heavy agents to terse, the terse arm is made of different WORK, and the
- *    delta measures that instead. The per-agent rows hold the agent fixed, so they are the numbers to
- *    trust; the top-line pair is context, not evidence.
- *
- * Even then, the model is different between the arms if you also changed it, and a flip is not
- * randomised. Read this as "did anything move", not as a verified saving.
- *
- * Reads only terminal, costed sessions (`turns > 0`), so a still-running row can't half-count.
+ * Count sessions by resolved verbosity over a trailing window. No cost, no tokens, no deltas — see
+ * the note above for why those were removed rather than caveated.
  */
-export function verbositySavings(db: DatabaseSync, windowDays = 30): VerbositySavings {
+export function verbosityAdoption(db: DatabaseSync, windowDays = 30): VerbosityAdoption {
   const since = Date.now() - windowDays * 86_400_000;
   // No tenant predicate: the DB file IS the tenant boundary, and term_sessions has no tenant column.
-  // A row predating this feature has verbosity NULL and cannot be attributed — it is neither arm.
   const rows = db
     .prepare(
-      `SELECT agent, verbosity,
-              COUNT(*)               AS sessions,
-              SUM(turns)             AS turns,
-              SUM(output_tokens)     AS output,
-              SUM(cost_usd)          AS usd
+      `SELECT agent, COALESCE(verbosity, '') AS verbosity, COUNT(*) AS n
          FROM term_sessions
-        WHERE created_at >= ? AND verbosity IN ('normal','terse')
-          AND cost_usd IS NOT NULL AND turns > 0
-        GROUP BY agent, verbosity`,
+        WHERE created_at >= ?
+        GROUP BY agent, COALESCE(verbosity, '')`,
     )
-    .all<{ agent: string; verbosity: string; sessions: number; turns: number; output: number; usd: number }>(since);
+    .all<{ agent: string; verbosity: string; n: number }>(since);
 
-  const perAgent = new Map<string, { normal?: typeof rows[number]; terse?: typeof rows[number] }>();
-  const totals: { normal?: { sessions: number; turns: number; output: number; usd: number }; terse?: { sessions: number; turns: number; output: number; usd: number } } = {};
+  const sessions = { normal: 0, terse: 0, unstamped: 0 };
+  const perAgent = new Map<string, { normal: number; terse: number }>();
   for (const r of rows) {
-    const key = r.verbosity === 'terse' ? 'terse' : 'normal';
-    const bucket = perAgent.get(r.agent) ?? {};
-    bucket[key] = r;
+    const level = r.verbosity === 'terse' ? 'terse' : r.verbosity === 'normal' ? 'normal' : 'unstamped';
+    sessions[level] += r.n;
+    if (level === 'unstamped') continue; // an unattributable row says nothing about adoption
+    const bucket = perAgent.get(r.agent) ?? { normal: 0, terse: 0 };
+    bucket[level] += r.n;
     perAgent.set(r.agent, bucket);
-    const t = totals[key] ?? { sessions: 0, turns: 0, output: 0, usd: 0 };
-    t.sessions += r.sessions; t.turns += r.turns; t.output += r.output ?? 0; t.usd += r.usd ?? 0;
-    totals[key] = t;
   }
 
   const byAgent = [...perAgent.entries()]
-    .filter(([, b]) => b.normal && b.terse) // both arms, or the row would compare an agent to itself
-    .map(([agent, b]) => ({ agent, ...compare(arm(b.normal), arm(b.terse)) }))
-    .sort((a, b) => b.terse.turns - a.terse.turns);
+    .map(([agent, b]) => ({ agent, ...b }))
+    .sort((a, b) => b.terse - a.terse || b.normal - a.normal || a.agent.localeCompare(b.agent));
 
-  return { ...compare(arm(totals.normal), arm(totals.terse)), byAgent };
+  return { windowDays, sessions, byAgent };
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,7 +52,7 @@ import { Consolidation, CONSOLIDATOR_ID } from './edge/consolidation';
 import { Digest } from './edge/digest';
 import { measureLearning } from './edge/measurement';
 import { buildInsights } from './edge/insights';
-import { verbositySavings } from './edge/verbosity';
+import { verbosityAdoption } from './edge/verbosity';
 import { buildImprovements } from './edge/improvements';
 import { Diagnosis, ANALYST_ID } from './edge/diagnosis';
 import { Improver, proposalSlug, IMPROVER_ID } from './edge/improver';
@@ -4570,13 +4570,16 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok: true, ...saved });
   }
 
-  // ── did terse output actually cost less? The measurement that ships WITH the verbosity flag, so the
-  //    claim can be checked against this workspace's own traffic instead of taken on faith. Read-only,
-  //    owner/admin (it exposes fleet-wide spend). `days` widens the trailing window.
-  if (method === 'GET' && p === '/api/settings/verbosity-savings') {
+  // ── how far has the terse flag actually spread? Counts only. The predecessor route
+  //    (/api/settings/verbosity-savings) reported cost-per-turn deltas and was retired in v0.389.0:
+  //    `output_tokens` is ~85% tool-call arguments, so it could not measure the narration the brief
+  //    acts on, and the console was rendering the result as a saving. The effect question belongs to
+  //    `npm run bench:verbosity` / `bench:verbosity-turns`, not to a query over live traffic.
+  //    Read-only, owner/admin. `days` widens the trailing window.
+  if (method === 'GET' && p === '/api/settings/verbosity-adoption') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
     const days = Math.max(1, Math.min(Math.floor(Number(url.searchParams.get('days')) || 30), 365));
-    return sendJson(res, 200, { windowDays: days, ...verbositySavings(os.db, days) });
+    return sendJson(res, 200, verbosityAdoption(os.db, days));
   }
 
   // ── fleet-wide sub-agent posture ('all' | 'none') — owner/admin only ──

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Separator } from '@/components/ui/separator'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu'
-import { api, isDraftTask, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type HostMetrics, type RequestMetricsSnapshot, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskChild, type TaskRun, type TaskPr, type TaskPrSummary, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskDiscussionDelivery, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type AgentProposalTrust, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type GoalUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbositySavings, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
+import { api, isDraftTask, EFFORTS, PERMISSION_MODES, type PermissionMode, type StateResp, type HostMetrics, type RequestMetricsSnapshot, type AgentInfo, type Session, type Msg, type Member, type Role, type TeamResp, type AgentAccess, type MemberIdentity, type IdentityProvider, IDENTITY_PROVIDERS, type Automation, type Task, type TaskEvent, type TaskAttachment, type TaskChild, type TaskRun, type TaskPr, type TaskPrSummary, type TaskTimelineEntry, type TaskDiscussionSummary, type TaskDiscussionDelivery, type TaskStatus, type AddTaskReq, type Goal, type GoalEvent, type GoalStatus, type GoalCounts, type GoalProgress, type AddGoalReq, type MemoryRecord, type MemoryHealth, type MemoryBackend, type MemorySettings, type MemorySettingsReq, type OllamaStatus, type KbPage, type KbRevision, type AgentRevision, type AgentStats, type AgentProposalTrust, type Recommendation, type DigestConfig, type DigestModel, type DreamingState, type Measurement, type Insights, type ImprovementTile, type MemoryCleanupPlan, type KbTidyPlan, type TaskReconcilePlan, type LibraryTidyPlan, type SessionTidyPlan, type StuckGoal, type TroubledAutomation, type PolicyDocument, type PolicyRule, type PolicyOutcome, type PolicyOp, type PolicyProposal, type PolicyRevision, type AutomationProposal, type AgentUpdateProposal, type GoalUpdateProposal, type DirListing, type FileEntry, type FileContent, type Artifact, type AppInfo, type AppFile, type AppCapabilities, type SkillSummary, type SkillsResp, type CatalogSkill, type CatalogAgent, type SkillSource, type RemoteSkill, type SkillshHit, type SkillRequest, type SecretRequest, type IntegrationsResp, type SlackStatus, type DiscordStatus, type TelegramStatus, type AuditEvent, type Effort, type RuntimeTuning, type RuntimeTuningPatch, type Verbosity, type VerbosityAdoption, type Concurrency, type RuntimeAccount, type RuntimeAccountKind, type RuntimeAccountsResp, type RuntimeLogin, type SecretMeta, type UpdateStatus, type UpdateApplyResult, type ActivityEvent, type ActivitySummaryRow, type SystemMetrics, type DepsReport, type DepStatus, type DepsInstallResult, type ChatTurn, type ChatArtifactRef, type ChatKbRef, type ChatAppRef, type RouterPreviewResp, type RouterCard, type SessionChain, type ChainNode, type ChainPending } from '@/lib/api'
 import { type Branding, type PublicBranding, type NotificationPrefs, DEFAULT_NOTIFICATION_PREFS, type PromptShortcut, type SessionMetrics, type Brief, type AutoApproval, type FeedItem, type FeedResponse, type FeedFilter, type TaskRunState, type GoalChatState } from '@/lib/api'
 import { applyAccent, applyFavicon, faviconDataUri, readableOn } from '@/lib/branding'
 import { ENTITY_ID_SRC, entityHref, isEntityId } from '@/lib/entity-links'
@@ -16481,52 +16481,51 @@ function KillSwitchCard({ me }: { me: Member }) {
   )
 }
 
-/** Did terse output actually cost less, on THIS workspace's traffic? Terse is a prompt instruction, not
- *  an enforced transform — the model can ignore it and compliance drifts by model and task — so the flag
- *  ships next to the number that can contradict it. Renders nothing until both arms have real runs. */
-function VerbositySavingsPanel() {
-  const [data, setData] = useState<VerbositySavings | null>(null)
-  useEffect(() => { api.verbositySavings().then((r) => { if (!r.error) setData(r) }).catch(() => {}) }, [])
+/** How far the terse flag has spread across this workspace — counts, not savings.
+ *
+ *  This panel used to render cost-per-turn and USD-per-turn deltas in green and amber. Those were
+ *  removed in v0.389.0 rather than caveated: `output_tokens` is ~85% tool-call arguments, so the
+ *  number never contained the narration the brief acts on, and against real traffic it swung ±50-90%
+ *  on tool-use volume alone — reading as a confident verdict either way. Whether terse WORKS is a
+ *  question for `npm run bench:verbosity` / `bench:verbosity-turns` (paired, controlled, CI that
+ *  refuses a verdict inside the noise), which measured its ceiling at ~1% of spend. What a console
+ *  can honestly show is who is running it. */
+function VerbosityAdoptionPanel() {
+  const [data, setData] = useState<VerbosityAdoption | null>(null)
+  useEffect(() => { api.verbosityAdoption().then((r) => { if (!r.error) setData(r) }).catch(() => {}) }, [])
   if (!data) return null
-  const { normal, terse } = data
-  if (!normal.sessions && !terse.sessions) return null // nothing has run under the flag yet
-
-  const pct = (v: number | null) => (v == null ? '—' : `${v > 0 ? '−' : '+'}${Math.abs(v)}%`)
-  const tone = (v: number | null) => (v == null ? 'text-muted-foreground' : v > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-amber-600 dark:text-amber-400')
+  const { normal, terse } = data.sessions
+  if (!normal && !terse) return null // nothing has run under the flag yet
 
   return (
     <div className="space-y-2 border-t pt-4">
-      <label className="text-sm font-medium">Terse output — measured, last {data.windowDays} days</label>
-      {!data.comparable ? (
-        <p className="text-sm text-muted-foreground">
-          {terse.sessions} terse and {normal.sessions} normal costed sessions so far — not enough of both to compare yet.
-          Numbers appear once each side has a handful of runs.
-        </p>
-      ) : (
-        <>
-          <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm">
-            <span className="text-muted-foreground">Output tokens / turn: <span className="font-mono">{normal.outputPerTurn.toLocaleString()} → {terse.outputPerTurn.toLocaleString()}</span> <span className={tone(data.outputDelta)}>{pct(data.outputDelta)}</span></span>
-            <span className="text-muted-foreground">USD / turn: <span className="font-mono">${normal.usdPerTurn.toFixed(3)} → ${terse.usdPerTurn.toFixed(3)}</span> <span className={tone(data.usdDelta)}>{pct(data.usdDelta)}</span></span>
-          </div>
-          <p className="text-[11px] text-muted-foreground">
-            Fleet-wide, this pair is <strong>confounded</strong>: if you flipped particular agents to terse, the two sides
-            are made of different work. The per-agent rows below hold the agent fixed — trust those.
-          </p>
-        </>
-      )}
+      <label className="text-sm font-medium">Terse output — where it is running, last {data.windowDays} days</label>
+      <div className="flex flex-wrap gap-x-6 gap-y-1 text-sm text-muted-foreground">
+        <span>Terse runs: <span className="font-mono text-foreground">{terse.toLocaleString()}</span></span>
+        <span>Normal runs: <span className="font-mono text-foreground">{normal.toLocaleString()}</span></span>
+        {data.sessions.unstamped > 0 && (
+          <span>Unstamped: <span className="font-mono">{data.sessions.unstamped.toLocaleString()}</span></span>
+        )}
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        Counts only. Terse is an output-style preference, not a cost control — measured against a
+        controlled benchmark its effect on spend is around <strong>1%</strong>, because narration is a
+        small share of what an agent emits. Run <code className="font-mono">npm run bench:verbosity</code> to
+        re-measure it; a comparison of live terse and normal runs cannot answer it, which is why the
+        old savings figures were removed.
+      </p>
       {data.byAgent.length > 0 && (
         <div className="overflow-x-auto">
           <table className="w-full text-xs">
             <thead className="text-muted-foreground">
-              <tr className="text-left"><th className="py-1 pr-4 font-medium">Agent</th><th className="py-1 pr-4 font-medium">Runs (normal/terse)</th><th className="py-1 pr-4 font-medium">Output / turn</th><th className="py-1 font-medium">USD / turn</th></tr>
+              <tr className="text-left"><th className="py-1 pr-4 font-medium">Agent</th><th className="py-1 pr-4 font-medium">Terse runs</th><th className="py-1 font-medium">Normal runs</th></tr>
             </thead>
             <tbody>
               {data.byAgent.map((a) => (
                 <tr key={a.agent} className="border-t">
                   <td className="py-1 pr-4 font-mono">{a.agent}</td>
-                  <td className="py-1 pr-4 text-muted-foreground">{a.normal.sessions}/{a.terse.sessions}</td>
-                  <td className="py-1 pr-4"><span className="font-mono">{a.normal.outputPerTurn.toLocaleString()} → {a.terse.outputPerTurn.toLocaleString()}</span> <span className={tone(a.outputDelta)}>{pct(a.outputDelta)}</span></td>
-                  <td className="py-1"><span className="font-mono">${a.normal.usdPerTurn.toFixed(3)} → ${a.terse.usdPerTurn.toFixed(3)}</span> <span className={tone(a.usdDelta)}>{pct(a.usdDelta)}</span></td>
+                  <td className="py-1 pr-4 font-mono">{a.terse.toLocaleString()}</td>
+                  <td className="py-1 font-mono">{a.normal.toLocaleString()}</td>
                 </tr>
               ))}
             </tbody>
@@ -16593,7 +16592,7 @@ function RuntimeDefaultsSettings({ me }: { me: Member }) {
           {hint && <span className="font-mono text-xs text-muted-foreground">{hint}</span>}
           {!hint && meta.updatedBy && <span className="text-[11px] text-muted-foreground">last set by {meta.updatedBy}</span>}
         </div>
-        <VerbositySavingsPanel />
+        <VerbosityAdoptionPanel />
         <div className="space-y-1 border-t pt-4">
           <label className="text-sm font-medium">Sub-agents</label>
           <p className="text-sm text-muted-foreground">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -61,26 +61,14 @@ export type RuntimeTuningPatch = {
   verbosity?: Verbosity | ''
 }
 
-/** One arm of the terse-vs-normal comparison, normalised per TURN (a longer run costs more because it
- *  did more, not because it was wordy). */
-export interface VerbosityArm {
-  sessions: number
-  turns: number
-  outputPerTurn: number
-  usdPerTurn: number
-}
-export interface VerbosityComparison {
-  normal: VerbosityArm
-  terse: VerbosityArm
-  /** Percent reduction terse vs normal (positive = cheaper). Null until both arms have enough runs. */
-  outputDelta: number | null
-  usdDelta: number | null
-  comparable: boolean
-}
-/** `byAgent` holds the agent fixed and is the number to trust; the top-line pair mixes different work. */
-export interface VerbositySavings extends VerbosityComparison {
+/** How far the terse flag has spread — counts only. The predecessor (`VerbositySavings`) carried
+ *  cost-per-turn deltas and was retired in v0.389.0: `output_tokens` is ~85% tool-call arguments, so
+ *  it never measured the narration the brief acts on. Whether terse WORKS is answered by
+ *  `npm run bench:verbosity` / `bench:verbosity-turns`, not by a query over live traffic. */
+export interface VerbosityAdoption {
   windowDays: number
-  byAgent: Array<{ agent: string } & VerbosityComparison>
+  sessions: { normal: number; terse: number; unstamped: number }
+  byAgent: Array<{ agent: string; normal: number; terse: number }>
   error?: string
 }
 
@@ -2028,7 +2016,7 @@ export const api = {
   agentRevert: (id: string, rev: number) => call<{ ok: boolean; id?: string; toRev?: number; rev?: number; error?: string }>('POST', `/api/agents/${encodeURIComponent(id)}/revert`, { rev }),
   runtimeDefaults: () => call<RuntimeTuning & { updatedAt?: number; updatedBy?: string; error?: string }>('GET', '/api/settings/runtime-defaults'),
   saveRuntimeDefaults: (tuning: RuntimeTuning) => call<{ ok: boolean; error?: string } & RuntimeTuning>('PUT', '/api/settings/runtime-defaults', tuning),
-  verbositySavings: (days = 30) => call<VerbositySavings>('GET', `/api/settings/verbosity-savings?days=${days}`),
+  verbosityAdoption: (days = 30) => call<VerbosityAdoption>('GET', `/api/settings/verbosity-adoption?days=${days}`),
   subagentDefault: () => call<{ mode: 'all' | 'none'; error?: string }>('GET', '/api/settings/subagent-default'),
   saveSubagentDefault: (mode: 'all' | 'none') => call<{ ok: boolean; mode?: 'all' | 'none'; error?: string }>('PUT', '/api/settings/subagent-default', { mode }),
   agentProposalTrust: () => call<{ trust: AgentProposalTrust; error?: string }>('GET', '/api/settings/agent-proposal-trust'),


### PR DESCRIPTION
## What

The verbosity flag shipped beside a query meant to falsify it — `verbositySavings()`, comparing terse and normal sessions' cost per turn on live traffic — and Settings → Runtime defaults rendered its deltas in green and amber. Four controlled benchmark runs established that the query cannot mean what it was read to mean, so it is **removed rather than caveated**.

## Why removal, not a caveat

Three defects, none fixable from inside a query over `term_sessions`:

1. **Wrong quantity.** `output_tokens` is ~85% `tool_use` arguments and ~18% thinking, so it barely contains the narration the brief compresses. Against the live instapods DB it called terse **28–92% worse** on four of five agents — that was tool-use volume, i.e. which task each agent happened to draw.
2. **A denominator the treatment moves.** Terse changes turn shape, so dividing by turns lets it inflate its own number. `marketing-manager` read 92% worse per turn and 25% *cheaper* per session, from the same rows.
3. **A cutover, not a split.** Every normal session predated 2026-08-07 and every terse one followed it.

A caveat under the numbers doesn't fix any of that — the panel still renders a confident red or green percentage, and that is what gets read.

## What replaces it

`verbosityAdoption()` — per-level session counts, per agent, over a trailing window. Pre-flag rows go in their own `unstamped` bucket rather than folding into `normal`, so the panel cannot overstate how far the flag has spread. A row count is a claim the data actually supports.

`GET /api/settings/verbosity-savings` → `GET /api/settings/verbosity-adoption`.

The panel's caption now states the measured ceiling — **~1% of spend**, because narration is a small share of what an agent emits — and points at `npm run bench:verbosity` for the effect question, which belongs to a controlled experiment rather than to a comparison of live runs that differ in what work they did.

## The part worth keeping

The nine removed test assertions were all **passing**. The per-turn arithmetic was correct throughout, including the guards against under-powered arms and against a longer terse run faking a regression. A well-tested number can still be the wrong number, and no amount of hygiene on the denominator turned `output_tokens` into a measure of narration.

## Scope

`TERSE_OUTPUT_BRIEF`, the flag, and its precedence chain are untouched — terse behaves exactly as before. It is just no longer described as a cost control.

`npm run test:governance` green (37/37 on `test:verbosity`, including the rewritten adoption section); `web` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)