### PR TITLE
feat(connectors): a Slack agent can read the thread it was tagged into (v0.424.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.424.0] - 2026-09-04
+### Added
+- **A Slack agent can read the thread it was tagged into.** A mention delivers one message, so an agent
+  pulled into the fifth reply of a live thread saw one line and nothing before it — and then either asked
+  the human to paste the conversation back or answered confidently about a thread it had never read. The
+  bot is already in the channel and already receives the event, so the rest was one authenticated call
+  away: the ingress now reads the thread (`conversations.replies`, last 30 messages, 800 chars each) and
+  hands it to the agent oldest-first, senders resolved to member names and other apps named by their bot
+  profile. Narrow on purpose — no call when the message *opens* its thread, none on the continuity path
+  (that session already holds the transcript), and never fatal. ⚠ History scopes are per conversation
+  type: `channels:history` is public channels only, a **private** channel needs **`groups:history`**
+  (`mpim:history` / `im:history` for group DMs / DMs). All four are in the bundled manifest, but an app
+  installed before them answers `missing_scope` — surfaced verbatim in the `slack.thread.unreadable`
+  audit line *and* in the agent's prompt, so it tells the human the real reason instead of inventing one.
+  Add the scope and reinstall. Pinned by `scripts/slack-ingress-test.cjs`.
+
 ## [0.423.0] - 2026-09-04
 ### Added
 - **A company Composio connection can be claimed back as one person's own** — the exact inverse of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,16 @@ new version heading in the same commit.
   type: `channels:history` is public channels only, a **private** channel needs **`groups:history`**
   (`mpim:history` / `im:history` for group DMs / DMs). All four are in the bundled manifest, but an app
   installed before them answers `missing_scope` — surfaced verbatim in the `slack.thread.unreadable`
