### PR TITLE
fix(prompt): name a tool that exists, and split memory/KB by kind (v0.413.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.413.5] - 2026-09-02
+### Fixed
+- **The prompt told agents to call a tool that doesn't exist.** `ask` was renamed `ask_human`, and three
+  injected instructions still named the old one — twice in the operating notes, once in the
+  unattended-turn brief. A prompt that names a missing tool teaches agents to fail. Nothing caught it:
+  `scripts/context-injection-test.cjs` is the only thing that checks the prompt and **it was never wired
+  into `npm run test:governance`**, so it had been failing silently — six assertions, since
+  `buildCompanyMd`'s signature changed under it. It is now wired in, its stale assertions rewritten
+  against the current contract, and it carries a new guard: **every tool the prompt names must exist**.
+
+### Changed
+- **The memory-vs-KB rule now splits by KIND of knowledge, not audience.** The prompt said *"memory is
+  for facts only you reuse; the KB is for the whole fleet"* — a test the agent cannot apply at write
+  time, because it asks them to predict who will need a fact later. Reading **22 live runs that wrote to
+  both stores** showed what agents had already converged on, and it *is* decidable: the **KB gets the
+  finding** (a root cause, a measured result, a runbook — *"proven end-to-end against production"*,
+  *"measured on 1026/1026 zones"*), **memory gets the technique** (*dev10 is the only box with Stripe
+  keys*; *psysh evaluates line by line*; *a `return 404` guard cannot be canaried by status code*). 19 of
+  22 pairs were complementary, 1 a pointer to the page, 2 near-duplicates. The prompt now states the rule
+  they were already following.
+- **`shared: true` is no longer advertised.** 22 of 2,523 memories on one live tenant used it, 37 of
+  10,907 on another — while `kb_write` did the same job. The capability remains in the tool schema; the
+  prompt stops offering a third destination nobody picks.
+
 ## [0.413.4] - 2026-09-02
 ### Fixed
 - **The Sessions view stopped rebuilding the whole history every six seconds.** `GET /api/sessions` is
@@ -27,7 +51,6 @@ new version heading in the same commit.
   paid 6 × (rows). Same six lookups, now `run_id IN (…)` + GROUP BY, chunked at 400. Byte-identical
   output over all 4,124 rows of a copy of the live DB; the summary path drops 21 → 17.9 ms. Pinned by
   `scripts/session-insights-stamp-test.cjs`.
