### PR TITLE
fix(runtime): install runtimes into a writable, on-PATH prefix (v0.391.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.391.2] - 2026-08-25
+### Fixed
+- **Runtime install failed on any box with a root-owned npm prefix**, which is the standard
+  NodeSource/apt layout: `npm install -g` targeted `/usr`, and the server — a non-root user, usually
+  under `ProtectSystem=strict` — cannot write there, so Install died with
+  `ENOENT … mkdir '/usr/lib/node_modules/<pkg>'`. Installs now go to `~/.local`, which the service user
+  can write, which is inside the hardened unit's `ReadWritePaths`, and whose `bin` is already the FIRST
+  entry of both the presence probe and the PATH every launch script exports — so the installed CLI is
+  the one the console reports AND the one a session runs.
+
 ## [0.391.1] - 2026-08-25
 ### Fixed
 - Runtime presence probing spawned `command -v` through a shell, so every Settings → Runtimes load

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.391.1",
+  "version": "0.391.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.391.1",
+      "version": "0.391.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.391.1",
+  "version": "0.391.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/edge/runtime-install.ts
+++ b/src/edge/runtime-install.ts
@@ -15,7 +15,7 @@
  *    real, persistent change to the host, not a per-session effect.
  */
 import { spawn, spawnSync } from 'node:child_process';
-import { accessSync, constants } from 'node:fs';
+import { accessSync, constants, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { CODING_RUNTIMES, CodingRuntimeId, RuntimeId, isCodingRuntime } from '../types';
 
@@ -34,8 +34,25 @@ export interface RuntimePresence {
 /** The PATH a launched session gets (see the launch scripts) — probe with the SAME one, or the
  *  console reports "missing" for a CLI the agent would in fact find, and vice versa. */
 function probePath(): string {
-  const extra = [`${process.env.HOME}/.local/bin`, '/opt/homebrew/bin', '/usr/local/bin'];
-  return [...extra, process.env.PATH || ''].filter(Boolean).join(':');
+  return [`${installPrefix()}/bin`, '/opt/homebrew/bin', '/usr/local/bin', process.env.PATH || '']
+    .filter(Boolean).join(':');
+}
+
+/**
+ * Where a console-driven install puts the CLI.
+ *
+ * NOT npm's own global prefix. On the common NodeSource/apt layout that is `/usr`, which the server
+ * cannot write: it runs as a non-root user, usually under `ProtectSystem=strict`, so `npm install -g`
+ * dies with `ENOENT … mkdir '/usr/lib/node_modules/<pkg>'` and the Install button is simply broken on
+ * every such box (seen live on a tenant box, 2026-08-25).
+ *
+ * `~/.local` is writable by the service user, is already inside the hardened unit's
+ * `ReadWritePaths=/home/<svc>`, and — the part that makes it correct rather than merely convenient —
+ * `~/.local/bin` is the FIRST entry of both {@link probePath} and the PATH every launch script
+ * exports. So a CLI installed here is the one the probe reports AND the one a session actually runs.
+ */
+function installPrefix(): string {
+  return join(process.env.HOME || '/tmp', '.local');
 }
 
 /** Resolve `bin` against a PATH string the way execvp does — first directory holding an executable
@@ -94,8 +111,12 @@ export function installRuntime(id: string, timeoutMs = 300_000): Promise<Install
     let out = '';
     let done = false;
     const finish = (r: InstallResult) => { if (!done) { done = true; resolve(r); } };
+    const prefix = installPrefix();
+    // npm reads every flag from `npm_config_*` too, so the prefix rides the ENV rather than being
+    // spliced into a constant argv — one mechanism that works for any npm-shaped install command.
+    try { mkdirSync(join(prefix, 'bin'), { recursive: true }); } catch (_) { /* npm will report it */ }
     const child = spawn(cmd, args, {
-      env: { ...process.env, PATH: probePath() },
+      env: { ...process.env, PATH: probePath(), npm_config_prefix: prefix },
       shell: false,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -112,7 +133,7 @@ export function installRuntime(id: string, timeoutMs = 300_000): Promise<Install
       // session immediately contradicts.
       const after = probe(spec.bin);
       if (after.installed) finish({ ok: true, version: after.version });
-      else finish({ ok: false, error: out.trim() || `${spec.bin} is still not on PATH after \`${spec.install.join(' ')}\`` });
+      else finish({ ok: false, error: out.trim() || `${spec.bin} is still not on PATH after \`${spec.install.join(' ')}\` (prefix ${prefix})` });
     });
   });
 }


### PR DESCRIPTION
Hit live on a tenant box right after #708/#709 went out. Clicking **Install** on Settings → Runtime → Runtimes failed:

```
npm error code ENOENT
npm error syscall mkdir
npm error path /usr/lib/node_modules/opencode-ai
npm error enoent ENOENT: no such file or directory, mkdir '/usr/lib/node_modules/opencode-ai'
```

## Cause

`npm install -g` targets npm's own global prefix. On that box — and on **any** standard NodeSource/apt layout — `npm prefix -g` is **`/usr`**. The server runs as a non-root user (`User=ubuntu`) under `ProtectSystem=strict`, so it cannot write `/usr/lib/node_modules`. The Install button was therefore broken on every such box, which is most Linux deploys.

(The Mac Mini didn't show it: homebrew's prefix is user-writable, so all three runtimes installed fine there.)

## Fix

Install into **`~/.local`** via `npm_config_prefix` (npm's env form of `--prefix`, so no argv surgery on the constant install command).

`~/.local` isn't just "somewhere writable" — it's the *correct* target on three counts:

1. writable by the service user, no root needed
2. already inside the hardened unit's `ReadWritePaths=/home/<svc>`
3. **`~/.local/bin` is the FIRST entry of both `probePath()` and the PATH every launch script exports**

So the CLI that gets installed is the one the console reports *and* the one a session actually runs — no chance of installing to a place the probe can't see, or of the probe reporting a different binary than the agent executes.

The failure message now also names the prefix, so a future failure says where it tried.

## Verification

Ran the real install against a throwaway `HOME`:

```
install -> {"ok":true,"version":"1.18.23"}
$HOME/.local/bin/opencode -> ../lib/node_modules/opencode-ai/bin/opencode.exe
```

The probe reported **1.18.23** — the freshly installed copy — ahead of the box's own homebrew 1.17.11, confirming the intended precedence.

`npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)