### PR TITLE
feat(sessions): a session hand-off DMs the person who now owns it (v0.414.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.414.0] - 2026-09-02
+### Added
+- **Handing a session to another member now DMs them.** `POST /api/sessions/:id/transfer` reassigns a
+  run's `run_as` — the new owner inherits accountability for something they didn't start — but the only
+  trace was an audit event and a row that quietly changed owner in someone else's console. A hand-off
+  nobody sees is a hand-off nobody picks up, so `transferSession` now fires a `TransferNotice` and the
+  registry DMs the new owner on their linked Slack/Discord (one line: who handed it over, the session
+  title, a console deep link). Always-on rather than gated on the `dm` preference — a transfer is one
+  person deliberately making another accountable, an ask rather than a lifecycle beat. The DM is bound to
+  the session, so replying in chat picks the conversation up with the agent. Audited
+  `session.transfer.notified`.
+
 ## [0.413.5] - 2026-09-02
 ### Fixed
 - **The prompt told agents to call a tool that doesn't exist.** `ask` was renamed `ask_human`, and three

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.413.5",
+  "version": "0.414.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.413.5",
+      "version": "0.414.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.413.5",
+  "version": "0.414.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -14,7 +14,7 @@ import * as path from 'path';
 import { spawn, ChildProcess } from 'child_process';
 import { AgentOS, loadAgentOS, readRootConfig, RootConfig } from './kernel';
 import { exampleCapabilities } from './capabilities/examples';
-import { TerminalManager, ApprovalNotice, QuestionNotice, MemberNotice, SessionEventNotice, ReviewNotice } from './terminal';
+import { TerminalManager, ApprovalNotice, QuestionNotice, MemberNotice, SessionEventNotice, TransferNotice, ReviewNotice } from './terminal';
 import { Automations } from './edge/automations';
 import { WAKE_KIND_DONE } from './edge/wakeups';
 import { AppSupervisor } from './edge/app-supervisor';
@@ -303,6 +303,9 @@ export class TenantRegistry {
     // the run's owner IF they opted into `dm` notifications (default off — the inbox bell already covers
     // it). The complete/waiting/crashed twin of the always-on approval/question DMs above.
     tm.setSessionEventNotifier((notice) => { void notifySessionEvent(os, tm, slack, discord, consoleOrigin, notice); });
+    // Session hand-off: when a run is transferred to another member, DM the new owner — they inherit
+    // accountability for something they didn't start, so it can't only land in a console view.
+    tm.setTransferNotifier((notice) => { void notifySessionTransferred(os, tm, slack, discord, consoleOrigin, notice); });
     const ttyd = launchTtyd(paths.tmuxSocket, ttydPort, paths.connectors);
     console.log(`  [tenant:${rec.slug}] home=${paths.home}  ttyd=:${ttydPort}`);
     return { record: rec, os, tm, autos, apps, slack, discord, telegram, clickup, ttyd, ttydPort, firstLogin: firstLogin ?? undefined };
@@ -760,6 +763,26 @@ export async function notifySessionEvent(os: AgentOS, tm: Pick<TerminalManager, 
   // the moment a human wants to say "retry it" or "now do the other half" (see Automations.continueSessionDm).
   bindDmRecipients(os, targets, (provider, externalId, memberId) => tm.bindSessionDm(notice.sessionId, provider, externalId, memberId));
   os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'session.event.notified', data: { kind: notice.kind, agent: notice.agent, targets: targets.length, dms } });
