### PR TITLE
fix(metrics): a parked long-poll no longer collects the blame for other code's stalls (v0.414.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.414.3] - 2026-09-02
+### Fixed
+- **A parked long-poll no longer collects the blame for other code's stalls.** The first stall the
+  recorder named on the live tenant was a 1,153 ms block pinned on `POST /api/tasks/wait` — a route whose
+  own handler time never exceeds 20 ms. `task_wait`/`ask` park their request for as long as a human or a
+  delegate takes, so on a busy tenant one is open across every block that happens meanwhile, and being
+  open is not being at fault. Blocking-by-design requests are now marked unattributable, and every stall
+  reports `openMs` — how long the blamed phase had already been open when the block began — so a phase
+  that was merely present is visible as such in Settings → System rather than reading as the culprit.
+
 ## [0.414.2] - 2026-09-02
 ### Fixed
 - **A stall caused by a request now names the request.** The first stall the new recorder caught on the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.414.2",
+  "version": "0.414.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.414.2",
+      "version": "0.414.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.414.2",
+  "version": "0.414.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/loop-stall-attribution-test.cjs
+++ b/scripts/loop-stall-attribution-test.cjs
@@ -77,6 +77,28 @@ const stalls = () => requestMetrics.snapshot(5).loop.stalls;
   assert(threw, 'phase() rethrows');
   assert(!stalls().some((s) => s.phase === 'test:throws') || stalls().every((s) => s.ms > 0), 'a throwing phase is closed, not left open forever');
 
+  // A long-poll (`task_wait`, `ask`) is open across everything on a busy tenant. Being open is not being
+  // at fault: the live recorder's first named stall was pinned on `POST /api/tasks/wait`, whose own
+  // handler never exceeds 20 ms.
+  console.log('\nblocking-by-design phases are never the suspect');
+  requestMetrics.reset();
+  const endWait = requestMetrics.beginPhase('route:POST /api/tasks/wait', { attributable: false });
+  await tick(60);
+  block(1200);
+  await tick(200);
+  endWait();
+  const parked = stalls()[0];
+  assert(parked && parked.phase === 'unattributed', 'an unattributable phase never takes the blame', JSON.stringify(stalls()));
+
+  requestMetrics.reset();
+  const endOpen = requestMetrics.beginPhase('route:GET /api/slow');
+  await tick(400);
+  block(1200);
+  await tick(200);
+  endOpen();
+  const aged = stalls()[0];
+  assert(aged && aged.phase === 'route:GET /api/slow' && aged.openMs >= 300, 'a blamed phase reports how long it had been open — a big openMs means it was merely present', JSON.stringify(stalls()));
+
   console.log('\nbounds');
   requestMetrics.reset();
   for (let i = 0; i < 24; i++) { requestMetrics.phase(`test:ring${i}`, () => block(1010)); await tick(120); }

--- a/src/edge/request-metrics.ts
+++ b/src/edge/request-metrics.ts
@@ -48,6 +48,13 @@ const RECENT_PHASES = 32;
  *  keeps both honest. */
 const BLOCKING_TOOLS = new Set(['ask', 'ask_human', 'ask_agent', 'task_wait', 'session_open:summary']);
 
