### PR TITLE
fix(sessions): put back a crashed row whose pane came back to life (v0.409.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.409.1] - 2026-08-31
+### Fixed
+- **A resurrected session stayed marked `crashed` for ever, while a human worked in it.** A crash mark is
+  a *claim* — "the pane is gone" — and unlike a human `stop` it plants no stay-stopped sentinel, because a
+  crash must remain recoverable. So ttyd's reconnect re-runs `attach.sh`, its `new-session -A` revives the
+  pane, `claude --resume` picks the transcript back up, and the work carries on. Nothing put the ROW back:
+  the only restore path, `restoreRunningAfterDelivery`, is scoped `AND status = 'done'` on purpose. Live
+  insta-ai (2026-08-31): **three** such rows, two with a person attached at that moment and one billing
+  `$313.64`, the oldest crash-marked **577 h** earlier. The cost is not RAM — it is that the console renders
+  live work as dead, `canResume` refuses to reopen it, and the concurrency cap under-counts real load.
+  `restoreResurrectedCrashes` now runs immediately after crash detection and puts such a row back to
+  `running` on either of two independent proofs: a client is **attached**, or `last_activity` is newer than
+  the `updated_at` stamped at the moment of the mark (governed work done *since* being declared dead). Both
+  are needed — a member's interactive session rarely stamps `last_activity`, and a detached-but-working run
+  has no client. It closes the stale "Crashed — <agent>" inbox card and audits `session.restored` with the
+  proof it used. What it does not undo: questions/approvals cancelled by `markCrashed` stay cancelled, and
+  the episode stays written.
+- This deliberately does not fight the crashed-orphan reap from 0.408.1. An **abandoned** crashed pane
+  satisfies neither proof, stays `crashed`, and is still reaped on sight; only a resurrected one is
+  restored, and it then lives or dies by the ordinary idle clock like any other running session. Both
+  paths, and their idempotence across ticks, are pinned by a new section 8 in
+  `scripts/idle-reaper-test.cjs`.
+
 ## [0.409.0] - 2026-08-31
 ### Added
 - **`WAITING_BRIEF` — every agent, both lanes: short polls, never one long sleep.** Two agents were

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.409.0",
+  "version": "0.409.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.409.0",
+      "version": "0.409.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.409.0",
+  "version": "0.409.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/idle-reaper-test.cjs
+++ b/scripts/idle-reaper-test.cjs
@@ -218,6 +218,68 @@ tm.reapIdleSessions();
 assert(statusOf(claimedShortCeiling) === 'stopped', 'claim ceiling below the idle timeout still applies');
 assert(statusOf(unclaimedSameAge) === 'running', '…and the longer idle timeout still protects unclaimed rows');
 