-  audit line *and* in the agent's prompt, so it tells the human the real reason instead of inventing one.
-  Add the scope and reinstall. Pinned by `scripts/slack-ingress-test.cjs`.
+  audit line, in an amber banner on Settings → Integrations, and in the agent's prompt. Add the scope and
+  reinstall. Pinned by `scripts/slack-ingress-test.cjs`.
+- **The missing scope is warned about deterministically, in the thread.** Telling the agent it is blind
+  is a *request* — the model may relay it, paraphrase it into something wrong, or answer as though
+  nothing were missing, and the run least able to notice it is blind is exactly this one. So the server
+  appends the warning to its own ack: which scope, for this conversation type (`groups:history` in a
+  private channel, `mpim:history` in a group DM), and that the app must be **reinstalled** after adding
+  it. `not_in_channel` gets the different fix it actually needs (invite the bot). And because the person
+  who tagged the bot is rarely the person who can add a scope, the same failure drives a banner on
+  Settings → Integrations for the admin, who never sees the thread.
 
 ## [0.423.0] - 2026-09-04
 ### Added

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -76,6 +76,35 @@ missing `files:read` scope instead of being saved as a "file"; and a non-`slack.
 outright (the URL arrives inside an untrusted event). Audit: `slack.file.received` / `.failed` /
 `.skipped`.
 
+### Thread history — what was said before you were tagged (v0.424.0)
+
+A mention delivers **one message**. Tag the bot on the fifth message of a live thread and, before this,
+it was handed that line alone — so it either asked the human to paste the conversation back or, worse,
+answered confidently about a thread it had never read. Reported from a live tenant on 2026-09-04, where
+the agent replied *"I only receive the text of the message that @-mentions me"* and then guessed at a
+cause.
+
+The bot is already in the channel and already receives the event, so the rest is one authenticated call
+away. `fetchThreadMessages` (`conversations.replies`) reads up to the **last 30** messages of the thread,
+each clipped to 800 chars, and `threadNote` folds them into the prompt oldest-first. Senders are labelled
+by the same resolution the run-as path uses, so a name in the transcript is a teammate the agent can look
+up; another app's posts are named by their bot profile (`Beszel: ALERT web-3 cpu 98%`). The triggering
+message is excluded — it is already in the prompt above.
+
+Deliberately narrow, because a read costs an API call per message:
+- **Only when there is history.** An un-threaded message's `thread_ts` falls back to its own `ts`; that
+  message *opens* the thread, so no call is made.
+- **Only past the continuity branch.** A resumed session already holds the transcript.
+- **Never fatal.** A failure audits `slack.thread.unreadable` `{ channel, thread, error }` and the run
+  proceeds, but the agent is *told* it is blind and why — an agent that knows a thread exists and cannot
+  read it will otherwise invent a reason and tell the human a wrong one.
+
+⚠ **Scopes are per conversation type.** `channels:history` covers **public** channels only — a private
+channel needs **`groups:history`**, a group DM `mpim:history`, a DM `im:history`. All four are in the
+bundled manifest, but an app created before them answers `missing_scope`, which is surfaced verbatim into
+both the audit line and the agent's prompt. The fix is always the same: add the scope in the Slack app
+config and **reinstall**.
+
 ### Replying in a thread the bot started (v0.416.0)
 
 `slack_threads` is keyed by **session id** — one reply target per run — so a thread the *bot* opened (a

--- a/docs/connectors/slack.md
+++ b/docs/connectors/slack.md
@@ -101,9 +101,26 @@ Deliberately narrow, because a read costs an API call per message:
 
 ⚠ **Scopes are per conversation type.** `channels:history` covers **public** channels only — a private
 channel needs **`groups:history`**, a group DM `mpim:history`, a DM `im:history`. All four are in the
-bundled manifest, but an app created before them answers `missing_scope`, which is surfaced verbatim into
-both the audit line and the agent's prompt. The fix is always the same: add the scope in the Slack app
-config and **reinstall**.
+bundled manifest, but an app created before them answers `missing_scope`. This is the trap the feature
+has: with `channels:history` alone it works in every public channel and fails in every private one, so it
+looks installed until the first private thread.
+
+So the missing scope is reported **deterministically, by the server, in three places** — the agent's own
+prompt is the weakest of them and never the only one:
+
+1. **In the thread**, appended to the ack (`threadReadWarning`): *"I can only see the message that tagged
+   me… the app is missing `groups:history`… an admin adds it and reinstalls."* The prompt is a *request*
+   — the model may relay it, paraphrase it into something wrong, or answer as though nothing were
+   missing, and the run least able to notice it is blind is exactly this one. The scope named is the one
+   for **that** conversation type, and `not_in_channel` gets the different fix it needs (invite the bot)
+   rather than sending an admin after a scope they already have.
+2. **In the console** — `SlackSocket.status().threadScopeError` `{ channel, scope, error, at }` drives an
+   amber banner on Settings → Integrations. The person who tagged the bot is rarely the person who can
+   add a scope, and that admin never sees the thread.
+3. **In the audit** — `slack.thread.unreadable` `{ channel, thread, error, scope }`.
+
+The fix is always the same: add the scope in the Slack app config (OAuth & Permissions → Bot Token
+Scopes) and **reinstall**.
 
 ### Replying in a thread the bot started (v0.416.0)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.423.0",
+  "version": "0.424.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.423.0",
+      "version": "0.424.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.423.0",
+  "version": "0.424.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/slack-ingress-test.cjs
+++ b/scripts/slack-ingress-test.cjs
@@ -217,6 +217,7 @@ console.log('\ndownload');
   const block = threaded.slice(threaded.indexOf('The thread this arrived in'), threaded.indexOf("When you're done"));
   assert(block.length > 0 && !/can you triage this\?/.test(block), 'the triggering message is not repeated inside the history block');
   assert(/ts=700\.0/.test(askedUrl) && new RegExp(`channel=${CH}`).test(askedUrl), 'the read is scoped to that channel + thread');
+  assert(!/⚠️/.test(posts[posts.length - 1].text), 'a thread that read fine gets a clean ack — no warning noise');
 
   // A first message in a channel opens its own thread: `thread_ts` falls back to `ts`, and there is no
   // history to read — spending an API call per message would be pure cost.
@@ -228,13 +229,35 @@ console.log('\ndownload');
   global.fetch = async () => ({ ok: true, json: async () => ({ ok: false, error: 'missing_scope' }) });
   before = routed.length;
   const auditBefore = aos.db.prepare("SELECT COUNT(*) c FROM audit_events WHERE type = 'slack.thread.unreadable'").get().c;
-  await sock.dispatch(env({ type: 'app_mention', channel: CH, channel_type: 'channel', user: 'U1', ts: '900.9', thread_ts: '700.0', text: '<@BOT> support-ops triage' }));
+  // A PRIVATE channel — the shape the report came from, and the one `channels:history` does not cover.
+  await sock.dispatch(env({ type: 'app_mention', channel: CH, channel_type: 'group', user: 'U1', ts: '900.9', thread_ts: '700.0', text: '<@BOT> support-ops triage' }));
   assert(routed.length === before + 1, 'an unreadable thread never blocks the run');
   const auditAfter = aos.db.prepare("SELECT COUNT(*) c FROM audit_events WHERE type = 'slack.thread.unreadable'").get().c;
   assert(auditAfter === auditBefore + 1, 'and the reason is audited, so the operator can see the missing scope');
   const blind = routed[routed.length - 1].task;
   assert(/missing_scope/.test(blind) && /groups:history/.test(blind), 'the agent is TOLD it is blind and why — it invented a reason for the human otherwise', blind.slice(0, 200));
   assert(/only see the message that mentioned you/.test(blind), 'and told to say so plainly instead of answering as if it had the thread');
+
+  // The prompt is a REQUEST — the model may relay it, paraphrase it wrong, or answer as if nothing were
+  // missing, and the run least able to notice it is blind is exactly this one. So the warning is written
+  // by the server and posted in the thread, deterministically, next to the ack.
+  const warned = posts[posts.length - 1];
+  assert(warned && warned.thread === '700.0', 'the warning lands in the thread the person is watching');
+  assert(/support-ops/.test(warned.text), 'alongside the ack, in one message (the ack is not replaced)');
+  assert(/groups:history/.test(warned.text), 'and names the scope for THIS conversation type — a private channel is `groups:history`, not `channels:history`', warned.text);
+  assert(/reinstall/i.test(warned.text), 'plus the step people forget: the scope does nothing until the app is reinstalled');
+
+  assert(slackApi.threadReadWarning('channel', 'missing_scope').includes('channels:history'), 'a public channel names channels:history');
+  assert(slackApi.threadReadWarning('mpim', 'missing_scope').includes('mpim:history'), 'a group DM names mpim:history');
+  assert(slackApi.threadReadWarning('im', 'missing_scope').includes('im:history'), 'a DM names im:history');
+  assert(/invite the bot/i.test(slackApi.threadReadWarning('group', 'not_in_channel')), 'not_in_channel is a different fix and says so, rather than sending an admin after a scope they already have');
+  assert(slackApi.threadReadWarning('group', 'ratelimited').includes('ratelimited'), 'an unknown error is still reported, verbatim');
+  assert(slackApi.threadReadWarning('group', '') === '' && slackApi.threadReadWarning('group') === '', 'and a thread that read fine adds nothing to the ack');
+
+  // The person who tagged the bot is not the person who can fix it, and the admin never sees the thread.
+  const st = sock.status();
+  assert(st.threadScopeError && st.threadScopeError.scope === 'groups:history' && st.threadScopeError.channel === CH,
+    'the failure is also held for the console, where the admin who can add the scope will see it');
   assert(/missing_scope/.test(String(aos.db.prepare("SELECT data FROM audit_events WHERE type = 'slack.thread.unreadable' ORDER BY ts DESC LIMIT 1").get().data)), 'verbatim — `missing_scope` is the one an operator must act on');
   global.fetch = realFetch;
 

--- a/scripts/slack-ingress-test.cjs
+++ b/scripts/slack-ingress-test.cjs
@@ -31,7 +31,7 @@ const assert = (c, name, d) => c ? (pass++, console.log(`  \x1b[32m✓\x1b[0m ${
 const slackApi = require(path.join(ROOT, 'dist/connectors/slack.js'));
 const { loadAgentOS } = require(path.join(ROOT, 'dist/kernel.js'));
 const { TerminalManager, inboxFileName } = require(path.join(ROOT, 'dist/terminal.js'));
-const { Automations, attachmentNote } = require(path.join(ROOT, 'dist/edge/automations.js'));
+const { Automations, attachmentNote, threadNote } = require(path.join(ROOT, 'dist/edge/automations.js'));
 const { SlackSocket } = require(path.join(ROOT, 'dist/edge/slack-socket.js'));
 
 const CH = 'C0OPS1234';
@@ -181,6 +181,61 @@ console.log('\ndownload');
   assert(/\.inbox\/crash\.png/.test(withFile.task), 'the agent is TOLD about the file, by the path it can read');
   assert(fs.existsSync(path.join(AGENT_DIR, '.inbox', 'crash.png')), 'and the bytes are actually on disk in its own folder');
   assert(fs.readFileSync(path.join(AGENT_DIR, '.inbox', 'crash.png')).length === 4, 'with the downloaded content, not a Slack HTML page');
+  global.fetch = realFetch;
+
+  // ── 8. the thread a mention landed in ────────────────────────────────────────
+  // Reported 2026-09-04: tagging the bot midway through an existing thread got "I only receive the text
+  // of the message that @-mentions me; the rest of this thread isn't visible to me" — true of the raw
+  // event, and the agent then guessed at a cause. The history is one authenticated call away.
+  console.log('\nthread history');
+  assert(threadNote() === '' && threadNote('') === '', 'no thread → nothing added to the prompt');
+  assert(/Alice: ship it/.test(threadNote('Alice: ship it')), 'a thread is handed over as plain text');
+
+  const replies = [
+    { ts: '700.0', user: 'U9', text: 'prod latency is up 4x since the deploy' },
+    { ts: '700.1', user: '', bot_id: 'B1', bot_profile: { name: 'Beszel' }, text: 'ALERT web-3 cpu 98%' },
+    { ts: '700.2', user: 'U9', text: 'x'.repeat(2000) },
+    { ts: '700.3', user: 'U1', text: '<@BOT> can you triage this?' },
+  ];
+  let askedUrl = '';
+  global.fetch = async (url, init) => {
+    if (/conversations\.replies/.test(String(url))) {
+      askedUrl = String(url); // users.info also runs here (name resolution) — only the history read matters
+      assert((init && init.headers && init.headers.authorization) === 'Bearer xoxb-test', 'the history read is authenticated as the bot');
+      return { ok: true, json: async () => ({ ok: true, messages: replies }) };
+    }
+    return { ok: true, json: async () => ({ ok: false, error: 'unexpected' }) };
+  };
+  sock.botUserId = 'BOT';
+  before = routed.length;
+  await sock.dispatch(env({ type: 'app_mention', channel: CH, channel_type: 'channel', user: 'U1', ts: '700.3', thread_ts: '700.0', text: '<@BOT> support-ops can you triage this?' }));
+  assert(routed.length === before + 1, 'a mention inside an existing thread still routes');
+  const threaded = routed[routed.length - 1].task;
+  assert(/prod latency is up 4x/.test(threaded), 'the agent is given what was said BEFORE it was tagged — the whole point');
+  assert(/Beszel: ALERT web-3 cpu 98%/.test(threaded), "including another app's posts, named by their bot profile");
+  assert(!/x{900}/.test(threaded), 'a giant pasted blob is clipped, so one message cannot become the prompt');
+  const block = threaded.slice(threaded.indexOf('The thread this arrived in'), threaded.indexOf("When you're done"));
+  assert(block.length > 0 && !/can you triage this\?/.test(block), 'the triggering message is not repeated inside the history block');
+  assert(/ts=700\.0/.test(askedUrl) && new RegExp(`channel=${CH}`).test(askedUrl), 'the read is scoped to that channel + thread');
+
+  // A first message in a channel opens its own thread: `thread_ts` falls back to `ts`, and there is no
+  // history to read — spending an API call per message would be pure cost.
+  askedUrl = '';
+  await sock.dispatch(env({ type: 'app_mention', channel: CH, channel_type: 'channel', user: 'U1', ts: '800.1', text: '<@BOT> support-ops hello' }));
+  assert(askedUrl === '', 'a mention that OPENS a thread reads no history');
+
+  // The failure that produced the report: an app created before `groups:history` was in the manifest.
+  global.fetch = async () => ({ ok: true, json: async () => ({ ok: false, error: 'missing_scope' }) });
+  before = routed.length;
+  const auditBefore = aos.db.prepare("SELECT COUNT(*) c FROM audit_events WHERE type = 'slack.thread.unreadable'").get().c;
+  await sock.dispatch(env({ type: 'app_mention', channel: CH, channel_type: 'channel', user: 'U1', ts: '900.9', thread_ts: '700.0', text: '<@BOT> support-ops triage' }));
+  assert(routed.length === before + 1, 'an unreadable thread never blocks the run');
+  const auditAfter = aos.db.prepare("SELECT COUNT(*) c FROM audit_events WHERE type = 'slack.thread.unreadable'").get().c;
+  assert(auditAfter === auditBefore + 1, 'and the reason is audited, so the operator can see the missing scope');
+  const blind = routed[routed.length - 1].task;
+  assert(/missing_scope/.test(blind) && /groups:history/.test(blind), 'the agent is TOLD it is blind and why — it invented a reason for the human otherwise', blind.slice(0, 200));
+  assert(/only see the message that mentioned you/.test(blind), 'and told to say so plainly instead of answering as if it had the thread');
+  assert(/missing_scope/.test(String(aos.db.prepare("SELECT data FROM audit_events WHERE type = 'slack.thread.unreadable' ORDER BY ts DESC LIMIT 1").get().data)), 'verbatim — `missing_scope` is the one an operator must act on');
   global.fetch = realFetch;
 
   console.log(`\n${pass} passed, ${fail} failed`);

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -311,3 +311,60 @@ export async function downloadSlackFile(
     return { error: e instanceof Error ? e.message : 'download failed' };
   }
 }
+
+/** One earlier message in the thread a mention landed in, normalized for the prompt block. */
+export interface SlackThreadMessage {
+  /** Slack `ts` — also the message's identity, so the caller can drop the triggering message itself. */
+  ts: string;
+  /** Sender's Slack user id ('' for a bot/app post). */
+  user: string;
+  /** A display name when the payload carries one (bot posts do; human posts don't — the caller resolves). */
+  name: string;
+  text: string;
+  bot: boolean;
+}
+
+/**
+ * Read the messages already in a thread (`conversations.replies`).
+ *
+ * Why this exists: an @mention delivers ONLY the mention's own text. A human who tags the bot on the
+ * fifth message of a thread is, in their head, handing over a conversation — and the agent, seeing one
+ * line, either asks them to paste it all back or (worse) invents a reason it cannot see the rest. The
+ * bot is a member of the channel and already receives the event, so the history is one authenticated
+ * call away; we fetch it here and inject it into the prompt.
+ *
+ * Scope note: `channels:history` covers PUBLIC channels only. A private channel needs `groups:history`,
+ * a group DM `mpim:history`, a DM `im:history` — a Slack app created before those were in the bundled
+ * manifest answers `missing_scope`, which is surfaced verbatim so the operator is told to add the scope
+ * and reinstall rather than the agent guessing.
+ *
+ * `oldest`-less and newest-last: Slack returns the thread in ascending order, so we take the LAST
+ * `limit` entries (the parent plus recent turns matter; the middle of a 300-reply thread does not).
+ */
+export async function fetchThreadMessages(
+  botToken: string,
+  channel: string,
+  threadTs: string,
+  limit: number,
+): Promise<{ messages: SlackThreadMessage[] } | { error: string }> {
+  if (!botToken || !channel || !threadTs) return { error: 'missing token, channel or thread' };
+  try {
+    const url =
+      `${SLACK_API}/conversations.replies?channel=${encodeURIComponent(channel)}` +
+      `&ts=${encodeURIComponent(threadTs)}&limit=${Math.max(1, Math.min(200, limit))}`;
+    const res = await fetch(url, { headers: { authorization: `Bearer ${botToken}` } });
+    const j: any = await res.json().catch(() => ({}));
+    if (!j?.ok) return { error: String(j?.error || `conversations.replies failed (${res.status})`) };
+    const raw = Array.isArray(j.messages) ? j.messages : [];
+    const messages: SlackThreadMessage[] = raw.map((m: any) => ({
+      ts: String(m?.ts || ''),
+      user: String(m?.user || ''),
+      name: String(m?.bot_profile?.name || m?.username || ''),
+      text: String(m?.text || ''),
+      bot: !!m?.bot_id || m?.subtype === 'bot_message' || !m?.user,
+    }));
+    return { messages: messages.slice(-limit) };
+  } catch (e) {
+    return { error: e instanceof Error ? e.message : 'conversations.replies failed' };
+  }
+}

--- a/src/connectors/slack.ts
+++ b/src/connectors/slack.ts
@@ -312,6 +312,40 @@ export async function downloadSlackFile(
   }
 }
 
+/** The history scope a conversation type needs. Slack splits them by conversation kind, which is the
+ *  whole trap: an app with `channels:history` works in every public channel and fails in every private
+ *  one, so the feature looks installed until the first private thread. */
+export function historyScopeFor(channelType: string): string {
+  if (channelType === 'group') return 'groups:history';
+  if (channelType === 'mpim') return 'mpim:history';
+  if (channelType === 'im') return 'im:history';
+  return 'channels:history';
+}
+
+/**
+ * The line the bot posts IN the thread when it could not read that thread — deterministic, written by
+ * the server, never by the model.
+ *
+ * The agent is told the same thing in its prompt, but a prompt is a request: the model may relay it,
+ * paraphrase it into something wrong, or answer as though nothing were missing. The one case that
+ * matters is exactly the case where the agent has the least context to notice, so the warning cannot
+ * depend on the agent noticing. Returns '' when there is nothing to warn about.
+ */
+export function threadReadWarning(channelType: string, error?: string): string {
+  if (!error) return '';
+  const scope = historyScopeFor(channelType);
+  if (error === 'missing_scope' || error === 'not_allowed_token_type') {
+    return `⚠️ I can only see the message that tagged me — I can't read this thread's earlier messages. ` +
+      `The Agentric Slack app is missing the \`${scope}\` scope for this conversation. ` +
+      `An admin adds it in the Slack app config (OAuth & Permissions → Bot Token Scopes) and reinstalls the app.`;
+  }
+  if (error === 'not_in_channel' || error === 'channel_not_found') {
+    return `⚠️ I can only see the message that tagged me — I can't read this thread's earlier messages ` +
+      `(Slack: \`${error}\`). Invite the bot to this channel so it can read the conversation it is asked about.`;
+  }
+  return `⚠️ I can only see the message that tagged me — reading this thread failed (Slack: \`${error}\`).`;
+}
+
 /** One earlier message in the thread a mention landed in, normalized for the prompt block. */
 export interface SlackThreadMessage {
   /** Slack `ts` — also the message's identity, so the caller can drop the triggering message itself. */

--- a/src/edge/automations.ts
+++ b/src/edge/automations.ts
@@ -298,6 +298,24 @@ const MAX_PAYLOAD_CHARS = 4000; // keep webhook payloads from flooding the task 
  * `stageInboundFiles` writes them there right after the spawn, so the agent can just Read the path.
  * An image is worth naming as such: without this the model has no reason to look at a file at all.
  */
+/**
+ * The thread a chat message landed in, rendered for the prompt.
+ *
+ * A mention delivers one line. When a human tags the bot on the fifth message of a thread they mean
+ * "handle THIS conversation", and an agent given only the mention has three bad options: ask them to
+ * paste it back, answer the wrong question, or invent a reason it cannot see the rest. So the ingress
+ * fetches the thread and hands it over as plain context. Empty string when there is no thread, when the
+ * mention IS the thread's first message, or when the platform refused (the ingress audits that).
+ */
+export function threadNote(history?: string, unreadable?: string): string {
+  if (history) return `\nThe thread this arrived in, oldest first (the message above is the newest — you have already been given it):\n${history}\n`;
+  // Say WHY it is missing rather than nothing. An agent that knows a thread exists but cannot read it
+  // invents a reason and tells the human a wrong one; the real error is short, actionable and the thing
+  // the operator has to fix, so hand it over verbatim.
+  if (unreadable) return `\nThis message is part of a longer thread you could NOT be given — reading it failed with Slack error \`${unreadable}\`. Answer from what you have, and say plainly that you can only see the message that mentioned you${unreadable === 'missing_scope' ? ' because the Slack app is missing the history scope for this conversation (`groups:history` for a private channel, `mpim:history` for a group DM) — an admin adds it in Settings → Integrations and reinstalls' : ''}.\n`;
+  return '';
+}
+
 export function attachmentNote(files?: { name: string }[]): string {
   if (!files?.length) return '';
   const lines = files.map((f) => `• .inbox/${inboxFileName(f.name)}`).join('\n');
@@ -1296,7 +1314,7 @@ export class Automations {
    * fire" is answerable from the audit row instead of by re-reading the filter.
    */
   async fireSlack(
-    event: { eventType: string; channel: string; threadTs: string; user: string; actorLabel: string; text: string; raw: unknown; files?: { name: string; data: Buffer }[] },
+    event: { eventType: string; channel: string; threadTs: string; user: string; actorLabel: string; text: string; raw: unknown; files?: { name: string; data: Buffer }[]; history?: string; historyError?: string },
     runAsMember?: string,
     opts: { channelWatch?: boolean; router?: boolean; fallbackAgent?: string } = {},
   ): Promise<{ fired: number; sessions: string[]; agents: string[]; reply?: string; dropped?: string }> {
@@ -1313,7 +1331,8 @@ export class Automations {
       `Triggered from Slack by ${event.actorLabel} (${event.eventType}) in channel ${event.channel}` +
       (event.threadTs ? ` (thread ${event.threadTs})` : '') + `.\n` +
       `Message:\n${event.text}\n` +
-      attachmentNote(event.files) + `\n` +
+      attachmentNote(event.files) +
+      threadNote(event.history, event.historyError) + `\n` +
       `When you're done, call the \`slack_reply\` tool with your answer — it posts back to this exact ` +
       `Slack thread (you don't need a channel id). Keep it concise.\n\n` +
       `Event payload:\n${JSON.stringify(event.raw, null, 2).slice(0, MAX_PAYLOAD_CHARS)}`;

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -16,7 +16,7 @@
  */
 import { AgentOS } from '../kernel';
 import { Automations, chatAck } from './automations';
-import { downloadSlackFile, explainSlackError, fetchThreadMessages, joinChannel, lookupBotUserId, lookupChannelByName, lookupUserByEmail, lookupUserEmail, openDmChannel, openSocketConnection, parseSlackEvent, postMessage, SlackFileRef } from '../connectors/slack';
+import { downloadSlackFile, explainSlackError, fetchThreadMessages, historyScopeFor, threadReadWarning, joinChannel, lookupBotUserId, lookupChannelByName, lookupUserByEmail, lookupUserEmail, openDmChannel, openSocketConnection, parseSlackEvent, postMessage, SlackFileRef } from '../connectors/slack';
 
 const RECONNECT_MIN_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
@@ -31,6 +31,11 @@ const MAX_THREAD_MESSAGES = 30;
 /** Per-message clip inside that block — a pasted stack trace is context, not the point. */
 const MAX_THREAD_CHARS = 800;
 
+/** Ack + the (usually empty) thread-read warning, as one message so the person sees both at once. */
+function withWarning(ack: string, warning: string): string {
+  return warning ? `${ack}\n\n${warning}` : ack;
+}
+
 export class SlackSocket {
   private ws?: WebSocket;
   private botUserId = '';
@@ -44,6 +49,10 @@ export class SlackSocket {
    *  Backs the identity-map auto-link so a notification never re-queries users.lookupByEmail per send. */
   private readonly userByEmailCache = new Map<string, string | null>();
   private lastError = '';
+  /** The most recent thread we were tagged into and could not read, kept for the console's Integrations
+   *  page. The in-thread warning tells the person who tagged us; this tells the admin who can fix it —
+   *  they are rarely the same person, and the admin never sees the thread. */
+  private lastThreadScopeError?: { channel: string; scope: string; error: string; at: number };
 
   constructor(
     private readonly os: AgentOS,
@@ -51,12 +60,16 @@ export class SlackSocket {
   ) {}
 
   /** Live status for the console (never returns the tokens). */
-  status(): { configured: boolean; connected: boolean; botUserId: string; lastError?: string } {
+  status(): {
+    configured: boolean; connected: boolean; botUserId: string; lastError?: string;
+    threadScopeError?: { channel: string; scope: string; error: string; at: number };
+  } {
     return {
       configured: this.os.settings.slackConfigured(),
       connected: this.ws?.readyState === WebSocket.OPEN,
       botUserId: this.botUserId,
       lastError: this.lastError || undefined,
+      threadScopeError: this.lastThreadScopeError,
     };
   }
 
@@ -199,7 +212,11 @@ export class SlackSocket {
     // continuation branch above, whose resumed session already holds the transcript. A failure here is
     // never fatal: the run proceeds without history and the reason is audited (`missing_scope` on a
     // private channel is the one an operator must act on — add `groups:history` and reinstall).
-    const { history, historyError } = await this.fetchThreadHistory(ev.channel, ev.threadTs, ev.raw?.ts);
+    const { history, historyError } = await this.fetchThreadHistory(ev.channel, ev.channelType, ev.threadTs, ev.raw?.ts);
+    // Deterministic, server-written, posted in the thread alongside the ack. The agent is told the same
+    // thing in its prompt, but a prompt is a request — and the run least able to notice it is blind is
+    // exactly this one. So the person who tagged us is told by the OS, not by the model.
+    const threadWarning = threadReadWarning(ev.channelType, historyError);
 
     // Not a thread continuation. A plain channel `message` (no @mention) normally reached us only because
     // the app subscribes to `message.channels` FOR that continuity — chatter in a channel the bot happens
@@ -237,7 +254,7 @@ export class SlackSocket {
           type: 'trigger.slack',
           data: { eventType: ev.eventType, channel: ev.channel, thread: true, ourThread: true, runAs: runAsMember ?? null, fired: r.fired, files: files.length || null },
         });
-        if (r.fired > 0) await postMessage(this.os.settings.slackBotToken(), ev.channel, chatAck(r.agents), ev.threadTs);
+        if (r.fired > 0) await postMessage(this.os.settings.slackBotToken(), ev.channel, withWarning(chatAck(r.agents), threadWarning), ev.threadTs);
         else if (r.reply) await postMessage(this.os.settings.slackBotToken(), ev.channel, r.reply, ev.threadTs);
         return;
       }
@@ -261,7 +278,7 @@ export class SlackSocket {
         });
       }
       if (watch.fired > 0) {
-        await postMessage(this.os.settings.slackBotToken(), ev.channel, chatAck(watch.agents), ev.threadTs);
+        await postMessage(this.os.settings.slackBotToken(), ev.channel, withWarning(chatAck(watch.agents), threadWarning), ev.threadTs);
       }
       return;
     }
@@ -348,7 +365,7 @@ export class SlackSocket {
     // answer via its own Slack egress tools. If nothing fired but the generic router returned a help
     // list (unknown/unaddressed `/agent`), post that so the sender learns how to reach the fleet.
     if (result.fired > 0) {
-      await postMessage(this.os.settings.slackBotToken(), ev.channel, chatAck(result.agents), ev.threadTs);
+      await postMessage(this.os.settings.slackBotToken(), ev.channel, withWarning(chatAck(result.agents), threadWarning), ev.threadTs);
     } else if (result.reply) {
       await postMessage(this.os.settings.slackBotToken(), ev.channel, result.reply, ev.threadTs);
     }
@@ -364,6 +381,7 @@ export class SlackSocket {
    */
   private async fetchThreadHistory(
     channel: string,
+    channelType: string,
     threadTs: string,
     ownTs?: unknown,
   ): Promise<{ history?: string; historyError?: string }> {
@@ -375,11 +393,13 @@ export class SlackSocket {
     const token = this.os.settings.slackBotToken();
     const got = await fetchThreadMessages(token, channel, threadTs, MAX_THREAD_MESSAGES);
     if ('error' in got) {
+      const scope = historyScopeFor(channelType);
       this.os.audit.append({
         ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'slack',
         type: 'slack.thread.unreadable',
-        data: { channel, thread: threadTs, error: got.error },
+        data: { channel, thread: threadTs, error: got.error, scope },
       });
+      this.lastThreadScopeError = { channel, scope, error: got.error, at: Date.now() };
       return { historyError: got.error };
     }
     const lines: string[] = [];

--- a/src/edge/slack-socket.ts
+++ b/src/edge/slack-socket.ts
@@ -16,7 +16,7 @@
  */
 import { AgentOS } from '../kernel';
 import { Automations, chatAck } from './automations';
-import { downloadSlackFile, explainSlackError, joinChannel, lookupBotUserId, lookupChannelByName, lookupUserByEmail, lookupUserEmail, openDmChannel, openSocketConnection, parseSlackEvent, postMessage, SlackFileRef } from '../connectors/slack';
+import { downloadSlackFile, explainSlackError, fetchThreadMessages, joinChannel, lookupBotUserId, lookupChannelByName, lookupUserByEmail, lookupUserEmail, openDmChannel, openSocketConnection, parseSlackEvent, postMessage, SlackFileRef } from '../connectors/slack';
 
 const RECONNECT_MIN_MS = 1_000;
 const RECONNECT_MAX_MS = 30_000;
@@ -25,6 +25,11 @@ const MAX_FILES = 5;
 /** Per-file ceiling. Big enough for a screenshot, a PDF or a log; small enough that a video doesn't
  *  stall the socket's dispatch or fill the agent folder. */
 const MAX_FILE_BYTES = 8 * 1024 * 1024;
+/** Earlier thread messages we hand the agent. Enough for the shape of a conversation, bounded so a
+ *  200-reply incident thread doesn't become the whole prompt. */
+const MAX_THREAD_MESSAGES = 30;
+/** Per-message clip inside that block — a pasted stack trace is context, not the point. */
+const MAX_THREAD_CHARS = 800;
 
 export class SlackSocket {
   private ws?: WebSocket;
@@ -187,6 +192,15 @@ export class SlackSocket {
       return;
     }
 
+    // The thread this landed in. Slack delivers only the mentioning message, so an agent tagged into an
+    // existing conversation has no idea what was said before it — the single most common way the bot
+    // reads as useless ("I can only see the message that mentioned me"). Fetched only when there IS an
+    // earlier conversation (`thread_ts` present and not this message's own `ts`) and only past the
+    // continuation branch above, whose resumed session already holds the transcript. A failure here is
+    // never fatal: the run proceeds without history and the reason is audited (`missing_scope` on a
+    // private channel is the one an operator must act on — add `groups:history` and reinstall).
+    const { history, historyError } = await this.fetchThreadHistory(ev.channel, ev.threadTs, ev.raw?.ts);
+
     // Not a thread continuation. A plain channel `message` (no @mention) normally reached us only because
     // the app subscribes to `message.channels` FOR that continuity — chatter in a channel the bot happens
     // to sit in, never a fresh trigger, so it is dropped rather than spamming the `/agent` router's help
@@ -210,7 +224,7 @@ export class SlackSocket {
       const ours = !!ev.threadTs && this.autos.knowsSlackThread(ev.channel, ev.threadTs);
       if (ours) {
         const r = await this.autos.fireSlack(
-          { eventType: ev.eventType, channel: ev.channel, threadTs: ev.threadTs, user: ev.user, actorLabel, text, raw: ev.raw, files },
+          { eventType: ev.eventType, channel: ev.channel, threadTs: ev.threadTs, user: ev.user, actorLabel, text, raw: ev.raw, files, history, historyError },
           runAsMember,
           { fallbackAgent: this.autos.agentForSlackThread(ev.channel, ev.threadTs) },
         );
@@ -229,7 +243,7 @@ export class SlackSocket {
       }
       if (!this.autos.watchesSlackChannel(ev.channel)) return;
       const watch = await this.autos.fireSlack(
-        { eventType: ev.eventType, channel: ev.channel, threadTs: ev.threadTs, user: ev.user, actorLabel, text, raw: ev.raw, files },
+        { eventType: ev.eventType, channel: ev.channel, threadTs: ev.threadTs, user: ev.user, actorLabel, text, raw: ev.raw, files, history, historyError },
         runAsMember,
         { channelWatch: true, router: false },
       );
@@ -314,6 +328,8 @@ export class SlackSocket {
         text,
         raw: ev.raw,
         files,
+        history,
+        historyError,
       },
       runAsMember,
     );
@@ -336,6 +352,46 @@ export class SlackSocket {
     } else if (result.reply) {
       await postMessage(this.os.settings.slackBotToken(), ev.channel, result.reply, ev.threadTs);
     }
+  }
+
+  /**
+   * Read the thread a message arrived in and render it for the prompt, or '' when there is nothing to
+   * add. Returns '' — never throws, never blocks the run — when the message opens its own thread, when
+   * the app lacks the history scope for this conversation type, or when Slack errors.
+   *
+   * Senders are labelled with the same resolution the run-as path uses, so a name in the transcript is
+   * the teammate the agent can look up, not a raw `U0123ABCD`.
+   */
+  private async fetchThreadHistory(
+    channel: string,
+    threadTs: string,
+    ownTs?: unknown,
+  ): Promise<{ history?: string; historyError?: string }> {
+    const own = String(ownTs || '');
+    if (!threadTs || !channel) return {};
+    // `threadTs` falls back to the message's own `ts` for an un-threaded message: that IS the thread's
+    // first message, so there is no history and no call worth making.
+    if (own && threadTs === own) return {};
+    const token = this.os.settings.slackBotToken();
+    const got = await fetchThreadMessages(token, channel, threadTs, MAX_THREAD_MESSAGES);
+    if ('error' in got) {
+      this.os.audit.append({
+        ts: Date.now(), runId: '-', tenant: this.os.tenant, principal: 'slack',
+        type: 'slack.thread.unreadable',
+        data: { channel, thread: threadTs, error: got.error },
+      });
+      return { historyError: got.error };
+    }
+    const lines: string[] = [];
+    for (const m of got.messages) {
+      if (own && m.ts === own) continue; // the triggering message is already in the prompt
+      const body = m.text.replace(/\s+$/, '');
+      if (!body) continue;
+      let who = m.name;
+      if (!who && m.user) who = m.user === this.botUserId ? 'Agentric (you)' : (await this.resolveActor(m.user)).actorLabel;
+      lines.push(`${who || 'someone'}: ${body.length > MAX_THREAD_CHARS ? `${body.slice(0, MAX_THREAD_CHARS)}…` : body}`);
+    }
+    return { history: lines.length ? lines.join('\n') : undefined };
   }
 
   /** Resolve a Slack user id → the member to run as (identity map first, then profile email) plus a

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18900,6 +18900,17 @@ function IntegrationsSettings({ me }: { me: Member }) {
               <strong> as the member who sent the message</strong> (matched by their Slack email → their connectors).
             </p>
             {slackState?.lastError && <p className="mt-1 font-mono text-[11px] text-destructive">last error: {slackState.lastError}</p>}
+            {slackState?.threadScopeError && (
+              <div className="mt-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-[11px] text-amber-800">
+                <strong>Agents can't read threads in {slackState.threadScopeError.channel}.</strong>{' '}
+                Slack answered <code className="font-mono">{slackState.threadScopeError.error}</code> when an agent tagged
+                into an existing thread tried to read what was said before it. Add the{' '}
+                <code className="font-mono">{slackState.threadScopeError.scope}</code> scope in the Slack app
+                (OAuth &amp; Permissions → Bot Token Scopes) and <strong>reinstall</strong>. Until then those agents see
+                only the message that mentioned them, and say so in the thread.
+                <span className="ml-1 opacity-70">({new Date(slackState.threadScopeError.at).toLocaleString()})</span>
+              </div>
+            )}
           </div>
           <SlackSetupGuide />
           <Field label="App-level token" help="Basic Information → App-Level Tokens. Scope: connections:write.">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1484,6 +1484,9 @@ export interface SlackStatus {
   botUserId: string
   lastError?: string
   error?: string
+  /** The most recent thread the bot was tagged into and could not read. The person who tagged it is
+   *  warned in the thread; this is for the admin who can actually add the scope, who never sees it. */
+  threadScopeError?: { channel: string; scope: string; error: string; at: number }
 }
 
 /** Live Discord Gateway status — same shape as SlackStatus. */


### PR DESCRIPTION
## The report

From a live tenant, 2026-09-04 — the bot, tagged partway through an existing Slack thread:

> No — I can't see them. I only receive the text of the message that @-mentions me; the rest of this thread isn't visible to me.

Both halves were problems. The first half was true and was ours: `fireSlack` passed the mention's own text and nothing else, so an agent pulled into a live conversation had one line of it. The second half was the agent filling the gap with a guess it then told a human as fact.

## What changed

`fetchThreadMessages` reads `conversations.replies` with the bot token; `threadNote` folds the result into the prompt oldest-first. Last 30 messages, 800 chars each. Senders are labelled by the same resolution the run-as path uses, so a name in the transcript is a teammate the agent can look up; another app's posts are named by their bot profile (`Beszel: ALERT web-3 cpu 98%`). The triggering message is excluded — it is already in the prompt above.

Narrow on purpose, because a read costs an API call per message:

- **No call when the message opens its own thread.** An un-threaded message's `thread_ts` falls back to its `ts`; there is no history to read.
- **No call on the continuity path.** A resumed session already holds the transcript.
- **Never fatal.** A failure audits `slack.thread.unreadable` `{ channel, thread, error }` and the run proceeds.

And the agent is *told* when it is blind, with the Slack error verbatim. That is the second half of the report: silence is what let it invent a cause.

## Scopes — the operator half

History scopes are per conversation type. `channels:history` covers **public** channels only; a private channel needs **`groups:history`**, a group DM `mpim:history`, a DM `im:history`. All four are already in the bundled manifest, so a Slack app created from it today is fine — but an app installed before them answers `missing_scope`, which now reaches both the audit line and the agent's reply. Fix is unchanged: add the scope, reinstall.

## Testing

`scripts/slack-ingress-test.cjs` grows a thread-history section (58 checks total, all green): history reaches the prompt, bot posts are named, a giant paste is clipped, the triggering message is not duplicated into the block, the read is scoped to that channel+thread, a thread-opening mention makes no call, and a `missing_scope` failure neither blocks the run nor stays silent. `npm run typecheck` + `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWZ6NRTH3FUw1yLYUtxCbG