### PR TITLE
fix(metrics): tool usage counts one tool call, not one loopback request (v0.424.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,27 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.424.1] - 2026-09-04
+### Fixed
+- **Tool-usage counts one tool CALL, not one loopback request.** The first live read of the v0.414.6
+  counters (2026-09-04, 2.5 days of data) put `task_wait: 4212` and `task_create: 1848` at the top of a
+  tenant's table — a tenant that had created **311 tasks** in the window. Neither number meant what it
+  said. `task_wait` polls `/api/tasks/wait` every 3s *inside one tool call*, `task_create({wait:true})`
+  runs that same loop under its OWN label, and `toolContext` (set once per `tools/call`) stamps
+  `x-aos-tool` on every request the call makes. So the metric was measuring how long agents **waited**,
+  not what they **chose to do**, and the two tools that block by design led the ranking for that reason
+  alone.
+
+  `x-aos-tool-seq` now carries the request's position within its tool call, and only seq 1 is counted.
+  The header still rides on *every* request, because the other consumer wants the opposite: per-tool
+  latency and the blocking-tool exemption in `request-metrics` need to see the polls (a poll that stalls
+  is a stall). An absent seq counts as 1, so an older MCP process outliving a server upgrade keeps being
+  counted rather than silently vanishing from the data.
+
+  Only the two blocking tools were distorted; the **used/unused set is unaffected**, which is the
+  question the counters were added to settle. Rows written before this fix keep the inflated counts for
+  `task_wait`/`task_create` — worth remembering when reading a window that spans 2026-09-04.
+
 ## [0.424.0] - 2026-09-04
 ### Added
 - **A Slack agent can read the thread it was tagged into.** A mention delivers one message, so an agent

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.424.0",
+  "version": "0.424.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.424.0",
+      "version": "0.424.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.424.0",
+  "version": "0.424.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/tool-usage-test.cjs
+++ b/scripts/tool-usage-test.cjs
@@ -112,7 +112,72 @@ console.log('\nboundaries\n');
   await new Promise((r) => setTimeout(r, 120));
   assert(toolUsage.pendingCount() === b2, 'a request without the headers is not counted');
 
+  // ONE COUNT PER TOOL CALL. A blocking tool polls a route in a loop under a single label — `task_wait`
+  // hits /api/tasks/wait every 3s inside one call, and `task_create({wait:true})` runs that same loop
+  // under its own name. Counting requests therefore measured how long an agent WAITED, not what it chose
+  // to do: the first live read (2026-09-04) showed `task_create: 1848` on a tenant that had created 311
+  // tasks. `x-aos-tool-seq` is the request's position within its call; only the first is counted.
+  const call = async (tool, seq) => {
+    const headers = { 'content-type': 'application/json', 'x-aos-secret': 'nope', 'x-aos-tool': tool, 'x-aos-agent': 'poller', 'x-aos-tenant': rtOs.tenant };
+    if (seq !== undefined) headers['x-aos-tool-seq'] = String(seq);
+    await fetch(`${base}/api/tasks/wait`, { method: 'POST', headers, body: JSON.stringify({ session: 'ses_none', id: 't1' }) }).catch(() => {});
+    await new Promise((r) => setTimeout(r, 60));
+  };
+  // One tool call that polled five times.
+  for (let i = 1; i <= 5; i++) await call('task_wait', i);
+  toolUsage.flush(rtOs.tenant, rtOs.db);
+  const waited = readToolUsage(rtOs.db, rtOs.tenant, 30).find((r) => r.agent === 'poller' && r.tool === 'task_wait');
+  assert(waited && waited.n === 1, 'a tool that polls 5 times counts as ONE call', `got ${waited ? waited.n : 'nothing'}`);
+
+  // A second, separate call of the same tool is its own count — the fix must not collapse real repeats.
+  await call('task_wait', 1);
+  toolUsage.flush(rtOs.tenant, rtOs.db);
+  const twice = readToolUsage(rtOs.db, rtOs.tenant, 30).find((r) => r.agent === 'poller' && r.tool === 'task_wait');
+  assert(twice && twice.n === 2, 'but a second tool call counts again', `got ${twice ? twice.n : 'nothing'}`);
+
+  // No header at all = 1. An MCP process outlives a server upgrade, so the old client that stamps no seq
+  // must keep being counted rather than silently vanishing from the data.
+  await call('recall', undefined);
+  toolUsage.flush(rtOs.tenant, rtOs.db);
+  const unstamped = readToolUsage(rtOs.db, rtOs.tenant, 30).find((r) => r.agent === 'poller' && r.tool === 'recall');
+  assert(unstamped && unstamped.n === 1, 'a request with no seq header still counts (older MCP client)', `got ${unstamped ? unstamped.n : 'nothing'}`);
+
   await new Promise((r) => server.close(r));
