### PR TITLE
perf(tests): governance suite 88s → 40s by not sleeping through it (v0.415.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.415.2] - 2026-09-03
+### Changed
+- **The governance suite runs in 40s instead of 88s.** Three of its 88 scripts were 61s of the total, all
+  of it real sleeping: `loop-stall-attribution` blocked the event loop for 1.2s some thirty times to cross
+  a hardcoded 1000ms stall threshold (39s), `attach-grace` aged tmux panes against `attach.sh`'s 0.25s
+  poll tick (12.7s), and `opencode-gate` sat out the plugin's 1s approval beat and 2s gate backoff (9.1s).
+  Each of those three constants is now env-overridable — `AOS_STALL_MS`, `AOS_ATTACH_TICK_S` /
+  `AOS_ATTACH_FLOOR_TICKS` / `AOS_ATTACH_CEILING_TICKS`, `AOS_GATE_POLL_MS` — and the tests set small
+  values, scaling their own waits by the same factor. Production sets none of them and its timing is
+  unchanged. What each test proves is threshold-independent (a block that CROSSES the line; a pane that
+  lands past the floor in ticks), so the shortened runs are the same proofs. Deliberately left alone:
+  `loopOverSecond`, a reported metric whose meaning IS its one-second threshold, and gate-hook.sh's twin
+  poll loop, which counts in whole seconds with shell arithmetic. Verified over three consecutive runs of
+  all three scripts with no flakes. Combined with v0.415.1, a steady-state 3-target deploy goes from ~314s
+  to well under a minute of build-and-test.
+
 ## [0.415.1] - 2026-09-03
 ### Changed
 - **`make-live.sh` builds every checkout in parallel and runs the governance suite once per commit.** A

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.415.1",
+  "version": "0.415.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.415.1",
+      "version": "0.415.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.415.1",
+  "version": "0.415.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/attach-grace-test.cjs
+++ b/scripts/attach-grace-test.cjs
@@ -66,6 +66,15 @@ const runAttach = (name) =>
     p.on('close', () => resolve({ err, ms: Date.now() - t0 }));
   });
 
