### PR TITLE
fix(memory): the launch preamble carries lessons, not past task prompts (v0.400.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.400.0] - 2026-08-27
+### Changed
+- **The launch preamble carries lessons, not a transcript of past assignments.** An episode's text opens
+  with the session's task line, so ranking the preamble against the task (v0.399.0) matched episodes
+  better than the lessons distilled from them — the bias was systematic, not incidental. Measured over 8
+  realistic agent/task pairs against the live instapods store: **28 of 64 preamble slots (44%) were raw
+  past task prompts**, and `check-resolve-tickets` spent 4 of 8 slots on near-identical replays of one
+  daily sweep while the reconciliation lesson it has been recalled on 185 times was crowded out. The
+  preamble now over-fetches 4×, drops anything tagged `episode` (or opening `Task:`, for rows predating
+  the tag), collapses near-identical survivors, and keeps the first `count` — on the fallback path too, so
+  which path answered never changes what kind of memory an agent is seeded with. After: **0 of 64 slots**
+  are episodes, and an engineer asked about repeated deploy failures is seeded with five concrete
+  deploy-failure lessons. Episodes remain what Dreaming and the consolidation gardener read. An agent
+  whose store is overwhelmingly episodic now gets a shorter preamble rather than a padded one.
+
 ## [0.399.0] - 2026-08-27
 ### Changed
 - **The launch-time memory preamble is ranked against the task, not the agent's all-time top 8.**

--- a/docs/memory-layer-plan.md
+++ b/docs/memory-layer-plan.md
@@ -641,6 +641,21 @@ bears on THIS work. Going through the provider also reinforces the hits
 (`recall_count`/`last_recalled_at`), so preloaded memories now participate in the usage signal that prune
 and re-ranking read instead of being invisible to it.
 
+**Episodes are excluded.** An episode's text OPENS with the session's task line, so a task-shaped query
+matches episodes better than the lessons distilled from them — task-ranking made that bias systematic.
+Measured over 8 realistic agent/task pairs against the live instapods store: **28 of 64 preamble slots
+(44%) were raw past task prompts**, and `check-resolve-tickets` spent 4 of 8 slots on near-identical
+replays of one daily sweep while the reconciliation lesson it has been recalled on 185 times was crowded
+out. The preamble now over-fetches (`PRELOAD_OVERFETCH` = 4×), drops anything tagged `episode` (or opening
+`Task:`, for rows predating the tag), collapses near-identical survivors on their first 80 chars
+(`distinctLines`), and keeps the first `count`. Same exclusion on the fallback path, so which path answered
+never changes WHAT KIND of memory an agent is seeded with. After: **0 of 64 slots** are episodes, and the
+engineer's deploy task is seeded with five concrete deploy-failure lessons instead. Episodes still exist
+for Dreaming and the consolidation gardener, which read them from the ledger directly — "what you already
+know" should be the conclusions, not a transcript of past assignments. One consequence worth knowing: an
+agent whose store is overwhelmingly episodic gets a SHORTER preamble (2 of 8 slots for
+`check-resolve-tickets`) rather than a padded one.
+
 **It degrades, never blocks.** No task text (a bare interactive session), a recall that throws, one that
 returns nothing, or one that hasn't answered within `PRELOAD_TIMEOUT_MS` = 2.5s → fall back to the old
 importance ordering. So the preamble is never worse than before, and an unreachable backend costs a launch

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.399.0",
+  "version": "0.400.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.399.0",
+      "version": "0.400.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.399.0",
+  "version": "0.400.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/memory-preload-test.cjs
+++ b/scripts/memory-preload-test.cjs
@@ -29,7 +29,7 @@ let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
-const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+const { TerminalManager, isEpisodeRecord, distinctLines } = require(path.join(ROOT, 'dist/terminal.js'));
 
 const aos = loadAgentOS();
 const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
