### PR TITLE
feat(connectors): claim a company Composio connection back as one person's own (v0.423.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.423.0] - 2026-09-04
+### Added
+- **A company Composio connection can be claimed back as one person's own** — the exact inverse of
+  sharing a personal one with the team, and it exists for the same reason. Someone completes the hosted
+  OAuth on the *company* shelf while signed in to their own Google/Slack account, and the result is a
+  connection every agent in the tenant can act through wearing one individual's identity; that is the
+  shape of the incident this whole thread started from. An account's entity is immutable on Composio's
+  side, so a claim can no more be a move than a share can - it is a marker the launcher enforces by
+  minting everyone ELSE's company session without it (`composio_claims`, `exclusionFor`). Console:
+  **Make it personal** / **Give back to company** on a company row, mirroring Share with team.
+  `POST /api/connections/claim`, audited `connector.claimed` / `connector.released`.
+- Two exclusions are expressible and the code picks between them: the claimed account is the only ACTIVE
+  one of its toolkit ⇒ `toolkits.disable` (Composio rejects an empty account pin), other active accounts
+  remain ⇒ pin the session to exactly those. Both verified against the live endpoint - a disabled toolkit
+  is genuinely unreachable, not merely hidden.
+
+### Note
+- Automation and system runs are excluded too: they act as nobody, so they have no business acting as the
+  claimer. A toolkit that cannot be enumerated is disabled rather than left open - over-restricting is
+  recoverable, under-restricting is the bug. The prompt follows the mint, so a claimed app is hidden from
+  every other run and shown to its claimer marked as their own.
+- Owner/admin only, since a company connection is org property and privatising one takes a capability
+  away from everyone. Whose it is comes from the account resolved in v0.422.0; when no member matches,
+  the caller names one.
+
 ## [0.422.2] - 2026-09-03
 ### Changed
 - **The expired-connection card no longer DMs Slack/Discord — Inbox only.** Every other review card is

--- a/docs/connectors/composio.md
+++ b/docs/connectors/composio.md
@@ -127,6 +127,47 @@ Two things worth knowing about it:
   rule for remote execution as a class. Their auto-approve signature is namespaced separately, so an
   "always approve" for a local command can never clear the same command on Composio's sandbox.
 
+## Claiming a company connection back (`src/connectors/composio-claims.ts`)
+
+The exact inverse of sharing, and it exists for the same reason. Someone completes the hosted OAuth on
+the **company** shelf while signed in to their own Google/Slack account — which happens constantly — and
+the result is a connection every agent in the tenant can act through, wearing one individual's identity.
+That is the shape of the incident that started this work.
+
+An account's entity is immutable on Composio's side, so a claim can no more be a move than a share can.
+It is a marker enforced at mint time, in the same place and by the same code path:
+
+| | marker | how the launcher enforces it |
+|---|---|---|
+| **Share** (`composio_shares`) | personal account → reachable by everyone | mint an EXTRA session under the owner's entity, allowlisted + pinned |
+| **Claim** (`composio_claims`) | company account → reachable by one member | mint the company session **minus** it, for everyone else |
+
+`exclusionFor` picks between the two expressible exclusions:
+
+- the claimed account is the **only** ACTIVE one of its toolkit → `toolkits.disable`, because Composio
+  rejects an empty account pin (`Array must contain at least 1 element`);
+- **other** active accounts of that toolkit remain → pin the session to exactly those.
+
+Both verified against the live endpoint: a disabled toolkit is genuinely unreachable, and
+`COMPOSIO_SEARCH_TOOLS` reports no connection for it rather than offering a dead one.
+
+Notes worth keeping:
+
+- **Automation and system runs are excluded too.** They act as nobody, so they have no business acting
+  as the claimer.
+- **A toolkit we cannot enumerate is disabled, not left open.** Over-restricting is recoverable — the
+  agent reports it cannot reach an app — while under-restricting silently hands a teammate's mailbox to
+  the whole fleet, which is the bug being fixed.
+- **The prompt follows the mint.** A claimed app is hidden from every other run's Composio section, and
+  shown to its claimer marked as their own account. Advertising an app the session cannot reach is the
+  same class of lie as not saying whose account it is.
+- **Owner/admin only**, because a company connection is org property and privatising one takes a
+  capability away from everyone. Whose it is comes from the resolved account (an email that matches a
+  member); when nothing matches, the caller names the member explicitly.
+- **A claim always lets go**: releasing talks to no remote (so a broken API key can never leave a toolkit
+  walled off), a claim on a deleted connection is pruned on the next refresh, and removing a member gives
+  their claimed connections back to the company.
+
 ## Whose account is it, really? (`src/connectors/composio-identity.ts`)
 
 **A Composio `user_id` is a SHELF, not an identity.** `service:<tenant>` means "the company's shelf"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.422.2",
+  "version": "0.423.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.422.2",
+      "version": "0.423.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.422.2",
+  "version": "0.423.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/composio-identity-test.cjs
+++ b/scripts/composio-identity-test.cjs
@@ -222,6 +222,63 @@ check('…and sends no Slack/Discord DM', dms === 0);
 tm.requestConnection('-', 'some-agent', { toolkit: 'linear', scope: 'company', reasoning: 'need it' });
 check('control: a card an agent is blocked on still DMs', dms === 1);
 
