### PR TITLE
fix(insights): the topic list names subjects again (v0.410.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.410.2] - 2026-08-31
+### Fixed
+- **The topic list names subjects again, now that it actually compounds.** v0.402.1 stopped the nightly
+  wipe, and four days of real accumulation showed what the wipe had been masking: instapods' injected
+  guidance read *"the fleet frequently works on: composio, **friday**, **monday**, dataforseo, gmail"* —
+  two of five were days of the week, at 33 each, ranked #2 and #3. Compounding didn't create that; a cron
+  repeats its title verbatim, so a cadence word outruns real subjects. Four rules, each from a class
+  observed on a live tenant: **calendar + cadence words** are stopped (`friday`, `monday`, `weekly`,
+  month names); **formats and protocols** are stopped (`http`, `html`, `json`, `bash`, `urls`, `pngs` —
+  databases and products deliberately are not, so `postgres`, `sqlite`, `stripe`, `wordpress` survive);
+  **generic verbs and state words** that reached the threshold are stopped (`evaluate`, `detect`,
+  `revise`, `success`, `urgent`, `tier`); and **email addresses are stripped before either extractor sees
+  the line**, which kills both the local part (`ahmad.hekma`, `justinhuckaby8`, `sarahmohib8` were all
+  fleet "topics") and the domain half (`gmail.com` at count 8) — a customer's identifier has no business
+  in every agent's system prompt. Plus the **generated `adjective-animal-NN` pod handle** (`proud-ibis-22`,
+  `jolly-owl-72`, `calm-tiger-80`) is no longer an entity. Replayed over the 714 real episodes that
+  produced the bad line, the guidance becomes *"composio, dataforseo, gmail, instapods, instapods.com"* —
+  all five real. `TOPICS_VERSION` → 5, so both tenants rebuild; the fingerprint guard added in v0.402.1
+  caught the un-bumped change on the first run, which is what it was built for.
+
 ## [0.410.1] - 2026-08-31
 ### Added
 - **Per-connector reference docs** — a new `docs/connectors/` set documenting every shipped native

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.410.1",
+  "version": "0.410.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.410.1",
+      "version": "0.410.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.410.1",
+  "version": "0.410.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/insights-signal-test.cjs
+++ b/scripts/insights-signal-test.cjs
@@ -153,6 +153,32 @@ console.log('\n\x1b[1mInsights signal — no prompt-injected or DM\'d number off
   assert(has('php8') && has('dev3') && has('oauth2'), 'php8 / dev3 / oauth2 survive');
   assert(has('log4j'), 'a short name with an interior digit is below the length bound and survives');
   assert(has('freescout'), 'a plain product name survives');
+
+  // ── the classes that reached the guidance line once the map started compounding for real ──────────
+  // Four days after TOPICS_VERSION 4 stopped the nightly wipe, instapods' injected guidance read
+  // "the fleet frequently works on: composio, friday, monday, dataforseo, gmail" — two of five were days
+  // of the week. Compounding did not create these; it made them visible and load-bearing, because a cron
+  // repeats its title verbatim and so outruns real subjects.
+  const got2 = new Map(topicCounts([
+    ep('Task: Use skill_propose to propose a new reusable skill named "friday-ops-report" for the weekly wrap.'),
+    ep('Task: Run the Monday marketing routine per your CLAUDE.md, then post the weekly digest.'),
+    ep('Task: Stop PPU billing + refund review for sarahmohib8@gmail.com (user 147627, FreeScout #3264).'),
+    ep('Task: Diagnose why ahmad.hekma@example.org cannot reach the dashboard.'),
+    ep('Task: Pod proud-ibis-22 is serving 502s; jolly-owl-72 and calm-tiger-80 look fine.'),
+    ep('Task: Return the HTML and JSON payloads over HTTP, then evaluate the urls.'),
+    ep('Task: Evaluate the Postgres restore and confirm Stripe webhooks still fire.'),
+  ]));
+  const has2 = (t) => got2.has(t);
+
+  assert(!has2('friday') && !has2('monday'), 'a day of the week is a cadence, not a subject', [...got2.keys()].join(','));
+  assert(!has2('weekly') && !has2('daily'), 'nor is a cadence word');
+  assert(!has2('sarahmohib8') && !has2('ahmad.hekma'), "a customer's email local part never becomes a topic");
+  assert(!has2('gmail.com') && !has2('example.org'), '…and neither does the domain half');
+  assert(!has2('proud-ibis-22') && !has2('jolly-owl-72') && !has2('calm-tiger-80'), 'a generated pod handle is not a workstream');
+  assert(!has2('html') && !has2('json') && !has2('http') && !has2('urls'), 'formats and protocols are how, not what');
+  assert(!has2('return') && !has2('evaluate'), 'a generic verb is not a subject');
+  // …and the real subjects in the same lines survive every one of those rules.
+  assert(has2('postgres') && has2('stripe') && has2('freescout'), 'real products still come through', [...got2.keys()].join(','));
 }
 
 // ── the extractor and TOPICS_VERSION must move together ─────────────────────────────────────────────
