### PR TITLE
fix(memory): recall the agent's own text, not the backend's rewrite (v0.398.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,33 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.398.0] - 2026-08-27
+### Fixed
+- **Agents recalled a paraphrase of their own memories.** A recall backend may transform the text it is
+  handed, and automem does: over `MEMORY_CONTENT_SOFT_LIMIT` (500 chars by default) with an LLM
+  configured, it replaces `content` with a ~300-char summary and **discards the original**. instawp's
+  average memory is 1305 chars, so **81%** of sampled recall hits existed nowhere in the mirror — a note
+  reading "Bunny edge-rule QA cannot be done on a `*.instawp.site` sandbox — it resolves to the PPU/OVH
+  origin and never traverses Bunny's edge…" came back as "Bunny edge-rule QA limitations. Testing on
+  `*.instawp.site` fails…", losing every exact command and `.env` name that made it worth storing. The
+  two stores also disagreed: Dreaming, consolidation and the Memory-hub read the mirror's original while
+  agents recalled the summary. `MirroredMemoryProvider.recall` now serves `content` from the mirror
+  whenever it holds that id; **ranking, ordering and score stay entirely the backend's**, and a record
+  the mirror has never seen passes through untouched, so this can only add fidelity. Backend-agnostic —
+  it holds for any store that rewrites, not just this setting. (instapods was unaffected: no LLM
+  configured there, so nothing was ever rewritten.)
+
+### Added
+- **`scripts/make-live.sh` deploys tenants on OTHER boxes.** A tenant reached over ssh (Linux/systemd)
+  now goes in `AOS_LIVE_REMOTE_TARGETS` as `tenant:ssh:checkout:port[:unit]`, alongside the existing
+  local `AOS_LIVE_TARGETS` — it was being deployed by hand, which is how one box sat 5 versions behind
+  while "make it live" reported success. Remote targets keep every guarantee the local lane has: preflight
+  (reachable without a password prompt, checkout present, unit known, node found) before anything is
+  touched; **every** checkout — local and remote — synced, built and tested before **any** service is
+  restarted; the running process must report the version just built; and a failure prints the exact
+  rollback command plus that box's journal. `--only` and `--dry-run` span both lanes, and a deployment
+  whose tenants are all remote no longer has a phantom local target invented for it.
+
 ## [0.397.0] - 2026-08-27
 ### Fixed
 - **Memory upkeep on an external backend pruned only half the store.** `MirroredMemoryProvider.maintain`

--- a/docs/memory-layer-plan.md
+++ b/docs/memory-layer-plan.md
@@ -589,6 +589,37 @@ would make the local ledger claim memories recall can never return. Pinned by
 **Note for existing automem tenants:** upkeep is still opt-in and no tenant has it enabled, so the
 historical duplicates are not removed by this change — it only makes the knob safe to turn on.
 
