### PR TITLE
fix(deploy): make-live reached only the first remote tenant — ssh was eating the target list (v0.419.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.419.1] - 2026-09-03
+### Fixed
+- **`make-live.sh` deployed only the FIRST remote tenant, and failed confusingly on the second.** Every
+  remote phase is a `while read ... done <<EOF` over the target list, and the `ssh` inside it inherited
+  that heredoc as stdin - so the first connection slurped the remaining entries and the loop ended one
+  tenant early. Preflight and the fetch/resolve phase silently skipped the second remote; the parallel
+  build phase, whose background subshells do NOT share that stdin, then did reach it and died on the
+  state file the earlier phase never wrote (`cat: .../<key>.old: No such file or directory`), naming a
+  tenant nothing in the log had mentioned. Invisible while exactly one remote was configured. `ssh -n`
+  closes it.
+
 ## [0.419.0] - 2026-09-03
 ### Fixed
 - **A file sent through ClickUp or Telegram reached the agent as nothing** — the last two of the four chat

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.419.0",
+  "version": "0.419.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.419.0",
+      "version": "0.419.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.419.0",
+  "version": "0.419.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/make-live.sh
+++ b/scripts/make-live.sh
@@ -114,7 +114,12 @@ for spec in ${AOS_LIVE_REMOTE_TARGETS:-}; do
 done
 
 REMOTE_NODE_BIN="${AOS_LIVE_REMOTE_NODE_BIN:-\$HOME/.nvm/versions/node/v22.22.0/bin}"
-SSH="ssh -o BatchMode=yes -o ConnectTimeout=10"
+# `-n` is load-bearing, not tidiness: every remote loop below is a `while read … done <<EOF`, and an
+# ssh that inherits that stdin SLURPS the rest of the heredoc. With one remote target nothing showed;
+# adding a second one made the first ssh swallow it, so preflight and phase 1a silently skipped it and
+# the parallel build phase (background subshells, which do not share that stdin) then died on the
+# state file phase 1a never wrote — "No such file or directory", naming a tenant nothing had mentioned.
+SSH="ssh -n -o BatchMode=yes -o ConnectTimeout=10"
 # Every remote command runs through one wrapper so the node PATH and `set -e` are never forgotten.
 on_remote() { # <ssh-target> <command…>
   local host="$1"; shift


### PR DESCRIPTION
Every remote phase in `scripts/make-live.sh` is a `while read … done <<EOF` over the configured targets, and the `ssh` inside the loop inherited that heredoc as its **stdin**. The first connection slurped the remaining entries, so the loop ended one tenant early.

Invisible for as long as exactly one remote was configured. Adding a second one produced a failure that pointed nowhere near the cause — preflight and the fetch/resolve phase silently skipped it, and then the parallel build phase (background subshells, which do *not* share that stdin) did iterate it and died on the state file the earlier phase never wrote:

```
cat: /var/folders/…/<tenant-key>.old: No such file or directory
build/test failed in <tenant-key> — every live server untouched
```

naming a tenant that had not appeared anywhere earlier in the log.

`ssh -n` closes it. The reason is written above the line so it does not get tidied away later as a stray flag.

### Verification

`npm run build` · `cd web && npm run build` · `npm run test:governance` all green. Confirmed against two configured remote targets: before the fix the second was never preflighted, after it both are fetched, resolved and reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLTkiZURqqPYvw4K7aM51V