### PR TITLE
fix(github): the bot-token migration could throw away a live credential (v0.439.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ new version heading in the same commit.
 
 ## [Unreleased]
 
+## [0.439.1] - 2026-09-10
+### Fixed
+- **The multi-org bot-token migration could throw away a live credential.** `migrateLegacyBotToken`
+  (v0.435.0) moves a pre-upgrade token from the bare `github_bot_token` vault slot onto the primary
+  installation's `github_bot_token:<id>` key — but it deleted the legacy slot *unconditionally*, so a
+  tenant that had a cached token and no resolved `github_installation_id` lost it with nothing written
+  in its place. The token stays valid for the hour, so the fix is simply to leave it alone until a
+  primary exists; the next `ensureBotToken` resolves one and the migration completes then. No live
+  tenant hit this (every one with a cached token also had a primary), but it was one settings row away.
+### Added
+- **`github.connect.initiated` now records the `redirect_uri` and client id it sent to GitHub.** GitHub
+  validates the redirect against the App's registered callback *after* the user logs in, and renders a
+  bare **404** when it doesn't match — which reads to the member as "Agentric is broken" and left no
+  trace anywhere in our audit trail. The only way to see what we actually sent was to ssh to the box and
+  re-derive it from the proxy headers. Now the first place you look answers it.
+  **For admins:** If a teammate gets a 404 from GitHub when connecting their account, the Audit page now
+  shows the exact callback URL we asked for — compare it with the Callback URL on your GitHub App.
+
 ## [0.439.0] - 2026-09-10
 ### Added
 - **A goal can now be judged on whether the number moved, not on whether work happened.** The Goals plane

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-os",
-  "version": "0.439.0",
+  "version": "0.439.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-os",
-      "version": "0.439.0",
+      "version": "0.439.1",
       "license": "MIT",
       "bin": {
         "agent-os": "bin/agent-os"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-os",
-  "version": "0.439.0",
+  "version": "0.439.1",
   "description": "A generic, governed operating system for running autonomous agents safely across brands. Ships with a local web console.",
   "license": "MIT",
   "type": "commonjs",

--- a/scripts/github-multi-org-test.cjs
+++ b/scripts/github-multi-org-test.cjs
@@ -126,6 +126,15 @@ async function main() {
   assert(migrated && migrated.token === 'ghs_legacy', 'a pre-multi-org token is still readable after the upgrade');
   assert(vault('github_bot_token:555') !== undefined && vault('github_bot_token') === undefined, 'it moves onto the primary’s suffixed key and the legacy slot is cleared');
   assert(gid.loadBotToken('Globex').token === globex.token, 'migration does not disturb another org’s cache');
+  // A legacy token with NO primary resolved yet must be LEFT ALONE, not thrown away: it is still a live
+  // credential, and the next ensureBotToken settles a primary to migrate it onto.
+  osx.secrets.set('testco', 'github_bot_token', legacy, { principal: '*' });
+  const savedPrimary = osx.settings.githubInstallationId();
+  osx.settings.setGithubInstallationId('', 'owner@test');
+  assert(gid.loadBotToken() === undefined, 'with no primary there is nothing to read...');
+  assert(vault('github_bot_token') === legacy, '...but the legacy token is preserved, not silently destroyed');
+  osx.settings.setGithubInstallationId(savedPrimary, 'owner@test');
+  assert(gid.loadBotToken().token === 'ghs_legacy', 'and it migrates as soon as a primary exists again');
 
   // ─── 5) Launch injection ────────────────────────────────────────────────────
   console.log('\n\x1b[1m5) Launch injection\x1b[0m');

--- a/src/edge/github-identity.ts
+++ b/src/edge/github-identity.ts
@@ -222,7 +222,12 @@ export class GithubIdentity {
     const legacy = this.os.secrets.getSync(this.os.tenant, '*', BOT_TOKEN_KEY);
     if (!legacy) return;
     const primary = this.os.settings.githubInstallationId();
-    if (primary && !this.os.secrets.getSync(this.os.tenant, '*', botTokenKey(primary))) {
+    // No primary to migrate ONTO yet → leave the legacy slot alone. Deleting here would throw away a
+    // live credential to no purpose: the token stays valid for the hour, and the next `ensureBotToken`
+    // resolves a primary, after which this runs again and moves it. (An earlier version deleted
+    // unconditionally, so a tenant with a cached token but no resolved installation silently lost it.)
+    if (!primary) return;
+    if (!this.os.secrets.getSync(this.os.tenant, '*', botTokenKey(primary))) {
       this.os.secrets.set(this.os.tenant, botTokenKey(primary), legacy, { principal: '*' });
     }
     this.os.secrets.delete(this.os.tenant, BOT_TOKEN_KEY, '*');

--- a/src/server.ts
+++ b/src/server.ts
@@ -5846,8 +5846,13 @@ async function handle(os: AgentOS, tm: TerminalManager, autos: Automations, req:
     if (!gh.configured()) return sendJson(res, 400, { error: 'GitHub is not set up — an owner/admin must add the App client id + secret in Connections → Creds' });
     // Remember where the member started (the profile page or Connections) so the callback returns there.
     const state = newGithubState(os.tenant, me.id, url.searchParams.get('return') || undefined);
-    const redirectUrl = gh.authorizeUrl(githubRedirectUri(req), state);
-    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'github.connect.initiated', data: {} });
+    const redirectUri = githubRedirectUri(req);
+    const redirectUrl = gh.authorizeUrl(redirectUri, state);
+    // Record the redirect_uri we asked GitHub for. GitHub validates it against the App's registered
+    // callback AFTER login and renders a bare 404 when it doesn't match — indistinguishable, to the
+    // member, from "Agentric is broken". Without this the only way to see what we sent was to ssh to
+    // the box and re-derive it from the proxy headers.
+    os.audit.append({ ts: Date.now(), runId: '-', tenant: os.tenant, principal: me.email, type: 'github.connect.initiated', data: { redirectUri, clientId: gh.clientId() } });
     return sendJson(res, 200, { redirectUrl });
   }
   // GitHub redirects the browser here after the member authorizes. The aos_sid cookie rides along


### PR DESCRIPTION
Found while checking whether the multi-org work (#807) is backward compatible, after a report of members getting a GitHub 404 when connecting their account on instawp.

## The bug

`migrateLegacyBotToken` (v0.435.0) moves a pre-upgrade token from the bare `github_bot_token` vault slot onto the primary installation's `github_bot_token:<id>` key. It deleted the legacy slot **unconditionally** — so a tenant with a cached token and no resolved `github_installation_id` lost it with nothing written in its place.

The token stays valid for the hour, so the fix is simply to leave it alone until a primary exists; the next `ensureBotToken` resolves one and the migration completes then.

No live tenant hit this — every one with a cached token also had a primary — but it was one settings row away from a silent credential loss.

## Also: making the 404 diagnosable

`github.connect.initiated` now records the `redirect_uri` and client id we sent to GitHub. GitHub validates the redirect against the App's registered callback **after** the user logs in and renders a bare 404 when it doesn't match — which reads to the member as "Agentric is broken" and left no trace anywhere in our audit trail. The only way to see what we actually sent was to ssh to the box and re-derive it from the proxy headers.

## On the instawp report itself

Not caused by the multi-org work, on the evidence from the live box (v0.437.1, which has phases 1–3):

- `github_installations` is **absent** from settings, so `orgs()` is empty and every phase-2/3 behaviour is inert there — the registry only populates when an admin re-saves the App credentials.
- `github_installation_id` is unchanged since 2026-07-19 and `github.bot_token.injected` has fired 6545 times, most recently minutes ago — the legacy→suffixed migration worked and the bot lane is healthy.
- `github.connect.initiated` fired 15 times, latest today, and the console navigates straight to the `redirectUrl` we mint — so the 404 is **github.com's page**, not ours.

## Verification

`scripts/github-multi-org-test.cjs` is 64 checks now — three new ones pin that a legacy token with no primary is preserved rather than destroyed, and that it migrates as soon as a primary exists again. Full `test:governance` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UfJRSqtHhuk7x51Cqy4NB5