### PR TITLE
fix(terminal): the browser terminal can be scrolled from a tablet (v0.407.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.407.3] - 2026-08-30
+### Fixed
+- **The browser terminal can be scrolled from a tablet.** A touch drag emits no wheel events, so the
+  wheel bridge in `Xterm.tsx` never fired on an iPad and the scrollback was simply unreachable — the pane
+  could not be scrolled at all. A one-finger vertical drag now translates into the same SGR wheel events
+  (button 64/65) the wheel handler sends while an app wants the mouse — so claude's TUI and tmux scroll
+  identically however you drive them — and into a local `term.scrollLines()` when no app does.
+  `touch-action: none` on the pane is what stops Safari panning the page instead of yielding the gesture;
+  it is restored on teardown. Rescued from a live box, where it had been hand-applied and re-stashed
+  across two deploys — box-local work is one `git reset --hard` from gone.
+
 ## [0.407.2] - 2026-08-30
 ### Fixed
 - **`degraded` automem is a lag, not an outage.** automem reports `degraded` / `drift_detected` while its

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.407.2",
+  "version": "0.407.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.407.2",
+      "version": "0.407.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.407.2",
+  "version": "0.407.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/Xterm.tsx
+++ b/web/src/Xterm.tsx
@@ -392,12 +392,61 @@ export function Xterm({
     }
     host.addEventListener('mouseup', onMouseUp)
 
+    // ── touch scrolling (iPad / tablets) ─────────────────────────────────────────────────────────
+    // A touch drag emits no wheel events, so the wheel bridge above never fires on a tablet and the
+    // scrollback is unreachable — the pane simply cannot be scrolled at all from an iPad. Translate a
+    // one-finger vertical drag into the SAME SGR wheel events the wheel handler sends while an app wants
+    // the mouse (claude's TUI / tmux), or a local term.scrollLines() otherwise, so the two input methods
+    // reach the app identically. Drag direction follows the content: finger up = look further down.
+    //
+    // `touch-action: none` is what stops Safari from panning the PAGE instead of giving us the gesture.
+    // Its cost is that pinch-zoom and page-pan no longer work while the finger is over the terminal —
+    // deliberate: the pane is the full-height surface on a tablet, so a gesture there is always meant for
+    // it. Restored on teardown rather than left on the node.
+    const priorTouchAction = host.style.touchAction
+    host.style.touchAction = 'none'
+    let touchY: number | null = null
+    let touchAcc = 0
+    const onTouchStart = (e: TouchEvent) => { if (e.touches.length === 1) { touchY = e.touches[0].clientY; touchAcc = 0 } else { touchY = null } }
+    const onTouchMove = (e: TouchEvent) => {
+      if (touchY === null || e.touches.length !== 1) return
+      const t = e.touches[0]
+      const cellH = host.clientHeight / Math.max(1, term.rows)
+      touchAcc += (touchY - t.clientY)
+      touchY = t.clientY
+      const lines = Math.trunc(touchAcc / cellH)
+      if (lines === 0) return
+      touchAcc -= lines * cellH
+      e.preventDefault()
+      if (appMouseWanted) {
+        const rect = host.getBoundingClientRect()
+        const col = Math.min(term.cols, Math.max(1, Math.floor(((t.clientX - rect.left) / rect.width) * term.cols) + 1))
+        const rowY = Math.min(term.rows, Math.max(1, Math.floor(((t.clientY - rect.top) / rect.height) * term.rows) + 1))
+        const btn = lines > 0 ? 65 : 64
+        let seq = ''
+        for (let k = 0; k < Math.min(Math.abs(lines), 8); k++) seq += `\x1b[<${btn};${col};${rowY}M`
+        send(C_INPUT + seq)
+      } else {
+        term.scrollLines(lines)
+      }
+    }
+    const onTouchEnd = () => { touchY = null }
+    host.addEventListener('touchstart', onTouchStart, { passive: true })
+    host.addEventListener('touchmove', onTouchMove, { passive: false })
+    host.addEventListener('touchend', onTouchEnd)
+    host.addEventListener('touchcancel', onTouchEnd)
+
     // Reflow on container resize.
     const ro = new ResizeObserver(() => { try { fit.fit() } catch { /* ignore */ } })
     ro.observe(host)
 
     return () => {
       host.removeEventListener('mouseup', onMouseUp)
+      host.removeEventListener('touchstart', onTouchStart)
+      host.removeEventListener('touchmove', onTouchMove)
+      host.removeEventListener('touchend', onTouchEnd)
+      host.removeEventListener('touchcancel', onTouchEnd)
+      host.style.touchAction = priorTouchAction
       ro.disconnect()
       dataDisp?.dispose(); resizeDisp?.dispose(); titleDisp?.dispose()
       try { ws.close() } catch { /* ignore */ }


### PR DESCRIPTION
## The bug

A touch drag emits no wheel events, so the wheel bridge in `Xterm.tsx` never fired on an iPad — the terminal scrollback was **completely unreachable**. Not "awkward on touch": the pane could not be scrolled at all.

## The fix

A one-finger vertical drag translates into the **same SGR wheel events** (button 64 up / 65 down) the existing wheel handler sends while an app wants the mouse — so claude's TUI and tmux scroll identically however you drive them — and into a local `term.scrollLines()` when no app does. Drag direction follows the content: finger up = look further down.

`touch-action: none` on the pane is what stops Safari panning the page instead of yielding us the gesture.

## Trade-off, on purpose

Pinch-zoom and page-pan stop working while the finger is over the terminal. That's deliberate — the pane is the full-height surface on a tablet, so a gesture there is always meant for it. The property is restored on teardown rather than left on the node.

Touch drag-to-select is still not a thing; it wasn't before either (the browser just panned the page), so this is strictly additive.

## Provenance — why this PR exists at all

This code was **already running on a live tenant**, hand-applied directly on the box. It had been stashed and re-applied by hand across two separate deploys (2026-08-28 and 2026-08-30) and appeared each time as `M web/src/Xterm.tsx` blocking a `git reset --hard`. It survived only because someone noticed it before resetting.

It's a real fix every tenant's terminal wants, so it belongs in main rather than in one box's working tree. Reviewed rather than transplanted: the one change from the box version is restoring `touch-action` on teardown instead of leaving it set on the node.

## Verification

- `npm run typecheck` ✅ · `cd web && npm run build` (tsc -b + vite) ✅ · `npm run test:governance` ✅
- Behaviour is browser-side and touch-only; there is no headless harness for it here. It has been in real use on a live tenant since 2026-08-28.

⚠ Note on versioning: #734 and #735 landed while this was in progress, so this is **0.407.3** — my first bump collided with an already-taken 0.407.1 and was corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)