### PR TITLE
fix(skills): a merged skill proposal stops asking to be reviewed (v0.404.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.404.1] - 2026-08-29
+### Fixed
+- **A merged skill proposal now stops asking to be reviewed.** The Skills console acts on the SKILL —
+  publish a draft, apply or discard a parked edit, delete one — and none of those routes ever touched the
+  `skill.proposed` Inbox card they resolve. Since "Needs you" is driven by `messages.status`, every
+  proposal a human had already merged sat there "awaiting review" forever (live tenants were carrying
+  several). The four routes now close the matching card (`POST /api/skills/:name/publish` and
+  `…/edit/apply` → approved; `…/edit/discard` and `DELETE /api/skills/:name` → rejected), matched by the
+  card's `args.skill` plus the `edit` flag that tells the draft and edit lanes apart, and the count is
+  audited alongside the act. Cards left open by the old code are healed once at boot from the library's own
+  state (a published draft reads as approved, a deleted one as rejected, an edit with nothing parked as
+  `resolved` — applied vs discarded is no longer distinguishable); anything genuinely pending is left
+  alone. The Inbox row renders the resolution (`published` / `applied` / `dismissed`) instead of a
+  permanent violet "review in Skills" badge, and names the edit lane for what it is. Pinned by
+  `scripts/skill-edit-proposal-test.cjs` (7 new checks, all of which fail against the old code).
+
 ## [0.404.0] - 2026-08-27
 ### Added
 - **Per-tool latency for every agent-facing MCP tool.** The request-metrics collector already answered

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.404.0",
+  "version": "0.404.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.404.0",
+      "version": "0.404.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.404.0",
+  "version": "0.404.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/skill-edit-proposal-test.cjs
+++ b/scripts/skill-edit-proposal-test.cjs
@@ -187,10 +187,49 @@ fs.rmSync(home, { recursive: true, force: true });
   const applyAgain = await (await fetch(base + '/api/skills/wp-version-upgrade/edit/apply', { method: 'POST', headers: { cookie } })).status;
   check('applying with nothing pending 404s', applyAgain === 404);
 
+  // ── the review card is closed by the act that resolves it ───────────────────
+  // The console acts on the SKILL, not the card, so nothing else will ever flip it: a merged proposal
+  // that stays `open` keeps asking to be reviewed in "Needs you" forever (which is what live tenants saw).
+  const cards = () => aos.db.prepare("SELECT id, status, args FROM messages WHERE type = 'skill.proposed' ORDER BY created_at").all()
+    .map((r) => ({ ...r, args: JSON.parse(r.args || '{}') }));
+  const cardFor = (skill, edit) => cards().filter((c) => c.args.skill === skill && (c.args.edit === true) === edit);
+  check('applying an edit closes its inbox card', cardFor('wp-version-upgrade', true).every((c) => c.status === 'approved'));
+  check('...and the new-draft card for another skill is untouched', cardFor('brand-new-skill', false)[0].status === 'open');
+
   await post('/api/skills/propose', { name: 'wp-version-upgrade', body: 'a third revision' });
+  check('a fresh edit proposal opens a new card', cardFor('wp-version-upgrade', true).some((c) => c.status === 'open'));
   const discarded = await asOwner('/api/skills/wp-version-upgrade/edit/discard');
   check('an owner discards an edit', discarded.ok === true);
   check('...leaving the live skill alone', aos.skills.get('wp-version-upgrade').content.includes('PHP check'));
