### PR TITLE
fix(insights): bump TOPICS_VERSION, and fingerprint the extractor (v0.402.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.402.1] - 2026-08-27
+### Fixed
+- **v0.401.0 changed the topic extractor without bumping `TOPICS_VERSION`, so nothing it stopped
+  extracting was actually removed.** `topics` is a cumulative map that decays only on a 21-day half-life;
+  the version counter exists precisely so a changed extractor clears the words it used to admit. It was
+  not bumped, so `wait`, `c05cl830mnd`, `d3cby9k`, `d2mp41k` and `already-contacted-in-90-days` all
+  survived in the live maps — and `wait:3` sat exactly on `MIN_TOPIC_COUNT`, so the guidance line every
+  instawp agent reads still said "the fleet frequently works on: freescout, apache2, **wait**". Bumped to
+  4; both tenants rebuild their map from the current corpus on the next pass. This is the **second** time
+  the counter was missed (v0.281.3 tightened `isEntity` the same way), and the warning telling you to bump
+  it sits two paragraphs above the constant — so a comment is demonstrably not enough. The insights test
+  now **fingerprints the extractor** (the `STOP` literal plus `topicCounts`/`properNouns`/`isEntity`) and
+  fails the build when it changes without a bump, naming the new hash and the version to move.
+
 ## [0.402.0] - 2026-08-27
 ### Fixed
 - **A finished run is no longer a delivery target for good news.** The wake queue picks a live pane by

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.402.0",
+  "version": "0.402.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.402.0",
+      "version": "0.402.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.402.0",
+  "version": "0.402.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/insights-signal-test.cjs
+++ b/scripts/insights-signal-test.cjs
@@ -24,7 +24,8 @@ delete process.env.AGENT_OS_SECRET_KEY;
 let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
-const { deriveGuidance, deriveRecommendations, recommendationResolved, topicCounts } = require(path.join(ROOT, 'dist/edge/dreaming.js'));
+const { deriveGuidance, deriveRecommendations, recommendationResolved, topicCounts, TOPICS_VERSION } = require(path.join(ROOT, 'dist/edge/dreaming.js'));
+const crypto = require('crypto');
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
 const { detectAlerts } = require(path.join(ROOT, 'dist/edge/alerts.js'));
 
@@ -152,6 +153,59 @@ console.log('\n\x1b[1mInsights signal — no prompt-injected or DM\'d number off
   assert(has('php8') && has('dev3') && has('oauth2'), 'php8 / dev3 / oauth2 survive');
   assert(has('log4j'), 'a short name with an interior digit is below the length bound and survives');
   assert(has('freescout'), 'a plain product name survives');
+}
+
+// ── the extractor and TOPICS_VERSION must move together ─────────────────────────────────────────────
+// `topics` is a CUMULATIVE map that decays only on a 21-day half-life, so changing what the extractor
+// ADMITS does nothing about what it already admitted — the old words keep their counts and keep
+// headlining the guidance line. TOPICS_VERSION exists to clear the map when the extractor's meaning
+// changes, and a comment saying "bump this" has now failed to enforce it TWICE:
+//   v0.281.3  tightened isEntity for opaque hex ids, no bump — the ids stayed.
+//   v0.401.0  stopped extracting `wait`, `c05cl830mnd`, `d3cby9k`, `already-contacted-in-90-days`,
+//             no bump — all four stayed in the live maps, and `wait:3` sat exactly on MIN_TOPIC_COUNT,
+//             so it was still in the guidance line every agent read.
+// So this fingerprints the extractor instead of trusting anyone to remember. When it fails, do BOTH
+// things it tells you to; the hash is not a rubber stamp to update on its own.
+{
+  console.log('\n\x1b[1m5) the extractor cannot change without clearing the maps it poisoned\x1b[0m');
+  const src = fs.readFileSync(path.join(ROOT, 'dist/edge/dreaming.js'), 'utf8');
+  // Slice the extractor's own regions out of the compiled module: the stop-list literal and the three
+  // functions that decide what counts as a topic. Compiled from the same TS, so a semantic change to any
+  // of them moves the hash; edits ELSEWHERE in the file do not.
+  // Each region must be FOUND and non-trivial. The first cut of this used '\n]);' to end the stop-list,
+  // but tsc emits the array literal on ONE line, so the marker never matched, the slice silently became a
+  // constant, and the whole stop-list contributed NOTHING to the hash — a fingerprint with a hole in it,
+  // which would have passed the very change that prompted this test. Hence the length floors: a broken
+  // anchor now fails here instead of quietly weakening the guard.
+  const region = (startMark, endMark, minLen) => {
+    const a = src.indexOf(startMark);
+    const b = a >= 0 ? src.indexOf(endMark, a + startMark.length) : -1;
+    const slice = a >= 0 && b > a ? src.slice(a, b) : '';
+    assert(slice.length >= minLen,
+      `fingerprint region "${startMark}" is intact`,
+      slice.length ? `only ${slice.length} chars, expected >= ${minLen}` : 'anchor or end marker not found in dist/edge/dreaming.js');
+    return slice;
+  };
+  const extractor = [
+    region('STOP = new Set', ']);', 2000),         // the stop-list literal, one line after compilation
+    region('function topicCounts', '\n}', 400),
+    region('function properNouns', '\n}', 1500),
+    region('function isEntity', '\n}', 400),
+  ].join('\u0000');
+  const hash = crypto.createHash('sha256').update(extractor).digest('hex').slice(0, 16);
+
+  // ⚠ When this fails: the extractor changed. Bump TOPICS_VERSION in src/edge/dreaming.ts so every live
+  // tenant rebuilds its topic map from the current corpus, THEN paste the new hash here.
+  const PINNED = { version: 4, hash: 'bc0f006a6d11ecf2' };
+
+  assert(hash === PINNED.hash,
+    'the extractor is unchanged since TOPICS_VERSION was last bumped',
+    `\n    extractor hash is ${hash}, pinned ${PINNED.hash}\n` +
+    `    → the topic extractor changed. Bump TOPICS_VERSION (currently ${TOPICS_VERSION}) so live tenants\n` +
+    `      clear the stale words it no longer admits, then set hash: '${hash}' here.`);
+  assert(TOPICS_VERSION === PINNED.version,
+    'TOPICS_VERSION matches the version this fingerprint was taken at',
+    `TOPICS_VERSION=${TOPICS_VERSION}, fingerprint pinned at ${PINNED.version}`);
 }
 
 fs.rmSync(HOME, { recursive: true, force: true });

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -77,9 +77,14 @@ const MIN_TOPIC_COUNT = 3;
  *
  * **Bump this in the same commit as any change to `isEntity`/`properNouns`/`STOP`.** v0.281.3 tightened
  * `isEntity` (opaque hex ids) without bumping, so the ids already stored stayed in the map — the exact
