### PR TITLE
fix(insights): the recommendations panel stops promising a deleted signal (v0.401.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.401.1] - 2026-08-27
+### Fixed
+- **The "Things to consider" panel no longer promises a signal that was deleted.** Its empty state read
+  "if agents start hitting friction — rejected actions, budget limits, *low success* — suggestions appear
+  here", but `low success` was retired in Step 0 (it divided self-reported successes by all sessions) and
+  cannot be produced. An empty panel therefore read as "all clear" when it meant "two narrow conditions
+  are watched and neither fired" — `policy.review` (≥3 rejected approvals at ≥20%) and `budget.review`
+  (≥2 budget stops), neither of which either live tenant crosses. The empty state now names both
+  conditions with their thresholds and says plainly that quality-keyed suggestions stay absent until a
+  derived outcome replaces the agent's own grade of its own work. Documented as §2f of
+  `docs/insights-revisit.md`, including the candidates deliberately rejected rather than invented to fill
+  the panel.
+
 ## [0.401.0] - 2026-08-27
 ### Fixed
 - **"The fleet frequently works on…" no longer names states and handles.** That list rides in every

--- a/docs/insights-revisit.md
+++ b/docs/insights-revisit.md
@@ -115,6 +115,37 @@ prompt.
 `measureLearning` defines an *intervention* as a `recommendation.applied` audit event. There is **1
 in the fleet's entire history**. "Is it working?" measures its own never-taken actions.
 
+### 2f. The recommendations panel is parked — and now says so (2026-08-27)
+
+`recommendation.applied`: **1 in the fleet's entire history** (instapods, 2026-06-25). Two months on,
+`learned_recommendations.open` is `[]` on both live tenants and has been throughout.
+
+That is not a bug. Step 0 retired `runtime.effort.high` because it fired off `success / sessions`, and
+what remains can only fire on two narrow, observable conditions:
+
+| id | fires when |
+| --- | --- |
+| `policy.review` | ≥3 rejected approvals in the recent window **and** ≥20% rejection rate |
+| `budget.review` | ≥2 budget stops in the recent window |
+
+Neither tenant crosses either — instapods ran 14 rejections and 12 budget stops *lifetime*, spread
+thin enough that no recent window qualifies. So the correct state of this surface is empty.
+
+The defect was the **empty-state copy**, which read "if agents start hitting friction — rejected
+actions, budget limits, *low success* — suggestions appear here". `low success` cannot be produced any
+more; the panel was promising a signal Step 0 deleted, so an empty panel read as "all clear" rather
+than "two narrow conditions, neither met". It now names both conditions with their thresholds and says
+plainly that quality-keyed suggestions are absent until a derived outcome replaces the self-grade.
+
+**Deliberately NOT done:** inventing new thresholds to fill the panel. Every candidate considered —
+"upkeep is disabled", "preload is off", "this agent stores runs but not lessons" — was either a setup
+nudge that belongs in the install wizard, or a quality claim resting on the same self-graded outcome
+Step 0 removed. Checked against live data, the lesson-drought idea also had no subject: the worst
+agent in either fleet stores 43% lessons, and the one that looked starved (`check-resolve-tickets`,
+2 of 8 preamble slots) turned out to be the *most* lesson-rich at 87% — its thin preamble was the
+177-way duplicate flood, fixed by the cleanup, not a content gap. A panel filled with plausible
+non-signals is the exact failure this document exists to correct.
+
 ## 3. Root causes, ranked
 
 1. **Built on telemetry that doesn't exist.** Self-graded outcome, near-zero variance, 40% missing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.401.0",
+  "version": "0.401.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.401.0",
+      "version": "0.401.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.401.0",
+  "version": "0.401.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15386,7 +15386,14 @@ function DreamingSettings({ me, onChanged }: { me: Member; onChanged?: () => voi
             <p className="text-xs text-muted-foreground">Changes the OS suggests from what it’s been seeing. Nothing happens until you decide — <strong>Apply</strong> makes the change (reversible), <strong>Dismiss</strong> hides it.</p>
           </div>
           {recs.length === 0
-            ? <div className="text-xs text-muted-foreground">Nothing to flag right now. If agents start hitting friction — rejected actions, budget limits, low success — suggestions appear here.</div>
+            ? <div className="space-y-1 text-xs text-muted-foreground">
+                <div>Nothing to flag right now. Two conditions are watched, both from the recent window:</div>
+                <ul className="ml-4 list-disc space-y-0.5">
+                  <li><strong>3+ rejected approvals</strong> at a 20%+ rejection rate — a capability may belong on the deny list, or the gate may just be friction.</li>
+                  <li><strong>2+ budget stops</strong> — raise the caps, or tighten what agents are asked to do.</li>
+                </ul>
+                <div>An empty panel means neither has fired, not that nothing could be improved. Suggestions keyed to run <em>quality</em> are deliberately absent until an outcome derived from observable facts replaces the agent’s own grade of its own work.</div>
+              </div>
             : recs.map((r) => (
                 <div key={r.id} className="rounded-md border p-3">
                   <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
`recommendation.applied` stands at **1 in the fleet's entire history** (instapods, 2026-06-25), and `learned_recommendations.open` is `[]` on both live tenants and has been throughout.

**That is the correct state, not a bug.** Step 0 retired `runtime.effort.high` for firing off `success / sessions`, and what remains can fire on only two narrow, observable conditions:

| id | fires when |
|---|---|
| `policy.review` | ≥3 rejected approvals in the recent window **and** ≥20% rejection rate |
| `budget.review` | ≥2 budget stops in the recent window |

Neither tenant crosses either — instapods logged 14 rejections and 12 budget stops *lifetime*, spread thin enough that no recent window qualifies.

## The actual defect

The empty state said:

> Nothing to flag right now. If agents start hitting friction — rejected actions, budget limits, **low success** — suggestions appear here.

`low success` cannot be produced any more. The panel was advertising a signal Step 0 deleted, so an empty panel read as *"all clear"* when it meant *"two narrow conditions are watched and neither fired"*.

It now names both conditions with their thresholds, and says plainly that suggestions keyed to run **quality** stay absent until an outcome derived from observable facts replaces the agent's own grade of its own work.

## What I deliberately did NOT build

Filling the panel was the obvious move and it's the wrong one. Every candidate was either a setup nudge that belongs in the install wizard (`upkeep is disabled`, `preload is off` — and both were just enabled fleet-wide, so they'd have no audience), or a quality claim resting on the same self-graded outcome Step 0 removed.

The most promising one — *"this agent stores runs but never lessons"* — I checked against live data before building it, and it had no subject:

```
worst agent, instapods : 50% lessons (researcher)
worst agent, instawp   : 43% lessons (triage)
```

No drought exists. And the agent that *looked* starved — `check-resolve-tickets`, filling only 2 of 8 preamble slots — turns out to be the **most lesson-rich in the fleet at 87%** (197 lessons vs 30 episodes). Its thin preamble was the 177-way duplicate flood crowding the over-fetch, fixed by the cleanup, not a content gap. Post-cleanup it fills 8/8.

A panel filled with plausible non-signals is the exact failure `docs/insights-revisit.md` exists to correct. Recorded there as §2f so the next person doesn't re-derive it.

Docs + console copy only; no behaviour change. `npm run typecheck` clean, `cd web && npm run build` clean, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)