### PR TITLE
fix(console): a task room's session had no way to open in its own tab (v0.419.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.419.2] - 2026-09-03
+### Fixed
+- **A task room's Session tab had no way to open that session on its own.** The embedded pane was
+  rendered with `standalone` - the flag that means "this IS the chrome-less popout at `#/term/<tmux>`,
+  so drop the Pop out and Focus buttons" - so inside a task room the terminal silently lost both, and
+  the only way to get a session into its own tab was to leave the room and find the run on the Sessions
+  page. The room is an embedded pane, not the popout, so it no longer passes the flag: "Pop out" (a real
+  anchor, so cmd/middle-click work) opens just the session, chrome-free, in a new browser tab.
+
 ## [0.419.1] - 2026-09-03
 ### Fixed
 - **`make-live.sh` deployed only the FIRST remote tenant, and failed confusingly on the second.** Every

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.419.1",
+  "version": "0.419.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.419.1",
+      "version": "0.419.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.419.1",
+  "version": "0.419.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10802,7 +10802,10 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
                   )}
                   {sessPending
                     ? <div className="flex flex-1 items-center justify-center bg-black text-sm text-neutral-500">opening session…</div>
-                    : <TerminalFrame key={sessTmux} session={sessRow} tmux={sessTmux} standalone />}
+                    // NOT `standalone` — the room is an embedded pane, not the chrome-less popout, so it keeps
+                    // its own "Pop out" (open just this session in a fresh tab, no room/console around it) and
+                    // "Focus" buttons. It used to pass `standalone` and silently lost both.
+                    : <TerminalFrame key={sessTmux} session={sessRow} tmux={sessTmux} />}
                 </div>
               )}
             </div>


### PR DESCRIPTION
A task room's **Session** tab rendered its terminal with `standalone` — the flag that means *"this IS the chrome-less popout at `#/term/<tmux>`"*, whose job is to drop the **Pop out** and **Focus** buttons so the bare view doesn't offer to pop itself out again.

Inside a room that reads as a plain "no chrome please", but it removed the only affordance for getting a session into a tab of its own: you had to leave the room, find the run on the Sessions page, and pop it out from there.

The room is an embedded pane, not the popout, so it stops passing the flag. **Pop out** is a real anchor, so ⌘/middle-click open it in a background tab too, and the target (`#/term/<tmux>`) renders outside the console shell — just the session, no sidebar, no room.

Verified: `npm run typecheck`, both bundles build, `npm run test:governance` 12/12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgJpL61B3SCdDEqozBDX3y