+### 17.2 Recall fidelity — the backend ranks, the mirror is the record (2026-08-27)
+
+A recall backend is free to transform the text it is handed, and automem does. Over
+`MEMORY_CONTENT_SOFT_LIMIT` (**500 chars** by default) with an LLM configured, `MEMORY_AUTO_SUMMARIZE`
+replaces `content` with a ~300-char LLM summary and **discards the original**
+(`automem/api/memory.py`). instawp's average memory is **1305 chars**, so most of that store was being
+rewritten at ingest — **81%** of sampled recall hits existed nowhere in the mirror. What an agent stored as
+
+> Bunny edge-rule QA cannot be done on a `*.instawp.site` sandbox — it resolves to the PPU/OVH origin and
+> never traverses Bunny's edge, so every probe returns 200 …
+
+came back from recall as *"Bunny edge-rule QA limitations. Testing on `*.instawp.site` fails…"* — same id,
+same ranking, none of the specifics that made it worth storing. And the two stores then disagreed:
+Dreaming, the consolidation gardener and the Memory-hub read the mirror's original while agents recalled
+the paraphrase.
+
+instapods was unaffected: no OpenAI client is configured there (local 384-dim embedder), so the
+summarizer returns `None` and content is kept verbatim — 2% divergence against instawp's 81%.
+
+`MirroredMemoryProvider.recall` now overlays each returned record's `content` from the mirror when the
+mirror holds that id (`SqliteMemoryProvider.contentByIds`). **Ranking, ordering and score stay entirely
+the backend's** — the embedding is computed over whatever the backend holds either way, so retrieval
+quality is untouched and only the text handed to the agent is restored. A record the mirror has never
+seen (stored before mirroring, or written straight to the backend) passes through unchanged, so this can
+only add fidelity, never drop a result. Best-effort: a mirror failure returns the backend's records as-is.
+
+Backend-agnostic on purpose — it holds for any future store that rewrites, not just this automem setting.
+Turning the setting off (`MEMORY_AUTO_SUMMARIZE=false`, or raising `MEMORY_CONTENT_SOFT_LIMIT` to the hard
+limit) is still worth doing on a rewriting deployment, since it stops paying an LLM call per write.
+Pinned by `scripts/memory-upkeep-test.cjs`.
+
 ## 18. Shared-scope memory — Phase 0 toward a KB (2026-06-23)
 
 Full plan + as-built deviations: [`shared-memory-phase0-plan.md`](./shared-memory-phase0-plan.md) (✅ shipped).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.397.0",
+  "version": "0.398.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.397.0",
+      "version": "0.398.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.397.0",
+  "version": "0.398.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/make-live.sh
+++ b/scripts/make-live.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# "Make it live" — deploy origin/main to this macOS box's tenant services.
+# "Make it live" — deploy origin/main to this deployment's tenant services, local and remote.
 #
 # A live service runs from a DEDICATED checkout (never the shared primary that several sessions edit
 # concurrently) and is supervised by launchd (com.agentos.<tenant> → scripts/run-tenant.sh <tenant> …
@@ -19,6 +19,18 @@
 #   AOS_LIVE_TENANT / AOS_LIVE_CHECKOUT / AOS_LIVE_LABEL / AOS_LIVE_PORT / AOS_LIVE_LOG
 #       the older single-tenant form, still honoured when AOS_LIVE_TARGETS is unset.
 #
+# A tenant on ANOTHER box (Linux/systemd, reached over ssh) goes in a second list — the mechanics differ
+# enough (ssh, systemctl instead of launchctl, the box's own node on a non-login PATH) that mixing them
+# into one loop would obscure both:
+#   AOS_LIVE_REMOTE_TARGETS="acme:user@your-remote-box.example.com:/home/agent-os/tools/agent-os:3012:agent-os-acme"
+#       one entry per tenant, `tenant:ssh:checkout:port[:unit]` (unit defaults to agent-os-<tenant>,
+#       and is restarted with `sudo systemctl restart <unit>`).
+#   AOS_LIVE_REMOTE_NODE_BIN   node/npm dir prepended to PATH on the remote box (nvm installs are not on
+#       a non-login PATH). Default: $HOME/.nvm/versions/node/v22.22.0/bin on the REMOTE side.
+#
+# Remote targets obey the same ordering guarantee as local ones: every checkout — local and remote —
+# is synced, built and tested before ANY service is restarted.
+#
 # Two tenants may share one checkout (each still has its own home, DB, port and launchd job). The
 # checkout is then synced/built ONCE and each service restarted — which is also why the phases below
 # are ordered build-everything-then-restart-everything.
@@ -31,6 +43,8 @@
 #  - A failed health check prints the exact rollback command rather than guessing.
 #  - Restarts happen one tenant at a time and stop at the first failure, so a bad deploy takes down at
 #    most one service; the report at the end says which tenants moved and which never got there.
+#  - A remote box is only ever reached with `ssh -o BatchMode=yes` — a deploy that would sit waiting on a
+#    password prompt fails fast in preflight instead of hanging.
 set -euo pipefail
 
 ENV_FILE="${AOS_LIVE_ENV:-$HOME/.agentric-live.env}"
