### PR TITLE
feat(agents): pick the runtime when creating an agent (v0.392.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.392.0] - 2026-08-25
+### Added
+- **Pick the runtime when creating an agent** (New agent → Runtime). `POST /api/agents` hardcoded
+  `runtime: 'claude-code'` and the create form had no picker, so the only way to get a Codex or
+  opencode agent was to create a Claude one and switch it afterwards. The field is optional and still
+  defaults to `claude-code`, so existing callers are unaffected. Tuning is validated against the chosen
+  runtime, so a cross-family model (the form's `opus` pre-fill on opencode) is refused at creation
+  instead of at the first launch, and the form clears it on switch. The create page shows the same
+  install prompt as the edit page when the box lacks that runtime's CLI.
+
 ## [0.391.2] - 2026-08-25
 ### Fixed
 - **Runtime install failed on any box with a root-owned npm prefix**, which is the standard

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.391.2",
+  "version": "0.392.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.391.2",
+      "version": "0.392.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.391.2",
+  "version": "0.392.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4213,7 +4213,14 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const claudeMd = String(b.claudeMd ?? '');
     // model/effort are per-agent overrides — each optional (omit → inherit the workspace default at
     // launch). Validate effort against the CLI's value set.
-    const { tuning, error: tErr } = sanitizeRuntimeTuning(b);
+    // The runtime an agent is BORN on. Defaults to claude-code (what every agent got before the picker
+    // existed), but it has to be settable here: it used to be hardcoded, so a Codex/opencode agent could
+    // only be made by creating a Claude one and switching it afterwards.
+    const runtime = (b.runtime === undefined || b.runtime === '') ? 'claude-code' : String(b.runtime) as RuntimeId;
+    if (!isCodingRuntime(runtime)) return sendJson(res, 400, { error: `runtime must be one of: ${Object.keys(CODING_RUNTIMES).join(', ')}` });
+    // Validate the tuning AGAINST that runtime, so a model belonging to another CLI is refused at
+    // creation rather than at the first launch (`opus` on Codex, a bare `claude-*` on opencode, …).
+    const { tuning, error: tErr } = sanitizeRuntimeTuning(b, runtime);
     if (tErr) return sendJson(res, 400, { error: tErr });
     // No forced model default: a blank field means "inherit the workspace default" (Settings →
     // Runtime defaults), same as effort/permission. The create form pre-fills the `opus` alias (which
@@ -4236,7 +4243,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       ...(category ? { category } : {}),
       principal: `svc-${id}`,
       policyContext: 'default@v3',
-      runtime: 'claude-code',
+      runtime,
       ...tuning,
       ...(examplePrompts ? { examplePrompts } : {}),
       ...(shellSecrets ? { shellSecrets } : {}),
@@ -4247,7 +4254,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     fs.writeFileSync(path.join(folder, 'agent.json'), JSON.stringify(manifest, null, 2) + '\n');
     fs.writeFileSync(path.join(folder, 'CLAUDE.md'), claudeMd);
     os.registerAgent({ ...manifest, dir: folder });
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.created', data: { agent: id, runtime: 'claude-code', dir: folder } });
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'agent.created', data: { agent: id, runtime, dir: folder } });
     return sendJson(res, 200, { ok: true, id });
   }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -12867,6 +12867,12 @@ function NewAgentPage({ me, onCreated }: { me: Member; onCreated: (id: string) =
   const [prompts, setPrompts] = useState('')
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
+  // The runtime the agent is BORN on. This used to be hardcoded server-side, so the only way to get a
+  // Codex/opencode agent was to create a Claude one and switch it afterwards.
+  const [runtime, setRuntime] = useState('claude-code')
+  const [runtimes, setRuntimes] = useState<RuntimePresence[]>([])
+  const [installing, setInstalling] = useState('')
+  useEffect(() => { api.runtimes().then((r) => { if (!r.error) setRuntimes(r.runtimes ?? []) }).catch(() => {}) }, [])
 
   if (me.role !== 'owner' && me.role !== 'admin') {
     return <div className="text-sm text-muted-foreground">Creating agents requires owner or admin.</div>
@@ -12879,7 +12885,7 @@ function NewAgentPage({ me, onCreated }: { me: Member; onCreated: (id: string) =
   const create = async () => {
     setBusy(true); setHint('')
     const examplePrompts = prompts.split('\n').map((s) => s.trim()).filter(Boolean)
-    const r = await api.createAgent({ id: slug, description: description.trim(), category: category.trim(), icon, claudeMd, examplePrompts, ...tuning })
+    const r = await api.createAgent({ id: slug, description: description.trim(), category: category.trim(), icon, claudeMd, examplePrompts, runtime, ...tuning })
     setBusy(false)
     if (!r.ok || r.error) return setHint('⚠ ' + (r.error || 'failed to create agent'))
     onCreated(r.id || slug)
@@ -12924,7 +12930,60 @@ function NewAgentPage({ me, onCreated }: { me: Member; onCreated: (id: string) =
             <p className="text-[11px] text-muted-foreground">Optional. The first becomes the spawn box’s prefill; the rest are one-click chips. Up to 6.</p>
           </div>
           <div className="space-y-1">
-            <TuningFields tuning={tuning} onChange={setTuning} modelPlaceholder="opus" />
+            {runtimes.length > 1 && (
+              <div className="space-y-1">
+                <label className="text-xs font-medium">Runtime</label>
+                <select
+                  value={runtime}
+                  onChange={(e) => {
+                    const next = e.target.value
+                    setRuntime(next)
+                    // The form pre-fills the Claude `opus` alias, which every other runtime rejects —
+                    // so clear a model that belongs to the runtime being left rather than letting the
+                    // server 400 on submit. Blank = inherit the workspace default.
+                    const m = tuning.model
+                    if (m) {
+                      const foreign = next === 'opencode' ? !m.includes('/')
+                        : next === 'codex' ? /^(claude|opus|sonnet|haiku|fable)\b/i.test(m)
+                        : /^(gpt|o[0-9]|codex|glm|kimi|deepseek)\b/i.test(m)
+                      if (foreign) setTuning((t) => ({ ...t, model: undefined }))
+                    }
+                    if (next !== 'claude-code') setTuning((t) => ({ ...t, permissionMode: undefined }))
+                  }}
+                  className="w-full rounded-md border bg-background px-2 py-1.5 text-sm"
+                >
+                  {runtimes.map((r) => <option key={r.id} value={r.id}>{r.label}</option>)}
+                </select>
+                {(() => {
+                  const info = runtimes.find((x) => x.id === runtime)
+                  if (!info || info.installed) return null
+                  // Creating an agent on a runtime this box lacks would produce an agent whose every
+                  // session parks on "the CLI is not on PATH". Offer the install here, as the edit
+                  // page does.
+                  return (
+                    <div className="space-y-1 rounded-md border border-amber-500/40 bg-amber-500/5 p-2">
+                      <p className="text-[11px] text-amber-700 dark:text-amber-500"><b>{info.label}</b> is not installed on this box, so sessions on it cannot start.</p>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          size="sm" variant="outline" className="h-6 text-[11px]" disabled={!!installing || me.role !== 'owner'}
+                          onClick={async () => {
+                            setInstalling(info.id); setHint('')
+                            const r = await api.installRuntime(info.id)
+                            setInstalling('')
+                            if (r.error || !r.ok) { setHint('⚠ ' + (r.error || 'install failed')); return }
+                            const list = await api.runtimes()
+                            setRuntimes(list.runtimes ?? [])
+                          }}
+                        >{installing === info.id ? 'Installing…' : `Install ${info.label}`}</Button>
+                        <code className="text-[10px] text-muted-foreground">{info.install}</code>
+                      </div>
+                      {me.role !== 'owner' && <p className="text-[11px] text-muted-foreground">An owner can install it.</p>}
+                    </div>
+                  )
+                })()}
+              </div>
+            )}
+            <TuningFields tuning={tuning} onChange={setTuning} modelPlaceholder={runtime === 'claude-code' ? 'opus' : 'inherit'} />
             <p className="text-[11px] text-muted-foreground">Per-agent overrides. Leave effort/permission on <span className="font-mono">inherit</span> to follow the workspace default (Settings → Runtime defaults). The gate-hook governs regardless of permission mode.</p>
           </div>
           <div className="space-y-1">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2017,7 +2017,7 @@ export const api = {
   taskReconcilePreview: () => call<{ ok: boolean; plan?: TaskReconcilePlan; error?: string }>('GET', '/api/insights/tasks/reconcile'),
   taskReconcileApply: () => call<{ ok: boolean; closed?: number; error?: string }>('POST', '/api/insights/tasks/reconcile'),
 
-  createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
+  createAgent: (input: { id: string; description: string; category?: string; claudeMd: string; examplePrompts?: string[]; shellSecrets?: string[]; icon?: string; runtime?: string } & RuntimeTuning) => call<{ ok: boolean; id?: string; error?: string }>('POST', '/api/agents', input),
   deleteAgent: (id: string) => call<{ ok: boolean; error?: string }>('DELETE', `/api/agents/${encodeURIComponent(id)}`),
   duplicateAgent: (id: string, newId: string) => call<{ ok: boolean; id?: string; error?: string }>('POST', `/api/agents/${encodeURIComponent(id)}/duplicate`, { newId }),
   agentCatalog: () => call<AgentCatalogResp>('GET', '/api/agents/catalog'),


### PR DESCRIPTION
Reported from the console: **"can't see harness option in `/#/new-agent`"** — correct, there wasn't one.

#708 shipped three runtimes, but the **create** path never got a picker: `POST /api/agents` hardcoded

```ts
runtime: 'claude-code',
```

and `NewAgentPage` had no runtime state at all, so it never sent one. The only way to get a Codex or opencode agent was to create a Claude one and switch it on the edit page afterwards.

## Change

- `POST /api/agents` accepts an optional `runtime`, validated against `CODING_RUNTIMES`. **Still defaults to `claude-code`**, so every existing caller and script is unaffected.
- Tuning is validated **against the chosen runtime**. This matters because the create form pre-fills the Claude `opus` alias — on opencode that used to be accepted and then break the first launch. Now it's a 400 at creation with the suggestion list, and the picker clears a cross-family model on switch (same rule as the edit page).
- The create page carries the same **not-installed → Install** prompt as the edit page, so you can't create an agent on a runtime whose CLI the box lacks without being told.
- `agent.created` audit now records the real runtime instead of always logging `claude-code`.

## Verification

End to end against a real server (`TenantRegistry` + `createHttpServer`):

```
opencode     model=anthropic/claude-opus-4-8  -> 200 runtime=opencode
codex        model=gpt-5-codex                -> 200 runtime=codex
claude-code  model=opus                       -> 200 runtime=claude-code
opencode     model=opus                       -> 400 "opus" is not an opencode model. Try one of: anthrop…
bogus        model=x                          -> 400 runtime must be one of: claude-code, codex, opencode
undefined    model=opus                       -> 200 runtime=claude-code
```

`npm run test:governance` green; both bundles build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)