### PR TITLE
fix(tasks): a delegate's result could come back to the wrong caller (v0.421.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.421.0] - 2026-09-03
+### Fixed
+- **A delegate's result could come back to the wrong caller.** The wake queue delivers per AGENT, so when
+  the caller's own transcript was cold it typed the result into any other live session of that agent
+  (`inject-sibling`) - which is the same agent mid-work on something else, usually for someone else, and
+  it answers into ITS audience. Measured on a live tenant over 30 days: 369 of 1532 pokes took that lane
+  and **64 of the 251 joinable ones landed in a run acting as a different member than the task owner**.
+  Lane 2 now refuses a destination whose `run_as` differs from the batch, or that has a Slack / Discord /
+  Telegram / ClickUp thread or DM binding of its own to reply into; a refused sibling falls through to the
+  resume lane - the caller's own transcript, which was always the right destination (`acceptsSibling` in
+  `src/edge/wakeups.ts`).
+- **`poke-done` no longer takes the sibling lane at all.** The cheapness that justified it was
+  "in-context"; in a sibling it is by definition out of context, so what was left was good news delivered
+  to the wrong conversation. A completion now reaches its own pane or it stands on the task.
+- **A dropped completion leaves a mark on the task.** `poke-done` at a cold caller is deliberately dropped
+  (v0.375.0), but from the board that is indistinguishable from a poke that got lost - which is how it was
+  reported. `dropDone` writes one `status` line onto the task via `TaskStore.markWakeDropped` ("... was not
+  woken - it had no live run, so the result stands here"): no extra card and no extra DM (the owner already
+  has the `task.notified` DM), and a `status` event rather than a `comment` so it can never become the
+  result `latestNote` quotes. `agent.poke.skipped` now distinguishes `done-cold-caller` /
+  `done-no-own-pane` / `done-wedged-caller`.
+- `scripts/wakeup-queue-test.cjs` gains cases 12-15 (63 assertions); docs/tasks-plan.md gains §3.9.
+
 ## [0.420.0] - 2026-09-03
 ### Fixed
 - **Every Composio action was governed as one anonymous `connector.call`.** Composio's Tool Router

--- a/docs/tasks-plan.md
+++ b/docs/tasks-plan.md
@@ -485,6 +485,45 @@ call and it may have left work behind.
 
 Pinned by `scripts/wakeup-queue-test.cjs` (cases 8-9) and `scripts/stranded-human-stop-test.cjs`.
 
+### 3.9 WHO reads it — the sibling lane is a different conversation
+
+§3.6 asked which lane, §3.8 asked what a lane costs. Neither asked **who ends up reading the answer.**
+
+Lane 2 (`inject-sibling`) was written on the premise that a wake-up "carries the task id, title and the
+delegate's note, so it needs no transcript context". That is true of the *reading* and false of the
+*replying*: the sibling is the same agent mid-work on something else, usually for someone else, and it
+answers into ITS audience — its `report` card goes to its own session owner, its `slack_reply` into its own
+thread. That is the user report *"in some cases it sends data back to the wrong caller"*.
+
+Measured on instawp, 30 days: **369 of 1532 pokes took the sibling lane**, and of the 251 that could be
+joined to their task, **64 (25%) landed in a run acting as a different member than the task owner** — one
+person's task body and result inside a run accountable to someone else.
+
+So lane 2 now asks two questions about the recipient before speaking there (`acceptsSibling`):
+
+| Test | Why |
+|---|---|
+| identical `run_as` across every pending row and the destination | otherwise the answer reaches the wrong human, and one member's work is read inside another's run |
+| destination has **no** `slack_threads` / `discord_threads` / `telegram_threads` / `clickup_threads` / `session_dms` binding | a session with an outward conversation replies INTO it |
+
+…and `poke-done` gives up lane 2 outright: the cheapness that justified it was "in-context", and in a
+sibling it is by definition out of context, so what remains is good news delivered to the wrong
+conversation. A completion reaches its OWN pane or it stands on the task.
+
+A refused sibling is **not** a held wake-up — the batch falls through to the resume lane, which is the
+caller's own transcript and was always the right destination. Cost on the measured window: ~43 extra
+resumes in 30 days (~1.4/day), all of them replacing a mis-delivery.
+
+**And a drop leaves a mark.** `poke-done` at a cold caller is a decision, but from the board it is
+indistinguishable from a poke that got lost — which is exactly how it was reported. `dropDone` now writes
+one `status` line onto the task (`TaskStore.markWakeDropped`, once per task): *"… was not woken — it had no
+live run, so the result stands here"*. Deliberately not a card and not a DM (the owner already has the
+`task.notified` DM for the completion itself), and deliberately a `status` event rather than a `comment`,
+because `latestNote` reads the newest comment as THE result and delivery bookkeeping must never become the
+answer a later poke quotes.
+
+Pinned by `scripts/wakeup-queue-test.cjs` (cases 12-15).
+
 ---
 
 ## 4. Agent-facing MCP tools — `src/memory/memory-mcp.ts`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.420.0",