+
+  // THE OTHER HALF. Everything above sends `x-aos-tool-seq` by hand; none of it proves the MCP client
+  // still stamps one. If it stops, the server keeps counting every request exactly as before and the
+  // data quietly goes back to being wrong — no error, no failing assertion anywhere else. So drive the
+  // real client: spawn it against a stub that never returns terminal, and watch one `task_wait` call
+  // poll under an increasing seq.
+  console.log('\nthe client half — the MCP stamps the sequence\n');
+  const http = require('http');
+  const { spawn } = require('child_process');
+  const seen = [];
+  let settle;
+  const done = new Promise((r) => (settle = r));
+  const stub = http.createServer((req, res) => {
+    req.resume();
+    req.on('end', () => {
+      seen.push({ tool: req.headers['x-aos-tool'], seq: req.headers['x-aos-tool-seq'] });
+      if (seen.length >= 2) settle();
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ ok: true, status: 'doing', terminal: false }));   // never terminal → it polls
+    });
+  });
+  await new Promise((r) => stub.listen(0, '127.0.0.1', r));
+  const child = spawn(process.execPath, [path.join(ROOT, 'dist/memory/memory-mcp.js')], {
+    env: { ...process.env, AOS_URL: `http://127.0.0.1:${stub.address().port}`, SESSION: 'ses_x', AGENT: 'probe', AOS_SECRET: 's', UNATTENDED: '1' },
+    stdio: ['pipe', 'pipe', 'inherit'],
+  });
+  child.stdin.write(JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'task_wait', arguments: { id: 't1', timeoutSeconds: 30 } } }) + '\n');
+  await Promise.race([done, new Promise((r) => setTimeout(r, 15000))]);
+  child.kill();
+  await new Promise((r) => stub.close(r));
+  const polls = seen.filter((x) => x.tool === 'task_wait');
+  assert(polls.length >= 2, 'one task_wait call makes repeated loopback requests', `saw ${polls.length}`);
+  assert(polls[0] && polls[0].seq === '1', 'the first carries seq 1 — the one that gets counted', JSON.stringify(polls[0]));
+  assert(polls[1] && polls[1].seq === '2', 'and each poll after it increments', polls.map((p) => p.seq).join(','));
+
   fs.rmSync(HOME, { recursive: true, force: true });
   console.log(`\n${fail ? '\x1b[31m' : '\x1b[32m'}${pass} passed, ${fail} failed\x1b[0m\n`);
   process.exit(fail ? 1 : 0);

--- a/src/memory/memory-mcp.ts
+++ b/src/memory/memory-mcp.ts
@@ -48,15 +48,32 @@ const TASK_WAIT_S = Number(process.env.AOS_TASK_WAIT_S) || 900;
  * dispatched without awaiting the last), so a module-level "current tool" variable would mislabel
  * interleaved calls; an AsyncLocalStorage keeps the name bound to its own async chain.
  */
