### PR TITLE
fix(runtime): probe runtime presence without spawning a shell (v0.391.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.391.1] - 2026-08-25
+### Fixed
+- Runtime presence probing spawned `command -v` through a shell, so every Settings → Runtimes load
+  and every agent-config read logged Node's `DEP0190` shell-argument warning (and spawned one shell
+  per runtime). Resolution is now an in-process PATH walk — same answer, no child process, no warning.
+
 ## [0.391.0] - 2026-08-25
 ### Added
 - **Third coding runtime: `opencode`.** Selectable per agent (Agents → Runtime tuning → Runtime),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.391.0",
+  "version": "0.391.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.391.0",
+      "version": "0.391.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.391.0",
+  "version": "0.391.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/runtime-install.ts
+++ b/src/edge/runtime-install.ts
@@ -15,6 +15,8 @@
  *    real, persistent change to the host, not a per-session effect.
  */
 import { spawn, spawnSync } from 'node:child_process';
+import { accessSync, constants } from 'node:fs';
+import { join } from 'node:path';
 import { CODING_RUNTIMES, CodingRuntimeId, RuntimeId, isCodingRuntime } from '../types';
 
 export interface RuntimePresence {
@@ -36,11 +38,26 @@ function probePath(): string {
   return [...extra, process.env.PATH || ''].filter(Boolean).join(':');
 }
 
+/** Resolve `bin` against a PATH string the way execvp does — first directory holding an executable
+ *  file of that name wins. Done in-process on purpose: shelling out to `command -v` needs
+ *  `shell: true`, which Node now warns about (DEP0190) on every call, and spawning a shell to answer
+ *  "does this file exist" is a process per probe on a page the console loads often. */
+function which(bin: string, path: string): boolean {
+  for (const dir of path.split(':')) {
+    if (!dir) continue;
+    try {
+      accessSync(join(dir, bin), constants.X_OK);
+      return true;
+    } catch (_) { /* not here — keep looking */ }
+  }
+  return false;
+}
+
 /** Is `bin` on PATH, and at what version? Never throws. */
 function probe(bin: string): { installed: boolean; version?: string } {
-  const env = { ...process.env, PATH: probePath() };
-  const found = spawnSync('command', ['-v', bin], { env, shell: '/bin/bash', timeout: 5000, encoding: 'utf8' });
-  if (found.status !== 0) return { installed: false };
+  const path = probePath();
+  const env = { ...process.env, PATH: path };
+  if (!which(bin, path)) return { installed: false };
   const v = spawnSync(bin, ['--version'], { env, timeout: 10000, encoding: 'utf8' });
   const line = String(v.stdout || '').split('\n').map((s) => s.trim()).filter(Boolean)[0];
   return { installed: true, version: line || undefined };


### PR DESCRIPTION
Follow-up to #708, caught while verifying runtime detection on the live box.

`runtimePresence()` resolved each runtime's binary with `spawnSync('command', ['-v', bin], { shell: '/bin/bash' })`. Node now emits **`DEP0190`** for any `spawn` that passes args with `shell: true`:

> Passing args to a child process with shell option true can lead to security vulnerabilities, as the arguments are not escaped, only concatenated.

Not exploitable here — `bin` comes from the `CODING_RUNTIMES` constant table, never from caller input — but it printed on **every** Settings → Runtimes load and every agent-config read, and spawned one shell per runtime to answer "does this file exist".

Now resolved in-process, the way `execvp` does: walk the PATH string, first directory holding an executable of that name wins. No child process, no warning.

## Verification
- All three runtimes still detected with identical versions on this box (Claude Code 2.1.245, Codex 0.146.0, opencode 1.17.11), warning gone
- Missing-binary path still reports `installed: false` rather than crashing
- `npm run test:governance` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)