### PR TITLE
perf(metrics): a stall caused by a request now names the request (v0.414.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.414.2] - 2026-09-02
+### Fixed
+- **A stall caused by a request now names the request.** The first stall the new recorder caught on the
+  live tenant read `unattributed` — a 1,028 ms block whose cause was sitting in the table right beside it
+  (`POST /api/tasks/update`, max 1,117 ms), unnamed only because requests weren't phases. They are now,
+  and attribution picks the **innermost** phase — the one begun last — rather than the outermost, which is
+  what makes marking a whole request safe: a request parked on an await is open while a timer blocks
+  inside it, and the timer, not the route, gets the blame. Both cases are pinned in
+  `scripts/loop-stall-attribution-test.cjs`.
+
 ## [0.414.1] - 2026-09-02
 ### Fixed
 - **The hand-off chain rail stopped scanning the whole session table per node.** `GET /api/sessions/:id/chain`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.414.1",
+  "version": "0.414.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.414.1",
+      "version": "0.414.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.414.1",
+  "version": "0.414.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/loop-stall-attribution-test.cjs
+++ b/scripts/loop-stall-attribution-test.cjs
@@ -13,7 +13,9 @@
  *   - a phase that CLOSED just before the sampler tick still gets the blame (the common case — the
  *     blocking call returns, then the tick fires);
  *   - the sink fires (that is what writes the audit row for a stall nobody was watching);
- *   - nested phases resolve to the outermost open one, and `phase()` closes on throw;
+ *   - nested phases resolve to the INNERMOST open one — which is what makes it safe to mark a whole
+ *     request as a phase (a timer that blocks while the request awaits is blamed on the timer);
+ *   - `phase()` closes on throw;
  *   - the ring is bounded and reset clears it. */
 const path = require('path');
 const ROOT = path.resolve(__dirname, '..');
@@ -55,7 +57,17 @@ const stalls = () => requestMetrics.snapshot(5).loop.stalls;
   requestMetrics.reset();
   requestMetrics.phase('test:outer', () => requestMetrics.phase('test:inner', () => block(1200)));
   await tick(200);
-  assert(stalls().some((s) => s.phase === 'test:outer'), 'nested phases resolve to the outermost open one', JSON.stringify(stalls()));
+  assert(stalls().some((s) => s.phase === 'test:inner'), 'nested phases resolve to the INNERMOST open one — the code actually holding the loop', JSON.stringify(stalls()));
+
+  // The case that makes it safe to mark a whole REQUEST as a phase: a request parked on an await is
+  // open while a timer blocks inside it, and the timer must take the blame, not the request.
+  requestMetrics.reset();
+  const endRequest = requestMetrics.beginPhase('route:GET /api/whatever');
+  await tick(60);
+  requestMetrics.phase('timer:blocking', () => block(1200));
+  await tick(200);
+  endRequest();
+  assert(stalls().some((s) => s.phase === 'timer:blocking'), 'a timer blocking inside an awaiting request is blamed on the timer', JSON.stringify(stalls()));
 
   requestMetrics.reset();
   let threw = false;

--- a/src/edge/request-metrics.ts
+++ b/src/edge/request-metrics.ts
@@ -35,7 +35,7 @@ const STALL_MS = 1_000;
 /** How many stalls to keep. Small on purpose: this is a lead, not a log. */
 const STALL_RING = 20;
 /** Closed phases kept for attribution — a stall that ends just before the tick still has a suspect. */
-const RECENT_PHASES = 8;
+const RECENT_PHASES = 32;
 
 /** Tools whose duration is a WAIT on something outside this process — a human, a delegate, or a spawned
  *  model — not work this process is doing. They are measured like everything else (hiding them would hide
@@ -180,9 +180,11 @@ export class RequestMetrics {
   private loopHist = new Array(BUCKETS.length).fill(0);
   /** Phases currently open, outermost first. A blocking phase is SYNCHRONOUS, so at most one is open
    *  when the loop is blocked — the stack exists so a nested marker can't orphan its parent. */
-  private openPhases: Array<{ label: string; at: number }> = [];
+  private openPhases: Array<{ label: string; at: number; seq: number }> = [];
+  /** Monotonic begin counter — the tie-break for "innermost" when two phases share a millisecond. */
+  private phaseSeq = 0;
   /** Recently CLOSED phases, newest last — a stall that ended microseconds before the tick that saw it. */
-  private closedPhases: Array<{ label: string; at: number; end: number }> = [];
+  private closedPhases: Array<{ label: string; at: number; end: number; seq: number }> = [];
   private stalls: StallRecord[] = [];
   private stallSink?: (s: StallRecord) => void;
   /** Lag of the most recent loop sample — what a request arriving now was plausibly delayed by. */