+  "version": "0.421.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.420.0",
+      "version": "0.421.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.420.0",
+  "version": "0.421.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/wakeup-queue-test.cjs
+++ b/scripts/wakeup-queue-test.cjs
@@ -18,6 +18,11 @@
  *   8 a `poke-done` INJECTS into a live pane but never resurrects a cold caller — good news is not worth a
  *     claude, and resurrecting one is what fed the delegation loop (see the wakeups.ts module header);
  *   9 a hand-back (`poke-blocked`) still resumes, and one in a batch carries the completions along.
+ *  12 the SIBLING lane refuses a run acting as a different member — 25% of live sibling injects were one,
+ *     and the answer came back to the wrong human (see the wakeups.ts module header);
+ *  13 …and refuses a sibling bound to its own Slack/Discord/DM conversation, for the same reason;
+ *  14 a `poke-done` never takes the sibling lane at all — out of context is not cheap, it is misdelivered;
+ *  15 a dropped completion leaves one line on the TASK, so the silence reads as a decision, not a loss.
  *
  * Isolated home; the session backend is stubbed, so no tmux and no real `claude` are involved.
  */
@@ -297,6 +302,60 @@ console.log('\n\x1b[1m11) a still-working session is preferred over a finished o
   const r = q.enqueue({ agent: 'caller', transcript: 'cs-absent', runAs: alice.id, source: 'tsk_sib', message: '⛔ handed back', title: 'p', kind: 'poke-stranded' });
   assert(r.ok && r.via === 'inject-sibling', 'delivered to a sibling', r);
   assert(r.sessionId === working, 'the STILL-WORKING sibling wins over two finished ones', { got: r.sessionId, working, older, newestFinished });
+}
+
+console.log('\n\x1b[1m12) the sibling lane refuses a run acting as a DIFFERENT member\x1b[0m');
+{
+  idleAgent();
+  const bob = aos.team.invite({ email: 'bob@testco.dev', role: 'member' }).member;
+  mkSession('cs-12', { pane: false });                              // the caller's own transcript: cold
+  const other = mkSession('cs-12-sib', { run_as: bob.id, spawned_by: bob.id });
+  const before = spawned.length;
+  const r = q.enqueue({ agent: 'caller', transcript: 'cs-12', runAs: alice.id, source: 'tsk_12', message: '⚠️ handed back', title: 'p', kind: 'poke-stranded' });
+  assert(r.ok && r.via === 'resume', 'it resumes the caller\'s OWN transcript instead', r);
+  assert(spawned.length === before + 1 && spawned[spawned.length - 1].resumeClaudeId === 'cs-12', 'on the right transcript', spawned[spawned.length - 1]);
+  assert(!injected.some((i) => i.tmux === 'aos-' + other), 'Bob\'s run was never typed into', other);
+}
+
+console.log('\n\x1b[1m13) …nor a sibling that answers into its own conversation\x1b[0m');
+{
+  idleAgent();
+  mkSession('cs-13', { pane: false });
+  const chat = mkSession('cs-13-sib');                               // same member, but Slack-bound
+  aos.db.prepare('INSERT INTO slack_threads (session_id, channel, thread_ts, created_at) VALUES (?,?,?,?)')
+    .run(chat, 'C123', '1725.0001', Date.now());
+  const before = spawned.length;
+  const r = q.enqueue({ agent: 'caller', transcript: 'cs-13', runAs: alice.id, source: 'tsk_13', message: '⚠️ handed back', title: 'p', kind: 'poke-stranded' });
+  assert(r.ok && r.via === 'resume', 'a thread-bound sibling would reply to the wrong audience', r);
+  assert(!injected.some((i) => i.tmux === 'aos-' + chat), 'so it is never typed into', chat);
+  assert(spawned.length === before + 1, 'and the wake-up still lands, on its own transcript');
+}
+
+console.log('\n\x1b[1m14) a `poke-done` never takes the sibling lane at all\x1b[0m');
+{
+  idleAgent();
+  mkSession('cs-14', { pane: false });                              // own transcript cold
+  const sib = mkSession('cs-14-sib');                               // a perfectly eligible sibling
+  const before = spawned.length;
+  const r = q.enqueue({ agent: 'caller', transcript: 'cs-14', runAs: alice.id, source: 'tsk_14', message: '✅ Really done: shipped', title: 'p', kind: WAKE_KIND_DONE });
+  assert(!r.ok && !r.queued, 'good news out of context is misdelivery, not a cheap delivery', r);
+  assert(!injected.some((i) => i.tmux === 'aos-' + sib), 'the sibling was left alone', sib);
+  assert(spawned.length === before, 'and nothing was resumed either');
+  assert(livePanes.has('aos-' + sib), 'nor was the sibling\'s run ended');
+}
+
+console.log('\n\x1b[1m15) a dropped completion leaves one line on the TASK\x1b[0m');
+{
+  idleAgent();
+  const t = aos.tasks.create({ tenant: aos.tenant, title: 'ship the thing', assignee: 'agent:worker', createdBy: 'agent:caller', owner: alice.id });
+  mkSession('cs-15', { pane: false });
+  q.enqueue({ agent: 'caller', transcript: 'cs-15', runAs: alice.id, source: t.id, message: '✅ Really done: shipped', title: 'p', kind: WAKE_KIND_DONE });
+  const ev = aos.db.prepare("SELECT * FROM task_events WHERE task_id = ? AND kind = 'status' AND body LIKE '%not woken%'").all(t.id);
+  assert(ev.length === 1, 'the drop is legible on the board, not a lost poke', ev.map((e) => e.body));
+  assert(aos.tasks.latestNote(t.id) === undefined, 'and it is NOT a comment — latestNote is the task RESULT', aos.tasks.latestNote(t.id));
+  // Re-fired: still one line, never a column of them.
+  q.enqueue({ agent: 'caller', transcript: 'cs-15', runAs: alice.id, source: t.id, message: '✅ Really done: shipped again', title: 'p', kind: WAKE_KIND_DONE });
+  assert(aos.db.prepare("SELECT COUNT(*) n FROM task_events WHERE task_id = ? AND body LIKE '%not woken%'").get(t.id).n === 1, 'written once');
 }
 
 console.log(`\n${fail === 0 ? '\x1b[32m' : '\x1b[31m'}${pass} passed, ${fail} failed\x1b[0m`);

