### PR TITLE
feat(tasks): who filed it, a top-level lens, and create opens the task (v0.430.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,35 @@ Every PR that bumps `package.json` moves its entries from **Unreleased** into a
 new version heading in the same commit.
 
 ## [Unreleased]
+
+## [0.430.0] - 2026-09-10
+### Added
+- **Tasks: who filed it.** `createdBy` has always been stored on every task and was never shown or
+  filterable, so on a board where agents file most of the rows a person's own tasks were unfindable and an
+  agent-generated sub-task looked exactly like one somebody wrote. The board now carries a **Filed by**
+  lens (`Anyone · I filed · People · Agents`, each with a facet count), names the filer on the card and in
+  the list row whenever that isn't the assignee, lists **Group: Filed by** in the list view, and stamps
+  `filed by …` in the task room's meta line.
+- **Tasks: a top-level lens.** A one-click *Top level* filter hides every task with a parent — the
+  decomposition an agent split out of its own work — leaving the work somebody actually asked for. Shown
+  only when the board holds sub-tasks, with a count of what it would hide. Board cards now also show a
+  `↳ <parent>` chip linking to the task they were split from.
+- Creating a task **opens it**. The create form used to drop you back on the board with the new card
+  somewhere in it; you then had to find your own task to add detail or dispatch it. It now navigates to
+  `#/tasks/<id>` — the room, where the next action is. (Board is refreshed first, so closing the room
+  lands on a list that already holds the card.)
+
+### Fixed
+- **List view: `Group: Chain` could not be selected.** The mode was implemented and named in the group
+  selector's label map, but had no `SelectItem` — so the hand-off-chain grouping was unreachable from the
+  dropdown and only appeared if `aos_tasks_group` was already set to it.
+
 ### Docs
+- `docs/clickup-task-bridge-plan.md` — plan for `/agentric` in a ClickUp comment: find-or-create one
+  Agentric task per ticket (`#<ticketId> <heading>`), repeat comments landing in that task's discussion
+  rather than spawning duplicates. Specs the reserved command, a `tasks.external_key` idempotency key
+  (which FreeScout and Slack threads want too), title/body/attachment sourcing, and identity — the task's
+  `createdBy` is what the new Filed-by lens reads. Docs only — no behaviour change.
 - `docs/github-multi-org-plan.md` — plan for making the company-bot GitHub lane multi-org. Today
   `ensureBotToken` stores one `github_installation_id` and resolves it as `installations[0]`, so an App
   installed on two orgs silently acts on one of them and 404s the other with no error at launch.

--- a/docs/clickup-task-bridge-plan.md
+++ b/docs/clickup-task-bridge-plan.md
@@ -1,0 +1,126 @@
+# `/agentric` — one ClickUp ticket, one Agentric task
+
+**Status:** proposed (not built). Requested by an InstaWP operator, 2026-09-10, alongside the board
+filters that shipped in v0.430.0.
+
+## What exists today
+
+A ClickUp Automation ("comment added") POSTs `/hooks/clickup?key=…&task_id=…`; `ClickupIngress.dispatch`
+fetches the latest comment and routes it:
+
+- a comment that isn't a `/command` is **ignored** (a ClickUp comment section is a shared human space, so
+  the `/command` gate is the addressing rule — deliberately unlike Slack/Discord, where *having spoken in
+  a thread* is enough);
+- `/agentname <request>` reaches the shared `/agent` front door and spawns a governed session bound to the
+  ClickUp task (`clickup_threads`), so `clickup_reply` answers on the same ticket;
+- a follow-up `/command` on a bound ticket **resumes that session** (`continueClickupThread`).
+
+So today a ClickUp ticket maps to *sessions*. It does not map to anything durable: nothing on the Agentric
+side outlives the run, and a second `/command` after the session is gone starts over.
+
+## What's asked for
+
+> `/agentric` in a ClickUp comment should create an Agentric task titled `#<ticketId> <ticket heading>`
+> with the ticket description as the body — and if that task already exists, put the new comment into its
+> discussion instead of creating a second one, so the same Agentric task is the place the work lives.
+
+That is the missing durable half: the ticket maps to a **Task**, and sessions hang off the task the way
+they already do everywhere else on the board.
+
+## Design
+
+### 1. A reserved command, intercepted before routing
+
+`/agentric` is handled in `ClickupIngress.dispatch` **before** `continueClickupThread` / `fireClickup` —
+it is not an agent name and must never fall through to the "unknown agent" help list. Add a small reserved
+set (`agentric`, plus the existing `agent-os` prefix `normalizeChatCommand` already strips) and refuse to
+create an agent whose id collides with it.
+
+Grammar:
+
+```
+/agentric <text>                 → link this ticket to a task; add <text> to its discussion
+/agentric <agent-id> <request>   → the same, and dispatch <agent-id> on that task
+```
+
+### 2. The idempotency key: a new `tasks.external_key`
+
+Find-or-create needs a stable link, and none of the existing columns provide one (labels aren't unique;
+`clickup_threads` binds *sessions*). Add:
+
+```sql
+ALTER TABLE tasks ADD COLUMN external_key TEXT;
+CREATE UNIQUE INDEX tasks_external_key ON tasks (tenant, external_key) WHERE external_key IS NOT NULL;
+```
+
+Value: `clickup:<clickup task id>`. `TaskStore.byExternalKey(key)` + an `externalKey` field on
+`TaskCreateInput`; the unique index makes a racing double webhook a constraint violation to swallow, not a
+duplicate task. This generalises deliberately — FreeScout tickets and Slack threads want the same column,
+and "replace ClickUp eventually" is only credible if an Agentric task can *be* the external record.
+
+### 3. Title, body, attachments
+
+The comment webhook carries neither the ticket's name nor its description, so add `fetchTask(token, id)`
+to `src/connectors/clickup.ts` (`GET /task/<id>` → `name`, `description`, `custom_id`, `url`, `status`).
+
+- **Title** — `#<custom_id ?? id> <name>`, exactly as asked. `custom_id` is the human-facing `#ABC-123`
+  when the ClickUp workspace has custom task ids on; fall back to the raw id.
+- **Body** — the ticket description, with the ticket URL as the first line (the backlink is what makes the
+  Agentric task usable without ClickUp open).
+- **Attachments** — `dispatch` already downloads a comment's files (presigned, expiring). On this path
+  there is no session to stage them into, so attach them to the task (`TaskStore.attach`).
+
+### 4. Repeat comments become discussion, not tasks
+
+Second and later `/agentric` comments on the same ticket resolve the existing task by `external_key` and
+append the comment through the same path `POST /api/tasks/say` uses — author = the resolved member, else
+`clickup`. Nothing else changes: status, assignee and priority stay whatever a human or agent set on the
+board.
+
+### 5. Identity
+
+Run-as resolution is unchanged (commenter email → member, else company identity). It matters more here
+than in the session path because the task ROW records it:
+
+- `owner` = the resolved member (so a later dispatch runs as the human who asked);
+- `createdBy` = that member, else `clickup`.
+
+`createdBy` is what the board's **Filed by** lens reads, so a ticket-born task is distinguishable from
+both a hand-filed one and an agent-filed sub-task without any extra field.
+
+### 6. Reply, once
+
+First link: one ClickUp comment carrying the Agentric task URL (and `remember()` its id, so our own
+comment doesn't re-trigger the webhook). Repeats: the 👀 reaction only — a comment per comment would
+double the noise on a shared ticket.
+
+### 7. Governance
+
+None of this is a new trust surface. Task creation and edits are auto-apply + audited (the safety net is
+the append-only `task_events` log, exactly as for the console and the MCP tools); only a *dispatched*
+session's effects reach the gateway, through the gate every other session uses. New audit events:
+`clickup.task.linked`, `clickup.task.discussed`.
+
+## Work
+
+| | |
+|---|---|
+| `src/state/db.ts` | `external_key` column + partial unique index |
+| `src/state/tasks.ts` | `externalKey` on create; `byExternalKey()` |
+| `src/connectors/clickup.ts` | `fetchTask()` |
+| `src/edge/clickup-ingress.ts` | reserved `/agentric` branch: find-or-create, discuss, attach, backlink |
+| `scripts/clickup-task-bridge-test.cjs` | pins: create → repeat → discussion (no second task); racing duplicate webhook; unmapped commenter → `clickup` author |
+
+Roughly half a day, plus the test. No console work — the resulting task is an ordinary task.
+
+## Open questions
+
+1. **Status sync.** Out of scope here (one-way: ClickUp → Agentric). Closing the Agentric task does not
+   close the ticket. Worth doing next if the bridge sticks, and it is where a two-way loop-guard gets
+   genuinely fiddly.
+2. **Which agent, if none is named.** `/agentric <text>` deliberately does *not* dispatch. Auto-routing it
+   would make a ticket comment spend money without anyone choosing to — the explicit
+   `/agentric <agent-id> …` form is the opt-in.
+3. **Retitling.** If the ticket is renamed in ClickUp, the task title goes stale. Cheap fix: refresh title
+   + body on each `/agentric` comment; skipped for now because it would silently overwrite a title someone
+   edited on the board.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.429.1",
+  "version": "0.430.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.429.1",
+      "version": "0.430.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.429.1",
+  "version": "0.430.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10160,6 +10160,18 @@ function matchesQuickStatus(t: Task, s: QuickStatus): boolean {
   return true
 }
 
