### PR TITLE
docs(connectors): per-connector reference for every native connector (v0.410.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.410.1] - 2026-08-31
+### Added
+- **Per-connector reference docs** — a new `docs/connectors/` set documenting every shipped native
+  connector as built: [ClickUp](docs/connectors/clickup.md) (webhook ingress via a ClickUp Automation,
+  the comment-id loop-guard, the `/command`-only gate, `clickup_threads` + `clickup_reply`),
+  [Slack](docs/connectors/slack.md) (Socket Mode, filters + channel watch, the three egress tools),
+  [Discord](docs/connectors/discord.md) (Gateway, privileged MESSAGE_CONTENT, real per-mention threads),
+  [Telegram](docs/connectors/telegram.md) (long polling, Group Privacy vs continuity),
+  [GitHub](docs/connectors/github.md) (App-minted bot token vs per-member user token, `github_refresh`)
+  and [Composio](docs/connectors/composio.md) (the minted Tool Router URL, `composio_shares`). Each page
+  carries setup, ingress path, egress tools, data model, audit events and the gotchas that already bit us.
+  The [index](docs/connectors/README.md) holds what every channel shares — run-as resolution, the `/agent`
+  router, thread continuity, governance — and `docs/connectors-and-triggers.md` now points at it.
+
 ## [0.410.0] - 2026-08-31
 ### Changed
 - **Remote Control is off by default for every governed session** — `terminal/claude-launch.sh` now writes

--- a/docs/connectors-and-triggers.md
+++ b/docs/connectors-and-triggers.md
@@ -1,5 +1,10 @@
 # Connectors & Triggers — ingress, egress, and identity
 
+> **Per-connector reference:** [`docs/connectors/`](./connectors/) documents each shipped native connector
+> as built — Slack, Discord, Telegram, ClickUp, GitHub, Composio — with setup, ingress path, egress tools,
+> data model, audit events and gotchas. Start there for "how do I wire up X"; this doc is the design
+> history and the identity model behind all of them.
+
 > **⚠ As-built note (2026-06-29).** This is the *original design spec*; the shipped implementation on
 > `main` **diverged** and is the source of truth. Differences: chat ingress is **native Socket Mode
 > (Slack) / Gateway (Discord)** over an outbound WebSocket — **not** the HTTP `POST /triggers/slack`

