### PR TITLE
docs(console): merge the duplicated Related row in Use cases (v0.393.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.393.1] - 2026-08-25
+### Fixed
+- **Docs → Use cases: the Related table no longer lists the same page twice.** The move into the
+  console collapsed five repo docs onto four manual pages, so `tasks-plan.md` and `memory-model.md`
+  both resolved to Memory, Knowledge & Tasks and the table shipped two rows with one destination.
+  Merged into a single row carrying both descriptions.
+
 ## [0.393.0] - 2026-08-25
 ### Added
 - **Use cases are in the console manual** (Docs → Use cases, second in the list, right after Getting

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.393.0",
+  "version": "0.393.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.393.0",
+      "version": "0.393.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.393.0",
+  "version": "0.393.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/docs/use-cases.md
+++ b/web/src/docs/use-cases.md
@@ -537,5 +537,4 @@ Honest failure modes, so you can skip them:
 | [Governance & approvals](#/docs/governance) | Policy, approvals, budgets, identity — what enforces a posture |
 | [Working with agents](#/docs/working-with-agents) | Every tool an agent can call, and its governance notes |
 | [Automations](#/docs/automations) | Wiring schedules, webhooks and chat triggers |
-| [Memory, Knowledge & Tasks](#/docs/shared-planes) | The task queue and the delegation model |
-| [Memory, Knowledge & Tasks](#/docs/shared-planes) | How an agent gets better at its job over time |
+| [Memory, Knowledge & Tasks](#/docs/shared-planes) | The task queue and the delegation model, and how an agent gets better at its job over time |


### PR DESCRIPTION
Follow-up to #712.

Moving the use-case catalog into the console collapsed five repo docs onto four manual pages — `docs/tasks-plan.md` and `docs/memory-model.md` both resolve to **Memory, Knowledge & Tasks** — so the Related table shipped two rows with one destination.

Merged into a single row carrying both descriptions.

`cd web && npm run build` clean; `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)