### PR TITLE
feat(governance): show what a retired-rule drop actually changes, not the rule text (v0.437.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.437.0] - 2026-09-10
+### Added
+- **Before you drop a retired rule, the console shows what actually changes — because a rule's effect
+  is not readable from the rule.** v0.428.0 surfaced rules the product retired that a tenant still
+  enforces, and left the drop to an owner's click. The click was still half-blind: it showed the rule
+  text. On expresstech the retired `shell.exec`+`risky` rule sat at **index 0, ahead of all three
+  `never` guardrails**, and first-match meant it SHADOWED every one of them — a `destructive` command,
+  a spend over the money cap and a bulk delete over the count cap were each being offered for approval
+  instead of refused outright. Dropping it made that tenant **stricter**, the opposite of what the
+  rule text suggested. `classificationDiff()` (`src/governance/policy.ts`) reuses the monotonicity
+  sweep's own arg space (`sampleArgDomains` / `sampleCapabilities`) to collect every DISTINCT verdict
+  that moves between two rulesets — both directions, deduped by capability + verdict pair + reason,
+  each with a **minimal** example (greedily shrunk from a sweep point, so a row reads
+  `{risky:true, destructive:true}` and not every branch arg the ruleset can key on). `retiredRuleImpact()`
+  applies it to a single drop; `GET /api/policy` carries it on each retired hit and Settings → Policy
+  renders the moving verdicts with direction, before → after, and the rule that applies afterwards,
+  plus an explicit note when a rule is shadowing a stricter one below it. ~6ms per rule on a real
+  8-rule document, and only tenants that actually carry a retired rule pay it.
+### Fixed
+- **Corrected the justification comment in `policy-baseline.ts`, which stated something false about the
+  fleet.** It argued the human-in-the-loop click was needed because the same retired rule was "pure
+  noise on instapods but a guardrail somebody is actually USING on expresstech (5 rejected of 26)".
+  Checking those rejections showed the opposite: four were the heredoc false-positive class fixed in
+  v0.425.1, and the fifth was an `rm -rf` carrying `destructive: true` — a command the ruleset should
+  never have offered for approval at all. The click stays, for a stronger reason now recorded in its
+  place: only classifying the whole ORDERED document both ways reveals what a removal does, in either
+  direction. Pinned by `scripts/policy-baseline-test.cjs`, now 44 cases.
+
 ## [0.436.0] - 2026-09-10
 ### Added
 - **An agent's task no longer lands on the board until a person accepts it.** Agents file essentially

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.436.0",
+  "version": "0.437.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.436.0",
+      "version": "0.437.0",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.436.0",
+  "version": "0.437.0",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/policy-baseline-test.cjs
+++ b/scripts/policy-baseline-test.cjs
@@ -17,7 +17,7 @@
  */
 const path = require('path');
 const fs = require('fs');
-const { baselineDrift, dropRetiredRules, RETIRED_RULES } =
+const { baselineDrift, dropRetiredRules, retiredRuleImpact, RETIRED_RULES } =
   require(path.resolve(__dirname, '..', 'dist/governance/policy-baseline'));
 
 let pass = 0;
@@ -125,6 +125,40 @@ check('the v0.17.0 shell.exec rule is declared', RETIRED_RULES.some((r) => JSON.
       out.doc.rules.every((r, i, arr) => arr.indexOf(r) === i) &&
       out.doc.rules.every((r) => doc.rules.includes(r)));
   }
