### PR TITLE
chore(git): ignore Claude Code's per-machine .claude/*.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,13 @@ dist/
 
 # Local process-per-tenant manifest (instance-specific; copy from config/tenants.example.json)
 config/tenants.json
+
+# Claude Code's per-machine local settings, written by `claude` itself the moment anyone runs it inside a
+# checkout (an output style, an allowed tool). It is not the project's config — `.claude/skills` and any
+# tracked settings stay tracked, only the `*.local.*` half is ignored. Why this matters beyond tidiness:
+# `scripts/make-live.sh` refuses to deploy a live checkout that has local changes (so nobody's hand-edit
+# is silently discarded), and an untracked file counts. On 2026-09-04 one `claude` run inside the instawp
+# live checkout left this file behind and blocked that tenant's deploy — the guard doing its job over a
+# file that carries none of the risk it guards against.
+.claude/settings.local.json
+.claude/*.local.json


### PR DESCRIPTION
`claude` writes `.claude/settings.local.json` into whatever checkout it runs in. On a **live** checkout that untracked file trips `scripts/make-live.sh`'s dirty guard and blocks that tenant's whole deploy.

That is exactly what happened to instawp on 2026-09-04: the box sat on v0.424.1 while every other tenant moved to v0.424.2, because of a file containing `{"outputStyle":"Concise"}`. The guard was doing its job (never silently discard someone's edit to a live checkout) over a file that carries none of the risk it guards against.

Ignores only the `*.local.*` half, so a project-level `.claude/` (skills, shared settings) can still be tracked. No runtime change — no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hX85iZ5BhHypPNrob8vnH