+// ── 9. claims: the inverse of sharing ────────────────────────────────────────────────────────────
+// Someone completes the hosted OAuth on the COMPANY shelf while signed in to their own account, and the
+// result is a connection every agent can act through wearing that individual's identity. The entity is
+// immutable on Composio's side, so a claim can no more be a move than a share can — it is a marker the
+// launcher enforces by minting everyone else's company session WITHOUT it.
+const { exclusionFor } = require(path.resolve(__dirname, '..', 'dist/connectors/composio-claims'));
+const CO = `service:${aos.tenant}`;
+const claim = (id, toolkit, memberId) => ({ id, toolkit, userId: CO, memberId, account: '', claimedBy: 'admin@x', createdAt: 1 });
+
+// One account, claimed: nobody else can reach the toolkit at all. Composio rejects an empty account pin
+// ("Array must contain at least 1 element"), so the only expressible exclusion is disabling the toolkit.
+let ex = exclusionFor([claim('ca_1', 'googlesheets', 'm_zubair')], new Map([['googlesheets', ['ca_1']]]), 'm_other');
+check('a sole claimed account disables its toolkit for everyone else', ex.disableToolkits.includes('googlesheets'));
+check('…and pins nothing, since there is nothing left to pin', Object.keys(ex.connectedAccounts).length === 0);
+
+// The claimer keeps it, untouched.
+ex = exclusionFor([claim('ca_1', 'googlesheets', 'm_zubair')], new Map([['googlesheets', ['ca_1']]]), 'm_zubair');
+check('the claimer still reaches their own account', !ex.disableToolkits.length && !Object.keys(ex.connectedAccounts).length);
+
+// A second, unclaimed account of the same app must survive for everyone else.
+ex = exclusionFor([claim('ca_1', 'googlesheets', 'm_zubair')], new Map([['googlesheets', ['ca_1', 'ca_2']]]), 'm_other');
+check('a sibling unclaimed account is kept by re-pinning, not disabled', !ex.disableToolkits.includes('googlesheets'));
+check('…and the claimed one is pinned out', JSON.stringify(ex.connectedAccounts.googlesheets) === '["ca_2"]');
+
+// An automation/system run has no member, so it is nobody — it must not act as the claimer.
+ex = exclusionFor([claim('ca_1', 'gmail', 'm_zubair')], new Map([['gmail', ['ca_1']]]), undefined);
+check('an automation run (no member) is excluded like everyone else', ex.disableToolkits.includes('gmail'));
+
+// Fail SAFE: a toolkit we cannot enumerate is disabled, never left open. Over-restricting is recoverable
+// (the agent reports it cannot reach an app); under-restricting hands a teammate's mailbox to the fleet.
+ex = exclusionFor([claim('ca_1', 'gmail', 'm_zubair')], new Map(), 'm_other');
+check('an unknown toolkit with a claim fails closed', ex.disableToolkits.includes('gmail'));
+check('no claims ⇒ no restriction at all', (() => {
+  const none = exclusionFor([], new Map([['gmail', ['ca_9']]]), 'm_other');
+  return !none.disableToolkits.length && !Object.keys(none.connectedAccounts).length;
+})());
+
+// The store, and the two ways a claim must let go.
+aos.composioClaims.claim(claim('ca_keep', 'gmail', owner.id));
+aos.composioClaims.claim(claim('ca_gone', 'notion', owner.id));
+check('claims are recorded', aos.composioClaims.list().length === 2);
+check('a claim on a deleted connection is pruned — otherwise it disables a toolkit forever',
+  aos.composioClaims.pruneEntity(CO, new Set(['ca_keep'])).length === 1 && aos.composioClaims.list().length === 1);
+check('removing the member gives the connection back to the company',
+  aos.composioClaims.releaseByMember(owner.id).length === 1 && aos.composioClaims.list().length === 0);
+
+// The prompt must not advertise an app this run cannot reach.
+aos.settings.setComposioApiKey('test-key', 'owner@testco');
+aos.composioIdentities.upsert([{ id: 'ca_hub', userId: CO, toolkit: 'hubspot', account: 'zubair@x.io', status: 'ACTIVE' }]);
+aos.composioClaims.claim(claim('ca_hub', 'hubspot', 'm_someone_else'));
+check('a claimed app is hidden from every other run\'s prompt', !/hubspot/.test(tm.buildCompanyMd('a', owner.id, false, '')));
+check('…while a sibling unclaimed account of another app is untouched', /googlesheets/.test(tm.buildCompanyMd('a', owner.id, false, '')));
+aos.composioClaims.claim(claim('ca_hub', 'hubspot', owner.id));
+const own = tm.buildCompanyMd('a', owner.id, false, '');
+check('…and shown to its claimer', /hubspot — zubair@x\.io/.test(own));
+check('…labelled as theirs, not the company\'s', /your OWN account, kept on the company shelf/.test(own));
+
 const total = pass + failures.length;
 if (failures.length) {
   console.error(`\nCOMPOSIO IDENTITY: ${pass}/${total} passed, ${failures.length} FAILED\n`);

--- a/src/connectors/composio-claims.ts
+++ b/src/connectors/composio-claims.ts
@@ -1,0 +1,158 @@
+/**
+ * Claiming a company Composio connection back as one person's own — the exact inverse of sharing.
+ *
+ * The two directions exist for the same reason and are enforced the same way. A connected account's
+ * owning entity is IMMUTABLE on Composio's side (no transfer API, and a Tool Router session may only pin
+ * accounts belonging to its own `user_id`), so neither "lend mine to the team" nor "take this one back
+ * out of the company shelf" can be a move. Both are markers Agentric enforces at mint time:
+ *
+ *   composio-shares.ts   personal account → reachable by everyone   (mint an EXTRA pinned session)
+ *   composio-claims.ts   company account  → reachable by one member (mint the company session MINUS it)
+ *
+ * The case it is for: someone completes the hosted OAuth on the **company** shelf while signed in to
+ * their own Google/Slack/whatever account. That happens by accident constantly, and the result is a
+ * connection every agent in the tenant can act through, wearing one individual's identity — the exact
+ * shape of the incident that started this work, where a company Google Sheets connection turned out to
+ * be a specific teammate's personal account and an agent "acting as the company" wrote into their Drive.
+ * Disconnecting and reconnecting on the right shelf is the only true fix, but it needs the person to be
+ * at a browser and re-authorise; a claim is the instant, reversible one that stops the bleeding.
+ *
+ * ENFORCEMENT (see `TerminalManager.composioSessionPlan`). A claim narrows the COMPANY session of every
+ * run that is not acting as the claimer — including automation and system runs, which have no member and
+ * therefore no business acting as one:
+ *
+ *   - the claimed account is the only ACTIVE one of its toolkit on the shelf → `toolkits.disable`,
+ *     because Composio rejects an empty account pin (`Array must contain at least 1 element`);
+ *   - other active accounts of that toolkit remain → pin the session to exactly those.
+ *
+ * Both were verified against the live endpoint: a disabled toolkit is genuinely unreachable, and
+ * `COMPOSIO_SEARCH_TOOLS` reports no connection for it rather than silently offering a dead one.
+ *
+ * Releasing deletes the row and the next session mints without it. Nothing on composio.dev changes in
+ * either direction, so a claim needs no re-authorisation and can always be undone.
+ */
+import { Db } from '../state/db';
+
+/** One company connection that is, in practice, a single person's account. */
+export interface ComposioClaim {
+  /** The Composio connected-account id (`ca_…`) on the COMPANY entity. */
+  id: string;
+  /** Toolkit slug (gmail, googlesheets, …) — what gets disabled or re-pinned for everyone else. */
+  toolkit: string;
+  /** The company service entity the account lives under. Unchanged by the claim; it cannot be moved. */
+  userId: string;
+  /** The member the account really belongs to — the only person whose runs still reach it. */
+  memberId: string;
+  /** The account the connection resolves to at claim time, for display without a live fetch. */
+  account: string;
+  /** Email of the owner/admin who filed the claim. */
+  claimedBy: string;
+  createdAt: number;
+}
+
+interface ClaimRow {
+  id: string;
+  toolkit: string;
+  user_id: string;
+  member_id: string;
+  account: string;
+  claimed_by: string;
+  created_at: number;
+}
+
+const toClaim = (r: ClaimRow): ComposioClaim => ({
+  id: r.id,
+  toolkit: r.toolkit,
+  userId: r.user_id,
+  memberId: r.member_id,
+  account: r.account || '',
+  claimedBy: r.claimed_by,
+  createdAt: r.created_at,
+});
+
+/** How to narrow one company session so it excludes the claims that are not the caller's. */
+export interface ClaimExclusion {
+  /** Toolkits to switch off entirely — every active account of theirs is claimed by someone else. */
+  disableToolkits: string[];
+  /** Toolkits to pin to their remaining unclaimed accounts. */
+  connectedAccounts: Record<string, string[]>;
+}
+
+/**
+ * Work out how to mint a company session for `actingMemberId` given the claims on the shelf and what is
+ * actually ACTIVE on it. Pure — the caller supplies the live/cached account list.
+ *
+ * `activeByToolkit` maps a toolkit to the ids of its ACTIVE company accounts. A toolkit missing from it
+ * is unknown to us, and an unknown toolkit with a claim is DISABLED rather than left open: over-
+ * restricting a session is recoverable (the agent reports it cannot reach an app), while under-
+ * restricting it silently hands someone else's mailbox to the whole fleet, which is the bug being fixed.
+ */
+export function exclusionFor(
+  claims: ComposioClaim[],
+  activeByToolkit: Map<string, string[]>,
+  actingMemberId?: string,
+): ClaimExclusion {
+  const out: ClaimExclusion = { disableToolkits: [], connectedAccounts: {} };
+  const foreign = claims.filter((c) => c.memberId !== actingMemberId);
+  for (const toolkit of new Set(foreign.map((c) => c.toolkit))) {
+    const claimedHere = new Set(foreign.filter((c) => c.toolkit === toolkit).map((c) => c.id));
+    const active = activeByToolkit.get(toolkit);
+    if (!active) { out.disableToolkits.push(toolkit); continue; }
+    const remaining = active.filter((id) => !claimedHere.has(id));
+    if (remaining.length) out.connectedAccounts[toolkit] = remaining;
+    else out.disableToolkits.push(toolkit);
+  }
+  return out;
+}
+
+export class ComposioClaimStore {
+  constructor(private readonly db: Db) {}
+
+  list(): ComposioClaim[] {
+    return this.db
+      .prepare('SELECT * FROM composio_claims ORDER BY created_at')
+      .all<ClaimRow>()
+      .map(toClaim);
+  }
+
+  get(id: string): ComposioClaim | undefined {
+    const r = this.db.prepare('SELECT * FROM composio_claims WHERE id = ?').get<ClaimRow>(id);
+    return r ? toClaim(r) : undefined;
+  }
+
+  /** Claim a company connection for one member. Idempotent — re-claiming re-points it. */
+  claim(c: Omit<ComposioClaim, 'createdAt'>): ComposioClaim {
+    const existing = this.get(c.id);
+    this.db
+      .prepare(
+        `INSERT INTO composio_claims (id, toolkit, user_id, member_id, account, claimed_by, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET toolkit = excluded.toolkit, user_id = excluded.user_id,
+           member_id = excluded.member_id, account = excluded.account, claimed_by = excluded.claimed_by`,
+      )
+      .run(c.id, c.toolkit, c.userId, c.memberId, c.account, c.claimedBy, existing?.createdAt ?? Date.now());
+    return this.get(c.id)!;
+  }
+
+  /** Back to the whole company. Returns whether a claim existed. */
+  release(id: string): boolean {
+    return this.db.prepare('DELETE FROM composio_claims WHERE id = ?').run(id).changes > 0;
+  }
+
+  /** Drop claims whose connection no longer exists on Composio — otherwise a deleted account would keep
+   *  disabling a toolkit for the whole tenant forever, with nothing in the console to explain why. */
+  pruneEntity(userId: string, liveIds: Set<string>): string[] {
+    const gone = this.list().filter((c) => c.userId === userId && !liveIds.has(c.id)).map((c) => c.id);
+    for (const id of gone) this.release(id);
+    return gone;
+  }
+
+  /** A removed member's claims go back to the company — an account nobody owns must not stay walled off. */
+  releaseByMember(memberId: string): string[] {
+    const rows = this.db
+      .prepare('SELECT id FROM composio_claims WHERE member_id = ?')
+      .all<{ id: string }>(memberId);
+    this.db.prepare('DELETE FROM composio_claims WHERE member_id = ?').run(memberId);
+    return rows.map((r) => r.id);
+  }
+}

--- a/src/connectors/composio.ts
+++ b/src/connectors/composio.ts
@@ -206,6 +206,12 @@ export async function initiateConnection(
  */
 export interface MintOptions {
   toolkits?: string[];
+  /** Toolkits to REMOVE from an otherwise unrestricted session. Used by claims (composio-claims.ts): a
+   *  company app privately claimed by one member is disabled in everyone else's company session. Verified
+   *  against the live endpoint — a disabled toolkit is genuinely unreachable, not merely hidden, and
+   *  `COMPOSIO_SEARCH_TOOLS` reports no connection for it. Mutually exclusive with `toolkits`: one mint
+   *  is either an allowlist (a borrowed share) or a denylist (a company session minus claims). */
+  disableToolkits?: string[];
   connectedAccounts?: Record<string, string[]>;
   manageConnections?: boolean;
 }
@@ -214,7 +220,9 @@ export interface MintOptions {
 function mintBody(userId: string, opts: MintOptions): string {
   return JSON.stringify({
     user_id: userId,
-    ...(opts.toolkits?.length ? { toolkits: { enable: opts.toolkits } } : {}),
+    ...(opts.toolkits?.length
+      ? { toolkits: { enable: opts.toolkits } }
+      : opts.disableToolkits?.length ? { toolkits: { disable: opts.disableToolkits } } : {}),
     ...(opts.connectedAccounts && Object.keys(opts.connectedAccounts).length
       ? { connected_accounts: opts.connectedAccounts }
       : {}),

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -26,6 +26,7 @@ import { CapabilityRegistry } from './capabilities/registry';
 import { ConnectorStore } from './connectors/connectors';
 import { ComposioShareStore } from './connectors/composio-shares';
 import { ComposioIdentityStore } from './connectors/composio-identity';
+import { ComposioClaimStore } from './connectors/composio-claims';
 import { HostStore } from './hosts/hosts';
 import { AutoApprovalStore } from './state/auto-approvals';
 import { Gateway } from './gateway/gateway';
@@ -129,6 +130,8 @@ export class AgentOS {
   readonly composioShares: ComposioShareStore;
   /** What each Composio connection REALLY is — the account behind the entity (composio-identity.ts). */
   readonly composioIdentities: ComposioIdentityStore;
+  /** Company connections claimed back as one member's own (composio-claims.ts) — sharing, inverted. */
+  readonly composioClaims: ComposioClaimStore;
   /** Host connections — governed reachable destinations (SSH / internal HTTP / DB). See host-connections-plan.md. */
   readonly hosts: HostStore;
   /** "Always approve THIS action" list, keyed on the decision-brief signature (auto-approvals.ts). */
@@ -155,6 +158,7 @@ export class AgentOS {
     this.connectors = new ConnectorStore(this.db);
     this.composioShares = new ComposioShareStore(this.db);
     this.composioIdentities = new ComposioIdentityStore(this.db);
+    this.composioClaims = new ComposioClaimStore(this.db);
     this.hosts = new HostStore(this.db);
     this.autoApprovals = new AutoApprovalStore(this.db);
     this.approvals = new SqliteApprovals(this.db);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2696,6 +2696,9 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     // Same rule for their shared Composio apps: the team borrowed those through THEIR entity, so the
     // grant dies with the account rather than leaving the fleet minting under a departed member.
     const sharesRemoved = os.composioShares.removeByOwner(teamMember[1]).length;
+    // …and any company connection claimed for them goes back to the company: an account nobody owns must
+    // not stay walled off from the whole fleet with no one able to explain why.
+    os.composioClaims.releaseByMember(teamMember[1]);
     os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'member.removed', data: { member: teamMember[1], connectorsRemoved, hostsRemoved, sharesRemoved } });
     return sendJson(res, 200, { ...out, connectorsRemoved, hostsRemoved, sharesRemoved });
   }
@@ -6557,8 +6560,18 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     const identities = os.composioIdentities.byConnection([
       serviceUserId(os.tenant), me.email, ...owners,
     ]);
-    const withAccount = <T extends { id: string }>(a: T): T & { account: string } =>
-      ({ ...a, account: identities.get(a.id)?.account ?? '' });
+    // Claims: a company row that is really one person's account. Carried on the row so the console can
+    // render whose it is (and offer to give it back) without a second call.
+    const claims = new Map(os.composioClaims.list().map((c) => [c.id, c]));
+    const memberName = (id: string): string => os.team.getMember(id)?.name || os.team.getMember(id)?.email || id;
+    const withAccount = <T extends { id: string }>(a: T): T & { account: string; claimedBy?: string; claimedByMember?: string } => {
+      const c = claims.get(a.id);
+      return {
+        ...a,
+        account: identities.get(a.id)?.account ?? '',
+        ...(c ? { claimedBy: memberName(c.memberId), claimedByMember: c.memberId } : {}),
+      };
+    };
     return sendJson(res, 200, {
       keySet: true,
       company: company.map(withAccount),
@@ -6608,6 +6621,53 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
       { userId: me.email, ownerMemberId: me.id },
     ], { notify: false });
     return sendJson(res, 200, { ok: true, removed, kept: doomed.length - removed.length });
+  }
+  // The inverse of sharing: a COMPANY connection that is really one person's account (someone completed
+  // the hosted OAuth while signed in to their own Google/Slack) is claimed back for them. Composio cannot
+  // move an account between entities, so this is a marker the launcher enforces — every OTHER run's
+  // company session is minted without it. Owner/admin only: a company connection is org property, and
+  // letting any member privatise one would silently take a capability away from the whole fleet.
+  if (method === 'POST' && p === '/api/connections/claim') {
+    const b = await readBody(req);
+    const id = String(b.id || '').trim();
+    const claimed = b.claimed !== false;
+    if (!id) return sendJson(res, 400, { error: 'id is required' });
+    if (!isAdmin(me)) return sendJson(res, 403, { error: 'only an owner or admin can change who a company connection belongs to' });
+    // Releasing talks to no remote, so it must ALWAYS be possible — a cleared or broken Composio key can
+    // never leave a toolkit walled off with no way to give it back.
+    if (!claimed) {
+      const existing = os.composioClaims.get(id);
+      if (!existing) return sendJson(res, 404, { error: 'that connection is not claimed' });
+      os.composioClaims.release(id);
+      os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'connector.released', data: { id, toolkit: existing.toolkit, member: existing.memberId } });
+      return sendJson(res, 200, { ok: true, claimed: false });
+    }
+    const key = os.settings.composioApiKey();
+    if (!key) return sendJson(res, 400, { error: 'no Composio API key' });
+    const entity = serviceUserId(os.tenant);
+    // Verified against Composio, so a claim can only ever name a real company connection.
+    const company = await listConnectedAccounts(key, entity);
+    const app = company.find((a) => a.id === id);
+    if (!app) return sendJson(res, 404, { error: 'that connection is not on the company shelf' });
+    // Who it belongs to: an explicit member, else the one whose email matches the account we resolved
+    // for it. The second is the common case and the reason resolving accounts came first — without it
+    // there is nothing to match on and the caller has to know.
+    const resolved = os.composioIdentities.byConnection([entity]).get(id)?.account ?? '';
+    const target = String(b.memberId || '').trim()
+      ? os.team.getMember(String(b.memberId).trim())
+      : (resolved ? os.team.getMemberByEmail(resolved) : undefined);
+    if (!target) {
+      return sendJson(res, 400, {
+        error: resolved
+          ? `no team member has the address ${resolved} — say which member this connection belongs to`
+          : 'this connection has no resolved account yet — run Check accounts, or say which member it belongs to',
+        resolved,
+      });
+    }
+    os.composioClaims.pruneEntity(entity, new Set(company.map((a) => a.id)));
+    os.composioClaims.claim({ id, toolkit: app.toolkit, userId: entity, memberId: target.id, account: resolved, claimedBy: me.email });
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'connector.claimed', data: { id, toolkit: app.toolkit, member: target.id, account: resolved } });
+    return sendJson(res, 200, { ok: true, claimed: true, member: { id: target.id, name: target.name } });
   }
   // Mark one of MY Composio connections available to the whole team — or take it back to just me.
   // Composio can't move an account between entities (its `user_id` is immutable and a session may only