--- a/src/edge/wakeups.ts
+++ b/src/edge/wakeups.ts
@@ -89,6 +89,35 @@
  * Measured against the same week: 131 of 275 injects were `poke-done` into a finished run and stop
  * happening; the 21 stranded/blocked ones that also targeted a finished run still deliver, so this costs
  * no extra resumes.
+ *
+ * ## A sibling is a different CONVERSATION, not a cheaper caller (2026-09-03)
+ *
+ * Every fix above asked whether a destination was live and whether it was worth a claude. None asked who
+ * ends up READING the answer. Lane 2 was written on the premise that the message "carries the task id,
+ * title and the delegate's note, so it needs no transcript context" — true of the reading, false of the
+ * replying. The sibling is the same agent mid-work on something else, for someone else, and it answers
+ * into ITS audience: its `report` card goes to its own session owner, its `slack_reply` into its own
+ * thread. That is the user report *"in some cases it sends data back to the wrong caller"*.
+ *
+ * Measured on live instawp, 30 days: 369 of 1532 pokes took the sibling lane, and of the 251 that could
+ * be joined to their task, **64 (25%) landed in a run acting as a different member than the task owner**
+ * — one person's task body and result inside a run accountable to someone else. So lane 2 now asks two
+ * questions about the recipient before it will speak there ({@link WakeupQueue.acceptsSibling}): the
+ * run-as identity must match every pending row, and the session must have no outward thread/DM binding of
+ * its own. A rejected sibling is not a held wake-up — the batch simply falls through to the resume lane,
+ * which is the caller's own transcript and was always the right destination.
+ *
+ * And {@link WAKE_KIND_DONE} gives up the sibling lane entirely. The cheapness that justified it was
+ * "in-context"; in a sibling it is by definition out of context, so what is left is good news delivered
+ * to the wrong conversation. A completion reaches its OWN pane or it stands on the task.
+ *
+ * ## A drop must leave a mark (same day)
+ *
+ * `poke-done` at a cold caller is a decision, but from the board it is indistinguishable from a poke that
+ * got lost — which is exactly how it was reported. {@link WakeupQueue.dropDone} now writes one `status`
+ * line onto the task ("… was not woken — it had no live run, so the result stands here"). Not a card and
+ * not a DM: the owner already has the `task.notified` DM for the completion itself, and a second ping
+ * about the plumbing is the noise this lane exists to avoid.
  */
 import { newId } from '../id';
 import { AgentOS } from '../kernel';
