### PR TITLE
fix(connectors): the expired-connection card outlived the problem it reported (v0.422.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.422.1] - 2026-09-03
+### Fixed
+- **An expired-connection card outlived the problem.** Reported within the hour of v0.422.0 shipping:
+  the expired connections were removed, the cache dropped to zero expired rows, and both cards sat in
+  NEEDS YOU still claiming an app was unavailable - with no way to clear them, since a review card
+  carries no reject path, so "I fixed this" and "I am ignoring this" looked identical. The card is now
+  DERIVED state, reconciled on every connection refresh: it stands only while at least one toolkit it
+  names still has an expired connection on that shelf, and reconnecting, deleting or pruning all retire
+  it (`connector.expired.cleared`). It also gained a Dismiss button as the manual escape hatch, and says
+  in its own body that it clears itself.
+- **A reconnected app no longer raises a card at all.** An expired row whose toolkit is live again is
+  housekeeping - "Clear replaced" in Connections deals with it - so it is recorded and marked notified
+  but never put in front of a human. Only an app with NO live account left is something anyone can act
+  on. Previously a card titled "gmail unavailable" also carried a clickup line reading "already
+  reconnected, this is the old record", which is not news.
+- **Two expired accounts of the same app were listed twice.** A live card read "google_search_console,
+  google_search_console unavailable" and "Reconnect google_search_console, google_search_console". The
+  card is now one line per toolkit, with the account beside it.
+- **"2 the company Composio connections have expired."** Fixed the sentence, and each app is now named
+  once rather than in both the opening line and the list.
+
 ## [0.422.0] - 2026-09-03
 ### Added
 - **Every Composio connection now says whose account it actually is.** A Composio `user_id` is a SHELF,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.422.0",
