### PR TITLE
fix(apps): an app's dispatch is owned by a real human, not an email (v0.412.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.412.2] - 2026-09-02
+### Fixed
+- **A hosted app's dispatch is owned by a real human again** (#559). `POST /api/app/dispatch` looked the
+  run-as identity up by email only and stored an **email** in `tasks.owner` — two defects in three lines.
+  The forwarded `X-Aos-Member` is an email, but `manifest.owner` (written by `app_create`) is a member
+  **id**, so the documented "else the app's accountable owner" fallback never resolved and a background
+  dispatch was created ownerless. And every consumer reads that column as an id: the task notifier
+  (`resolveRecipients` → `getMember`) delivered to nobody, `t.owner === me.id` never matched the owner's
+  own board, and the value rode through `dispatchTask` into the session's `run_as`. The route now
+  resolves **both forms** and stores the id.
+### Changed
+- **One definition of the both-forms member lookup** — `TeamStore.resolveMemberRef(ref)` (id **or**
+  email → member). It replaces the four hand-rolled `getMember(raw) ?? getMemberByEmail(raw)` pairs in
+  `server.ts`, `terminal.ts` (×2) and `task-reconcile.ts`; behaviour is unchanged at those call sites.
+- **Migration: `tasks.owner` emails are canonicalised to member ids**, the sibling of the `run_as` sweep
+  from v0.307.1. An email matching no member is left alone rather than discarded. `scripts/run-as-identity-test.cjs`
+  grows a fourth section covering the lookup, the delivery consequence and the migration (36 checks).
+
 ## [0.412.1] - 2026-09-02
 ### Changed
 - **Console dependency refresh (lockfile only).** Batched the ten open Dependabot bumps for `web/` into

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.412.1",
+  "version": "0.412.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.412.1",
+      "version": "0.412.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.412.1",
+  "version": "0.412.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/run-as-identity-test.cjs
+++ b/scripts/run-as-identity-test.cjs
@@ -16,6 +16,11 @@
  *   2. The consequence at launch: a prefixed-provenance run gets the company-bot GH_TOKEN untouched
  *      rather than a garbage principal — and the same run with a real run-as member gets THEIR token.
  *   3. The one-time migration NULLs colon-bearing run_as rows already on disk, and leaves member ids.