+// attach.sh polls on a fixed tick, and this test has to age a pane past its floor in REAL time — at the
+// shipped 0.25s tick that was 12.7s of every deploy spent sleeping. Run the script on a 5x faster tick
+// and scale every wait here by the same factor: the floor (12 ticks) and ceiling (480 ticks) are
+// unchanged in TICKS, so what's under test — "follow the marker, not a fixed guess" — is identical.
+const TICK_S = 0.05;
+const SCALE = TICK_S / 0.25;
+const ms = (shipped) => Math.round(shipped * SCALE); // a duration expressed in shipped-tick terms
+process.env.AOS_ATTACH_TICK_S = String(TICK_S);
+
 const marker = (id) => path.join(dir, `session-${id}.launching`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const fail = (msg) => { console.error('FAIL ' + msg); cleanup(); process.exit(1); };
@@ -75,30 +84,30 @@ const fail = (msg) => { console.error('FAIL ' + msg); cleanup(); process.exit(1)
   const slow = 'ses_slowlaunch';
   fs.writeFileSync(marker(slow), '');
   const slowRun = runAttach('aos-' + slow);
-  await sleep(6000);
+  await sleep(ms(6000));
   spawnSync('tmux', ['-S', sock, 'new-session', '-d', '-s', 'aos-' + slow, 'sleep', '60'], { stdio: 'ignore' });
   fs.rmSync(marker(slow), { force: true }); // the server clears it once the pane exists
   const r1 = await slowRun;
   if (GONE.test(r1.err)) fail(`slow launch surfaced tmux's "can't find session" — the 13s-spawn bug is back:\n${r1.err.trim()}`);
   if (!NO_TTY.test(r1.err)) fail(`slow launch did not reach the pane (expected a no-tty attach failure), got:\n${r1.err.trim()}`);
-  if (r1.ms < 6000) fail(`slow launch returned in ${r1.ms}ms — it cannot have waited for a +6s pane`);
-  console.log(`  ok  slow launch (+6s pane) attaches after ${(r1.ms / 1000).toFixed(1)}s — no "can't find session"`);
+  if (r1.ms < ms(6000)) fail(`slow launch returned in ${r1.ms}ms — it cannot have waited for a +6s pane`);
+  console.log(`  ok  slow launch (pane at +6s in shipped ticks) attaches after ${(r1.ms / 1000).toFixed(1)}s — no "can't find session"`);
 
   // ---- 2. No marker, no pane: still a prompt ~3s give-up, so a dead session can't hang. ----------
   const r2 = await runAttach('aos-ses_neverexisted');
   if (!GONE.test(r2.err)) fail(`a genuinely dead session should end in tmux's not-found, got:\n${r2.err.trim()}`);
-  if (r2.ms > 6000) fail(`no-marker give-up took ${r2.ms}ms — the ~3s floor regressed into a long hang`);
+  if (r2.ms > ms(6000)) fail(`no-marker give-up took ${r2.ms}ms — the ~3s floor regressed into a long hang`);
   console.log(`  ok  no marker → gives up in ${(r2.ms / 1000).toFixed(1)}s (floor intact)`);
 
   // ---- 3. Failed launch: marker cleared, pane never came. Must not sit out the ceiling. ----------
   const bad = 'ses_launchfailed';
   fs.writeFileSync(marker(bad), '');
   const badRun = runAttach('aos-' + bad);
-  await sleep(2000);
+  await sleep(ms(2000));
   fs.rmSync(marker(bad), { force: true }); // launchAgentRuntime's `finally` — released on failure too
   const r3 = await badRun;
   if (!GONE.test(r3.err)) fail(`a failed launch should end in tmux's not-found, got:\n${r3.err.trim()}`);
-  if (r3.ms > 15000) fail(`failed launch waited ${r3.ms}ms — it sat toward the 120s ceiling instead of following the marker`);
+  if (r3.ms > ms(15000)) fail(`failed launch waited ${r3.ms}ms — it sat toward the 120s ceiling instead of following the marker`);
   console.log(`  ok  failed launch → releases in ${(r3.ms / 1000).toFixed(1)}s (follows the marker, not the ceiling)`);
 
   cleanup();

--- a/scripts/loop-stall-attribution-test.cjs
+++ b/scripts/loop-stall-attribution-test.cjs
@@ -23,6 +23,14 @@ const ROOT = path.resolve(__dirname, '..');
 let pass = 0, fail = 0;
 const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${name}`)) : (fail++, console.log(`  \x1b[31m✗ ${name}\x1b[0m${d ? ' — ' + d : ''}`));
 
+// Shrink the stall threshold before the module is loaded (STALL_MS is read once, at import). The
+// attribution logic under test is threshold-independent — it just needs a block that CROSSES the line
+// — so proving it at 100ms is the same proof as at the shipped 1s, and takes a tenth as long. This
+// file used to be 39s of a 87s governance suite, all of it spent blocking on purpose.
+const STALL = 100;
+const BLOCK = STALL + 50; // comfortably over, with room for timer jitter on a loaded box
+process.env.AOS_STALL_MS = String(STALL);
+
 const { requestMetrics } = require(path.join(ROOT, 'dist/edge/request-metrics.js'));
 
 const block = (ms) => { const t = Date.now(); while (Date.now() - t < ms) { /* hold the loop */ } };
@@ -35,27 +43,27 @@ const stalls = () => requestMetrics.snapshot(5).loop.stalls;
   requestMetrics.start(50);
 
   console.log('\nattribution');
-  requestMetrics.phase('test:namedBlock', () => block(1200));
+  requestMetrics.phase('test:namedBlock', () => block(BLOCK));
   await tick(200);
   const named = stalls().find((s) => s.phase === 'test:namedBlock');
-  assert(!!named && named.ms >= 1000, 'a block inside a named phase is attributed to it', JSON.stringify(stalls()));
+  assert(!!named && named.ms >= STALL, 'a block inside a named phase is attributed to it', JSON.stringify(stalls()));
   assert(seen.some((s) => s.phase === 'test:namedBlock'), 'the sink fires for it (this is what writes the audit row)');
 
   requestMetrics.reset();
-  block(1200);
+  block(BLOCK);
   await tick(200);
   assert(stalls().some((s) => s.phase === 'unattributed'), 'a block with nothing declared reads unattributed', JSON.stringify(stalls()));
 
   requestMetrics.reset();
   const done = requestMetrics.beginPhase('test:closedBeforeTick');
-  block(1200);
+  block(BLOCK);
   done();                        // the blocking call returns BEFORE the sampler gets to run
   await tick(200);
   assert(stalls().some((s) => s.phase === 'test:closedBeforeTick'), 'a phase closed just before the tick still gets the blame', JSON.stringify(stalls()));
 
   console.log('\nphase bookkeeping');
   requestMetrics.reset();
-  requestMetrics.phase('test:outer', () => requestMetrics.phase('test:inner', () => block(1200)));
+  requestMetrics.phase('test:outer', () => requestMetrics.phase('test:inner', () => block(BLOCK)));
   await tick(200);
   assert(stalls().some((s) => s.phase === 'test:inner'), 'nested phases resolve to the INNERMOST open one — the code actually holding the loop', JSON.stringify(stalls()));
 
@@ -64,7 +72,7 @@ const stalls = () => requestMetrics.snapshot(5).loop.stalls;
   requestMetrics.reset();
   const endRequest = requestMetrics.beginPhase('route:GET /api/whatever');
   await tick(60);
-  requestMetrics.phase('timer:blocking', () => block(1200));
+  requestMetrics.phase('timer:blocking', () => block(BLOCK));
   await tick(200);
   endRequest();
   assert(stalls().some((s) => s.phase === 'timer:blocking'), 'a timer blocking inside an awaiting request is blamed on the timer', JSON.stringify(stalls()));
@@ -72,7 +80,7 @@ const stalls = () => requestMetrics.snapshot(5).loop.stalls;
   requestMetrics.reset();
   let threw = false;
   try { requestMetrics.phase('test:throws', () => { throw new Error('boom'); }); } catch { threw = true; }
-  block(1200);
+  block(BLOCK);
   await tick(200);
   assert(threw, 'phase() rethrows');
   assert(!stalls().some((s) => s.phase === 'test:throws') || stalls().every((s) => s.ms > 0), 'a throwing phase is closed, not left open forever');
@@ -84,7 +92,7 @@ const stalls = () => requestMetrics.snapshot(5).loop.stalls;
   requestMetrics.reset();
   const endWait = requestMetrics.beginPhase('route:POST /api/tasks/wait', { attributable: false });
   await tick(60);
-  block(1200);
+  block(BLOCK);
   await tick(200);
   endWait();
   const parked = stalls()[0];
@@ -93,7 +101,7 @@ const stalls = () => requestMetrics.snapshot(5).loop.stalls;
   requestMetrics.reset();
   const endOpen = requestMetrics.beginPhase('route:GET /api/slow');
   await tick(400);
-  block(1200);
+  block(BLOCK);
   await tick(200);
   endOpen();
   const aged = stalls()[0];
@@ -101,7 +109,7 @@ const stalls = () => requestMetrics.snapshot(5).loop.stalls;
 
   console.log('\nbounds');
   requestMetrics.reset();
-  for (let i = 0; i < 24; i++) { requestMetrics.phase(`test:ring${i}`, () => block(1010)); await tick(120); }
+  for (let i = 0; i < 24; i++) { requestMetrics.phase(`test:ring${i}`, () => block(BLOCK)); await tick(120); }
   assert(stalls().length <= 20, 'the ring is bounded', String(stalls().length));
   requestMetrics.reset();
   assert(stalls().length === 0, 'reset clears the ring');

--- a/scripts/opencode-gate-test.cjs
+++ b/scripts/opencode-gate-test.cjs
@@ -41,6 +41,9 @@ async function load({ unattended = false, responses = [], statuses = [] } = {}) 
   process.env.AOS_TENANT = 'acme';
   process.env.UNATTENDED = unattended ? '1' : '';
   process.env.AOS_UNATTENDED_APPROVAL_WAIT_S = '2';
+  // The plugin polls the gate on a 1s beat and backs off 2s on an unreachable one, so the fail-closed
+  // cases here sat in real sleeps for 9.1s of every deploy. Shorten the beat, not the behaviour.
+  process.env.AOS_GATE_POLL_MS = '50';
   const calls = { classify: 0, status: 0, reported: [] };
   globalThis.fetch = async (url, init) => {
     const u = String(url);

--- a/src/edge/request-metrics.ts
+++ b/src/edge/request-metrics.ts
@@ -30,8 +30,13 @@ const BUCKETS = [1, 2, 5, 10, 25, 50, 100, 250, 500, 1_000, 2_500, 5_000, 10_000
 /** How many distinct route templates to track before lumping the rest into `other`. */
 const MAX_ROUTES = 300;
 
-/** Lag at or above which a tick is recorded as a STALL (with its phase) rather than just binned. */
-const STALL_MS = 1_000;
+/** Lag at or above which a tick is recorded as a STALL (with its phase) rather than just binned.
+ *  Overridable ONLY so the suite can prove this machinery without sleeping through it: attribution
+ *  behaves identically at 100ms and at 1s, but a test that blocks the loop for 1.2s some thirty times
+ *  spent 39s of every deploy — 45% of the whole governance suite — doing nothing. Production never
+ *  sets it; `loopOverSecond` below stays pinned to a literal second, since that one is a REPORTED
+ *  metric whose meaning is its threshold. */
+const STALL_MS = Number(process.env.AOS_STALL_MS) > 0 ? Number(process.env.AOS_STALL_MS) : 1_000;
 /** How many stalls to keep. Small on purpose: this is a lead, not a log. */
 const STALL_RING = 20;
 /** Closed phases kept for attribution — a stall that ends just before the tick still has a suspect. */

--- a/terminal/attach.sh
+++ b/terminal/attach.sh
@@ -47,8 +47,12 @@ fi
 # so it should never be reached). With no marker at all — an older session, a resurrect, a
 # mock/agent-runner pane — the original ~3s floor applies unchanged.
 MARK="${AOS_SESSION_DIR:-}/session-$ID.launching"
-FLOOR=12      # ~3s   — the no-marker wait, as before
-CEILING=480   # ~120s — hard stop; a stale marker must never hang the terminal open forever
+# Tick length and the two bounds are env-overridable for the SUITE only: attach-grace-test has to age a
+# pane past the floor in real time, and at the shipped 0.25s tick that cost 12.7s of every deploy. The
+# logic under test is the same at any tick; production never sets these.
+TICK="${AOS_ATTACH_TICK_S:-0.25}"
+FLOOR="${AOS_ATTACH_FLOOR_TICKS:-12}"      # ~3s   — the no-marker wait, as before
+CEILING="${AOS_ATTACH_CEILING_TICKS:-480}" # ~120s — hard stop; a stale marker must never hang the terminal open forever
 i=0
 while [ "$i" -lt "$CEILING" ]; do
   # Past the floor with no launch in flight → it really is gone. Stop waiting and decide below.
@@ -56,7 +60,7 @@ while [ "$i" -lt "$CEILING" ]; do
   # One line of feedback for the slow-box case, so the pane isn't blank while we wait. tmux clears
   # the screen on attach, so this never survives into the session itself.
   if [ "$i" -eq 0 ] && [ -f "$MARK" ]; then printf 'starting session…\r\n'; fi
-  sleep 0.25
+  sleep "$TICK"
   if tmux -S "$SOCK" has-session -t "$NAME" 2>/dev/null; then
     exec tmux -u -S "$SOCK" attach -t "$NAME"
   fi

--- a/terminal/opencode-gate-plugin.js
+++ b/terminal/opencode-gate-plugin.js
@@ -23,6 +23,12 @@ const SECRET = process.env.AOS_SECRET || "";
 const TENANT = process.env.AOS_TENANT || "";
 const UNATTENDED = process.env.UNATTENDED === "1";
 const APPROVAL_WAIT_S = Number(process.env.AOS_UNATTENDED_APPROVAL_WAIT_S || "180");
+// How long to sleep between gate retries and between approval polls. Env-overridable for the suite
+// only (opencode-gate-test spent 9.1s of every deploy sitting in these sleeps); production never sets
+// it. Deliberately NOT mirrored into gate-hook.sh's twin loop: that one counts `waited` in whole
+// seconds with shell arithmetic, so a sub-second poll would silently break its timeout accounting —
+// and nothing in the suite waits on it. The governed BEHAVIOUR of the two stays identical.
+const POLL_MS = Number(process.env.AOS_GATE_POLL_MS) > 0 ? Number(process.env.AOS_GATE_POLL_MS) : 1000;
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
@@ -188,13 +194,13 @@ export const AgentricGate = async () => {
         // Unreachable or an unrecognised decision: wait and ask again. The agent blocks here;
         // ungoverned action is impossible.
         console.error("Agentric: gate unreachable — blocking this action until it responds…");
-        await sleep(2000);
+        await sleep(POLL_MS * 2);
       }
 
       console.error("Agentric: this action needs approval — see the inbox. Waiting…");
       let waited = 0;
       for (;;) {
-        await sleep(1000);
+        await sleep(POLL_MS);
         const status = await pollStatus(gateId);
         if (status === "allow") return;
         if (status === "deny") throw new Error("Agentric: rejected by human.");


### PR DESCRIPTION
Follow-up to #773, which parallelized the deploy but left the suite itself untouched.

## Where the 88s went

Three of 88 scripts were 61s of the total, all real waiting:

| script | time | what it was waiting on |
|---|---|---|
| `loop-stall-attribution` | 39.0s | ~30 × 1.2s event-loop blocks, to cross a hardcoded 1000ms stall threshold |
| `attach-grace` | 12.7s | aging tmux panes against `attach.sh`'s 0.25s poll tick |
| `opencode-gate` | 9.1s | the plugin's 1s approval beat + 2s gate backoff |
| the other 76 combined | 12.3s | actual work |

## The change

Each of those constants becomes env-overridable — `AOS_STALL_MS`, `AOS_ATTACH_TICK_S` / `AOS_ATTACH_FLOOR_TICKS` / `AOS_ATTACH_CEILING_TICKS`, `AOS_GATE_POLL_MS` — and the tests set small values, scaling their own waits by the same factor. **Production sets none of them; its timing is unchanged.**

These are the same tests, not weaker ones. What each proves is threshold-independent: a block that *crosses* the stall line is the same proof at 100ms as at 1s, and `attach.sh`'s floor and ceiling are counted in **ticks**, which don't move — only the tick's duration does.

Two things deliberately left alone:
- `loopOverSecond` in `request-metrics.ts` — a **reported metric** whose meaning *is* its one-second threshold. Shrinking it would change what a number in the console means.
- `gate-hook.sh`'s twin poll loop — it counts `waited` in whole seconds with shell arithmetic, so a sub-second poll would silently break its timeout accounting, and nothing in the suite waits on it. The governed behaviour of the two gate implementations stays identical.

## Result

```
suite: 88.3s → 40s          (exit 0)
loop-stall-attribution: 39.0s → 9.9s   (12/12 pass)
attach-grace:           12.7s → 2.8s
opencode-gate:           9.1s → 0.5s
```

Flakiness is the obvious risk of tightening timing margins, so all three ran three consecutive times: clean every time, zero failed assertions. Full suite green, `typecheck` green.

Combined with #773, a steady-state 3-target deploy goes from ~314s to well under a minute of build-and-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dnc6GYiqaKp8JGLxmYgYGD