+  "version": "0.422.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.422.0",
+      "version": "0.422.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.422.0",
+  "version": "0.422.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/composio-identity-test.cjs
+++ b/scripts/composio-identity-test.cjs
@@ -165,6 +165,49 @@ check('the agent is told to stop and ask when the acting account is wrong', /sto
 aos.settings.setComposioApiKey('', 'owner@testco');
 check('a workspace with no Composio key gets no section', !/whose account you are about to act as/i.test(tm.buildCompanyMd('some-agent', owner.id, false, '')));
 
+// ── 7. the expiry card: one line per app, honest grammar, and it clears itself ───────────────────
+// A card that outlives its condition is worse than no card — it sits in NEEDS YOU claiming an app is
+// unavailable after the human has already fixed it, and a review card has no reject path, so there is
+// no way to make it go away. That happened live the afternoon this shipped.
+const ENTITY = `service:${aos.tenant}`;
+const openCards = () => aos.db.prepare("SELECT id, title, body, args FROM messages WHERE type = 'connection.expired' AND status = 'open'").all();
+
+// Two expired accounts of the SAME app, plus one that has already been reconnected.
+aos.composioIdentities.upsert([
+  { id: 'x1', userId: ENTITY, toolkit: 'google_search_console', account: 'a@x.io', status: 'EXPIRED' },
+  { id: 'x2', userId: ENTITY, toolkit: 'google_search_console', account: 'a@x.io', status: 'EXPIRED' },
+  { id: 'x3', userId: ENTITY, toolkit: 'clickup', status: 'EXPIRED' },
+  { id: 'x4', userId: ENTITY, toolkit: 'clickup', status: 'ACTIVE' },
+]);
+tm.notifyExpiredConnections(ENTITY);
+let cards = openCards();
+check('one card is posted', cards.length === 1);
+check('two expired accounts of one app are ONE line, not two', (cards[0].body.match(/google_search_console/g) || []).length === 1);
+check('a reconnected app raises nothing — it is housekeeping, not news', !/clickup/.test(cards[0].body + cards[0].title));
+check('the title names only what is actually unavailable', cards[0].title === 'Connection expired — google_search_console unavailable');
+check('the body reads as English', /^The company Composio connection has expired, and nothing else is connected for this app/.test(cards[0].body));
+check('…and says it will clear itself', /clears itself/.test(cards[0].body));
+check('a personal shelf says "Your"', (() => {
+  aos.composioIdentities.upsert([{ id: 'y1', userId: owner.email, toolkit: 'linear', status: 'EXPIRED' }]);
+  tm.notifyExpiredConnections(owner.email, owner.id);
+  const mine = openCards().find((c) => JSON.parse(c.args).entity === owner.email);
+  return mine && /^Your Composio connection has expired/.test(mine.body);
+})());
+
+// The same connections are still expired → the card must stand.
+tm.reconcileExpiredCards(ENTITY);
+check('the card stands while the app is still expired', openCards().some((c) => JSON.parse(c.args).entity === ENTITY));
+// The human reconnects it (or deletes it — either way nothing is expired any more).
+aos.composioIdentities.upsert([
+  { id: 'x1', userId: ENTITY, toolkit: 'google_search_console', account: 'a@x.io', status: 'ACTIVE' },
+  { id: 'x2', userId: ENTITY, toolkit: 'google_search_console', account: 'a@x.io', status: 'ACTIVE' },
+]);
+check('the card closes itself once nothing is expired', tm.reconcileExpiredCards(ENTITY) === 1 && !openCards().some((c) => JSON.parse(c.args).entity === ENTITY));
+check('…and another shelf\'s card is left alone', openCards().some((c) => JSON.parse(c.args).entity === owner.email));
+// Deleting the connection outright (the live case: the rows were pruned, not reconnected) also clears it.
+aos.composioIdentities.pruneEntity(owner.email, new Set());
+check('deleting the expired connection clears its card too', tm.reconcileExpiredCards(owner.email) === 1 && openCards().length === 0);
+
 const total = pass + failures.length;
 if (failures.length) {
   console.error(`\nCOMPOSIO IDENTITY: ${pass}/${total} passed, ${failures.length} FAILED\n`);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4859,6 +4859,9 @@ export class TerminalManager {
       const stale = accounts.filter((a) => a.status.toUpperCase() === 'EXPIRED');
       expired += stale.length;
       if (opts.notify !== false && stale.length) this.notifyExpiredConnections(userId, ownerMemberId);
+      // ALWAYS, including when nothing is expired — that is exactly the case that has to retire a card
+      // whose problem the human has already fixed.
+      this.reconcileExpiredCards(userId);
     }
     this.audit('-', 'system', 'connector.identity.refreshed', { entities: [...seen.keys()], resolved, expired });
     return { resolved, expired };
@@ -4877,31 +4880,77 @@ export class TerminalManager {
     const live = new Set(
       this.os.composioIdentities.forEntity(userId).filter((i) => i.status.toUpperCase() === 'ACTIVE').map((i) => i.toolkit),
     );
-    // A toolkit with NO live account left is a capability the fleet has actually lost; one that has been
-    // reconnected is just an old row. Say which is which, because only the first needs anyone to act.
-    const lost = due.filter((d) => !live.has(d.toolkit));
-    const scope = ownerMemberId ? 'your' : 'the company';
+    // Reconnecting leaves the old row behind, so an expired connection whose toolkit is live again is
+    // housekeeping, not news — "Clear replaced" in Connections deals with it. Only a toolkit with NO
+    // live account left is a capability the fleet has actually lost, and only that is worth a card in
+    // someone's NEEDS YOU column. Mark the rest notified so they stop being reconsidered every refresh.
+    const lostToolkits = [...new Set(due.filter((d) => !live.has(d.toolkit)).map((d) => d.toolkit))];
+    this.os.composioIdentities.markNotified(due.map((d) => d.id));
+    this.audit('-', 'system', 'connector.expired', {
+      entity: userId, toolkits: [...new Set(due.map((d) => d.toolkit))], lost: lostToolkits,
+    });
+    if (!lostToolkits.length) return;
+    // One line per TOOLKIT, not per connection row: two expired accounts of the same app are one
+    // problem, and listing "google_search_console, google_search_console" reads like a bug (it was one).
+    const accountOf = (t: string): string => due.find((d) => d.toolkit === t && d.account)?.account ?? '';
+    const whose = ownerMemberId ? 'Your' : 'The company';
+    const n = lostToolkits.length;
+    // Each app is named ONCE — in the list, where its account can sit beside it. The opening line stays
+    // generic so a single-app card doesn't say the same slug twice in three lines.
     const body = [
-      `${due.length} ${scope} Composio connection${due.length === 1 ? ' has' : 's have'} expired:`,
-      ...due.map((d) => `- ${d.toolkit}${d.account ? ` (${d.account})` : ''}${live.has(d.toolkit) ? ' — already reconnected, this is the old record' : ' — nothing else is connected for this app, so agents cannot use it at all'}`),
+      `${whose} Composio connection${n === 1 ? ' has' : 's have'} expired, and nothing else is connected for ${n === 1 ? 'this app' : 'these apps'} — so agents cannot use ${n === 1 ? 'it' : 'them'} at all:`,
+      ...lostToolkits.map((t) => `- ${t}${accountOf(t) ? ` (${accountOf(t)})` : ''}`),
       '',
-      lost.length
-        ? `Reconnect ${lost.map((l) => l.toolkit).join(', ')} in Connections to restore ${lost.length === 1 ? 'it' : 'them'}.`
-        : 'Nothing is missing — these rows can be cleared from Connections.',
+      `Reconnect ${n === 1 ? 'it' : 'them'} in Connections to restore ${n === 1 ? 'it' : 'them'}. This card clears itself once nothing is expired.`,
     ].join('\n');
     this.postReviewCard({
       type: 'connection.expired',
       sessionId: '-',
       agent: 'system',
-      title: lost.length
-        ? `Connection expired — ${lost.map((l) => l.toolkit).join(', ')} unavailable`
-        : `${due.length} expired Composio connection${due.length === 1 ? '' : 's'} to clear`,
+      title: `Connection expired — ${lostToolkits.join(', ')} unavailable`,
       body,
-      args: { entity: userId, toolkits: due.map((d) => d.toolkit), lost: lost.map((l) => l.toolkit) },
+      args: { entity: userId, toolkits: lostToolkits, lost: lostToolkits },
       audience: ownerMemberId ? { kind: 'member', id: ownerMemberId } : { kind: 'admins' },
     });
-    this.os.composioIdentities.markNotified(due.map((d) => d.id));
-    this.audit('-', 'system', 'connector.expired', { entity: userId, toolkits: due.map((d) => d.toolkit), lost: lost.map((l) => l.toolkit) });
+  }
+
+  /**
+   * Close any expired-connection card whose premise has gone away.
+   *
+   * A card that outlives its condition is worse than no card: it sits in NEEDS YOU claiming an app is
+   * unavailable after the human has already dealt with it, and there is nothing they can do to make it
+   * go away — a review card carries no reject path, so "I fixed this" and "I am ignoring this" look
+   * identical. That happened the same afternoon this shipped: the expired connections were removed, the
+   * cache dropped to zero expired rows, and both cards stayed open.
+   *
+   * So the card is DERIVED state, reconciled on every refresh: it stands only while at least one of the
+   * toolkits it names still has an expired connection under that entity. Reconnected, deleted, or
+   * pruned all clear it — the card is about an expiry, and once no expiry remains there is nothing to
+   * report. Mirrors how an approval message derives its status from the approvals table at read time.
+   */
+  private reconcileExpiredCards(userId: string): number {
+    const expired = new Set(
+      this.os.composioIdentities.forEntity(userId)
+        .filter((i) => i.status.toUpperCase() === 'EXPIRED')
+        .map((i) => i.toolkit),
+    );
+    const open = this.db
+      .prepare(`SELECT id, args FROM messages WHERE type = 'connection.expired' AND status = 'open'`)
+      .all<{ id: string; args: string | null }>();
+    let closed = 0;
+    for (const row of open) {
+      let a: Record<string, unknown> = {};
+      try { a = row.args ? JSON.parse(row.args) : {}; } catch { /* tolerate a corrupt payload */ }
+      if (String(a.entity ?? '') !== userId) continue;
+      const named: string[] = Array.isArray(a.toolkits) ? (a.toolkits as unknown[]).map(String) : [];
+      // No toolkits recorded (a card from before this shape) → it can never be reconciled by name, so
+      // treat "nothing is expired on this shelf" as enough to retire it.
+      if (named.some((t) => expired.has(t))) continue;
+      this.db.prepare(`UPDATE messages SET status = 'resolved' WHERE id = ?`).run(row.id);
+      closed++;
+      this.audit('-', 'system', 'connector.expired.cleared', { entity: userId, toolkits: named });
+    }
+    return closed;
   }
 
   /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6389,6 +6389,12 @@ function ActionItem({ m, me, onOpen, onDismiss }: { m: Msg; me: Member; onOpen: 
           <Button render={<a href={navHref(review.page, review.detail)} />} size="sm" variant={canDecide ? 'ghost' : 'default'} className="h-7 px-2.5 text-xs">
             {canDecide ? 'See the full diff' : `Review in ${review.label}`}
           </Button>
+          {/* An OS notice, not an agent's proposal: there is nothing to approve or reject, so without this
+              a human who has already fixed the problem has no way to clear the card. It also self-heals
+              server-side on the next connection refresh — this is the manual escape hatch. */}
+          {m.type === 'connection.expired' && (
+            <Button size="sm" variant="ghost" className="h-7 px-2 text-xs" onClick={() => onDismiss(m.id)}>Dismiss</Button>
+          )}
           {isAgentEdit && !canDecide && <span className="text-[11px] text-muted-foreground">an owner has to approve this one</span>}
           {hint && <span className="font-mono text-[11px] text-muted-foreground">{hint}</span>}
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -968,7 +968,7 @@ export interface AutoApproval {
 
 export interface Msg {
   id: string
-  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'goal.ready' | 'goal.update.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed' | 'agent.update.proposed'
+  type: 'task' | 'update' | 'approval' | 'question' | 'completed' | 'artifact' | 'notification' | 'skill.proposed' | 'goal.proposed' | 'goal.ready' | 'goal.update.proposed' | 'skill.request' | 'secret.request' | 'host.proposed' | 'policy.proposal' | 'app.proposed' | 'automation.proposed' | 'agent.update.proposed' | 'connection.request' | 'connection.expired'
   sessionId: string
   agent: string
   title: string


### PR DESCRIPTION
Follow-up to #785, reported within the hour of it shipping: *"even after removing the expired connection these things still stay."*

Confirmed on the box — the identity cache held **zero** expired rows (the connections had been removed) while both `connection.expired` cards were still `status='open'` in NEEDS YOU, claiming an app was unavailable. And there was no way to clear them: a review card carries no reject path, so "I fixed this" and "I am ignoring this" looked identical.

## The card is now derived state

`reconcileExpiredCards` runs on every connection refresh, for **every** entity — including entities with nothing expired, which is precisely the case that has to close a card. A card stands only while at least one toolkit it names still has an expired connection on that shelf; reconnecting, deleting and pruning all retire it (`connector.expired.cleared`). Same shape as an approval message deriving its status from the approvals table at read time.

It also gained a **Dismiss** button as the manual escape hatch, and now says in its own body that it clears itself.

## Three more things the live cards got wrong

The screenshot shows all of them:

- **A reconnected app raised a card at all.** An expired row whose toolkit is live again is housekeeping — "Clear replaced" in Connections deals with it — so it is now recorded and marked notified but never put in front of a human. Only an app with **no** live account left is something anyone can act on. The live card titled *"gmail unavailable"* also carried a clickup line reading *"already reconnected, this is the old record"*, which is not news.
- **Two expired accounts of the same app were listed once each**, giving `google_search_console, google_search_console unavailable` and *"Reconnect google_search_console, google_search_console"*. One line per toolkit now, with the account beside it.
- **"2 the company Composio connections have expired."** Grammar fixed, and each app is named once rather than in both the opening sentence and the list.

Before / after body:

```
2 the company Composio connections have expired:
- clickup — already reconnected, this is the old record
- gmail — nothing else is connected for this app, so agents cannot use it at all
```
```
The company Composio connection has expired, and nothing else is connected for this app —
so agents cannot use it at all:
- gmail

Reconnect it in Connections to restore it. This card clears itself once nothing is expired.
```

## Verification

`npm run typecheck`, `npm run build`, `cd web && npm run build`, full `npm run test:governance` green. Four new checks in `scripts/composio-identity-test.cjs` (46 total) pin that the card stands while the app is still expired, that a reconnected app raises nothing, that two accounts of one app are one line, and that **deleting** the connection — the live case, where rows were pruned rather than reconnected — clears the card too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgJpL61B3SCdDEqozBDX3y