--- a/src/state/db.ts
+++ b/src/state/db.ts
@@ -129,6 +129,22 @@ function migrate(db: Db): void {
     );
     CREATE INDEX IF NOT EXISTS idx_composio_identities_user ON composio_identities (user_id);
 
+    -- Company Composio connections that are really ONE person's account (composio-claims.ts) — the exact
+    -- inverse of composio_shares. Someone completes the hosted OAuth on the company shelf while signed in
+    -- to their own Google/Slack account, and the result is a connection every agent can act through
+    -- wearing that individual's identity. The entity is immutable on Composio's side, so this cannot be a
+    -- move: it is a marker the launcher enforces by minting everyone ELSE's company session without it.
+    CREATE TABLE IF NOT EXISTS composio_claims (
+      id         TEXT PRIMARY KEY,       -- the Composio connected-account id (ca_...) on the company entity
+      toolkit    TEXT NOT NULL,          -- toolkit slug — what gets disabled or re-pinned for everyone else
+      user_id    TEXT NOT NULL,          -- the company service entity (unchanged; it cannot be moved)
+      member_id  TEXT NOT NULL,          -- the member it really belongs to (prunes with the member)
+      account    TEXT NOT NULL DEFAULT '', -- resolved account at claim time, for display
+      claimed_by TEXT NOT NULL,          -- email of the owner/admin who filed it
+      created_at INTEGER NOT NULL
+    );
+    CREATE INDEX IF NOT EXISTS idx_composio_claims_member ON composio_claims (member_id);
+
     -- Host connections — reachable destinations (SSH box / internal HTTP / DB) an agent may talk to,
     -- as a first-class governed thing (docs/host-connections-plan.md). Phase 2a stores them; the
     -- governance that reads them (net.connect/ssh.exec + allow-list) is Phase 2b. Mirrors connectors'

