### PR TITLE
fix(runtime): the resume path asks whether it can authenticate too (v0.413.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.413.1] - 2026-09-02
+### Fixed
+- **The resume path could still start an un-authenticated run.** v0.412.0 refuses a launch whose credential
+  can't be read, but a *resurrection* never passes through the server's launch path: `attach.sh` re-execs
+  `claude-launch.sh` with `RESUME=1`, which sources the persisted env and starts the runtime directly. On
+  instapods that gap produced a session at 05:44Z — 34 minutes after the operator believed the box was
+  fixed — that came up `Not logged in`, burned a turn and ended at $0. The launcher now asks the server
+  first, over the same loopback + session-secret channel it already uses for `/api/ended`
+  (`POST /api/credential-check` → `TerminalManager.checkResumeCredentials`), so detection stays in ONE
+  implementation instead of being rewritten in bash. Fails **open** by construction: no `AOS_URL`, an
+  unreachable server, a 5 s timeout or any unparseable answer proceeds exactly as before — only an explicit
+  `ok:false` stops the launch. A refusal holds the pane open with a shell rather than exiting, since ttyd
+  re-dials the instant a pane dies and would otherwise spin the refusal in a loop.
+- The launch and resume refusals now share one `refuseForLockedCredential` path (audit, crashed row, owner
+  card, pool badge, cooldown alert), so they cannot drift apart. Nine new assertions in
+  `scripts/credential-preflight-test.cjs`.
+
 ## [0.413.0] - 2026-09-02
 ### Fixed
 - **A stale cross-agent edit proposal no longer clobbers a newer prompt silently.** Several agents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.413.0",
+  "version": "0.413.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.413.0",
+      "version": "0.413.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.413.0",
+  "version": "0.413.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/credential-preflight-test.cjs
+++ b/scripts/credential-preflight-test.cjs
@@ -137,6 +137,31 @@ console.log('\nLaunch pre-flight');
   setPlatform('darwin');
 }
 
+console.log('\nResume path (attach.sh → claude-launch.sh)');
+{
+  // The resume lane re-execs the launcher directly from a persisted env file — no server decision in the
+  // middle — so the launch pre-flight never sees it. These pin the contract that closes that gap without
+  // a SECOND implementation of "is this credential readable" living in bash.
+  const server = fs.readFileSync(path.join(ROOT, 'src/server.ts'), 'utf8');
+  const launcher = fs.readFileSync(path.join(ROOT, 'terminal/claude-launch.sh'), 'utf8');
+
+  const route = server.slice(server.indexOf("p === '/api/credential-check'"), server.indexOf("p === '/api/resumed'"));
+  assert(route.length > 0, 'the server exposes POST /api/credential-check');
+  assert(route.includes('sessionSecretOk(session)'), 'the route is gated by the session secret, like every other loopback route');
+  assert(route.includes('checkResumeCredentials'), 'the route delegates to the ONE shared readiness check');
+
+  assert(/preflight_credentials\(\)/.test(launcher), 'the launcher defines a resume pre-flight');
+  assert(/RESUMED_FROM_ENV" = "1" \] && ! preflight_credentials/.test(launcher),
+    'the pre-flight runs on the RESUME lane only — a fresh spawn was already checked server-side');
+  // Fail-open is the whole safety argument for putting a network call in front of every resurrection.
+  const fn = launcher.slice(launcher.indexOf('preflight_credentials() {'), launcher.indexOf('if [ "$RESUMED_FROM_ENV"'));
+  assert((fn.match(/return 0/g) || []).length >= 4, 'every failure mode inside the pre-flight returns 0 (proceed)', `${(fn.match(/return 0/g) || []).length} found`);
+  assert(fn.includes('-m 5'), 'the probe is time-bounded, so an unresponsive server cannot hang a resurrection');
+  assert(fn.includes('j.ok === false'), 'only an EXPLICIT ok:false refuses — an unparseable answer proceeds');
+  assert(/! preflight_credentials; then\n(.|\n)*?exec bash/.test(launcher),
+    'a refusal holds the pane open with a shell rather than exiting into ttyd\'s reconnect loop');
+}
+
 setPlatform(realPlatform);
 child.spawnSync = realSpawnSync;
 try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1623,6 +1623,22 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     return sendJson(res, 200, { ok });
   }
   // attach-wrapper signal that a stopped session was resurrected (→ mark running again).
