### PR TITLE
fix(memory): the shared pool carries knowledge, not fleet statistics (v0.411.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.411.1] - 2026-09-01
+### Fixed
+- **The tenant-shared memory pool carries knowledge again, not fleet statistics.** A shared memory reaches
+  EVERY agent, and the self-learning pass writes one tenant-scoped digest per pass — *"Fleet self-learning
+  (pass 31, since 2026-07-01): 768 sessions, 43% success. Recurring topics: …"* — with nothing retiring
+  it. They accumulated until they **were** the shared pool: **51 of 72 shared memories on instapods, 48 of
+  85 on instawp**. Observed directly while running the loop experiment: an agent with no memories of its
+  own got a launch preamble that was **6 of 8 slots of fleet statistics** and nothing about its task. Two
+  changes. (1) A dreaming digest is now **preamble noise** (`isPreambleNoise`, alongside episodes) on both
+  the task-ranked and salience-fallback paths — it stays fully recallable, since an oversight agent asking
+  "how is the fleet doing" wants exactly this, it is simply not launch context. (2) Each pass now
+  **supersedes** the previous digest instead of appending: the id rides on `dreaming_state.lastInsightId`
+  (preserved through `normalizeState`, the same field-dropping trap `topicsVersion` fell into) and the old
+  one is deleted after the new one is written, so a failure leaves one extra rather than none. A digest is
+  a cumulative snapshot — pass N+1 restates everything pass N said — so keeping both was keeping a stale
+  copy.
+
 ## [0.411.0] - 2026-09-01
 ### Fixed
 - **The session summarizer stopped silently degrading — it now uses the runtime-account pool.** Chasing a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.411.0",
+  "version": "0.411.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.411.0",
+      "version": "0.411.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.411.0",
+  "version": "0.411.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/insights-signal-test.cjs
+++ b/scripts/insights-signal-test.cjs
@@ -24,7 +24,7 @@ delete process.env.AGENT_OS_SECRET_KEY;
 let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
-const { deriveGuidance, deriveRecommendations, recommendationResolved, topicCounts, TOPICS_VERSION } = require(path.join(ROOT, 'dist/edge/dreaming.js'));
+const { deriveGuidance, deriveRecommendations, recommendationResolved, topicCounts, normalizeState, TOPICS_VERSION } = require(path.join(ROOT, 'dist/edge/dreaming.js'));
 const crypto = require('crypto');
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
 const { detectAlerts } = require(path.join(ROOT, 'dist/edge/alerts.js'));
@@ -232,6 +232,22 @@ console.log('\n\x1b[1mInsights signal — no prompt-injected or DM\'d number off
   assert(TOPICS_VERSION === PINNED.version,
     'TOPICS_VERSION matches the version this fingerprint was taken at',
     `TOPICS_VERSION=${TOPICS_VERSION}, fingerprint pinned at ${PINNED.version}`);
+}
+
+// ── the shared Insight supersedes, it does not accumulate ────────────────────────────────────────────
+// The dreaming pass writes ONE tenant-scoped digest per pass, and every shared memory reaches EVERY
+// agent. With no retirement they piled up: 51 of 72 shared memories on live instapods, 48 of 85 on
+// instawp — two thirds of the whole shared pool, all superseded snapshots of each other.
+{
+  console.log('\n\x1b[1m6) the shared Insight supersedes rather than accumulates\x1b[0m');
+  // `lastInsightId` is what lets pass N+1 retire pass N's digest. Dropping it in normalizeState would
+  // silently restore the pile-up — the exact failure mode topicsVersion already had once.
+  const rt = normalizeState({ firstPass: 1, passes: 3, totals: {}, topics: {}, recent: [], lastInsightId: 'mem_abc' });
+  assert(rt.lastInsightId === 'mem_abc', 'lastInsightId survives normalizeState (else the digests pile up again)', JSON.stringify(rt.lastInsightId));
+  const legacy = normalizeState({ firstPass: 1, passes: 1, totals: {}, topics: {}, recent: [] });
+  assert(legacy.lastInsightId === undefined, 'a state written before the field carries none, and simply has nothing to retire');
+  const junk = normalizeState({ firstPass: 1, passes: 1, totals: {}, topics: {}, recent: [], lastInsightId: 42 });
+  assert(junk.lastInsightId === undefined, 'a non-string id is discarded rather than passed to delete()');
 }
 
 fs.rmSync(HOME, { recursive: true, force: true });

