### PR TITLE
feat(sessions): a lifetime ceiling, and upkeep that says it ran (v0.410.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.410.5] - 2026-09-01
+### Added
+- **A hard age ceiling for detached interactive sessions** (`interactiveMaxHours`, default **168 h**,
+  Settings → Concurrency). Every existing timeout measures *idleness*, and `markTurnBusy` stamps
+  `last_activity` on **every tool call** — so a session whose agent keeps working never looks idle however
+  old it gets, and none of the idle clocks can reach it. Measured on live instawp *after* the wake-queue
+  fix had already removed the biggest source of that traffic: **18 sessions still running, 15 interactive,
+  at 1007 h / 266 h / 263 h / 166 h / 120 h — every one reporting only 18–24 h idle**, skipped by the 72 h
+  reaper on every tick. The oldest had been open **42 days**. Age is the honest question for those. Like
+  the ceilings beside it, this one overrides the claimed and blocked-on-a-human exemptions (past it the
+  session is abandoned by definition) but **never** cuts one with somebody attached. Clamped 1 h–90 d;
+  `0` disables. Audited `session.reaped` with `reason: 'max-lifetime'`.
+
+### Fixed
+- **Memory upkeep now records that it ran, even when it changed nothing.** `runMemoryMaintenance` audited
+  only `if (res.pruned || res.merged)`, which made "upkeep is running and finding nothing" indistinguishable
+  from "upkeep is not running at all" — a live instawp check read five days of silence as a broken
+  scheduler when the store was simply clean. Every pass now writes `memory.maintained` with a `noop` flag;
+  the `removed` id list is left out of the row (it is only useful to the caller replaying it onto a
+  backend, and would bloat every pass). ~1 event/day/tenant against ~32k gate events/week.
+
 ## [0.410.4] - 2026-09-01
 ### Fixed
 - **`GET /api/sessions` stopped costing the box a fifth of its event loop.** Measured on the live

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.410.4",
+  "version": "0.410.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.410.4",
+      "version": "0.410.5",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.410.4",
+  "version": "0.410.5",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/idle-reaper-test.cjs
+++ b/scripts/idle-reaper-test.cjs
@@ -27,6 +27,11 @@ const { TerminalManager } = require(path.join(ROOT, 'dist/terminal.js'));
 
 const aos = loadAgentOS();
 const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
+// Each section below isolates ONE clock. The AGE ceiling (section 7b) would otherwise fire underneath
+// them — several fixtures are deliberately 200–400h old to exercise an idle/claim/blocked rule — so it
+// stays off until the section that owns it, and is switched off again afterwards.
+assert(aos.settings.interactiveMaxHours() === 168, 'AGE ceiling: unset → 168h (7d) default'); // asserted here, before anything sets it
+aos.settings.setInteractiveMaxHours(0);
 // Stub the backend so the sweep is deterministic without a real tmux server.
 let attached = new Set();               // tmux names with a "client" attached
 const killed = [];
@@ -173,6 +178,56 @@ const blockedForever = mkSession({ created_at: Date.now() - 200 * H });
 askAt(blockedForever, 150);
 tm.reapIdleSessions();
 assert(statusOf(blockedForever) === 'running', '0 → a 150h-old block is never cut');
