### PR TITLE
fix(deploy): one make-live run could land two tenants on two different commits (v0.419.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.419.3] - 2026-09-03
+### Fixed
+- **A single `make-live.sh` run could put two tenants on two different commits.** Every checkout fetched
+  and then resolved `$REF` for itself, which is a race with whoever is merging: a box that fetched a
+  second later got a newer commit than its siblings. One run on 2026-09-03 put one tenant live on 0.419.2
+  and two on 0.419.1 and reported success for all three — each box really had been verified against the
+  version it had itself built, so nothing in the deploy was in a position to notice. `$REF` is now
+  resolved exactly once, up front (from the first local checkout, or the first remote on a remote-only
+  box), every checkout is pinned to that sha, and a checkout that does not have the commit after its
+  fetch fails by name instead of quietly deploying something else. The run now opens with the line
+  `deploy target: origin/main @ <sha>`.
+
 ## [0.419.2] - 2026-09-03
 ### Fixed
 - **A task room's Session tab had no way to open that session on its own.** The embedded pane was

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.419.2",
+  "version": "0.419.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.419.2",
+      "version": "0.419.3",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.419.2",
+  "version": "0.419.3",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/make-live.sh
+++ b/scripts/make-live.sh
@@ -51,6 +51,9 @@
 #    most one service; the report at the end says which tenants moved and which never got there.
 #  - A remote box is only ever reached with `ssh -o BatchMode=yes` — a deploy that would sit waiting on a
 #    password prompt fails fast in preflight instead of hanging.
+#  - EVERY checkout lands on the SAME commit: $REF is resolved once, up front, and each checkout is
+#    pinned to that sha. Resolving per-checkout raced whoever was merging — a box that fetched a second
+#    later deployed a different commit, and the run still reported success.
 set -euo pipefail
 
 ENV_FILE="${AOS_LIVE_ENV:-$HOME/.agentric-live.env}"
@@ -182,6 +185,29 @@ done <<EOF
 $REMOTES
 EOF
 
+# ── phase 0b: resolve ONE commit for the whole deploy ────────────────────────────
+# Every checkout used to fetch and then resolve $REF for ITSELF. That is a race with whoever is merging:
+# a checkout that fetches after a merge lands resolves a different commit than its siblings that fetched
+# a second earlier. On 2026-09-03 one tenant went live on 0.419.2 while the other two went live on
+# 0.419.1 — out of a single run that reported success for all three, because each box was verified
+# against the version it had itself built. A deploy is one commit everywhere or it is not a deploy, so
+# $REF is resolved exactly ONCE, here, and every checkout is pinned to that sha.
+#
+# The pin is read from the first local checkout, or the first remote when this box deploys only remotes.
+PIN_SRC="$(printf '%s' "$CHECKOUTS" | awk '{print $1}')"
+if [ -n "$PIN_SRC" ]; then
+  git -C "$PIN_SRC" fetch -q origin
+  TARGET="$(git -C "$PIN_SRC" rev-parse --verify -q "$REF^{commit}")" \
+    || fail "cannot resolve $REF in $PIN_SRC"
+else
+  PIN_SSHT="$(printf '%s' "$REMOTES" | head -1 | cut -d: -f2)"
+  PIN_CO="$(printf '%s' "$REMOTES" | head -1 | cut -d: -f3)"
+  on_remote "$PIN_SSHT" "git -C '$PIN_CO' fetch -q origin"
+  TARGET="$(on_remote "$PIN_SSHT" "git -C '$PIN_CO' rev-parse --verify -q '$REF^{commit}'")" \
+    || fail "cannot resolve $REF on $PIN_SSHT:$PIN_CO"
+fi
+say "deploy target: $REF @ ${TARGET:0:7} — every checkout is pinned to this commit"
+
 say "targets: $(printf '%s%s' "$TARGETS" "$REMOTES" | cut -d: -f1 | tr '\n' ' ')"
 
 # ── phase 1: sync + build every checkout (no service is restarted in here) ───────
@@ -216,7 +242,9 @@ for CHECKOUT in $CHECKOUTS; do
   cd "$CHECKOUT"
   git fetch -q origin
   OLD="$(git rev-parse HEAD)"
-  NEW="$(git rev-parse "$REF")"
+  NEW="$TARGET"
+  git rev-parse --verify -q "$NEW^{commit}" >/dev/null \
+    || fail "$CHECKOUT: $REF pinned to $NEW, but that commit is not here after a fetch"
   K="$(key_for "$CHECKOUT")"
   echo "$OLD" >"$STATE/$K.old"
   echo "$NEW" >"$STATE/$K.new"
@@ -256,7 +284,9 @@ while IFS=: read -r TENANT SSHT CHECKOUT PORT UNIT; do
   [ -n "$TENANT" ] || continue
   OLD="$(on_remote "$SSHT" "git -C '$CHECKOUT' rev-parse HEAD")"
   on_remote "$SSHT" "git -C '$CHECKOUT' fetch -q origin"
-  NEW="$(on_remote "$SSHT" "git -C '$CHECKOUT' rev-parse '$REF'")"
+  NEW="$TARGET"
+  on_remote "$SSHT" "git -C '$CHECKOUT' rev-parse --verify -q '$NEW^{commit}' >/dev/null" \
+    || fail "$TENANT: $REF pinned to $NEW, but that commit is not on $SSHT:$CHECKOUT after a fetch"
   K="$(key_for "$SSHT$CHECKOUT")"
   echo "$OLD" >"$STATE/$K.old"
   echo "$NEW" >"$STATE/$K.new"


### PR DESCRIPTION
Every checkout fetched and then resolved `$REF` for **itself**. That races whoever is merging: a checkout that fetches a second after a merge lands resolves a newer commit than its siblings.

It happened on 2026-09-03 — one tenant went live on 0.419.2 while two went live on 0.419.1, out of a **single run that reported success for all three**. Nothing in the deploy was in a position to notice: each box's health check compares against the version that box had itself built, and each one was right about its own.

### The fix

`$REF` is resolved exactly once, up front — from the first local checkout, or the first remote on a box that deploys only remotes — and every checkout is pinned to that sha. A checkout that does not have the commit after its own fetch (force-push, a different origin) fails by name rather than quietly deploying whatever it does have.

The run now opens with the line it was missing:

```
deploy target: origin/main @ d0282b6 — every checkout is pinned to this commit
```

Also adds the guarantee to the safety-properties list in the script header, next to the ordering guarantee it belongs with.

### Verification

- `--dry-run` across three targets (one local, two remote): one pin line, all three resolve to the same sha.
- Negative: `AOS_LIVE_REF=<unpushed sha>` fails at the pin — `cannot resolve <sha> in <checkout>` — before touching any box.
- `npm run build` · `cd web && npm run build` · `npm run test:governance` all green.

The per-checkout "pinned commit missing after fetch" guard is not exercised by a test — reproducing it needs a force-push against a live checkout, which is not worth staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JLTkiZURqqPYvw4K7aM51V