### PR TITLE
fix(wakeups): a finished run is not a delivery target for good news (v0.402.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.402.0] - 2026-08-27
+### Fixed
+- **A finished run is no longer a delivery target for good news.** The wake queue picks a live pane by
+  `reachable` — the PANE — which is deliberate, but `report` is the agent saying the RUN is over, and its
+  pane stays reachable regardless. Measured on live instawp over 7 days: **55% of injects (152 of 275)
+  landed in a session that had already reported**, resurrecting it in place — the very thing `dropDone`
+  refuses to spawn a claude for. The archetype was a `support-ops` run that reported success at **+152
+  seconds** and was then held open **6.5 hours** by ten injects (still `running` 49h later). And the
+  inject lane is not free: sessions that received one ran **78 API calls against 42**, at **381k context
+  per call against 277k**, costing **93% more per run** — 14% of runs consuming 24% of spend, because the
+  message lands in a transcript that then keeps growing and every subsequent call re-reads all of it.
+  (The gate itself is 1ms at p50 over 32,515 samples; it was never the tax.) Now a **done-only** batch
+  treats a finished run as no target at all and drops, exactly as it would for a cold caller — the result
+  is durable in the task and the human already has the card — while any other batch merely **prefers** a
+  still-working session, so a stranding or hand-back still injects rather than spending a resume. Against
+  the same week: 131 of 275 injects stop happening, and the 21 stranded/blocked deliveries into a
+  finished run still land, so this costs **no extra resumes**. Pinned by two new sections in
+  `scripts/wakeup-queue-test.cjs`.
+
 ## [0.401.1] - 2026-08-27
 ### Fixed
 - **The "Things to consider" panel no longer promises a signal that was deleted.** Its empty state read

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.401.1",
+  "version": "0.402.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.401.1",
+      "version": "0.402.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.401.1",
+  "version": "0.402.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/wakeup-queue-test.cjs
+++ b/scripts/wakeup-queue-test.cjs
@@ -262,6 +262,43 @@ console.log('\n\x1b[1m9) a HAND-BACK still resumes — and carries any completio
   assert(s.ok && s.via === 'resume' && spawned.length === n2 + 1, 'a stranding wakes the caller too', s);
 }
 
+console.log('\n\x1b[1m10) a FINISHED run is not a delivery target for good news\x1b[0m');
+{
+  idleAgent();
+  // `report` is the agent saying it is done. Its pane stays reachable (that is the attachable lane), which
+  // is why 55% of live injects landed in one — a resurrection in place of a run that had already finished.
+  const reported = (id) => aos.audit.append({ ts: Date.now(), runId: id, tenant: aos.tenant, principal: 'caller', type: 'session.reported', data: {} });
+
+  const fin = mkSession('cs-fin');
+  reported(fin);
+  const r = q.enqueue({ agent: 'caller', transcript: 'cs-fin', runAs: alice.id, source: 'tsk_fin', message: '✅ done', title: 'p', kind: 'poke-done' });
+  assert(!r.ok, 'good news is NOT injected into a run that already reported', r);
+  const row = aos.db.prepare("SELECT * FROM agent_wakeups WHERE source = 'tsk_fin'").get();
+  assert(row.status === 'dropped', 'it drops, exactly as it would for a cold caller', row);
+  assert(aos.db.prepare("SELECT COUNT(*) n FROM audit_events WHERE run_id = ? AND type = 'session.inject'").get(fin).n === 0, 'the finished pane was never typed into');
+
+  // …but a STRANDING still reaches it: somebody is stuck, and an inject beats spending a resume.
+  const r2 = q.enqueue({ agent: 'caller', transcript: 'cs-fin', runAs: alice.id, source: 'tsk_str', message: '⛔ handed back', title: 'p', kind: 'poke-stranded' });
+  assert(r2.ok && r2.via === 'inject' && r2.sessionId === fin, 'a hand-back still injects into the finished pane', r2);
+  assert(spawned.filter((x) => x.spawnedBy === 'poke:tsk_str').length === 0, 'and costs no resume');
+}
+
+console.log('\n\x1b[1m11) a still-working session is preferred over a finished one\x1b[0m');
+{
+  idleAgent();
+  const reported = (id) => aos.audit.append({ ts: Date.now(), runId: id, tenant: aos.tenant, principal: 'caller', type: 'session.reported', data: {} });
+  const older = mkSession('cs-old');           // finished, but NEWER in creation order below
+  reported(older);
+  const working = mkSession('cs-work');        // still running, no report
+  // The sibling lane picks the newest live session; `working` is newest here, so prove the preference by
+  // making the FINISHED one newest instead.
+  const newestFinished = mkSession('cs-new-fin');
+  reported(newestFinished);
+  const r = q.enqueue({ agent: 'caller', transcript: 'cs-absent', runAs: alice.id, source: 'tsk_sib', message: '⛔ handed back', title: 'p', kind: 'poke-stranded' });
+  assert(r.ok && r.via === 'inject-sibling', 'delivered to a sibling', r);
+  assert(r.sessionId === working, 'the STILL-WORKING sibling wins over two finished ones', { got: r.sessionId, working, older, newestFinished });
+}
+
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);
 try { fs.rmSync(HOME, { recursive: true, force: true }); } catch { /* best effort */ }
 process.exit(fail === 0 ? 0 : 1);

