### PR TITLE
fix(memory): a janitor-reaped session is remembered (v0.414.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.414.8] - 2026-09-03
+### Fixed
+- **A session reaped by the idle-interactive janitor is now remembered.** Every other teardown path writes
+  an episode — `markEnded` (normal end, and `teardownUnattended` through it), `markCrashed`, and
+  `stopSession`, the human kill button. The janitor did its own teardown and skipped it, so an abandoned
+  interactive session simply evaporated. Over 30 days: **3 of 29** janitor-reaped sessions on instapods
+  and **18 of 136** on instawp had an episode, and those came from a `report` earlier in the run, not from
+  the reap — ~144 sessions closed with nothing kept. The `max-lifetime` ceiling added in v0.410.5 inherited
+  the same gap.
+
+  **The point is not recall value.** These runs never filed a `report`, so they take the audit branch and
+  read *"Task: … / Outcome: stopped / Activity: 315 governed actions"* — and episodes are already excluded
+  from launch preambles. The point is that episodes are what **Dreaming and the consolidator read**, and
+  they were seeing only sessions that ended tidily. Every abandoned interactive run was invisible to topic
+  extraction — and those carry the fleet's human-initiated work (*"How are we doing marketing-wise"*,
+  *"give me the top gainers of the past 10 days"*). A biased sample is worse than a thin one. Volume is
+  ~5/day across both tenants, already covered by dedupe and prune.
+- **A deleted session no longer produces a phantom episode.** Audit events outlive the row (the log is
+  append-only), so composing from them alone wrote an episode with no task line, attributed to an agent
+  that can no longer be named. `writeEpisode` now returns when the session row is gone. Seen live on
+  instawp: one janitor-reaped run whose row had been deleted mid-flight, its activity list still carrying
+  `session.deleted`.
+
 ## [0.414.7] - 2026-09-02
 ### Added
 - **Named the three synchronous steps behind the one route that still blocks the loop.** With the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.414.7",
+  "version": "0.414.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.414.7",
+      "version": "0.414.8",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.414.7",
+  "version": "0.414.8",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/idle-reaper-test.cjs
+++ b/scripts/idle-reaper-test.cjs
@@ -335,6 +335,51 @@ tm.reapIdleSessions();
 assert(aos.db.prepare("SELECT COUNT(*) c FROM audit_events WHERE type='session.restored'").get().c === before, 'a second sweep restores nothing again');
 assert(!killed.includes('aos-CRASH-ZOMBIE'), '…and does not re-kill the already-reaped zombie (its pane is gone now)');
 