@@ -47,7 +61,7 @@ while [ $# -gt 0 ]; do
     --force)      FORCE=1 ;;
     --only)       shift; ONLY="${1:?--only needs a tenant slug}" ;;
     --only=*)     ONLY="${1#--only=}" ;;
-    -h|--help)    sed -n '2,32p' "$0"; exit 0 ;;
+    -h|--help)    sed -n '2,48p' "$0"; exit 0 ;;
     *)            echo "unknown option: $1 (try --help)" >&2; exit 2 ;;
   esac
   shift
@@ -71,20 +85,52 @@ if [ -n "${AOS_LIVE_TARGETS:-}" ]; then
     TARGETS="$TARGETS$t:$c:$p:$l
 "
   done
-else
+elif [ -z "${AOS_LIVE_REMOTE_TARGETS:-}" ]; then
+  # Only fall back to the single-tenant form when NOTHING else is configured — a deployment whose only
+  # tenants are remote must not have a phantom local `acme` invented for it.
   t="${AOS_LIVE_TENANT:-acme}"
   TARGETS="$t:${AOS_LIVE_CHECKOUT:-$HOME/agent-os-live}:${AOS_LIVE_PORT:-3010}:${AOS_LIVE_LABEL:-com.agentos.$t}
 "
 fi
 
+# Remote tenants: `tenant:ssh:checkout:port[:unit]`, normalised the same way.
+REMOTES=""
+for spec in ${AOS_LIVE_REMOTE_TARGETS:-}; do
+  t="${spec%%:*}"; rest="${spec#*:}"
+  h="${rest%%:*}"; rest="${rest#*:}"
+  c="${rest%%:*}"; rest="${rest#*:}"
+  p="${rest%%:*}"
+  u="${rest#*:}"; [ "$u" = "$p" ] && u="agent-os-$t"
+  [ -n "$t" ] && [ -n "$h" ] && [ -n "$c" ] && [ -n "$p" ] \
+    || fail "bad AOS_LIVE_REMOTE_TARGETS entry: $spec (want tenant:ssh:checkout:port[:unit])"
+  REMOTES="$REMOTES$t:$h:$c:$p:$u
+"
+done
+
+REMOTE_NODE_BIN="${AOS_LIVE_REMOTE_NODE_BIN:-\$HOME/.nvm/versions/node/v22.22.0/bin}"
+SSH="ssh -o BatchMode=yes -o ConnectTimeout=10"
+# Every remote command runs through one wrapper so the node PATH and `set -e` are never forgotten.
+on_remote() { # <ssh-target> <command…>
+  local host="$1"; shift
+  # shellcheck disable=SC2029  # the PATH expansion is deliberately remote-side
+  $SSH "$host" "export PATH=\"$REMOTE_NODE_BIN:\$PATH\"; set -e; $*"
+}
+
 if [ -n "$ONLY" ]; then
   PICKED="$(printf '%s' "$TARGETS" | grep "^$ONLY:" || true)"
-  [ -n "$PICKED" ] || fail "--only $ONLY: not in the configured targets ($(printf '%s' "$TARGETS" | cut -d: -f1 | tr '\n' ' '))"
-  TARGETS="$PICKED
+  PICKED_R="$(printf '%s' "$REMOTES" | grep "^$ONLY:" || true)"
+  [ -n "$PICKED" ] || [ -n "$PICKED_R" ] \
+    || fail "--only $ONLY: not in the configured targets ($(printf '%s%s' "$TARGETS" "$REMOTES" | cut -d: -f1 | tr '\n' ' '))"
+  TARGETS="$PICKED"; [ -n "$TARGETS" ] && TARGETS="$TARGETS
+"
+  REMOTES="$PICKED_R"; [ -n "$REMOTES" ] && REMOTES="$REMOTES
 "
 fi
 
