### PR TITLE
feat(runtime): Remote Control stays off unless a human asks for it (v0.410.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.410.0] - 2026-08-31
+### Changed
+- **Remote Control is off by default for every governed session** — `terminal/claude-launch.sh` now writes
+  `"remoteControlAtStartup": false` into each session's `--settings` file. Remote Control (claude.ai/code
+  and the Claude mobile app driving a local session) normally waits for an explicit `/remote-control`
+  (`/rc`), but auto-connect is a **user-level** toggle: the box owner turning on "Enable Remote Control for
+  all sessions" in their own `~/.claude/settings.json` would silently register EVERY tenant's every
+  interactive session as a remote session on THEIR personal claude.ai account — each transcript mirrored to
+  Anthropic servers for sync, and a phone handed a prompt box into a governed agent. Same undeclared-input
+  class as `enabledPlugins` (see `AOS_CLAUDE_CONFIG_ISOLATION`), and the same fix shape as
+  `crossSessionInbound: "refuse"`: pin it at the settings layer, where a `--settings` value outranks user
+  settings and a project/local `false` outranks even managed settings. Deliberately **not**
+  `disableRemoteControl`, which kills the feature outright — a human attached in the browser terminal can
+  still type `/rc` to connect that one session on purpose.
+
 ## [0.409.1] - 2026-08-31
 ### Fixed
 - **A resurrected session stayed marked `crashed` for ever, while a human worked in it.** A crash mark is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -720,6 +720,14 @@ drift and prints the one-line fix.
   `terminal/claude-launch.sh` (`crossSessionInbound: "refuse"` + `isolatePeerMachines: true`) rather than
   by denying the tools, since the same `SendMessage` also serves subagents/agent teams inside one session.
   When claude-code updates, diff the tools reference against that routing table.
+- **Remote Control is pinned OFF for every governed session** (`remoteControlAtStartup: false` in
+  `terminal/claude-launch.sh`). It normally needs an explicit `/remote-control` (`/rc`), but auto-connect
+  is a **user-level** setting: the box owner flipping "Enable Remote Control for all sessions" would
+  register every tenant's every interactive session as a remote session on THEIR personal claude.ai
+  account — transcript mirrored to Anthropic servers, phone gets a prompt box into a governed agent.
+  Deliberately NOT `disableRemoteControl` (which kills the feature outright): a human attached in the
+  browser terminal can still type `/rc` on purpose. Same undeclared-input class as the `~/.claude` note
+  below.
 - **The box owner's `~/.claude` is an undeclared input to every agent.** A session runs as the same OS user
   as the human who owns the machine, so it loads their user-scope `settings.json` — `enabledPlugins` above
   all, which drags in a plugin's subagent types, skills, slash commands and **SessionStart prompt hooks**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.409.1",
+  "version": "0.410.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.409.1",
+      "version": "0.410.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.409.1",
+  "version": "0.410.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -195,9 +195,20 @@ if [ -n "${CLAUDE_OUTPUT_STYLE:-}" ]; then
     OUTPUT_STYLE_LINE="  \"outputStyle\": \"$SAFE_STYLE\","
   fi
 fi
+# REMOTE CONTROL (claude.ai/code + the Claude mobile app driving a local session) is OFF for governed
+# runs. It only activates on an explicit `/remote-control` (`/rc`) — EXCEPT when auto-connect is on, and
+# auto-connect is a USER-level setting: the box owner flipping "Enable Remote Control for all sessions"
+# in their own ~/.claude/settings.json would silently register EVERY tenant's every interactive session
+# as a remote session on THEIR personal claude.ai account, mirroring each transcript to Anthropic servers
+# and handing a phone a prompt box into a governed agent — the same undeclared-input class as
+# `enabledPlugins` (see AOS_CLAUDE_CONFIG_ISOLATION). So we pin auto-connect off here; a --settings value
+# wins over user settings, and project/local `false` wins even over managed settings, so the safe
+# direction holds. NOT `disableRemoteControl` — that kills the feature outright, and a human who has
+# attached to a session in the browser terminal should still be able to type `/rc` deliberately.
 cat > .claude/aos-settings.json <<JSON
 {
 $OUTPUT_STYLE_LINE
+  "remoteControlAtStartup": false,
   "crossSessionInbound": "refuse",
   "isolatePeerMachines": true,
   "skipDangerousModePermissionPrompt": true,


### PR DESCRIPTION
`terminal/claude-launch.sh` now writes `"remoteControlAtStartup": false` into every governed session's `--settings` file.

**Why.** Remote Control (claude.ai/code + the Claude mobile app driving a local session) only activates on an explicit `/remote-control` (`/rc`) — *unless* auto-connect is on, and auto-connect is a **user-level** setting. The box owner flipping "Enable Remote Control for all sessions" in their own `~/.claude/settings.json` would silently register EVERY tenant's every interactive session as a remote session on THEIR personal claude.ai account: the transcript mirrored to Anthropic servers for cross-device sync, and a phone handed a prompt box into a governed agent. Nobody edits anything on our side for that to happen.

Same undeclared-input class as `enabledPlugins` (see `AOS_CLAUDE_CONFIG_ISOLATION`), and the same fix shape as `crossSessionInbound: "refuse"`: pin it at the settings layer, where a `--settings` value outranks user settings and a project/local `false` outranks even managed settings.

**Not `disableRemoteControl`.** That kills the feature outright. A human who has attached to a session in the browser terminal should still be able to type `/rc` and connect that one session deliberately — which is exactly the requested posture: off globally, on by hand.

Docs: CLAUDE.md → Gotchas gains the note next to the cross-session-messaging one.

**Verified:** `bash -n terminal/claude-launch.sh`, `npm run build`, `npm run test:governance` (all green at v0.410.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)