--- a/docs/connectors/README.md
+++ b/docs/connectors/README.md
@@ -1,0 +1,101 @@
+# Native connectors — reference
+
+How Agentric talks to the outside world, connector by connector. Each page documents the **as-built**
+integration: setup, ingress path, egress tools, data model, audit events, and the gotchas that already
+bit us.
+
+| Connector | Ingress | Egress | Public URL needed? | Page |
+|---|---|---|---|---|
+| **Slack** | Socket Mode (outbound WS) | `slack_reply`, `slack_send`, `slack_dm`, digest, DMs | no | [slack.md](slack.md) |
+| **Discord** | Gateway (outbound WS) | `discord_reply`, `discord_send`, `discord_dm`, digest, DMs | no | [discord.md](discord.md) |
+| **Telegram** | long polling (`getUpdates`) | `telegram_reply` | no | [telegram.md](telegram.md) |
+| **ClickUp** | webhook (`POST /hooks/clickup`) | `clickup_reply` | **yes** | [clickup.md](clickup.md) |
+| **GitHub** | — (credential source) | `GH_TOKEN` in the shell + API bearer; `github_refresh` | no | [github.md](github.md) |
+| **Composio** | webhook (`POST /triggers/composio`) | the SaaS long tail, via a minted Tool Router URL | for triggers only | [composio.md](composio.md) |
+
+Design history and the five original use cases live in [`../connectors-and-triggers.md`](../connectors-and-triggers.md)
+— note its as-built banner: the shipped tree diverged from that spec, and these pages are the current
+source of truth.
+
+## Two planes
+
+The word "connector" used to smuggle together two opposite things. They are separate here:
+
+- **Ingress (triggers)** — how the outside world *starts or feeds* an agent: a Slack mention, a Discord
+  DM, a Telegram command, a ClickUp comment, a Composio webhook. Company-owned, configured once by an
+  owner/admin.
+- **Egress (connectors)** — what an agent *uses to act*: post a message, send mail, read a repo. Always an
+  MCP tool call materialised into the session's `.mcp.json`, always through the gate hook.
+
+The company app is usually **bidirectional**: the same Slack bot token that receives events is the
+identity that posts.
+
+## What every native channel shares
+
+**One company app, per-member identity.** Each channel is configured once, workspace-wide. Per-member
+behaviour rides on top of that single app: every inbound event names a sender, which is resolved to an
+Agentric member and becomes the run's **run-as** identity (their personal connectors, their inbox), with
+`canRun` enforced on that principal. Resolution order differs by channel:
+
+| Channel | Sender → member |
+|---|---|
+| Slack | identity map (`slack`) → Slack profile **email** → `getMemberByEmail` |
+| Discord | identity map (`discord`) only — a bot cannot read a user's email |
+| Telegram | identity map (`telegram`) only — no email exposed |
+| ClickUp | commenter **email** → `getMemberByEmail` |
+
+Unmapped senders fall back to the company identity. The map is `member_identities`
+(`IDENTITY_PROVIDERS = slack | discord | telegram | email | github`), edited on the Team page under
+**Chat IDs**, one handle per provider, PK `(provider, external_id)`.
+
+**Run-as vs provenance.** A session row separates `spawned_by` (provenance — `automation:<id>`,
+`chat:<agent>`, or the console member) from `run_as` (the identity it acts under). A chat-triggered run is
+owned by the automation for provenance yet acts as — and is visible to — the human who sent the message.
+
+**The `/agent` router — automations are optional.** When an inbound message matches no automation,
+`Automations.routeChat` / `routeUnmatched` parses a leading `/agent-name` and spawns that agent as a
+one-off governed run. `/agent-os <agent> <request>` and the bare `/<agent> <request>` both work, on every
+channel (the `/agent-os` namespace prefix is normalised away). An unaddressed or unknown name posts a help
+list back. Toggle: `chatRouterEnabled` (Settings → Integrations, default on). So connecting a bot once
+makes the **whole fleet** reachable; per-channel automations become overrides.
+
+**Thread continuity.** A follow-up on a bound thread resumes the *same* transcript
+(`claude --resume`, pinned via `term_sessions.claude_session_id`) instead of re-triggering. One binding
+table per channel, all written at `createSession` and all read back by the reply tool so the agent never
+supplies — or can spoof — a destination:
+
+| Channel | Table | Thread key |
+|---|---|---|
+| Slack | `slack_threads` | channel + `thread_ts` |
+| Discord | `discord_threads` | the branched thread (or channel/DM) |
+| Telegram | `telegram_threads` | chat id (+ forum topic id) |
+| ClickUp | `clickup_threads` | task id |
+
+**Governance.** Every egress is an `mcp__*` call through the gate hook → policy → audit. Triggered runs
+additionally obey `canRun(runAs, agentId)` before firing. The reply/send tools are session-secret-gated
+loopback calls to `/api/*` routes that sit **before** the member-auth gate — see
+[`../agent-mcp-tools.md`](../agent-mcp-tools.md) for the tool ↔ route ↔ store matrix. Chat egress is
+audit-only, no policy gate (`slack.send`, `slack.dm`, `discord.send`, `discord.dm`, `clickup.reply`).
+
+**Out-of-band notifications** — approvals, agent questions, task events, login links, the EOD digest —
+resolve recipients in exactly one place, `resolveRecipients(os, audience)` in
+`src/governance/recipients.ts` (`approvers` / `admins` / `member` / `sessionOwner`), and share `deliverDM`
+(identity map → `dmUser`). Never re-derive members in a new notifier.
+
+**Zero dependencies.** Every client uses the global `fetch` / `WebSocket` (Node 22+). No `ws`, no vendor
+SDK. Every call returns `{ error }` rather than throwing, so a flaky network degrades gracefully.
+
+## Generic MCP connectors
+
+Beyond the native six, `src/connectors/connectors.ts` stores arbitrary MCP servers materialised into each
+session's `.mcp.json`:
+
+- **Transport** — `stdio` (a local launch command + `env`) or `http` / `sse` (a URL + `headers`).
+- **Scope** — `org` (company-wide, one shared identity, fanned into every member's sessions) or `personal`
+  (`ownerMemberId`; injected only into that member's own sessions), plus the `shared` flag that lends a
+  personal connector to the team **acting as its owner**.
+- **Composio is the exception**: `mintsUrl('composio')` is true, so its URL is minted per launch rather
+  than stored.
+
+Credentials for stored connectors live in the gitignored data home, not the repo. A multi-tenant
+deployment should move those values into the vault.

--- a/docs/connectors/clickup.md
+++ b/docs/connectors/clickup.md
@@ -1,0 +1,134 @@
+# ClickUp connector
+
+**Status:** shipped (v0.260.0). **Kind:** ingress (webhook) + egress (comment).
+**Code:** `src/connectors/clickup.ts` (API client) · `src/edge/clickup-ingress.ts` (dispatcher) ·
+`/hooks/clickup` + `/api/agent/clickup/reply` (`src/server.ts`) · `clickup_threads` (`src/state/db.ts`).
+
+ClickUp is the one native chat-like channel that is genuinely a **webhook**, not a socket. Slack dials
+out over Socket Mode, Discord over the Gateway, Telegram long-polls — ClickUp has none of those, so a
+ClickUp **Automation** POSTs to us instead. Everything downstream (run-as, `/agentname` routing, thread
+continuity, the gate, audit) is the same machinery the socket channels use.
+
+The product point: this is the in-platform replacement for the old agent-orch `/ceoagent` ClickUp
+command — same "comment at an agent on a task" ergonomics, but every effect rides the mediated gateway.
+
+## Setup
+
+Owner/admin, **Settings → Integrations → ClickUp**:
+
+1. **API token** — a ClickUp personal or team token (`pk_…`). One company token, shared workspace-wide;
+   it both reads the triggering comment and posts the agent's replies.
+2. **Webhook secret** — generated for you the moment a token is saved (`crypto.randomBytes(24)` hex) if
+   one isn't already set. The console then shows the full hook path to paste into ClickUp.
+3. In **ClickUp**, create an Automation on the space/folder/list you want covered:
+   - *When*: **Comment posted**
+   - *Then*: **Call webhook** → `POST https://<your-host>/hooks/clickup?key=<secret>&task_id={{task.id}}`
+
+There is nothing to dial and nothing to restart — the integration is live as soon as the Automation
+exists. Clearing the API token removes every `clickup` automation (the server reports
+`removedClickupAutomations`).
+
+Settings keys: `clickup_api_token`, `clickup_webhook_secret` (`src/governance/settings.ts`). Neither
+value is ever returned by the API — `clickupMeta()` reports only presence + who last touched it, and the
+integrations view returns a redacted hint.
+
+## How an inbound comment becomes a session
+
+`POST /hooks/clickup` sits in the **public** route block (it authenticates itself via `?key=`), placed
+*before* the generic `/hooks/<id>` so the literal `clickup` isn't read as an automation id. Missing or
+wrong key → 503/401; no `ClickupIngress` on the runtime → 503.
+
+`ClickupIngress.dispatch(taskId, payload)` then:
+
+1. **Fetches the comment.** The ClickUp Automation payload carries **no comment text**, so we call
+   `GET /task/{id}/comment` and take the newest (`fetchLatestComment`).
+2. **Loop-guard.** A comment id we already acted on or posted ourselves is skipped. Deliberately keyed on
+   **comment id, not the token's user id** — the API token is usually a *personal* token, so the human
+   running `/agentname` often *is* the token user; guarding by user id silently swallowed their commands
+   (a real bug). The `handled` set is bounded (500 → trimmed to 300).
+3. **Command gate, before continuity.** A ClickUp task's comment section is a **shared space**, not a
+   dedicated bot thread, and every comment on a covered task fires the webhook. So only a comment matching
+   `/^\s*\/[A-Za-z0-9]/` acts; anything else is `not a command` and is never delivered into a bound
+   session. This also drops our own acks and replies for free.
+4. **Marks handled, then reacts 👀.** The comment id is remembered *before* dispatch so a racing duplicate
+   webhook can't double-spawn. The acknowledgement is an `eyes` reaction on the triggering comment, not an
+   "on it" comment — quieter, and it can't re-trigger anything. ⚠ ClickUp wants the emoji **shortcode**
+   (`eyes`), not the unicode character.
+5. **Resolves run-as.** Commenter email → `TeamStore.getMemberByEmail` → that member. The session then runs
+   as the actual human (their personal connectors, their inbox). Unmapped → the company identity. Same
+   shape as Slack's user→email→member mapping.
+6. **Continuity first.** `Automations.continueClickupThread` looks up the newest session bound to this task
+   (`clickup_threads` → `TerminalManager.sessionForClickupThread`) and resumes that transcript rather than
+   re-triggering. A still-busy agent gets a "pick this up next" note instead of an overlapping run.
+7. **Else routes.** `Automations.fireClickup` fires every enabled `clickup` automation whose `filter`
+   matches the task id (`''` / `*` = any); with no match it falls through to `routeUnmatched` — the shared
+   `/agent` front door. So `/agent-os <agent> <request>`, or the bare `/<agent> <request>`, reaches any
+   agent **with no per-agent automation**. (The `/agent-os` namespace prefix is normalised away and works
+   on every channel.) A help-list / disambiguation reply is posted as a comment, and its id is remembered
+   so the webhook it triggers is skipped.
+
+The generated task prompt (`fireClickup`) tells the agent to fetch the full task first — on ClickUp the
+**task description** usually holds the real request and the comment is just the trigger.
+
+Audit: `trigger.clickup` `{ task, status, sessions }` on every inbound POST, whatever the outcome.
+
+## How an agent replies
+
+`clickup_reply` — an MCP tool exposed **only** on ClickUp-triggered sessions (`CLICKUP_REPLY=1`, set by
+`TerminalManager.launchAgentRuntime` when the session has a bound task). It takes text only:
+
+```
+clickup_reply({ text })  →  POST /api/agent/clickup/reply  →  ClickupIngress.reply(sessionId, text)
+```
+
+The task id comes from the server-side `clickup_threads` binding written at `createSession`, so the agent
+never supplies — and cannot spoof — a task id. A non-ClickUp session has no binding and gets
+`no ClickUp task bound to this session`. The reply's own comment id is remembered (loop-guard), so posting
+doesn't re-trigger the ingress.
+
+ClickUp comments are **plain text** — no markdown. `src/governance/chat-links.ts` renders links as
+`label: url` for `clickup` (and `telegram`) rather than masked markup.
+
+Audit: `clickup.reply` `{ task, chars }` / `clickup.reply.failed` `{ task, error }`. Never the body.
+
+## Data model
+
+```sql
+CREATE TABLE IF NOT EXISTS clickup_threads (
+  session_id TEXT, task_id TEXT, comment_id TEXT, created_at INTEGER
+);
+```
+The ClickUp analogue of `slack_threads` / `discord_threads` / `telegram_threads`: the **task id is the
+thread key** (the natural ClickUp "thread"), bound at spawn, read back by `clickup_reply` and by
+`sessionForClickupThread` for continuity.
+
+## Automations
+
+A `clickup` trigger type exists (`Automation.type`) for **per-task-scoped overrides** — its `filter` is
+matched against the task id (`''` / `*` = any). It is optional by design: the `/agent` router already
+makes the whole fleet reachable, so automations are the exception, not the setup step.
+
+## API surface (`src/connectors/clickup.ts`)
+
+All calls use the global `fetch` (Node 22+), return `{ error }` instead of throwing, and hit
+`https://api.clickup.com/api/v2`.
+
+| Function | ClickUp endpoint | Used for |
+|---|---|---|
+| `fetchLatestComment(token, taskId)` | `GET /task/{id}/comment` | ingress enrichment (webhook has no text) |
+| `addComment(token, taskId, text)` | `POST /task/{id}/comment` | the agent's reply + router help text |
+| `addReaction(token, commentId, 'eyes')` | `POST /comment/{id}/reaction` | the 👀 "picked it up" ack |
+| `authedUser(token)` | `GET /user` | Settings "test connection" |
+| `taskUrl(taskId)` | — | `https://app.clickup.com/t/<id>` deep-links |
+
+## Gotchas
+
+- **The Automation payload has no comment text.** Anything that needs the body must re-fetch it. That's
+  also why the hook URL must carry `task_id={{task.id}}`.
+- **Guard by comment id, not user id** — personal tokens make the operator and the bot the same ClickUp
+  user (see step 2).
+- **Only `/command` comments act.** Plain task chatter is intentionally ignored; a ClickUp task comment
+  section is shared with humans who are not talking to an agent.
+- **Reactions take shortcodes**, not emoji characters.
+- **Plain text only** — markdown will render literally in a ClickUp comment.
+- Digest reference-extraction treats `86xxxxxxx`-shaped ids as ClickUp tasks (`src/edge/digest.ts`).

--- a/docs/connectors/composio.md
+++ b/docs/connectors/composio.md
@@ -1,0 +1,105 @@
+# Composio connector
+
+**Status:** shipped. **Kind:** egress tool-hub (hundreds of SaaS apps) + webhook ingress.
+**Code:** `src/connectors/composio.ts` (mint + API) · `src/connectors/composio-shares.ts` (team sharing) ·
+`src/connectors/connectors.ts` (the generic connector store) · `POST /triggers/composio` (`src/server.ts`).
+**See also:** `docs/composio-connection-request-plan.md`,
+`docs/tool-marketplace-eval-monid-vs-composio.md`.
+
+Composio is how an agent reaches the long tail of SaaS — Gmail, Google Drive, Linear, Notion, Salesforce
+and the rest — without Agentric shipping a client per app. It is also **the one connector whose endpoint
+is minted, not stored.**
+
+## The mint
+
+A Slack/GitHub stdio connector has a fixed launch command; a generic remote connector has a fixed URL.
+Composio's **Tool Router** is different: the MCP endpoint is a **per-user, pre-signed session URL**
+created on demand by POSTing the user's id to Composio's API. So the workspace only ever stores the
+**Composio API key**; at each session launch we exchange it — **scoped to the launching identity** — for
+a fresh session URL and write *that* into the per-session `.mcp.json`.
+
+Two transports for the same mint (`mintsUrl(type)` is true only for `composio`):
+- `mintToolRouterSession` — blocking `curl` (mirrors `terminal/gate-hook.sh`), for callers already off the
+  hot path;
+- `mintToolRouterSessionAsync` — `fetch`, for the session-launch path. Blocking the event loop for ~1.5 s
+  per launch stalled every other request on this single-threaded server.
+
+The API key is read case-insensitively out of the connector's `x-api-key` header (`apiKeyOf`).
+`COMPOSIO_API_BASE` overrides the endpoint so tests can point at a local stub.
+
+## Whose identity a mint runs as
+
+The Composio `user_id` is **per connector, not per session**:
+
+| Connector class | Composio `user_id` |
+|---|---|
+| **service** (stored `scope = 'org'`) | a fixed entity — `serviceUserId(tenant)` = `service:<tenant>` |
+| **personal** (private or shared) | the connector **owner's** email — a shared connector still acts as its owner, never the borrower |
+
+Selection at launch is `(service) ∪ (shared personal) ∪ (run-as member's own personal)`. Personal
+connectors should prefer Composio precisely because **no durable token lands on disk** — only a
+short-lived minted URL.
+
+## Sharing one connected account with the team (`composio_shares`)
+
+Two facts, both verified against the live API, force the design:
+
+- a connected account's **`user_id` is immutable** — there is no transfer API, so sharing cannot be a move;
+- a Tool Router session may **only pin accounts belonging to its own `user_id`** ("Could not find connected
+  account(s) … belonging to user …"), so a teammate's app cannot be pulled into your session.
+
+So sharing is a **local marker** — `composio_shares` holds `(connection id, toolkit, owning entity,
+owner member, name, sharedBy)` — that the launcher enforces. `ComposioShareStore.mintsFor(actingMember)`
+groups every *other* member's shares by owner, and `buildMcpConfigJson` mints **one extra Tool Router
+session per owner**: under that owner's entity, but restricted to
+`{ toolkits: { enable: […] }, connected_accounts: { … }, manage_connections: { enable: false } }`.
+
+A borrower therefore reaches exactly the shared connections and nothing else of that person's Composio
+account, and cannot add or revoke connections under an entity that isn't theirs. Verified live: asked to
+"list files in Google Drive", an unrestricted session offers `googledrive` tools while the borrowed one
+can only offer the shared `gmail`.
+
+Consequences worth keeping:
+
+- **Nothing changes on composio.dev in either direction** — sharing and un-sharing are reversible and need
+  no re-authorisation (`POST /api/connections/share {id, shared}`).
+- **Granting is owner-only and verified remotely** (the account must appear under the caller's own entity),
+  so nobody publishes a teammate's — or the company's — connection by guessing an id.
+- **Revoking is local-only and never gated on the key**, so a cleared or broken Composio key can't leave
+  the team stuck with a share they can't take back. Owner *or* admin may revoke; only the owner may grant.
+- A share dies with its connection, with its owner (member removal), and is pruned when the account is
+  revoked straight on composio.dev.
+- An automation/system spawn (no run-as member) **does** get shared apps — the owner opted in explicitly,
+  the same rule as a `personal + shared` connector.
+
+## Console routes
+
+`GET /api/composio/toolkits` (`listToolkits`) · `GET /api/connections` (`listConnectedAccounts`) ·
+`POST /api/connections/connect` (`initiateConnection`) · `POST /api/connections/disconnect`
+(`deleteConnectedAccount`) · `POST /api/connections/share` · `GET /api/connections/requests` (an agent
+asking a human to connect an app it needs).
+
+Settings keys: `composio_api_key`, `composio_webhook_secret`.
+
+## Ingress — `POST /triggers/composio`
+
+Composio is also the **webhook ingress lane** (Slack/Discord/Telegram are socket-native; ClickUp is its
+own webhook). The route verifies the payload against the workspace webhook secret
+(`verifyComposioWebhook`, HMAC + `timingSafeEqual`), normalises it (`parseComposioEvent` →
+`{ triggerSlug, toolkit, … }`), and `Automations.fireComposio` dispatches it to matching `composio`
+automations. Audit: `trigger.composio` `{ trigger, toolkit, fired }`.
+
+## Governance
+
+Every Composio tool call is an `mcp__*` call, so it hits the gate hook → policy → audit like everything
+else. Rules key off the capability id **and** the args (the gate is handed the tool input), e.g.
+`email.send` to a recipient outside the org → `yellow`/`red`.
+
+## Gotchas
+
+- **The endpoint is minted per launch** — there is no stored URL to inspect or curl. Debug a bad session
+  by re-minting, not by looking for a saved endpoint.
+- **A borrowed session acts as its owner.** Surface that in any "share with team" UI: lending an app means
+  teammates act *as you*.
+- **Sharing is local state.** A connection revoked directly on composio.dev leaves a stale row until it is
+  pruned.

--- a/docs/connectors/discord.md
+++ b/docs/connectors/discord.md
@@ -1,0 +1,65 @@
+# Discord connector
+
+**Status:** shipped. **Kind:** ingress (Gateway) + egress (reply, proactive send/DM, digest, DMs).
+**Code:** `src/connectors/discord.ts` (API client) · `src/edge/discord-socket.ts` (connection + dispatch) ·
+`discord_threads` (`src/state/db.ts`).
+
+A one-for-one mirror of the Slack path over Discord's **Gateway** — Discord's equivalent of Socket Mode.
+One company bot, one token, outbound WebSocket, **no public URL**.
+
+## Setup
+
+Owner/admin, **Settings → Integrations → Discord**: a single bot token (`discord_bot_token`;
+`discordConfigured()` = token present). Then:
+
+1. In the Discord Developer Portal, **Bot → Privileged Gateway Intents → enable MESSAGE CONTENT.**
+   Without it messages arrive with empty `content` and nothing routes.
+2. Invite the bot with the console's **one-click invite button** — a bot's user id *is* its application
+   id, so once the Gateway reaches READY the invite URL is built automatically (nothing to paste).
+
+Intents subscribed: `GUILD_MESSAGES (1<<9) | DIRECT_MESSAGES (1<<12) | MESSAGE_CONTENT (1<<15)` = 37376.
+
+## Connection lifecycle
+
+Heartbeat-driven, unlike Slack: `getGatewayUrl` → connect → **HELLO** (server-chosen heartbeat interval)
+→ **IDENTIFY** → **READY**, which hands back the bot's own user id (the analogue of Slack's `auth.test`)
+so self/bot messages are ignored. Reconnect backoff is 1 s → 30 s with zombie detection (a missed
+`HEARTBEAT_ACK`). Deliberately **no RESUME** — every reconnect re-IDENTIFYs, matching `SlackSocket`'s
+stance; a reconnect may miss the handful of events in the gap, which is acceptable for trigger dispatch.
+
+Audit: `discord.connected` `{ botUserId, guilds }` — the READY guild count is the "is it actually
+installed anywhere" signal.
+
+## Ingress and threading
+
+Run-as resolution differs from Slack in one important way: **a Discord bot cannot read a user's email**,
+so there is no email fallback. The Discord user id is mapped through the **identity map**
+(`member_identities`, provider `discord`, `memberByExternalId`), populated on the Team page (Chat IDs).
+Unmapped senders run as the company identity.
+
+A leading `<@BOTID>` mention is stripped before routing, so the `/agent` prefix parses.
+
+**Threading is real, not implied.** For a guild @mention the socket branches an actual Discord **thread**
+off the user's message (`startThread`), binds the *thread* to the session, and keeps the ack and every
+`discord_reply` inside it. DMs have no threads → the reply uses a message reference in the DM. A
+thread-create failure falls back to the parent channel. Continuity is keyed on the bound channel/thread in
+`discord_threads`.
+
+## Egress
+
+| Tool | Exposed when | Does |
+|---|---|---|
+| `discord_reply` | `DISCORD_REPLY=1` (Discord-triggered session) | replies in the bound thread/channel |
+| `discord_send` | `DISCORD_EGRESS=1` (Discord configured) | posts to any channel by id |
+| `discord_dm` | `DISCORD_EGRESS=1` | DMs any person by Discord user id |
+
+Audit-only, no policy gate: `discord.send` / `discord.dm` `{ channel|to, id, chars }`. Discord is also a
+carrier for approval/question/task DMs and the EOD digest (`digest_discord_channel`).
+
+## Gotchas
+
+- **MESSAGE_CONTENT is privileged.** Forget it and every message body is empty — the failure is silent,
+  not an error.
+- **No email → the identity map is mandatory** for per-member run-as. An unlinked person's runs act as the
+  company, with the company's connectors.
+- Sub-second gaps around a reconnect can drop events (no RESUME, by design).

--- a/docs/connectors/github.md
+++ b/docs/connectors/github.md
@@ -1,0 +1,85 @@
+# GitHub connector
+
+**Status:** shipped. **Kind:** credential source (no chat ingress) — the shell's `GH_TOKEN` and a bearer
+for GitHub API tools.
+**Code:** `src/connectors/github.ts` (App/OAuth client) · `src/edge/github-identity.ts` (vault + refresh) ·
+`/api/github/*` (`src/server.ts`) · injection in `src/terminal.ts`.
+**See also:** `docs/github-integration-plan.md`, `docs/per-member-github-plan.md`.
+
+GitHub is not a chat channel. One company **GitHub App**, registered once and installed on the org's
+repos, is the single credential source for both consumption paths:
+
+- the **shell** — a token is exported as `GH_TOKEN` / `GITHUB_TOKEN` at launch, so plain `git` and `gh`
+  authenticate; and
+- **governed API tools** — the same token is a valid bearer for a GitHub MCP connector.
+
+**Why an App, not a static PAT:** an installation token is org-scoped, carries only the App's
+fine-grained per-repo permissions, and **expires hourly**. It is minted on demand, so nothing long-lived
+is ever handed to an agent. The App's private key never leaves the server (encrypted vault), and the
+RS256 JWT we sign to obtain a token lives ≤ 9 minutes (GitHub's ceiling is 10; `iat` is back-dated 30 s
+for clock skew).
+
+## Two identities, one App
+
+| Path | Whose token | Stored where | Lifetime |
+|---|---|---|---|
+| **Company bot** | the App **installation** token | vault `*` → `github_bot_token` (cached) | ~1 h, refreshed 25 min early |
+| **Per-member** | that member's GitHub **user** token (OAuth) | vault under `principal = <member id>` → `github_user` | ~8 h, refreshed 10 min early |
+
+At launch `injectMemberGithub` runs right after the shell-secret injection: if the run's **run-as member**
+has linked their own GitHub account, **their** user token **overrides** the bot's `GH_TOKEN`, so commits
+and PRs are authored as the actual human. The bot is the fallback — a run with no linked run-as human
+acts as the bot. Audited `github.token.injected`.
+
+Member tokens are **never** stored in the tenant-wide `*` scope, so no agent can read another member's
+token via `secret_get`. The App's OAuth client secret and RSA private key sit under `*`; the client id is
+a plain setting.
+
+## Setup
+
+Owner/admin, **Settings → Integrations → GitHub**. Either half works on its own and the setup wizard
+counts either:
+
+- **OAuth pair** (`github_client_id` + client secret in the vault) → members can link their own accounts
+  and commit as themselves.
+- **App id + private key** (`github_app_id`, `github_installation_id`, PEM in the vault) → the company-bot
+  push token.
+
+The **manifest flow** (`GET /api/github/manifest` → GitHub → `GET /api/github/manifest-callback`) creates
+the App and captures the credentials in one round trip (`convertAppManifest`), storing the resulting
+`github_app_slug` — which is what builds the "install on repos" link. The installation id is auto-resolved
+(`listInstallations`).
+
+Per-member linking: `GET /api/github/connect` → GitHub authorize → `GET /api/github/callback`
+(`exchangeUserCode`); `GET /api/github/me` reports link + installation status; `POST /api/github/disconnect`
+drops the stored blob.
+
+⚠ **Never rename a live GitHub App slug** — the slug is baked into every per-member install URL.
+
+## Self-recovery: `github_refresh`
+
+An agent whose injected `GH_TOKEN` dies mid-run (`git`/`gh` → `Bad credentials`) can call the
+`github_refresh` MCP tool. It **forces** a refresh (`GithubIdentity.forceRefresh` via the stored `ghr_`
+refresh token) — unlike launch-time `ensureFresh`, which only acts inside the expiry skew — and hands back
+the fresh token so the agent can `export GH_TOKEN=…` itself (a process's env cannot be mutated from
+outside; the git credential helper and `gh` re-read `$GH_TOKEN` at call time). It is the agent's own,
+already-injected identity, so there is no new exposure. Typed statuses tell it to stop retrying and have
+the human re-link when there is no refresh token.
+
+## API surface (`src/connectors/github.ts`)
+
+Zero-dependency: the global `fetch` plus `node:crypto` for RS256. Every call returns `{ error }` rather
+than throwing.
+
+`appJwt` · `authorizeUrl` · `exchangeUserCode` · `refreshUserToken` · `convertAppManifest` ·
+`githubUser` · `appMetadata` · `userInstallationStatus` · `listInstallations` · `mintInstallationToken` ·
+`pullRequest` · `InstallationTokenCache`.
+
+## Gotchas
+
+- **A dead injected token is worse than none** — `gh` prefers `$GH_TOKEN` over the keyring, so an expired
+  injected token *shadows* a working login. Stale-at-launch tokens are therefore withheld rather than
+  exported (v0.338.1).
+- **PR authorship = whoever last set `GH_TOKEN`.** The bot wins on any run with no linked run-as human;
+  that is the expected behaviour, not a bug.
+- The App slug is load-bearing for install URLs (see above).

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -1,0 +1,105 @@
+# Slack connector
+
+**Status:** shipped. **Kind:** ingress (Socket Mode) + egress (reply, proactive send/DM, digest, DMs for
+approvals/questions/tasks/login links).
+**Code:** `src/connectors/slack.ts` (API client) · `src/edge/slack-socket.ts` (connection + dispatch) ·
+`slack_threads` (`src/state/db.ts`).
+
+One company Slack app serves the whole workspace in **both directions**: the same bot token that receives
+events is the identity that posts. Per-member behaviour rides on top of that single app — each inbound
+event names the Slack user, which is how a run gets the right human's identity.
+
+## Why Socket Mode
+
+The Node server dials **out** to Slack over a WebSocket (`apps.connections.open` → a single-use `wss://`
+URL). **No public URL, no inbound port** — a Tailscale-private or on-prem box that can reach
+`*.slack.com` outbound works with zero ingress. Reconnects use 1 s → 30 s backoff, and a `generation`
+counter makes a stale socket's handlers no-op after a token change or restart. Zero dependency: the
+global `WebSocket` (Node 22+), no `ws` package.
+
+## Setup
+
+Owner/admin, **Settings → Integrations → Slack**. Two tokens:
+
+| Setting key | Token | Needed for |
+|---|---|---|
+| `slack_app_token` | app-level `xapp-…` (`connections:write`) | opening the Socket Mode connection |
+| `slack_bot_token` | bot `xoxb-…` | `chat.postMessage`, `users.info`, `conversations.*` |
+
+`slackConfigured()` requires **both**. The console's Integrations page carries the app **manifest** with
+the current scope list — an app created before a scope was added needs the scope added *and* a reinstall.
+DMs specifically need `im:write`. The socket re-dials automatically when either token changes.
+
+Event subscriptions: `app_mention` covers @mentions. Plain in-thread replies and channel-watch messages
+only arrive if the app also subscribes to `message.channels` / `message.groups` / `message.im` **and** the
+bot is in the channel.
+
+## Ingress — mention, DM, or watched channel
+
+For each inbound user message the socket:
+
+1. **Strips a leading bot mention** (`<@BOTID>`) so an `/agent` prefix parses.
+2. **Resolves run-as** — the identity map (`member_identities`, provider `slack`) first, then the Slack
+   profile **email** → `getMemberByEmail`. Unmapped → the company identity. `canRun` is enforced on the
+   resolved principal.
+3. **Acks in-thread immediately**, threading on `thread_ts ?? ts` — so a mention starts a thread.
+4. **Continuity first** — a follow-up inside a thread already bound in `slack_threads` continues *that*
+   conversation: `Automations.continueSlackThread` finds the newest session for `channel`+`thread_ts`
+   (`TerminalManager.sessionForSlackThread`) and spawns a run that `claude --resume`s the **same
+   transcript**. A busy agent gets a "pick this up next" note rather than an overlapping run. This needs
+   the pinned claude id — unattended runs launch with `--session-id $CLAUDE_SESSION_ID`, stored in
+   `term_sessions.claude_session_id`.
+5. **Else fires `slack` automations**, then falls through to the shared `/agent` router.
+
+Audit: `slack.connected` `{ botUserId }` on READY; `trigger.slack` per dispatch.
+
+### Filters and channel watch (v0.390.0)
+
+A `slack` automation's `filter` is `<scope> [when …] [unless …]`:
+
+- **scope** — exact event type or channel id; `''` / `*` = any.
+- **clauses** — the `webhook-ingress.ts` predicate grammar (`evaluatePredicates`) over the Slack event,
+  with `text` = the mention-stripped body and `actor` = the resolved sender.
+
+Naming a **channel id** also turns the automation into a **channel watch**: the socket stops dropping
+non-mention messages there and calls `fireSlack(…, { channelWatch: true, router: false })`. Deliberately
+narrow — only an *exactly channel-scoped* automation is woken (a `*` scope quietly eating every message in
+every channel would multiply a live tenant's spend with nobody having edited anything), and the `/agent`
+router never runs on a watch. Bot-posted messages are always dropped (`ev.fromBot`); an integration that
+*posts* reports belongs on a webhook automation instead.
+
+Slack filters are validated **at save time** — the predicate layer fails open at runtime, so that is the
+only place a typo is caught. Pinned by `scripts/slack-content-filter-test.cjs`.
+
+## Egress
+
+| Tool | Exposed when | Does |
+|---|---|---|
+| `slack_reply` | `SLACK_REPLY=1` (Slack-triggered session) | replies on the bound thread — no channel id passed |
+| `slack_send` | `SLACK_EGRESS=1` (Slack configured) | posts to **any** channel by id or name, auto-joining public channels |
+| `slack_dm` | `SLACK_EGRESS=1` | DMs **any** person by Slack user id or email |
+
+`slack_send`/`slack_dm` are proactive: off-thread, unattended, no policy gate — audit only
+(`slack.send` / `slack.dm` with `{ channel|to, ts, chars }`), the same posture as `slack_reply`.
+
+Slack is also the default carrier for out-of-band notifications: approval cards
+(`setApprovalNotifier` → `notifyApprovers`), agent questions (`setQuestionNotifier`), Task events
+(`notifyTaskEvent`), self-service login links (`notifyLoginLink`), and the end-of-day fleet digest
+(`digest_enabled` + `digest_channel` + `digest_hour`). Every one resolves its recipients through the
+single `resolveRecipients(os, audience)` in `src/governance/recipients.ts` and shares `deliverDM`.
+
+## Data model
+
+```sql
+CREATE TABLE IF NOT EXISTS slack_threads (session_id, channel, thread_ts, …);
+```
+Bound at `createSession`; read back by `slack_reply` and by `sessionForSlackThread` for continuity.
+
+## Gotchas
+
+- **App Home → Messages Tab must be enabled** or the bot cannot receive or reply to DMs — check this
+  before debugging DM routing.
+- **Scopes are add-then-reinstall.** An older app silently lacks any scope added since it was installed.
+- **`app_mention` is not enough for threads.** Plain replies need `message.*` subscriptions *and* the bot
+  in-channel.
+- A `*`-scoped automation is not a channel watch — only an exact channel id is (by design).

--- a/docs/connectors/telegram.md
+++ b/docs/connectors/telegram.md
@@ -1,0 +1,69 @@
+# Telegram connector
+
+**Status:** shipped. **Kind:** ingress (long polling) + egress (reply).
+**Code:** `src/connectors/telegram.ts` (Bot API client) · `src/edge/telegram-socket.ts` (poll loop +
+dispatch) · `telegram_threads` (`src/state/db.ts`).
+
+The third native chat channel, mirroring `DiscordSocket` one-for-one. One company bot from **@BotFather**,
+one token, and the same trust model as Slack/Discord: the server dials **out**, so **no public URL** and
+zero ingress.
+
+## Why long polling
+
+`getUpdates` holds an HTTPS connection open for up to `timeout` seconds (25 s here) and returns the next
+batch. That keeps the posture identical to Socket Mode / the Gateway on a Tailscale-private box, and it is
+*simpler* than both: no WebSocket, no heartbeat, no opcodes, no app-level token — just an abortable
+in-flight request in a loop with 1 s → 30 s backoff on error. `offset` confirms everything below it (so
+Telegram drops those from the queue) and asks for the next batch; startup does a `timeout=0` drain.
+
+## Setup
+
+Owner/admin, **Settings → Integrations → Telegram**: one bot token from @BotFather
+(`telegram_bot_token`, `<botid>:<hash>`; `telegramConfigured()` = token present). `getMe` validates the
+token and returns the bot's id + username (the id ignores its own/other bots' messages; the username
+detects an @-mention in a group).
+
+The socket registers per-agent slash commands with `setMyCommands` (`telegramCommandName(agentId)`), so
+agents show up in Telegram's command menu.
+
+**⚠ Group Privacy.** By default a Telegram bot in a group only sees messages that are commands (`/cmd`),
+@-mention it, or reply to one of its messages. Mention/command ingress works either way — but **plain
+follow-ups (thread continuity) require Group Privacy disabled in @BotFather**.
+
+## Ingress
+
+`parseTelegramUpdate` normalises an update into a `TelegramMessageEvent`. A message fires when it
+@-mentions the bot in a group or is sent in a private chat. Run-as resolves the Telegram user id through
+the **identity map** (`member_identities`, provider `telegram`) — Telegram exposes no email, so as with
+Discord there is no email fallback; unmapped senders run as the company identity.
+
+Then the usual: continuity first, then `telegram` automations, then the shared `/agent` router.
+
+Audit: `telegram.connected` `{ botId, username }`; `trigger.telegram` per dispatch.
+
+## Threading
+
+Telegram bots can't branch a thread off a message in a normal group (forum topics need admin rights), so
+unlike Discord there is no per-mention thread. Replies go back into the **same chat**, as a reply to the
+triggering message. Continuity is keyed on **chat id (+ forum topic id when present)** — the Discord
+per-channel model:
+
+```sql
+CREATE TABLE IF NOT EXISTS telegram_threads (session_id, chat_id, message_thread_id, message_id, …);
+CREATE INDEX idx_telegram_threads_chat ON telegram_threads (chat_id, message_thread_id);
+```
+
+## Egress
+
+`telegram_reply` — exposed only on Telegram-triggered sessions (`TELEGRAM_REPLY=1`), routed via
+`POST /api/agent/telegram/reply`. Chat + reply target come from the server-side binding; the agent sends
+text only.
+
+Messages are sent **without a `parse_mode`**, i.e. plain text — so `src/governance/chat-links.ts` renders
+links as `label: url` for `telegram` (same as ClickUp) instead of masked markup.
+
+## Gotchas
+
+- **Group Privacy on = no continuity.** Only commands/mentions/replies reach the bot.
+- **No email → the identity map is mandatory** for per-member run-as.
+- Forum topics: continuity keys on `(chat_id, message_thread_id)`, so the same chat's topics stay separate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.410.0",
+  "version": "0.410.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.410.0",
+      "version": "0.410.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.410.0",
+  "version": "0.410.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",


### PR DESCRIPTION
## What

New `docs/connectors/` — an **as-built** reference page per shipped native connector, plus an index for what they all share. Started with ClickUp (the least documented), then covered the rest.

| Page | Covers |
|---|---|
| `clickup.md` | webhook ingress via a ClickUp Automation, the re-fetch (payload has no comment text), the **comment-id** loop-guard and why it is *not* keyed on the token's user id, the `/command`-only gate placed ahead of continuity, the `eyes` **shortcode** ack, `clickup_threads` + `clickup_reply`, plain-text replies |
| `slack.md` | Socket Mode + the two tokens, filters + channel watch (and why only an exact channel id is a watch), `--resume` thread continuity, the three egress tools, the notification carriers |
| `discord.md` | Gateway lifecycle, privileged `MESSAGE_CONTENT`, identity-map-only run-as (no email), real per-mention threads |
| `telegram.md` | long polling, Group Privacy vs continuity, chat-id (+ forum topic) threading |
| `github.md` | App-minted bot token vs per-member user token, injection order, `github_refresh`, the dead-token-shadows-keyring trap |
| `composio.md` | the minted Tool Router URL, per-connector `user_id`, `composio_shares` and why sharing cannot be a move, `/triggers/composio` |
| `README.md` | the two planes, run-as resolution per channel, the `/agent` router, the four continuity tables, governance, generic MCP connectors |

`docs/connectors-and-triggers.md` gets a pointer at the top and stays the design history — its as-built banner already said the shipped tree diverged from it; these pages are now the source of truth for "how do I wire up X".

## Notes

- Docs + version bump only, no code touched.
- All identifiers stay placeholders per the public-repo rule.
- `npm run build` + `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)