--- a/src/edge/wakeups.ts
+++ b/src/edge/wakeups.ts
@@ -65,6 +65,30 @@
  * A `poke-done` still injects into a live pane — cheap, in-context, exactly what it was built for. What
  * goes away is resurrecting an agent to tell it good news. Any other `kind` (the legacy `poke`, a future
  * `approval`) keeps the full ladder: this narrows on an explicit declaration, never by default.
+ *
+ * ## "A live pane is free" is only true while the run is unfinished (2026-08-27)
+ *
+ * The resume lane was suppressed successfully — 14 of 289 deliveries on live instawp over 7 days. But the
+ * cost moved rather than vanished. Sessions that received an inject ran **78 API calls against 42**, at
+ * **381k context per call against 277k**, costing **93% more per run** ($24.62 vs $12.74) — 14% of runs
+ * consuming 24% of spend. The per-CALL price is identical; injects simply cause many more calls, on a
+ * transcript that keeps growing, and each call re-reads all of it. That is the latency, not the gate
+ * (measured at 1ms p50 over 32,515 samples).
+ *
+ * And 55% of injects landed in a run that had ALREADY reported. `reachable` is the pane, not the run:
+ * `report` is the agent saying it is finished, and injecting good news there resurrects it in place —
+ * precisely what {@link dropDone} refuses to spawn a claude for. The archetype was a support-ops run that
+ * reported success at +152 SECONDS and was then held open 6.5 hours by ten injects.
+ *
+ * So {@link WakeupQueue.deliver} now reads `session.reported` as well as `reachable`:
+ *  - a **done-only** batch treats a finished run as no target at all (it drops, as it would for a cold
+ *    caller — the result is durable in the task and the human already has the card);
+ *  - any other batch merely PREFERS a still-working session, because when somebody is stuck an inject
+ *    into a finished pane still beats spending a resume.
+ *
+ * Measured against the same week: 131 of 275 injects were `poke-done` into a finished run and stop
+ * happening; the 21 stranded/blocked ones that also targeted a finished run still deliver, so this costs
+ * no extra resumes.
  */
 import { newId } from '../id';
 import { AgentOS } from '../kernel';