+  // Resume pre-flight: the launcher asks, before exec'ing the runtime, whether this environment can
+  // authenticate at all. A resurrection (attach.sh → claude-launch.sh with RESUME=1) never passes through
+  // the server's launch path, so without this a locked-keychain box quietly resurrects panes that come up
+  // "Not logged in" and burn a turn each. Answering here — rather than re-implementing the probe in bash —
+  // keeps ONE implementation of what "usable credential" means. Fails OPEN by construction: only an
+  // explicit `blocked` verdict stops a launch, so a server blip can never wedge the fleet.
+  if (method === 'POST' && p === '/api/credential-check') {
+    const b = await readBody(req);
+    const session = String(b.session || '');
+    if (!tm.hasSession(session)) return sendJson(res, 404, { error: 'unknown session' });
+    if (!sessionSecretOk(session)) return sendJson(res, 403, { error: 'bad session secret' });
+    const runtime = String(b.runtime || 'claude-code') as RuntimeId;
+    if (!isCodingRuntime(runtime)) return sendJson(res, 400, { error: `unknown runtime: ${runtime}` });
+    const blocked = tm.checkResumeCredentials(session, String(b.configDir || ''), runtime);
+    return sendJson(res, 200, blocked ? { ok: false, ...blocked } : { ok: true });
+  }
   if (method === 'POST' && p === '/api/resumed') {
     const b = await readBody(req);
     const session = String(b.session || '');

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3779,18 +3779,52 @@ export class TerminalManager {
     try { blocked = preflightCredential(runtime, env); }
     catch { return true; }                              // a probe that can't run must never block a launch
     if (!blocked) return true;
-    const why = `the macOS login keychain is locked, so ${CODING_RUNTIMES[runtime].label} cannot read the credential for ${blocked.dir} — this run would start, authenticate as nobody and end with no work done`;
-    this.audit(o.id, o.agent, 'session.launch.refused', { runtime, reason: 'credential unreadable: keychain locked', dir: blocked.dir, service: blocked.service });
-    this.db.prepare("UPDATE term_sessions SET status = 'crashed', busy_since = NULL, updated_at = ? WHERE id = ?").run(Date.now(), o.id);
-    this.addMessage({ type: 'completed', sessionId: o.id, agent: o.agent, title: `Could not start — ${o.agent}`, body: `Did not launch: ${why}.`, status: 'open', outcome: 'crashed', audienceKind: 'sessionOwner', audienceId: o.id });
+    this.refuseForLockedCredential(o.id, o.agent, runtime, blocked.dir, blocked.service);
+    return false;
+  }
+
+  /**
+   * The same question, asked by the RESUME path instead of the launch path.
+   *
+   * A resurrection does not go through `launch()` at all: `attach.sh` re-execs `claude-launch.sh` with
+   * `RESUME=1`, which sources the persisted env file and starts claude directly — pure shell, no server
+   * decision in the middle. So the launch pre-flight cannot see it, and on 2026-09-02 a session
+   * resurrected that way came up `Not logged in` and burned a turn 34 minutes after the operator believed
+   * the box was fixed. The launcher now asks HERE, over the same loopback + session-secret channel it
+   * already uses for `/api/ended` and `/api/resumed`, so detection stays in one implementation rather
+   * than being re-written in bash.
+   *
+   * `configDir` is whatever the resumed environment carries (empty → the box default). Returns the
+   * blocking condition, having already recorded it, or null to proceed.
+   */
+  checkResumeCredentials(sessionId: string, configDir: string, runtime: CodingRuntimeId = 'claude-code'): { reason: 'keychain_locked'; dir: string; message: string } | null {
+    const agent = this.sessionAgent(sessionId) ?? 'system';
+    let blocked: { dir: string; service: string } | null = null;
+    try { blocked = preflightCredential(runtime, configDir ? { [CODING_RUNTIMES[runtime].credentialEnv.configDirVar]: configDir } : {}); }
+    catch { return null; }
+    if (!blocked) return null;
+    this.refuseForLockedCredential(sessionId, agent, runtime, blocked.dir, blocked.service);
+    return { reason: 'keychain_locked', dir: blocked.dir, message: TerminalManager.lockedCredentialWhy(runtime, blocked.dir) };
+  }
+
+  private static lockedCredentialWhy(runtime: CodingRuntimeId, dir: string): string {
+    return `the macOS login keychain is locked, so ${CODING_RUNTIMES[runtime].label} cannot read the credential for ${dir} — this run would start, authenticate as nobody and end with no work done`;
+  }
+
+  /** Record a refused run: audit, crash the row, tell its owner, badge the pool account, alert admins.
+   *  Shared by the launch and resume pre-flights so the two can never disagree about what a refusal is. */
+  private refuseForLockedCredential(sessionId: string, agent: string, runtime: CodingRuntimeId, dir: string, service: string): void {
+    const why = TerminalManager.lockedCredentialWhy(runtime, dir);
+    this.audit(sessionId, agent, 'session.launch.refused', { runtime, reason: 'credential unreadable: keychain locked', dir, service });
+    this.db.prepare("UPDATE term_sessions SET status = 'crashed', busy_since = NULL, updated_at = ? WHERE id = ?").run(Date.now(), sessionId);
+    this.addMessage({ type: 'completed', sessionId, agent, title: `Could not start — ${agent}`, body: `Did not launch: ${why}.`, status: 'open', outcome: 'crashed', audienceKind: 'sessionOwner', audienceId: sessionId });
     // Badge the pool row this dir belongs to, so Settings → Runtime shows the cause where an operator
     // would go looking for it rather than only in one session's card.
     try {
-      const acct = this.os.runtimeAccounts.list().find((a) => a.runtime === runtime && a.configDir === blocked!.dir);
+      const acct = this.os.runtimeAccounts.list().find((a) => a.runtime === runtime && a.configDir === dir);
       if (acct) this.os.runtimeAccounts.recordCheck(runtime, acct.name, { ok: false, note: 'macOS login keychain is locked — the credential cannot be read from this security session' });
     } catch { /* badging is a nicety */ }
-    this.alertCredentialsLocked(blocked.dir);
-    return false;
+    this.alertCredentialsLocked(dir);
   }
 
   /** Tell a human, once per cooldown. This is the half the 2026-09-01 incident was missing: the refusal

--- a/terminal/claude-launch.sh
+++ b/terminal/claude-launch.sh
@@ -328,6 +328,38 @@ RUNTIME_ARGS=()
 # expands to nothing when MCP_ARGS/SYS_ARGS are empty instead of tripping "unbound variable".
 COMMON_ARGS=(--settings .claude/aos-settings.json "${MCP_ARGS[@]+"${MCP_ARGS[@]}"}" "${SYS_ARGS[@]+"${SYS_ARGS[@]}"}" "${RUNTIME_ARGS[@]+"${RUNTIME_ARGS[@]}"}")
 
+# RESUME pre-flight. A resurrection (attach.sh → this script with RESUME=1) never passes through the
+# server's launch path, so the credential check that guards a fresh spawn has never seen it: on a box whose
+# macOS login keychain is locked, claude comes up "Not logged in", burns a turn and ends at $0 — the exact
+# silent failure the launch pre-flight exists to stop. Ask the server, which owns the one implementation of
+# "is this credential readable", over the same loopback + session-secret channel as /api/ended.
+#
+# Fails OPEN on purpose: no AOS_URL, an unreachable server, a timeout or any unparseable answer proceeds
+# exactly as before. Only an explicit ok:false stops the launch, so this can never wedge a fleet.
+preflight_credentials() {
+  [ -n "${AOS_URL:-}" ] && [ -n "${SESSION:-}" ] || return 0
+  local body out msg
+  body=$(node -e 'console.log(JSON.stringify({session:process.argv[1],configDir:process.argv[2]||""}))' \
+    "$SESSION" "${CLAUDE_CONFIG_DIR:-}" 2>/dev/null) || return 0
+  out=$(curl -s -m 5 -X POST "$AOS_URL/api/credential-check" -H 'content-type: application/json' \
+    -H "x-aos-secret: ${AOS_SECRET:-}" -H "x-aos-tenant: ${AOS_TENANT:-}" -d "$body" 2>/dev/null) || return 0
+  msg=$(printf '%s' "$out" | node -e '
+    let s = "";
+    process.stdin.on("data", (d) => { s += d; });
+    process.stdin.on("end", () => {
+      try { const j = JSON.parse(s); if (j && j.ok === false) process.stdout.write(String(j.message || "credentials are not readable")); } catch {}
+    });' 2>/dev/null) || return 0
+  [ -n "$msg" ] || return 0
+  red "Not started — $msg"
+  dim "Fix the credential (Settings → Runtime → Runtime accounts), then reopen this session."
+  return 1
+}
+if [ "$RESUMED_FROM_ENV" = "1" ] && ! preflight_credentials; then
+  # Hold the pane open rather than exiting: ttyd re-dials the instant a pane dies, which would spin this
+  # same refusal in a loop. A shell lets the human read the reason and close the tab.
+  exec bash
+fi
+
 if [ "${RESIDENT:-}" = "1" ] || [ "${UNATTENDED:-}" = "1" ]; then
   # UNATTENDED lane — the single path for every run with no human at the keyboard: automation/cron/task
   # runs (UNATTENDED=1) AND warm chat sessions (RESIDENT=1). An INTERACTIVE, ATTACHABLE claude (NOT


### PR DESCRIPTION
Follow-up to #751, which closed the launch path only.

## The gap

A resurrection never passes through the server's launch path: `attach.sh` re-execs `claude-launch.sh` with `RESUME=1`, which sources the persisted env file and starts the runtime directly — pure shell, no server decision in the middle. On instapods that produced a session at 05:44Z, **34 minutes after the operator believed the box was fixed**, which came up `Not logged in`, burned a turn and ended at \$0.

## The fix

The launcher asks the server before exec'ing the runtime, over the same loopback + session-secret channel it already uses for `/api/ended`:

`POST /api/credential-check` → `TerminalManager.checkResumeCredentials` → the same `preflightCredential` the launch path calls. One implementation of "is this credential readable", rather than a second copy in bash.

**Fails open by construction** — no `AOS_URL`, an unreachable server, a 5 s timeout, or any unparseable answer proceeds exactly as before. Only an explicit `ok:false` stops a launch, so this can never wedge a fleet.

A refusal **holds the pane open with a shell** instead of exiting: ttyd re-dials the instant a pane dies, so exiting would spin the refusal in a loop.

Launch and resume refusals now share one `refuseForLockedCredential` path (audit, crashed row, owner card, pool badge, cooldown alert) so they can't drift apart.

## Tests

Nine assertions added to `scripts/credential-preflight-test.cjs` (24 total), pinning the secret gate, the single-implementation delegation, RESUME-only invocation, and each fail-open property. `npm run typecheck`, `npm run build`, `npm run test:governance` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)