@@ -91,6 +91,45 @@ const setPreload = (cfg) => aos.settings.setMemoryConfig({ ...(aos.settings.memo
   // an agent in a workspace with nothing shared and nothing of its own gets no preamble at all
   aos.db.prepare("DELETE FROM memories WHERE scope = 'tenant'").run();
   assert((await tm.memoryPreamble('brand-new-agent', 'anything at all')) === '', 'with nothing to say, the preamble is omitted rather than emitted empty');
+
+  // ── episodes are for Dreaming, not for the prompt ───────────────────────────────────────────────
+  console.log('\nthe preamble carries lessons, not a transcript of past assignments\n');
+  aos.db.prepare('DELETE FROM memories').run();
+  // What the live store looks like: many episodes that OPEN with the task (so a task-shaped query matches
+  // them best), and one distilled lesson that is what the agent actually needs.
+  for (let i = 0; i < 10; i++) {
+    const r = await remember('qa', `Task: Run the nightly Bunny edge-rule sweep on the canary. Outcome: success. Pass ${i}.`, 0.8);
+    aos.db.prepare("UPDATE memories SET tags = '[\"episode\",\"session-end\"]' WHERE id = ?").run(r.id);
+  }
+  await remember('qa', 'Bunny edge-rule QA cannot be done on a *.instawp.site sandbox — it never traverses the edge, so every probe returns a misleading 200. Use the canary pull zone.', 0.7);
+
+  const qa = await tm.memoryPreamble('qa', 'Run the nightly Bunny edge-rule sweep and check the results.');
+  const items = qa.split('\n').filter((l) => l.startsWith('- '));
+  assert(items.length > 0, 'the preamble is still produced when episodes dominate the store');
+  assert(!items.some((l) => l.includes('Task: Run the nightly')), 'raw session episodes are kept OUT of the prompt', items[0]);
+  assert(items.some((l) => /never traverses the edge/.test(l)), 'the distilled lesson is what the agent is seeded with');
+
+  // …and the salience fallback obeys the same rule, so which path answered can't change what kind of
+  // memory an agent gets.
+  const qaFallback = await tm.memoryPreamble('qa', '');
+  assert(!qaFallback.includes('Task: Run the nightly'), 'the salience fallback excludes episodes too');
+
+  console.log('\nunit: the two rules the preamble is built on\n');
+  assert(isEpisodeRecord({ tags: ['episode', 'session-end'], content: 'anything' }), 'an episode is identified by its tag');
+  assert(isEpisodeRecord({ content: 'Task: do the thing\nOutcome: success' }), '…and by its Task: opening when tags are missing');
+  assert(!isEpisodeRecord({ tags: ['lesson'], content: 'A durable fact about the system.' }), 'a lesson is not an episode');
+  assert(!isEpisodeRecord({ content: 'Tasks queue up behind a slow migration.' }), 'a memory merely mentioning tasks is not an episode');
+
+  // The key is the first 80 chars, so the fixture has to share that much — which is the real shape:
+  // two writes of the same lesson that diverge only in a trailing detail.
+  const head = 'Bunny edge-rule QA cannot be done on a *.instawp.site sandbox — it never traverses the edge';
+  const collapsed = distinctLines([`${head}, so probes return 200. (A)`, `${head}, so probes return 200. (B)`, 'A different fact entirely.'], 8);
+  assert(collapsed.length === 2, 'near-identical entries collapse to one slot', JSON.stringify(collapsed));
+  assert(collapsed[0].endsWith('(A)'), 'the best-ranked copy of a repeated fact is the one kept');
+  // Short memories that merely start alike are NOT collapsed — the rule is a duplicate guard, not a topic
+  // filter, so two brief facts on the same subject both survive.
+  assert(distinctLines(['Deploys fail on Node 18.', 'Deploys fail on Go 1.22.'], 8).length === 2, 'two short distinct facts both survive');
+  assert(distinctLines(['a', 'b', 'c', 'd'], 2).length === 2, 'the cap is respected');
 
   console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m\n`);
   try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3869,6 +3869,10 @@ export class TerminalManager {
    *  procedure; feeding all of it to a semantic search returns the fleet's most generic memories,
    *  because the distinctive words are buried under boilerplate. The first sentences carry the subject. */
   private static readonly PRELOAD_QUERY_MAX = 400;
+  /** Over-fetch factor for the preamble. Episodes are filtered out AFTER retrieval (no backend expresses
+   *  "exclude this tag" — automem's tag_mode is `all`), so ask for more than we need and keep the first
+   *  `count` that survive. */
+  private static readonly PRELOAD_OVERFETCH = 4;
   /** A launch must never wait on the memory store. Past this, fall back to the local ranking and go. */
   private static readonly PRELOAD_TIMEOUT_MS = 2_500;
 
@@ -3893,6 +3897,17 @@ export class TerminalManager {
    * Falls back to the old importance ordering whenever the task-ranked path can't answer — no task text
    * (a bare interactive session), a recall that throws, times out, or returns nothing. So the preamble is
    * never worse than it was, and a slow or unreachable backend costs a launch at most PRELOAD_TIMEOUT_MS.
+   *
+   * **Episodes are excluded.** An episode's text OPENS with the session's task line, so a task-shaped
+   * query matches episodes better than it matches the lessons distilled from them — measuring 8 realistic
+   * agent/task pairs against the live instapods store, **44% of preamble slots (28/64)** came back as raw
+   * past task prompts, and one agent spent 4 of 8 slots on near-identical replays of the same daily sweep
+   * while the reconciliation lesson it has been recalled on 185 times was crowded out. Task-ranking made
+   * that bias systematic, so the retrieval has to correct for it. Episodes exist for Dreaming and the
+   * consolidation gardener, which read them from the ledger directly; "what you already know" should be
+   * the conclusions, not a transcript of past assignments. Same reason near-identical survivors are
+   * collapsed: v0.396.0 stops byte-identical episodes being STORED, but older rows differing by a few
+   * characters would otherwise take several slots to say one thing.
    */
   private async memoryPreamble(selfAgent?: string, task?: string): Promise<string> {
     const preload = this.os.settings.memoryConfig()?.preload;
@@ -3913,10 +3928,18 @@ export class TerminalManager {
           timer = setTimeout(() => rej(new Error('preload recall timed out')), TerminalManager.PRELOAD_TIMEOUT_MS);
         });
         const hits = await Promise.race([
-          this.os.memory.recall({ tenant: this.os.tenant, agentId: selfAgent, query, limit: n, scope: 'all' }),
+          // Over-fetch: episodes and near-duplicates are dropped below, and no backend can express
+          // "exclude this tag" in the query itself (automem's tag_mode is `all`, an AND-filter).
+          this.os.memory.recall({
+            tenant: this.os.tenant,
+            agentId: selfAgent,
+            query,
+            limit: Math.min(n * TerminalManager.PRELOAD_OVERFETCH, 100),
+            scope: 'all',
+          }),
           timeout,
         ]);
-        lines = hits.map((h) => h.content);
+        lines = distinctLines(hits.filter((h) => !isEpisodeRecord(h)).map((h) => h.content), n);
         relevant = lines.length > 0;
       } catch {
         /* fall through to the salience ordering below */
@@ -3927,15 +3950,21 @@ export class TerminalManager {
 
     if (!lines.length) {
       try {
-        lines = this.db
-          .prepare(
-            `SELECT content FROM memories
-             WHERE tenant = ? AND (scope = 'tenant' OR (scope = 'agent' AND agent_id = ?))
-             ORDER BY COALESCE(importance, 0.5) DESC, COALESCE(last_recalled_at, created_at) DESC
-             LIMIT ?`,
-          )
-          .all<{ content: string }>(this.os.tenant, selfAgent, n)
-          .map((r) => r.content);
+        // Same exclusion on the fallback path (`tags` is a JSON array in the ledger), so which path
+        // answered never changes WHAT KIND of memory an agent is seeded with.
+        lines = distinctLines(
+          this.db
+            .prepare(
+              `SELECT content FROM memories
+               WHERE tenant = ? AND (scope = 'tenant' OR (scope = 'agent' AND agent_id = ?))
+                 AND COALESCE(tags, '') NOT LIKE '%"episode"%'
+               ORDER BY COALESCE(importance, 0.5) DESC, COALESCE(last_recalled_at, created_at) DESC
+               LIMIT ?`,
+            )
+            .all<{ content: string }>(this.os.tenant, selfAgent, n * TerminalManager.PRELOAD_OVERFETCH)
+            .map((r) => r.content),
+          n,
+        );
       } catch {
         return ''; // preamble is best-effort; a query failure must never block a session launch
       }
@@ -7686,6 +7715,33 @@ function composeEpisode(
   const content = [taskLine, `Outcome: ${outcome}`, `Activity: ${parts.join(', ')}.`].filter((l) => l !== '').join('\n').trim();
   const { importance, signals } = episodeSalience('audit', outcome, events);
   return { content, outcome, source: 'audit', importance, signals };
+}
+
+/** Is this record a session EPISODE rather than a distilled lesson? Tagged `episode` at write time
+ *  (`writeEpisode`); the `Task:` opening is the belt-and-braces check for rows stored before the tag, or
+ *  by a backend that drops tags on the way back. */
+export function isEpisodeRecord(r: { content?: string; tags?: string[] }): boolean {
+  if (r.tags?.includes('episode')) return true;
+  return /^\s*Task:/.test(r.content ?? '');
+}
+
+/** Collapse near-identical entries and cap at `limit`. Two memories that open the same ~80 characters say
+ *  the same thing for a reader's purposes — several slots for one fact is the failure this prevents (one
+ *  live agent's preamble spent 4 of 8 slots on replays of the same daily sweep). Order is preserved, so
+ *  the best-ranked copy of a repeated fact is the one kept. */
+export function distinctLines(contents: string[], limit: number): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const c of contents) {
+    const text = (c ?? '').trim();
+    if (!text) continue;
+    const key = text.replace(/\s+/g, ' ').slice(0, 80).toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(text);
+    if (out.length >= limit) break;
+  }
+  return out;
 }
 
 /** Derive a short, single-line session title from an agent's free-text report summary:


### PR DESCRIPTION
Follow-up to #719, found by measuring it against live data rather than assuming it worked.

## The bias task-ranking introduced

An episode's text **opens with the session's task line**. So ranking the preamble against the task matches episodes better than it matches the lessons distilled from them — the bias is systematic, not incidental.

Measured over 8 realistic agent/task pairs against the live instapods store:

```
6/8 episodes   engineer :: Deploys keep failing for one customer pod
7/8 episodes   engineer :: Add a retry budget to the deploy pipeline
4/8 episodes   check-resolve-tickets :: Sweep open support tickets   (3 near-duplicate)
…
TOTAL: 28/64 slots are raw episodes (44%), 3 near-duplicate slots
```

`check-resolve-tickets` spent **4 of 8 slots on near-identical replays of one daily sweep**, while the reconciliation lesson that agent has been recalled on **185 times** was crowded out entirely. v0.396.0 stops byte-identical episodes being *stored*; these differ by a few characters, survive dedupe, and were being promoted into every prompt.

## The fix

Over-fetch (`PRELOAD_OVERFETCH` = 4×) → drop anything tagged `episode` (or opening `Task:`, for rows predating the tag or a backend that drops tags on the way back) → collapse near-identical survivors on their first 80 chars → keep the first `count`.

The over-fetch-and-filter shape is forced: no backend can express *"exclude this tag"* in the query itself — automem's `tag_mode` is an AND-filter. The same exclusion runs on the **salience fallback**, so which path answered never changes what kind of memory an agent is seeded with.

## After, same 8 pairs

```
TOTAL: 0/64 slots are raw episodes (0%), 0 near-duplicate slots
```

And the content is what you'd want an engineer to start with:

```
engineer :: "repeated deploy failures on their pod"
  - a run of identical `deploy_failed` events on one pod is NOT evidence a user is stuck…
  - the canonical unit is a "stuck-user EPISODE", not a raw deploy_failed event…
  - a failed deploy is type='deploy_failed' on BOTH deploy paths as of PR #427…
  - measured over ALL 242 failed rows in prod `deployments` — do not reason about deploy…
  - backtesting a classifier against the FULL prod corpus is what finds the copy…
```

**One consequence worth stating plainly:** an agent whose store is overwhelmingly episodic now gets a *shorter* preamble — `check-resolve-tickets` fills 2 of 8 slots — rather than a padded one. Two real lessons beat eight replays, and the historical episode cleanup will widen it.

Episodes are still exactly what Dreaming and the consolidation gardener consume; they read the ledger directly and are unaffected.

## Test

`scripts/memory-preload-test.cjs` grows to **26 checks**, with a fixture in the live shape (10 tagged episodes that open with the task, one distilled lesson):

```
✓ raw session episodes are kept OUT of the prompt
✓ the distilled lesson is what the agent is seeded with
✓ the salience fallback excludes episodes too
✓ an episode is identified by its tag
✓ …and by its Task: opening when tags are missing
✓ a memory merely mentioning tasks is not an episode
✓ near-identical entries collapse to one slot
✓ two short distinct facts both survive
… 26 passed, 0 failed
```

`npm run typecheck` clean, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)