-console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}IDLE REAPER: ${pass}/${pass + fail} passed\x1b[0m`);
-try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
-process.exit(fail === 0 ? 0 : 1);
+// Runs LAST and async, because writeEpisode stores through the memory provider — a promise that audits
+// in `.then()` — so its record lands a tick after the sweep returns. Everything above is synchronous.
+(async () => {
+  const settle = () => new Promise((r) => setImmediate(() => setImmediate(() => setTimeout(r, 40))));
+
+  console.log('\n\x1b[1m9) a janitor-reaped session is REMEMBERED\x1b[0m');
+  // Every OTHER teardown path writes an episode — markEnded (normal end, and teardownUnattended through
+  // it), markCrashed, and stopSession (the human kill button). The idle-interactive janitor did its own
+  // teardown and skipped it, so an abandoned interactive session evaporated. Measured over 30 days
+  // before this: 3 of 29 reaped sessions on instapods and 18 of 136 on instawp had an episode, and those
+  // came from a `report` earlier in the run, not from the reap. Episodes are what Dreaming and the
+  // consolidator read, so the learning loop was seeing only sessions that ended tidily.
+  aos.settings.setInteractiveIdleTimeoutHours(48);
+  aos.settings.setInteractiveMaxHours(0);
+  aos.settings.setClaimedMaxHours(72);
+  aos.settings.setBlockedMaxHours(72);
+  // Restore the file's default liveness stub. Section 8 replaces it to exercise crash detection, and
+  // sweep 0 runs FIRST — leaving it in place marks these rows `crashed` before the idle sweep sees them,
+  // and markCrashed would write the episode instead, so the test would pass without exercising the fix.
+  tm.backend.aliveNames = () => new Set(aos.db.prepare('SELECT tmux FROM term_sessions').all().map((r) => r.tmux));
+
+  const worked = mkSession({ created_at: Date.now() - 100 * H, task: 'How are we doing marketing-wise for InstaPods?' });
+  for (let i = 0; i < 3; i++) aos.audit.append({ ts: Date.now(), runId: worked, tenant: aos.tenant, principal: 'caller', type: 'gate.decision', data: '{}' });
+  tm.reapIdleSessions();
+  assert(statusOf(worked) === 'stopped', 'the idle session is still reaped');
+  await settle();
+  const ep = aos.db.prepare("SELECT COUNT(*) n FROM audit_events WHERE run_id=? AND type='episode.stored'").get(worked).n;
+  assert(ep === 1, 'and its run is remembered — an episode is written before the pane dies', `got ${ep}`);
+  // Match THIS session's own task text, not "the newest memory" — that would pass on one an earlier
+  // section happened to write.
+  const mem = aos.db.prepare("SELECT content FROM memories WHERE tenant=? AND content LIKE '%marketing-wise%' LIMIT 1").get(aos.tenant);
+  assert(mem && /Outcome: stopped/.test(mem.content), 'the episode records that it was stopped, not that it succeeded', mem && mem.content.slice(0, 90));
+
+  // A DELETED session leaves its audit events behind (the log is append-only) but has no row. Composing
+  // from those alone would write a task-less episode attributed to an agent we can no longer name.
+  const ghost = mkSession({ created_at: Date.now() - 100 * H });
+  aos.audit.append({ ts: Date.now(), runId: ghost, tenant: aos.tenant, principal: 'caller', type: 'gate.decision', data: '{}' });
+  aos.db.prepare('DELETE FROM term_sessions WHERE id = ?').run(ghost);
+  const before = aos.db.prepare('SELECT COUNT(*) n FROM memories WHERE tenant=?').get(aos.tenant).n;
+  tm.reapIdleSessions();
+  await settle();
+  const after = aos.db.prepare('SELECT COUNT(*) n FROM memories WHERE tenant=?').get(aos.tenant).n;
+  assert(after === before, 'a deleted session writes no episode — junk addressed to nobody', `${before} -> ${after}`);
+
+  console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}IDLE REAPER: ${pass}/${pass + fail} passed\x1b[0m`);
+  try { fs.rmSync(HOME, { recursive: true, force: true }); } catch {}
+  process.exit(fail === 0 ? 0 : 1);
+})();

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -3515,6 +3515,20 @@ export class TerminalManager {
             if (!overLifetime && (blockedCutoff == null || blockedAt >= blockedCutoff)) continue;
             if (!overLifetime) reason = 'blocked-timeout';
           }
+          // Remember the run before killing it. Every OTHER teardown path writes an episode —
+          // `markEnded` (normal end, and `teardownUnattended` through it), `markCrashed`, and
+          // `stopSession` (the human kill button) — but this janitor did its own teardown and skipped it,
+          // so an abandoned interactive session evaporated. Measured over 30 days: 3 of 29 reaped
+          // sessions on instapods and 18 of 136 on instawp had an episode, and those came from a `report`
+          // earlier in the run, not from the reap.
+          //
+          // The point is NOT recall value — these take the audit branch (no `report` was ever filed), so
+          // they read "Task: … / Outcome: stopped / Activity: 315 governed actions". It is that episodes
+          // are what Dreaming and the consolidator READ, and they were seeing only sessions that ended
+          // tidily. Every abandoned interactive run — and those carry the fleet's human-initiated work,
+          // "How are we doing marketing-wise", "give me the top gainers of the past 10 days" — was
+          // invisible to topic extraction. A biased sample is worse than a thin one.
+          this.writeEpisode(r.id, r.agent, terminal ? undefined : 'stopped');
           this.backend.kill(space, r.tmux);
           // Preserve a completed session's outcome — only a still-running one becomes 'stopped'.
           this.db.prepare("UPDATE term_sessions SET status = ?, busy_since = NULL, updated_at = ? WHERE id = ?").run(terminal ? r.status : 'stopped', Date.now(), r.id);