+// Who FILED the task. `createdBy` has always been stored (member id | `agent:<id>`) and was never shown
+// or filterable, so on a board where agents file most of the rows a person's own tasks were unfindable —
+// and an agent-filed sub-task looked exactly like one you'd written yourself. 'me' is the narrow case of
+// 'human'; both are answered from the row, so this is a lens, not a schema change.
+type TaskAuthor = '' | 'me' | 'human' | 'agent'
+function matchesAuthor(t: Task, a: TaskAuthor, meId: string): boolean {
+  if (a === 'me') return t.createdBy === meId
+  if (a === 'human') return !t.createdBy.startsWith('agent:')
+  if (a === 'agent') return t.createdBy.startsWith('agent:')
+  return true
+}
+
 function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; agents: AgentInfo[]; taskId: string; onOpen: (tmux: string, title: string) => void; nav: (r: Route, detail?: string) => void; backTo: (fallback: Route) => BackTarget }) {
   const [members, setMembers] = useState<Member[]>([])
   useEffect(() => { api.team().then((r) => setMembers(r.members ?? [])).catch(() => {}) }, [])
@@ -10233,9 +10245,9 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
   useEffect(() => { localStorage.setItem('aos_task_room_side', roomSide ? '1' : '0') }, [roomSide])
   // Sticky like the view mode next to it — the grouping is a way of *reading* the board, and having it
   // snap back to Priority on every visit made Chain in particular feel like a toy rather than a lens.
-  const [listGroup, setListGroup] = useState<'priority' | 'status' | 'assignee' | 'goal' | 'chain' | 'none'>(() => {
+  const [listGroup, setListGroup] = useState<'priority' | 'status' | 'assignee' | 'author' | 'goal' | 'chain' | 'none'>(() => {
     const v = localStorage.getItem('aos_tasks_group')
-    return v === 'status' || v === 'assignee' || v === 'goal' || v === 'chain' || v === 'none' ? v : 'priority'
+    return v === 'status' || v === 'assignee' || v === 'author' || v === 'goal' || v === 'chain' || v === 'none' ? v : 'priority'
   })
   useEffect(() => { localStorage.setItem('aos_tasks_group', listGroup) }, [listGroup])
   const [mine, setMine] = useState(false)
@@ -10251,6 +10263,11 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
   // opens exactly as it always has.
   const [fStatus, setFStatus] = useState<'' | 'open' | 'blocked' | 'done'>('')
   const [fUnassigned, setFUnassigned] = useState(false)
+  // Authorship lens (see `matchesAuthor`) + the sub-task brake next to it: `fRoot` hides anything with a
+  // parent, so the board shows the work somebody actually asked for rather than the decomposition an
+  // agent generated under it. Both default off — the view opens exactly as it always has.
+  const [fAuthor, setFAuthor] = useState<TaskAuthor>('')
+  const [fRoot, setFRoot] = useState(false)
   const [sort, setSort] = useState<'priority' | 'due' | 'updated'>('priority')
   // drag-and-drop
   const [dragId, setDragId] = useState<string | null>(null)
@@ -10329,6 +10346,35 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
     )
   }
 
+  /** Who filed the task, on a card — shown only when that isn't the assignee (when it is, the assignee
+   *  badge already says it). This is the one place the board distinguishes a task a PERSON wrote from a
+   *  sub-task an AGENT split out of its own work, which used to render identically. */
+  const filedByChip = (t: Task) => {
+    if (!t.createdBy || t.createdBy === t.assignee) return null
+    return (
+      <span className="inline-flex items-center gap-1 text-[10px] text-muted-foreground/80" title={`Filed by ${nameOf(t.createdBy)}`}>
+        <span className="shrink-0 opacity-70">by</span>{assigneeIcon(t.createdBy, 'h-3 w-3')}
+        <span className="max-w-[7rem] truncate">{nameOf(t.createdBy)}</span>
+      </span>
+    )
+  }
+  /** The parent this task was split out of — an agent decomposing its work is the usual author, so the
+   *  chip is what tells you a row is a sub-task rather than something anyone asked for directly. */
+  const parentChip = (t: Task) => {
+    if (!t.parentId) return null
+    const parent = taskById(t.parentId)
+    return (
+      <a
+        href={navHref('tasks', t.parentId)}
+        onClick={(e) => { e.stopPropagation(); onNavClick(() => openTask(t.parentId!))(e) }}
+        title={`Sub-task of: ${parent ? parent.title : t.parentId}`}
+        className="inline-flex min-w-0 items-center gap-0.5 rounded bg-muted px-1 text-[10px] text-muted-foreground no-underline hover:text-foreground hover:underline"
+      >
+        <span className="shrink-0">↳</span><span className="max-w-[8rem] truncate">{parent ? parent.title : t.parentId}</span>
+      </a>
+    )
+  }
+
   const load = async () => {
     const r = await api.tasks(q)
     setTasks(r.tasks ?? [])
@@ -10392,7 +10438,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
   // One predicate for every lens, with `skip` naming a dimension to ignore. That's what lets each quick
   // filter show a count of what picking it would actually yield *given the other filters* — a facet count,
   // not a global tally, so "Blocked 7" doesn't promise 7 when you're already narrowed to one assignee.
-  const passes = (t: Task, skip?: 'status' | 'unassigned' | 'overdue'): boolean => {
+  const passes = (t: Task, skip?: 'status' | 'unassigned' | 'overdue' | 'author' | 'root'): boolean => {
     if (mine && t.assignee !== me.id) return false
     if (fAssignee && t.assignee !== fAssignee) return false
     if (fLabel && !t.labels.includes(fLabel)) return false
@@ -10402,6 +10448,8 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
     if (fLive && !liveOf(t)) return false
     if (skip !== 'unassigned' && fUnassigned && t.assignee) return false
     if (skip !== 'status' && !matchesQuickStatus(t, fStatus)) return false
+    if (skip !== 'author' && !matchesAuthor(t, fAuthor, me.id)) return false
+    if (skip !== 'root' && fRoot && t.parentId) return false
     return true
   }
   const visible = (tasks ?? []).filter((t) => passes(t))
@@ -10409,10 +10457,13 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
   const statusPool = (tasks ?? []).filter((t) => passes(t, 'status'))
   const statusCount = (s: '' | 'open' | 'blocked' | 'done') => statusPool.filter((t) => matchesQuickStatus(t, s)).length
   const unassignedCount = (tasks ?? []).filter((t) => passes(t, 'unassigned') && !t.assignee).length
+  const authorPool = (tasks ?? []).filter((t) => passes(t, 'author'))
+  const authorCount = (a: TaskAuthor) => authorPool.filter((t) => matchesAuthor(t, a, me.id)).length
+  const subCount = (tasks ?? []).filter((t) => passes(t, 'root') && t.parentId).length
   const overdueCount = (tasks ?? []).filter((t) => passes(t, 'overdue') && dueMeta(t.dueAt, t.status)?.overdue).length
   const goalsPresent = [...new Set((tasks ?? []).map((t) => t.goalId).filter(Boolean) as string[])]
-  const filterActive = mine || fAssignee || fLabel || fPriority !== '' || fGoal || fOverdue || fLive || fStatus !== '' || fUnassigned
-  const clearFilters = () => { setMine(false); setFAssignee(''); setFLabel(''); setFPriority(''); setFGoal(''); setFOverdue(false); setFLive(false); setFStatus(''); setFUnassigned(false) }
+  const filterActive = mine || fAssignee || fLabel || fPriority !== '' || fGoal || fOverdue || fLive || fStatus !== '' || fUnassigned || fAuthor !== '' || fRoot
+  const clearFilters = () => { setMine(false); setFAssignee(''); setFLabel(''); setFPriority(''); setFGoal(''); setFOverdue(false); setFLive(false); setFStatus(''); setFUnassigned(false); setFAuthor(''); setFRoot(false) }
 
   const liveTasks = visible.filter((t) => liveOf(t))
   const liveCount = liveTasks.length
@@ -10431,7 +10482,12 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
     const r = await api.addTask(req)
     if (r.error) return setHint('⚠ ' + r.error)
     setTitle(''); setBody(''); setAssignee(''); setAutoDispatch(false); setPriority(2); setMode('headless'); setDue(''); setGoalId(''); setCriteria(''); setNewDeps([]); setShowNew(false)
-    load()
+    await load()
+    // Land IN the task you just filed. Creating one used to drop you back on the board with the new card
+    // somewhere in it — on a busy board you then had to hunt for your own task to add detail or dispatch
+    // it. The room is where the next action lives, so go there. (Board first, so closing the room via
+    // `backTo` returns to a list that already holds the card.)
+    if (r.task?.id) openTask(r.task.id)
   }
   // Re-link or complete a task and the goal's derived progress moves with it, so refresh the goal
   // list too — otherwise the "part of goal" banner keeps showing the pre-edit bar.
@@ -10511,6 +10567,8 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
               <span className="text-[10px] text-muted-foreground">{workers[t.id].agents.length} ran</span>
             </span>
           )}
