### PR TITLE
fix(insights): topics name subjects, not states and handles (v0.401.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.401.0] - 2026-08-27
+### Fixed
+- **"The fleet frequently works on…" no longer names states and handles.** That list rides in every
+  agent's system prompt via the learned guidance, so a junk token there is a junk token in every prompt.
+  The first clean pass after the topic accumulator was fixed surfaced exactly two failure shapes. (1) A
+  shouted imperative reads as an **acronym** to `properNouns` (short, all-caps, standing alone), so a
+  prompt writing "WAIT for it to finish" promoted `wait` to a proper noun — instawp told every agent the
+  fleet frequently works on "freescout, apache2, **wait**". Those status words are now stopped. (2)
+  `isEntity` admitted anything containing a digit (the rule that keeps `php8`/`v3`), which let opaque
+  handles through: the Slack channel id `c05cl830mnd`, site ids `d3cby9k`/`d2mp41k`, and the task slug
+  `already-contacted-in-90-days`. A real tech name carries its digits at the **end**; a digit buried
+  mid-token is an id, so those are now rejected above a length bound — `apache2`, `php8`, `dev3`,
+  `oauth2` and `log4j` all still pass, and a token the corpus consistently capitalizes still wins on
+  `proper` whatever its shape. Pinned by a new section in `scripts/insights-signal-test.cjs`.
+
 ## [0.400.0] - 2026-08-27
 ### Changed
 - **The launch preamble carries lessons, not a transcript of past assignments.** An episode's text opens

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.400.0",
+  "version": "0.401.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.400.0",
+      "version": "0.401.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.400.0",
+  "version": "0.401.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/insights-signal-test.cjs
+++ b/scripts/insights-signal-test.cjs
@@ -24,7 +24,7 @@ delete process.env.AGENT_OS_SECRET_KEY;
 let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
-const { deriveGuidance, deriveRecommendations, recommendationResolved } = require(path.join(ROOT, 'dist/edge/dreaming.js'));
+const { deriveGuidance, deriveRecommendations, recommendationResolved, topicCounts } = require(path.join(ROOT, 'dist/edge/dreaming.js'));
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
 const { detectAlerts } = require(path.join(ROOT, 'dist/edge/alerts.js'));
 
