### PR TITLE
chore(metrics): name the three synchronous steps behind the last loop-blocking route (v0.414.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.414.7] - 2026-09-02
+### Added
+- **Named the three synchronous steps behind the one route that still blocks the loop.** With the
+  recorder running for an hour, `POST /api/tasks/update` is the only remaining loop-blocker on the live
+  tenant — three stalls of 1.00–1.05 s, each with an `openMs` of 44–87 ms, i.e. the phase had just begun
+  when the block started, so it IS the cause (unlike the parked `task_wait` false positive #766 fixed).
+  Its own store call is 0.5–1.5 ms measured against a copy of the live DB, so the second is spent
+  somewhere else on that path: the audit sink (`audit:append` — a SQLite insert plus an `appendFileSync`
+  per run file, on the path of every governed action), the task store write (`task:update.store`) or the
+  Inbox card the notifier writes inline (`task:notify.card`). All three now name themselves, so the next
+  occurrence says which — rather than another round of reading code and guessing.
+
 ## [0.414.6] - 2026-09-02
 ### Added
 - **Per-agent MCP tool-usage counters — the read tools are finally visible.** The `mcp__agentos__*` tools

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.414.6",
+  "version": "0.414.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.414.6",
+      "version": "0.414.7",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.414.6",
+  "version": "0.414.7",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/src/governance/audit.ts
+++ b/src/governance/audit.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { AuditEvent, AuditSink } from '../types';
 import { Db } from '../state/db';
+import { requestMetrics } from '../edge/request-metrics';
 
 /** Keeps events in memory — handy for tests, demos, and the Console to read back. */
 export class InMemoryAuditSink implements AuditSink {
@@ -94,6 +95,9 @@ export function pruneAuditMirror(db: Db, days: number, now = Date.now(), limit =
 export class TeeAuditSink implements AuditSink {
   constructor(private readonly sinks: AuditSink[]) {}
   append(event: AuditEvent): void {
-    for (const s of this.sinks) s.append(event);
+    // NAMED for the loop-stall recorder: every sink here is synchronous (a SQLite insert, an
+    // `appendFileSync` per run file), this runs on the path of every governed action, and an unnamed
+    // block is exactly what the 156-second stall hunt could not attribute. Two array writes per event.
+    requestMetrics.phase('audit:append', () => { for (const s of this.sinks) s.append(event); });
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1958,7 +1958,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
         error: 'Say what this is blocked on: call task_update again with blockedOn:"human" (only a person can decide or approve), "agent" (another agent owes you something) or "external" (a third party, build or vendor). It decides who gets woken — "human" alerts the task owner instead of resuming the agent that handed you this.',
       });
     }
-    const task = os.tasks.update(id, {
+    const task = requestMetrics.phase('task:update.store', () => os.tasks.update(id, {
       status: typeof b.status === 'string' ? (b.status as TaskStatus) : undefined,
       assignee: b.assignee === null ? null : (b.assignee === 'me' ? `agent:${agent}` : (typeof b.assignee === 'string' ? b.assignee : undefined)),
       priority: typeof b.priority === 'number' ? b.priority : undefined,
@@ -1973,7 +1973,7 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       blockedOn: b.blockedOn === null ? null : (TASK_BLOCKED_ON as readonly string[]).includes(String(b.blockedOn)) ? (b.blockedOn as TaskBlockedOn) : undefined,
       note: typeof b.note === 'string' ? b.note : undefined,
       by: `agent:${agent}`,
-    });
+    }));
     if (!task) return sendJson(res, 200, { ok: false, error: 'task not found' });
     os.audit.append({ ts: Date.now(), runId: session, tenant: os.tenant, principal: `agent:${agent}`, type: task.status === 'done' ? 'task.completed' : 'task.updated', data: { id: task.id, status: task.status } });
     return sendJson(res, 200, { ok: true, task });

--- a/src/tenant-registry.ts
+++ b/src/tenant-registry.ts
@@ -30,6 +30,7 @@ import { Audience, approvalAudience, resolveRecipients } from './governance/reci
 import { ChatPlatform, chatLink, consolePage } from './governance/chat-links';
 import { controlHome, resolvePaths, resolveTenantPaths } from './home';
 import { TenantRecord, TenantStore } from './state/control';
+import { requestMetrics } from './edge/request-metrics';
 
 export interface TenantRuntime {
   record: TenantRecord;
@@ -537,7 +538,8 @@ export async function notifyTaskEvent(os: AgentOS, tm: Pick<TerminalManager, 'po
   if (!recipients.length) return;
   const t = notice.task;
   const agentLabel = t.assignee?.startsWith('agent:') ? t.assignee.slice('agent:'.length) : 'tasks';
-  tm.postTaskCard({ taskId: t.id, agent: agentLabel, title: card.title, body: t.title, audience: card.audience, event: card.event });
+  requestMetrics.phase('task:notify.card', () =>
+    tm.postTaskCard({ taskId: t.id, agent: agentLabel, title: card.title, body: t.title, audience: card.audience, event: card.event }));
   // Deep-link straight to the task's permalink (`#/tasks/<id>`), so the DM is one tap from the board.
   const url = consolePage(consoleOrigin, 'tasks', t.id);
   const text = (p: ChatPlatform) => `📋 ${card.title} — \`${t.title}\` (${t.id}).\nOpen it in the ${chatLink(p, url, 'Agentric console')}.`;


### PR DESCRIPTION
An hour of the stall recorder (#764–#766) on the live instawp tenant leaves exactly **one** loop-blocker:

```
1052 ms  route:POST /api/tasks/update  openMs=44
1040 ms  route:POST /api/tasks/update  openMs=46
1009 ms  route:POST /api/tasks/update  openMs=87
```

The small `openMs` is what makes this real rather than another false positive: the phase had been open only ~50 ms when the block began, so it *is* the thing running — unlike the parked `task_wait` that #766 stopped blaming.

Its own store call measures **0.5–1.5 ms** against a copy of the live DB (`TaskStore.update`, `task_events` insert, FTS, `latestNote` — all sub-millisecond), so the second is spent elsewhere on that path. Rather than read the code and guess a fourth time, the three synchronous candidates now name themselves:

- `audit:append` — the tee sink: a SQLite insert plus `mkdirSync` + `appendFileSync` into a per-run JSONL. On the path of **every governed action**, so if this is it, the finding is much bigger than one route.
- `task:update.store` — the store write itself.
- `task:notify.card` — the Inbox card the task notifier writes inline before it awaits the DM.

Instrumentation only; no behaviour change. Two array writes and a `Date.now()` per marked call.

Full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)