@@ -7596,7 +7610,13 @@ export class TerminalManager {
   private writeEpisode(sessionId: string, agent: string, outcomeOverride?: string): void {
     if (this.episoded.has(sessionId)) return;
     if (this.db.prepare("SELECT 1 FROM audit_events WHERE run_id = ? AND type = 'episode.stored'").get(sessionId)) return;
-    const task = this.db.prepare('SELECT task FROM term_sessions WHERE id = ?').get<{ task: string }>(sessionId)?.task ?? '';
+    // A DELETED session has no row. Its audit events survive (the log is append-only), so composing from
+    // them would write an episode with no task line, attributed to an agent we can no longer name — junk
+    // addressed to nobody. Seen live on instawp: one janitor-reaped run whose row had been deleted
+    // mid-flight, whose activity list still carried `session.deleted`.
+    const row = this.db.prepare('SELECT task FROM term_sessions WHERE id = ?').get<{ task: string }>(sessionId);
+    if (!row) return;
+    const task = row.task ?? '';
     const report = this.db.prepare("SELECT outcome, body FROM messages WHERE session_id = ? AND type = 'completed' ORDER BY created_at DESC LIMIT 1").get<{ outcome: string | null; body: string }>(sessionId);
     const events = this.db.prepare('SELECT type, data FROM audit_events WHERE run_id = ? ORDER BY ts').all<{ type: string; data: string }>(sessionId);
     const ep = composeEpisode(task, report, events, outcomeOverride);


### PR DESCRIPTION
Answering "does a stopped or reaped session collect memory?" — human stops yes, the janitor no.

| teardown path | writes an episode? | 30 days |
|---|---|---|
| human stop (`stopSession`) | ✅ | 108/108 · 358/360 |
| turn-end / done-orphan / idle-backstop | ✅ | via `markEnded` |
| crash | ✅ | via `markCrashed` |
| **idle-interactive janitor** | ❌ | **3 of 29** · **18 of 136** |
| **claimed-abandoned / blocked-timeout** | ❌ | 1 of 3 · 1 of 6 |

The janitor did its own teardown — `backend.kill` → `UPDATE status` → cancel → audit — and never called `markEnded`. **~144 sessions closed in 30 days with nothing kept.** The `max-lifetime` ceiling from v0.410.5 inherited the same gap.

## Why this is worth fixing — and why it isn't what it looks like

I checked what those episodes would actually say before changing anything. All 156 would write something; none would be empty. But they never filed a `report`, so they take the audit branch:

```
Task: Package https://github.com/trycompai/crm as a 1-Click app — research…
Outcome: stopped
Activity: 315 governed actions, 3 kb.written, 3 facts remembered, 1 lesson.
```

That is **not** valuable recall — and episodes are already excluded from launch preambles (v0.400.0). Many of these runs had also already called `remember`/`kb_write`, so the agent's deliberate knowledge survived regardless.

**The real argument is bias.** Episodes are what Dreaming and the consolidator read, and they were seeing only sessions that ended tidily. Every abandoned interactive run was invisible to topic extraction — and those carry the fleet's human-initiated work:

> *"How are we doing marketing-wise for InstaPods?"* · *"give me the top gainers of the past 10 days"* · *"In this doc … we haven't covered"*

A biased sample is worse than a thin one. Volume is ~5/day across both tenants, already covered by dedupe and prune.

## Also: no phantom episodes for deleted sessions

Audit events outlive the row (append-only log), so composing from them alone wrote an episode with **no task line, attributed to an agent that no longer exists**. `writeEpisode` now returns when the row is gone. Seen live on instawp — one janitor-reaped run whose row had been deleted mid-flight, its activity still carrying `session.deleted`.

## Test

Two things about it worth stating, because both would have produced a green test that proved nothing:

- It runs **last and async** — `writeEpisode` stores through the memory provider and audits in `.then()`, so asserting synchronously passed or failed on timing.
- It **restores the file's default liveness stub** first. Section 8 replaces it to exercise crash detection, and sweep 0 runs before the idle sweep — leaving it marked the row `crashed`, so `markCrashed` wrote the episode and the assertion passed without touching the new code. Caught because the outcome read `crashed` instead of `stopped`.

```
✓ the idle session is still reaped
✓ and its run is remembered — an episode is written before the pane dies
✓ the episode records that it was stopped, not that it succeeded
✓ a deleted session writes no episode — junk addressed to nobody
```

2 fail on the previous code. 69/69 in the file, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)