-const toolContext = new AsyncLocalStorage<string>();
+const toolContext = new AsyncLocalStorage<{ tool: string; seq: number }>();
 
 /** Headers for a loopback agent call: the session bearer + tenant route, plus any extras (e.g. JSON). */
 function H(extra: Record<string, string> = {}): Record<string, string> {
   // `x-aos-tool` and `x-aos-agent` are TELEMETRY only — the server buckets per-tool latency by the
   // first (request-metrics.ts) and counts per-agent tool usage by the pair (tool-usage.ts). Neither
   // grants anything. Authority stays with the session secret above.
-  const tool = toolContext.getStore();
-  return { 'x-aos-secret': SECRET, ...(TENANT ? { 'x-aos-tenant': TENANT } : {}), ...(AGENT ? { 'x-aos-agent': AGENT } : {}), ...(tool ? { 'x-aos-tool': tool } : {}), ...extra };
+  //
+  // `x-aos-tool-seq` counts this request's position WITHIN its tool call, and exists because the two
+  // consumers want different things from the same header. Latency wants every request (a poll that
+  // stalls is a stall); usage wants one count per tool call, because a tool call is what the model
+  // actually decided to do. They diverge badly: `task_wait` polls /api/tasks/wait every 3s inside ONE
+  // call, and `task_create({wait:true})` runs that same loop under its OWN label — so the first read of
+  // this data (2026-09-04) showed `task_wait: 4212` and `task_create: 1848` on a tenant that had created
+  // 311 tasks. ~83% of the second number was poll spill. The counts led the table for a reason that had
+  // nothing to do with agent behaviour. Only seq 1 is counted; the header still rides on every request
+  // so per-tool latency and the blocking-tool exemption are unchanged.
+  const ctx = toolContext.getStore();
+  const seq = ctx ? ++ctx.seq : 0;
+  return {
+    'x-aos-secret': SECRET,
+    ...(TENANT ? { 'x-aos-tenant': TENANT } : {}),
+    ...(AGENT ? { 'x-aos-agent': AGENT } : {}),
+    ...(ctx ? { 'x-aos-tool': ctx.tool, 'x-aos-tool-seq': String(seq) } : {}),
+    ...extra,
+  };
 }
 
 interface JsonRpc {
@@ -3230,7 +3247,7 @@ async function handle(req: JsonRpc): Promise<void> {
     // indexed row-test and a by-id build. Sharing a bucket made the tool table rank a deliberate model
     // call second-slowest in the system and hid any regression on the cheap path behind its average.
     const label = name === 'session_open' && args.summary ? 'session_open:summary' : name;
-    return toolContext.run(label ?? 'unknown', async () => {
+    return toolContext.run({ tool: label ?? 'unknown', seq: 0 }, async () => {
     try {
       const text =
         name === 'recall' ? await recall(args)

--- a/src/server.ts
+++ b/src/server.ts
@@ -332,9 +332,16 @@ export function createHttpServer(registry: TenantRegistry): http.Server {
       // place a READ tool is observable at all: the loopback tools sit before the member-auth gate, so
       // the PreToolUse hook never sees them, and only the writing ones audit anything. A Map bump here,
       // never a write — the flush timer in startServer does the I/O.
+      // One count per TOOL CALL, not per request: `x-aos-tool-seq` is the request's position within its
+      // call, and only the first is counted. A blocking tool polls a route in a loop under one label
+      // (`task_wait` every 3s; `task_create({wait:true})` runs that loop under its own name), so counting
+      // requests measured how long agents waited, not what they chose to do — on a tenant that created
+      // 311 tasks it read `task_create: 1848`. An absent header counts as 1, so a caller that doesn't
+      // stamp a seq (an older MCP process outliving a server upgrade) is not silently dropped.
       const usageAgent = String(req.headers['x-aos-agent'] || '').trim();
       const usageTenant = String(req.headers['x-aos-tenant'] || '').trim() || registry.default()?.os.tenant || '';
-      if (tool && usageAgent) toolUsage.record(usageTenant, usageAgent, tool);
+      const toolSeq = Number(req.headers['x-aos-tool-seq'] ?? 1);
+      if (tool && usageAgent && (!Number.isFinite(toolSeq) || toolSeq <= 1)) toolUsage.record(usageTenant, usageAgent, tool);
     });
     // Superadmin control plane — host-independent (bearer-gated), so it sits before tenant routing.
     if ((req.url || '').split('?')[0].startsWith('/api/admin/')) {


### PR DESCRIPTION
First read of the v0.414.6 tool-usage counters, 2.5 days in. The reads are being captured — `kb_read`, `recall`, `task_get`, `check_inbox`, `session_history` all show up, which was the entire blind half. But the table was led by two numbers that don't mean what they say:

```
task_wait:   4212
task_create: 1848      ← on a tenant that created 311 tasks in the window
```

## Cause

`task_wait` polls `/api/tasks/wait` every 3s **inside one tool call**. `task_create({wait:true})` runs that same loop under its *own* label. And `toolContext` is set once per `tools/call`, so `H()` stamped `x-aos-tool` on every request the call made.

The metric was measuring **how long agents waited**, not **what they chose to do** — and the two tools that block by design led the ranking purely for that reason. ~83% of the `task_create` count was poll spill.

## Fix

`x-aos-tool-seq` carries the request's position within its tool call; the server counts only seq 1.

The header still rides on **every** request, because the two consumers want opposite things from it:

| consumer | wants |
|---|---|
| `request-metrics` (per-tool latency, blocking-tool exemption) | every request — a poll that stalls *is* a stall |
| `tool-usage` (what the agent reached for) | one per tool call |

An absent seq counts as 1, so an older MCP process outliving a server upgrade keeps being counted rather than silently vanishing from the data.

## Scope

Only the two blocking tools were distorted. **The used/unused set is unaffected** — that's the question the counters were added to settle, and it survives intact:

- 44 of 76 tools used across both tenants; 32 never seen (7 of those conditional, so possibly never *exposed*)
- widest agent is 27 tools; 20 of 37 agents used 5–14

Rows written before this fix keep the inflated `task_wait`/`task_create` counts — noted in the changelog, worth remembering when reading a window spanning 2026-09-04.

## Test

Both halves are pinned **separately**, because the server-side fix is inert if the client stops stamping and that failure is silent — the counts just go back to being wrong with nothing erroring.

```
✓ a tool that polls 5 times counts as ONE call
✓ but a second tool call counts again
✓ a request with no seq header still counts (older MCP client)
✓ one task_wait call makes repeated loopback requests
✓ the first carries seq 1 — the one that gets counted
✓ and each poll after it increments
```

The last three spawn the **real MCP** against a stub that never returns terminal, and watch one `task_wait` call poll. Reverting `server.ts` alone fails 2; reverting `memory-mcp.ts` alone fails the other 2. 20/20 in the file, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)