+          {filedByChip(t)}
+          {parentChip(t)}
           {t.autoDispatch && <Badge variant="outline" className="px-1.5 py-0 text-[10px]">auto</Badge>}
           {/* What a blocked task waits on, as its delegate declared it. The column header says "Needs you",
               which is only true for `human` — this says which of the three it actually is, and `human` is
@@ -10592,7 +10650,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
     ) : (
       <div className="space-y-3.5">
         <div className="flex items-center gap-1.5 font-mono text-xs text-muted-foreground">
-          <span>{detail.task.id}{detail.task.owner ? ` · as ${nameOf(detail.task.owner)}` : ''}</span>
+          <span>{detail.task.id}{detail.task.owner ? ` · as ${nameOf(detail.task.owner)}` : ''}{detail.task.createdBy ? ` · filed by ${nameOf(detail.task.createdBy)}` : ''}</span>
           {draftNow && <Badge variant="outline" className="px-1.5 py-0 font-sans text-[10px]" title="never dispatched — no session has worked this yet, so it's still yours to edit or delete">draft</Badge>}
         </div>
 
@@ -10975,6 +11033,29 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
           <button onClick={() => setMine(false)} className={`px-2.5 py-1 ${!mine ? 'bg-muted font-medium' : 'text-muted-foreground'}`}>All</button>
           <button onClick={() => setMine(true)} className={`border-l px-2.5 py-1 ${mine ? 'bg-muted font-medium' : 'text-muted-foreground'}`}>My tasks</button>
         </div>
+        {/* Who FILED it. Sits next to "My tasks" (which is about the ASSIGNEE) because the two answer
+            different questions — what's on my plate vs. what I asked for. */}
+        <div className="inline-flex overflow-hidden rounded-md border" title="Filter by who filed the task">
+          {([['', 'Anyone'], ['me', 'I filed'], ['human', 'People'], ['agent', 'Agents']] as [TaskAuthor, string][]).map(([a, label], i) => {
+            const on = fAuthor === a
+            return (
+              <button
+                key={a || 'any'}
+                onClick={() => setFAuthor(a)}
+                title={a === 'me' ? 'Tasks you created yourself' : a === 'human' ? 'Tasks a person created' : a === 'agent' ? 'Tasks an agent created (its own work and the sub-tasks it split out)' : 'No author filter'}
+                className={`inline-flex items-center gap-1 px-2.5 py-1 ${i ? 'border-l' : ''} ${on ? 'bg-muted font-medium' : 'text-muted-foreground'}`}
+              >
+                {a === 'agent' && <Bot className="h-3.5 w-3.5" />}{a === 'human' && <Users className="h-3.5 w-3.5" />}{label}
+                {a !== '' && <span className="font-mono text-[10px] tabular-nums opacity-70">{authorCount(a)}</span>}
+              </button>
+            )
+          })}
+        </div>
+        {subCount > 0 && (
+          <button onClick={() => setFRoot((v) => !v)} title="Hide sub-tasks — show only the work somebody asked for, not the decomposition under it" className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 ${fRoot ? 'border-primary bg-primary/10 font-medium text-foreground' : 'text-muted-foreground'}`}>
+            <FolderTree className="h-3.5 w-3.5" />Top level<span className="font-mono text-[10px] tabular-nums opacity-70">{subCount} sub</span>
+          </button>
+        )}
         <button onClick={() => setFUnassigned((v) => !v)} title="Work nobody has picked up" className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 ${fUnassigned ? 'border-amber-500 bg-amber-500/10 text-amber-600' : 'text-muted-foreground'}`}>
           <User className="h-3.5 w-3.5" />Unassigned{unassignedCount > 0 && <span className="font-mono text-[10px] tabular-nums">{unassignedCount}</span>}
         </button>
@@ -11002,9 +11083,11 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
         <button onClick={() => setFOverdue((v) => !v)} className={`inline-flex items-center gap-1 rounded-md border px-2 py-1 ${fOverdue ? 'border-red-500 bg-red-500/10 text-red-600' : 'text-muted-foreground'}`}><AlertTriangle className="h-3.5 w-3.5" />Overdue{overdueCount > 0 && <span className="font-mono text-[10px] tabular-nums">{overdueCount}</span>}</button>
         {view === 'list' && (
           <>
-            <Select items={{ priority: 'Group: Priority', status: 'Group: Status', assignee: 'Group: Assignee', goal: 'Group: Goal', chain: 'Group: Chain', none: 'Group: None' }} value={listGroup} onValueChange={(v) => v && setListGroup(v as typeof listGroup)}>
+            {/* `chain` was in the trigger's label map but had no SelectItem, so the mode the list already
+                implemented could not actually be picked. Listed now, alongside the new author grouping. */}
+            <Select items={{ priority: 'Group: Priority', status: 'Group: Status', assignee: 'Group: Assignee', author: 'Group: Filed by', goal: 'Group: Goal', chain: 'Group: Chain', none: 'Group: None' }} value={listGroup} onValueChange={(v) => v && setListGroup(v as typeof listGroup)}>
               <SelectTrigger className="h-7 w-36 text-xs"><SelectValue /></SelectTrigger>
-              <SelectContent><SelectItem value="priority">Group: Priority</SelectItem><SelectItem value="status">Group: Status</SelectItem><SelectItem value="assignee">Group: Assignee</SelectItem><SelectItem value="goal">Group: Goal</SelectItem><SelectItem value="none">Group: None</SelectItem></SelectContent>
+              <SelectContent><SelectItem value="priority">Group: Priority</SelectItem><SelectItem value="status">Group: Status</SelectItem><SelectItem value="assignee">Group: Assignee</SelectItem><SelectItem value="author">Group: Filed by</SelectItem><SelectItem value="goal">Group: Goal</SelectItem><SelectItem value="chain">Group: Chain</SelectItem><SelectItem value="none">Group: None</SelectItem></SelectContent>
             </Select>
             <Select items={{ priority: 'Sort: Priority', due: 'Sort: Due date', updated: 'Sort: Updated' }} value={sort} onValueChange={(v) => v && setSort(v as typeof sort)}>
               <SelectTrigger className="h-7 w-36 text-xs"><SelectValue /></SelectTrigger>
@@ -11168,6 +11251,7 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
               if (listGroup === 'priority') groups = [0, 1, 2, 3].map((p) => ({ key: String(p), label: <span className="flex items-center gap-2"><PriorityPips p={p} />{PRIORITY_LABEL[p]}</span>, items: within(visible.filter((t) => t.priority === p)) })).filter((g) => g.items.length)
               else if (listGroup === 'status') groups = (['doing', 'blocked', 'todo', 'done', 'cancelled'] as TaskStatus[]).map((s) => ({ key: s, label: <span className="flex items-center gap-2"><StatusDot status={s} /><span className="capitalize">{s}</span></span>, items: within(visible.filter((t) => t.status === s)) })).filter((g) => g.items.length)
               else if (listGroup === 'assignee') groups = [...new Set(visible.map((t) => t.assignee || ''))].sort().map((k) => ({ key: k || 'none', label: <span>{k ? assigneeChip(k, 'h-3.5 w-3.5') : 'Unassigned'}</span>, items: within(visible.filter((t) => (t.assignee || '') === k)) })).filter((g) => g.items.length)
+              else if (listGroup === 'author') groups = [...new Set(visible.map((t) => t.createdBy || ''))].sort().map((k) => ({ key: k || 'none', label: <span>{k ? assigneeChip(k, 'h-3.5 w-3.5') : 'Unknown'}</span>, items: within(visible.filter((t) => (t.createdBy || '') === k)) })).filter((g) => g.items.length)
               else if (listGroup === 'goal') groups = [...new Set(visible.map((t) => t.goalId || ''))].sort((a, b) => (a ? goalTitle(a) : 'zzz').localeCompare(b ? goalTitle(b) : 'zzz')).map((k) => ({ key: k || 'none', label: <span className="flex items-center gap-1.5">{k ? <><Target className="h-3.5 w-3.5 text-muted-foreground" /><a href={navHref('goals', k)} onClick={onNavClick(() => nav('goals', k))} className="text-muted-foreground no-underline hover:text-foreground hover:underline">{goalTitle(k)}</a></> : 'No goal'}</span>, items: within(visible.filter((t) => (t.goalId || '') === k)) })).filter((g) => g.items.length)
               else if (listGroup === 'chain') {
                 chain = chainOrder(visible, within)
@@ -11210,6 +11294,11 @@ function TasksPage({ me, agents, taskId, onOpen, nav, backTo }: { me: Member; ag
                         </div>
                         <div className="hidden w-32 shrink-0 items-center gap-1.5 truncate text-xs text-muted-foreground sm:flex">
                           <span className="min-w-0 truncate">{t.assignee ? assigneeChip(t.assignee, 'h-3.5 w-3.5') : '—'}</span>
+                          {/* The filer, when it isn't the assignee — the same distinction the board card
+                              makes, kept in the list so switching view doesn't lose it. */}
+                          {t.createdBy && t.createdBy !== t.assignee && (
+                            <span className="shrink-0 opacity-60" title={`Filed by ${nameOf(t.createdBy)}`}>{assigneeIcon(t.createdBy, 'h-3 w-3')}</span>
+                          )}
                           {workers[t.id] && (
                             <span title={`worked by ${workers[t.id].agents.map((a) => `${a.id} (${a.runs} run${a.runs === 1 ? '' : 's'}${a.alive ? ', live' : ''})`).join(' · ')}`}><AgentStack agents={workers[t.id].agents} /></span>
                           )}


### PR DESCRIPTION
Asked for by an InstaWP operator: their own tasks were hard to find among agent-filed ones, and there was no way to tell an agent's sub-task apart from a task a person wrote.

## Changes
- **Filed-by lens.** Anyone · I filed · People · Agents, each with a facet count. Reads `createdBy`, which was already stored on every task but never shown, so there's no schema change.
- **Filer chip** on board cards and list rows whenever the filer isn't the assignee. The task room's meta line now says `filed by …`, and the list view gets **Group: Filed by**.
- **Top-level filter** hides tasks that have a parent. Board cards now show a `↳ <parent>` link on sub-tasks.
- **Creating a task opens it** at `#/tasks/<id>` instead of returning you to the board.
- **Fix:** you couldn't select `Group: Chain`. It was in the label map but had no `SelectItem`.
- **Spec only:** `docs/clickup-task-bridge-plan.md`. `/agentric` on a ClickUp ticket finds or creates one Agentric task per ticket, and later comments go into that task's discussion.

## Verification
- `web` tsc + build, root `npm run typecheck`, `npm run test:governance`: all pass.
- Checked visually on a scratch tenant seeded with human-filed, agent-filed and sub-tasks, using Playwright. Covered: board, the I-filed lens (facet counts update), list grouped by filer, and create landing in the room with `filed by`.

Console-only change. `web/dist` is served off disk, so it goes live without a server restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HA3jrB7rENd2zadgxP56Lu