+ *   4. The same identity contract one table over: `tasks.owner` (#559). `POST /api/app/dispatch` looked
+ *      the run-as up by EMAIL only and stored an EMAIL — so a hosted app's dispatch was ownerless
+ *      whenever it fell back to the manifest's member-id owner, and when it did resolve, the address it
+ *      stored matched no consumer (the task notifier resolves an owner by id). Covers the both-forms
+ *      lookup, the delivery consequence, and the migration over rows already written.
  *
  * Usage:  npm run build && node scripts/run-as-identity-test.cjs
  */
@@ -112,6 +117,36 @@ async function main() {
   assert(runAsOf('s_gone') === 'ex-staff@test', 'an email matching no member is left alone (not discarded)');
   assert(db.prepare('SELECT spawned_by FROM term_sessions WHERE id = ?').get('s_chat').spawned_by === 'chat:triage',
     'provenance (spawned_by) is untouched — only the identity column is cleaned');
+
+  // ─── 4) tasks.owner — the same contract, one table over (#559) ─────────────
+  console.log('\n\x1b[1m4) tasks.owner is a member id (app dispatch)\x1b[0m');
+  const { resolveRecipients } = require(path.join(ROOT, 'dist/governance/recipients.js'));
+  const email = osx.team.getMember(memberId).email;
+
+  // The lookup the route performs. BOTH forms must resolve — an app forwards `X-Aos-Member` as an
+  // email, while `manifest.owner` (written by app_create) is a member id.
+  assert(osx.team.resolveMemberRef(email)?.id === memberId, 'resolveMemberRef: an email → the member id');
+  assert(osx.team.resolveMemberRef(memberId)?.id === memberId, 'resolveMemberRef: a member id → itself (the manifest.owner case)');
+  assert(osx.team.resolveMemberRef('  ' + email.toUpperCase() + '  ')?.id === memberId, 'resolveMemberRef: trimmed + case-insensitive');
+  assert(osx.team.resolveMemberRef('nobody@nowhere') === undefined, 'resolveMemberRef: an unknown reference → undefined (ownerless, not a bogus owner)');
+  assert(osx.team.resolveMemberRef('') === undefined, 'resolveMemberRef: an empty reference → undefined');
+
+  // The consequence: a task's owner is only notified when the column holds an id.
+  const mk = (id, owner) => osx.db.prepare(
+    'INSERT INTO tasks (id, tenant, title, body, status, priority, labels, assignee, owner, created_by, created_at, updated_at, updated_by) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)',
+  ).run(id, osx.tenant, 't', 'b', 'todo', 2, '[]', 'agent:triage', owner, 'app:notes', Date.now(), Date.now(), 'app:notes');
+  mk('tsk_id', memberId);
+  mk('tsk_email', email);
+  mk('tsk_gone', 'ex-staff@test');
+  assert(resolveRecipients(osx, { kind: 'task', id: 'tsk_id' }).length === 1, 'a member-id owner resolves to a recipient');
+  assert(resolveRecipients(osx, { kind: 'task', id: 'tsk_email' }).length === 0, 'an EMAIL owner resolves to nobody — the silent cost the route used to write');
+
+  openDb(path.join(HOME, 'agent-os.db')); // re-runs migrate() over the same file
+  const ownerOf = (id) => osx.db.prepare('SELECT owner FROM tasks WHERE id = ?').get(id).owner;
+  assert(ownerOf('tsk_email') === memberId, 'migration CANONICALISES an email task owner to the member id');
+  assert(ownerOf('tsk_id') === memberId, 'migration LEAVES a real member id alone');
+  assert(ownerOf('tsk_gone') === 'ex-staff@test', 'an email matching no member is left alone (not discarded)');
+  assert(resolveRecipients(osx, { kind: 'task', id: 'tsk_email' }).length === 1, 'the migrated row now reaches its owner');
 
   console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m`);
   fs.rmSync(HOME, { recursive: true, force: true });

--- a/src/edge/task-reconcile.ts
+++ b/src/edge/task-reconcile.ts
@@ -201,7 +201,7 @@ function endedByHuman(os: AgentOS, sessionId: string): boolean {
     .get<{ principal: string | null }>(sessionId);
   const by = row?.principal;
   if (!by || by === 'system') return false;
-  return !!(os.team.getMemberByEmail(by) ?? os.team.getMember(by));
+  return !!os.team.resolveMemberRef(by);
 }
 
 export function sweepStrandedTasks(

--- a/src/governance/team.ts
+++ b/src/governance/team.ts
@@ -54,6 +54,20 @@ export class TeamStore {
     const r = this.db.prepare('SELECT * FROM members WHERE email = ?').get<MemberRow>(email.toLowerCase());
     return r ? toMember(r) : undefined;
   }
+  /**
+   * Resolve a member REFERENCE in either of the two forms that reach us — a member id or an email —
+   * without the caller having to know which it holds. Both are in circulation by design: the console
+   * and manifests carry ids, while a forwarded `X-Aos-Member` header, an invite and a chat identity
+   * carry emails. Every id-only lookup on a reference that might be an email (or the reverse) has the
+   * same silent failure mode: `undefined`, an ownerless record, and a notification delivered to nobody
+   * — #559 was exactly that, an email-only lookup applied to an app manifest's member-id owner.
+   * Callers that persist the result should store `.id`, the canonical form.
+   */
+  resolveMemberRef(ref: string): Member | undefined {
+    const raw = (ref ?? '').trim();
+    if (!raw) return undefined;
+    return this.getMember(raw) ?? this.getMemberByEmail(raw);
+  }
   count(): number {
     return this.db.prepare('SELECT COUNT(*) AS n FROM members').get<{ n: number }>()!.n;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -2354,9 +2354,15 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!goal) return sendJson(res, 400, { error: 'goal is required' });
     // Run-as: the human currently using the app (forwarded from the trusted X-Aos-Member the app got),
     // else the app's accountable owner. Validate it resolves to a real member; unknown → ownerless.
+    // BOTH FORMS on the way in, a member ID on the way out — the two halves of one bug (#559). The
+    // forwarded `X-Aos-Member` is an EMAIL while `manifest.owner` is a member id, so an email-only
+    // lookup left every ownerless-by-manifest dispatch with no accountable human at all; and storing
+    // `.email` put an address into `tasks.owner`, which every consumer reads as an id — the task
+    // notifier (`resolveRecipients` → `getMember`) delivered to nobody, `t.owner === me.id` never
+    // matched its own board, and the value rode through `dispatchTask` into the session's `run_as`.
     const wantRunAs = String(b.runAsMember || manifest.owner || '').trim();
-    const runAsMember = wantRunAs ? os.team.getMemberByEmail(wantRunAs) : undefined;
-    const owner = runAsMember?.email;
+    const runAsMember = wantRunAs ? os.team.resolveMemberRef(wantRunAs) : undefined;
+    const owner = runAsMember?.id;
     const mode = b.mode === 'interactive' ? 'interactive' : 'headless';
     const task = os.tasks.create({
       tenant: os.tenant, title: goal.slice(0, 80), body: goal, assignee: `agent:${agent}`,
@@ -2709,7 +2715,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       const raw = String(ab.runAs || '').trim();
       if (!raw) runAs = undefined;
       else {
-        const m = os.team.getMember(raw) ?? os.team.getMemberByEmail(raw);
+        const m = os.team.resolveMemberRef(raw);
         if (!m) return sendJson(res, 400, { error: `unknown member "${raw}" for runAs` });
         runAs = m.id;
       }

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -1161,6 +1161,16 @@ function migrate(db: Db): void {
              WHERE run_as IS NOT NULL AND instr(run_as, '@') > 0
                AND EXISTS (SELECT 1 FROM members m WHERE m.email = lower(term_sessions.run_as))`);
 
+  // Same shape, one table over: `tasks.owner` is the accountable human and is read as a MEMBER id
+  // everywhere (`resolveRecipients` → `getMember`, `t.owner === me.id` on the board, `dispatchTask`
+  // passing it through as the session's run-as). `POST /api/app/dispatch` stored an EMAIL there, so a
+  // run triggered from a hosted app notified nobody and never matched its own owner's board. The route
+  // now stores an id; this canonicalises the rows already written, on the same terms as the sweep above
+  // — an email that resolves to no member is left alone rather than discarded.
+  db.exec(`UPDATE tasks SET owner = (SELECT m.id FROM members m WHERE m.email = lower(tasks.owner))
+             WHERE owner IS NOT NULL AND instr(owner, '@') > 0
+               AND EXISTS (SELECT 1 FROM members m WHERE m.email = lower(tasks.owner))`);
+
   // WHEN an approval was decided (epoch ms), NULL while pending. `questions` already records `answered_at`;
   // this brings approvals to parity so the unified feed (src/state/feed.ts) can order a RESOLVED decision
   // by when you decided it, not by when it was raised — without a per-row scan of `audit_events`.

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -1785,7 +1785,7 @@ export class TerminalManager {
     const asMember = (v?: string): string | undefined => {
       const raw = (v ?? '').trim();
       if (!raw) return undefined;
-      return (this.os.team.getMember(raw) ?? this.os.team.getMemberByEmail(raw))?.id;
+      return this.os.team.resolveMemberRef(raw)?.id;
     };
     return asMember(runAs) ?? asMember(spawnedBy);
   }
@@ -6385,7 +6385,7 @@ export class TerminalManager {
     let runAs: string | undefined;
     if ((spec.runAs || '').trim()) {
       const raw = String(spec.runAs).trim();
-      const m = this.os.team.getMember(raw) ?? this.os.team.getMemberByEmail(raw);
+      const m = this.os.team.resolveMemberRef(raw);
       if (!m) return { ok: false, error: `unknown member "${raw}" for runAs — pass a member id or email (use directory_lookup), or omit runAs to run as the company identity` };
       runAs = m.id;
     }


### PR DESCRIPTION
Closes #559.

## The bug

`POST /api/app/dispatch` (`src/server.ts`) resolved the run-as identity with an email-only lookup and stored an email:

```ts
const wantRunAs = String(b.runAsMember || manifest.owner || '').trim();
const runAsMember = wantRunAs ? os.team.getMemberByEmail(wantRunAs) : undefined;
const owner = runAsMember?.email;
```

Two defects in three lines:

1. **The owner fallback never resolved.** The forwarded `X-Aos-Member` is an email, but `manifest.owner` (written by `app_create`) is a member **id** — so `getMemberByEmail("m_…")` returned undefined and a dispatch without a forwarded member was created **ownerless**. The comment above the line ("else the app's accountable owner") did not hold.
2. **An email in an id column.** `tasks.owner` is read as a member id everywhere: the task notifier (`resolveRecipients` → `getMember`), the board's `t.owner === me.id`, and `dispatchTask` passing it through as the session's `run_as`. The address the route stored matched no consumer, so the owner got no card and no DM.

The session-visibility half the issue reported has already self-healed: `resolveActingMember` (v0.307.1, #562) canonicalises `run_as` on write and migrates the rows. That fix stopped at `term_sessions`; this is the same contract one table over.

## The fix

- The route resolves **both forms** and stores `.id`.
- That lookup gets one definition — **`TeamStore.resolveMemberRef(ref)`** (id *or* email → member) — replacing the four hand-rolled `getMember(raw) ?? getMemberByEmail(raw)` pairs in `server.ts`, `terminal.ts` (×2) and `task-reconcile.ts`. Behaviour unchanged at those call sites.
- **Migration** for rows already written, on the same terms as the `run_as` sweep: an email in `tasks.owner` is canonicalised to its member id; an email matching no member is left alone rather than discarded.

## Verification

`scripts/run-as-identity-test.cjs` grows a fourth section — the both-forms lookup (email, member id, trimmed/mixed case, unknown, empty), the delivery consequence (`resolveRecipients` on a `task` audience returns 1 for an id owner and **0** for an email owner), and the migration including that the migrated row now reaches its owner. 36 checks pass; `npm run test:governance` green; both bundles build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)