+}
+
+// ── 9. Drop IMPACT — a rule's effect is not readable from the rule ────────────────────────────────
+//     The expresstech case, reproduced exactly: the retired rule at index 0 sits AHEAD of the three
+//     `never` guardrails, so first-match shadows all of them and a destructive command is offered for
+//     approval instead of refused. Dropping it makes the tenant STRICTER. Nobody could see that by
+//     reading the rule, which is the whole reason the preview exists — so it is pinned here.
+{
+  const T = { moneyCapUsd: 100, bulkDeleteCount: 25 };
+  const doc = { ...BUNDLED, rules: [STALE, ...BUNDLED.rules] };
+  const impact = retiredRuleImpact(doc, 0, BUNDLED, T);
+
+  check('impact: reports changes', impact.length >= 2);
+  const strict = impact.filter((c) => c.direction === 'stricter');
+  check('impact: finds the SHADOWED hard deny (destructive)',
+    strict.some((c) => c.args.destructive === true && c.before === 'approve:owner' && c.after === 'deny'));
+  check('impact: finds the shadowed money cap', strict.some((c) => typeof c.args.amountUsd === 'number' && c.after === 'deny'));
+  check('impact: finds the shadowed bulk-delete cap', strict.some((c) => typeof c.args.deleteCount === 'number' && c.after === 'deny'));
+  check('impact: also reports the genuine loosening (plain risky ⇒ allow)',
+    impact.some((c) => c.direction === 'looser' && c.before === 'approve:owner' && c.after === 'allow'));
+  check('impact: stricter rows sort first', impact[0].direction === 'stricter');
+  check('impact: examples are MINIMAL (no unrelated args carried along)',
+    strict.every((c) => Object.keys(c.args).length <= 2));
+  check('impact: each row names the rule that now applies', impact.every((c) => typeof c.afterReason === 'string' && c.afterReason.length > 0));
+
+  // A rule with nothing left to shadow: same stale rule, but placed BELOW the nevers.
+  const below = { ...BUNDLED, rules: [...BUNDLED.rules, STALE] };
+  const belowImpact = retiredRuleImpact(below, below.rules.length - 1, BUNDLED, T);
+  check('impact: below the guardrails, only the loosening remains',
+    belowImpact.length > 0 && belowImpact.every((c) => c.direction === 'looser'));
+
+  check('impact: an index that is not retired previews nothing', retiredRuleImpact(doc, 3, BUNDLED, T).length === 0);
+  check('impact: an out-of-range index previews nothing', retiredRuleImpact(doc, 99, BUNDLED, T).length === 0);
+  check('impact: a clean document previews nothing', retiredRuleImpact(BUNDLED, 0, BUNDLED, T).length === 0);
 }
 
 console.log(`policy-baseline-test: ${pass} passed, ${failures.length} failed`);

--- a/src/governance/policy-baseline.ts
+++ b/src/governance/policy-baseline.ts
@@ -16,7 +16,7 @@
  *     (`578d047`) because it fires on any command merely MENTIONING deploy/prod/drop/delete — ordinary
  *     English in a commit message or a changelog. It kept firing on instawp (~70 approvals/14d, cleared
  *     by hand 2026-07-27), on instapods (15 in 30d, **11/11 approved** — zero signal, cleared by hand
- *     2026-09-07) and, at the time of writing, still fires on expresstech.
+ *     2026-09-07) and on expresstech until 2026-09-10.
  *
  * Nobody found any of those from the product: each took a human auditing the approvals table by hand,
  * months late. That invisibility — not the rule itself — is the defect this module fixes.
@@ -30,13 +30,26 @@
  * baseline rule is not reaching this tenant, and no engine-level guard covers it".
  *
  * The RETIRE direction cannot use `stricterDecision` at all — by construction that only ever tightens.
- * It is also the direction where an automatic rewrite would be genuinely dangerous, because it LOOSENS
- * governance on a live tenant with no human in the loop. The fleet says so plainly: the identical stale
- * rule is pure noise on instapods (11/11 approved, 0 rejected) and a guardrail somebody is actually
- * USING on expresstech (26 in 60d — 7 approved, **5 rejected**, 14 cancelled). Same rule, same text,
- * opposite verdicts. So a retired rule is surfaced with its evidence and dropped only when an OWNER
- * clicks, through the same `applyPolicyDocument` path as any edit — snapshotted to `policy_revisions`,
- * hot-reloaded, audited, one-click revertable.
+ * So a retired rule is surfaced with its evidence and dropped only when an OWNER clicks, through the
+ * same `applyPolicyDocument` path as any edit — snapshotted to `policy_revisions`, hot-reloaded,
+ * audited, one-click revertable.
+ *
+ * ⚠ **The original reason given here for keeping a human in the loop was wrong, and the real one is
+ * stronger.** This comment used to argue that the same stale rule was "pure noise on instapods but a
+ * guardrail somebody is actually USING on expresstech (5 rejected of 26)". Checking those rejections
+ * on 2026-09-10 showed the opposite: four were the heredoc false-positive class, and the fifth was an
+ * `rm -rf` carrying `destructive: true` — a command the ruleset should never have offered for approval
+ * at all. On expresstech the retired rule sat at **index 0, ahead of `* destructive → never`**, and
+ * first-match meant it SHADOWED the hard deny, downgrading a refusal to an approvable owner card.
+ * Dropping it made that tenant STRICTER:
+ *
+ *     destructive shell command, as expresstech was:  approve:owner  (shell.exec: risky)
+ *                             with the stale rule gone:  deny         (any action: destructive)
+ *
+ * The lesson is not "auto-dropping would have been fine" — it is that **a rule's effect is not readable
+ * from the rule**. Only classifying the whole ORDERED document both ways reveals what a removal does,
+ * in either direction. That is why the click stays, and why it is now shown with
+ * {@link retiredRuleImpact} rather than with rule text alone.
  *
  * ## The safety property
  *