@@ -196,7 +222,7 @@ console.log('\n\x1b[1mInsights signal — no prompt-injected or DM\'d number off
 
   // ⚠ When this fails: the extractor changed. Bump TOPICS_VERSION in src/edge/dreaming.ts so every live
   // tenant rebuilds its topic map from the current corpus, THEN paste the new hash here.
-  const PINNED = { version: 4, hash: 'bc0f006a6d11ecf2' };
+  const PINNED = { version: 5, hash: '9a38a1fda7cb687d' };
 
   assert(hash === PINNED.hash,
     'the extractor is unchanged since TOPICS_VERSION was last bumped',

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -84,7 +84,7 @@ const MIN_TOPIC_COUNT = 3;
  * `scripts/insights-signal-test.cjs` now fingerprints the extractor and fails the build when it changes
  * without a bump.
  */
-export const TOPICS_VERSION = 4;
+export const TOPICS_VERSION = 5;
 const STOP = new Set(['task', 'outcome', 'session', 'after', 'then', 'with', 'this', 'that', 'from', 'into', 'your', 'their', 'about', 'over', 'when', 'while', 'should', 'would', 'could', 'have', 'been', 'were', 'them', 'they', 'will', 'just', 'also', 'using', 'used', 'ran', 'run', 'done', 'made', 'make', 'need', 'needs', 'some', 'more', 'than', 'only', 'each', 'both', 'unknown', 'none',
   // Procedural / plumbing words — they describe HOW an agent worked, not WHAT the fleet works on, so they
   // drown the real topics ("slack, check, report, completed, summary" is a useless "frequently works on").
@@ -100,7 +100,23 @@ const STOP = new Set(['task', 'outcome', 'session', 'after', 'then', 'with', 'th
   // ACRONYM to `properNouns` (short, all-caps, standing alone), which promoted it to a proper noun —
   // instawp's first clean pass told every agent "the fleet frequently works on: freescout, apache2,
   // WAIT". These are states a run passes through, never subjects it works on.
-  'wait', 'waiting', 'block', 'blocked', 'blocking', 'advanced', 'live', 'record', 'records', 'library', 'note', 'notes']);
+  'wait', 'waiting', 'block', 'blocked', 'blocking', 'advanced', 'live', 'record', 'records', 'library', 'note', 'notes',
+  // CALENDAR words. Recurring automations name their cadence in the task title ("friday-ops-report", the
+  // Monday routine), and a cron repeats verbatim, so these compound FASTER than real subjects: four days
+  // after the topic map began accumulating for real, `friday:33` and `monday:33` ranked #2 and #3 on
+  // instapods and were being injected into every agent's prompt as work the fleet does.
+  'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday', 'weekly', 'daily', 'nightly',
+  'january', 'february', 'march', 'april', 'june', 'july', 'august', 'september', 'october', 'november', 'december',
+  // FORMATS + PROTOCOLS. How a thing was written down, not what was worked on. (Databases and products
+  // are deliberately NOT here — `postgres`, `sqlite`, `stripe`, `wordpress` are real subjects.)
+  'http', 'https', 'html', 'css', 'json', 'yaml', 'yml', 'xml', 'csv', 'png', 'pngs', 'jpg', 'jpeg', 'svg', 'pdf',
+  'url', 'urls', 'bash', 'shell', 'stdout', 'stderr', 'utf-8',
+  // GENERIC VERBS + STATE WORDS that reached the threshold on live tenants, and their obvious siblings.
+  // These describe what happened to something, never the something.
+  'evaluate', 'evaluated', 'detect', 'detected', 'revise', 'revised', 'remove', 'removed', 'return', 'returned',
+  'success', 'successful', 'urgent', 'restrict', 'restricted', 'confirming', 'confirmed', 'drafting', 'drafted',
+  'persist', 'automate', 'automated', 'select', 'selected', 'cover', 'covered', 'edited', 'stale', 'final',
+  'tier', 'tiers']);
 
 export class DreamingEngine {
   constructor(private readonly os: AgentOS) {}
@@ -350,7 +366,14 @@ export function topicCounts(episodes: EpisodeRow[], nameStop: Set<string> = new 
 
 /** The first meaningful line of an episode, with the `Task:` prefix stripped. */
 function firstLine(e: EpisodeRow): string {
-  return (e.content.split('\n').map((l) => l.trim()).find((l) => l) ?? '').replace(/^Task:\s*/i, '');
+  const raw = (e.content.split('\n').map((l) => l.trim()).find((l) => l) ?? '').replace(/^Task:\s*/i, '');
+  // Strip EMAIL ADDRESSES before either extractor sees the line. A support/billing task names the
+  // customer it is about, and the local part tokenises into what looks like a proper noun — live
+  // instapods surfaced `ahmad.hekma`, `justinhuckaby8`, `luke.collins2710` and instawp `sarahmohib8` as
+  // things "the fleet frequently works on", and the domain half put `gmail.com` at count 8. Neither is a
+  // subject, and a customer's identifier has no business riding in every agent's system prompt. Corpus-
+  // internal, so it needs no roster: the `@` is the evidence. `memberNameStop` still covers the team.
+  return raw.replace(/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/g, ' ');
 }
 
 const WORD_RE = /[A-Za-z][A-Za-z0-9.-]{3,}/g;
@@ -452,6 +475,11 @@ function isEntity(token: string, proper: Set<string>): boolean {
   // Bounded by length so short legitimate names (`log4j`, `s3`) are untouched, and a token the corpus
   // consistently capitalizes is a name whatever its shape, so `proper` still wins.
   if (!proper.has(token) && token.length >= 7 && /\d/.test(token.replace(/[\d-]+$/, ''))) return false;
+  // A GENERATED HANDLE — the `adjective-animal-NN` shape this product mints for pods. It ends in digits,
+  // so the mid-token rule above deliberately spares it, and `token.includes('.')`/`\d` admits it. Live
+  // instapods carried `proud-ibis-22`, `jolly-owl-72`, `calm-tiger-80`, `warm-ibis-87`, `happy-raven-26`,
+  // `bold-falcon-22` and `fancy-raven-20` as fleet topics. One customer's pod is not a workstream.
+  if (/^[a-z]+-[a-z]+-\d+$/.test(token)) return false;
   // A FILENAME qualifies on its base name, never its extension — otherwise the dot rule (meant for
   // hostnames and versions) admits every path an agent mentions, including format placeholders like
   // `yyyy-mm-dd.md`. `.com`/`.io` are not code extensions, so real hostnames still pass below.


### PR DESCRIPTION
v0.402.1 stopped the nightly wipe of the topic map. **Four days of real accumulation then showed what the wipe had been masking.**

instapods' injected guidance, live in every agent's system prompt:

> The fleet frequently works on: composio, **friday**, **monday**, dataforseo, gmail

Two of five were days of the week, at 33 each, ranked #2 and #3. Compounding didn't create that — a cron repeats its title verbatim (`"friday-ops-report"`, the Monday routine), so a cadence word outruns real subjects. The wipe had just been resetting the count every night.

## Four rules, each from a class observed live

| class | stopped | evidence |
|---|---|---|
| calendar + cadence | `friday`, `monday`, `weekly`, month names | `friday:33`, `monday:33` |
| formats + protocols | `http`, `html`, `json`, `bash`, `urls`, `pngs` | `http:6`, `html:4`, `bash:4` |
| generic verbs / state | `evaluate`, `detect`, `revise`, `success`, `urgent`, `tier` | `tier:9`, `evaluate:6`, `detect:5` |
| **email addresses** | stripped before either extractor reads the line | `ahmad.hekma:3`, `sarahmohib8`, `gmail.com:8` |

Databases and products are deliberately **not** stopped — `postgres`, `sqlite`, `stripe`, `wordpress` are real subjects and still come through.

The email rule matters beyond noise: those are **customer identifiers**, and they were riding in every agent's system prompt. The `@` is corpus-internal evidence, so it needs no roster; `memberNameStop` still covers the team.

Also: the generated `adjective-animal-NN` pod handle (`proud-ibis-22`, `jolly-owl-72`, `calm-tiger-80`) is no longer an entity — it ends in digits, so the mid-token rule from #721 deliberately spared it.

## Replayed over the real corpus

Against the **714 actual episodes** that produced the bad line:

```
before:  composio, friday, monday, dataforseo, gmail
after:   composio, dataforseo, gmail, instapods, instapods.com
```

All five real. Residual junk, all below the guidance threshold: bare first names not attached to an email (`oleh`, `shane`) and one host id (`instapod-nbg1-1`). Left alone deliberately — inventing a rule for them without evidence is the mistake this change corrects.

## The guard worked

`TOPICS_VERSION` → 5 so both tenants rebuild. The fingerprint test added in v0.402.1 **failed on the first run of the suite**, naming both the new hash and the version to move:

```
✗ the extractor is unchanged since TOPICS_VERSION was last bumped
    extractor hash is 9a38a1fda7cb687d, pinned bc0f006a6d11ecf2
✗ TOPICS_VERSION matches the version this fingerprint was taken at — TOPICS_VERSION=5, pinned at 4
```

That is exactly what it was built for, two PRs ago.

8 new assertions in `scripts/insights-signal-test.cjs` (41 total in that file), including that real products survive every rule. `npm run typecheck` clean, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)