+console.log('\n\x1b[1m8) crashed rows: reaped when abandoned, RESTORED when resurrected\x1b[0m');
+// A crash mark is a claim, not a fact. It plants no stay-stopped sentinel (a crash must stay
+// recoverable), so ttyd's reconnect re-runs attach.sh, `new-session -A` revives the pane and
+// `claude --resume` carries on — while the row stays `crashed` for ever. Live insta-ai had three such
+// rows, two with a human attached, the oldest marked 577h earlier. The inverse case is stayflexi's:
+// a genuinely abandoned crashed pane holding ~430MB of claude for 93h that no reaper's query could see.
+aos.settings.setInteractiveIdleTimeoutHours(48);
+aos.settings.setClaimedMaxHours(72);
+attached = new Set();
+killed.length = 0;
+
+// Only these rows report a live pane; everything else looks gone, so the older sections stay quiet.
+// A killed pane really disappears here, as it does in tmux — that is what stops the sweep re-reaping and
+// re-auditing a terminal row every tick (the `!alive.has(tmux)` guard is the only thing holding it, since
+// a reaped `crashed`/`done` row deliberately keeps its status).
+const livePanes = new Set();
+tm.backend.aliveNames = () => new Set(livePanes);
+tm.backend.kill = (_space, tmux) => { killed.push(tmux); livePanes.delete(tmux); };
+
+const crashedAt = Date.now() - 90 * H;
+// (a) resurrected + someone attached right now — the insta-ai case
+const resAttached = mkSession({ status: 'crashed', tmux: 'aos-RES-ATTACHED', created_at: Date.now() - 577 * H, updated_at: crashedAt, last_activity: null });
+livePanes.add('aos-RES-ATTACHED'); attached.add('aos-RES-ATTACHED');
+// (b) resurrected + working since the mark, nobody watching
+const resWorking = mkSession({ status: 'crashed', tmux: 'aos-RES-WORKING', created_at: Date.now() - 400 * H, updated_at: crashedAt, last_activity: Date.now() - 1 * H });
+livePanes.add('aos-RES-WORKING');
+// (c) live pane but NOTHING since the mark — genuinely abandoned, the stayflexi case
+const crashedZombie = mkSession({ status: 'crashed', tmux: 'aos-CRASH-ZOMBIE', created_at: Date.now() - 93 * H, updated_at: Date.now() - 1 * H, last_activity: crashedAt });
+livePanes.add('aos-CRASH-ZOMBIE');
+// (d) crashed with the pane truly gone — must be left entirely alone
+const crashedGone = mkSession({ status: 'crashed', tmux: 'aos-CRASH-GONE', created_at: Date.now() - 93 * H, updated_at: crashedAt, last_activity: null });
+
+// The stale "Crashed — <agent>" card the restore has to close.
+aos.db.prepare("INSERT INTO messages (id,type,session_id,agent,title,body,status,outcome,created_at) VALUES (?,?,?,?,?,?,?,?,?)")
+  .run('msg_res1', 'completed', resAttached, 'website-bot', 'Crashed — website-bot', 'died', 'open', 'crashed', crashedAt);
+
+tm.reapIdleSessions();
+
+assert(statusOf(resAttached) === 'running', 'crashed + live pane + ATTACHED → restored to running');
+assert(!killed.includes('aos-RES-ATTACHED'), '…and its pane was NOT killed');
+assert(statusOf(resWorking) === 'running', 'crashed + live pane + activity since the mark → restored');
+assert(!killed.includes('aos-RES-WORKING'), '…and its pane was NOT killed');
+// The v0.408.1 reap must survive the restore: neither proof holds here, so it stays terminal and dies.
+assert(statusOf(crashedZombie) === 'crashed', 'crashed + live pane + nothing since the mark → NOT restored');
+assert(killed.includes('aos-CRASH-ZOMBIE'), '…it is reaped on sight, keeping its crashed status');
+assert(statusOf(crashedGone) === 'crashed', 'crashed + pane genuinely gone → left alone');
+assert(!killed.includes('aos-CRASH-GONE'), '…and not re-killed (no re-audit loop every tick)');
+
+const card = aos.db.prepare("SELECT status FROM messages WHERE id='msg_res1'").get();
+assert(card && card.status === 'resolved', 'the stale "Crashed" inbox card is closed on restore');
+const rev = aos.db.prepare("SELECT data FROM audit_events WHERE type='session.restored' AND run_id=? LIMIT 1").get(resAttached);
+assert(rev && JSON.parse(rev.data).via === 'attached', 'audited session.restored with the proof used');
+const rev2 = aos.db.prepare("SELECT data FROM audit_events WHERE type='session.restored' AND run_id=? LIMIT 1").get(resWorking);
+assert(rev2 && JSON.parse(rev2.data).via === 'activity', '…and "activity" for the unattended one');
+
+// Idempotence: a second tick must not re-restore, re-audit or re-kill anything.
+const before = aos.db.prepare("SELECT COUNT(*) c FROM audit_events WHERE type='session.restored'").get().c;
+killed.length = 0;
+tm.reapIdleSessions();
+assert(aos.db.prepare("SELECT COUNT(*) c FROM audit_events WHERE type='session.restored'").get().c === before, 'a second sweep restores nothing again');
+assert(!killed.includes('aos-CRASH-ZOMBIE'), '…and does not re-kill the already-reaped zombie (its pane is gone now)');
+
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}IDLE REAPER: ${pass}/${pass + fail} passed\x1b[0m`);
 try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
 process.exit(fail === 0 ? 0 : 1);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3201,6 +3201,16 @@ export class TerminalManager {
     // `crashed` and fire its (always-on) notification NOW, instead of waiting for the next console poll.
     this.sweepCrashed(alive);
 
+    // (0b) …and the inverse. A crash mark is a CLAIM ("the pane is gone"), and unlike a human `stop` it
+    // plants no stay-stopped sentinel — deliberately, because a crash should be recoverable. So ttyd's
+    // reconnect re-runs `attach.sh`, whose `new-session -A` revives the pane and `claude --resume`s the
+    // transcript, and the work simply carries on. Nothing put the ROW back: the only restore path,
+    // `restoreRunningAfterDelivery`, is scoped `AND status = 'done'` on purpose. The result is a session
+    // that is alive, attached and billing while the console renders it dead, `canResume` refuses it, and
+    // the concurrency cap under-counts it. Live insta-ai (2026-08-31): THREE such rows, two with a human
+    // attached at that moment, the oldest crash-marked 577 h earlier.
+    this.restoreResurrectedCrashes(alive);
+
     // (1) resident warm-chat idle reap. This is what BOUNDS the warm-pane model: a chat session holds a
     // live claude (hundreds of MB) between turns, so it must give the box back when the conversation
     // goes quiet — the next message revives it in place, resuming the same transcript.
@@ -3606,6 +3616,47 @@ export class TerminalManager {
     this.cancelPendingApprovals(sessionId, 'system');
     this.backend.kill(space, tmux);
     this.audit(sessionId, 'system', 'session.reaped', { reason });
+  }
+
+  /**
+   * Put back a `crashed` row whose pane is demonstrably alive AND in use — the crash claim has been
+   * falsified by evidence, exactly as {@link restoreRunningAfterDelivery} does for a `done` row that kept
+   * running. Two independent proofs, either sufficient:
+   *   · a client is ATTACHED — someone is looking at it right now;
+   *   · `last_activity` is NEWER than `updated_at`, which `markCrashed` stamps at the moment of the mark —
+   *     i.e. the session has done governed work SINCE being declared dead.
+   * Both are needed: a member's interactive session rarely stamps `last_activity` (so attachment covers
+   * it), and a detached-but-working run has no client (so the activity clock covers it).
+   *
+   * This deliberately does NOT fight the crashed-orphan reap added alongside it. A genuinely abandoned
+   * crashed pane satisfies neither proof, stays `crashed`, and is reaped on sight; only a resurrected one
+   * is restored, and it then lives or dies by the ordinary idle clock like any other running session.
+   * Requires a real liveness poll — with none we can falsify nothing, so we leave every row alone.
+   *
+   * What it does NOT undo: the questions/approvals `markCrashed` cancelled stay cancelled (someone may
+   * have acted on that), and the episode stays written. Only the row's status, the stale "Crashed" inbox
+   * card, and the audit trail are corrected.
+   */
+  private restoreResurrectedCrashes(alive: Set<string> | null): void {
+    if (!alive) return; // no liveness signal — nothing can be falsified
+    const rows = this.db.prepare("SELECT id, tmux, agent, run_as, spawned_by, last_activity, updated_at FROM term_sessions WHERE status = 'crashed'")
+      .all<{ id: string; tmux: string; agent: string; run_as: string | null; spawned_by: string | null; last_activity: number | null; updated_at: number }>();
+    for (const r of rows) {
+      try {
+        if (!alive.has(r.tmux)) continue;                       // pane really is gone — the mark was right
+        const attached = this.backend.hasClient(this.spaceFor(r.run_as ?? r.spawned_by), r.tmux) === true;
+        const workedSince = r.last_activity != null && r.last_activity > r.updated_at;
+        if (!attached && !workedSince) continue;
+        const restored = this.db.prepare("UPDATE term_sessions SET status = 'running', updated_at = ? WHERE id = ? AND status = 'crashed'")
+          .run(Date.now(), r.id);
+        if (!restored.changes) continue;                        // raced with another writer — leave it be
+        // The "Crashed — <agent>" card is now a lie about a live session; close it rather than leave the
+        // owner's Inbox asserting a death that didn't stick.
+        this.db.prepare("UPDATE messages SET status = 'resolved' WHERE session_id = ? AND type = 'completed' AND outcome = 'crashed' AND status = 'open'")
+          .run(r.id);
+        this.audit(r.id, r.agent, 'session.restored', { from: 'crashed', via: attached ? 'attached' : 'activity' });
+      } catch { /* one bad row must not stop the sweep */ }
+    }
   }
 
   /** Is this session blocked on a human right now (a pending question OR a pending approval)? Used to


### PR DESCRIPTION
Follow-up to #738, found by sweeping the rest of the fleet for the leak that one fixed. No other box had it — but insta-ai had the *inverse* bug, which is worse.

## What's wrong

A crash mark is a **claim**, not a fact: `sweepCrashed` stamps `crashed` when a liveness poll can't see the pane. Unlike a human `stop` it plants no stay-stopped sentinel — deliberately, because a crash should stay recoverable. So ttyd's reconnect re-runs `attach.sh`, its `new-session -A` revives the pane, `claude --resume` picks the transcript back up, and the work carries on.

Nothing ever put the row back. The only restore path is scoped on purpose:

```ts
// src/terminal.ts — restoreRunningAfterDelivery
"UPDATE term_sessions SET status = 'running' … WHERE id = ? AND status = 'done'"
```

Live insta-ai, 2026-08-31 — three rows, all `status='crashed'`, all with a live pane:

```
ses_0639ed121189d95b  engineer     as randhir  attached=1  claude up 35m
ses_c84aecaa0e431b9d  site-porter  as naeem    attached=1  claude up 1h39m   $35.35
ses_e02981f81c0ea4b2  site-porter  as naeem    attached=0  claude up 6 days  $313.64
```

Two people were working in them at the moment of the check. The oldest was crash-marked 577 h earlier.

The cost isn't RAM — it's that the console renders live work as dead, `canResume` refuses to reopen it (`crashed` reads as "the sweep buried it"), and the concurrency cap under-counts real load.

## The fix

`restoreResurrectedCrashes` runs immediately after crash detection, before any reaper looks at a `crashed` row, and restores it to `running` on either of two independent proofs:

- a client is **attached** — someone is looking at it right now;
- **`last_activity > updated_at`** — `markCrashed` stamps `updated_at` at the moment of the mark, so this means governed work happened *since* the session was declared dead.

Both are needed: a member's interactive session rarely stamps `last_activity` (attachment covers it), and a detached-but-working run has no client (the activity clock covers it). Requires a real liveness poll — with none, nothing can be falsified, so every row is left alone.

Also closes the stale `Crashed — <agent>` inbox card, and audits `session.restored` with the proof used. It does **not** undo what `markCrashed` cancelled: those questions/approvals stay cancelled (someone may have acted on that) and the episode stays written.

## It does not fight #738

An **abandoned** crashed pane satisfies neither proof, stays `crashed`, and is still reaped on sight — that's stayflexi's 93 h zombie. Only a **resurrected** one is restored, and it then lives or dies by the ordinary idle clock like any other running session. Verified against both real cases before writing the code.

## Verification

New section 8 in `scripts/idle-reaper-test.cjs` (already in the gate suite), 13 assertions covering: attached → restored; activity-since-mark → restored; live pane but nothing since the mark → **not** restored, reaped on sight keeping its status; pane genuinely gone → left alone; the card closed; both audit reasons; and idempotence across two ticks with no re-restore, re-audit or re-kill.

`54/54` in that file, whole `npm run test:governance` green, both bundles build clean.