-command -v launchctl >/dev/null || fail "launchctl not found — this script is for the macOS box"
+# launchctl is only needed for LOCAL tenants — a box that deploys nothing but remotes doesn't need it.
+if [ -n "$TARGETS" ]; then
+  command -v launchctl >/dev/null || fail "launchctl not found — local targets need the macOS box"
+fi
 
 # Per-checkout scratch state (bash 3.2 on macOS has no associative arrays): one file per checkout,
 # named after its path, holding the commit it was on before the sync — that's what a rollback needs.
@@ -109,7 +155,23 @@ done <<EOF
 $TARGETS
 EOF
 
-say "targets: $(printf '%s' "$TARGETS" | cut -d: -f1 | tr '\n' ' ')"
+# Remote preflight: reachable without a prompt, checkout present, unit known. Done before ANY build so
+# an unreachable box costs nothing.
+while IFS=: read -r TENANT SSHT CHECKOUT PORT UNIT; do
+  [ -n "$TENANT" ] || continue
+  $SSH "$SSHT" true 2>/dev/null \
+    || fail "$TENANT: cannot ssh to $SSHT without a prompt (BatchMode) — check your key/agent"
+  on_remote "$SSHT" "[ -d '$CHECKOUT/.git' ]" \
+    || fail "$TENANT: no checkout at $CHECKOUT on $SSHT"
+  on_remote "$SSHT" "systemctl cat '$UNIT' >/dev/null 2>&1" \
+    || fail "$TENANT: systemd unit $UNIT not found on $SSHT"
+  on_remote "$SSHT" "command -v node >/dev/null" \
+    || fail "$TENANT: no node on $SSHT at PATH $REMOTE_NODE_BIN (set AOS_LIVE_REMOTE_NODE_BIN)"
+done <<EOF
+$REMOTES
+EOF
+
+say "targets: $(printf '%s%s' "$TARGETS" "$REMOTES" | cut -d: -f1 | tr '\n' ' ')"
 
 # ── phase 1: sync + build every checkout (no service is restarted in here) ───────
 for CHECKOUT in $CHECKOUTS; do
@@ -171,6 +233,63 @@ for CHECKOUT in $CHECKOUTS; do
   fi
 done
 