+  check('...and closing the card as rejected', cardFor('wp-version-upgrade', true).every((c) => c.status !== 'open'));
+
+  // publish / dismiss close the OTHER lane's card (a proposed draft, not an edit).
+  const published = await asOwner('/api/skills/brand-new-skill/publish');
+  check('an owner publishes a proposed draft', published.ok === true);
+  check('...which closes its card as approved', cardFor('brand-new-skill', false).every((c) => c.status === 'approved'));
+
+  await post('/api/skills/propose', { name: 'throwaway-draft', description: 'Nope.', body: 'step one' });
+  check('a dismissable draft has an open card', cardFor('throwaway-draft', false)[0].status === 'open');
+  const dropped = await (await fetch(base + '/api/skills/throwaway-draft', { method: 'DELETE', headers: { cookie } })).json();
+  check('deleting a proposed draft is the dismiss action', dropped.ok === true);
+  check('...and closes its card as rejected', cardFor('throwaway-draft', false).every((c) => c.status === 'rejected'));
+
+  // ── boot heal: cards left open by the pre-fix routes ───────────────────────
+  // Simulate the live tenants: an already-merged proposal whose card the old code never touched.
+  const stale = (id, args) => aos.db.prepare("INSERT INTO messages (id, session_id, agent, type, title, body, args, status, created_at) VALUES (?, ?, 'wp-agent', 'skill.proposed', 'stale', 'stale', ?, 'open', ?)")
+    .run(id, session.id, JSON.stringify(args), Date.now());
+  stale('m-stale-edit', { skill: 'wp-version-upgrade', edit: true });   // edit already applied/discarded
+  stale('m-stale-pub', { skill: 'brand-new-skill' });                   // draft already published
+  stale('m-stale-gone', { skill: 'throwaway-draft' });                  // draft already deleted
+  aos.skills.propose({ name: 'still-pending', description: 'Waiting.', body: 'x', agent: 'wp-agent', session: session.id });
+  stale('m-live-draft', { skill: 'still-pending' });                    // genuinely still awaiting review
+  const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
+  new TerminalManager(aos, base, path.join(serverHome, 'heal.sock'));   // the boot sweep runs in the constructor
+  const byId = Object.fromEntries(aos.db.prepare("SELECT id, status FROM messages WHERE type = 'skill.proposed'").all().map((r) => [r.id, r.status]));
+  check('boot heals a stale edit card (fate no longer knowable → resolved)', byId['m-stale-edit'] === 'resolved');
+  check('boot heals a stale card for a now-published draft as approved', byId['m-stale-pub'] === 'approved');
+  check('boot heals a stale card for a deleted draft as rejected', byId['m-stale-gone'] === 'rejected');
+  check('boot leaves a genuinely pending draft card open', byId['m-live-draft'] === 'open');
 
   server.close();
   fs.rmSync(serverHome, { recursive: true, force: true });

--- a/src/server.ts
+++ b/src/server.ts
@@ -5555,7 +5555,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // interactive session, materialise the now-published skill into it + `/reload-skills` instead of
     // waiting for next launch. Bounded to the proposer — a broadcast to the whole fleet would be disruptive.
     const reloaded = proposer ? tm.refreshAgentSkills(proposer).reloaded : 0;
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.published', data: { skill: name, reloaded } });
+    // Close the Inbox review card — the console acts on the skill, so nothing else would ever resolve it.
+    const closed = tm.resolveSkillProposals(name, 'new', 'approved');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.published', data: { skill: name, reloaded, cards: closed } });
     return sendJson(res, 200, { ok: true, skill: os.skills.get(name), reloaded });
   }
   // Apply an agent-proposed EDIT to an existing skill (owner/admin): the parked text becomes the live
@@ -5568,7 +5570,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const applied = os.skills.applyEdit(name);
     if (!applied) return sendJson(res, 404, { error: 'no pending edit for this skill' });
     const reloaded = applied.agent ? tm.refreshAgentSkills(applied.agent).reloaded : 0;
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.edit.applied', data: { skill: name, proposedBy: applied.agent, reloaded } });
+    const closed = tm.resolveSkillProposals(name, 'edit', 'approved');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.edit.applied', data: { skill: name, proposedBy: applied.agent, reloaded, cards: closed } });
     return sendJson(res, 200, { ok: true, skill: os.skills.get(name), reloaded });
   }
   // Discard an agent-proposed edit (owner/admin) — drops the parked text, live skill untouched.
@@ -5578,7 +5581,8 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const name = skillEditDrop[1];
     const proposer = os.skills.pendingEdit(name)?.agent;
     if (!os.skills.discardEdit(name)) return sendJson(res, 404, { error: 'no pending edit for this skill' });
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.edit.dismissed', data: { skill: name, proposedBy: proposer } });
+    const closed = tm.resolveSkillProposals(name, 'edit', 'rejected');
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'skill.edit.dismissed', data: { skill: name, proposedBy: proposer, cards: closed } });
     return sendJson(res, 200, { ok: true });
   }
   // List open agent skill-requests for the Skills page review section (owner/admin).