@@ -45,7 +58,7 @@
  * it is classified as tenant-authored and never offered for removal. Inherited product text is
  * retirable; a human's intent is not, and the two are told apart by exact match rather than by guessing.
  */
-import { PolicyDocument, PolicyRule } from './policy';
+import { ClassificationChange, PolicyDocument, PolicyRule, classificationDiff } from './policy';
 
 /** A rule the product deliberately removed from the bundled default, with the receipt for WHY. */
 export interface RetiredRule {
@@ -93,6 +106,9 @@ export interface DriftRule {
 export interface RetiredHit extends DriftRule {
   since: string;
   reason: string;
+  /** What changes if it is dropped (see {@link retiredRuleImpact}). Filled in by the caller that has
+   *  the live thresholds; absent when nothing computed it. */
+  impact?: ClassificationChange[];
 }
 
 export interface PolicyDrift {
@@ -167,4 +183,30 @@ export function dropRetiredRules(
   const kill = new Set(indices.filter((i) => retirable.has(i)));
   const dropped = doc.rules.filter((_, i) => kill.has(i));
   return { doc: { ...doc, rules: doc.rules.filter((_, i) => !kill.has(i)) }, dropped };
+}
+
+/**
+ * What actually CHANGES if the rule at `index` is dropped — the before/after classification diff, not
+ * the rule text.
+ *
+ * This is the answer to the expresstech shadowing case in the header: the rule read as a guardrail and
+ * behaved as a hole, and no amount of staring at it would have said so. An owner deciding whether to
+ * drop a rule is shown the verdicts that move, with a minimal example for each and which direction it
+ * goes, so "this makes destructive commands DENY instead of asking you" is on screen before the click.
+ *
+ * Returns `[]` for an index that is out of range or not currently retired (nothing to preview), and for
+ * a drop that changes no classification at all — a rule that was fully shadowed by an earlier one, which
+ * is itself worth seeing as "removing this changes nothing".
+ */
+export function retiredRuleImpact(
+  doc: PolicyDocument,
+  index: number,
+  baseline: PolicyDocument,
+  thresholds: Record<string, number> = {},
+  ledger: RetiredRule[] = RETIRED_RULES,
+  limit = 8,
+): ClassificationChange[] {
+  const { doc: without, dropped } = dropRetiredRules(doc, [index], baseline, ledger);
+  if (!dropped.length) return [];
+  return classificationDiff(doc, without, thresholds, limit);
 }

--- a/src/governance/policy.ts
+++ b/src/governance/policy.ts
@@ -407,6 +407,119 @@ function firstLoosening(before: PolicyDocument, after: PolicyDocument, threshold
   return null;
 }
 
+/** One classification that changes between two documents, with a MINIMAL example that shows it. */
+export interface ClassificationChange {
+  capability: string;
+  /** The smallest arg set that still produces this before/after pair — see `minimize` below. */
+  args: Record<string, unknown>;
+  /** Rendered verdicts: `allow` | `deny` | `approve:owner` | `approve:admin`. */
+  before: string;
+  after: string;
+  /** Which way it moves. `stricter` = the change tightens this case, `looser` = it opens it up. */
+  direction: 'stricter' | 'looser';
+  beforeReason: string;
+  afterReason: string;
+}
+
+const renderDecision = (d: Decision): string => (d.effect === 'approve' ? `approve:${d.level}` : d.effect);
+
+/**
+ * Every DISTINCT way two rulesets classify the same attempt differently, most-consequential first.
+ *
+ * `firstLoosening` answers "is this change safe?" with one counter-example and stops. This answers a
+ * different question — "what does this change actually DO?" — so it collects both directions, dedupes
+ * by (capability, verdict pair, reason pair), and hands back a MINIMAL example for each.
+ *
+ * Why it has to exist: a rule's effect is not readable from the rule. On expresstech the retired
+ * `shell.exec`+`risky` rule sat at index 0, ahead of `* destructive → never`, and first-match meant it
+ * SHADOWED the hard deny — a destructive command was being offered for approval instead of refused.
+ * Nobody could see that by reading the rule; it took classifying the whole ordered document both ways.
+ * So anything that asks a human to approve a ruleset change owes them this diff, not the rule text.
+ *
+ * Reuses the same finite arg space as the monotonicity sweep (`sampleArgDomains` / `sampleCapabilities`),
+ * so it explores exactly what the ruleset can branch on. Bounded by `limit`; the sweep itself is capped
+ * by `MAX_SWEEP_COMBOS` and degrades to per-arg variation for a huge product, exactly like `firstLoosening`.
+ */
+export function classificationDiff(
+  before: PolicyDocument,
+  after: PolicyDocument,
+  thresholds: Record<string, number> = {},
+  limit = 12,
+): ClassificationChange[] {
+  const eB = new JsonPolicyEngine(before); eB.setThresholds(() => thresholds);
+  const eA = new JsonPolicyEngine(after); eA.setThresholds(() => thresholds);
+  const ctx = {} as RunContext;
+  const classify = (cap: string, args: Record<string, unknown>) => ({
+    b: eB.classify({ capabilityId: cap, args } as ActionAttempt, ctx),
+    a: eA.classify({ capabilityId: cap, args } as ActionAttempt, ctx),
+  });
+
+  /**
+   * Shrink an example to the args that actually MATTER. A raw sweep point sets every branch arg the
+   * ruleset can key on, which renders as unreadable noise ({risky:true, destructive:true, deleteCount:0,
+   * emailExternal:false, …}); dropping each arg that changes neither verdict leaves the pair that
+   * explains the row ({risky:true, destructive:true}). Greedy and order-dependent, which is fine — any
+   * minimal witness explains the change equally well.
+   */
+  const minimize = (cap: string, args: Record<string, unknown>, want: string): Record<string, unknown> => {
+    const out = { ...args };
+    for (const k of Object.keys(args)) {
+      const trial = { ...out };
+      delete trial[k];
+      const { b, a } = classify(cap, trial);
+      if (`${renderDecision(b)}→${renderDecision(a)}` === want) delete out[k];
+    }
+    return out;
+  };
+
+  const seen = new Set<string>();
+  const changes: ClassificationChange[] = [];
+  const consider = (cap: string, args: Record<string, unknown>): void => {
+    const { b, a } = classify(cap, args);
+    const rb = renderDecision(b);
+    const ra = renderDecision(a);
+    if (rb === ra) return;
+    const key = `${cap}|${rb}|${ra}|${b.reason}|${a.reason}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+    changes.push({
+      capability: cap === WILDCARD_PROBE ? 'any capability' : cap,
+      args: minimize(cap, args, `${rb}→${ra}`),
+      before: rb,
+      after: ra,
+      direction: decisionRank(a) > decisionRank(b) ? 'stricter' : 'looser',
+      beforeReason: b.reason,
+      afterReason: a.reason,
+    });
+  };
+
+  const caps = sampleCapabilities(before, after);
+  const domains = [...sampleArgDomains(before, after, thresholds).entries()];
+  const combos = caps.length * domains.reduce((n, [, vals]) => n * vals.length, 1);
+  if (combos <= MAX_SWEEP_COMBOS) {
+    for (const cap of caps) {
+      const total = domains.reduce((n, [, vals]) => n * vals.length, 1);
+      for (let i = 0; i < total && changes.length < limit; i++) {
+        const args: Record<string, unknown> = {};
+        let idx = i;
+        for (const [arg, vals] of domains) { args[arg] = vals[idx % vals.length]; idx = Math.floor(idx / vals.length); }
+        consider(cap, args);
+      }
+      if (changes.length >= limit) break;
+    }
+  } else {
+    for (const cap of caps) {
+      const base: Record<string, unknown> = {};
+      for (const [arg] of domains) base[arg] = false;
+      consider(cap, base);
+      for (const [arg, vals] of domains) for (const v of vals) { if (changes.length >= limit) break; consider(cap, { ...base, [arg]: v }); }
+      if (changes.length >= limit) break;
+    }
+  }
+  // A tightening a human is about to lose is the point of the whole preview — surface those first.
+  return changes.sort((x, y) => (x.direction === y.direction ? 0 : x.direction === 'stricter' ? -1 : 1));
+}
+
 /**
  * Produce the candidate document for a proposed policy change, or an error. TIGHTEN-ONLY: refuses any
  * delta that loosens a guardrail, removes/weakens a hard-deny, or changes the default. Callers persist +

--- a/src/kernel.ts
+++ b/src/kernel.ts
@@ -51,7 +51,7 @@ import { VideoJobStore } from './state/video-jobs';
 import { StubIdentity } from './governance/identity';
 import { InMemoryIdempotencyStore } from './gateway/idempotency';
 import { JsonPolicyEngine, PolicyDocument, PolicyRule, policyContextMismatch } from './governance/policy';
-import { PolicyDrift, baselineDrift, dropRetiredRules } from './governance/policy-baseline';
+import { PolicyDrift, baselineDrift, dropRetiredRules, retiredRuleImpact } from './governance/policy-baseline';
 import { EnvSecretsVault, SqliteSecretsVault } from './edge/secrets';
 import { resolveMasterKey } from './edge/secret-crypto';
 import { seedBuiltinAgents } from './edge/agent-catalog';
@@ -266,7 +266,15 @@ export class AgentOS {
     if (!(this.policy instanceof JsonPolicyEngine)) return null;
     const baseline = this.bundledPolicyDocument();
     if (!baseline) return null;
-    return baselineDrift(this.policy.document, baseline);
+    const drift = baselineDrift(this.policy.document, baseline);
+    // Attach WHAT CHANGES if each retired rule is dropped. A rule's effect is not readable from the
+    // rule — on expresstech this one sat ahead of three `never` guardrails and shadowed all of them, so
+    // dropping it made that tenant stricter, not looser. An owner is asked to click; they get the diff.
+    // Costs a bounded sweep (~6ms on a real 8-rule document) and only for tenants that actually carry a
+    // retired rule — a clean tenant pays nothing because `retired` is empty.
+    const thresholds = this.settings.governanceThresholds() as unknown as Record<string, number>;
+    for (const hit of drift.retired) hit.impact = retiredRuleImpact(this.policy.document, hit.index, baseline, thresholds);
+    return drift;
   }
 
   /**

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20254,6 +20254,34 @@ function PolicyDriftPanel({ drift, canEdit, dirty, onDropped }: {
                 </Button>
               ) : null}
             </div>
+
+            {/* What actually changes if you drop it. A rule's effect is NOT readable from the rule: on
+                one live tenant this same rule sat ahead of three `never` guardrails and shadowed all
+                three, so dropping it made that tenant stricter. Show the verdicts that move. */}
+            {hit.impact?.length ? (
+              <div className="mt-2 space-y-1 border-t border-amber-500/20 pt-2">
+                <div className="text-[11px] uppercase tracking-wider text-muted-foreground">If you drop it</div>
+                {hit.impact.map((c, i) => (
+                  <div key={i} className="flex flex-wrap items-baseline gap-x-2 text-xs">
+                    <span className={c.direction === 'stricter' ? 'font-medium text-emerald-600' : 'font-medium text-amber-600'}>
+                      {c.direction === 'stricter' ? 'stricter' : 'looser'}
+                    </span>
+                    <code className="text-[11px]">{c.capability} {JSON.stringify(c.args)}</code>
+                    <span className="text-muted-foreground">{c.before} → <strong>{c.after}</strong></span>
+                    <span className="text-muted-foreground">({c.afterReason})</span>
+                  </div>
+                ))}
+                {hit.impact.some((c) => c.direction === 'stricter') ? (
+                  <div className="text-xs text-muted-foreground">
+                    This rule currently matches FIRST and shadows a stricter rule below it — dropping it lets that one apply again.
+                  </div>
+                ) : null}
+              </div>
+            ) : hit.impact ? (
+              <div className="mt-2 border-t border-amber-500/20 pt-2 text-xs text-muted-foreground">
+                Dropping it changes no classification — an earlier rule already covers everything it matches.
+              </div>
+            ) : null}
           </div>
         ))}
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1604,12 +1604,23 @@ export interface PolicyResp {
   drift?: PolicyDrift
   error?: string
 }
+/** One classification that moves when a rule is dropped — the preview behind the Drop button. */
+export interface ClassificationChange {
+  capability: string
+  args: Record<string, unknown>
+  before: string
+  after: string
+  direction: 'stricter' | 'looser'
+  beforeReason: string
+  afterReason: string
+}
 /** A rule the product retired that this tenant still enforces (see src/governance/policy-baseline.ts). */
 export interface RetiredHit {
   index: number
   rule: PolicyRule
   since: string
   reason: string
+  impact?: ClassificationChange[]
 }
 /** How far a tenant's persisted ruleset has drifted from the shipped default. */
 export interface PolicyDrift {


### PR DESCRIPTION
## Why

v0.428.0 surfaced rules the product retired that a tenant still enforces, and left the drop to an owner's click. The click was still half-blind — it showed the **rule**. **A rule's effect is not readable from the rule.**

On expresstech the retired `shell.exec`+`risky` rule sat at **index 0, ahead of all three `never` guardrails**. First-match meant it *shadowed* every one of them:

```
stricter  shell.exec {"risky":true,"destructive":true}   approve:owner → deny   (any action: destructive)
stricter  shell.exec {"risky":true,"amountUsd":501}      approve:owner → deny   (any action: amountUsd > 500)
stricter  shell.exec {"risky":true,"deleteCount":26}     approve:owner → deny   (any action: deleteCount > 25)
looser    shell.exec {"risky":true}                      approve:owner → allow  (default policy)
```

Dropping it made that tenant **stricter** — the opposite of what the rule text suggested, and invisible without classifying the whole *ordered* document both ways. Any tenant carrying that rule at the top had the same three holes.

## What ships

`classificationDiff()` (`src/governance/policy.ts`) reuses the monotonicity sweep's own arg space (`sampleArgDomains` / `sampleCapabilities`) to collect every **distinct** verdict that moves between two rulesets:

- **both directions** (`firstLoosening` answers "is this safe?" with one counter-example and stops; this answers "what does this *do*?"),
- deduped by capability + verdict pair + reason,
- each with a **minimal** example, greedily shrunk from its sweep point — a row reads `{risky:true, destructive:true}`, not every branch arg the ruleset can key on,
- stricter rows sorted first, since a tightening you're about to lose is the point.

`retiredRuleImpact()` applies it to a single drop. `GET /api/policy` carries it per retired hit; Settings → Policy renders direction, before → after, the rule that applies afterwards, and an explicit note when a rule is shadowing a stricter one below it.

**Cost:** ~6ms per rule on a real 8-rule document, 9ms end-to-end over HTTP. Only tenants that actually carry a retired rule pay it — a clean tenant has no hits.

## Also: a correction

The justification comment in `policy-baseline.ts` stated something **false about the fleet** — that the same rule was "a guardrail somebody is actually USING on expresstech (5 rejected of 26)". Checking those rejections: four were the heredoc false-positive class fixed in v0.425.1, and the fifth was an `rm -rf` carrying `destructive: true` that should never have been approvable at all. The click stays, for the stronger reason now recorded in its place.

## Verification

- `scripts/policy-baseline-test.cjs` **32 → 44 cases**: the shadowing case, minimality of examples, the below-the-guardrails case where only the loosening remains, and the not-retired / out-of-range / clean no-ops.
- End-to-end over HTTP on a scratch tenant: `impact` present in the payload with live thresholds resolved from settings, stricter rows first.
- `npm run typecheck`, `cd web && npm run build`, full `npm run test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gwz3ZqU9iid84Sc6EzUt9M