+
+console.log('\n\x1b[1m7b) the LIFETIME ceiling — the backstop the idle clocks structurally cannot be\x1b[0m');
+{
+  // Every other clock here measures IDLENESS, and `markTurnBusy` stamps `last_activity` on EVERY tool
+  // call. So a session whose agent keeps working never looks idle however old it gets. Live instawp,
+  // measured after the wake-queue fix had already removed the biggest source of that traffic: 15
+  // interactive sessions running at 120–1007h, every one reporting under a day idle, skipped every tick.
+  aos.settings.setInteractiveIdleTimeoutHours(72);
+  aos.settings.setBlockedMaxHours(72);
+  aos.settings.setClaimedMaxHours(72);
+
+  assert(aos.settings.setInteractiveMaxHours(0) === 0, 'set 0 → off');
+  assert(aos.settings.setInteractiveMaxHours(99999) === 24 * 90, 'clamps to 90 days max');
+
+  // off = the old behaviour: age alone never closes anything.
+  aos.settings.setInteractiveMaxHours(0);
+  const ancientOff = mkSession({ created_at: Date.now() - 1007 * H, last_activity: Date.now() - 18 * H });
+  tm.reapIdleSessions();
+  assert(statusOf(ancientOff) === 'running', '0 → a 1007h session with 18h idle is never cut');
+
+  aos.settings.setInteractiveMaxHours(168);
+  // THE LIVE SHAPE: ancient, but recently active — invisible to every idle-based clock.
+  const ancientBusy = mkSession({ created_at: Date.now() - 1007 * H, last_activity: Date.now() - 18 * H });
+  const weekOldBusy = mkSession({ created_at: Date.now() - 266 * H, last_activity: Date.now() - 19 * H });
+  const youngBusy   = mkSession({ created_at: Date.now() - 120 * H, last_activity: Date.now() - 3 * H });
+  tm.reapIdleSessions();
+  assert(statusOf(ancientBusy) === 'stopped', '1007h old + 18h idle → closed on AGE (the live case)');
+  assert(statusOf(weekOldBusy) === 'stopped', '266h old + 19h idle → closed on age');
+  assert(statusOf(youngBusy) === 'running', '120h old is under the 168h ceiling → left alone');
+
+  const ev = aos.db.prepare("SELECT data FROM audit_events WHERE type='session.reaped' AND run_id=? ORDER BY ts DESC LIMIT 1").get(ancientBusy);
+  assert(ev && JSON.parse(ev.data).reason === 'max-lifetime', 'audited as max-lifetime, not idle-interactive', ev && ev.data);
+
+  // It overrides the exemptions the other ceilings honour — past this age the session is abandoned by
+  // definition, whoever claimed it or whatever it is waiting on.
+  const ancientClaimed = mkSession({ created_at: Date.now() - 400 * H, last_activity: Date.now() - 1 * H, claimed_by: 'm_bob' });
+  const ancientBlocked = mkSession({ created_at: Date.now() - 400 * H, last_activity: Date.now() - 1 * H });
+  askAt(ancientBlocked, 1);   // asked an hour ago — nowhere near the blocked ceiling
+  tm.reapIdleSessions();
+  assert(statusOf(ancientClaimed) === 'stopped', 'age overrides an active take-over claim');
+  assert(statusOf(ancientBlocked) === 'stopped', 'age overrides a fresh block on a human');
+
+  // …but never the one rule that matters: somebody is literally attached right now.
+  const ancientAttached = mkSession({ created_at: Date.now() - 1007 * H, last_activity: Date.now() - 1 * H, tmux: 'aos-LIFETIME-ATTACHED' });
+  attached.add('aos-LIFETIME-ATTACHED');
+  tm.reapIdleSessions();
+  assert(statusOf(ancientAttached) === 'running', 'ATTACHED → never cut, whatever the age');
+
+  aos.settings.setInteractiveMaxHours(0); // hand the baton back — later sections own other clocks
+}
 
 console.log('\n\x1b[1m7) the claim ceiling — a take-over expires, it is not a permanent exemption\x1b[0m');
 aos.settings.setInteractiveIdleTimeoutHours(48);

