### PR TITLE
fix(agents): a stale cross-agent edit proposal can no longer clobber a newer prompt in silence (v0.413.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+
+## [0.413.0] - 2026-09-02
+### Fixed
+- **A stale cross-agent edit proposal no longer clobbers a newer prompt silently.** Several agents
+  proposing edits to ONE agent is by design (the 10-card cap is per-proposer; only an identical delta
+  from the same proposer is deduped), but every `agent.update.proposed` card carries a **full
+  replacement** CLAUDE.md resolved when it was written — so approving a second card reverts the first.
+  The approve route already detected that (`baseHash` mismatch) and returned `staleBase` + a warning,
+  but `web/src/lib/api.ts` didn't type either field, so the console dropped them: an owner clicking
+  Approve on three queued cards saw three successes and never learned two were undone. Now
+  `GET /api/agents/proposals` stamps `stale` on each card whose pinned `baseHash` no longer matches the
+  target's prompt, the target's settings page badges those cards **out of date** (with Reject as the
+  weighted button and a confirm dialog that spells out the replacement), a banner names the collision
+  whenever more than one queued card rewrites the prompt, and the post-approve warning is surfaced —
+  stickily on the agent page, inline on the Inbox card. Pinned by a new section 4 in
+  `scripts/proposal-surfacing-test.cjs`.
+
 ### Changed
 - **README trimmed by a quarter and brought back in step with the code.** It still claimed **two**
   runtimes (opencode has been the third since v0.391.0), never mentioned the setup wizard, runtime

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.412.2",
+  "version": "0.413.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.412.2",
+      "version": "0.413.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.412.2",
+  "version": "0.413.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/proposal-surfacing-test.cjs
+++ b/scripts/proposal-surfacing-test.cjs
@@ -5,7 +5,9 @@
  *   2. the card's MESSAGE id is the proposal id the approve/reject routes accept, so the inline
  *      Approve & apply button can act straight off the inbox row;
  *   3. GET /api/agents/proposals (no target) returns every open proposal with its target — the roster
- *      badge's data source — and drops the card once it's approved.
+ *      badge's data source — and drops the card once it's approved;
+ *   4. when two cards target ONE agent's CLAUDE.md, approving the first flags the second `stale` in that
+ *      list, and approving it anyway returns `staleBase` + a warning — the console's clobber notice.
  */
 const fs = require('fs');
 const os = require('os');
@@ -77,6 +79,26 @@ const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${
   const card2 = (Array.isArray(msgs2) ? msgs2 : msgs2.messages).find((m) => m.id === card.id);
   assert(card2 && card2.status === 'approved', 'and the card leaves "Needs you" for Activity', card2 && card2.status);
   assert(fs.readFileSync(path.join(aos.paths.userAgents, TARGET, 'CLAUDE.md'), 'utf8').includes('## Shipping'), 'the edit really landed');
+
+  console.log('\n\x1b[1m4) two cards on one target — the second is flagged stale BEFORE it is approved\x1b[0m');
+  // Several agents proposing on ONE agent is allowed by design (the 10-card cap is per-proposer, and only an
+  // identical delta from the same proposer is deduped). Each card carries a FULL replacement prompt, so
+  // approving a second one silently reverts the first. That is what `stale` warns about.
+  const pa = tm.proposeAgentUpdate(session.id, EDITOR, { id: TARGET, rationale: 'add a rollback section', claudeMdAppend: '## Rollback\n\nRoll back on red.\n' });
+  const pb = tm.proposeAgentUpdate(session.id, EDITOR, { id: TARGET, rationale: 'add an on-call section', claudeMdAppend: '## On-call\n\nPage the owner.\n' });
+  assert(pa.outcome === 'pending_approval' && pb.outcome === 'pending_approval', 'both queue — a target takes more than one open proposal', { a: pa.outcome, b: pb.outcome });
+  const both = await get('/api/agents/proposals');
+  assert(both.proposals.length === 2, 'both are listed', both.proposals.length);
+  assert(both.proposals.every((x) => x.stale === false), 'neither is stale while the prompt has not moved', both.proposals.map((x) => x.stale));
+  const first = both.proposals.find((x) => (x.rationale || '').includes('rollback'));
+  const okA = await post(`/api/agents/proposals/${first.id}/approve`);
+  assert(okA.ok === true && !okA.staleBase, 'approving the first is clean — nothing to clobber', okA);
+  const left = await get('/api/agents/proposals');
+  assert(left.proposals.length === 1 && left.proposals[0].stale === true, 'the survivor is now flagged stale — the badge the reviewer sees', left.proposals.map((x) => ({ id: x.id, stale: x.stale })));
+  const okB = await post(`/api/agents/proposals/${left.proposals[0].id}/approve`);
+  assert(okB.ok === true && okB.staleBase === true && !!okB.warning, 'approving it anyway returns staleBase + a warning the console can show', okB);
+  const finalMd = fs.readFileSync(path.join(aos.paths.userAgents, TARGET, 'CLAUDE.md'), 'utf8');
+  assert(finalMd.includes('## On-call') && !finalMd.includes('## Rollback'), 'and it really did revert the first edit — which is why the warning matters', { onCall: finalMd.includes('## On-call'), rollback: finalMd.includes('## Rollback') });
 
   server.close();
   await registry.stopAll?.();

--- a/src/server.ts
+++ b/src/server.ts
@@ -2753,7 +2753,21 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
   if (method === 'GET' && p === '/api/agents/proposals') {
     if (me.role !== 'owner') return sendJson(res, 403, { error: 'owner required' });
     const target = url.searchParams.get('target') || undefined;
-    return sendJson(res, 200, { proposals: tm.openAgentUpdateProposals(target), canApprove: true });
+    // Stamp `stale` on every card whose pinned baseHash no longer matches the target's CLAUDE.md. Several
+    // agents proposing on ONE target is normal (the 10-card cap is per-proposer, and only an identical delta
+    // from the same proposer is deduped), and each card carries a FULL replacement prompt — so approving a
+    // second one silently reverts the first. The approve route already detects that and warns; surfacing it
+    // in the LIST is what lets a reviewer avoid the clobber instead of being told about it afterwards.
+    const claudeMdNow = new Map<string, string>();
+    const proposals = tm.openAgentUpdateProposals(target).map((pr) => {
+      if (!pr.baseHash || !('claudeMd' in pr.fields)) return { ...pr, stale: false };
+      if (!claudeMdNow.has(pr.target)) {
+        const ag = os.agents.get(pr.target);
+        claudeMdNow.set(pr.target, ag ? readAgentSnapshot(ag).claudeMd : '');
+      }
+      return { ...pr, stale: contentHash(claudeMdNow.get(pr.target) ?? '') !== pr.baseHash };
+    });
+    return sendJson(res, 200, { proposals, canApprove: true });
   }
   const agUpdApprove = p.match(/^\/api\/agents\/proposals\/([\w.-]+)\/approve$/);
   if (method === 'POST' && agUpdApprove) {

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -6606,15 +6606,22 @@ export class TerminalManager {
   setAgentUpdateProposalStatus(id: string, status: 'approved' | 'rejected'): void {
     this.db.prepare(`UPDATE messages SET status = ? WHERE id = ? AND type = 'agent.update.proposed'`).run(status, id);
   }
-  /** Open agent-edit proposals (all targets, or just one when `target` is given) — for the console review list. */
-  openAgentUpdateProposals(target?: string): { id: string; agent: string; target: string; fields: Record<string, unknown>; rationale?: string; preview?: string; createdAt: number }[] {
+  /**
+   * Open agent-edit proposals (all targets, or just one when `target` is given) — for the console review list.
+   *
+   * `baseHash` rides along so the caller can tell the reviewer, BEFORE they click Approve, that the target's
+   * CLAUDE.md moved since this card was written (several agents proposing on one target is normal — the cap
+   * is per-proposer — and each card carries a FULL replacement text, so approving two in a row makes the
+   * second silently revert the first).
+   */
+  openAgentUpdateProposals(target?: string): { id: string; agent: string; target: string; fields: Record<string, unknown>; rationale?: string; preview?: string; baseHash?: string; createdAt: number }[] {
     return this.db
       .prepare(`SELECT id, agent, args, created_at FROM messages WHERE type = 'agent.update.proposed' AND status = 'open' ORDER BY created_at DESC`)
       .all<{ id: string; agent: string; args: string | null; created_at: number }>()
       .map((r) => {
         let a: Record<string, unknown> = {};
         try { a = r.args ? JSON.parse(r.args) : {}; } catch { /* tolerate corrupt payload */ }
-        return { id: r.id, agent: r.agent, target: String(a.target ?? ''), fields: (a.fields ?? {}) as Record<string, unknown>, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, createdAt: r.created_at };
+        return { id: r.id, agent: r.agent, target: String(a.target ?? ''), fields: (a.fields ?? {}) as Record<string, unknown>, rationale: a.rationale ? String(a.rationale) : undefined, preview: a.preview ? String(a.preview) : undefined, baseHash: a.baseHash ? String(a.baseHash) : undefined, createdAt: r.created_at };
       })
       .filter((p) => p.target && (!target || p.target === target.trim().toLowerCase()));
   }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6341,7 +6341,10 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
       const r = approve ? await api.approveAgentUpdateProposal(m.id) : await api.rejectAgentUpdateProposal(m.id)
       setBusy(false)
       if (r.error || !r.ok) return setHint('⚠ ' + (r.error ?? 'failed'))
-      setHint(approve ? 'applied' : 'rejected')
+      // A stale approve replaced text that landed after this card was written. The server says so; passing
+      // that through is the only notice the reviewer gets that they just undid a newer edit.
+      const clobbered = (r as { warning?: string }).warning // only the approve response carries one
+      setHint(approve ? (clobbered ? '⚠ applied — ' + clobbered : 'applied') : 'rejected')
     }
     return (
       <div className="rounded-lg border border-violet-300 bg-violet-50/40 px-3 py-2.5">
@@ -13806,19 +13809,31 @@ function AgentUpdateProposalsCard({ agentId, onApplied }: { agentId: string; onA
   const [expanded, setExpanded] = useState<string | null>(null)
   const [busy, setBusy] = useState('')
   const [hint, setHint] = useState('')
+  const [warn, setWarn] = useState('')            // a clobber notice — sticky, unlike `hint`
   const load = () => api.agentUpdateProposals(agentId).then((r) => setProps(r.error ? [] : (r.proposals ?? []))).catch(() => setProps([]))
-  useEffect(() => { setProps(null); setHint(''); setExpanded(null); load(); api.agentClaude(agentId).then((r) => setCurrent(r.content ?? '')).catch(() => {}) }, [agentId]) // eslint-disable-line react-hooks/exhaustive-deps
+  useEffect(() => { setProps(null); setHint(''); setWarn(''); setExpanded(null); load(); api.agentClaude(agentId).then((r) => setCurrent(r.content ?? '')).catch(() => {}) }, [agentId]) // eslint-disable-line react-hooks/exhaustive-deps
   const act = async (id: string, approve: boolean) => {
-    if (approve && !window.confirm(`Apply this edit to ${agentId}?\n\nIt rewrites the agent's listing/CLAUDE.md and records a revision (revertable below). The change applies on the agent's next session.`)) return
-    setBusy(id); setHint('')
+    const pr = (props ?? []).find((x) => x.id === id)
+    // A stale card's full replacement prompt would revert whatever landed after it was written — say so
+    // BEFORE the click, since the server applies it and only warns afterwards.
+    const confirmText = pr?.stale
+      ? `Apply this OUT-OF-DATE edit to ${agentId}?\n\n${agentId}'s CLAUDE.md has changed since this was proposed. This card carries a full replacement prompt, so applying it REPLACES that newer text.\n\nUsually you want Reject instead, and let ${pr.agent} redo the edit on the current prompt. The revision is revertable below either way.`
+      : `Apply this edit to ${agentId}?\n\nIt rewrites the agent's listing/CLAUDE.md and records a revision (revertable below). The change applies on the agent's next session.`
+    if (approve && !window.confirm(confirmText)) return
+    setBusy(id); setHint(''); setWarn('')
     const r = approve ? await api.approveAgentUpdateProposal(id) : await api.rejectAgentUpdateProposal(id)
     setBusy('')
     if (r.error || !r.ok) return setHint('⚠ ' + (r.error ?? 'failed'))
     setHint(approve ? 'applied — see Revision history' : 'rejected')
+    const clobbered = (r as { warning?: string }).warning // only the approve response carries one
+    if (approve && clobbered) setWarn(clobbered)   // sticky: a silent clobber is the bug this card exists to prevent
     load(); if (approve) { onApplied(); api.agentClaude(agentId).then((x) => setCurrent(x.content ?? '')).catch(() => {}) }
     setTimeout(() => setHint(''), 3000)
   }
   if (!props || props.length === 0) return null // silent for non-owners and when nothing is pending
+  // Two+ cards rewriting the same prompt collide by construction: each holds a FULL replacement, so the
+  // second approval undoes the first. Name that up front rather than letting the reviewer discover it.
+  const promptCards = props.filter((pr) => 'claudeMd' in pr.fields).length
   const FIELD_LABEL: Record<string, string> = { description: 'description', claudeMd: 'CLAUDE.md (system prompt)', category: 'category', model: 'model', effort: 'effort', icon: 'icon', examplePrompts: 'starter prompts' }
   return (
     <Card className="border-violet-300 bg-violet-50/40">
@@ -13827,6 +13842,12 @@ function AgentUpdateProposalsCard({ agentId, onApplied }: { agentId: string; onA
           <div className="flex items-center gap-2 text-xs font-medium text-violet-800"><Pencil className="h-3.5 w-3.5" /> Proposed edits from other agents ({props.length})</div>
           {hint && <span className="font-mono text-[11px] text-muted-foreground">{hint}</span>}
         </div>
+        {promptCards > 1 && (
+          <div className="rounded border border-amber-300 bg-amber-50 px-2.5 py-1.5 text-[11px] text-amber-900">
+            {promptCards} of these rewrite the CLAUDE.md, and each carries the <em>whole</em> prompt as it stood when proposed. Approving more than one replaces the earlier one’s text. Approve the best, reject the rest, and let their authors redo them against the new prompt.
+          </div>
+        )}
+        {warn && <div className="rounded border border-amber-300 bg-amber-50 px-2.5 py-1.5 text-[11px] text-amber-900">⚠ {warn}</div>}
         {props.map((pr) => {
           const keys = Object.keys(pr.fields)
           const isExp = expanded === pr.id
@@ -13835,7 +13856,9 @@ function AgentUpdateProposalsCard({ agentId, onApplied }: { agentId: string; onA
               <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
                 <Bot className="h-3 w-3 shrink-0" /><span className="font-medium text-foreground">{pr.agent}</span>
                 <span>· {new Date(pr.createdAt).toLocaleString()}</span>
+                {pr.stale && <Badge variant="outline" className="border-amber-400 px-1.5 py-0 text-[10px] font-normal text-amber-800">out of date</Badge>}
               </div>
+              {pr.stale && <div className="text-[11px] text-amber-800">The CLAUDE.md changed after this was written — applying it replaces that newer text with the “Proposed” side below.</div>}
               {pr.rationale && <div className="text-sm">{pr.rationale}</div>}
               <div className="flex flex-wrap gap-1">
                 {keys.map((k) => <Badge key={k} variant="outline" className="px-1.5 py-0 text-[10px] font-normal">{FIELD_LABEL[k] ?? k}</Badge>)}
@@ -13857,8 +13880,9 @@ function AgentUpdateProposalsCard({ agentId, onApplied }: { agentId: string; onA
                 </div>
               )}
               <div className="flex items-center gap-2 pt-1">
-                <Button size="sm" disabled={!!busy} onClick={() => act(pr.id, true)}>Approve & apply</Button>
-                <Button size="sm" variant="outline" disabled={!!busy} onClick={() => act(pr.id, false)}>Reject</Button>
+                {/* On a stale card the safe move is Reject, so that is the one that carries the weight. */}
+                <Button size="sm" variant={pr.stale ? 'outline' : 'default'} disabled={!!busy} onClick={() => act(pr.id, true)}>Approve & apply</Button>
+                <Button size="sm" variant={pr.stale ? 'default' : 'outline'} disabled={!!busy} onClick={() => act(pr.id, false)}>Reject</Button>
               </div>
             </div>
           )

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1059,6 +1059,10 @@ export interface AgentUpdateProposal {
   fields: { description?: string; claudeMd?: string; category?: string; model?: string; effort?: string; icon?: string; examplePrompts?: string[] }
   rationale?: string
   preview?: string
+  /** The target's CLAUDE.md changed after this card was written, so its full replacement text would revert
+   *  that newer change. Set by the server per card — the reviewer's cue to reject it and let the proposer
+   *  redo the edit on the current text. Only ever true for a `claudeMd` proposal. */
+  stale?: boolean
   createdAt: number
 }
 export interface GoalUpdateProposal {
@@ -1966,7 +1970,10 @@ export const api = {
   approveAutomationProposal: (id: string, runAs?: string) => call<{ ok: boolean; automation?: Automation; error?: string }>('POST', `/api/automations/proposals/${id}/approve`, runAs !== undefined ? { runAs } : {}),
   rejectAutomationProposal: (id: string) => call<{ ok: boolean; error?: string }>('POST', `/api/automations/proposals/${id}/reject`),
   agentUpdateProposals: (target?: string) => call<{ proposals: AgentUpdateProposal[]; canApprove?: boolean; error?: string }>('GET', '/api/agents/proposals' + (target ? '?target=' + encodeURIComponent(target) : '')),
-  approveAgentUpdateProposal: (id: string) => call<{ ok: boolean; target?: string; rev?: number; error?: string }>('POST', `/api/agents/proposals/${id}/approve`),
+  // `staleBase`/`warning`: the target's CLAUDE.md had moved since this edit was proposed, so applying it
+  // replaced that newer text. Surface the warning — it is the only notice the reviewer gets that an earlier
+  // approval was just undone (rev is revertable from the agent's History).
+  approveAgentUpdateProposal: (id: string) => call<{ ok: boolean; target?: string; rev?: number; staleBase?: boolean; warning?: string; error?: string }>('POST', `/api/agents/proposals/${id}/approve`),
   rejectAgentUpdateProposal: (id: string, note?: string) => call<{ ok: boolean; error?: string }>('POST', `/api/agents/proposals/${id}/reject`, { note }),
   goalUpdateProposals: (goal?: string) => call<{ proposals: GoalUpdateProposal[]; canApprove?: boolean; error?: string }>('GET', '/api/goals/proposals' + (goal ? '?goal=' + encodeURIComponent(goal) : '')),
   approveGoalUpdateProposal: (id: string) => call<{ ok: boolean; goalId?: string; status?: GoalStatus; error?: string }>('POST', `/api/goals/proposals/${id}/approve`),


### PR DESCRIPTION
## The gap

Several agents proposing edits to ONE agent is by design — the 10-card cap is per-proposer, and only an identical delta from the same proposer is deduped. But every `agent.update.proposed` card carries a **full replacement** CLAUDE.md, resolved when the card was written, so approving a second card reverts whatever the first one landed.

The approve route already noticed: it compares the card's pinned `baseHash` against the target's current prompt and returns `staleBase` + a warning. **The console threw both away** — `web/src/lib/api.ts` typed the approve response as `{ ok, target, rev, error }` — so an owner working through three queued cards saw three successes and never learned two had been undone.

Found on a live tenant with 3 queued proposals on one agent.

## The fix

- `GET /api/agents/proposals` stamps `stale` per card (pinned `baseHash` vs the target's current CLAUDE.md, read once per target). The reviewer is told **before** the click, not after.
- The target's settings page badges a stale card **out of date**, says what approving it would replace, weights **Reject** as the primary button, and spells the replacement out in the confirm dialog.
- A banner names the collision whenever more than one queued card rewrites the prompt.
- The post-approve warning is surfaced — sticky on the agent page, inline on the Inbox review card.

Nothing is blocked: an owner who wants the stale edit can still take it, and the revision stays revertable from History.

## Test

New section 4 in `scripts/proposal-surfacing-test.cjs` — queues two cards on one target, asserts neither is stale, approves one, asserts the survivor flips to `stale: true`, then approves it anyway and asserts `staleBase` + a warning come back **and** that it really did revert the first edit. 18 passed, 0 failed; full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)