-
 ## [0.413.3] - 2026-09-02
 ### Fixed
 - **The Agents page stopped blocking the whole server for two seconds.** `GET /api/agents/stats` —

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.413.4",
+  "version": "0.413.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.413.4",
+      "version": "0.413.5",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.413.4",
+  "version": "0.413.5",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/context-injection-test.cjs
+++ b/scripts/context-injection-test.cjs
@@ -56,6 +56,22 @@ async function main() {
   assert(base.includes('a fact (memory) vs. your standing instructions (CLAUDE.md)'), 'self-improvement subsection present');
   assert(/agent_update\b/.test(base) && /change to how you ALWAYS operate → your CLAUDE\.md/.test(base), 'self-improvement explains agent_update vs remember vs both');
   assert(base.includes('agent:peer') && !base.includes('agent:tester'), 'fleet roster lists peers, excludes self');
+
+  // MEMORY vs KB. The old rule split them by AUDIENCE — "facts only you reuse" vs "the whole fleet" —
+  // which asks the agent to predict who will need a fact, at the moment it cannot know. Reading 22 live
+  // runs that wrote to BOTH stores showed what agents actually do, and it is decidable at write time:
+  // the KB gets the FINDING (a root cause, a measured result, a runbook — 'proven end-to-end against
+  // production', 'measured on 1026/1026 zones'), memory gets the TECHNIQUE (dev10 is the only box with
+  // Stripe keys; psysh evaluates line by line; a `return 404` guard cannot be canaried by status code).
+  // 19 of 22 pairs were complementary, 1 a pointer, 2 near-duplicates. The prompt now states the rule
+  // they had already converged on.
+  assert(base.includes('Memory or the Knowledge Base?'), 'the memory-vs-KB rule is stated');
+  assert(/The finding goes in the KB/.test(base) && /The technique goes in memory/.test(base), 'and it splits by KIND of knowledge, not audience');
+  assert(!/Memory is for facts only \*you\* reuse/.test(base), 'the old audience-based rule is gone — it was not decidable at write time');
+  // `shared: true` is no longer advertised: 22 of 2,523 memories on one live tenant and 37 of 10,907 on
+  // another used it, while kb_write did the same job. The capability remains in the tool schema; we just
+  // stop offering a third destination nobody picks. Every choice offered is a chance to choose wrong.
+  assert(!/shared: ?true/.test(base), 'the unused shared-memory channel is no longer advertised in the prompt');
   assert(!base.includes('Messaging — use the native integration first'), 'no native-messaging block when Slack/Discord unconfigured');
   assert(!base.includes('What you already know'), 'no recall preamble when preload is off');
 
@@ -85,24 +101,48 @@ async function main() {
   assert(!preloadOff.includes('What you already know'), 'preamble still absent while preload disabled');
 
   aos.settings.setMemoryConfig({ backend: 'sqlite', preload: { enabled: true, count: 8 } });
-  const preloadOn = build('tester');
-  assert(preloadOn.includes('What you already know — your most salient memories'), 'preamble present when preload enabled');
+  // v0.399.0 moved the preamble OUT of buildCompanyMd: it is I/O (a recall), so the async launcher
+  // resolves it and hands it in, keeping prompt assembly synchronous. These assertions still called the
+  // old one-arg shape and had been failing ever since — invisibly, because this file was never wired into
+  // `npm run test:governance`. Both are fixed below: build the preamble the way the launcher does, and
+  // the file now runs in CI so it cannot rot again.
+  const withPreamble = async (agent, task) => tm.buildCompanyMd(agent, undefined, false, await tm.memoryPreamble(agent, task));
+
+  // The preamble is one section of a longer prompt, and later sections use "- " too — so bound the count
+  // to the preamble's own block (up to the next heading) rather than everything after its title.
+  const preambleBullets = (md) => {
+    const i = md.indexOf('What you already know');
+    if (i < 0) return 0;
+    const rest = md.slice(i);
+    const end = rest.indexOf('\n#', 1);
+    return (end > 0 ? rest.slice(0, end) : rest).split('\n').filter((l) => l.startsWith('- ')).length;
+  };
+  aos.settings.setMemoryConfig({ backend: 'sqlite', preload: { enabled: true, count: 8 } });
+  const preloadOn = await withPreamble('tester', 'deploy the service and restart it after the build');
+  assert(preloadOn.includes('What you already know'), 'preamble present when preload enabled');
   assert(preloadOn.includes('PRIVATE-DEPLOY-GOTCHA'), "preamble includes the agent's own memories");
   assert(preloadOn.includes('SHARED-COMPANY-FACT'), 'preamble includes tenant-shared memories');
   assert(!preloadOn.includes('OTHERS-PRIVATE-SECRET'), "preamble does NOT leak another agent's private memories");
-  // Importance ordering: the 0.9 private fact should sort above the 0.2 note (both present, high first).
-  assert(preloadOn.indexOf('PRIVATE-DEPLOY-GOTCHA') < preloadOn.indexOf('low-value note'), 'preamble ranks by importance (high before low)');
+  // Selection is now by RELEVANCE to the task (v0.399.0), not importance — and an irrelevant memory is
+  // not ranked last, it is not seeded AT ALL. That is the stronger property, so assert it directly: the
+  // deploy gotcha is in, the unrelated note is out, for a deploy task.
+  assert(!preloadOn.includes('low-value note'), 'a memory irrelevant to the task is not seeded at all');
 
-  // count clamp
+  // count clamp. Needs TWO task-relevant memories, or the cap is untestable — with only one relevant
+  // memory a count of 1 and a count of 8 both yield one bullet, and the assertion would pass for the
+  // wrong reason.
+  await aos.memory.store({ tenant: aos.tenant, agentId: 'tester', content: 'SECOND-DEPLOY-FACT the build step must run before the restart', importance: 0.7 });
+  aos.settings.setMemoryConfig({ backend: 'sqlite', preload: { enabled: true, count: 8 } });
+  const two = await withPreamble('tester', 'deploy the service and restart it after the build');
+  assert(preambleBullets(two) >= 2, 'both task-relevant memories are seeded when the count allows', 'got ' + preambleBullets(two));
   aos.settings.setMemoryConfig({ backend: 'sqlite', preload: { enabled: true, count: 1 } });
-  const one = build('tester');
-  const bullets = (one.split('What you already know')[1] || '').split('\n').filter((l) => l.startsWith('- ')).length;
-  assert(bullets === 1, 'preamble honours the count (1 requested → 1 bullet)', `got ${bullets}`);
+  const one = await withPreamble('tester', 'deploy the service and restart it after the build');
+  assert(preambleBullets(one) === 1, 'preamble honours the count (1 requested → 1 bullet)', 'got ' + preambleBullets(one));
 
   console.log('\n\x1b[1m3) OS-owned MCP tool list (dist/memory/memory-mcp.js)\x1b[0m');
   const always = await mcpTools({});
   const alwaysNames = always.map((t) => t.name);
-  const EXPECTED_ALWAYS = ['recall', 'remember', 'revise', 'forget', 'kb_search', 'kb_write', 'ask', 'report', 'update', 'publish', 'schedule', 'task_create', 'task_update', 'agent_update', 'secret_put', 'secret_get', 'check_inbox'];
+  const EXPECTED_ALWAYS = ['recall', 'remember', 'revise', 'forget', 'kb_search', 'kb_write', 'ask_human', 'report', 'update', 'publish', 'schedule', 'task_create', 'task_update', 'agent_update', 'secret_put', 'secret_get', 'check_inbox'];
   const missing = EXPECTED_ALWAYS.filter((n) => !alwaysNames.includes(n));
   assert(missing.length === 0, `always-on tools all present (${alwaysNames.length} total)`, `missing: ${missing.join(', ')}`);
   assert(!alwaysNames.some((n) => /slack|discord/.test(n)), 'no slack/discord tools without egress flags');
@@ -120,6 +160,25 @@ async function main() {
   const reply = await mcpTools({ SLACK_REPLY: '1', DISCORD_REPLY: '1' });
   const rNames = reply.map((t) => t.name);
   assert(rNames.includes('slack_reply') && rNames.includes('discord_reply'), 'reply tools appear with *_REPLY=1');
+
+  // EVERY TOOL THE PROMPT NAMES MUST EXIST. `ask` was renamed `ask_human`, and the prompt kept telling
+  // agents to call `ask` — in the operating notes twice and in the unattended-turn brief once. Nothing
+  // caught it: this file is the only thing that checks the prompt, and it was never wired into
+  // `npm run test:governance`, so it had been failing silently since the signature change in v0.399.0.
+  // A prompt that names a tool which does not exist is a prompt that teaches agents to fail.
+  console.log('\n\x1b[1m2b) Every tool the prompt names exists\x1b[0m');
+  {
+    const { AGENT_OS_OPERATING_NOTES } = require(path.join(ROOT, 'dist/terminal.js'));
+    const { UNATTENDED_TURN_BRIEF } = require(path.join(ROOT, 'dist/edge/background-work.js'));
+    const prose = AGENT_OS_OPERATING_NOTES + '\n' + (UNATTENDED_TURN_BRIEF || '');
+    // Field names and statuses are also backticked, so only check identifiers that look like tool calls:
+    // snake_case, or a known bare-word tool. Anything else is prose and is skipped deliberately.
+    const cited = [...new Set((prose.match(/`([a-z][a-z0-9_]{2,})`/g) || []).map((x) => x.slice(1, -1)))]
+      .filter((x) => x.includes('_') || ['recall', 'remember', 'revise', 'forget', 'report', 'update', 'publish', 'notify', 'schedule', 'unschedule', 'stop'].includes(x));
+    const unknown = cited.filter((c) => !alwaysNames.includes(c) && !eNames.includes(c) && !rNames.includes(c));
+    assert(unknown.length === 0, 'every tool named in the prompt is actually exposed', unknown.join(', '));
+  }
+
 
   console.log('\n\x1b[1m4) Launch-script permission pre-allow (claude-launch.sh)\x1b[0m');
   const launch = fs.readFileSync(path.join(ROOT, 'terminal/claude-launch.sh'), 'utf8');

--- a/src/edge/background-work.ts
+++ b/src/edge/background-work.ts
@@ -225,7 +225,7 @@ export const UNATTENDED_TURN_BRIEF =
   '**When you genuinely have to wait, use the OS instead of the turn:**\n' +
   '- `task_wait` (or `task_create({ wait: true })`) — blocks until a delegated agent finishes and ' +
   'resumes you with its result. This is the supported hand-off; it survives your turn ending.\n' +
-  '- `ask` — blocks on a person and keeps your session alive while their Inbox card is pending.\n' +
+  '- `ask_human` — blocks on a person and keeps your session alive while their Inbox card is pending.\n' +
   '- `schedule` — defers a FUTURE run of yourself (minutes to days out) when the thing you need cannot ' +
   'happen inside this run at all. Report what you did first; the scheduled run picks it up.\n' +
   '- `task_create` — park the remainder as durable work rather than holding a session open for it.\n\n' +

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -159,12 +159,21 @@ into this prompt — you must reach for it:
   self-contained fact per memory; skip routine steps and run-specific trivia — remembering everything
   is as useless as remembering nothing.
 
+**Memory or the Knowledge Base?** Ask what KIND of thing you learned, not who might want it:
+- **The finding goes in the KB** (\`kb_write\`) — what is true about the system, written for someone who
+  wasn't there: a root cause, a measured result, a runbook, a convention. It gets a title and a reader.
+- **The technique goes in memory** (\`remember\`) — how to work on this system, for your own next run:
+  which box has the credentials, which tool lies to you, which probe can't fail, the flag that wasted an
+  hour. Nobody wants a wiki page called "psysh evaluates line by line", and you will want it again.
+When one run produces both, write both — the page for the finding, the memory for what it cost you to
+get there. If the finding is big, a memory pointing at the page is worth more than a second copy of it.
+
 ## Talking to the human — use the Inbox, not just the terminal
 Your terminal output may not be read. The operator lives in the Inbox:
-- \`ask\` when you're blocked on a judgement only the human can make — it waits for their reply. Prefer
+- \`ask_human\` when you're blocked on a judgement only the human can make — it waits for their reply. Prefer
   asking over guessing on anything risky or ambiguous. This is the ONLY way to ask a person here: there
   is no human at your terminal, so a native multiple-choice/interactive prompt just hangs unanswered —
-  always use \`ask\` (or plain text if you're in a chat), never an interactive picker.
+  always use \`ask_human\` (or plain text if you're in a chat), never an interactive picker.
 - \`report\` exactly once when you finish, with the outcome and a one-line summary, so the result is
   visible without anyone reading the terminal. If the task taught you something durable, pass it in
   \`lessons\` — it's saved to your memory as a note to your future self.
@@ -201,9 +210,7 @@ Other agents run in this workspace and you share state with them. You are a node
   a draft for a human to approve.
 - **Knowledge Base** (\`kb_*\`) is the fleet's shared, living wiki. \`kb_search\` before assuming a fact
   isn't already written down; \`kb_write\` durable facts, runbooks, and conventions that help *other*
-  agents and humans. (Memory is for facts only *you* reuse; the KB is for the whole fleet.)
-- **Shared memory**: \`remember\` with \`shared: true\` publishes a fact fleet-wide instead of only to
-  your own recall — use it for things the whole team should know.
+  agents and humans. (Which store gets what: see "Memory or the Knowledge Base?" above.)
 - **Skills** (\`skill_propose\`): when you work out HOW to do something repeatable and non-obvious — a
   multi-step procedure another agent could follow verbatim — propose it as a skill. That's *procedural*
   memory (a reusable playbook), distinct from a *fact* (\`remember\`/\`report\` lessons) or a wiki page


### PR DESCRIPTION
Two findings from reviewing every prompt we inject into a session.

## 1. The prompt told agents to call a tool that doesn't exist

`ask` was renamed **`ask_human`**. Three injected instructions still named the old one — twice in the operating notes, once in `UNATTENDED_TURN_BRIEF`:

> `- \`ask\` when you're blocked on a judgement only the human can make`

A prompt that names a missing tool teaches agents to fail.

**Nothing caught it.** `scripts/context-injection-test.cjs` is the only thing that checks the prompt, and it **was never wired into `npm run test:governance`** — so it had been failing silently with six assertions ever since `buildCompanyMd`'s signature changed under it (preamble moved to the async launcher in v0.399.0; `verbosity` dropped later). It's now wired in, rewritten against the current contract, and carries a new guard: **every tool the prompt names must be exposed**.

Two rewrites are stronger than what they replaced:
- Selection is by **relevance** now, so an irrelevant memory isn't ranked last — it isn't seeded at all. That's what the test asserts.
- The count-cap assertion needed a **second** task-relevant memory, or a cap of 1 and a cap of 8 both yield one bullet and it passes for the wrong reason.

## 2. The memory-vs-KB rule wasn't decidable at write time

It read *"memory is for facts only **you** reuse; the KB is for the whole fleet"* — an **audience** test, which asks an agent to predict who will need a fact later. They can't, so the conscientious answer is "write both".

I read **22 live runs that wrote to both stores** and they'd already converged on a rule that *is* decidable:

| | gets |
|---|---|
| **KB** | the **finding** — root cause, measured result, runbook, for someone who wasn't there (*"proven end-to-end against production"*, *"measured on 1026/1026 zones"*) |
| **Memory** | the **technique** — *dev10 is the only box with Stripe keys*; *psysh evaluates line by line*; *a `return 404` guard cannot be canaried by status code* |

**19 of 22 complementary, 1 a pointer to the page, 2 near-duplicates.** The prompt now states the rule they were already following.

> Worth recording: an earlier token-overlap measurement said 87–92% of preloaded memories were "already in the KB", which I read as redundancy. It wasn't — it was **topical** overlap. Same systems, different claims. My negative control only tested *other-domain* text, so it couldn't catch that. Reading the pairs is what corrected it.

Also drops **`shared: true`** from the prompt — 22 of 2,523 memories on one live tenant used it, 37 of 10,907 on another, while `kb_write` did the same job. The capability stays in the tool schema; we stop offering a third destination nobody picks.

## Test

`context-injection-test.cjs`: **37 passed, 0 failed**, now in CI. Full `npm run test:governance` green, `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)