### PR TITLE
fix(tests): the resumability gate no longer depends on the box's own claude login (v0.429.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ new version heading in the same commit.
   (`useHttpPath` → a session-secret loopback route), the member-lane guard that keeps a linked human's
   PR authorship, and the `gh`-doesn't-read-git-helpers gap. Docs only — no behaviour change.
 
+## [0.429.1] - 2026-09-10
+### Fixed
+- `scripts/headless-resumable-test.cjs` isolates its `CLAUDE_CONFIG_DIR`. The new launch pre-flight reads
+  the box's real claude login, so on a box whose login has lapsed — the box you most want to run the
+  deploy gate on — nine assertions failed for a reason unrelated to resumability. Caught running the gate
+  on the instawp box, whose expired default login was the outage in 0.429.0.
+
 ## [0.429.0] - 2026-09-10
 ### Fixed
 - **A pooled runtime account was disabled for another run's failure, and the whole tenant fell onto a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.429.0",
+  "version": "0.429.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.429.0",
+      "version": "0.429.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.429.0",
+  "version": "0.429.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/headless-resumable-test.cjs
+++ b/scripts/headless-resumable-test.cjs
@@ -22,6 +22,14 @@ const HOME = fs.mkdtempSync(path.join(os.tmpdir(), 'aos-headless-resumable-test-
 process.env.AGENT_OS_HOME = HOME;
 process.env.AGENT_OS_TENANT = 'testco';
 process.env.AOS_NO_TTYD = '1';
+// Launch pre-flight reads the box's REAL claude login, and refuses a launch when it is dead (expired with
+// no refresh token). That is correct in production and makes this suite ambient: on a box whose login has
+// lapsed — exactly the box you most want to run the gate on before deploying — every launch here is
+// refused and nine assertions fail for a reason that has nothing to do with resumability. Point the probe
+// at an empty dir instead: no credential at all keeps its long-standing fail-open behaviour, and the
+// refusal itself is pinned by scripts/runtime-account-misattribution-test.cjs.
+process.env.CLAUDE_CONFIG_DIR = path.join(HOME, 'claude-config');
+fs.mkdirSync(process.env.CLAUDE_CONFIG_DIR, { recursive: true });
 delete process.env.AGENT_OS_SECRET_KEY;
 
 let pass = 0, fail = 0;


### PR DESCRIPTION
Follow-up to #801, found by running the deploy gate on the instawp box before restarting it.

The 0.429.0 launch pre-flight reads the box's real credential dir and refuses a launch when that login
is dead. `scripts/headless-resumable-test.cjs` spawns launches without isolating `CLAUDE_CONFIG_DIR`, so
on a box whose login has lapsed — precisely the box you most want the gate to run on — nine of its
assertions fail for a reason that has nothing to do with resumability, and the deploy stops on a red
suite that is describing the box, not the code.

It now points at an empty scratch dir: no credential keeps the long-standing fail-open path, and the
refusal itself stays pinned by `runtime-account-misattribution-test.cjs`.

Verified on the instawp box: `npm run test:governance` → 2296 assertions, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HA3jrB7rENd2zadgxP56Lu