+# ── phase 1b: sync + build every remote checkout (still nothing restarted) ───────
+while IFS=: read -r TENANT SSHT CHECKOUT PORT UNIT; do
+  [ -n "$TENANT" ] || continue
+  OLD="$(on_remote "$SSHT" "git -C '$CHECKOUT' rev-parse HEAD")"
+  on_remote "$SSHT" "git -C '$CHECKOUT' fetch -q origin"
+  NEW="$(on_remote "$SSHT" "git -C '$CHECKOUT' rev-parse '$REF'")"
+  echo "$OLD" >"$STATE/$(key_for "$SSHT$CHECKOUT").old"
+
+  if [ "$OLD" = "$NEW" ]; then
+    say "$SSHT:$CHECKOUT: already at ${NEW:0:7} — rebuilding + restarting anyway"
+  else
+    say "$SSHT:$CHECKOUT: deploying ${OLD:0:7} → ${NEW:0:7}"
+    on_remote "$SSHT" "git -C '$CHECKOUT' --no-pager log --oneline '$OLD..$NEW'" | sed 's/^/  /'
+  fi
+
+  DIRTY="$(on_remote "$SSHT" "git -C '$CHECKOUT' status --porcelain")"
+  if [ -n "$DIRTY" ] && [ "$FORCE" -ne 1 ]; then
+    echo "$DIRTY" | sed 's/^/  /'
+    fail "$SSHT:$CHECKOUT has local changes (above) — rerun with --force to discard them"
+  fi
+
+  [ "$DRY" -eq 1 ] && continue
+
+  on_remote "$SSHT" "git -C '$CHECKOUT' reset --hard -q '$NEW'"
+
+  if [ "$OLD" != "$NEW" ]; then
+    if ! on_remote "$SSHT" "git -C '$CHECKOUT' diff --quiet '$OLD' '$NEW' -- package-lock.json package.json"; then
+      say "$TENANT: root deps changed → npm install"
+      on_remote "$SSHT" "cd '$CHECKOUT' && npm install --no-audit --no-fund >/dev/null"
+    fi
+    if ! on_remote "$SSHT" "git -C '$CHECKOUT' diff --quiet '$OLD' '$NEW' -- web/package-lock.json web/package.json"; then
+      say "$TENANT: web deps changed → npm install"
+      on_remote "$SSHT" "cd '$CHECKOUT/web' && npm install --no-audit --no-fund >/dev/null"
+    fi
+  fi
+
+  say "$TENANT: building server"
+  on_remote "$SSHT" "cd '$CHECKOUT' && npm run build >/tmp/aos-make-live-build.log 2>&1" \
+    || { on_remote "$SSHT" "tail -30 /tmp/aos-make-live-build.log" >&2 || true; fail "$TENANT: server build failed on $SSHT — every live server untouched"; }
+  say "$TENANT: building console"
+  on_remote "$SSHT" "cd '$CHECKOUT/web' && npm run build >/tmp/aos-make-live-build.log 2>&1" \
+    || { on_remote "$SSHT" "tail -30 /tmp/aos-make-live-build.log" >&2 || true; fail "$TENANT: web build failed on $SSHT — every live server untouched"; }
+
+  if [ "$SKIP_TESTS" -eq 1 ]; then
+    say "$TENANT: skipping governance suite (--skip-tests)"
+  else
+    say "$TENANT: running governance suite"
+    # AOS_NO_TTYD: a suite run that builds a TenantRegistry spawns a ttyd per tenant and only
+    # startServer's stopAll reaps it — on a live box those leak and pin every core.
+    on_remote "$SSHT" "cd '$CHECKOUT' && AOS_NO_TTYD=1 npm run test:governance >/tmp/aos-make-live-tests.log 2>&1" \
+      || { on_remote "$SSHT" "tail -20 /tmp/aos-make-live-tests.log" >&2 || true; fail "$TENANT: governance suite failed on $SSHT — NOTHING restarted"; }
+    on_remote "$SSHT" "tail -1 /tmp/aos-make-live-tests.log"
+  fi
+done <<EOF
+$REMOTES
+EOF
+
 if [ "$DRY" -eq 1 ]; then say "dry run — nothing changed"; exit 0; fi
 
 # ── phase 2: restart + verify each service ───────────────────────────────────────
@@ -210,6 +329,41 @@ Roll back with:
   esac
 done <<EOF
 $TARGETS
+EOF
+
+while IFS=: read -r TENANT SSHT CHECKOUT PORT UNIT; do
+  [ -n "$TENANT" ] || continue
+  OLD="$(cat "$STATE/$(key_for "$SSHT$CHECKOUT").old")"
+  VERSION="$(on_remote "$SSHT" "node -p \"require('$CHECKOUT/package.json').version\"")"
+
+  say "restarting $UNIT on $SSHT (:$PORT)"
+  on_remote "$SSHT" "sudo systemctl restart '$UNIT'"
+
+  # Same check as the local lane: the RUNNING process must report the version we just built, else a
+  # long-running server is still holding its old code in memory.
+  LIVE=""
+  for _ in $(seq 1 30); do
+    sleep 1
+    LIVE="$(on_remote "$SSHT" "curl -fsS --max-time 2 http://127.0.0.1:$PORT/health" 2>/dev/null || true)"
+    case "$LIVE" in *"\"version\":\"$VERSION\""*) break ;; esac
+  done
+
+  case "$LIVE" in
+    *"\"version\":\"$VERSION\""*)
+      say "live: $LIVE"
+      DEPLOYED="$DEPLOYED $TENANT"
+      ;;
+    *)
+      echo "--- last 30 journal lines for $UNIT on $SSHT ---" >&2
+      on_remote "$SSHT" "journalctl -u '$UNIT' -n 30 --no-pager" >&2 || true
+      [ -n "$DEPLOYED" ] && warn "already deployed before this failure:$DEPLOYED"
+      fail "$TENANT: health check never reported v$VERSION (last response: ${LIVE:-none}).
+Roll back with:
+  ssh $SSHT \"git -C $CHECKOUT reset --hard $OLD && cd $CHECKOUT && npm run build && (cd web && npm run build) && sudo systemctl restart $UNIT\""
+      ;;
+  esac
+done <<EOF
+$REMOTES
 EOF
 
 say "done in $(( $(date +%s) - START ))s —$DEPLOYED"

