### PR TITLE
fix(connectors): the expired-connection card is Inbox-only, no Slack/Discord DM (v0.422.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.422.2] - 2026-09-03
+### Changed
+- **The expired-connection card no longer DMs Slack/Discord — Inbox only.** Every other review card is
+  an agent BLOCKED on a human (a credential, a skill, a policy change: nothing proceeds until someone
+  answers), so interrupting them out-of-band is the point. An expired connection is not that - it is a
+  standing condition nobody is waiting on, true for as long as it is true, and it retires itself once
+  the app is reconnected. A DM for it is a notification about state, which is exactly the noise that
+  makes the cards people MUST answer easy to miss. `postReviewCard` gained a `quiet` flag for this
+  class; the DM path is otherwise unchanged.
+
 ## [0.422.1] - 2026-09-03
 ### Fixed
 - **An expired-connection card outlived the problem.** Reported within the hour of v0.422.0 shipping:

--- a/docs/connectors/composio.md
+++ b/docs/connectors/composio.md
@@ -173,7 +173,10 @@ nothing anywhere saying so.
 
 - **Status is cached on every refresh**, and a newly-expired connection posts a `connection.expired`
   card (audited `connector.expired`) to whoever can reauthorise it — the shelf's member, or the admins
-  tier for the company shelf. Deduped per connection for a week. The card distinguishes the two cases,
+  tier for the company shelf. Deduped per connection for a week. **Inbox only, no Slack/Discord DM**
+  (`quiet: true`): every other review card is an agent blocked on a human, but this one is a standing
+  condition nobody is waiting on, so a DM would only add to the chat noise that buries the cards that
+  do need answering. The card distinguishes the two cases,
   because only one needs anyone to act: *reconnected already, this is the old row* vs *nothing else is
   connected for this app, so agents cannot use it at all*.
 - **The console** shows an expired row with a **Reconnect** button (the same hosted OAuth), and hides

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.422.1",
+  "version": "0.422.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.422.1",
+      "version": "0.422.2",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.422.1",
+  "version": "0.422.2",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/composio-identity-test.cjs
+++ b/scripts/composio-identity-test.cjs
@@ -208,6 +208,20 @@ check('…and another shelf\'s card is left alone', openCards().some((c) => JSON
 aos.composioIdentities.pruneEntity(owner.email, new Set());
 check('deleting the expired connection clears its card too', tm.reconcileExpiredCards(owner.email) === 1 && openCards().length === 0);
 
+// ── 8. the card is Inbox-only — no Slack/Discord DM ─────────────────────────────────────────────
+// Every other review card is an agent BLOCKED on a human, so interrupting them is the point. An expired
+// connection is a standing condition nobody is waiting on, and it self-heals — a DM for it is pure noise
+// on top of chat that is already noisy enough to bury the cards people must answer.
+let dms = 0;
+tm.setReviewNotifier(() => { dms++; });
+aos.composioIdentities.upsert([{ id: 'z1', userId: ENTITY, toolkit: 'notion', status: 'EXPIRED' }]);
+tm.notifyExpiredConnections(ENTITY);
+check('an expired-connection card lands in the Inbox', openCards().some((c) => /notion/.test(c.title)));
+check('…and sends no Slack/Discord DM', dms === 0);
+// The control: a card someone IS blocked on still pushes out-of-band.
+tm.requestConnection('-', 'some-agent', { toolkit: 'linear', scope: 'company', reasoning: 'need it' });
+check('control: a card an agent is blocked on still DMs', dms === 1);
+
 const total = pass + failures.length;
 if (failures.length) {
   console.error(`\nCOMPOSIO IDENTITY: ${pass}/${total} passed, ${failures.length} FAILED\n`);

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -4911,6 +4911,11 @@ export class TerminalManager {
       body,
       args: { entity: userId, toolkits: lostToolkits, lost: lostToolkits },
       audience: ownerMemberId ? { kind: 'member', id: ownerMemberId } : { kind: 'admins' },
+      // Inbox only. An expired connection is a standing condition, not a question anyone is blocked on:
+      // it stays true until someone reconnects the app, and the card retires itself when they do. A DM
+      // for it is a notification about state, which is exactly the kind of chat noise that makes the
+      // approvals and questions people MUST answer harder to see.
+      quiet: true,
     });
   }
 
@@ -6038,7 +6043,7 @@ export class TerminalManager {
    * fires in ONE place — parity with how approvals/questions/tasks already reach a human. The notifier is
    * advisory: a failed push never wedges the request.
    */
-  private postReviewCard(input: { type: ReviewCardKind; sessionId: string; agent: string; title: string; body: string; args?: Record<string, unknown>; summary?: string; audience?: Audience; link?: ReviewNotice['link'] }): void {
+  private postReviewCard(input: { type: ReviewCardKind; sessionId: string; agent: string; title: string; body: string; args?: Record<string, unknown>; summary?: string; audience?: Audience; link?: ReviewNotice['link']; quiet?: boolean }): void {
     // Providing/publishing/granting is an owner/admin act — address the review card to the admin tier by
     // default. A caller can override (e.g. a personal connection request, which only its own member can
     // complete) by passing an explicit `audience`.
@@ -6049,6 +6054,12 @@ export class TerminalManager {
       ...(input.args ? { args: input.args } : {}),
       audienceKind: audience.kind, audienceId: audienceIdOf(audience),
     });
+    // `quiet`: Inbox only, no Slack/Discord DM. Every OTHER review card is an agent BLOCKED on a human —
+    // it asked for a credential, a skill, a policy change, and nothing proceeds until someone answers, so
+    // interrupting them is the point. A card the OS raises about its own state is not that: nobody is
+    // waiting on it, it is true for as long as it is true, and it self-heals. Pushing it out-of-band adds
+    // to the chat noise that already makes the signal cards easy to miss.
+    if (input.quiet) return;
     try { this.reviewNotifier?.({ sessionId: input.sessionId, agent: input.agent, kind: input.type, title: input.title, summary: input.summary ?? input.body, audience, ...(input.link ? { link: input.link } : {}) }); }
     catch { /* out-of-band push is advisory — never let it wedge the request */ }
   }


### PR DESCRIPTION
Follow-up to #786. Feedback: *"Don't send a warning via discord or slack. It is too redundant (too much noise already)."*

Agreed, and the distinction is a real one worth encoding rather than special-casing:

- **Every other review card is an agent blocked on a human.** It asked for a credential, a skill, a policy change — nothing proceeds until someone answers. Interrupting them out-of-band is the point.
- **An expired connection is a standing condition nobody is waiting on.** It is true for as long as it is true, and since #786 it retires itself once the app is reconnected. A DM for it is a notification about state — exactly the noise that makes the cards people *must* answer easy to miss.

So `postReviewCard` gains a `quiet` flag: card in the Inbox, no DM. The DM path is otherwise untouched, and the test pins the control — a card an agent is blocked on still pushes out-of-band.

`npm run typecheck`, both builds, full `npm run test:governance` green; `scripts/composio-identity-test.cjs` now 49 checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgJpL61B3SCdDEqozBDX3y