--- a/scripts/memory-preload-test.cjs
+++ b/scripts/memory-preload-test.cjs
@@ -29,7 +29,7 @@ let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
-const { TerminalManager, isEpisodeRecord, distinctLines } = require(path.join(ROOT, 'dist/terminal.js'));
+const { TerminalManager, isEpisodeRecord, isPreambleNoise, distinctLines } = require(path.join(ROOT, 'dist/terminal.js'));
 
 const aos = loadAgentOS();
 const tm = new TerminalManager(aos, 'http://127.0.0.1:0', path.join(HOME, 'tmux.sock'));
@@ -114,7 +114,38 @@ const setPreload = (cfg) => aos.settings.setMemoryConfig({ ...(aos.settings.memo
   const qaFallback = await tm.memoryPreamble('qa', '');
   assert(!qaFallback.includes('Task: Run the nightly'), 'the salience fallback excludes episodes too');
 
-  console.log('\nunit: the two rules the preamble is built on\n');
+  // ── the SHARED pool must carry knowledge, not fleet statistics ──────────────────────────────────
+  console.log('\nthe shared pool seeds knowledge, not statistics\n');
+  aos.db.prepare('DELETE FROM memories').run();
+  // The live shape: the dreaming pass writes one tenant-scoped digest per pass and they accumulate — 51 of
+  // 72 shared memories on instapods, 48 of 85 on instawp. Shared memories reach EVERY agent, so a newcomer
+  // with no memories of its own got a preamble that was 6 of 8 slots of fleet statistics.
+  for (let i = 20; i < 26; i++) {
+    const r = await remember('dreamer', `Fleet self-learning (pass ${i}, since 2026-07-01): 768 sessions - 376 reported success, 150 never reported an outcome. Recurring topics: incus, instapods, github.`, 0.6, 'tenant');
+    aos.db.prepare("UPDATE memories SET tags = '[\"dreaming\",\"learned\"]' WHERE id = ?").run(r.id);
+  }
+  const shared = await remember('consolidator', 'Bunny edge-rule QA cannot be done on a *.instawp.site sandbox - it never traverses the edge, so every probe returns a misleading 200. Use the canary pull zone.', 0.7, 'tenant');
+  void shared;
+
+  // The probe deliberately uses wording the digests match BEST ("fleet", "sessions", "reported
+  // outcomes") — otherwise ranking alone buries them and the assertion passes without the filter doing
+  // anything. On the previous code this query returned them at the top.
+  const seeded = await tm.memoryPreamble('brand-new-agent', 'Review the recent fleet sessions and their reported outcomes across instapods.');
+  const nItems = seeded.split('\n').filter((l) => l.startsWith('- '));
+  assert(!nItems.some((l) => /Fleet self-learning/.test(l)), 'a dreaming digest is never seeded, even when it is the BEST match for the task', nItems.join(' | ').slice(0, 160));
+
+  const knowledge = await tm.memoryPreamble('brand-new-agent', 'Run the nightly Bunny edge-rule sweep.');
+  assert(/never traverses the edge/.test(knowledge), 'real shared knowledge still is');
+
+  // …and the salience fallback (no task text) obeys the same rule.
+  const nFallback = await tm.memoryPreamble('brand-new-agent', '');
+  assert(!nFallback.includes('Fleet self-learning'), 'the salience fallback excludes dreaming digests too');
+
+  console.log('\nunit: the rules the preamble is built on\n');
+  assert(isPreambleNoise({ tags: ['dreaming', 'learned'], content: 'Fleet self-learning (pass 31)...' }), 'a dreaming digest is preamble noise');
+  assert(isPreambleNoise({ tags: ['episode'], content: 'Task: x' }), '…so is an episode');
+  assert(!isPreambleNoise({ tags: ['lesson'], content: 'A durable fact about the system.' }), 'a lesson is not');
+
   assert(isEpisodeRecord({ tags: ['episode', 'session-end'], content: 'anything' }), 'an episode is identified by its tag');
   assert(isEpisodeRecord({ content: 'Task: do the thing\nOutcome: success' }), '…and by its Task: opening when tags are missing');
   assert(!isEpisodeRecord({ tags: ['lesson'], content: 'A durable fact about the system.' }), 'a lesson is not an episode');

--- a/src/edge/dreaming.ts
+++ b/src/edge/dreaming.ts
@@ -40,6 +40,10 @@ interface DreamState {
    *  fall into the gap between a pass's `until` and the next `since` and be silently skipped. Absent on
    *  states written before this field existed → we fall back to the old marker (see `dream`). */
   watermark?: number;
+  /** The tenant-shared Insight this pass wrote, so the NEXT pass can retire it. One summary per pass,
+   *  each superseding the last — without this they accumulate: live instapods held 51 and instawp 48,
+   *  two thirds of everything in the shared pool. */
+  lastInsightId?: string;
   /** Which topic EXTRACTOR produced `topics`. Bumped when the extractor changes meaning; a state carrying
    *  an older version has its topic map reset on the next pass (see TOPICS_VERSION). */
   topicsVersion?: number;
@@ -295,6 +299,18 @@ export class DreamingEngine {
       const topTopics = topTopicList(state.topics, 6).filter(([, v]) => v.count >= MIN_TOPIC_COUNT).map(([k]) => k).join(', ') || '—';
       const summary = `Fleet self-learning (pass ${state.passes}, since ${new Date(state.firstPass).toISOString().slice(0, 10)}): ${t.sessions} sessions — ${t.success} reported success, ${t.unknown} never reported an outcome. Recurring topics: ${topTopics}. Friction so far: ${t.rejected} approvals rejected, ${t.budgetStops} budget stops, ${t.errors} errors. Details: [[${DREAM_SECTION}/${DREAM_SLUG}]].`;
       const rec = await this.os.memory.store({ tenant: this.os.tenant, agentId: 'dreamer', content: summary, tags: ['dreaming', 'learned'], type: 'Insight', importance: 0.6, scope: 'tenant', metadata: { passes: state.passes, window, sessions: win.sessions } });
+      // SUPERSEDE the previous pass's summary. It is a cumulative snapshot — pass N+1 restates everything
+      // pass N said, over a longer window — so keeping both is keeping a stale copy. One per pass with no
+      // retirement is how the shared pool filled with them (51 of 72 on instapods, 48 of 85 on instawp),
+      // and a shared memory reaches EVERY agent. Best-effort and ordered after the write, so a failure
+      // leaves one extra summary rather than none.
+      const prior = state.lastInsightId;
+      state.lastInsightId = rec.id;
+      this.os.settings.setDreamingState(state as unknown as Record<string, unknown>, by);
+      if (prior && prior !== rec.id) {
+        try { await this.os.memory.delete({ tenant: this.os.tenant, agentId: 'dreamer', id: prior, admin: true }); }
+        catch { /* the next pass will try again */ }
+      }
       insightId = rec.id;
     } catch { /* best-effort */ }
 
@@ -331,7 +347,10 @@ export function normalizeState(raw: Record<string, unknown>): DreamState {
   // permanently below the bar — its "the fleet frequently works on …" guidance line never fired once, and
   // the fleet Insight every agent recalls read "Recurring topics: —".
   const topicsVersion = Number.isFinite(Number(raw.topicsVersion)) ? Number(raw.topicsVersion) : undefined;
-  return { firstPass: num(raw.firstPass, Date.now()), passes: num(raw.passes, 0), totals, topics, recent, watermark, topicsVersion };
+  // Carried for the same reason as `topicsVersion`, and dropped here would fail the same way: the pass
+  // would forget which Insight it wrote and stop superseding it, so they would pile up again.
+  const lastInsightId = typeof raw.lastInsightId === 'string' && raw.lastInsightId ? raw.lastInsightId : undefined;
+  return { firstPass: num(raw.firstPass, Date.now()), passes: num(raw.passes, 0), totals, topics, recent, watermark, topicsVersion, lastInsightId };
 }
 
 function zeroTally(): Tally {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4163,7 +4163,7 @@ export class TerminalManager {
           }),
           timeout,
         ]);
-        lines = distinctLines(hits.filter((h) => !isEpisodeRecord(h)).map((h) => h.content), n);
+        lines = distinctLines(hits.filter((h) => !isPreambleNoise(h)).map((h) => h.content), n);
         relevant = lines.length > 0;
       } catch {
         /* fall through to the salience ordering below */
@@ -4182,6 +4182,7 @@ export class TerminalManager {
               `SELECT content FROM memories
                WHERE tenant = ? AND (scope = 'tenant' OR (scope = 'agent' AND agent_id = ?))
                  AND COALESCE(tags, '') NOT LIKE '%"episode"%'
+                 AND COALESCE(tags, '') NOT LIKE '%"dreaming"%'
                ORDER BY COALESCE(importance, 0.5) DESC, COALESCE(last_recalled_at, created_at) DESC
                LIMIT ?`,
             )
@@ -8103,6 +8104,29 @@ function composeEpisode(
 export function isEpisodeRecord(r: { content?: string; tags?: string[] }): boolean {
   if (r.tags?.includes('episode')) return true;
   return /^\s*Task:/.test(r.content ?? '');
+}
+
+/**
+ * Is this record unfit to be SEEDED into a working agent's prompt?
+ *
+ * Two classes, both real memories that belong in the store and neither of which helps someone about to do
+ * a job:
+ *  - an **episode** — a transcript of a past assignment (see {@link isEpisodeRecord});
+ *  - a **dreaming summary** — the self-learning pass's own tenant-scoped digest, "Fleet self-learning
+ *    (pass 31, since 2026-07-01): 768 sessions, 43% success. Recurring topics: …". That is a statistic
+ *    ABOUT the fleet, not knowledge FOR the work, and one is written per pass, so they accumulate.
+ *
+ * Measured on live tenants: the tenant-shared pool was **51 of 72 memories on instapods and 48 of 85 on
+ * instawp** — two thirds of everything shared across the fleet — and because shared memories reach every
+ * agent, an agent thin on its own memories got a preamble that was **6 of 8 slots of fleet statistics**.
+ * Observed directly: a zero-memory agent's launch preamble carried six pass summaries and nothing about
+ * its task.
+ *
+ * They stay recallable (an oversight agent asking "how is the fleet doing" wants exactly this, and the
+ * Memory hub counts them) — they are simply not launch context.
+ */
+export function isPreambleNoise(r: { content?: string; tags?: string[] }): boolean {
+  return isEpisodeRecord(r) || !!r.tags?.includes('dreaming');
 }
 
 /** Collapse near-identical entries and cap at `limit`. Two memories that open the same ~80 characters say


### PR DESCRIPTION
Found while auditing whether the memory system is real or a facade. The per-agent layer is real. The **shared** layer had become mostly noise.

## The problem

A tenant-shared memory reaches **every** agent. The self-learning pass writes one tenant-scoped digest per pass:

> Fleet self-learning (pass 31, since 2026-07-01): 768 sessions — 376 reported success, 150 never reported an outcome. Recurring topics: incus, instapods, github.

Nothing ever retired them, so they accumulated until they **were** the shared pool:

| tenant | shared memories | of those, dreaming digests |
|---|---|---|
| instapods | 72 | **51** |
| instawp | 85 | **48** |

Observed directly while running the loop experiment: an agent with no memories of its own got a launch preamble that was **6 of 8 slots of fleet statistics**, and nothing about its task. A statistic *about* the fleet occupying the space meant for knowledge *for* the work.

## The fix

**1. A dreaming digest is preamble noise.** `isPreambleNoise` generalises `isEpisodeRecord`, applied on **both** the task-ranked path and the salience fallback — so which path answered can't change what kind of memory an agent is seeded with.

They stay fully recallable: an oversight agent asking *"how is the fleet doing"* wants exactly this, and the Memory hub counts them. They're simply not launch context.

**2. Each pass supersedes the previous digest** instead of appending. The id rides on `dreaming_state.lastInsightId`, preserved through `normalizeState` — the same field-dropping trap `topicsVersion` fell into, so the test pins the round-trip. The delete is ordered *after* the write and is best-effort, so a failure leaves one extra digest rather than none.

A digest is a cumulative snapshot — pass N+1 restates everything pass N said over a longer window — so keeping both was keeping a stale copy.

## Test

One note on rigour: the preamble probe deliberately uses wording the digests match **best** ("fleet", "sessions", "reported outcomes"). With a neutral task, ranking alone buried them and the assertion passed while the filter did nothing — a test that would have shipped green either way.

```
✓ a dreaming digest is never seeded, even when it is the BEST match for the task
✓ real shared knowledge still is
✓ the salience fallback excludes dreaming digests too
✓ a dreaming digest is preamble noise
✓ lastInsightId survives normalizeState (else the digests pile up again)
✓ a non-string id is discarded rather than passed to delete()
```

2 assertions fail on the previous code in `memory-preload-test.cjs` (32 total), 3 added to `insights-signal-test.cjs` (44 total). `npm run typecheck` clean, full `npm run test:governance` green.

## Not in this PR

The ~99 digests already sitting in the two live pools. They'll stop growing, but existing ones only retire one per pass. A one-off cleanup is a data change and wants its own go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)