--- a/scripts/memory-upkeep-test.cjs
+++ b/scripts/memory-upkeep-test.cjs
@@ -110,6 +110,35 @@ const setAge = (id, days) => aos.db.prepare('UPDATE memories SET created_at = ? 
   assert(b3.rows.size === 1, 'the duplicate is deleted from the backend too — automem does NOT dedupe these itself');
   void dupA; void dupB;
 
+  // ── C. recall serves the agent's OWN text, whatever the backend did to it ───────────────────────
+  console.log('\nrecall fidelity — the backend ranks, the mirror is the record\n');
+
+  /** A backend that rewrites on ingest, exactly as automem does over MEMORY_CONTENT_SOFT_LIMIT. */
+  class RewritingBackend extends FakeBackend {
+    async store(input) {
+      const rec = await super.store(input);
+      const short = { ...rec, content: `Summary of: ${input.content.slice(0, 20)}…` };
+      this.rows.set(rec.id, short);
+      return rec; // the mirror is handed the record with the ORIGINAL content, as automem's POST returns
+    }
+    async recall() { return [...this.rows.values()]; }
+  }
+
+  const b4 = new RewritingBackend();
+  const p4 = new MirroredMemoryProvider(b4, mirror);
+  const original = 'Bunny edge-rule QA cannot be done on a *.instawp.site sandbox — it resolves to the PPU/OVH origin and never traverses the edge, so every probe returns 200.';
+  const stored = await p4.store({ tenant: aos.tenant, agentId: 'qa', content: original, tags: [], type: 'Pattern', importance: 0.8 });
+  const got = await p4.recall({ tenant: aos.tenant, agentId: 'qa', query: 'bunny edge rule', limit: 5 });
+  const hit = got.find((r) => r.id === stored.id);
+  assert(!!hit, 'the backend still decides what comes back and in what order');
+  assert(hit.content === original, 'recall returns the agent\'s OWN text, not the backend\'s rewrite', `got: ${hit && hit.content}`);
+  assert(b4.rows.get(stored.id).content.startsWith('Summary of:'), 'the backend really did hold a rewritten copy — the test would pass vacuously otherwise');
+
+  // a row the mirror has never seen keeps whatever the backend holds — this can only add fidelity
+  b4.rows.set('bk_orphan', { id: 'bk_orphan', tenant: aos.tenant, agentId: 'qa', content: 'only the backend knows this', tags: [], type: 'Insight', ts: Date.now(), scope: 'agent' });
+  const got2 = await p4.recall({ tenant: aos.tenant, agentId: 'qa', query: 'orphan', limit: 5 });
+  assert(got2.some((r) => r.id === 'bk_orphan' && r.content === 'only the backend knows this'), 'a record the mirror does not hold is passed through untouched');
+
   // ── B. the learning state's extractor version survives a load ───────────────────────────────────
   console.log('\ndreaming — the topic accumulator is not wiped on every load\n');
   const roundTripped = normalizeState({ firstPass: 1, passes: 9, totals: {}, topics: { freescout: { count: 30, lastSeen: 2 } }, recent: [], watermark: 5, topicsVersion: 3 });

--- a/src/memory/mirror.ts
+++ b/src/memory/mirror.ts
@@ -48,7 +48,45 @@ export class MirroredMemoryProvider implements MemoryProvider {
     if (q.query && out.length) {
       try { this.mirror.reinforce(out.map((r) => r.id)); } catch { /* mirror is best-effort */ }
     }
-    return out;
+    return this.withCanonicalContent(out);
+  }
+
+  /**
+   * The backend RANKS; the mirror is the record of what the agent actually wrote.
+   *
+   * A recall backend is free to transform the text it was handed, and automem does: over
+   * `MEMORY_CONTENT_SOFT_LIMIT` (500 chars by default) with an LLM configured, `MEMORY_AUTO_SUMMARIZE`
+   * replaces `content` with a ~300-char LLM summary and DISCARDS the original. On the live instawp
+   * tenant — average memory 1305 chars — that hit most of the store: 81% of sampled recall hits existed
+   * nowhere in the mirror, and the specifics that made them useful were gone. What an agent stored as
+   *
+   *   "Bunny edge-rule QA cannot be done on a *.instawp.site sandbox — it resolves to the PPU/OVH origin
+   *    and never traverses Bunny's edge, so every probe returns 200 …"
+   *
+   * came back as "Bunny edge-rule QA limitations. Testing on *.instawp.site fails…". Same id, same
+   * ranking, no `.env` names, no exact commands. Worse, the two stores then disagreed: Dreaming, the
+   * consolidation gardener and the Memory-hub all read the mirror's original while agents recalled the
+   * paraphrase.
+   *
+   * So content is served from the mirror whenever the mirror has that id. Ranking, ordering and score
+   * stay entirely the backend's — this restores fidelity without touching retrieval quality (the
+   * embedding is computed over whatever the backend holds either way). A row the mirror doesn't know
+   * (stored before mirroring, or written directly to the backend) keeps the backend's own copy, so this
+   * can only ever add fidelity, never drop a result. Best-effort: a mirror failure returns the backend's
+   * records unchanged.
+   */
+  private withCanonicalContent(out: MemoryRecord[]): MemoryRecord[] {
+    if (!out.length) return out;
+    try {
+      const canonical = this.mirror.contentByIds(out.map((r) => r.id));
+      if (!canonical.size) return out;
+      return out.map((r) => {
+        const content = canonical.get(r.id);
+        return content != null && content !== r.content ? { ...r, content } : r;
+      });
+    } catch {
+      return out; // mirror is best-effort — never fail a recall over it
+    }
   }
 
   async update(input: UpdateInput): Promise<MemoryRecord | null> {

--- a/src/memory/sqlite-provider.ts
+++ b/src/memory/sqlite-provider.ts
@@ -180,6 +180,22 @@ export class SqliteMemoryProvider implements MemoryProvider {
       .run(Date.now(), ...ids);
   }
 
+  /**
+   * The stored content for a set of ids, as the agent wrote it. Used by `MirroredMemoryProvider` to serve
+   * canonical text behind an external backend that transforms what it is given (automem summarises any
+   * memory over 500 chars and discards the original). Ids the table doesn't hold are simply absent from
+   * the map, so the caller falls back to whatever the backend returned.
+   */
+  contentByIds(ids: string[]): Map<string, string> {
+    const out = new Map<string, string>();
+    if (!ids.length) return out;
+    const rows = this.db
+      .prepare(`SELECT id, content FROM memories WHERE id IN (${ids.map(() => '?').join(',')})`)
+      .all<{ id: string; content: string }>(...ids);
+    for (const r of rows) out.set(r.id, r.content);
+    return out;
+  }
+
   async maintain(opts: MemoryMaintenance): Promise<MemoryMaintenanceResult> {
     let pruned = 0;
     let merged = 0;


### PR DESCRIPTION
Closes both items left open by #717.

## 1. Agents were recalling a paraphrase of their own memories

A recall backend may transform the text it is handed, and automem does. Over `MEMORY_CONTENT_SOFT_LIMIT` (**500 chars** by default) with an LLM configured, `MEMORY_AUTO_SUMMARIZE` replaces `content` with a ~300-char summary and **discards the original** (`automem/api/memory.py:488-516`).

instawp's average memory is **1305 chars** — so most of that store was rewritten at ingest. Measured: **81%** of sampled recall hits existed nowhere in the mirror. Same id, same ranking, different text:

```
MIRROR : Bunny edge-rule QA cannot be done on a *.instawp.site sandbox — it resolves to the
         PPU/OVH origin and never traverses Bunny's edge, so every probe returns 200 …
AUTOMEM: Bunny edge-rule QA limitations. Testing on *.instawp.site fails as it resolves to
         PPU/OVH, returning misleading 200 responses. Use canary PZ 5518711 instead.
```

Every exact command and `.env` name — the reason the memory was worth storing — gone. And the two stores then disagreed: Dreaming, the consolidation gardener and the Memory-hub read the mirror's original while agents recalled the summary.

**instapods was unaffected** (2% divergence vs instawp's 81%): no OpenAI client is configured there, so the summarizer returns `None`. That contrast is what made the mechanism identifiable.

**Fix:** `MirroredMemoryProvider.recall` overlays `content` from the mirror when the mirror holds that id.

- **Ranking, ordering and score stay entirely the backend's.** The embedding is computed over whatever the backend holds either way, so retrieval quality is untouched — only the text handed to the agent is restored.
- A record the mirror has never seen (pre-mirror, or written straight to the backend) **passes through unchanged**, so this can only add fidelity, never drop a result.
- Best-effort: a mirror failure returns the backend's records as-is.
- **Backend-agnostic** — it holds for any store that rewrites, not just this setting. Turning `MEMORY_AUTO_SUMMARIZE` off is still worth doing on a rewriting deployment (it stops paying an LLM call per write), but the OS no longer depends on it.

## 2. `make-live.sh` deploys tenants on other boxes

A tenant reached over ssh now goes in `AOS_LIVE_REMOTE_TARGETS` as `tenant:ssh:checkout:port[:unit]`, alongside the existing local `AOS_LIVE_TARGETS`. It was being deployed by hand — which is how one box sat **5 versions behind** while "make it live" reported success.

The remote lane keeps every guarantee the local one has:

- **Preflight before anything is touched** — reachable without a password prompt (`ssh -o BatchMode=yes`, so a deploy fails fast instead of hanging), checkout present, systemd unit known, node found on the box's non-login PATH.
- **Every checkout — local and remote — synced, built and tested before ANY service restarts**, so a bad commit leaves every running server untouched.
- The running process must report **the version just built**, else the deploy fails.
- On failure: the exact rollback command **plus that box's journal**.
- `--only` and `--dry-run` span both lanes, and a deployment whose tenants are all remote no longer has a phantom local `acme` target invented for it.
- Suite runs with `AOS_NO_TTYD=1` on the remote box — a governance run there would otherwise leak a ttyd per tenant.

Verified against all three lanes (dry-run, nothing changed):

```
targets: instapods doosra <remote>
--only <remote>  → targets: <remote>
--only bogus     → not in the configured targets (instapods doosra <remote>)
```

Real hosts stay out of the repo — the examples are placeholders and the values live in the untracked `~/.agentric-live.env`.

## Test

`scripts/memory-upkeep-test.cjs` grows to **21 checks** (from 17), including a backend that rewrites on ingest exactly as automem does:

```
✓ the backend still decides what comes back and in what order
✓ recall returns the agent's OWN text, not the backend's rewrite
✓ the backend really did hold a rewritten copy — the test would pass vacuously otherwise
✓ a record the mirror does not hold is passed through untouched
… 21 passed, 0 failed
```

The fidelity check fails on the previous code (`got: Summary of: Bunny edge-rule QA c…`). `npm run typecheck` clean, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)