+/** Is this MCP tool one whose clock is a human/delegate rather than code? Also decides whether its
+ *  request may be BLAMED for an event-loop stall: a request that is parked on a wait is open across
+ *  every block that happens meanwhile, and being open is not being at fault. */
+export function isBlockingTool(tool: string): boolean {
+  return BLOCKING_TOOLS.has(tool);
+}
+
 export interface RouteStat {
   /** `GET /api/sessions/:id` — method + normalized path template. */
   route: string;
@@ -86,6 +93,10 @@ export interface StallRecord {
   at: number;
   /** How long the loop was blocked (ms). */
   ms: number;
+  /** How long the blamed phase had ALREADY been open when the block started. A few ms means the phase
+   *  is almost certainly the cause; many seconds means it was merely open across it (a long-poll), and
+   *  the real blocker is unmarked code running inside that window. */
+  openMs?: number;
   /** The phase open across the stall — `route:GET /api/sessions`, `upkeep:dreaming`, … or `unattributed`
    *  when nothing declared itself (which is itself a finding: the blocker is code with no marker). */
   phase: string;
@@ -180,11 +191,11 @@ export class RequestMetrics {
   private loopHist = new Array(BUCKETS.length).fill(0);
   /** Phases currently open, outermost first. A blocking phase is SYNCHRONOUS, so at most one is open
    *  when the loop is blocked — the stack exists so a nested marker can't orphan its parent. */
-  private openPhases: Array<{ label: string; at: number; seq: number }> = [];
+  private openPhases: Array<{ label: string; at: number; seq: number; attributable: boolean }> = [];
   /** Monotonic begin counter — the tie-break for "innermost" when two phases share a millisecond. */
   private phaseSeq = 0;
   /** Recently CLOSED phases, newest last — a stall that ended microseconds before the tick that saw it. */
-  private closedPhases: Array<{ label: string; at: number; end: number; seq: number }> = [];
+  private closedPhases: Array<{ label: string; at: number; end: number; seq: number; attributable: boolean }> = [];
   private stalls: StallRecord[] = [];
   private stallSink?: (s: StallRecord) => void;
   /** Lag of the most recent loop sample — what a request arriving now was plausibly delayed by. */
@@ -221,8 +232,8 @@ export class RequestMetrics {
    * (or use {@link phase}). Cheap by construction — two array writes, no timers, no allocation per tick —
    * because it wraps things that run on every request.
    */
-  beginPhase(label: string): () => void {
-    const entry = { label, at: Date.now(), seq: ++this.phaseSeq };
+  beginPhase(label: string, opts: { attributable?: boolean } = {}): () => void {
+    const entry = { label, at: Date.now(), seq: ++this.phaseSeq, attributable: opts.attributable !== false };
     this.openPhases.push(entry);
     let closed = false;
     return () => {
@@ -230,7 +241,7 @@ export class RequestMetrics {
       closed = true;
       const i = this.openPhases.lastIndexOf(entry);
       if (i >= 0) this.openPhases.splice(i, 1);
-      this.closedPhases.push({ label: entry.label, at: entry.at, end: Date.now(), seq: entry.seq });
+      this.closedPhases.push({ label: entry.label, at: entry.at, end: Date.now(), seq: entry.seq, attributable: entry.attributable });
       if (this.closedPhases.length > RECENT_PHASES) this.closedPhases.shift();
     };
   }
@@ -259,17 +270,19 @@ export class RequestMetrics {
     const end = at + ms;
     // Candidates: every phase that was open at any point inside the blocked interval — still open, or
     // closed during it (the common case, since the blocking call returns before the tick that sees it).
-    let best: { label: string; seq: number } | undefined;
-    const consider = (p: { label: string; at: number; end?: number; seq: number }) => {
+    let best: { label: string; seq: number; at: number } | undefined;
+    const consider = (p: { label: string; at: number; end?: number; seq: number; attributable: boolean }) => {
+      if (!p.attributable) return;                   // a long-poll that is merely OPEN, not running
       if (p.at > end) return;                        // began after the block ended
       if (p.end !== undefined && p.end < at) return; // ended before it began
       // Innermost = begun LAST. `seq` rather than `at`, because two nested phases routinely share a
       // millisecond and a timestamp comparison would then pick by iteration order — i.e. at random.
-      if (!best || p.seq > best.seq) best = { label: p.label, seq: p.seq };
+      if (!best || p.seq > best.seq) best = { label: p.label, seq: p.seq, at: p.at };
     };
     for (const p of this.openPhases) consider(p);
     for (const p of this.closedPhases) consider(p);
     const rec: StallRecord = { at, ms: Math.round(ms), phase: best?.label ?? 'unattributed' };
+    if (best) rec.openMs = Math.max(0, at - best.at);
     this.stalls.push(rec);
     if (this.stalls.length > STALL_RING) this.stalls.shift();
     try { this.stallSink?.(rec); } catch { /* a sink must never break the sampler */ }

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ import { TenantRegistry, TenantRuntime, notifyLoginLink, notifyInsightAlert } fr
 import { ProcessJanitor } from './edge/process-janitor';
 import { hostMetrics, availableBytes } from './edge/host-metrics';
 import { pruneAuditMirror } from './governance/audit';
-import { requestMetrics, normalizePath } from './edge/request-metrics';
+import { requestMetrics, normalizePath, isBlockingTool } from './edge/request-metrics';
 import { pendingAlerts } from './edge/alerts';
 import { exampleCapabilities } from './capabilities/examples';
 import { governedCapabilities } from './capabilities/normalize';
@@ -303,7 +303,16 @@ export function createHttpServer(registry: TenantRegistry): http.Server {
     // rather than reading `unattributed`. Safe to hold across the handler's awaits because attribution
     // takes the INNERMOST open phase: a timer that blocks while this request is parked on an await
     // opened later, so it — not this route — is named.
-    const endPhase = requestMetrics.beginPhase(`route:${req.method || 'GET'} ${normalizePath((req.url || '/').split('?')[0])}`);
+    // A tool that BLOCKS by design (`task_wait`, `ask`, …) parks its request for as long as a human or a
+    // delegate takes, so it is open across everything — and being open is not being at fault. It is marked
+    // unattributable, or it would collect the blame for every stall on a busy tenant purely by being there.
+    // Live proof: the first named stall after this shipped was a 1,153 ms block pinned on
+    // `POST /api/tasks/wait`, whose own handler time never exceeds 20 ms.
+    const reqTool = String(req.headers['x-aos-tool'] || '').trim();
+    const endPhase = requestMetrics.beginPhase(
+      `route:${req.method || 'GET'} ${normalizePath((req.url || '/').split('?')[0])}`,
+      { attributable: !isBlockingTool(reqTool) },
+    );
     res.once('close', endPhase);
     res.once('finish', () => {
       endPhase();

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16432,7 +16432,7 @@ function EndpointTimingsPanel() {
                     {snap.loop.stalls.slice(0, 6).map((st) => (
                       <tr key={`${st.at}-${st.phase}`} className="border-t first:border-t-0">
                         <td className="py-1 pr-3 font-medium tabular-nums text-red-500">{ms(st.ms)}</td>
-                        <td className="py-1 pr-3 font-mono">{st.phase}</td>
+                        <td className="py-1 pr-3 font-mono">{st.phase}{st.openMs != null && st.openMs > 2000 && <span className="ml-1 text-muted-foreground" title="the phase was already open this long when the block began — it was probably present, not guilty">(open {ms(st.openMs)} first)</span>}</td>
                         <td className="py-1 text-right text-muted-foreground">{new Date(st.at).toLocaleTimeString()}</td>
                       </tr>
                     ))}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -248,6 +248,9 @@ export interface RequestMetricsSnapshot {
 export interface StallRecord {
   at: number
   ms: number
+  /** How long the blamed phase had already been open when the block began — a big number means it was
+   *  merely open across the stall (a long-poll), not the thing running. */
+  openMs?: number
   /** `upkeep:auditRetention`, `automations:tick`, `spawn:git fetch`, … or `unattributed`. */
   phase: string
 }


### PR DESCRIPTION
Second correction from live data, and the reason it's worth shipping rather than shrugging at: the attribution was confidently wrong.

The first stall #765 named on the live instawp tenant was **1,153 ms on `POST /api/tasks/wait`** — a route whose own handler time, in the same table, never exceeds **20 ms**. `task_wait` and `ask` park their request for as long as a human or a delegate takes (that is why they're already flagged `blocking` in the tools table), and at 177 requests/min one of them is open across essentially every block that happens. Being open is not being at fault.

- blocking-by-design requests are marked **unattributable** — they can never be the suspect;
- every stall now carries **`openMs`**: how long the blamed phase had already been open when the block began. A few ms means the phase is the cause; many seconds means it was present, not guilty. The console shows it as `(open 8.0s first)` beside the phase.

Pinned in `scripts/loop-stall-attribution-test.cjs`. Full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)