@@ -194,8 +223,8 @@ export class WakeupQueue {
     // PANE), never the row's `status`: a session that called `report` still has the REPL we type into.
     const transcripts = new Set(pending.map((p) => p.transcript));
     const live = this.db
-      .prepare('SELECT id, tmux, claude_session_id AS cs FROM term_sessions WHERE agent = ? ORDER BY created_at DESC LIMIT 50')
-      .all<{ id: string; tmux: string; cs: string | null }>(agentId)
+      .prepare('SELECT id, tmux, claude_session_id AS cs, run_as AS runAs FROM term_sessions WHERE agent = ? ORDER BY created_at DESC LIMIT 50')
+      .all<{ id: string; tmux: string; cs: string | null; runAs: string | null }>(agentId)
       .filter((r) => this.tm.reachable(r.id));
     // A run that has REPORTED is finished — it said so. Its pane is still reachable (that is the whole
     // point of the attachable lane), which made it look like a free delivery target, and 55% of injects
@@ -218,7 +247,12 @@ export class WakeupQueue {
     const pool = live.filter((r) => !finished.has(r.id));
     if (!doneOnly) pool.push(...live.filter((r) => finished.has(r.id)));
     const own = pool.find((r) => r.cs && transcripts.has(r.cs));
-    const dest = own ?? pool[0];
+    // The SIBLING lane is not the caller — it is the same agent in a different conversation, and that
+    // difference is the whole bug (see "A sibling is a different conversation" in the module header). It
+    // is offered a wake-up only when there is something for it to DO (never good news alone) and only
+    // when speaking there cannot put one person's work in front of another: same run-as identity, and no
+    // outward thread/DM binding of its own to answer into.
+    const dest = own ?? (doneOnly ? undefined : pool.find((r) => this.acceptsSibling(r, pending)));
     if (dest) {
       const via = own ? 'inject' : 'inject-sibling';
       const injected = this.tm.injectToSession(dest.id, message, true, principal);
@@ -234,13 +268,13 @@ export class WakeupQueue {
       if (!own) return { ok: false, reason: 'sibling session did not accept the wake-up — queued for retry', queued: true };
       // …unless a resume was never on the table: killing a wedged run only to drop the news would cost
       // the run and deliver nothing. Leave it alone and settle.
-      if (doneOnly) return this.dropDone(agentId, pending);
+      if (doneOnly) return this.dropDone(agentId, pending, 'done-wedged-caller');
       this.tm.stopSession(dest.id, 'system');
     }
 
-    // Lane 3 — nothing of this agent is live. Resume the transcript in a fresh `poke:` run. One session
-    // for ALL pending wake-ups: they were coalesced above, so N completions cost one claude, not N.
-    if (doneOnly) return this.dropDone(agentId, pending);
+    // Lane 3 — nothing this batch may speak into. Resume the transcript in a fresh `poke:` run. One
+    // session for ALL pending wake-ups: they were coalesced above, so N completions cost one claude, not N.
+    if (doneOnly) return this.dropDone(agentId, pending, live.length ? 'done-no-own-pane' : 'done-cold-caller');
     if (opts.budget !== undefined && opts.budget <= 0) {
       this.bump(pending);
       return { ok: false, reason: 'at the concurrency cap — queued for the next tick', queued: true };
@@ -309,8 +343,19 @@ export class WakeupQueue {
    * card. (Expiry means "we could not reach the caller and someone should know"; this means "there was
    * nothing here worth reaching it for".) Audited so the count is visible next to the pokes that did fire.
    */
-  private dropDone(agentId: string, rows: Row[]): WakeupDelivery {
+  private dropDone(agentId: string, rows: Row[], reason: string = 'done-cold-caller'): WakeupDelivery {
     this.settle(rows, 'dropped', 'none', null);
+    // Leave the trace on the TASK. A drop is a decision, but from the board it is indistinguishable from
+    // a poke that got lost — which is how this lane was read as a bug for weeks. One `status` line, no
+    // card and no DM: the owner already has the `task.notified` DM for the completion itself, and a
+    // second ping about the plumbing is the noise this whole lane exists to avoid.
+    for (const r of rows) {
+      try {
+        if (this.os.tasks.get(r.source)) this.os.tasks.markWakeDropped(r.source, agentId);
+      } catch {
+        // the audit event below is the record; the task line is the courtesy
+      }
+    }
     this.os.audit.append({
       ts: Date.now(),
       runId: '-',
@@ -321,11 +366,47 @@ export class WakeupQueue {
         caller: agentId,
         source: rows[rows.length - 1].source,
         sources: rows.length > 1 ? rows.map((r) => r.source) : undefined,
-        reason: 'done-cold-caller',
+        reason,
         kind: WAKE_KIND_DONE,
       },
     });
     return { ok: false, reason: 'caller is cold and the hand-off is done — the result stands in the task', queued: false };
+  }
+
+  /**
+   * May this batch be typed into a live session that is NOT its own transcript?
+   *
+   * Two conditions, both about WHO ends up reading the answer rather than about liveness:
+   *
+   *  - **same run-as.** A sibling run acts as a different member often enough to matter (64 of 251
+   *    sibling injects on live instawp over 30 days), and injecting there puts one person's task body,
+   *    title and result inside a run accountable to somebody else.
+   *  - **no outward binding.** A session bound to a Slack/Discord/Telegram/ClickUp thread or a DM has a
+   *    conversation it answers into. Anything typed there is liable to be replied to THAT audience — the
+   *    "sent the result back to the wrong caller" report. Its own transcript may be chat-bound (that is
+   *    the caller's own conversation); a sibling's may not.
+   *
+   * A mixed batch is held to the strictest reading: one identity across every pending row, or no sibling.
+   */
+  private acceptsSibling(dest: { id: string; runAs: string | null }, pending: Row[]): boolean {
+    const owners = new Set(pending.map((p) => p.run_as ?? ''));
+    if (owners.size !== 1) return false;
+    if ((dest.runAs ?? '') !== [...owners][0]) return false;
+    return !this.boundToConversation(dest.id);
+  }
+
+  /** Does this session answer into an outward thread or DM of its own? One query over every binding table
+   *  the chat lanes write (`terminal.ts` binds each on ingress; `session_dms` on an outbound DM). */
+  private boundToConversation(sessionId: string): boolean {
+    const row = this.db
+      .prepare(`SELECT 1 AS x FROM slack_threads WHERE session_id = ?
+                UNION ALL SELECT 1 FROM discord_threads WHERE session_id = ?
+                UNION ALL SELECT 1 FROM telegram_threads WHERE session_id = ?
+                UNION ALL SELECT 1 FROM clickup_threads WHERE session_id = ?
+                UNION ALL SELECT 1 FROM session_dms WHERE session_id = ?
+                LIMIT 1`)
+      .get<{ x: number }>(sessionId, sessionId, sessionId, sessionId, sessionId);
+    return !!row;
   }
 
   private settle(rows: Row[], status: 'delivered' | 'expired' | 'dropped', via: string, sessionId: string | null): void {

--- a/src/state/tasks.ts
+++ b/src/state/tasks.ts
@@ -50,6 +50,10 @@ const OVERDUE_MARK = '⏰ went overdue';
 /** Sentinel body for the one-time "its run ended without closing this" event, per stranding SESSION — so a
  *  task stranded twice (re-dispatched, stranded again) wakes its caller once per dead run, not once ever. */
 const strandedMark = (sessionId: string): string => `⚠️ run ended without closing this (${sessionId})`;
+/** Sentinel body for the one-time "the caller agent was not woken with this result" event. The completion
+ *  poke is deliberately dropped when the caller is not running (see `edge/wakeups.ts`), and a drop with no
+ *  trace reads exactly like a lost poke — this is where the silence becomes legible. */
+const wakeDroppedMark = (agent: string): string => `💤 ${agent} was not woken — it had no live run, so the result stands here`;
 
 /**
  * What the {@link TaskStore} notifier sink receives on a meaningful task change. The store stays
@@ -342,6 +346,22 @@ export class TaskStore {
       .get<{ 1: number }>(id, mark);
     if (existing) return false;
     this.addEvent(id, 'status', mark, 'system', sessionId);
+    return true;
+  }
+
+  /**
+   * Record a one-time "the caller was not woken with this outcome" marker; returns true only the FIRST
+   * time so a re-fired hand-off writes one line, not a column of them. Written as a `status` event rather
+   * than a `comment` deliberately: {@link latestNote} reads the newest comment as THE result of the task,
+   * and a piece of delivery bookkeeping must never become the answer a later poke quotes.
+   */
+  markWakeDropped(id: string, agent: string): boolean {
+    const mark = wakeDroppedMark(agent);
+    const existing = this.db
+      .prepare(`SELECT 1 FROM task_events WHERE task_id = ? AND kind = 'status' AND body = ? LIMIT 1`)
+      .get<{ 1: number }>(id, mark);
+    if (existing) return false;
+    this.addEvent(id, 'status', mark, 'system');
     return true;
   }
 


### PR DESCRIPTION
Two symptoms from live instawp, one subsystem.

**1. "the chained task auto-closes but the caller gets no summary"** — working as designed since v0.375.0, but invisibly. `ses_54a0b3078c727018` (qa → caller `billing-ops`) audits `agent.poke.skipped {"reason":"done-cold-caller"}`: a `poke-done` injects into a live caller and is dropped at a cold one, because resurrecting an agent to tell it good news is what fed the delegation loop. Correct — but from the board a drop is indistinguishable from a lost poke.

**2. "in some cases it sends data back to the wrong caller"** — a real bug. The queue delivers per AGENT, so a cold caller transcript sends the result down `inject-sibling`, into any other live session of that agent. That session is the same agent mid-work on something else, usually for someone else, and it answers into ITS audience.

Measured on instawp, 30 days:

| | |
|---|---|
| `agent.poked` | 1532 |
| via `inject` (own transcript) | 607 |
| via **`inject-sibling`** | **369** |
| via `resume` | 77 |
| `agent.poke.skipped` | 259 |

Of the 251 sibling injects joinable to their task, **64 (25%) landed in a run acting as a different member than the task owner** — e.g. an `engineer` result for a task owned by one member injected into a session running as another, mid an unrelated task.

## Changes

- **`acceptsSibling`** — lane 2 requires identical `run_as` across every pending row and the destination, and refuses a destination with a `slack_threads` / `discord_threads` / `telegram_threads` / `clickup_threads` / `session_dms` binding of its own. A refused sibling is not a held wake-up: the batch falls through to the resume lane, which is the caller's own transcript and was always the right destination (~43 extra resumes/30d on the measured window, each replacing a mis-delivery).
- **`poke-done` gives up the sibling lane entirely.** The cheapness that justified it was "in-context"; in a sibling it is by definition out of context. A completion reaches its own pane or it stands on the task.
- **`dropDone` leaves a mark** — one `status` line on the task via `TaskStore.markWakeDropped`, written once. Not a card and not a DM (the owner already has the `task.notified` DM for the completion), and a `status` event rather than a `comment` so delivery bookkeeping can never become the result `latestNote` quotes. `agent.poke.skipped` now distinguishes `done-cold-caller` / `done-no-own-pane` / `done-wedged-caller`.

## Validation

`npm run typecheck`, both bundles built, `npm run test:governance` green. `scripts/wakeup-queue-test.cjs` gains cases 12-15 → 63 assertions:

- 12 sibling acting as a different member is refused, and the wake-up resumes the caller's own transcript instead
- 13 a Slack-bound sibling is refused for the same reason
- 14 `poke-done` never takes the sibling lane, spawns nothing, and leaves the sibling's run alone
- 15 a dropped completion writes exactly one task line, and never as a `comment`

Docs: `docs/tasks-plan.md` §3.9; module header of `src/edge/wakeups.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnfdYu5gx68waYMYsXQ15V