--- a/src/terminal.ts
+++ b/src/terminal.ts
@@ -20,6 +20,7 @@ import { agentEditable, applyAgentEdit, assessClaudeMdEdit, contentHash, diffSta
 import { mintToolRouterSessionAsync, COMPOSIO_KEY_HEADER, serviceUserId, type MintOptions } from './connectors/composio';
 import { listConnectedAccounts } from './connectors/composio';
 import { activeToolkits, resolveIdentities } from './connectors/composio-identity';
+import { exclusionFor } from './connectors/composio-claims';
 import { isCodingRuntime, runtimeSupports, CODING_RUNTIMES, CodingRuntimeId, ActionAttempt, AgentManifest, ApprovalLevel, AuditEvent, Decision, Member, RiskClass, Role, RunContext, RuntimeTuning, TaskRun, TaskStatus, TaskWorkers, TaskTimelineEntry, TaskDiscussionSummary, canApprove, resolveRuntimeTuning, riskClassForLevel } from './types';
 import { enrichArgs, autoClearsApproval, redactSecrets } from './governance/enricher';
 import { isolateClaudeConfig } from './edge/config-isolation';
@@ -4807,6 +4808,19 @@ export class TerminalManager {
     return JSON.stringify(config, null, 2);
   }
 
+  /** ACTIVE company accounts grouped by toolkit, from the identity cache — what `exclusionFor` needs to
+   *  decide between disabling a toolkit outright and re-pinning it to the accounts nobody has claimed.
+   *  A toolkit absent here is unknown to us, and `exclusionFor` disables it rather than leaving a claimed
+   *  account reachable; over-restricting is recoverable, under-restricting is the bug. */
+  private activeCompanyAccounts(entity: string): Map<string, string[]> {
+    const byToolkit = new Map<string, string[]>();
+    for (const i of this.os.composioIdentities.forEntity(entity)) {
+      if (i.status.toUpperCase() !== 'ACTIVE') continue;
+      byToolkit.set(i.toolkit, [...(byToolkit.get(i.toolkit) ?? []), i.id]);
+    }
+    return byToolkit;
+  }
+
   /** Has this entity's cached identity/status gone stale (or never been resolved)? Keeps the launch-time
    *  refresh to roughly once every six hours per entity rather than once per session. */
   private composioIdentityStale(userId: string, maxAgeMs = 6 * 60 * 60 * 1000): boolean {
@@ -4843,7 +4857,11 @@ export class TerminalManager {
       if (!accounts.length) continue;
       // Status first, so an expired connection is recorded even when the identity probe fails.
       this.os.composioIdentities.upsert(accounts.map((a) => ({ id: a.id, userId, toolkit: a.toolkit, status: a.status })));
-      this.os.composioIdentities.pruneEntity(userId, new Set(accounts.map((a) => a.id)));
+      const liveIds = new Set(accounts.map((a) => a.id));
+      this.os.composioIdentities.pruneEntity(userId, liveIds);
+      // A claim on a connection that no longer exists would keep disabling its toolkit for the whole
+      // tenant forever, with nothing in the console left to explain why.
+      this.os.composioClaims.pruneEntity(userId, liveIds);
       // ONLY toolkits with a live account — probing one without would make Composio initiate a
       // connection rather than report its absence (see composio-identity.ts).
       const found = await resolveIdentities(key, userId, activeToolkits(accounts));
@@ -4966,8 +4984,16 @@ export class TerminalManager {
    * never be told about a namespace it doesn't have, or left blind about one it does.
    */
   private composioSessionPlan(memberId: string | undefined, agent: string): Array<{ id: string; userId: string; scope: 'personal' | 'company' | 'shared'; ownerMemberId?: string; opts?: MintOptions }> {
+    const companyEntity = serviceUserId(this.os.tenant);
+    // Claims (composio-claims.ts): a company connection that is really ONE person's account is minted
+    // OUT of everyone else's company session — including automation/system runs, which have no member
+    // and so no business acting as one. The exact inverse of a share, enforced in the same place.
+    const claims = this.os.composioClaims.list().filter((c) => c.userId === companyEntity);
+    const companyOpts: MintOptions = claims.length
+      ? exclusionFor(claims, this.activeCompanyAccounts(companyEntity), memberId)
+      : {};
     const sessions: Array<{ id: string; userId: string; scope: 'personal' | 'company' | 'shared'; ownerMemberId?: string; opts?: MintOptions }> = [
-      { id: 'composio-company', userId: serviceUserId(this.os.tenant), scope: 'company' },
+      { id: 'composio-company', userId: companyEntity, scope: 'company', ...(claims.length ? { opts: companyOpts } : {}) },
     ];
     // `composio` → the running member's OWN connected apps (their email as user_id); `composio-company`
     // → apps connected under the shared service entity, usable by every agent. Automation/system spawns
@@ -5010,6 +5036,12 @@ export class TerminalManager {
     if (!this.os.settings.composioApiKey()) return '';
     const plan = this.composioSessionPlan(memberId, agent);
     const cached = this.os.composioIdentities;
+    // A claimed app sits on the company shelf but belongs to one person. The claimer's own runs still
+    // reach it, and they are told so explicitly — otherwise "it is on the company shelf" reads as
+    // "it is the company's", which is the misreading that put a teammate's Drive in an agent's hands.
+    const claimedBy = new Map(this.os.composioClaims.list().map((c) => [c.id, c.memberId]));
+    const claimNote = (id: string): string =>
+      claimedBy.has(id) ? ' — your OWN account, kept on the company shelf; no other agent can use it' : '';
     const lines: string[] = [];
     for (const s of plan) {
       const who = s.scope === 'personal'
@@ -5017,9 +5049,16 @@ export class TerminalManager {
         : s.scope === 'company'
           ? 'the apps connected at the COMPANY level, shared by every agent'
           : `apps **${this.os.team.getMember(s.ownerMemberId ?? '')?.name || s.userId}** lent to the team`;
-      const accounts = cached.forEntity(s.userId).filter((i) => i.status.toUpperCase() === 'ACTIVE');
+      let accounts = cached.forEntity(s.userId).filter((i) => i.status.toUpperCase() === 'ACTIVE');
+      // A claimed company app is minted out of this session unless the run acts as its claimer, so it
+      // must not be advertised here either — telling an agent about an app it cannot reach is the same
+      // class of lie as not telling it whose account an app is.
+      if (s.scope === 'company') {
+        const mine = new Map(this.os.composioClaims.list().filter((c) => c.userId === s.userId).map((c) => [c.id, c.memberId]));
+        accounts = accounts.filter((a) => !mine.has(a.id) || mine.get(a.id) === memberId);
+      }
       const detail = accounts.length
-        ? accounts.map((a) => `    - ${a.toolkit} — ${a.account || 'account unknown'}`).join('\n')
+        ? accounts.map((a) => `    - ${a.toolkit} — ${a.account || 'account unknown'}${claimNote(a.id)}`).join('\n')
         : '    - (nothing resolved yet — check Connections in the console before assuming an app is there)';
       lines.push(`- **\`${s.id}\`** — ${who}:\n${detail}`);
     }

--- a/web/src/connectors.tsx
+++ b/web/src/connectors.tsx
@@ -375,12 +375,15 @@ function ConnectorRow({ c, me, busy, onToggle, onRemove, onShare }: {
 /** A live Composio-connected app row (company or personal). Shows the connection's distinguishing
  *  handle/alias so multiple accounts of the same app (e.g. two Gmails) are told apart.
  *  `onShare` is passed for a row the viewer owns — the "available to the team / just me" toggle. */
-function ComposioRow({ app, canRemove, busy, onRemove, onShare, onReconnect, sharedBy }: {
-  app: { id: string; toolkit: string; status: string; name?: string; account?: string; shared?: boolean }
+function ComposioRow({ app, canRemove, busy, onRemove, onShare, onReconnect, onClaim, sharedBy }: {
+  app: { id: string; toolkit: string; status: string; name?: string; account?: string; shared?: boolean; claimedBy?: string }
   canRemove: boolean; busy: boolean; onRemove?: () => void
   onShare?: (shared: boolean) => void
   /** Offered on an EXPIRED row — re-runs the OAuth for this toolkit on this shelf. */
   onReconnect?: () => void
+  /** COMPANY rows only — the inverse of onShare: hand a connection that is really one person's account
+   *  back to them, or give it back to the company. */
+  onClaim?: (claimed: boolean) => void
   /** Set on a BORROWED row (a teammate shared it) — shown instead of the share control. */
   sharedBy?: string
 }) {
@@ -393,7 +396,7 @@ function ComposioRow({ app, canRemove, busy, onRemove, onShare, onReconnect, sha
   // individual's login underneath, and that is who owns the documents an agent creates through it.
   // Lead with it, and fall back to the opaque handle only while it is still unresolved.
   const expired = app.status.toUpperCase() !== 'ACTIVE'
-  const detail = [app.account || handle, sharedBy ? `shared by ${sharedBy}` : '', 'via Composio'].filter(Boolean).join(' · ')
+  const detail = [app.account || handle, sharedBy ? `shared by ${sharedBy}` : '', app.claimedBy ? `only ${app.claimedBy}` : '', 'via Composio'].filter(Boolean).join(' · ')
   return (
     <Row
       name={app.toolkit}
@@ -403,14 +406,23 @@ function ComposioRow({ app, canRemove, busy, onRemove, onShare, onReconnect, sha
         <>
           {statusBadge(app.status.toLowerCase(), expired ? 'warn' : 'ok')}
           {app.shared && statusBadge('shared with team', 'ok')}
+          {app.claimedBy && statusBadge(`personal — ${app.claimedBy}`, 'warn')}
         </>
       }
-      right={(onShare || onRemove || (expired && onReconnect)) ? (
+      right={(onShare || onClaim || onRemove || (expired && onReconnect)) ? (
         <>
           {expired && onReconnect && (
             <Button size="sm" variant="outline" disabled={busy} onClick={onReconnect}
               title="Re-run this app's OAuth — until you do, agents cannot use it">
               Reconnect
+            </Button>
+          )}
+          {onClaim && !expired && (
+            <Button size="sm" variant="outline" disabled={busy} onClick={() => onClaim(!app.claimedBy)}
+              title={app.claimedBy
+                ? 'Give it back to the company — every agent can use it again'
+                : "This app is really one person's own account: keep it working for them, and stop every other agent acting through it"}>
+              {app.claimedBy ? 'Give back to company' : 'Make it personal'}
             </Button>
           )}
           {onShare && !expired && (
@@ -600,7 +612,7 @@ export function GithubMineCard() {
   )
 }
 
-function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRemove, onShare, onDisconnectComposio, onShareComposio, onReconnectComposio, onToggleHost, onRemoveHost, onShareHost, onEditHost, onPublishHost }: {
+function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRemove, onShare, onDisconnectComposio, onShareComposio, onClaimComposio, onReconnectComposio, onToggleHost, onRemoveHost, onShareHost, onEditHost, onPublishHost }: {
   me: Member | null
   connectors: Connector[]
   hosts: Host[]
@@ -612,6 +624,7 @@ function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRem
   onShare: (id: string, shared: boolean) => void
   onDisconnectComposio: (id: string, scope: 'company' | 'personal', label: string) => void
   onShareComposio: (id: string, shared: boolean, label: string) => void
+  onClaimComposio: (id: string, claimed: boolean, label: string, account?: string) => void
   onReconnectComposio: (toolkit: string, scope: 'company' | 'personal') => void
   onToggleHost: (id: string, enabled: boolean) => void
   onRemoveHost: (id: string) => void
@@ -680,6 +693,7 @@ function ConnectedList({ me, connectors, hosts, ov, conns, busy, onToggle, onRem
           {companyApps.map((a) => (
             <ComposioRow key={a.id} app={a} canRemove={isAdmin} busy={busy === a.id}
               onRemove={() => onDisconnectComposio(a.id, 'company', a.toolkit)}
+              onClaim={isAdmin ? (claimed) => onClaimComposio(a.id, claimed, a.toolkit, a.account) : undefined}
               onReconnect={isAdmin ? () => onReconnectComposio(a.toolkit, 'company') : undefined} />
           ))}
           {sharedApps.map((a) => (
@@ -1101,6 +1115,30 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
     if (r.redirectUrl) window.open(r.redirectUrl, '_blank', 'noopener')
   }
 
+  // The inverse of "Share with team": a company connection that is really one person's own account —
+  // somebody completed the hosted OAuth while signed in to it — is handed back to them. Composio cannot
+  // move an account between shelves, so it stays where it is and the launcher mints it out of every
+  // other run's session.
+  const claimComposio = async (id: string, claimed: boolean, label: string, account?: string) => {
+    if (claimed && !window.confirm(
+      `Make ${label}${account ? ` (${account})` : ''} personal?\n\nIt stays on the company shelf — Composio can't move a connection — but from the next session only its owner's runs can act through it. Every other agent loses it.`,
+    )) return
+    setBusy(id)
+    let r = await api.claimConnection({ id, claimed })
+    // No resolved account, or one that matches nobody: the server can't guess whose it is, so ask.
+    if (r.error && claimed && /which member/.test(r.error)) {
+      const who = window.prompt(`${r.error}\n\nEmail of the member this connection belongs to:`, r.resolved || '')
+      if (!who) { setBusy(''); return }
+      const m = (await api.team()).members?.find((x) => x.email.toLowerCase() === who.trim().toLowerCase())
+      if (!m) { setBusy(''); return window.alert(`No team member with the address ${who.trim()}.`) }
+      r = await api.claimConnection({ id, claimed, memberId: m.id })
+    }
+    setBusy('')
+    if (r.error) return window.alert('Could not change who this belongs to: ' + r.error)
+    loadConnections()
+    loadOverview()
+  }
+
   // Re-ask Composio whose account each connection really is, and what has expired. A live probe, so it
   // is a button rather than something every page load pays for.
   const [checking, setChecking] = useState(false)
@@ -1179,6 +1217,7 @@ export function ConnectorsPage({ me }: { me: Member | null }) {
         onShare={share}
         onDisconnectComposio={disconnectComposio}
         onShareComposio={shareComposio}
+        onClaimComposio={claimComposio}
         onReconnectComposio={reconnectComposio}
         onToggleHost={toggleHost}
         onRemoveHost={removeHost}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1507,6 +1507,10 @@ export interface ComposioConnection {
   account?: string
   /** Mine only: the owner marked it available to the whole team (composio_shares). */
   shared?: boolean
+  /** Company only: this connection is really one person's account (composio_claims) — their display
+   *  name. No other run reaches it. The inverse of `shared`. */
+  claimedBy?: string
+  claimedByMember?: string
 }
 /** A teammate's connection they marked available to the team — borrowed, not owned. */
 export interface SharedConnection {
@@ -2193,6 +2197,8 @@ export const api = {
   saveReview: (reviewMd: string) => call<CompanySettings & { ok: boolean; error?: string }>('PUT', '/api/settings/review', { reviewMd }),
   connections: () => call<ConnectionsResp>('GET', '/api/connections'),
   refreshConnections: () => call<{ ok?: boolean; resolved?: number; expired?: number; error?: string }>('POST', '/api/connections/refresh', {}),
+  claimConnection: (body: { id: string; claimed: boolean; memberId?: string }) =>
+    call<{ ok?: boolean; claimed?: boolean; member?: { id: string; name: string }; resolved?: string; error?: string }>('POST', '/api/connections/claim', body),
   pruneConnections: () => call<{ ok?: boolean; removed?: string[]; kept?: number; error?: string }>('POST', '/api/connections/prune', {}),
   integrationsOverview: () => call<IntegrationsOverview>('GET', '/api/integrations/overview'),
   composioToolkits: () => call<{ toolkits: { slug: string; name: string }[]; error?: string }>('GET', '/api/composio/toolkits'),


### PR DESCRIPTION
> *"for personal connections, we can share it with team, lets do the same with company connection to move it as a personal thing as well in case we connected by mistake."*

Built as the exact inverse of sharing, because it's the same problem from the other side. Someone completes the hosted OAuth on the **company** shelf while signed in to their own Google/Slack account, and the result is a connection every agent in the tenant can act through wearing one individual's identity — the shape of the incident this whole thread started from.

## It can't be a move, so it's a marker — same as sharing

A connected account's entity is immutable on Composio's side (no transfer API, and a Tool Router session may only pin accounts of its own `user_id`). So neither direction is a move; both are markers enforced at mint time, in the same place:

| | marker | how the launcher enforces it |
|---|---|---|
| **Share** (`composio_shares`) | personal account → reachable by everyone | mint an **extra** session under the owner's entity, allowlisted + pinned |
| **Claim** (`composio_claims`) | company account → reachable by one member | mint the company session **minus** it, for everyone else |

`exclusionFor` picks between the two exclusions Composio actually accepts:

- the claimed account is the **only** ACTIVE one of its toolkit → `toolkits.disable`, because an empty account pin is rejected (`Array must contain at least 1 element`);
- **other** active accounts of that toolkit remain → pin the session to exactly those.

Both verified against the live endpoint before building on them — a disabled toolkit is genuinely unreachable, and `COMPOSIO_SEARCH_TOOLS` reports no connection for it rather than offering a dead one:

```
baseline              | toolkits found: ["googlesheets"] | connection statuses: ["googlesheets"]
googlesheets disabled | toolkits found: ["googlesuper"]  | connection statuses: ["googlesuper"]
```

## Console

**Make it personal** / **Give back to company** on a company row, mirroring Share with team / Just me. The row then reads `googlesheets · zubair@expresstech.io · only Zubair` with a `personal — Zubair` badge.

## Four deliberate choices

- **Automation and system runs are excluded too.** They act as nobody, so they have no business acting as the claimer.
- **A toolkit that can't be enumerated is disabled, not left open.** Over-restricting is recoverable — the agent reports it can't reach an app — while under-restricting silently hands a teammate's mailbox to the fleet, which is the bug being fixed.
- **The prompt follows the mint.** A claimed app is hidden from every other run's Composio section and shown to its claimer marked as their own. Advertising an app the session can't reach is the same class of lie as not saying whose account it is.
- **Owner/admin only**, because a company connection is org property and privatising one takes a capability away from everyone. Whose it is comes from the account resolved in v0.422.0; when no member matches, the caller names one.

A claim always lets go: releasing talks to no remote (a broken API key can never leave a toolkit walled off), a claim on a deleted connection is pruned on the next refresh, and removing a member gives their claims back to the company.

## Worth knowing

The connection **stays on the company shelf** — that's a Composio constraint, not a choice — so it still appears in the Company section, badged, rather than moving to Mine. Functionally it's private to its owner from the next session onward. If you want it genuinely off the company shelf, that's disconnect + reconnect under your own Connections, which needs the OAuth done again.

## Verification

`npm run typecheck`, `npm run build`, `cd web && npm run build`, full `npm run test:governance` green. 15 new checks in `scripts/composio-identity-test.cjs` (64 total), including that an automation run is excluded, that an unenumerable toolkit fails closed, that a sibling unclaimed account survives, and that the claimed app is hidden from other runs' prompts but shown to its claimer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgJpL61B3SCdDEqozBDX3y