@@ -220,7 +222,7 @@ export class RequestMetrics {
    * because it wraps things that run on every request.
    */
   beginPhase(label: string): () => void {
-    const entry = { label, at: Date.now() };
+    const entry = { label, at: Date.now(), seq: ++this.phaseSeq };
     this.openPhases.push(entry);
     let closed = false;
     return () => {
@@ -228,7 +230,7 @@ export class RequestMetrics {
       closed = true;
       const i = this.openPhases.lastIndexOf(entry);
       if (i >= 0) this.openPhases.splice(i, 1);
-      this.closedPhases.push({ label: entry.label, at: entry.at, end: Date.now() });
+      this.closedPhases.push({ label: entry.label, at: entry.at, end: Date.now(), seq: entry.seq });
       if (this.closedPhases.length > RECENT_PHASES) this.closedPhases.shift();
     };
   }
@@ -245,14 +247,29 @@ export class RequestMetrics {
     this.stallSink = sink;
   }
 
-  /** Attribute a blocked interval to the phase that spanned it. An OPEN phase that began before the
-   *  interval is the answer; otherwise the most recent phase that overlapped it; otherwise nothing
-   *  declared itself, which narrows the hunt to code with no marker. */
+  /**
+   * Attribute a blocked interval to the phase that spanned it. The INNERMOST open phase wins, not the
+   * outermost: phases nest by containment (a request is open while it awaits, and a timer that fires
+   * during that await opens INSIDE it), so the newest one is the code actually holding the loop — and
+   * for genuinely nested synchronous work it is also the more specific answer. Failing an open phase,
+   * the most recent one that overlapped the interval (the common case: the blocking call returns, then
+   * the tick fires). Failing both, nothing declared itself — which narrows the hunt to unmarked code.
+   */
   private recordStall(at: number, ms: number): void {
     const end = at + ms;
-    const open = this.openPhases.find((p) => p.at <= end);
-    const overlapping = [...this.closedPhases].reverse().find((p) => p.end >= at && p.at <= end);
-    const rec: StallRecord = { at, ms: Math.round(ms), phase: open?.label ?? overlapping?.label ?? 'unattributed' };
+    // Candidates: every phase that was open at any point inside the blocked interval — still open, or
+    // closed during it (the common case, since the blocking call returns before the tick that sees it).
+    let best: { label: string; seq: number } | undefined;
+    const consider = (p: { label: string; at: number; end?: number; seq: number }) => {
+      if (p.at > end) return;                        // began after the block ended
+      if (p.end !== undefined && p.end < at) return; // ended before it began
+      // Innermost = begun LAST. `seq` rather than `at`, because two nested phases routinely share a
+      // millisecond and a timestamp comparison would then pick by iteration order — i.e. at random.
+      if (!best || p.seq > best.seq) best = { label: p.label, seq: p.seq };
+    };
+    for (const p of this.openPhases) consider(p);
+    for (const p of this.closedPhases) consider(p);
+    const rec: StallRecord = { at, ms: Math.round(ms), phase: best?.label ?? 'unattributed' };
     this.stalls.push(rec);
     if (this.stalls.length > STALL_RING) this.stalls.shift();
     try { this.stallSink?.(rec); } catch { /* a sink must never break the sampler */ }

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import { TenantRegistry, TenantRuntime, notifyLoginLink, notifyInsightAlert } fr
 import { ProcessJanitor } from './edge/process-janitor';
 import { hostMetrics, availableBytes } from './edge/host-metrics';
 import { pruneAuditMirror } from './governance/audit';
-import { requestMetrics } from './edge/request-metrics';
+import { requestMetrics, normalizePath } from './edge/request-metrics';
 import { pendingAlerts } from './edge/alerts';
 import { exampleCapabilities } from './capabilities/examples';
 import { governedCapabilities } from './capabilities/normalize';
@@ -299,7 +299,14 @@ export function createHttpServer(registry: TenantRegistry): http.Server {
     // behind a blocking timer isn't mistaken for a slow route. One counter update, no I/O, no DB write.
     const startedNs = process.hrtime.bigint();
     const arrivalStall = requestMetrics.currentStallMs();
+    // Name the request as a PHASE too, so a stall caused by a handler is attributed to that handler
+    // rather than reading `unattributed`. Safe to hold across the handler's awaits because attribution
+    // takes the INNERMOST open phase: a timer that blocks while this request is parked on an await
+    // opened later, so it — not this route — is named.
+    const endPhase = requestMetrics.beginPhase(`route:${req.method || 'GET'} ${normalizePath((req.url || '/').split('?')[0])}`);
+    res.once('close', endPhase);
     res.once('finish', () => {
+      endPhase();
       const ms = Number(process.hrtime.bigint() - startedNs) / 1e6;
       const pathname = (req.url || '/').split('?')[0];
       requestMetrics.observe(req.method || 'GET', pathname, res.statusCode, ms, arrivalStall);


### PR DESCRIPTION
Follow-up to #764, from its first live catch.

The recorder deployed with #764 caught a stall within five minutes: **1,028 ms, `unattributed`**. Its cause was sitting in the same table — `POST /api/tasks/update`, max 1,117 ms — unnamed only because requests weren't marked as phases.

- every request is now a phase (`route:POST /api/tasks/:id/update`, template-normalized like the timings table);
- attribution picks the **innermost** phase (begun last) rather than the outermost. This is what makes marking a whole request safe: a request parked on an await stays open while a timer blocks *inside* it, and the timer — begun later — takes the blame, not the route;
- "begun last" is a monotonic sequence, not a timestamp: two nested phases routinely share a millisecond, and comparing timestamps then picks by iteration order, i.e. at random. That was a genuinely flaky assertion for one run before the sequence went in.

Both cases are pinned in `scripts/loop-stall-attribution-test.cjs` (nested → innermost; timer-inside-awaiting-request → timer). Full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)