- * failure this counter exists to prevent.
+ * failure this counter exists to prevent. v0.401.0 then did it AGAIN — it stopped extracting `wait`,
+ * `c05cl830mnd`, `d3cby9k` and `already-contacted-in-90-days`, and every one of them stayed in the live
+ * maps, with `wait:3` sitting exactly on {@link MIN_TOPIC_COUNT} and therefore still headlining the
+ * guidance line every agent reads. A comment is evidently not enough to enforce this, so
+ * `scripts/insights-signal-test.cjs` now fingerprints the extractor and fails the build when it changes
+ * without a bump.
  */
-const TOPICS_VERSION = 3;
+export const TOPICS_VERSION = 4;
 const STOP = new Set(['task', 'outcome', 'session', 'after', 'then', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'run', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none',
   // Procedural / plumbing words — they describe HOW an agent worked, not WHAT the fleet works on, so they
   // drown the real topics ("slack, check, report, completed, summary" is a useless "frequently works on").


### PR DESCRIPTION
Found while reviewing how insights are doing after #721. **#721 was half-effective and I missed why.**

## The defect

v0.401.0 stopped *extracting* `wait`, `c05cl830mnd`, `d3cby9k`, `d2mp41k` and `already-contacted-in-90-days` — and removed **none** of them, because it did not bump `TOPICS_VERSION`.

`topics` is a **cumulative** map that decays only on a 21-day half-life. Changing what the extractor admits does nothing about what it already admitted. The counter exists precisely to clear the map when the extractor's meaning changes.

Live state on instawp *after* the fix shipped and deployed:

```
topics: freescout:8, apache2:3, wait:3, lupinus.fi:2, adminer:1, …
        c05cl830mnd:1, d3cby9k:1, d2mp41k:1
```

`wait:3` sits exactly on `MIN_TOPIC_COUNT`, so the guidance line **every agent reads** still says:

> The fleet frequently works on: freescout, apache2, **wait**.

Bumped to 4. Both tenants rebuild from the current corpus on their next pass.

## Why a comment wasn't enough

This is the **second** time. The warning is two paragraphs above the constant:

> **Bump this in the same commit as any change to `isEntity`/`properNouns`/`STOP`.** v0.281.3 tightened `isEntity` (opaque hex ids) without bumping, so the ids already stored stayed in the map — the exact failure this counter exists to prevent.

I read that file, edited `STOP` and `isEntity`, and bumped nothing. So `scripts/insights-signal-test.cjs` now **fingerprints the extractor** — the `STOP` literal plus `topicCounts` / `properNouns` / `isEntity`, sliced out of the compiled module — and fails the build when it moves without a bump:

```
✗ the extractor is unchanged since TOPICS_VERSION was last bumped
    extractor hash is bc0f006a6d11ecf2, pinned 254d6cb99ba9993e
    → the topic extractor changed. Bump TOPICS_VERSION (currently 4) so live tenants
      clear the stale words it no longer admits, then set hash: 'bc0f006a6d11ecf2' here.
```

## A hole in the first cut of that test

Worth recording, because it nearly shipped: the stop-list region ended at `'\n]);'`, but **tsc emits the array literal on one line**, so the marker never matched, the slice silently became the constant `MISSING:…`, and the entire stop-list contributed **nothing** to the hash. That fingerprint would have passed the very change that prompted it.

Each region now asserts a length floor, so a broken anchor fails loudly instead of quietly weakening the guard:

```
✓ fingerprint region "STOP = new Set" is intact
✓ fingerprint region "function topicCounts" is intact
✓ fingerprint region "function properNouns" is intact
✓ fingerprint region "function isEntity" is intact
```

And both perturbation classes are verified to trip it — adding a `STOP` entry: **CAUGHT**; changing the `isEntity` length bound: **CAUGHT**.

`npm run typecheck` clean, full `npm run test:governance` green (33 checks in this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)