@@ -5763,7 +5767,10 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // DELETE — also the "dismiss" action for a proposal (drops the draft folder). Audit the intent.
     const wasProposed = !!os.skills.get(name)?.proposed;
     const ok = os.skills.remove(name);
-    if (ok) os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: wasProposed ? 'skill.proposal.dismissed' : 'skill.deleted', data: { skill: name } });
+    // A deleted skill's review cards are dead either way: a dismissed draft is rejected, and a deleted
+    // published skill can't have its parked edit reviewed (remove() drops that edit with the folder).
+    const closed = ok ? tm.resolveSkillProposals(name, 'new', 'rejected') + tm.resolveSkillProposals(name, 'edit', 'rejected') : 0;
+    if (ok) os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: wasProposed ? 'skill.proposal.dismissed' : 'skill.deleted', data: { skill: name, cards: closed } });
     return sendJson(res, ok ? 200 : 404, ok ? { ok: true } : { error: 'skill not found' });
   }
 

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -908,6 +908,39 @@ export class TerminalManager {
     });
     this.refreshTranscriptRoots();
     this.sweepLaunchMarkers();
+    this.sweepStaleSkillProposals();
+  }
+
+  /** One-shot boot heal for review cards left open by the pre-v0.404.1 skills routes, which resolved the
+   *  SKILL but never its 'skill.proposed' card — so a published draft / applied edit sat in "Needs you"
+   *  forever. Re-derives each open card's fate from the library (the only source of truth left): a draft
+   *  that is now published reads as approved, one whose folder is gone as rejected, and an edit card with
+   *  no parked edit as `resolved` (applied vs discarded is no longer distinguishable — and the card is
+   *  dead either way). Anything still genuinely pending is left alone. Cheap: open cards only, once per
+   *  process. */
+  private sweepStaleSkillProposals(): void {
+    try {
+      const rows = this.db
+        .prepare(`SELECT id, args FROM messages WHERE type = 'skill.proposed' AND status = 'open'`)
+        .all<{ id: string; args: string | null }>();
+      if (!rows.length) return;
+      const upd = this.db.prepare(`UPDATE messages SET status = ? WHERE id = ?`);
+      let healed = 0;
+      for (const r of rows) {
+        let a: Record<string, unknown> = {};
+        try { a = r.args ? JSON.parse(r.args) : {}; } catch { continue; }
+        const name = String(a.skill ?? '');
+        if (!name) continue;
+        const skill = this.os.skills.get(name);
+        let status: string | undefined;
+        if (a.edit === true) { if (!skill || !this.os.skills.pendingEdit(name)) status = 'resolved'; }
+        else if (!skill) status = 'rejected';
+        else if (!skill.proposed) status = 'approved';
+        if (!status) continue;
+        upd.run(status, r.id); healed++;
+      }
+      if (healed) this.audit('-', 'system', 'skill.proposals.healed', { count: healed });
+    } catch { /* advisory — never block boot on a heal */ }
   }
 
   /** Teach the transcript reader where rotated sessions wrote their conversations. Without it the console's
@@ -5780,6 +5813,28 @@ export class TerminalManager {
   /** Mark a 'skill.request' card resolved once a human approved (installed) or dismissed it. */
   setSkillRequestStatus(id: string, status: 'approved' | 'rejected'): void {
     this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'skill.request'`).run(status, id);
+  }
+
+  /** Mark the open 'skill.proposed' review card(s) for a skill resolved once a human acted on it —
+   *  published/dismissed a proposed DRAFT, or applied/discarded a proposed EDIT. Unlike `skill.request`
+   *  (approved by card id) the skills console acts on the SKILL, not the card, so the card is found by
+   *  its payload: `args.skill` plus the `edit` flag that tells the two lanes apart. Without this the
+   *  card sat "awaiting review" in the Inbox forever after the human had already merged it. Returns how
+   *  many cards were closed. */
+  resolveSkillProposals(skill: string, lane: 'new' | 'edit', status: 'approved' | 'rejected'): number {
+    const rows = this.db
+      .prepare(`SELECT id, args FROM messages WHERE type = 'skill.proposed' AND status = 'open'`)
+      .all<{ id: string; args: string | null }>();
+    const upd = this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'skill.proposed'`);
+    let closed = 0;
+    for (const r of rows) {
+      let a: Record<string, unknown> = {};
+      try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate a corrupt payload */ }
+      if (String(a.skill ?? '') !== skill) continue;
+      if ((a.edit === true ? 'edit' : 'new') !== lane) continue;
+      upd.run(status, r.id); closed++;
+    }
+    return closed;
   }
 
   /** Open (unresolved) skill.request cards — the Skills page's agent-request review section. */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6449,9 +6449,16 @@ function FeedItem({ m, members = [], onOpen, onOpenArtifact, onOpenTask, onOpenG
     detail = m.body
     badge = <Badge variant="outline" className="border-amber-300 px-1.5 py-0 text-[10px] font-normal text-amber-700">important</Badge>
   } else if (m.type === 'skill.proposed') {
-    Icon = Sparkles; iconCls = 'text-violet-600'; highlight = true
-    verb = 'proposed a skill'; detail = m.body
-    badge = <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">review in Skills</Badge>
+    // Two lanes on one card type: a NEW draft (published/dismissed on the Skills page) and an EDIT to a
+    // live skill (applied/discarded there). Either way the card carries its own resolution, so a merged
+    // proposal stops asking to be reviewed.
+    const isEdit = (m.args as { edit?: boolean } | undefined)?.edit === true
+    const resolvedS = m.status === 'approved' ? (isEdit ? 'applied' : 'published') : m.status === 'rejected' ? 'dismissed' : ''
+    Icon = Sparkles; iconCls = resolvedS ? 'text-muted-foreground' : 'text-violet-600'; highlight = !resolvedS
+    verb = isEdit ? 'proposed a skill edit' : 'proposed a skill'; detail = m.body
+    badge = resolvedS
+      ? <ResolutionChip status={m.status} word={resolvedS} />
+      : <Badge variant="outline" className="border-violet-300 px-1.5 py-0 text-[10px] font-normal text-violet-700">review in Skills</Badge>
   } else if (m.type === 'host.proposed') {
     Icon = Server; iconCls = 'text-violet-600'; highlight = true
     verb = 'proposed a host'; detail = m.body


### PR DESCRIPTION
## The bug

Skill proposal cards stayed in the Inbox as "awaiting review" after the human had already merged them — live tenants were carrying several (a watchdog agent's cf-verify + logtriage edits, merged days ago, still in "Needs you").

Cause: the Skills console acts on the **skill**, not the card. `POST /api/skills/:name/publish`, `…/edit/apply`, `…/edit/discard` and `DELETE /api/skills/:name` all resolved the skill and never touched the `skill.proposed` `messages` row. `isActionRequired` is `status === 'open'`, so the card asked forever. (`skill.request` cards were fine — they're approved *by card id*, so they flip their own status.)

## The fix

- `TerminalManager.resolveSkillProposals(skill, lane, status)` — finds the open cards by payload (`args.skill` + the `edit` flag that separates the draft and edit lanes) and closes them. Wired into all four routes (publish / apply → `approved`, discard / delete → `rejected`); the count rides along in the audit event.
- **Boot heal** for cards the old code stranded: re-derives each open card's fate from the library — published draft → approved, deleted → rejected, edit card with nothing parked → `resolved` (applied vs discarded is no longer distinguishable, and the card is dead either way). Genuinely pending cards are untouched. Once per process, open cards only.
- Console: the Inbox row renders the resolution (`published` / `applied` / `dismissed`) and drops the highlight, instead of a permanent violet "review in Skills" badge; an edit card now says "proposed a skill edit".

## Known gap (not in this PR)

The same class exists for `host.proposed`, `app.proposed`, `goal.proposed` and `goal.ready` — none of them flip their card either. Their resolving actions are more diffuse; happy to do them as a follow-up.

## Validation

`npm run typecheck`, `cd web && npm run build`, `npm run test:governance` — all green. `scripts/skill-edit-proposal-test.cjs` gains 7 checks (66 total); against the pre-fix `src/` **all 7 fail**, so the falsifier bites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)