--- a/scripts/memory-upkeep-test.cjs
+++ b/scripts/memory-upkeep-test.cjs
@@ -110,6 +110,33 @@ const setAge = (id, days) => aos.db.prepare('UPDATE memories SET created_at = ? 
   assert(b3.rows.size === 1, 'the duplicate is deleted from the backend too — automem does NOT dedupe these itself');
   void dupA; void dupB;
 
+  // ── B2. an upkeep pass says it ran, even when it changed nothing ────────────────────────────────
+  console.log('\nupkeep is observable — a quiet pass is not a silent one\n');
+  {
+    // `runMemoryMaintenance` used to audit only `if (res.pruned || res.merged)`, which made "upkeep is
+    // running and finding nothing" indistinguishable from "upkeep is not running at all". A live instawp
+    // check read five days of silence as a broken scheduler; the store was simply clean.
+    aos.db.prepare('DELETE FROM memories').run();
+    aos.db.prepare("DELETE FROM audit_events WHERE type = 'memory.maintained'").run();
+    aos.settings.setMemoryConfig({ ...(aos.settings.memoryConfig() ?? { backend: 'sqlite' }), maintenance: { pruneAfterDays: 90, keepImportance: 0.6, dedupeThreshold: 0.95 } }, 'test');
+
+    await aos.runMemoryMaintenance('scheduler');
+    const quiet = aos.db.prepare("SELECT data FROM audit_events WHERE type = 'memory.maintained' ORDER BY ts DESC LIMIT 1").get();
+    assert(!!quiet, 'a pass that deleted nothing still records that it ran');
+    const qd = quiet ? JSON.parse(quiet.data) : {};
+    assert(qd.noop === true, '…and flags itself a no-op, so a quiet pass is legible at a glance', JSON.stringify(qd));
+    assert(qd.removed === undefined, 'the id list is left out of the audit row — it would bloat every pass');
+
+    // …and a pass that DID delete says so, with the counts.
+    // Inserted straight into the table: this section only exercises the AUDIT of a pass, and going through
+    // a provider here would drag in whichever embedder the config above happens to have wired.
+    aos.db.prepare("INSERT INTO memories (id, tenant, agent_id, content, tags, type, importance, created_at, recall_count) VALUES (?,?,?,?,'[]','Insight',0.2,?,0)")
+      .run('mem_prunable', aos.tenant, 'engineer', 'prunable note', Date.now() - 200 * 86_400_000);
+    await aos.runMemoryMaintenance('scheduler');
+    const busy = JSON.parse(aos.db.prepare("SELECT data FROM audit_events WHERE type = 'memory.maintained' ORDER BY ts DESC LIMIT 1").get().data);
+    assert(busy.noop === false && busy.pruned === 1, 'a pass that pruned reports the count and is not a no-op', JSON.stringify(busy));
+  }
+
   // ── C. recall serves the agent's OWN text, whatever the backend did to it ───────────────────────
   console.log('\nrecall fidelity — the backend ranks, the mirror is the record\n');
 

--- a/src/governance/settings.ts
+++ b/src/governance/settings.ts
@@ -98,6 +98,7 @@ const MAX_CONCURRENT_KEY = 'max_concurrent_sessions'; // whole-box concurrency c
 const INTERACTIVE_IDLE_HOURS_KEY = 'interactive_idle_timeout_hours'; // auto-close a detached member session idle past this; unset → 48h, 0 → off
 const UNATTENDED_MAX_HOURS_KEY = 'unattended_max_runtime_hours'; // hard runtime ceiling for a headless/unattended run (stuck-mid-turn backstop); unset → 24h, 0 → off
 const BLOCKED_MAX_HOURS_KEY = 'blocked_max_hours'; // force-close an interactive session waiting this long on an unanswered card; unset → 72h, 0 → off
+const INTERACTIVE_MAX_HOURS_KEY = 'interactive_max_hours'; // hard AGE ceiling for a detached interactive session; unset → 168h, 0 → off
 const CLAIMED_MAX_HOURS_KEY = 'claimed_max_hours'; // force-close a CLAIMED interactive session idle this long; unset → 72h, 0 → off (permanent take-over exemption)
 const UNATTENDED_NO_PROGRESS_MIN_KEY = 'unattended_no_progress_minutes'; // reap a headless run that never made a tool call (never-started: rate-limit/trust-hang/lost-prompt); unset → 30m, 0 → off
 const KILL_SWITCH_KEY = 'kill_switch'; // workspace-wide emergency stop (JSON KillSwitchState)
@@ -1203,6 +1204,40 @@ export class SettingsStore {
     if (!Number.isFinite(n)) return 72; // unset → default
     if (n <= 0) return 0;               // explicit 0 → disabled (permanent take-over exemption)
     return Math.min(Math.max(Math.round(n), 1), 24 * 30);
+  }
+
+  /**
+   * Hard AGE ceiling for a detached interactive session, measured from `created_at` — the backstop the
+   * idle clock cannot be.
+   *
+   * Every other ceiling in this family measures IDLENESS, and idleness is stamped by `markTurnBusy` on
+   * **every tool call**. So a session whose agent is still working — or is woken periodically — never goes
+   * idle, however old it gets, and {@link interactiveIdleTimeoutHours} never sees it. Live instawp,
+   * measured after the wake-queue fix had already removed the largest source of that activity: 18 sessions
+   * still `running`, 15 of them interactive, ages **1007 h / 266 h / 263 h / 166 h / 120 h** — and every
+   * one reporting only 18–24 h idle, so the 72 h reaper skipped them on every tick. The oldest had been
+   * open **42 days**.
+   *
+   * Age is the honest question for those: not "has it been quiet long enough" but "has this been open
+   * longer than any real piece of work". Like the ceilings above it, this one **overrides** the claimed and
+   * blocked-on-a-human exemptions — past it the session is abandoned by definition — but it never cuts one
+   * with somebody **attached**, which remains the only unconditional exemption in the sweep.
+   *
+   * Default **168 h** (7 days): comfortably longer than the 72 h idle/claim/blocked ceilings, so it only
+   * ever catches what they structurally cannot. Clamped 1 h–90 d; `0` disables.
+   */
+  interactiveMaxHours(): number {
+    const n = Number(this.getRow(INTERACTIVE_MAX_HOURS_KEY)?.value);
+    if (!Number.isFinite(n)) return 168; // unset → default
+    if (n <= 0) return 0;                // explicit 0 → disabled
+    return Math.min(Math.max(Math.round(n), 1), 24 * 90);
+  }
+
+  setInteractiveMaxHours(hours: number, by?: string): number {
+    const n = Number(hours);
+    const clamped = !Number.isFinite(n) || n < 0 ? 168 : n === 0 ? 0 : Math.min(Math.max(Math.round(n), 1), 24 * 90);
+    this.set(INTERACTIVE_MAX_HOURS_KEY, String(clamped), by);
+    return this.interactiveMaxHours();
   }
 
   setClaimedMaxHours(hours: number, by?: string): number {

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -239,9 +239,15 @@ export class AgentOS {
     const opts = this.settings.memoryConfig()?.maintenance;
     if (!this.memory.maintain || !opts) return { pruned: 0, merged: 0 };
     const res = await this.memory.maintain(opts);
-    if (res.pruned || res.merged) {
-      this.audit.append({ ts: Date.now(), runId: '-', tenant: this.tenant, principal: by, type: 'memory.maintained', data: { ...res } });
-    }
+    // Audit EVERY pass, including the ones that changed nothing. This used to fire only when something
+    // was deleted, which made "upkeep is running and finding nothing" indistinguishable from "upkeep is
+    // not running at all" — a live instawp check read five days of silence as a broken scheduler when the
+    // store was simply clean. A pass is ~1 event/day/tenant against ~32k gate events/week, so the cost of
+    // saying so is nil, and `removed` is dropped from the payload (the ids are only useful to the caller
+    // replaying them onto a backend, and a long list bloats every row).
+    const { removed, ...summary } = res;
+    void removed;
+    this.audit.append({ ts: Date.now(), runId: '-', tenant: this.tenant, principal: by, type: 'memory.maintained', data: { ...summary, noop: !res.pruned && !res.merged } });
     return res;
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -4819,11 +4819,11 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const value = os.settings.maxConcurrentSessions(); // operator override (null = unset)
     const resolved = autos.concurrencyCap();           // effective cap the scheduler enforces (0 = unlimited)
     const source = envLocked ? 'env' : value != null ? 'setting' : 'derived';
-    return sendJson(res, 200, { value, resolved, derived: derivedConcurrencyCap(), source, envLocked, alive: tm.aliveSessionCount(), admitted: tm.admissionSessionCount(), parked: tm.parkedSessionCount(), idleHours: os.settings.interactiveIdleTimeoutHours(), unattendedMaxHours: os.settings.unattendedMaxHours(), unattendedNoProgressMinutes: os.settings.unattendedNoProgressMinutes(), blockedMaxHours: os.settings.blockedMaxHours(), claimedMaxHours: os.settings.claimedMaxHours() });
+    return sendJson(res, 200, { value, resolved, derived: derivedConcurrencyCap(), source, envLocked, alive: tm.aliveSessionCount(), admitted: tm.admissionSessionCount(), parked: tm.parkedSessionCount(), idleHours: os.settings.interactiveIdleTimeoutHours(), unattendedMaxHours: os.settings.unattendedMaxHours(), unattendedNoProgressMinutes: os.settings.unattendedNoProgressMinutes(), blockedMaxHours: os.settings.blockedMaxHours(), claimedMaxHours: os.settings.claimedMaxHours(), interactiveMaxHours: os.settings.interactiveMaxHours() });
   }
   if (method === 'PUT' && p === '/api/settings/concurrency') {
     if (!isAdmin(me)) return sendJson(res, 403, { error: 'owner or admin required' });
-    const b = await readBody(req) as { value?: unknown; idleHours?: unknown; unattendedMaxHours?: unknown; unattendedNoProgressMinutes?: unknown; blockedMaxHours?: unknown; claimedMaxHours?: unknown };
+    const b = await readBody(req) as { value?: unknown; idleHours?: unknown; unattendedMaxHours?: unknown; unattendedNoProgressMinutes?: unknown; blockedMaxHours?: unknown; claimedMaxHours?: unknown; interactiveMaxHours?: unknown };
     // Cap: `null`/'' clears the override (→ derived default); 0 = unlimited; N>0 = cap. Only touched when the
     // key is present, so a PUT that only sets idleHours leaves the cap alone.
     if ('value' in b) {
@@ -4865,6 +4865,12 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.blockedMax.updated', data: { blockedMaxHours: savedH } });
     }
     // Claim ceiling (hours): how long a claimed-but-untouched session keeps its take-over exemption. 0 = off.
+    if ('interactiveMaxHours' in b) {
+      const h = Number(b.interactiveMaxHours);
+      if (!Number.isFinite(h) || h < 0) return sendJson(res, 400, { error: 'interactiveMaxHours must be a non-negative number (0 = off)' });
+      const savedH = os.settings.setInteractiveMaxHours(h, me.email);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'settings.interactiveMax.updated', data: { interactiveMaxHours: savedH } });
+    }
     if ('claimedMaxHours' in b) {
       const h = Number(b.claimedMaxHours);
       if (!Number.isFinite(h) || h < 0) return sendJson(res, 400, { error: 'claimedMaxHours must be a non-negative number (0 = off)' });

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3387,20 +3387,31 @@ export class TerminalManager {
       // still never cut (checked below) — that is what "a human owns it" should have meant all along.
       const claimedHours = this.os.settings.claimedMaxHours();
       const claimedCutoff = claimedHours > 0 ? Date.now() - claimedHours * 3600_000 : null;
-      // Widen the scan to the more permissive of the two clocks, then decide per row — otherwise a claim
-      // ceiling SHORTER than the idle timeout would never see its own rows.
+      // LIFETIME CEILING. Every clock above measures IDLENESS, and `markTurnBusy` stamps `last_activity`
+      // on every tool call — so a session whose agent still works never goes idle, however old it gets,
+      // and none of them can ever see it. Live instawp after the wake-queue fix: 15 interactive sessions
+      // `running` at 1007 h / 266 h / 263 h / 166 h / 120 h, every one reporting 18–24 h idle, skipped on
+      // every tick. Age answers what idleness cannot. See `interactiveMaxHours`.
+      const lifetimeHours = this.os.settings.interactiveMaxHours();
+      const lifetimeCutoff = lifetimeHours > 0 ? Date.now() - lifetimeHours * 3600_000 : null;
+      // Widen the scan to the more permissive of the two IDLE clocks, then decide per row — otherwise a
+      // claim ceiling SHORTER than the idle timeout would never see its own rows. The lifetime ceiling is
+      // ORed in rather than folded into that max: it reads `created_at`, and the rows it exists for are
+      // precisely the ones a `last_activity` filter excludes.
       const scanCutoff = claimedCutoff == null ? idleCutoff : Math.max(idleCutoff, claimedCutoff);
-      const stale = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, claimed_by, last_activity, created_at FROM term_sessions WHERE headless = 0 AND resident = 0 AND status IN ('running','done','crashed') AND COALESCE(last_activity, created_at) < ?")
-        .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; claimed_by: string | null; last_activity: number | null; created_at: number }>(scanCutoff);
+      const stale = this.db.prepare("SELECT id, tmux, run_as, spawned_by, agent, status, claimed_by, last_activity, created_at FROM term_sessions WHERE headless = 0 AND resident = 0 AND status IN ('running','done','crashed') AND (COALESCE(last_activity, created_at) < ? OR (? IS NOT NULL AND created_at < ?))")
+        .all<{ id: string; tmux: string; run_as: string | null; spawned_by: string | null; agent: string; status: string; claimed_by: string | null; last_activity: number | null; created_at: number }>(scanCutoff, lifetimeCutoff, lifetimeCutoff);
       for (const r of stale) {
         try {
           const idleSince = r.last_activity ?? r.created_at;
           const terminal = r.status === 'done' || r.status === 'crashed'; // see sweep 2 — a crashed row can still hold a pane
           // Claimed: exempt unless the claim itself has gone stale. Unclaimed: the ordinary idle clock —
           // re-checked here because the scan may have been widened past it for the claimed rows.
+          // Past the lifetime ceiling every idle-based exemption is moot — that is the point of it.
+          const overLifetime = lifetimeCutoff != null && r.created_at < lifetimeCutoff;
           if (r.claimed_by) {
-            if (claimedCutoff == null || idleSince >= claimedCutoff) continue;
-          } else if (idleSince >= idleCutoff) {
+            if (!overLifetime && (claimedCutoff == null || idleSince >= claimedCutoff)) continue;
+          } else if (!overLifetime && idleSince >= idleCutoff) {
             continue;
           }
           // A reaped 'running' row flips to 'stopped' and drops out of the query next tick; a 'done' row keeps
@@ -3411,11 +3422,13 @@ export class TerminalManager {
           if (this.backend.hasClient(space, r.tmux) === true) continue; // someone's attached — it's in use
           // Blocked on a person: leave it — unless nobody has answered inside the ceiling above, at which
           // point it is abandoned, not waiting.
-          let reason = r.claimed_by ? 'claimed-abandoned' : 'idle-interactive';
+          let reason = overLifetime ? 'max-lifetime' : r.claimed_by ? 'claimed-abandoned' : 'idle-interactive';
           const blockedAt = this.oldestPendingBlockAt(r.id);
           if (blockedAt !== undefined) {
-            if (blockedCutoff == null || blockedAt >= blockedCutoff) continue;
-            reason = 'blocked-timeout';
+            // Blocked on a person: leave it — unless nobody answered inside the ceiling, or the session is
+            // past its lifetime, at which point it is abandoned rather than waiting.
+            if (!overLifetime && (blockedCutoff == null || blockedAt >= blockedCutoff)) continue;
+            if (!overLifetime) reason = 'blocked-timeout';
           }
           this.backend.kill(space, r.tmux);
           // Preserve a completed session's outcome — only a still-running one becomes 'stopped'.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17526,6 +17526,7 @@ function ConcurrencySettings({ me }: { me: Member }) {
   const [noProg, setNoProg] = useState('')  // headless no-progress reap, minutes; '0' = off
   const [blocked, setBlocked] = useState('') // interactive blocked-on-a-card ceiling, hours; '0' = off
   const [claimed, setClaimed] = useState('') // take-over claim ceiling, hours; '0' = off
+  const [lifetime, setLifetime] = useState('') // hard AGE ceiling for a detached interactive session; '0' = off
   const [busy, setBusy] = useState(false)
   const [hint, setHint] = useState('')
   const canEdit = me.role === 'owner' || me.role === 'admin'
@@ -17539,6 +17540,7 @@ function ConcurrencySettings({ me }: { me: Member }) {
     setNoProg(String(r.unattendedNoProgressMinutes))
     setBlocked(String(r.blockedMaxHours))
     setClaimed(String(r.claimedMaxHours))
+    setLifetime(String(r.interactiveMaxHours))
   }).catch(() => {})
   useEffect(() => { load() }, [])
 
@@ -17548,16 +17550,18 @@ function ConcurrencySettings({ me }: { me: Member }) {
   const noProgDirty = data != null && noProg.trim() !== String(data.unattendedNoProgressMinutes)
   const blockedDirty = data != null && blocked.trim() !== String(data.blockedMaxHours)
   const claimedDirty = data != null && claimed.trim() !== String(data.claimedMaxHours)
-  const dirty = capDirty || idleDirty || maxRunDirty || noProgDirty || blockedDirty || claimedDirty
+  const lifetimeDirty = data != null && lifetime.trim() !== String(data.interactiveMaxHours)
+  const dirty = capDirty || idleDirty || maxRunDirty || noProgDirty || blockedDirty || claimedDirty || lifetimeDirty
   const save = async () => {
     setBusy(true); setHint('')
-    const body: { value?: number | null; idleHours?: number; unattendedMaxHours?: number; unattendedNoProgressMinutes?: number; blockedMaxHours?: number; claimedMaxHours?: number } = {}
+    const body: { value?: number | null; idleHours?: number; unattendedMaxHours?: number; unattendedNoProgressMinutes?: number; blockedMaxHours?: number; claimedMaxHours?: number; interactiveMaxHours?: number } = {}
     if (capDirty) body.value = input.trim() === '' ? null : Number(input)
     if (idleDirty) body.idleHours = Number(idle)
     if (maxRunDirty) body.unattendedMaxHours = Number(maxRun)
     if (noProgDirty) body.unattendedNoProgressMinutes = Number(noProg)
     if (blockedDirty) body.blockedMaxHours = Number(blocked)
     if (claimedDirty) body.claimedMaxHours = Number(claimed)
+    if (lifetimeDirty) body.interactiveMaxHours = Number(lifetime)
     const r = await api.saveConcurrency(body)
     setBusy(false)
     if (r.error) return setHint('⚠ ' + r.error)
@@ -17691,6 +17695,26 @@ function ConcurrencySettings({ me }: { me: Member }) {
             Taking a run over hands its lifecycle to you — so the idle timeout above stops applying. Nothing ever expires a claim, so
             someone who claims a session and closes the tab creates an immortal pane. Past this age the claim lapses and the janitor
             reclaims it. Someone actually attached is never cut.
+          </p>
+        </div>
+        <div className="space-y-1.5 border-t pt-4">
+          <label className="text-xs font-medium text-muted-foreground">Close a detached session older than (hours)</label>
+          <div className="flex items-center gap-3">
+            <Input
+              type="number" min={0} step={1} value={lifetime}
+              onChange={(e) => setLifetime(e.target.value)}
+              placeholder="168"
+              disabled={!canEdit}
+              className="h-8 w-40 font-mono text-xs"
+            />
+            <span className="text-[11px] text-muted-foreground">0 = no age limit · nobody attached</span>
+          </div>
+          <p className="text-[11px] text-muted-foreground">
+            Every timeout above measures <em>idleness</em>, and idleness resets on each tool call — so a session whose agent keeps
+            working never looks idle, however old it gets, and none of them can reach it. Measured on a live tenant: fifteen sessions
+            open <span className="font-mono">120–1007 h</span>, every one reporting under a day idle, skipped on every tick. This one
+            asks the honest question instead — has it been open longer than any real piece of work — and overrides the claim and
+            blocked exemptions. Someone actually attached is still never cut.
           </p>
         </div>
         <div className="flex items-center gap-3">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -115,6 +115,9 @@ export interface Concurrency {
   blockedMaxHours: number
   /** Expire a take-over claim untouched for this many hours, so a claimed session stops being immortal (0 = off; default 72). */
   claimedMaxHours: number
+  /** Hard AGE ceiling (hours) for a detached interactive session — the backstop the idle clocks cannot be,
+   *  since idleness resets on every tool call (0 = off; default 168). */
+  interactiveMaxHours: number
 }
 
 /** One credential set in the runtime rotation pool (never carries the api-key value, only its vault ref). */


### PR DESCRIPTION
Two gaps found by re-checking the earlier fixes against live data.

## 1. A hard age ceiling for detached interactive sessions

Every existing timeout measures **idleness** — and `markTurnBusy` stamps `last_activity` on **every tool call**. So a session whose agent keeps working never looks idle however old it gets, and no idle clock can reach it.

Measured on live instawp *after* the wake-queue fix (#723) had already removed the biggest source of that traffic:

```
running=18   interactive=15
1007h old, idle 18h   infra-ops     ← 42 days
 266h old, idle 19h   marketer
 263h old, idle 24h   infra-ops
 166h old, idle 23h   infra-ops
 120h old, idle 23h   engineer
```

Every one reporting under a day idle, so the 72 h reaper skipped them on every tick — forever.

Age is the honest question for those. `interactiveMaxHours` defaults to **168 h (7 days)** — comfortably past the 72 h idle/claim/blocked ceilings, so it only ever catches what they *structurally* cannot.

- **Overrides** the claimed and blocked-on-a-human exemptions — past that age the session is abandoned by definition.
- **Never** cuts one with somebody attached. That stays the only unconditional exemption in the sweep.
- Clamped 1 h–90 d, `0` disables, audited `session.reaped` with `reason: 'max-lifetime'`.

One structural change worth flagging: the scan filters on `COALESCE(last_activity, created_at)`, and the rows this ceiling exists for are exactly the ones that filter **excludes** — so the age cutoff is ORed into the query rather than folded into the idle max.

## 2. Upkeep records that it ran, even when it changed nothing

`runMemoryMaintenance` audited only `if (res.pruned || res.merged)`, so *"upkeep is running and finding nothing"* and *"upkeep is not running at all"* looked identical. I misread five days of instawp silence as a dead scheduler during the recheck; the store was simply clean.

Every pass now writes `memory.maintained` with a `noop` flag. The `removed` id list is dropped from the row — it is only useful to the caller replaying it onto a backend, and would bloat every pass. Cost: ~1 event/day/tenant against ~32k gate events/week.

## Tests

`idle-reaper-test.cjs` gains section 7b, built on the live shape (**65 checks total**):

```
✓ 1007h old + 18h idle → closed on AGE (the live case)
✓ 266h old + 19h idle → closed on age
✓ 120h old is under the 168h ceiling → left alone
✓ audited as max-lifetime, not idle-interactive
✓ age overrides an active take-over claim
✓ age overrides a fresh block on a human
✓ ATTACHED → never cut, whatever the age
✓ 0 → a 1007h session with 18h idle is never cut
```

`memory-upkeep-test.cjs` gains the quiet-pass audit (25 total). **8 assertions fail on the previous code.**

Note on the existing reaper tests: several deliberately create 200–400 h-old fixtures to exercise one *idle* rule, and the new ceiling would fire underneath them. Each section now owns exactly one clock — the age ceiling is off until section 7b and switched off again after, which is how the other clocks already treat each other.

`npm run typecheck` clean, `cd web && npm run build` clean, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)