+}
+
+/**
+ * DM the member a session was just handed off to. Always-on (unlike the routine session-event beats,
+ * which respect the `dm` pref): a transfer is one person deliberately making another accountable for a
+ * run, so it's an ask, not a lifecycle notification. Single named recipient — never a broadcast; the
+ * previous owner isn't notified (they performed or authorised the hand-off). The DM is bound to the
+ * session so the new owner can reply straight into the conversation they just inherited. Best-effort,
+ * audited.
+ */
+export async function notifySessionTransferred(os: AgentOS, tm: Pick<TerminalManager, 'bindSessionDm'>, slack: Pick<SlackSocket, 'dmUser' | 'userIdForEmail'>, discord: Pick<DiscordSocket, 'dmUser'>, consoleOrigin: string, notice: TransferNotice): Promise<void> {
+  const targets = resolveRecipients(os, { kind: 'member', id: notice.to });
+  if (!targets.length) return;
+  const what = notice.title ? `“${notice.title}” (${notice.agent})` : `a ${notice.agent} session`;
+  const url = consolePage(consoleOrigin, 'sessions', notice.sessionId);
+  const text = (p: ChatPlatform) => `🤝 ${notice.byName} handed you ${what} — you're now the owner.
+_Reply here to pick it up with ${notice.agent}_, or open it in the ${chatLink(p, url, 'Agentric console')}.`;
+  const dms = await deliverDM(slack, discord, os, targets, text);
+  bindDmRecipients(os, targets, (provider, externalId, memberId) => tm.bindSessionDm(notice.sessionId, provider, externalId, memberId));
+  os.audit.append({ ts: Date.now(), runId: notice.sessionId, tenant: os.tenant, principal: 'system', type: 'session.transfer.notified', data: { to: notice.to, agent: notice.agent, dms } });
 }
 
 /**

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -766,6 +766,22 @@ export interface SessionEventNotice {
   message: string;
 }
 
+/** What the transfer sink receives when a session is handed off to another member ({@link
+ *  TerminalManager.transferSession}). The new owner inherits accountability for a run they didn't start,
+ *  so the registry DMs them out-of-band on their linked Slack/Discord — a hand-off nobody sees is a
+ *  hand-off nobody picks up. Always-on (not gated on the `dm` pref): a deliberate person-to-person
+ *  reassignment is a direct ask, not a lifecycle beat. */
+export interface TransferNotice {
+  sessionId: string;
+  agent: string;
+  /** Member id of the new owner (the session's new `run_as`). */
+  to: string;
+  /** The human who performed the hand-off. */
+  byName: string;
+  /** Session display title, when it has one. */
+  title?: string;
+}
+
 /** Everything the runtime launcher needs for ONE launch of a session row. Named (rather than inline)
  *  because the launch is now scheduled and executed in two steps — see `launchAgentRuntime`. */
 interface LaunchSpec {
@@ -909,6 +925,11 @@ export class TerminalManager {
    *  once the chat sockets exist; absent = no push (the inbox card is always written regardless). */
   private sessionEventNotifier?: (notice: SessionEventNotice) => void;
   setSessionEventNotifier(fn: (notice: SessionEventNotice) => void): void { this.sessionEventNotifier = fn; }
+  /** Optional sink notified when a session is handed off to another member, so the registry can DM the
+   *  new owner. Set by the registry once the chat sockets exist; absent = no push (the transfer itself
+   *  still happens and is audited regardless). */
+  private transferNotifier?: (notice: TransferNotice) => void;
+  setTransferNotifier(fn: (notice: TransferNotice) => void): void { this.transferNotifier = fn; }
   private fireSessionEvent(sessionId: string, agent: string, kind: SessionEventNotice['kind'], title: string, message: string): void {
     try { this.sessionEventNotifier?.({ sessionId, agent, kind, title, message }); } catch { /* advisory — never let a push wedge the caller */ }
   }
@@ -7843,14 +7864,18 @@ export class TerminalManager {
    *  real member; a no-op transfer (already owned by them) succeeds quietly. Audited `session.transferred`.
    *  The caller applies the ownership gate (owner/admin or current owner). */
   transferSession(sessionId: string, by: Member, toMemberId: string): { ok: boolean; error?: string; runAs?: string } {
-    const r = this.db.prepare('SELECT id, agent, run_as FROM term_sessions WHERE id = ?')
-      .get<{ id: string; agent: string; run_as: string | null }>(sessionId);
+    const r = this.db.prepare('SELECT id, agent, run_as, title FROM term_sessions WHERE id = ?')
+      .get<{ id: string; agent: string; run_as: string | null; title: string | null }>(sessionId);
     if (!r) return { ok: false, error: 'unknown session' };
     const target = this.os.team.getMember(toMemberId);
     if (!target) return { ok: false, error: 'unknown member' };
     if (r.run_as === target.id) return { ok: true, runAs: target.id };
     this.db.prepare('UPDATE term_sessions SET run_as = ?, updated_at = ? WHERE id = ?').run(target.id, Date.now(), sessionId);
     this.audit(sessionId, by.email, 'session.transferred', { from: r.run_as, to: target.id, agent: r.agent });
+    // Tell the new owner out-of-band (Slack/Discord DM) — they now own a run they didn't start, and the
+    // inbox alone doesn't reach someone who isn't looking at the console. Advisory: never fail the
+    // transfer on a notification.
+    try { this.transferNotifier?.({ sessionId, agent: r.agent, to: target.id, byName: by.name || by.email, title: r.title ?? undefined }); } catch { /* advisory */ }
     return { ok: true, runAs: target.id };
   }
 


### PR DESCRIPTION
Transferring a session reassigns its `run_as` — the accountable human — but the only trace was an audit event and a row that changed owner inside someone else's console. The new owner inherits a run they never started and hears nothing about it.

`TerminalManager.transferSession` now fires a `TransferNotice`; the tenant registry's `notifySessionTransferred` DMs the new owner on their linked Slack/Discord — who handed it over, the session title, a console deep link.

- **Always-on**, not gated on the `dm` preference: unlike the routine started/finished beats, a transfer is one person deliberately making another accountable, so it's an ask.
- **Single named recipient**, never a broadcast. The previous owner isn't notified (they performed or authorised the hand-off).
- The DM is **bound to the session**, so replying in chat picks the conversation back up with the agent.
- Best-effort and wrapped — a notification never fails the transfer. Audited `session.transfer.notified`.

Verified: `npm run typecheck`, `npm run test:governance` (14 passed), and an in-process harness driving `transferSession` on a scratch home — the notice fires with the right member id, title and hand-off name, and a no-op transfer (already owned) stays quiet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)