@@ -118,6 +118,40 @@ console.log('\n\x1b[1mInsights signal — no prompt-injected or DM\'d number off
   const chatty = realistic({ recent: [{ day: 'd1', ts: NOW - DAY, sessions: 40, success: 38, failure: 0, stopped: 0, approved: 0, rejected: 0, budgetStops: 0, errors: 0, topics: [] }] });
   assert(deriveGuidance(quiet) === deriveGuidance(chatty), 'guidance is identical whether 10% or 95% of runs reported', `\n${deriveGuidance(quiet)}\n---\n${deriveGuidance(chatty)}`);
   assert(JSON.stringify(deriveRecommendations(quiet, 'medium', NOW)) === JSON.stringify(deriveRecommendations(chatty, 'medium', NOW)), 'recommendations are identical too');
+}
+
+// ── topics: what "the fleet frequently works on" is allowed to name ──────────────────────────────────
+// This list rides in every agent's system prompt via deriveGuidance, so a junk token there is a junk
+// token in every prompt. The fixtures are the exact shapes instapods and instawp surfaced on their first
+// pass after the topic accumulator was fixed (2026-08-27).
+{
+  console.log('\n\x1b[1m4) topics — subjects, not states or handles\x1b[0m');
+  const ep = (content) => ({ content, created_at: NOW });
+  const got = new Map(topicCounts([
+    ep('Task: WAIT for the FreeScout migration to finish, then verify apache2 is serving.'),
+    ep('Task: WAIT for the queue to drain before restarting apache2.'),
+    ep('Task: WAIT — do not proceed until the apache2 restart lands.'),
+    ep('Task: Post the daily summary to Slack channel c05cl830mnd for the docs bot.'),
+    ep('Task: Investigate site d3cby9k failing to load after the migration.'),
+    ep('Task: Investigate site d2mp41k timing out on checkout.'),
+    ep('Task: Skip anyone already-contacted-in-90-days when building the outreach list.'),
+    ep('Task: Verify the php8 upgrade on dev3 did not break the oauth2 callback.'),
+    ep('Task: Verify php8 handles the log4j scan and dev3 stays green.'),
+  ]));
+  const has = (t) => got.has(t);
+
+  // A shouted imperative reads as an ACRONYM to properNouns (short, all-caps, standing alone), which is
+  // how instawp's first clean pass told every agent the fleet "frequently works on … WAIT".
+  assert(!has('wait'), 'a shouted imperative is not a topic', [...got.keys()].join(','));
+  // Opaque handles the hex rule misses: a digit buried MID-token is an id or a slug, not a name.
+  assert(!has('c05cl830mnd'), 'a Slack channel id is not a topic');
+  assert(!has('d3cby9k') && !has('d2mp41k'), 'site handles are not topics');
+  assert(!has('already-contacted-in-90-days'), 'a task slug is not a topic');
+  // …while real tech names carry their digits at the END, and must survive.
+  assert(has('apache2') && got.get('apache2') === 3, 'apache2 survives, counted once per episode');
+  assert(has('php8') && has('dev3') && has('oauth2'), 'php8 / dev3 / oauth2 survive');
+  assert(has('log4j'), 'a short name with an interior digit is below the length bound and survives');
+  assert(has('freescout'), 'a plain product name survives');
 }
 
 fs.rmSync(HOME, { recursive: true, force: true });

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -90,7 +90,12 @@ const STOP = new Set(['task', 'outcome', 'session', 'after', 'then', 'with', 'th
   'lets', 'please', 'want', 'wants', 'wanted', 'like', 'would', 'give', 'tell', 'know', 'here', 'there', 'what', 'which', 'where', 'whether', 'still', 'back', 'next', 'first', 'last', 'good', 'great', 'thing', 'things', 'stuff', 'working', 'work', 'going', 'getting', 'recent', 'recently', 'latest', 'today', 'yesterday', 'tomorrow', 'current', 'currently', 'again', 'once', 'above', 'below', 'help', 'lets', 'able', 'sure', 'okay', 'yeah', 'issue', 'issues', 'problem', 'problems', 'thanks', 'quick', 'quickly',
   // Imperative scaffolding from step-by-step test/QA prompts ("Test the … tools end-to-end, then STOP. Do
   // ONLY these steps … EXACTLY") — describes how a run was scripted, not a subject the fleet works on.
-  'stop', 'exactly', 'step', 'steps', 'only', 'test', 'tests', 'tool', 'tools', 'end', 'ping', 'pls', 'else', 'anything', 'everything', 'something', 'nothing']);
+  'stop', 'exactly', 'step', 'steps', 'only', 'test', 'tests', 'tool', 'tools', 'end', 'ping', 'pls', 'else', 'anything', 'everything', 'something', 'nothing',
+  // Shouted imperatives and status words. A prompt that writes "WAIT for it to finish" reads as an
+  // ACRONYM to `properNouns` (short, all-caps, standing alone), which promoted it to a proper noun —
+  // instawp's first clean pass told every agent "the fleet frequently works on: freescout, apache2,
+  // WAIT". These are states a run passes through, never subjects it works on.
+  'wait', 'waiting', 'block', 'blocked', 'blocking', 'advanced', 'live', 'record', 'records', 'library', 'note', 'notes']);
 
 export class DreamingEngine {
   constructor(private readonly os: AgentOS) {}
@@ -319,7 +324,7 @@ function parse(s: string): Record<string, unknown> {
 /** Count topic keywords across the window's episode task/summary lines. `nameStop` holds team-member
  *  name tokens (built per-pass from the roster) — a person's name describes WHO asked, not WHAT the fleet
  *  works on, so "the fleet frequently works on … vikas, singhal" is noise; drop them alongside STOP. */
-function topicCounts(episodes: EpisodeRow[], nameStop: Set<string> = new Set()): [string, number][] {
+export function topicCounts(episodes: EpisodeRow[], nameStop: Set<string> = new Set()): [string, number][] {
   const proper = properNouns(episodes);
   const counts = new Map<string, number>();
   for (const e of episodes) {
@@ -435,6 +440,13 @@ function isEntity(token: string, proper: Set<string>): boolean {
   // hex ids through — live globex surfaced `f90fc16d7fb9a19` as something "the fleet frequently works
   // on". A long hex/base36 run with no vowel structure is a handle, not a name.
   if (/^[0-9a-f]{8,}$/i.test(token) || /^[a-z]{2,4}_[0-9a-f]{6,}$/i.test(token)) return false;
+  // …and neither is a mixed handle the hex rule misses. A real tech name carries its digits at the END
+  // (`apache2`, `php8`, `dev3`, `oauth2`, `utf-8`) — a digit buried in the MIDDLE of a long token is an
+  // id or a slug. instawp's first clean pass surfaced `d3cby9k`, `d2mp41k` and the Slack channel id
+  // `c05cl830mnd` as fleet topics; instapods surfaced the task slug `already-contacted-in-90-days`.
+  // Bounded by length so short legitimate names (`log4j`, `s3`) are untouched, and a token the corpus
+  // consistently capitalizes is a name whatever its shape, so `proper` still wins.
+  if (!proper.has(token) && token.length >= 7 && /\d/.test(token.replace(/[\d-]+$/, ''))) return false;
   // A FILENAME qualifies on its base name, never its extension — otherwise the dot rule (meant for
   // hostnames and versions) admits every path an agent mentions, including format placeholders like
   // `yyyy-mm-dd.md`. `.com`/`.io` are not code extensions, so real hostnames still pass below.


### PR DESCRIPTION
`The fleet frequently works on: X, Y, Z` rides in **every agent's system prompt** via the learned guidance — so a junk token there is a junk token in every prompt. The first clean pass after #717 fixed the topic accumulator surfaced two distinct failure shapes on live data.

## 1. A shouted imperative reads as an acronym

`properNouns` promotes a short, all-caps, standalone word to a proper noun. A prompt writing **"WAIT for it to finish"** therefore made `wait` a name, and instawp's pass 1 told every agent:

> The fleet frequently works on: freescout, apache2, **wait**.

Those status words (`wait`, `blocked`, `advanced`, `live`, `record`, …) are states a run passes through, never subjects it works on. Stopped.

## 2. `isEntity` let opaque handles through

The digit rule exists to keep `php8` / `v3`, but it admits **anything** containing a digit. Live output:

| token | what it actually is |
|---|---|
| `c05cl830mnd` | a Slack channel id |
| `d3cby9k`, `d2mp41k` | site handles |
| `already-contacted-in-90-days` | a task slug |

A real tech name carries its digits at the **end**; a digit buried mid-token is an id. Rejected above a length bound, so short names are untouched and `proper` still wins for a consistently-capitalized token whatever its shape.

Same fixture, before → after:

```
before: apache2:3, wait:3, c05cl830mnd:1, d3cby9k:1, d2mp41k:1,
        already-contacted-in-90-days:1, php8:2, dev3:2, oauth2:1, log4j:1, freescout:1
after:  apache2:3, php8:2, dev3:2, freescout:1, oauth2:1, log4j:1
```

## Test

`topicCounts` is exported; a new section in `scripts/insights-signal-test.cjs` pins both rules against the exact token shapes the two tenants produced:

```
✓ a shouted imperative is not a topic
✓ a Slack channel id is not a topic
✓ site handles are not topics
✓ a task slug is not a topic
✓ apache2 survives, counted once per episode
✓ php8 / dev3 / oauth2 survive
✓ a short name with an interior digit is below the length bound and survives
✓ a plain product name survives
… 27 passed, 0 failed
```

`npm run typecheck` clean, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)