### PR TITLE
docs(console): use cases in the Docs manual (v0.393.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.393.0] - 2026-08-25
+### Added
+- **Use cases are in the console manual** (Docs → Use cases, second in the list, right after Getting
+  started). The catalog shipped in v0.386.0 as `docs/use-cases.md` — a repo file reachable only from
+  the README's docs table — so the one page written to answer "what do I automate first?" was
+  invisible to the people asking it, who are in the console, not the GitHub tree. The console Docs
+  nav is a hand-maintained list (`web/src/docs/index.ts`); the page had no entry in it.
+
+### Changed
+- **`docs/use-cases.md` moved to `web/src/docs/use-cases.md`** rather than being copied, so there is
+  one source of truth instead of two 500-line files free to drift. The README's docs table points at
+  the new path. Body text is unchanged; only the five cross-doc links were retargeted from repo-relative
+  paths (`governance-model.md`) to in-console routes (`#/docs/governance`) — `mdComponents.a` opens any
+  non-`#` href in a NEW TAB, so left as they were those links would have opened a blank tab on a
+  nonexistent relative URL.
+
 ## [0.392.0] - 2026-08-25
 ### Added
 - **Pick the runtime when creating an agent** (New agent → Runtime). `POST /api/agents` hardcoded

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ curl -fsSL https://raw.githubusercontent.com/vikasprogrammer/agentric/main/scrip
 
 | Doc | What is in it |
 |---|---|
-| [`docs/use-cases.md`](docs/use-cases.md) | What to automate first — proven agent shapes, triggers, and safety postures |
+| [`web/src/docs/use-cases.md`](web/src/docs/use-cases.md) | What to automate first — proven agent shapes, triggers, and safety postures (also in the console under **Docs → Use cases**) |
 | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | The design rationale and the gateway spine |
 | [`docs/PILLARS.md`](docs/PILLARS.md) | Every product pillar and its real implementation status |
 | [`docs/governance-model.md`](docs/governance-model.md) | Policy, approvals, budgets, identity |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.392.0",
+  "version": "0.393.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.392.0",
+      "version": "0.393.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.392.0",
+  "version": "0.393.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/docs/index.ts
+++ b/web/src/docs/index.ts
@@ -3,6 +3,7 @@
 // build time via Vite ?raw imports; adding a page = add the .md file + one entry here.
 import whatIsAgentric from './what-is-agentric.md?raw'
 import gettingStarted from './getting-started.md?raw'
+import useCases from './use-cases.md?raw'
 import coreConcepts from './core-concepts.md?raw'
 import workingWithAgents from './working-with-agents.md?raw'
 import automations from './automations.md?raw'
@@ -18,6 +19,7 @@ export type DocPage = { slug: string; title: string; body: string }
 export const docPages: DocPage[] = [
   { slug: 'what-is-agentric', title: 'What is Agentric?', body: whatIsAgentric },
   { slug: 'getting-started', title: 'Getting started', body: gettingStarted },
+  { slug: 'use-cases', title: 'Use cases', body: useCases },
   { slug: 'core-concepts', title: 'Core concepts', body: coreConcepts },
   { slug: 'working-with-agents', title: 'Working with agents', body: workingWithAgents },
   { slug: 'automations', title: 'Automations', body: automations },

--- a/web/src/docs/use-cases.md
+++ b/web/src/docs/use-cases.md
@@ -443,7 +443,7 @@ loosen it after the agent has a track record you have personally reviewed.
 The postures are conventions you write into the agent's prompt. What **enforces** them is the policy
 layer — capabilities the agent may use, which ones stop for a human, and at what approval level. Write
 the posture into the prompt so the agent understands its job, and into policy so the boundary holds even
-if the prompt is ignored. See [`docs/governance-model.md`](governance-model.md).
+if the prompt is ignored. See [Governance & approvals](#/docs/governance).
 
 ---
 
@@ -532,10 +532,10 @@ Honest failure modes, so you can skip them:
 
 ## Related
 
-| Document | What it covers |
+| Page | What it covers |
 |---|---|
-| [`docs/governance-model.md`](governance-model.md) | Policy, approvals, budgets, identity — what enforces a posture |
-| [`docs/agent-mcp-tools.md`](agent-mcp-tools.md) | Every tool an agent can call, and its governance notes |
-| [`docs/connectors-and-triggers.md`](connectors-and-triggers.md) | Wiring schedules, webhooks and chat triggers |
-| [`docs/tasks-plan.md`](tasks-plan.md) | The task queue and the delegation model |
-| [`docs/memory-model.md`](memory-model.md) | How an agent gets better at its job over time |
+| [Governance & approvals](#/docs/governance) | Policy, approvals, budgets, identity — what enforces a posture |
+| [Working with agents](#/docs/working-with-agents) | Every tool an agent can call, and its governance notes |
+| [Automations](#/docs/automations) | Wiring schedules, webhooks and chat triggers |
+| [Memory, Knowledge & Tasks](#/docs/shared-planes) | The task queue and the delegation model |
+| [Memory, Knowledge & Tasks](#/docs/shared-planes) | How an agent gets better at its job over time |


### PR DESCRIPTION
## What

The use-case catalog shipped in v0.386.0 as `docs/use-cases.md` — a repo file reachable only from the README's docs table. The console Docs nav is a separate, hand-maintained list (`web/src/docs/index.ts`), and the page had no entry in it. So the one page written to answer *"what do I automate first?"* was invisible to the people asking it, who are in the console, not the GitHub tree.

Registered as **Use cases**, second in the nav, right after Getting started.

## Moved, not copied

Two 500-line copies of the same doc are free to drift, so the file was `git mv`'d into `web/src/docs/` and the README's docs table now points at the new path.

Body text is unchanged (verbatim). The only edits are 7 lines: the five cross-doc links, retargeted from repo-relative paths to in-console routes, plus the Related table's header word.

That retarget is load-bearing, not cosmetic — `mdComponents.a` in `web/src/App.tsx` routes a `#`-prefixed href in place and opens **every other href in a new tab**. Left as `(governance-model.md)`, each of those links would have opened a blank tab on a nonexistent relative URL.

`docs/agent-mcp-tools.md`, `docs/connectors-and-triggers.md`, `docs/tasks-plan.md` and `docs/memory-model.md` have no exact console counterpart, so they point at the nearest manual page (Working with agents, Automations, Memory/Knowledge/Tasks). Two Related rows therefore share a target with different descriptions.

## Verification

- `npm run typecheck` clean
- `cd web && npm run build` clean — the `?raw` import bundles
- `npm run test:governance` — full suite green (version-sync included, bumped with `npm version`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)