@@ -173,8 +197,28 @@ export class WakeupQueue {
       .prepare('SELECT id, tmux, claude_session_id AS cs FROM term_sessions WHERE agent = ? ORDER BY created_at DESC LIMIT 50')
       .all<{ id: string; tmux: string; cs: string | null }>(agentId)
       .filter((r) => this.tm.reachable(r.id));
-    const own = live.find((r) => r.cs && transcripts.has(r.cs));
-    const dest = own ?? live[0];
+    // A run that has REPORTED is finished — it said so. Its pane is still reachable (that is the whole
+    // point of the attachable lane), which made it look like a free delivery target, and 55% of injects
+    // measured on live instawp landed in one. For GOOD NEWS that is a resurrection in place: the same
+    // thing `dropDone` already refuses to spawn a claude for, done to a run that merely hasn't been torn
+    // down yet. It is not free either — an injected session ran 78 API calls against 42, at 381k context
+    // per call against 277k, costing 93% more per run, because the message lands in a transcript that
+    // then keeps growing. So a done-only batch treats a finished run as no target at all, and every
+    // batch prefers a still-working session over a finished one.
+    const finished = new Set<string>(
+      live.length
+        ? this.db
+            .prepare(`SELECT DISTINCT run_id FROM audit_events WHERE type = 'session.reported' AND run_id IN (${live.map(() => '?').join(',')})`)
+            .all<{ run_id: string }>(...live.map((r) => r.id))
+            .map((r) => r.run_id)
+        : [],
+    );
+    // Ordering, not exclusion, for anything that isn't good news: when somebody is STUCK, injecting into a
+    // finished-but-live pane still beats spending a resume — it just goes to the bottom of the list.
+    const pool = live.filter((r) => !finished.has(r.id));
+    if (!doneOnly) pool.push(...live.filter((r) => finished.has(r.id)));
+    const own = pool.find((r) => r.cs && transcripts.has(r.cs));
+    const dest = own ?? pool[0];
     if (dest) {
       const via = own ? 'inject' : 'inject-sibling';
       const injected = this.tm.injectToSession(dest.id, message, true, principal);


### PR DESCRIPTION
Found while answering "why does execution take forever on instawp". It isn't the gate — that measures **1ms at p50 over 32,515 samples**. It's that sessions never end, and the wake queue is why.

## What the numbers say (live instawp, 7 days)

The resume lane was suppressed successfully — **14 of 289** deliveries. But the cost moved rather than vanished:

| | never injected | received inject(s) |
|---|---|---|
| runs | 547 | 87 |
| **API calls per run** | 42 | **78** (+86%) |
| **context per call** | 277k | **381k** (+38%) |
| cost per run | $12.74 | **$24.62** (+93%) |
| cost per *call* | $0.307 | $0.314 |

Per-call price is identical. Injects don't make calls dearer — they cause **many more of them, on a transcript that keeps growing**, and every call re-reads all of it. 14% of runs consume **24% of spend**.

## The specific defect

`deliver()` picks a target by `reachable` — the pane — which was itself a deliberate fix (v0.334.1, status is not liveness). But `report` is the agent saying the **run** is over; its pane stays reachable regardless.

**55% of injects (152 of 275) landed in a session that had already reported.** That's a resurrection in place — exactly what `dropDone` already refuses to spawn a claude for, done to a run that merely hasn't been torn down yet.

The archetype, which is the session that prompted this: `support-ops` reported success at **+152 seconds**, then ten injects held it open **6.5 hours**. It was still `running` 49 hours later.

## The rule

Split by what the wake-up is *for*, same as the resume lane already does:

- **done-only batch** → a finished run is **no target at all**; it drops, exactly as it would for a cold caller. The result is durable in the task and the human already has the card.
- **anything else** (`poke-stranded`, `poke-blocked`, legacy `poke`) → merely **prefer** a still-working session. When somebody is stuck, an inject into a finished pane still beats spending a resume.

Ordering, not exclusion, for the stuck cases — which is what makes this free. Exact split for the measured week:

```
131  REPORTED target / poke-done      → stops happening
105  working target  / poke-done      → unchanged
 16  REPORTED target / poke-stranded  → still delivers
 10  working target  / poke-stranded  → unchanged
  5  REPORTED target / poke|blocked   → still delivers
  8  working target  / poke|blocked   → unchanged
```

**131 of 275 injects removed, zero extra resumes.**

## Test

Two new sections in `scripts/wakeup-queue-test.cjs` — 50 checks total, **4 fail on the previous code**:

```
✓ good news is NOT injected into a run that already reported
✓ it drops, exactly as it would for a cold caller
✓ the finished pane was never typed into
✓ a hand-back still injects into the finished pane
✓ and costs no resume
✓ the STILL-WORKING sibling wins over two finished ones
```

`npm run typecheck` clean, full `npm run test:governance` green.

## Not in this PR

The other half of the diagnosis: **31 sessions are still `running` on instawp, the oldest at 1037 hours (43 days)**. Sweep 3 (idle interactive janitor, 72h on that tenant) should catch them, but `markTurnBusy` stamps `last_activity` on **every tool call** — so the clock measures silence-since-last-tool-call, and these get used just often enough to never age out. There is a max-*idle* but **no max-lifetime**. Reaping human-opened sessions is a product decision, so it's written up rather than changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)